### PR TITLE
Correct doc blocks according to cs guidelines

### DIFF
--- a/app/Config/Schema/db_acl.php
+++ b/app/Config/Schema/db_acl.php
@@ -19,7 +19,6 @@
  */
 
 /**
- *
  * Using the Schema command line utility
  * cake schema run create DbAcl
  *
@@ -30,7 +29,7 @@ class DbAclSchema extends CakeSchema {
  * Before event.
  *
  * @param array $event The event data.
- * @return boolean success
+ * @return bool success
  */
 	public function before($event = array()) {
 		return true;

--- a/app/Config/Schema/i18n.php
+++ b/app/Config/Schema/i18n.php
@@ -19,7 +19,6 @@
  */
 
 /**
- *
  * Using the Schema command line utility
  *
  * Use it to configure database for i18n

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -278,7 +278,6 @@
 	//Configure::write('Config.timezone', 'Europe/Paris');
 
 /**
- *
  * Cache Engine Configuration
  * Default settings provided below
  *

--- a/app/View/Emails/html/default.ctp
+++ b/app/View/Emails/html/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Emails/text/default.ctp
+++ b/app/View/Emails/text/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Errors/error400.ctp
+++ b/app/View/Errors/error400.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Errors/error500.ctp
+++ b/app/View/Errors/error500.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/Emails/html/default.ctp
+++ b/app/View/Layouts/Emails/html/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/Emails/text/default.ctp
+++ b/app/View/Layouts/Emails/text/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/ajax.ctp
+++ b/app/View/Layouts/ajax.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/error.ctp
+++ b/app/View/Layouts/error.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/flash.ctp
+++ b/app/View/Layouts/flash.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Pages
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/app/index.php
+++ b/app/index.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -160,7 +160,7 @@ class Cache {
  * Finds and builds the instance of the required engine class.
  *
  * @param string $name Name of the config array that needs an engine instance built
- * @return boolean
+ * @return bool
  * @throws CacheException
  */
 	protected static function _buildEngine($name) {
@@ -201,7 +201,7 @@ class Cache {
  * the Engine instance is also unset.
  *
  * @param string $name A currently configured cache config you wish to remove.
- * @return boolean success of the removal, returns false when the config does not exist.
+ * @return bool success of the removal, returns false when the config does not exist.
  */
 	public static function drop($name) {
 		if (!isset(self::$_config[$name])) {
@@ -269,7 +269,7 @@ class Cache {
  * Permanently remove all expired and deleted data
  *
  * @param string $config [optional] The config name you wish to have garbage collected. Defaults to 'default'
- * @param integer $expires [optional] An expires timestamp. Defaults to NULL
+ * @param int $expires [optional] An expires timestamp. Defaults to NULL
  * @return void
  */
 	public static function gc($config = 'default', $expires = null) {
@@ -292,7 +292,7 @@ class Cache {
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached - anything except a resource
  * @param string $config Optional string configuration name to write to. Defaults to 'default'
- * @return boolean True if the data was successfully cached, false on failure
+ * @return bool True if the data was successfully cached, false on failure
  */
 	public static function write($key, $value, $config = 'default') {
 		$settings = self::settings($config);
@@ -362,7 +362,7 @@ class Cache {
  * Increment a number under the key and return incremented value.
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to add
+ * @param int $offset How much to add
  * @param string $config Optional string configuration name. Defaults to 'default'
  * @return mixed new value, or false if the data doesn't exist, is not integer,
  *    or if there was an error fetching it.
@@ -390,7 +390,7 @@ class Cache {
  * Decrement a number under the key and return decremented value.
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @param string $config Optional string configuration name. Defaults to 'default'
  * @return mixed new value, or false if the data doesn't exist, is not integer,
  *   or if there was an error fetching it
@@ -429,7 +429,7 @@ class Cache {
  *
  * @param string $key Identifier for the data
  * @param string $config name of the configuration to use. Defaults to 'default'
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public static function delete($key, $config = 'default') {
 		$settings = self::settings($config);
@@ -453,9 +453,9 @@ class Cache {
 /**
  * Delete all keys from the cache.
  *
- * @param boolean $check if true will check expiration, otherwise delete all
+ * @param bool $check if true will check expiration, otherwise delete all
  * @param string $config name of the configuration to use. Defaults to 'default'
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	public static function clear($check = false, $config = 'default') {
 		if (!self::isInitialized($config)) {
@@ -471,7 +471,7 @@ class Cache {
  *
  * @param string $group name of the group to be cleared
  * @param string $config name of the configuration to use. Defaults to 'default'
- * @return boolean True if the cache group was successfully cleared, false otherwise
+ * @return bool True if the cache group was successfully cleared, false otherwise
  */
 	public static function clearGroup($group, $config = 'default') {
 		if (!self::isInitialized($config)) {
@@ -486,7 +486,7 @@ class Cache {
  * Check if Cache has initialized a working config for the given name.
  *
  * @param string $config name of the configuration to use. Defaults to 'default'
- * @return boolean Whether or not the config name has been initialized.
+ * @return bool Whether or not the config name has been initialized.
  */
 	public static function isInitialized($config = 'default') {
 		if (Configure::read('Cache.disable')) {

--- a/lib/Cake/Cache/CacheEngine.php
+++ b/lib/Cake/Cache/CacheEngine.php
@@ -42,7 +42,7 @@ abstract class CacheEngine {
  * Called automatically by the cache frontend
  *
  * @param array $settings Associative array of parameters for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  */
 	public function init($settings = array()) {
 		$settings += $this->settings + array(
@@ -67,7 +67,7 @@ abstract class CacheEngine {
  *
  * Permanently remove all expired and deleted data
  *
- * @param integer $expires [optional] An expires timestamp, invalidating all data before.
+ * @param int $expires [optional] An expires timestamp, invalidating all data before.
  * @return void
  */
 	public function gc($expires = null) {
@@ -78,8 +78,8 @@ abstract class CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache for.
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache for.
+ * @return bool True if the data was successfully cached, false on failure
  */
 	abstract public function write($key, $value, $duration);
 
@@ -95,7 +95,7 @@ abstract class CacheEngine {
  * Increment a number under the key and return incremented value
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to add
+ * @param int $offset How much to add
  * @return New incremented value, false otherwise
  */
 	abstract public function increment($key, $offset = 1);
@@ -104,7 +104,7 @@ abstract class CacheEngine {
  * Decrement a number under the key and return decremented value
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New incremented value, false otherwise
  */
 	abstract public function decrement($key, $offset = 1);
@@ -113,15 +113,15 @@ abstract class CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	abstract public function delete($key);
 
 /**
  * Delete all keys from the cache
  *
- * @param boolean $check if true will check expiration, otherwise delete all
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @param bool $check if true will check expiration, otherwise delete all
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	abstract public function clear($check);
 
@@ -131,7 +131,7 @@ abstract class CacheEngine {
  * the same result.
  *
  * @param string $group name of the group to be cleared
- * @return boolean
+ * @return bool
  */
 	public function clearGroup($group) {
 		return false;

--- a/lib/Cake/Cache/Engine/ApcEngine.php
+++ b/lib/Cake/Cache/Engine/ApcEngine.php
@@ -38,7 +38,7 @@ class ApcEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  * @see CacheEngine::__defaults
  */
 	public function init($settings = array()) {
@@ -55,8 +55,8 @@ class ApcEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  */
 	public function write($key, $value, $duration) {
 		$expires = 0;
@@ -86,7 +86,7 @@ class ApcEngine extends CacheEngine {
  * Increments the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to increment
+ * @param int $offset How much to increment
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
@@ -97,7 +97,7 @@ class ApcEngine extends CacheEngine {
  * Decrements the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
@@ -108,7 +108,7 @@ class ApcEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		return apc_delete($key);
@@ -117,9 +117,9 @@ class ApcEngine extends CacheEngine {
 /**
  * Delete all keys from the cache. This will clear every cache config using APC.
  *
- * @param boolean $check If true, nothing will be cleared, as entries are removed
+ * @param bool $check If true, nothing will be cleared, as entries are removed
  *    from APC as they expired. This flag is really only used by FileEngine.
- * @return boolean True Returns true.
+ * @return bool True Returns true.
  */
 	public function clear($check) {
 		if ($check) {
@@ -181,7 +181,7 @@ class ApcEngine extends CacheEngine {
  * old values will remain in storage until they expire.
  *
  * @param string $group The group to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		apc_inc($this->settings['prefix'] . $group, 1, $success);

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -53,7 +53,7 @@ class FileEngine extends CacheEngine {
 /**
  * True unless FileEngine::__active(); fails
  *
- * @var boolean
+ * @var bool
  */
 	protected $_init = true;
 
@@ -64,7 +64,7 @@ class FileEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  */
 	public function init($settings = array()) {
 		$settings += array(
@@ -93,8 +93,8 @@ class FileEngine extends CacheEngine {
 /**
  * Garbage collection. Permanently remove all expired and deleted data
  *
- * @param integer $expires [optional] An expires timestamp, invalidating all data before.
- * @return boolean True if garbage collection was successful, false on failure
+ * @param int $expires [optional] An expires timestamp, invalidating all data before.
+ * @return bool True if garbage collection was successful, false on failure
  */
 	public function gc($expires = null) {
 		return $this->clear(true);
@@ -105,8 +105,8 @@ class FileEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $data Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  */
 	public function write($key, $data, $duration) {
 		if ($data === '' || !$this->_init) {
@@ -200,7 +200,7 @@ class FileEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		if ($this->_setKey($key) === false || !$this->_init) {
@@ -217,8 +217,8 @@ class FileEngine extends CacheEngine {
 /**
  * Delete all values from the cache
  *
- * @param boolean $check Optional - only delete expired cache items
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @param bool $check Optional - only delete expired cache items
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	public function clear($check) {
 		if (!$this->_init) {
@@ -255,8 +255,8 @@ class FileEngine extends CacheEngine {
  * Used to clear a directory of matching files.
  *
  * @param string $path The path to search.
- * @param integer $now The current timestamp
- * @param integer $threshold Any file not modified after this value will be deleted.
+ * @param int $now The current timestamp
+ * @param int $threshold Any file not modified after this value will be deleted.
  * @return void
  */
 	protected function _clearDirectory($path, $now, $threshold) {
@@ -304,7 +304,7 @@ class FileEngine extends CacheEngine {
  * Not implemented
  *
  * @param string $key The key to decrement
- * @param integer $offset The number to offset
+ * @param int $offset The number to offset
  * @return void
  * @throws CacheException
  */
@@ -316,7 +316,7 @@ class FileEngine extends CacheEngine {
  * Not implemented
  *
  * @param string $key The key to decrement
- * @param integer $offset The number to offset
+ * @param int $offset The number to offset
  * @return void
  * @throws CacheException
  */
@@ -329,8 +329,8 @@ class FileEngine extends CacheEngine {
  * for the cache file the key is referring to.
  *
  * @param string $key The key
- * @param boolean $createKey Whether the key should be created if it doesn't exists, or not
- * @return boolean true if the cache key could be set, false otherwise
+ * @param bool $createKey Whether the key should be created if it doesn't exists, or not
+ * @return bool true if the cache key could be set, false otherwise
  */
 	protected function _setKey($key, $createKey = false) {
 		$groups = null;
@@ -369,7 +369,7 @@ class FileEngine extends CacheEngine {
 /**
  * Determine is cache directory is writable
  *
- * @return boolean
+ * @return bool
  */
 	protected function _active() {
 		$dir = new SplFileInfo($this->settings['path']);
@@ -406,7 +406,7 @@ class FileEngine extends CacheEngine {
  * Recursively deletes all files under any directory named as $group
  *
  * @param string $group The group to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		$this->_File = null;

--- a/lib/Cake/Cache/Engine/MemcacheEngine.php
+++ b/lib/Cake/Cache/Engine/MemcacheEngine.php
@@ -59,7 +59,7 @@ class MemcacheEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  */
 	public function init($settings = array()) {
 		if (!class_exists('Memcache')) {
@@ -131,8 +131,8 @@ class MemcacheEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  * @see http://php.net/manual/en/memcache.set.php
  */
 	public function write($key, $value, $duration) {
@@ -156,7 +156,7 @@ class MemcacheEngine extends CacheEngine {
  * Increments the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to increment
+ * @param int $offset How much to increment
  * @return New incremented value, false otherwise
  * @throws CacheException when you try to increment with compress = true
  */
@@ -173,7 +173,7 @@ class MemcacheEngine extends CacheEngine {
  * Decrements the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New decremented value, false otherwise
  * @throws CacheException when you try to decrement with compress = true
  */
@@ -190,7 +190,7 @@ class MemcacheEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		return $this->_Memcache->delete($key);
@@ -199,9 +199,9 @@ class MemcacheEngine extends CacheEngine {
 /**
  * Delete all keys from the cache
  *
- * @param boolean $check If true no deletes will occur and instead CakePHP will rely
+ * @param bool $check If true no deletes will occur and instead CakePHP will rely
  *   on key TTL values.
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	public function clear($check) {
 		if ($check) {
@@ -232,8 +232,8 @@ class MemcacheEngine extends CacheEngine {
  * Connects to a server in connection pool
  *
  * @param string $host host ip address or name
- * @param integer $port Server port
- * @return boolean True if memcache server was connected
+ * @param int $port Server port
+ * @return bool True if memcache server was connected
  */
 	public function connect($host, $port = 11211) {
 		if ($this->_Memcache->getServerStatus($host, $port) === 0) {
@@ -284,7 +284,7 @@ class MemcacheEngine extends CacheEngine {
  * old values will remain in storage until they expire.
  *
  * @param string $group The group to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		return (bool)$this->_Memcache->increment($this->settings['prefix'] . $group);

--- a/lib/Cake/Cache/Engine/MemcachedEngine.php
+++ b/lib/Cake/Cache/Engine/MemcachedEngine.php
@@ -70,7 +70,7 @@ class MemcachedEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  * @throws CacheException when you try use authentication without Memcached compiled with SASL support
  */
 	public function init($settings = array()) {
@@ -199,8 +199,8 @@ class MemcachedEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  * @see http://php.net/manual/en/memcache.set.php
  */
 	public function write($key, $value, $duration) {
@@ -225,7 +225,7 @@ class MemcachedEngine extends CacheEngine {
  * Increments the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to increment
+ * @param int $offset How much to increment
  * @return New incremented value, false otherwise
  * @throws CacheException when you try to increment with compress = true
  */
@@ -237,7 +237,7 @@ class MemcachedEngine extends CacheEngine {
  * Decrements the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New decremented value, false otherwise
  * @throws CacheException when you try to decrement with compress = true
  */
@@ -249,7 +249,7 @@ class MemcachedEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		return $this->_Memcached->delete($key);
@@ -258,9 +258,9 @@ class MemcachedEngine extends CacheEngine {
 /**
  * Delete all keys from the cache
  *
- * @param boolean $check If true no deletes will occur and instead CakePHP will rely
+ * @param bool $check If true no deletes will occur and instead CakePHP will rely
  *   on key TTL values.
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	public function clear($check) {
 		if ($check) {
@@ -317,7 +317,7 @@ class MemcachedEngine extends CacheEngine {
  * old values will remain in storage until they expire.
  *
  * @param string $group The group to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		return (bool)$this->_Memcached->increment($this->settings['prefix'] . $group);

--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -51,7 +51,7 @@ class RedisEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  */
 	public function init($settings = array()) {
 		if (!class_exists('Redis')) {
@@ -76,7 +76,7 @@ class RedisEngine extends CacheEngine {
 /**
  * Connects to a Redis server
  *
- * @return boolean True if Redis server was connected
+ * @return bool True if Redis server was connected
  */
 	protected function _connect() {
 		$return = false;
@@ -107,8 +107,8 @@ class RedisEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  */
 	public function write($key, $value, $duration) {
 		if (!is_int($value)) {
@@ -142,7 +142,7 @@ class RedisEngine extends CacheEngine {
  * Increments the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to increment
+ * @param int $offset How much to increment
  * @return New incremented value, false otherwise
  * @throws CacheException when you try to increment with compress = true
  */
@@ -154,7 +154,7 @@ class RedisEngine extends CacheEngine {
  * Decrements the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New decremented value, false otherwise
  * @throws CacheException when you try to decrement with compress = true
  */
@@ -166,7 +166,7 @@ class RedisEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		return $this->_Redis->delete($key) > 0;
@@ -175,9 +175,9 @@ class RedisEngine extends CacheEngine {
 /**
  * Delete all keys from the cache
  *
- * @param boolean $check Whether or not expiration keys should be checked. If
+ * @param bool $check Whether or not expiration keys should be checked. If
  *   true, no keys will be removed as cache will rely on redis TTL's.
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	public function clear($check) {
 		if ($check) {
@@ -214,7 +214,7 @@ class RedisEngine extends CacheEngine {
  * old values will remain in storage until they expire.
  *
  * @param string $group The group name to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		return (bool)$this->_Redis->incr($this->settings['prefix'] . $group);

--- a/lib/Cake/Cache/Engine/WincacheEngine.php
+++ b/lib/Cake/Cache/Engine/WincacheEngine.php
@@ -40,7 +40,7 @@ class WincacheEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  * @see CacheEngine::__defaults
  */
 	public function init($settings = array()) {
@@ -57,8 +57,8 @@ class WincacheEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  */
 	public function write($key, $value, $duration) {
 		$expires = time() + $duration;
@@ -91,7 +91,7 @@ class WincacheEngine extends CacheEngine {
  * Increments the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to increment
+ * @param int $offset How much to increment
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
@@ -102,7 +102,7 @@ class WincacheEngine extends CacheEngine {
  * Decrements the value of an integer cached key
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
@@ -113,7 +113,7 @@ class WincacheEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		return wincache_ucache_delete($key);
@@ -123,9 +123,9 @@ class WincacheEngine extends CacheEngine {
  * Delete all keys from the cache. This will clear every
  * item in the cache matching the cache config prefix.
  *
- * @param boolean $check If true, nothing will be cleared, as entries will
+ * @param bool $check If true, nothing will be cleared, as entries will
  *   naturally expire in wincache..
- * @return boolean True Returns true.
+ * @return bool True Returns true.
  */
 	public function clear($check) {
 		if ($check) {
@@ -180,7 +180,7 @@ class WincacheEngine extends CacheEngine {
  * old values will remain in storage until they expire.
  *
  * @param string $group The group to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		$success = null;

--- a/lib/Cake/Cache/Engine/XcacheEngine.php
+++ b/lib/Cake/Cache/Engine/XcacheEngine.php
@@ -41,7 +41,7 @@ class XcacheEngine extends CacheEngine {
  * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
  * @param array $settings array of setting for the engine
- * @return boolean True if the engine has been successfully initialized, false if not
+ * @return bool True if the engine has been successfully initialized, false if not
  */
 	public function init($settings = array()) {
 		if (php_sapi_name() !== 'cli') {
@@ -62,8 +62,8 @@ class XcacheEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
- * @return boolean True if the data was successfully cached, false on failure
+ * @param int $duration How long to cache the data, in seconds
+ * @return bool True if the data was successfully cached, false on failure
  */
 	public function write($key, $value, $duration) {
 		$expires = time() + $duration;
@@ -94,7 +94,7 @@ class XcacheEngine extends CacheEngine {
  * If the cache key is not an integer it will be treated as 0
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to increment
+ * @param int $offset How much to increment
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
@@ -106,7 +106,7 @@ class XcacheEngine extends CacheEngine {
  * If the cache key is not an integer it will be treated as 0
  *
  * @param string $key Identifier for the data
- * @param integer $offset How much to subtract
+ * @param int $offset How much to subtract
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
@@ -117,7 +117,7 @@ class XcacheEngine extends CacheEngine {
  * Delete a key from the cache
  *
  * @param string $key Identifier for the data
- * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
 		return xcache_unset($key);
@@ -126,9 +126,9 @@ class XcacheEngine extends CacheEngine {
 /**
  * Delete all keys from the cache
  *
- * @param boolean $check If true no deletes will occur and instead CakePHP will rely
+ * @param bool $check If true no deletes will occur and instead CakePHP will rely
  *   on key TTL values.
- * @return boolean True if the cache was successfully cleared, false otherwise
+ * @return bool True if the cache was successfully cleared, false otherwise
  */
 	public function clear($check) {
 		$this->_auth();
@@ -165,7 +165,7 @@ class XcacheEngine extends CacheEngine {
  * old values will remain in storage until they expire.
  *
  * @param string $group The group to clear.
- * @return boolean success
+ * @return bool success
  */
 	public function clearGroup($group) {
 		return (bool)xcache_inc($this->settings['prefix'] . $group, 1);
@@ -178,7 +178,7 @@ class XcacheEngine extends CacheEngine {
  * This has to be done because xcache_clear_cache() needs to pass Basic Http Auth
  * (see xcache.admin configuration settings)
  *
- * @param boolean $reverse Revert changes
+ * @param bool $reverse Revert changes
  * @return void
  */
 	protected function _auth($reverse = false) {

--- a/lib/Cake/Configure/ConfigReaderInterface.php
+++ b/lib/Cake/Configure/ConfigReaderInterface.php
@@ -36,7 +36,7 @@ interface ConfigReaderInterface {
  *
  * @param string $key The identifier to write to.
  * @param array $data The data to dump.
- * @return boolean True on success or false on failure.
+ * @return bool True on success or false on failure.
  */
 	public function dump($key, $data);
 

--- a/lib/Cake/Configure/IniReader.php
+++ b/lib/Cake/Configure/IniReader.php
@@ -153,7 +153,7 @@ class IniReader implements ConfigReaderInterface {
  * @param string $key The identifier to write to. If the key has a . it will be treated
  *  as a plugin prefix.
  * @param array $data The data to convert to ini file.
- * @return integer Bytes saved.
+ * @return int Bytes saved.
  */
 	public function dump($key, $data) {
 		$result = array();

--- a/lib/Cake/Configure/PhpReader.php
+++ b/lib/Cake/Configure/PhpReader.php
@@ -83,7 +83,7 @@ class PhpReader implements ConfigReaderInterface {
  * @param string $key The identifier to write to. If the key has a . it will be treated
  *  as a plugin prefix.
  * @param array $data Data to dump.
- * @return integer Bytes saved.
+ * @return int Bytes saved.
  */
 	public function dump($key, $data) {
 		$contents = '<?php' . "\n" . '$config = ' . var_export($data, true) . ';';

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -220,7 +220,7 @@ class AclShell extends AppShell {
  *
  * @param string $class Class name that is being used.
  * @param array $node Array of node information.
- * @param integer $indent indent level.
+ * @param int $indent indent level.
  * @return void
  */
 	protected function _outputNode($class, $node, $indent) {
@@ -519,7 +519,7 @@ class AclShell extends AppShell {
 /**
  * Checks that given node exists
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function nodeExists() {
 		if (!isset($this->args[0]) || !isset($this->args[1])) {
@@ -559,7 +559,7 @@ class AclShell extends AppShell {
  *
  * @param string $class Class type you want (Aro/Aco)
  * @param string|array $identifier A mixed identifier for finding the node.
- * @return integer Integer of NodeId. Will trigger an error if nothing is found.
+ * @return int Integer of NodeId. Will trigger an error if nothing is found.
  */
 	protected function _getNodeId($class, $identifier) {
 		$node = $this->Acl->{$class}->node($identifier);

--- a/lib/Cake/Console/Command/ConsoleShell.php
+++ b/lib/Cake/Console/Command/ConsoleShell.php
@@ -484,7 +484,7 @@ class ConsoleShell extends AppShell {
  * Tells if the specified model is included in the list of available models
  *
  * @param string $modelToCheck The model to check.
- * @return boolean true if is an available model, false otherwise
+ * @return bool true if is an available model, false otherwise
  */
 	protected function _isValidModel($modelToCheck) {
 		return in_array($modelToCheck, $this->models);
@@ -494,7 +494,7 @@ class ConsoleShell extends AppShell {
  * Reloads the routes configuration from app/Config/routes.php, and compiles
  * all routes found
  *
- * @return boolean True if config reload was a success, otherwise false
+ * @return bool True if config reload was a success, otherwise false
  */
 	protected function _loadRoutes() {
 		Router::reload();

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -39,7 +39,7 @@ class SchemaShell extends AppShell {
 /**
  * is this a dry run?
  *
- * @var boolean
+ * @var bool
  */
 	protected $_dry = null;
 

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -34,7 +34,7 @@ class ServerShell extends AppShell {
 /**
  * Default ListenPort
  *
- * @var integer
+ * @var int
  */
 	const DEFAULT_PORT = 80;
 

--- a/lib/Cake/Console/Command/Task/BakeTask.php
+++ b/lib/Cake/Console/Command/Task/BakeTask.php
@@ -41,7 +41,7 @@ class BakeTask extends AppShell {
 /**
  * Flag for interactive mode
  *
- * @var boolean
+ * @var bool
  */
 	public $interactive = false;
 

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -285,7 +285,7 @@ class ControllerTask extends BakeTask {
  *
  * @param string $controllerName Controller name
  * @param string $admin Admin route to use
- * @param boolean $wannaUseSession Set to true to use sessions, false otherwise
+ * @param bool $wannaUseSession Set to true to use sessions, false otherwise
  * @return string Baked actions
  */
 	public function bakeActions($controllerName, $admin = null, $wannaUseSession = true) {

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -200,7 +200,7 @@ class DbConfigTask extends AppShell {
  * Output verification message and bake if it looks good
  *
  * @param array $config The config data.
- * @return boolean True if user says it looks good, false otherwise
+ * @return bool True if user says it looks good, false otherwise
  */
 	protected function _verify($config) {
 		$config += $this->_defaultConfig;
@@ -247,7 +247,7 @@ class DbConfigTask extends AppShell {
  * Assembles and writes database.php
  *
  * @param array $configs Configuration settings to use
- * @return boolean Success
+ * @return bool Success
  */
 	public function bake($configs) {
 		if (!is_dir($this->path)) {

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -44,7 +44,7 @@ class ExtractTask extends AppShell {
 /**
  * Merge all domain and category strings into the default.pot file
  *
- * @var boolean
+ * @var bool
  */
 	protected $_merge = false;
 
@@ -93,21 +93,21 @@ class ExtractTask extends AppShell {
 /**
  * Holds whether this call should extract model validation messages
  *
- * @var boolean
+ * @var bool
  */
 	protected $_extractValidation = true;
 
 /**
  * Holds the validation string domain to use for validation messages when extracting
  *
- * @var boolean
+ * @var bool
  */
 	protected $_validationDomain = 'default';
 
 /**
  * Holds whether this call should extract the CakePHP Lib messages
  *
- * @var boolean
+ * @var bool
  */
 	protected $_extractCore = false;
 
@@ -678,8 +678,8 @@ class ExtractTask extends AppShell {
 /**
  * Get the strings from the position forward
  *
- * @param integer &$position Actual position on tokens array
- * @param integer $target Number of strings to extract
+ * @param int &$position Actual position on tokens array
+ * @param int $target Number of strings to extract
  * @return array Strings extracted
  */
 	protected function _getStrings(&$position, $target) {
@@ -728,9 +728,9 @@ class ExtractTask extends AppShell {
  * Indicate an invalid marker on a processed file
  *
  * @param string $file File where invalid marker resides
- * @param integer $line Line number
+ * @param int $line Line number
  * @param string $marker Marker found
- * @param integer $count Count
+ * @param int $count Count
  * @return void
  */
 	protected function _markerError($file, $line, $marker, $count) {
@@ -793,7 +793,7 @@ class ExtractTask extends AppShell {
  * Returns whether this execution is meant to extract string only from directories in folder represented by the
  * APP constant, i.e. this task is extracting strings from same application.
  *
- * @return boolean
+ * @return bool
  */
 	protected function _isExtractingApp() {
 		return $this->_paths === array(APP);
@@ -803,7 +803,7 @@ class ExtractTask extends AppShell {
  * Checks whether or not a given path is usable for writing.
  *
  * @param string $path Path to folder
- * @return boolean true if it exists and is writable, false otherwise
+ * @return bool true if it exists and is writable, false otherwise
  */
 	protected function _isPathUsable($path) {
 		return is_dir($path) && is_writable($path);

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -316,7 +316,7 @@ class FixtureTask extends BakeTask {
  * Generate String representation of Records
  *
  * @param array $tableInfo Table schema array
- * @param integer $recordCount The number of records to generate.
+ * @param int $recordCount The number of records to generate.
  * @return array Array of records to use in the fixture.
  */
 	protected function _generateRecords($tableInfo, $recordCount = 1) {

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -161,8 +161,8 @@ class ModelTask extends BakeTask {
  *
  * @param array $options Array of options to use for the selections. indexes must start at 0
  * @param string $prompt Prompt to use for options list.
- * @param integer $default The default option for the given prompt.
- * @return integer Result of user choice.
+ * @param int $default The default option for the given prompt.
+ * @return int Result of user choice.
  */
 	public function inOptions($options, $prompt = null, $default = null) {
 		$valid = false;
@@ -186,7 +186,7 @@ class ModelTask extends BakeTask {
 /**
  * Handles interactive baking
  *
- * @return boolean
+ * @return bool
  */
 	protected function _interactive() {
 		$this->hr();
@@ -342,7 +342,7 @@ class ModelTask extends BakeTask {
  * Handles Generation and user interaction for creating validation.
  *
  * @param Model $model Model to have validations generated for.
- * @return array $validate Array of user selected validations.
+ * @return array validate Array of user selected validations.
  */
 	public function doValidation($model) {
 		if (!$model instanceof Model) {
@@ -812,7 +812,7 @@ class ModelTask extends BakeTask {
  * Assembles and writes a Model file.
  *
  * @param string|object $name Model name or object
- * @param array|boolean $data if array and $name is not an object assume bake data, otherwise boolean.
+ * @param array|bool $data if array and $name is not an object assume bake data, otherwise boolean.
  * @return string
  */
 	public function bake($name, $data = array()) {

--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -90,7 +90,7 @@ class PluginTask extends AppShell {
  * Bake the plugin, create directories and files
  *
  * @param string $plugin Name of the plugin in CamelCased format
- * @return boolean
+ * @return bool
  */
 	public function bake($plugin) {
 		$pathOptions = App::path('plugins');

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -142,7 +142,7 @@ class ProjectTask extends AppShell {
 /**
  * Checks PHP's include_path for CakePHP.
  *
- * @return boolean Indicates whether or not CakePHP exists on include_path
+ * @return bool Indicates whether or not CakePHP exists on include_path
  */
 	public function cakeOnIncludePath() {
 		$paths = explode(PATH_SEPARATOR, ini_get('include_path'));
@@ -231,7 +231,7 @@ class ProjectTask extends AppShell {
  * and points app/console/cake.php to the right place
  *
  * @param string $path Project path.
- * @return boolean success
+ * @return bool success
  */
 	public function consolePath($path) {
 		$File = new File($path . 'Console' . DS . 'cake.php');
@@ -252,7 +252,7 @@ class ProjectTask extends AppShell {
  * Generates and writes 'Security.salt'
  *
  * @param string $path Project path
- * @return boolean Success
+ * @return bool Success
  */
 	public function securitySalt($path) {
 		$File = new File($path . 'Config' . DS . 'core.php');
@@ -272,7 +272,7 @@ class ProjectTask extends AppShell {
  * Generates and writes 'Security.cipherSeed'
  *
  * @param string $path Project path
- * @return boolean Success
+ * @return bool Success
  */
 	public function securityCipherSeed($path) {
 		$File = new File($path . 'Config' . DS . 'core.php');
@@ -293,7 +293,7 @@ class ProjectTask extends AppShell {
  * Writes cache prefix using app's name
  *
  * @param string $dir Path to project
- * @return boolean Success
+ * @return bool Success
  */
 	public function cachePrefix($dir) {
 		$app = basename($dir);
@@ -310,8 +310,8 @@ class ProjectTask extends AppShell {
  * Generates and writes CAKE_CORE_INCLUDE_PATH
  *
  * @param string $path Project path
- * @param boolean $hardCode Whether or not define calls should be hardcoded.
- * @return boolean Success
+ * @param bool $hardCode Whether or not define calls should be hardcoded.
+ * @return bool Success
  */
 	public function corePath($path, $hardCode = true) {
 		if (dirname($path) !== CAKE_CORE_INCLUDE_PATH) {
@@ -331,8 +331,8 @@ class ProjectTask extends AppShell {
  * Replaces the __CAKE_PATH__ placeholder in the template files.
  *
  * @param string $filename The filename to operate on.
- * @param boolean $hardCode Whether or not the define should be uncommented.
- * @return boolean Success
+ * @param bool $hardCode Whether or not the define should be uncommented.
+ * @return bool Success
  */
 	protected function _replaceCorePath($filename, $hardCode) {
 		$contents = file_get_contents($filename);
@@ -354,7 +354,7 @@ class ProjectTask extends AppShell {
  * Enables Configure::read('Routing.prefixes') in /app/Config/core.php
  *
  * @param string $name Name to use as admin routing
- * @return boolean Success
+ * @return bool Success
  */
 	public function cakeAdmin($name) {
 		$path = (empty($this->configPath)) ? APP . 'Config' . DS : $this->configPath;

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -103,7 +103,7 @@ class TestTask extends BakeTask {
  * Handles interactive baking
  *
  * @param string $type The type of object to bake a test for.
- * @return string|boolean
+ * @return string|bool
  */
 	protected function _interactive($type = null) {
 		$this->interactive = true;
@@ -129,7 +129,7 @@ class TestTask extends BakeTask {
  *
  * @param string $type Type of object to bake test case for ie. Model, Controller
  * @param string $className the 'cake name' for the class ie. Posts for the PostsController
- * @return string|boolean
+ * @return string|bool
  */
 	public function bake($type, $className) {
 		$plugin = null;
@@ -242,7 +242,7 @@ class TestTask extends BakeTask {
  * Currently only model, and controller are supported
  *
  * @param string $type The Type of object you are generating tests for eg. controller
- * @return boolean
+ * @return bool
  */
 	public function typeCanDetectFixtures($type) {
 		$type = strtolower($type);
@@ -254,7 +254,7 @@ class TestTask extends BakeTask {
  *
  * @param string $package The package of object you are generating tests for eg. controller
  * @param string $class the Classname of the class the test is being generated for.
- * @return boolean
+ * @return bool
  */
 	public function isLoadableClass($package, $class) {
 		App::uses($class, $package);
@@ -466,7 +466,7 @@ class TestTask extends BakeTask {
  * Controllers require a mock class.
  *
  * @param string $type The type of object tests are being generated for eg. controller.
- * @return boolean
+ * @return bool
  */
 	public function hasMockClass($type) {
 		$type = strtolower($type);

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -342,7 +342,7 @@ class ViewTask extends BakeTask {
  *
  * @param string $action Action to bake
  * @param string $content Content to write
- * @return boolean Success
+ * @return bool Success
  */
 	public function bake($action, $content = '') {
 		if ($content === true) {
@@ -455,7 +455,7 @@ class ViewTask extends BakeTask {
  * Returns associations for controllers models.
  *
  * @param Model $model The Model instance.
- * @return array $associations
+ * @return array associations
  */
 	protected function _associations(Model $model) {
 		$keys = array('belongsTo', 'hasOne', 'hasMany', 'hasAndBelongsToMany');

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -336,7 +336,7 @@ class TestShell extends Shell {
  *
  * @param string $file The file to map.
  * @param string $category The test file category.
- * @param boolean $throwOnMissingFile Whether or not to throw an exception.
+ * @param bool $throwOnMissingFile Whether or not to throw an exception.
  * @return array array(type, case)
  * @throws Exception
  */

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -67,10 +67,10 @@ class ConsoleErrorHandler {
  * Handle errors in the console environment. Writes errors to stderr,
  * and logs messages if Configure::read('debug') is 0.
  *
- * @param integer $code Error code
+ * @param int $code Error code
  * @param string $description Description of the error.
  * @param string $file The file the error occurred in.
- * @param integer $line The line the error occurred on.
+ * @param int $line The line the error occurred on.
  * @param array $context The backtrace of the error.
  * @return void
  */
@@ -95,7 +95,7 @@ class ConsoleErrorHandler {
 /**
  * Wrapper for exit(), used for testing.
  *
- * @param integer $code The exit code.
+ * @param int $code The exit code.
  * @return void
  */
 	protected function _stop($code = 0) {

--- a/lib/Cake/Console/ConsoleInput.php
+++ b/lib/Cake/Console/ConsoleInput.php
@@ -37,7 +37,7 @@ class ConsoleInput {
  * 2. Handle we are attached to must be stdin.
  * Allows rich editing with arrow keys and history when inputting a string.
  *
- * @var boolean
+ * @var bool
  */
 	protected $_canReadline;
 
@@ -70,8 +70,8 @@ class ConsoleInput {
 /**
  * Checks if data is available on the stream
  *
- * @param integer $timeout An optional time to wait for data
- * @return boolean True for data available, false otherwise
+ * @param int $timeout An optional time to wait for data
+ * @return bool True for data available, false otherwise
  */
 	public function dataAvailable($timeout = 0) {
 		$readFds = array($this->_input);

--- a/lib/Cake/Console/ConsoleInputArgument.php
+++ b/lib/Cake/Console/ConsoleInputArgument.php
@@ -41,7 +41,7 @@ class ConsoleInputArgument {
 /**
  * Is this option required?
  *
- * @var boolean
+ * @var bool
  */
 	protected $_required;
 
@@ -57,7 +57,7 @@ class ConsoleInputArgument {
  *
  * @param string|array $name The long name of the option, or an array with all the properties.
  * @param string $help The help text for this option
- * @param boolean $required Whether this argument is required. Missing required args will trigger exceptions
+ * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
  * @param array $choices Valid choices for this option.
  */
 	public function __construct($name, $help = '', $required = false, $choices = array()) {
@@ -85,7 +85,7 @@ class ConsoleInputArgument {
 /**
  * Generate the help for this argument.
  *
- * @param integer $width The width to make the name of the option.
+ * @param int $width The width to make the name of the option.
  * @return string
  */
 	public function help($width = 0) {
@@ -123,7 +123,7 @@ class ConsoleInputArgument {
 /**
  * Check if this argument is a required argument
  *
- * @return boolean
+ * @return bool
  */
 	public function isRequired() {
 		return (bool)$this->_required;
@@ -133,7 +133,7 @@ class ConsoleInputArgument {
  * Check that $value is a valid choice for this argument.
  *
  * @param string $value The choice to validate.
- * @return boolean
+ * @return bool
  * @throws ConsoleException
  */
 	public function validChoice($value) {

--- a/lib/Cake/Console/ConsoleInputOption.php
+++ b/lib/Cake/Console/ConsoleInputOption.php
@@ -48,7 +48,7 @@ class ConsoleInputOption {
 /**
  * Is the option a boolean option. Boolean options do not consume a parameter.
  *
- * @var boolean
+ * @var bool
  */
 	protected $_boolean;
 
@@ -72,7 +72,7 @@ class ConsoleInputOption {
  * @param string|array $name The long name of the option, or an array with all the properties.
  * @param string $short The short alias for this option
  * @param string $help The help text for this option
- * @param boolean $boolean Whether this option is a boolean option. Boolean options don't consume extra tokens
+ * @param bool $boolean Whether this option is a boolean option. Boolean options don't consume extra tokens
  * @param string $default The default value for this option.
  * @param array $choices Valid choices for this option.
  * @throws ConsoleException
@@ -118,7 +118,7 @@ class ConsoleInputOption {
 /**
  * Generate the help for this this option.
  *
- * @param integer $width The width to make the name of the option.
+ * @param int $width The width to make the name of the option.
  * @return string
  */
 	public function help($width = 0) {
@@ -168,7 +168,7 @@ class ConsoleInputOption {
 /**
  * Check if this option is a boolean option
  *
- * @return boolean
+ * @return bool
  */
 	public function isBoolean() {
 		return (bool)$this->_boolean;
@@ -178,7 +178,7 @@ class ConsoleInputOption {
  * Check that a value is a valid choice for this option.
  *
  * @param string $value The choice to validate.
- * @return boolean
+ * @return bool
  * @throws ConsoleException
  */
 	public function validChoice($value) {

--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -81,7 +81,7 @@ class ConsoleInputSubcommand {
 /**
  * Generate the help for this this subcommand.
  *
- * @param integer $width The width to make the name of the subcommand.
+ * @param int $width The width to make the name of the subcommand.
  * @return string
  */
 	public function help($width = 0) {

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -136,7 +136,7 @@ class ConsoleOptionParser {
  * Construct an OptionParser so you can define its behavior
  *
  * @param string $command The command name this parser is for. The command name is used for generating help.
- * @param boolean $defaultOptions Whether you want the verbose and quiet options set. Setting
+ * @param bool $defaultOptions Whether you want the verbose and quiet options set. Setting
  *  this to false will prevent the addition of `--verbose` & `--quiet` options.
  */
 	public function __construct($command = null, $defaultOptions = true) {
@@ -165,7 +165,7 @@ class ConsoleOptionParser {
  * Static factory method for creating new OptionParsers so you can chain methods off of them.
  *
  * @param string $command The command name this parser is for. The command name is used for generating help.
- * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @param bool $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
 	public static function create($command, $defaultOptions = true) {
@@ -506,7 +506,7 @@ class ConsoleOptionParser {
  * @param string $subcommand If present and a valid subcommand that has a linked parser.
  *    That subcommands help will be shown instead.
  * @param string $format Define the output format, can be text or xml
- * @param integer $width The width to format user content to. Defaults to 72
+ * @param int $width The width to format user content to. Defaults to 72
  * @return string Generated help.
  */
 	public function help($subcommand = null, $format = 'text', $width = 72) {
@@ -604,7 +604,7 @@ class ConsoleOptionParser {
  * Check to see if $name has an option (short/long) defined for it.
  *
  * @param string $name The name of the option.
- * @return boolean
+ * @return bool
  */
 	protected function _optionExists($name) {
 		if (substr($name, 0, 2) === '--') {

--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -47,21 +47,21 @@ class ConsoleOutput {
 /**
  * Raw output constant - no modification of output text.
  *
- * @var integer
+ * @var int
  */
 	const RAW = 0;
 
 /**
  * Plain output - tags will be stripped.
  *
- * @var integer
+ * @var int
  */
 	const PLAIN = 1;
 
 /**
  * Color output - Convert known tags in to ANSI color escape codes.
  *
- * @var integer
+ * @var int
  */
 	const COLOR = 2;
 
@@ -82,7 +82,7 @@ class ConsoleOutput {
 /**
  * The current output type. Manipulated with ConsoleOutput::outputAs();
  *
- * @var integer
+ * @var int
  */
 	protected $_outputAs = self::COLOR;
 
@@ -171,8 +171,8 @@ class ConsoleOutput {
  * are passed, outputs just a newline.
  *
  * @param string|array $message A string or a an array of strings to output
- * @param integer $newlines Number of newlines to append
- * @return integer Returns the number of bytes returned from writing to stdout.
+ * @param int $newlines Number of newlines to append
+ * @return int Returns the number of bytes returned from writing to stdout.
  */
 	public function write($message, $newlines = 1) {
 		if (is_array($message)) {
@@ -232,7 +232,7 @@ class ConsoleOutput {
  * Writes a message to the output stream.
  *
  * @param string $message Message to write.
- * @return boolean success
+ * @return bool success
  */
 	protected function _write($message) {
 		return fwrite($this->_output, $message);
@@ -281,7 +281,7 @@ class ConsoleOutput {
 /**
  * Get/Set the output type to use. The output type how formatting tags are treated.
  *
- * @param integer $type The output type to use. Should be one of the class constants.
+ * @param int $type The output type to use. Should be one of the class constants.
  * @return mixed Either null or the value if getting.
  */
 	public function outputAs($type = null) {

--- a/lib/Cake/Console/HelpFormatter.php
+++ b/lib/Cake/Console/HelpFormatter.php
@@ -33,14 +33,14 @@ class HelpFormatter {
 /**
  * The maximum number of arguments shown when generating usage.
  *
- * @var integer
+ * @var int
  */
 	protected $_maxArgs = 6;
 
 /**
  * The maximum number of options shown when generating usage.
  *
- * @var integer
+ * @var int
  */
 	protected $_maxOptions = 6;
 
@@ -56,7 +56,7 @@ class HelpFormatter {
 /**
  * Get the help as formatted text suitable for output on the command line.
  *
- * @param integer $width The width of the help output.
+ * @param int $width The width of the help output.
  * @return string
  */
 	public function text($width = 72) {
@@ -160,7 +160,7 @@ class HelpFormatter {
  * Iterate over a collection and find the longest named thing.
  *
  * @param array $collection The collection to find a max length of.
- * @return integer
+ * @return int
  */
 	protected function _getMaxLength($collection) {
 		$max = 0;
@@ -173,7 +173,7 @@ class HelpFormatter {
 /**
  * Get the help as an xml string.
  *
- * @param boolean $string Return the SimpleXml object or a string. Defaults to true.
+ * @param bool $string Return the SimpleXml object or a string. Defaults to true.
  * @return string|SimpleXmlElement See $string
  */
 	public function xml($string = true) {

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -34,21 +34,21 @@ class Shell extends Object {
 /**
  * Output constant making verbose shells.
  *
- * @var integer
+ * @var int
  */
 	const VERBOSE = 2;
 
 /**
  * Output constant for making normal shells.
  *
- * @var integer
+ * @var int
  */
 	const NORMAL = 1;
 
 /**
  * Output constants for making quiet shells.
  *
- * @var integer
+ * @var int
  */
 	const QUIET = 0;
 
@@ -62,7 +62,7 @@ class Shell extends Object {
 /**
  * If true, the script will ask for permission to perform actions.
  *
- * @var boolean
+ * @var bool
  */
 	public $interactive = true;
 
@@ -239,7 +239,7 @@ class Shell extends Object {
 /**
  * If $uses is an array load each of the models in the array
  *
- * @return boolean
+ * @return bool
  */
 	protected function _loadModels() {
 		if (is_array($this->uses)) {
@@ -303,7 +303,7 @@ class Shell extends Object {
 /**
  * Loads tasks defined in public $tasks
  *
- * @return boolean
+ * @return bool
  */
 	public function loadTasks() {
 		if ($this->tasks === true || empty($this->tasks) || empty($this->Tasks)) {
@@ -318,7 +318,7 @@ class Shell extends Object {
  * Check to see if this shell has a task with the provided name.
  *
  * @param string $task The task name to check.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::hasTask
  */
 	public function hasTask($task) {
@@ -329,7 +329,7 @@ class Shell extends Object {
  * Check to see if this shell has a callable method by the given name.
  *
  * @param string $name The method name to check.
- * @return boolean
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::hasMethod
  */
 	public function hasMethod($name) {
@@ -574,7 +574,7 @@ class Shell extends Object {
  * - `indent` Indent the text with the string provided. Defaults to null.
  *
  * @param string $text Text the text to format.
- * @param string|integer|array $options Array of options to use, or an integer to wrap the text to.
+ * @param string|int|array $options Array of options to use, or an integer to wrap the text to.
  * @return string Wrapped / indented text
  * @see String::wrap()
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::wrapText
@@ -595,9 +595,9 @@ class Shell extends Object {
  * While using Shell::VERBOSE means it will only display when verbose output is toggled.
  *
  * @param string|array $message A string or a an array of strings to output
- * @param integer $newlines Number of newlines to append
- * @param integer $level The message's output level, see above.
- * @return integer|boolean Returns the number of bytes returned from writing to stdout.
+ * @param int $newlines Number of newlines to append
+ * @param int $level The message's output level, see above.
+ * @return int|bool Returns the number of bytes returned from writing to stdout.
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::out
  */
 	public function out($message = null, $newlines = 1, $level = Shell::NORMAL) {
@@ -619,7 +619,7 @@ class Shell extends Object {
  * are passed outputs just a newline.
  *
  * @param string|array $message A string or a an array of strings to output
- * @param integer $newlines Number of newlines to append
+ * @param int $newlines Number of newlines to append
  * @return void
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::err
  */
@@ -630,7 +630,7 @@ class Shell extends Object {
 /**
  * Returns a single or multiple linefeeds sequences.
  *
- * @param integer $multiplier Number of times the linefeed sequence should be repeated
+ * @param int $multiplier Number of times the linefeed sequence should be repeated
  * @return string
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::nl
  */
@@ -641,8 +641,8 @@ class Shell extends Object {
 /**
  * Outputs a series of minus characters to the standard output, acts as a visual separator.
  *
- * @param integer $newlines Number of newlines to pre- and append
- * @param integer $width Width of the line, defaults to 63
+ * @param int $newlines Number of newlines to pre- and append
+ * @param int $width Width of the line, defaults to 63
  * @return void
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::hr
  */
@@ -691,7 +691,7 @@ class Shell extends Object {
  *
  * @param string $path Where to put the file.
  * @param string $contents Content to put in the file.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::createFile
  */
 	public function createFile($path, $contents) {
@@ -729,7 +729,7 @@ class Shell extends Object {
 /**
  * Action to create a Unit Test
  *
- * @return boolean Success
+ * @return bool Success
  */
 	protected function _checkUnitTest() {
 		if (class_exists('PHPUnit_Framework_TestCase')) {
@@ -820,7 +820,7 @@ class Shell extends Object {
  * creates the singular name for use in views.
  *
  * @param string $name The plural underscored value.
- * @return string $name
+ * @return string name
  */
 	protected function _singularName($name) {
 		return Inflector::variable(Inflector::singularize($name));
@@ -860,7 +860,7 @@ class Shell extends Object {
  * Find the correct path for a plugin. Scans $pluginPaths for the plugin you want.
  *
  * @param string $pluginName Name of the plugin you want ie. DebugKit
- * @return string $path path to the correct plugin.
+ * @return string path path to the correct plugin.
  */
 	protected function _pluginPath($pluginName) {
 		if (CakePlugin::loaded($pluginName)) {
@@ -874,7 +874,7 @@ class Shell extends Object {
  * If you don't wish to see in your stdout or stderr everything that is logged
  * through CakeLog, call this function with first param as false
  *
- * @param boolean $enable whether to enable CakeLog output or not
+ * @param bool $enable whether to enable CakeLog output or not
  * @return void
  */
 	protected function _useLogger($enable = true) {

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -43,7 +43,7 @@ class ShellDispatcher {
  * a status code of either 0 or 1 according to the result of the dispatch.
  *
  * @param array $args the argv from PHP
- * @param boolean $bootstrap Should the environment be bootstrapped.
+ * @param bool $bootstrap Should the environment be bootstrapped.
  */
 	public function __construct($args = array(), $bootstrap = true) {
 		set_time_limit(0);
@@ -116,7 +116,7 @@ class ShellDispatcher {
 /**
  * Initializes the environment and loads the CakePHP core.
  *
- * @return boolean Success.
+ * @return bool Success.
  */
 	protected function _bootstrap() {
 		if (!defined('ROOT')) {
@@ -182,7 +182,7 @@ class ShellDispatcher {
 /**
  * Dispatches a CLI request
  *
- * @return boolean
+ * @return bool
  * @throws MissingShellMethodException
  */
 	public function dispatch() {
@@ -360,7 +360,7 @@ class ShellDispatcher {
 /**
  * Stop execution of the current script
  *
- * @param integer|string $status see http://php.net/exit for values
+ * @param int|string $status see http://php.net/exit for values
  * @return void
  */
 	protected function _stop($status = 0) {

--- a/lib/Cake/Console/Templates/default/views/form.ctp
+++ b/lib/Cake/Console/Templates/default/views/form.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/views/index.ctp
+++ b/lib/Cake/Console/Templates/default/views/index.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/views/view.ctp
+++ b/lib/Cake/Console/Templates/default/views/view.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
@@ -21,7 +21,7 @@ class DbAclSchema extends CakeSchema {
  * Before event.
  *
  * @param array $event The event data.
- * @return boolean success
+ * @return bool success
  */
 	public function before($event = array()) {
 		return true;

--- a/lib/Cake/Console/Templates/skel/Config/Schema/i18n.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/i18n.php
@@ -10,7 +10,6 @@
  */
 
 /**
- *
  * Using the Schema command line utility
  *
  * Use it to configure database for i18n
@@ -30,7 +29,7 @@ class I18nSchema extends CakeSchema {
  * Before event.
  *
  * @param array $event The event data.
- * @return boolean success
+ * @return bool success
  */
 	public function before($event = array()) {
 		return true;

--- a/lib/Cake/Console/Templates/skel/Config/Schema/sessions.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/sessions.php
@@ -10,7 +10,6 @@
  */
 
 /**
- *
  * Using the Schema command line utility
  * cake schema run create Sessions
  *

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -261,7 +261,6 @@
 	//date_default_timezone_set('UTC');
 
 /**
- *
  * Cache Engine Configuration
  * Default settings provided below
  *

--- a/lib/Cake/Console/Templates/skel/View/Emails/html/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Emails/html/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/skel/View/Emails/text/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Emails/text/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Errors
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Errors
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts.Email.html
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Layouts/Emails/text/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/Emails/text/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/skel/View/Layouts/ajax.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/ajax.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Pages
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/index.php
+++ b/lib/Cake/Console/Templates/skel/index.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app
  * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -155,8 +153,8 @@ class Component extends Object {
  *
  * @param Controller $controller Controller with components to beforeRedirect
  * @param string|array $url Either the string or URL array that is being redirected to.
- * @param integer $status The status code of the redirect
- * @param boolean $exit Will the script exit.
+ * @param int $status The status code of the redirect
+ * @param bool $exit Will the script exit.
  * @return array|void Either an array or null.
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::beforeRedirect
  */

--- a/lib/Cake/Controller/Component/Acl/AclInterface.php
+++ b/lib/Cake/Controller/Component/Acl/AclInterface.php
@@ -28,7 +28,7 @@ interface AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function check($aro, $aco, $action = "*");
 
@@ -38,7 +38,7 @@ interface AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function allow($aro, $aco, $action = "*");
 
@@ -48,7 +48,7 @@ interface AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function deny($aro, $aco, $action = "*");
 
@@ -58,7 +58,7 @@ interface AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function inherit($aro, $aco, $action = "*");
 

--- a/lib/Cake/Controller/Component/Acl/DbAcl.php
+++ b/lib/Cake/Controller/Component/Acl/DbAcl.php
@@ -67,7 +67,7 @@ class DbAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success (true if ARO has access to action in ACO, false otherwise)
+ * @return bool Success (true if ARO has access to action in ACO, false otherwise)
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/access-control-lists.html#checking-permissions-the-acl-component
  */
 	public function check($aro, $aco, $action = "*") {
@@ -80,8 +80,8 @@ class DbAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $actions Action (defaults to *)
- * @param integer $value Value to indicate access type (1 to give access, -1 to deny, 0 to inherit)
- * @return boolean Success
+ * @param int $value Value to indicate access type (1 to give access, -1 to deny, 0 to inherit)
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/access-control-lists.html#assigning-permissions
  */
 	public function allow($aro, $aco, $actions = "*", $value = 1) {
@@ -94,7 +94,7 @@ class DbAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/access-control-lists.html#assigning-permissions
  */
 	public function deny($aro, $aco, $action = "*") {
@@ -107,7 +107,7 @@ class DbAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function inherit($aro, $aco, $action = "*") {
 		return $this->allow($aro, $aco, $action, 0);
@@ -119,7 +119,7 @@ class DbAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  * @see allow()
  */
 	public function grant($aro, $aco, $action = "*") {
@@ -132,7 +132,7 @@ class DbAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  * @see deny()
  */
 	public function revoke($aro, $aco, $action = "*") {

--- a/lib/Cake/Controller/Component/Acl/IniAcl.php
+++ b/lib/Cake/Controller/Component/Acl/IniAcl.php
@@ -55,7 +55,7 @@ class IniAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function allow($aro, $aco, $action = "*") {
 	}
@@ -66,7 +66,7 @@ class IniAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function deny($aro, $aco, $action = "*") {
 	}
@@ -77,7 +77,7 @@ class IniAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function inherit($aro, $aco, $action = "*") {
 	}
@@ -90,7 +90,7 @@ class IniAcl extends Object implements AclInterface {
  * @param string $aro ARO
  * @param string $aco ACO
  * @param string $action Action
- * @return boolean Success
+ * @return bool Success
  */
 	public function check($aro, $aco, $action = null) {
 		if (!$this->config) {

--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -27,14 +27,14 @@ class PhpAcl extends Object implements AclInterface {
 /**
  * Constant for deny
  *
- * @var boolean
+ * @var bool
  */
 	const DENY = false;
 
 /**
  * Constant for allow
  *
- * @var boolean
+ * @var bool
  */
 	const ALLOW = true;
 
@@ -124,7 +124,7 @@ class PhpAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function allow($aro, $aco, $action = "*") {
 		return $this->Aco->access($this->Aro->resolve($aro), $aco, $action, 'allow');
@@ -136,7 +136,7 @@ class PhpAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function deny($aro, $aco, $action = "*") {
 		return $this->Aco->access($this->Aro->resolve($aro), $aco, $action, 'deny');
@@ -148,7 +148,7 @@ class PhpAcl extends Object implements AclInterface {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function inherit($aro, $aco, $action = "*") {
 		return false;
@@ -161,7 +161,7 @@ class PhpAcl extends Object implements AclInterface {
  * @param string $aro ARO
  * @param string $aco ACO
  * @param string $action Action
- * @return boolean true if access is granted, false otherwise
+ * @return bool true if access is granted, false otherwise
  */
 	public function check($aro, $aco, $action = "*") {
 		$allow = $this->options['policy'];

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -104,7 +104,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function check($aro, $aco, $action = "*") {
 		return $this->_Instance->check($aro, $aco, $action);
@@ -117,7 +117,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function allow($aro, $aco, $action = "*") {
 		return $this->_Instance->allow($aro, $aco, $action);
@@ -130,7 +130,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function deny($aro, $aco, $action = "*") {
 		return $this->_Instance->deny($aro, $aco, $action);
@@ -143,7 +143,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  */
 	public function inherit($aro, $aco, $action = "*") {
 		return $this->_Instance->inherit($aro, $aco, $action);
@@ -155,7 +155,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  * @deprecated Will be removed in 3.0.
  */
 	public function grant($aro, $aco, $action = "*") {
@@ -169,7 +169,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
- * @return boolean Success
+ * @return bool Success
  * @deprecated Will be removed in 3.0.
  */
 	public function revoke($aro, $aco, $action = "*") {

--- a/lib/Cake/Controller/Component/Auth/AbstractPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/AbstractPasswordHasher.php
@@ -65,7 +65,7 @@ abstract class AbstractPasswordHasher {
  *
  * @param string|array $password Plain text password to hash or data array.
  * @param string $hashedPassword Existing hashed password.
- * @return boolean True if hashes match else false.
+ * @return bool True if hashes match else false.
  */
 	abstract public function check($password, $hashedPassword);
 

--- a/lib/Cake/Controller/Component/Auth/ActionsAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ActionsAuthorize.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -32,7 +30,7 @@ class ActionsAuthorize extends BaseAuthorize {
  *
  * @param array $user The user to authorize
  * @param CakeRequest $request The request needing authorization.
- * @return boolean
+ * @return bool
  */
 	public function authorize($user, CakeRequest $request) {
 		$Acl = $this->_Collection->load('Acl');

--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -86,7 +86,7 @@ abstract class BaseAuthenticate {
  *
  * @param string|array $username The username/identifier, or an array of find conditions.
  * @param string $password The password, only used if $username param is string.
- * @return boolean|array Either false on failure, or an array of user data.
+ * @return bool|array Either false on failure, or an array of user data.
  */
 	protected function _findUser($username, $password = null) {
 		$userModel = $this->settings['userModel'];

--- a/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
@@ -78,7 +78,7 @@ abstract class BaseAuthorize {
  *
  * @param array $user Active user data
  * @param CakeRequest $request Request instance.
- * @return boolean
+ * @return bool
  */
 	abstract public function authorize($user, CakeRequest $request);
 

--- a/lib/Cake/Controller/Component/Auth/BlowfishAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishAuthenticate.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
@@ -39,7 +39,7 @@ class BlowfishPasswordHasher extends AbstractPasswordHasher {
  *
  * @param string $password Plain text password to hash.
  * @param string $hashedPassword Existing hashed password.
- * @return boolean True if hashes match else false.
+ * @return bool True if hashes match else false.
  */
 	public function check($password, $hashedPassword) {
 		return $hashedPassword === Security::hash($password, 'blowfish', $hashedPassword);

--- a/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
@@ -57,7 +57,7 @@ class ControllerAuthorize extends BaseAuthorize {
  *
  * @param array $user Active user data
  * @param CakeRequest $request Request instance.
- * @return boolean
+ * @return bool
  */
 	public function authorize($user, CakeRequest $request) {
 		return (bool)$this->_Controller->isAuthorized($user);

--- a/lib/Cake/Controller/Component/Auth/CrudAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/CrudAuthorize.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -78,7 +76,7 @@ class CrudAuthorize extends BaseAuthorize {
  *
  * @param array $user The user to authorize
  * @param CakeRequest $request The request needing authorization.
- * @return boolean
+ * @return bool
  */
 	public function authorize($user, CakeRequest $request) {
 		if (!isset($this->settings['actionMap'][$request->params['action']])) {

--- a/lib/Cake/Controller/Component/Auth/FormAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/FormAuthenticate.php
@@ -41,7 +41,7 @@ class FormAuthenticate extends BaseAuthenticate {
  * @param CakeRequest $request The request that contains login information.
  * @param string $model The model used for login verification.
  * @param array $fields The fields to be checked.
- * @return boolean False if the fields have not been supplied. True if they exist.
+ * @return bool False if the fields have not been supplied. True if they exist.
  */
 	protected function _checkFields(CakeRequest $request, $model, $fields) {
 		if (empty($request->data[$model])) {

--- a/lib/Cake/Controller/Component/Auth/SimplePasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/SimplePasswordHasher.php
@@ -46,7 +46,7 @@ class SimplePasswordHasher extends AbstractPasswordHasher {
  *
  * @param string $password Plain text password to hash.
  * @param string $hashedPassword Existing hashed password.
- * @return boolean True if hashes match else false.
+ * @return bool True if hashes match else false.
  */
 	public function check($password, $hashedPassword) {
 		return $hashedPassword === $this->hash($password);

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -211,7 +211,7 @@ class AuthComponent extends Component {
  * Error to display when user attempts to access an object or action to which they do not have
  * access.
  *
- * @var string|boolean Error message or boolean false to suppress flash message
+ * @var string|bool
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#AuthComponent::$authError
  */
 	public $authError = null;
@@ -277,7 +277,7 @@ class AuthComponent extends Component {
  * of login form data.
  *
  * @param Controller $controller A reference to the instantiating controller object
- * @return boolean
+ * @return bool
  */
 	public function startup(Controller $controller) {
 		$methods = array_flip(array_map('strtolower', $controller->methods));
@@ -318,7 +318,7 @@ class AuthComponent extends Component {
  * Checks whether current action is accessible without authentication.
  *
  * @param Controller $controller A reference to the instantiating controller object
- * @return boolean True if action is accessible without authentication else false
+ * @return bool True if action is accessible without authentication else false
  */
 	protected function _isAllowed(Controller $controller) {
 		$action = strtolower($controller->request->params['action']);
@@ -338,7 +338,7 @@ class AuthComponent extends Component {
  * is returned.
  *
  * @param Controller $controller A reference to the controller object.
- * @return boolean True if current action is login action else false.
+ * @return bool True if current action is login action else false.
  */
 	protected function _unauthenticated(Controller $controller) {
 		if (empty($this->_authenticateObjects)) {
@@ -379,7 +379,7 @@ class AuthComponent extends Component {
  * Normalizes $loginAction and checks if current request URL is same as login action.
  *
  * @param Controller $controller A reference to the controller object.
- * @return boolean True if current action is login action else false.
+ * @return bool True if current action is login action else false.
  */
 	protected function _isLoginAction(Controller $controller) {
 		$url = '';
@@ -396,7 +396,7 @@ class AuthComponent extends Component {
  * Handle unauthorized access attempt
  *
  * @param Controller $controller A reference to the controller object
- * @return boolean Returns false
+ * @return bool Returns false
  * @throws ForbiddenException
  * @see AuthComponent::$unauthorizedRedirect
  */
@@ -422,7 +422,7 @@ class AuthComponent extends Component {
 /**
  * Attempts to introspect the correct values for object properties.
  *
- * @return boolean True
+ * @return bool True
  */
 	protected function _setDefaults() {
 		$defaults = array(
@@ -446,7 +446,7 @@ class AuthComponent extends Component {
  *
  * @param array $user The user to check the authorization of. If empty the user in the session will be used.
  * @param CakeRequest $request The request to authenticate for. If empty, the current request will be used.
- * @return boolean True if $user is authorized, otherwise false
+ * @return bool True if $user is authorized, otherwise false
  */
 	public function isAuthorized($user = null, CakeRequest $request = null) {
 		if (empty($user) && !$this->user()) {
@@ -590,7 +590,7 @@ class AuthComponent extends Component {
  * will also change the session id in order to help mitigate session replays.
  *
  * @param array $user Either an array of user data, or null to identify a user using the current request.
- * @return boolean True on login success, false on failure
+ * @return bool True on login success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#identifying-users-and-logging-them-in
  */
 	public function login($user = null) {
@@ -663,7 +663,7 @@ class AuthComponent extends Component {
  * Similar to AuthComponent::user() except if the session user cannot be found, connected authentication
  * objects will have their getUser() methods called. This lets stateless authentication methods function correctly.
  *
- * @return boolean true if a user can be found, false if one cannot.
+ * @return bool true if a user can be found, false if one cannot.
  */
 	protected function _getUser() {
 		$user = $this->user();
@@ -812,7 +812,7 @@ class AuthComponent extends Component {
 /**
  * Check whether or not the current user has data in the session, and is considered logged in.
  *
- * @return boolean true if the user is logged in, false otherwise
+ * @return bool true if the user is logged in, false otherwise
  * @deprecated Since 2.5. Use AuthComponent::user() directly.
  */
 	public function loggedIn() {

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -92,7 +92,7 @@ class CookieComponent extends Component {
  * Indicates that the cookie should only be transmitted over a secure HTTPS connection.
  * When set to true, the cookie will only be set if a secure connection exists.
  *
- * @var boolean
+ * @var bool
  */
 	public $secure = false;
 
@@ -112,7 +112,7 @@ class CookieComponent extends Component {
  * Set to true to make HTTP only cookies. Cookies that are HTTP only
  * are not accessible in JavaScript.
  *
- * @var boolean
+ * @var bool
  */
 	public $httpOnly = false;
 
@@ -208,8 +208,8 @@ class CookieComponent extends Component {
  *
  * @param string|array $key Key for the value
  * @param mixed $value Value
- * @param boolean $encrypt Set to true to encrypt value, false otherwise
- * @param integer|string $expires Can be either the number of seconds until a cookie
+ * @param bool $encrypt Set to true to encrypt value, false otherwise
+ * @param int|string $expires Can be either the number of seconds until a cookie
  *   expires, or a strtotime compatible time offset.
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html#CookieComponent::write
@@ -294,7 +294,7 @@ class CookieComponent extends Component {
  * Returns true if given variable is set in cookie.
  *
  * @param string $key Variable name to check for
- * @return boolean True if variable is there
+ * @return bool True if variable is there
  */
 	public function check($key = null) {
 		if (empty($key)) {
@@ -400,8 +400,8 @@ class CookieComponent extends Component {
  * CookieComponent::write(string, string, boolean, 8400);
  * CookieComponent::write(string, string, boolean, '5 Days');
  *
- * @param integer|string $expires Can be either Unix timestamp, or date string
- * @return integer Unix timestamp
+ * @param int|string $expires Can be either Unix timestamp, or date string
+ * @return int Unix timestamp
  */
 	protected function _expire($expires = null) {
 		if ($expires === null) {

--- a/lib/Cake/Controller/Component/EmailComponent.php
+++ b/lib/Cake/Controller/Component/EmailComponent.php
@@ -282,7 +282,7 @@ class EmailComponent extends Component {
  *  If you are rendering a template this variable will be sent to the templates as `$content`
  * @param string $template Template to use when sending email
  * @param string $layout Layout to use to enclose email body
- * @return boolean Success
+ * @return bool Success
  */
 	public function send($content = null, $template = null, $layout = null) {
 		$lib = new CakeEmail();
@@ -444,7 +444,7 @@ class EmailComponent extends Component {
  * Helps prevent header injection / manipulation on user content.
  *
  * @param string $value Value to strip
- * @param boolean $message Set to true to indicate main message content
+ * @param bool $message Set to true to indicate main message content
  * @return string Stripped value
  */
 	protected function _strip($value, $message = false) {

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -47,7 +47,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Determines whether or not callbacks will be fired on this component
  *
- * @var boolean
+ * @var bool
  */
 	public $enabled = true;
 
@@ -245,8 +245,8 @@ class RequestHandlerComponent extends Component {
  *
  * @param Controller $controller A reference to the controller
  * @param string|array $url A string or array containing the redirect location
- * @param integer|array $status HTTP Status for redirect
- * @param boolean $exit Whether to exit script, defaults to `true`.
+ * @param int|array $status HTTP Status for redirect
+ * @param bool $exit Whether to exit script, defaults to `true`.
  * @return void
  */
 	public function beforeRedirect(Controller $controller, $url, $status = null, $exit = true) {
@@ -280,7 +280,7 @@ class RequestHandlerComponent extends Component {
  * "304 Not Modified" header.
  *
  * @param Controller $controller Controller instance.
- * @return boolean false if the render process should be aborted
+ * @return bool false if the render process should be aborted
  */
 	public function beforeRender(Controller $controller) {
 		if ($this->settings['checkHttpCache'] && $this->response->checkNotModified($this->request)) {
@@ -291,7 +291,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current HTTP request is Ajax, false otherwise
  *
- * @return boolean True if call is Ajax
+ * @return bool True if call is Ajax
  * @deprecated use `$this->request->is('ajax')` instead.
  */
 	public function isAjax() {
@@ -301,7 +301,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current HTTP request is coming from a Flash-based client
  *
- * @return boolean True if call is from Flash
+ * @return bool True if call is from Flash
  * @deprecated use `$this->request->is('flash')` instead.
  */
 	public function isFlash() {
@@ -311,7 +311,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current request is over HTTPS, false otherwise.
  *
- * @return boolean True if call is over HTTPS
+ * @return bool True if call is over HTTPS
  * @deprecated use `$this->request->is('ssl')` instead.
  */
 	public function isSSL() {
@@ -321,7 +321,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call accepts an XML response, false otherwise
  *
- * @return boolean True if client accepts an XML response
+ * @return bool True if client accepts an XML response
  */
 	public function isXml() {
 		return $this->prefers('xml');
@@ -330,7 +330,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call accepts an RSS response, false otherwise
  *
- * @return boolean True if client accepts an RSS response
+ * @return bool True if client accepts an RSS response
  */
 	public function isRss() {
 		return $this->prefers('rss');
@@ -339,7 +339,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call accepts an Atom response, false otherwise
  *
- * @return boolean True if client accepts an RSS response
+ * @return bool True if client accepts an RSS response
  */
 	public function isAtom() {
 		return $this->prefers('atom');
@@ -349,7 +349,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if user agent string matches a mobile web browser, or if the
  * client accepts WAP content.
  *
- * @return boolean True if user agent is a mobile web browser
+ * @return bool True if user agent is a mobile web browser
  */
 	public function isMobile() {
 		return $this->request->is('mobile') || $this->accepts('wap');
@@ -358,7 +358,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the client accepts WAP content
  *
- * @return boolean
+ * @return bool
  */
 	public function isWap() {
 		return $this->prefers('wap');
@@ -367,7 +367,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call a POST request
  *
- * @return boolean True if call is a POST
+ * @return bool True if call is a POST
  * @deprecated Use $this->request->is('post'); from your controller.
  */
 	public function isPost() {
@@ -377,7 +377,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call a PUT request
  *
- * @return boolean True if call is a PUT
+ * @return bool True if call is a PUT
  * @deprecated Use $this->request->is('put'); from your controller.
  */
 	public function isPut() {
@@ -387,7 +387,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call a GET request
  *
- * @return boolean True if call is a GET
+ * @return bool True if call is a GET
  * @deprecated Use $this->request->is('get'); from your controller.
  */
 	public function isGet() {
@@ -397,7 +397,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Returns true if the current call a DELETE request
  *
- * @return boolean True if call is a DELETE
+ * @return bool True if call is a DELETE
  * @deprecated Use $this->request->is('delete'); from your controller.
  */
 	public function isDelete() {
@@ -408,7 +408,7 @@ class RequestHandlerComponent extends Component {
  * Gets Prototype version if call is Ajax, otherwise empty string.
  * The Prototype library sets a special "Prototype version" HTTP header.
  *
- * @return string|boolean When Ajax the prototype version of component making the call otherwise false
+ * @return string|bool When Ajax the prototype version of component making the call otherwise false
  */
 	public function getAjaxVersion() {
 		$httpX = env('HTTP_X_PROTOTYPE_VERSION');
@@ -444,7 +444,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Gets remote client IP
  *
- * @param boolean $safe Use safe = false when you think the user might manipulate
+ * @param bool $safe Use safe = false when you think the user might manipulate
  *   their HTTP_CLIENT_IP header. Setting $safe = false will also look at HTTP_X_FORWARDED_FOR
  * @return string Client IP address
  * @deprecated use $this->request->clientIp() from your, controller instead.
@@ -659,7 +659,7 @@ class RequestHandlerComponent extends Component {
  *    like 'application/x-shockwave'.
  * @param array $options If $type is a friendly type name that is associated with
  *    more than one type of content, $index is used to select which content-type to use.
- * @return boolean Returns false if the friendly type name given in $type does
+ * @return bool Returns false if the friendly type name given in $type does
  *    not exist in the type map, or if the Content-type header has
  *    already been set by this method.
  * @see RequestHandlerComponent::setContent()

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -145,14 +145,14 @@ class SecurityComponent extends Component {
  * Whether to validate POST data. Set to false to disable for data coming from 3rd party
  * services, etc.
  *
- * @var boolean
+ * @var bool
  */
 	public $validatePost = true;
 
 /**
  * Whether to use CSRF protected forms. Set to false to disable CSRF protection on forms.
  *
- * @var boolean
+ * @var bool
  * @see http://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
  * @see SecurityComponent::$csrfExpires
  */
@@ -173,7 +173,7 @@ class SecurityComponent extends Component {
  * the chances of users getting invalid requests because of token consumption.
  * It has the side effect of making CSRF less secure, as tokens are reusable.
  *
- * @var boolean
+ * @var bool
  */
 	public $csrfUseOnce = true;
 
@@ -186,7 +186,7 @@ class SecurityComponent extends Component {
  * When tokens are evicted, the oldest ones will be removed, as they are the most likely
  * to be dead/expired.
  *
- * @var integer
+ * @var int
  */
 	public $csrfLimit = 100;
 
@@ -355,7 +355,7 @@ class SecurityComponent extends Component {
  * Check if HTTP methods are required
  *
  * @param Controller $controller Instantiating controller
- * @return boolean true if $method is required
+ * @return bool true if $method is required
  */
 	protected function _methodsRequired(Controller $controller) {
 		foreach (array('Post', 'Get', 'Put', 'Delete') as $method) {
@@ -378,7 +378,7 @@ class SecurityComponent extends Component {
  * Check if access requires secure connection
  *
  * @param Controller $controller Instantiating controller
- * @return boolean true if secure connection required
+ * @return bool true if secure connection required
  */
 	protected function _secureRequired(Controller $controller) {
 		if (is_array($this->requireSecure) && !empty($this->requireSecure)) {
@@ -399,7 +399,7 @@ class SecurityComponent extends Component {
  * Check if authentication is required
  *
  * @param Controller $controller Instantiating controller
- * @return boolean true if authentication required
+ * @return bool true if authentication required
  */
 	protected function _authRequired(Controller $controller) {
 		if (is_array($this->requireAuth) && !empty($this->requireAuth) && !empty($this->request->data)) {
@@ -439,7 +439,7 @@ class SecurityComponent extends Component {
  * Validate submitted form
  *
  * @param Controller $controller Instantiating controller
- * @return boolean true if submitted form is valid
+ * @return bool true if submitted form is valid
  */
 	protected function _validatePost(Controller $controller) {
 		if (empty($controller->request->data)) {
@@ -524,7 +524,7 @@ class SecurityComponent extends Component {
  * Manually add CSRF token information into the provided request object.
  *
  * @param CakeRequest $request The request object to add into.
- * @return boolean
+ * @return bool
  */
 	public function generateToken(CakeRequest $request) {
 		if (isset($request->params['requested']) && $request->params['requested'] === 1) {
@@ -570,7 +570,7 @@ class SecurityComponent extends Component {
  * it will be removed from the list of valid tokens.
  *
  * @param Controller $controller A controller to check
- * @return boolean Valid csrf token.
+ * @return bool Valid csrf token.
  */
 	protected function _validateCsrf(Controller $controller) {
 		$token = $this->Session->read('_Token');

--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -48,7 +48,7 @@ class SessionComponent extends Component {
  * @param string $name The name of the key your are setting in the session.
  * 							This should be in a Controller.key format for better organizing
  * @param string $value The value you want to store in a session.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#SessionComponent::write
  */
 	public function write($name, $value = null) {
@@ -75,7 +75,7 @@ class SessionComponent extends Component {
  * In your controller: $this->Session->delete('Controller.sessKey');
  *
  * @param string $name the name of the session key you want to delete
- * @return boolean true is session variable is set and can be deleted, false is variable was not set.
+ * @return bool true is session variable is set and can be deleted, false is variable was not set.
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#SessionComponent::delete
  */
 	public function delete($name) {
@@ -88,7 +88,7 @@ class SessionComponent extends Component {
  * In your controller: $this->Session->check('Controller.sessKey');
  *
  * @param string $name the name of the session key you want to check
- * @return boolean true is session variable is set, false if not
+ * @return bool true is session variable is set, false if not
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#SessionComponent::check
  */
 	public function check($name) {
@@ -142,7 +142,7 @@ class SessionComponent extends Component {
  *
  * In your controller: $this->Session->valid();
  *
- * @return boolean true is session is valid, false is session is invalid
+ * @return bool true is session is valid, false is session is invalid
  */
 	public function valid() {
 		return CakeSession::valid();
@@ -180,7 +180,7 @@ class SessionComponent extends Component {
 /**
  * Returns a bool, whether or not the session has been started.
  *
- * @return boolean
+ * @return bool
  */
 	public function started() {
 		return CakeSession::started();

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -79,7 +79,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * The default value is `true`.
  *
- * @var mixed A single name as a string or a list of names as an array.
+ * @var mixed
  * @link http://book.cakephp.org/2.0/en/controllers.html#components-helpers-and-uses
  */
 	public $uses = true;
@@ -90,7 +90,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * Example: `public $helpers = array('Html', 'Js', 'Time', 'Ajax');`
  *
- * @var mixed A single name as a string or a list of names as an array.
+ * @var mixed
  * @link http://book.cakephp.org/2.0/en/controllers.html#components-helpers-and-uses
  */
 	public $helpers = array();
@@ -162,14 +162,14 @@ class Controller extends Object implements CakeEventListener {
  * Set to true to automatically render the view
  * after action logic.
  *
- * @var boolean
+ * @var bool
  */
 	public $autoRender = true;
 
 /**
  * Set to true to automatically render the layout around views.
  *
- * @var boolean
+ * @var bool
  */
 	public $autoLayout = true;
 
@@ -287,7 +287,7 @@ class Controller extends Object implements CakeEventListener {
 /**
  * Holds any validation errors produced by the last call of the validateErrors() method.
  *
- * @var array Validation errors, or false if none
+ * @var array
  */
 	public $validationErrors = null;
 
@@ -347,7 +347,7 @@ class Controller extends Object implements CakeEventListener {
  * Lazy loads models using the loadModel() method if declared in $uses
  *
  * @param string $name Property name to check.
- * @return boolean
+ * @return bool
  */
 	public function __isset($name) {
 		switch ($name) {
@@ -506,7 +506,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param ReflectionMethod $method The method to be invoked.
  * @param CakeRequest $request The request to check.
- * @return boolean
+ * @return bool
  */
 	protected function _isPrivateAction(ReflectionMethod $method, CakeRequest $request) {
 		$privateAction = (
@@ -691,7 +691,7 @@ class Controller extends Object implements CakeEventListener {
 /**
  * Queries & sets valid HTTP response codes & messages.
  *
- * @param integer|array $code If $code is an integer, then the corresponding code/message is
+ * @param int|array $code If $code is an integer, then the corresponding code/message is
  *        returned if it exists, null if it does not exist. If $code is an array,
  *        then the 'code' and 'message' keys of each nested array are added to the default
  *        HTTP codes. Example:
@@ -717,8 +717,8 @@ class Controller extends Object implements CakeEventListener {
  * dynamic models for the time being.
  *
  * @param string $modelClass Name of model class to load
- * @param integer|string $id Initial ID the instanced model class should have
- * @return boolean True if the model was found
+ * @param int|string $id Initial ID the instanced model class should have
+ * @return bool True if the model was found
  * @throws MissingModelException if the model class cannot be found.
  */
 	public function loadModel($modelClass = null, $id = null) {
@@ -748,8 +748,8 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
- * @param integer $status Optional HTTP status code (eg: 404)
- * @param boolean $exit If true, exit() will be called after the redirect
+ * @param int $status Optional HTTP status code (eg: 404)
+ * @param bool $exit If true, exit() will be called after the redirect
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::redirect
  */
@@ -796,8 +796,8 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param mixed $response Response from beforeRedirect callback
  * @param string|array $url The same value of beforeRedirect
- * @param integer $status The same value of beforeRedirect
- * @param boolean $exit The same value of beforeRedirect
+ * @param int $status The same value of beforeRedirect
+ * @param bool $exit The same value of beforeRedirect
  * @return array Array with keys url, status and exit
  */
 	protected function _parseBeforeRedirect($response, $url, $status, $exit) {
@@ -873,7 +873,7 @@ class Controller extends Object implements CakeEventListener {
 /**
  * Returns number of errors in a submitted FORM.
  *
- * @return integer Number of errors
+ * @return int Number of errors
  * @deprecated This method will be removed in 3.0
  */
 	public function validate() {
@@ -959,7 +959,7 @@ class Controller extends Object implements CakeEventListener {
  * Returns the referring URL for this request.
  *
  * @param string $default Default URL to use if HTTP_REFERER cannot be read from headers
- * @param boolean $local If true, restrict referring URLs to local server
+ * @param bool $local If true, restrict referring URLs to local server
  * @return string Referring URL
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::referer
  */
@@ -993,7 +993,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param string $message Message to display to the user
  * @param string|array $url Relative string or array-based URL to redirect to after the time expires
- * @param integer $pause Time to show the message
+ * @param int $pause Time to show the message
  * @param string $layout Layout you want to use, defaults to 'flash'
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::flash
@@ -1015,7 +1015,7 @@ class Controller extends Object implements CakeEventListener {
  * @param string|array $op A string containing an SQL comparison operator, or an array matching operators
  *        to fields
  * @param string $bool SQL boolean operator: AND, OR, XOR, etc.
- * @param boolean $exclusive If true, and $op is an array, fields not included in $op will not be
+ * @param bool $exclusive If true, and $op is an array, fields not included in $op will not be
  *        included in the returned conditions
  * @return array An array of model conditions
  * @deprecated Will be removed in 3.0.
@@ -1111,8 +1111,8 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
- * @param integer $status Optional HTTP status code (eg: 404)
- * @param boolean $exit If true, exit() will be called after the redirect
+ * @param int $status Optional HTTP status code (eg: 404)
+ * @param bool $exit If true, exit() will be called after the redirect
  * @return mixed
  *   false to stop redirection event,
  *   string controllers a new redirection URL or
@@ -1135,7 +1135,7 @@ class Controller extends Object implements CakeEventListener {
  * This method should be overridden in child classes.
  *
  * @param string $method name of method called example index, edit, etc.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/controllers.html#callbacks
  */
 	public function beforeScaffold($method) {
@@ -1146,7 +1146,7 @@ class Controller extends Object implements CakeEventListener {
  * Alias to beforeScaffold()
  *
  * @param string $method Method name.
- * @return boolean
+ * @return bool
  * @see Controller::beforeScaffold()
  * @deprecated Will be removed in 3.0.
  */
@@ -1158,7 +1158,7 @@ class Controller extends Object implements CakeEventListener {
  * This method should be overridden in child classes.
  *
  * @param string $method name of method called either edit or update.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/controllers.html#callbacks
  */
 	public function afterScaffoldSave($method) {
@@ -1169,7 +1169,7 @@ class Controller extends Object implements CakeEventListener {
  * Alias to afterScaffoldSave()
  *
  * @param string $method Method name.
- * @return boolean
+ * @return bool
  * @see Controller::afterScaffoldSave()
  * @deprecated Will be removed in 3.0.
  */
@@ -1181,7 +1181,7 @@ class Controller extends Object implements CakeEventListener {
  * This method should be overridden in child classes.
  *
  * @param string $method name of method called either edit or update.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/controllers.html#callbacks
  */
 	public function afterScaffoldSaveError($method) {
@@ -1192,7 +1192,7 @@ class Controller extends Object implements CakeEventListener {
  * Alias to afterScaffoldSaveError()
  *
  * @param string $method Method name.
- * @return boolean
+ * @return bool
  * @see Controller::afterScaffoldSaveError()
  * @deprecated Will be removed in 3.0.
  */
@@ -1206,7 +1206,7 @@ class Controller extends Object implements CakeEventListener {
  * Method MUST return true in child classes
  *
  * @param string $method name of method called example index, edit, etc.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/controllers.html#callbacks
  */
 	public function scaffoldError($method) {
@@ -1217,7 +1217,7 @@ class Controller extends Object implements CakeEventListener {
  * Alias to scaffoldError()
  *
  * @param string $method Method name.
- * @return boolean
+ * @return bool
  * @see Controller::scaffoldError()
  * @deprecated Will be removed in 3.0.
  */

--- a/lib/Cake/Controller/Scaffold.php
+++ b/lib/Cake/Controller/Scaffold.php
@@ -76,7 +76,7 @@ class Scaffold {
 /**
  * Valid session.
  *
- * @var boolean
+ * @var bool
  */
 	protected $_validSession = null;
 

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -88,7 +88,7 @@ class App {
 /**
  * Reset paths instead of merging
  *
- * @var boolean
+ * @var bool
  */
 	const RESET = true;
 
@@ -122,7 +122,7 @@ class App {
 /**
  * Whether or not to return the file that is loaded.
  *
- * @var boolean
+ * @var bool
  */
 	public static $return = false;
 
@@ -184,14 +184,14 @@ class App {
 /**
  * Indicates whether the class cache should be stored again because of an addition to it
  *
- * @var boolean
+ * @var bool
  */
 	protected static $_cacheChange = false;
 
 /**
  * Indicates whether the object cache should be stored again because of an addition to it
  *
- * @var boolean
+ * @var bool
  */
 	protected static $_objectCacheChange = false;
 
@@ -199,7 +199,7 @@ class App {
  * Indicates the the Application is in the bootstrapping process. Used to better cache
  * loaded classes while the cache libraries have not been yet initialized
  *
- * @var boolean
+ * @var bool
  */
 	public static $bootstrapping = false;
 
@@ -270,7 +270,7 @@ class App {
  * If reset is set to true, all loaded plugins will be forgotten and they will be needed to be loaded again.
  *
  * @param array $paths associative array with package names as keys and a list of directories for new search paths
- * @param boolean|string $mode App::RESET will set paths, App::APPEND with append paths, App::PREPEND will prepend paths (default)
+ * @param bool|string $mode App::RESET will set paths, App::APPEND with append paths, App::PREPEND will prepend paths (default)
  * 	App::REGISTER will register new packages and their paths, %s in path will be replaced by APP path
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::build
@@ -422,7 +422,7 @@ class App {
  *
  * @param string $type Type of object, i.e. 'Model', 'Controller', 'View/Helper', 'file', 'class' or 'plugin'
  * @param string|array $path Optional Scan only the path given. If null, paths for the chosen type will be used.
- * @param boolean $cache Set to false to rescan objects of the chosen type. Defaults to true.
+ * @param bool $cache Set to false to rescan objects of the chosen type. Defaults to true.
  * @return mixed Either false on incorrect / miss. Or an array of found objects.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::objects
  */
@@ -529,7 +529,7 @@ class App {
  * if a class is name `MyCustomClass` the file name should be `MyCustomClass.php`
  *
  * @param string $className the name of the class to load
- * @return boolean
+ * @return bool
  */
 	public static function load($className) {
 		if (!isset(self::$_classMap[$className])) {
@@ -592,15 +592,15 @@ class App {
  * @param string|array $type The type of Class if passed as a string, or all params can be passed as
  *   an single array to $type.
  * @param string $name Name of the Class or a unique name for the file
- * @param boolean|array $parent boolean true if Class Parent should be searched, accepts key => value
+ * @param bool|array $parent boolean true if Class Parent should be searched, accepts key => value
  *   array('parent' => $parent, 'file' => $file, 'search' => $search, 'ext' => '$ext');
  *   $ext allows setting the extension of the file name
  *   based on Inflector::underscore($name) . ".$ext";
  * @param array $search paths to search for files, array('path 1', 'path 2', 'path 3');
  * @param string $file full name of the file to search for including extension
- * @param boolean $return Return the loaded file, the file must have a return
+ * @param bool $return Return the loaded file, the file must have a return
  *   statement in it to work: return $variable;
- * @return boolean true if Class is already in memory or if file is found and loaded, false if not
+ * @return bool true if Class is already in memory or if file is found and loaded, false if not
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#including-files-with-app-import
  */
 	public static function import($type = null, $name = null, $parent = true, $search = array(), $file = null, $return = false) {
@@ -662,8 +662,8 @@ class App {
  * @param string $plugin camel cased plugin name if any
  * @param string $type name of the packed where the class is located
  * @param string $originalType type name as supplied initially by the user
- * @param boolean $parent whether to load the class parent or not
- * @return boolean true indicating the successful load and existence of the class
+ * @param bool $parent whether to load the class parent or not
+ * @return bool true indicating the successful load and existence of the class
  */
 	protected static function _loadClass($name, $plugin, $type, $originalType, $parent) {
 		if ($type === 'Console/Command' && $name === 'Shell') {
@@ -700,7 +700,7 @@ class App {
  * @param string $plugin camel cased plugin name if any
  * @param array $search list of paths to search the file into
  * @param string $file filename if known, the $name param will be used otherwise
- * @param boolean $return whether this function should return the contents of the file after being parsed by php or just a success notice
+ * @param bool $return whether this function should return the contents of the file after being parsed by php or just a success notice
  * @return mixed if $return contents of the file after php parses it, boolean indicating success otherwise
  */
 	protected static function _loadFile($name, $plugin, $search, $file, $return) {
@@ -738,7 +738,7 @@ class App {
  * @param string $plugin camel cased plugin name if any
  * @param string $file file name if known
  * @param string $ext file extension if known
- * @return boolean true if the file was loaded successfully, false otherwise
+ * @return bool true if the file was loaded successfully, false otherwise
  */
 	protected static function _loadVendor($name, $plugin, $file, $ext) {
 		if ($mapped = self::_mapped($name, $plugin)) {

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -183,7 +183,7 @@ class CakePlugin {
  *
  * @param string $plugin name of the plugin, if null will operate on all plugins having enabled the
  * loading of routes files
- * @return boolean
+ * @return bool
  */
 	public static function routes($plugin = null) {
 		if ($plugin === null) {
@@ -237,7 +237,7 @@ class CakePlugin {
  * Include file, ignoring include error if needed if file is missing
  *
  * @param string $file File to include
- * @param boolean $ignoreMissing Whether to ignore include error for missing files
+ * @param bool $ignoreMissing Whether to ignore include error for missing files
  * @return mixed
  */
 	protected static function _includeFile($file, $ignoreMissing = false) {

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -62,7 +62,7 @@ class Configure {
  * - Include app/Config/bootstrap.php.
  * - Setup error/exception handlers.
  *
- * @param boolean $boot Whether to do bootstrapping.
+ * @param bool $boot Whether to do bootstrapping.
  * @return void
  */
 	public static function bootstrap($boot = true) {
@@ -147,7 +147,7 @@ class Configure {
  * @param string|array $config The key to write, can be a dot notation value.
  * Alternatively can be an array containing key(s) and value(s).
  * @param mixed $value Value to set for var
- * @return boolean True if write was successful
+ * @return bool True if write was successful
  * @link http://book.cakephp.org/2.0/en/development/configuration.html#Configure::write
  */
 	public static function write($config, $value = null) {
@@ -194,7 +194,7 @@ class Configure {
  * Returns true if given variable is set in Configure.
  *
  * @param string $var Variable name to check for
- * @return boolean True if variable is there
+ * @return bool True if variable is there
  */
 	public static function check($var = null) {
 		if (empty($var)) {
@@ -256,7 +256,7 @@ class Configure {
  * and make any future attempts to use it cause an Exception.
  *
  * @param string $name Name of the reader to drop.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function drop($name) {
 		if (!isset(self::$_readers[$name])) {
@@ -286,8 +286,8 @@ class Configure {
  *
  * @param string $key name of configuration resource to load.
  * @param string $config Name of the configured reader to use to read the resource identified by $key.
- * @param boolean $merge if config files should be merged instead of simply overridden
- * @return boolean False if file not found, true if load successful.
+ * @param bool $merge if config files should be merged instead of simply overridden
+ * @return bool False if file not found, true if load successful.
  * @throws ConfigureException Will throw any exceptions the reader raises.
  * @link http://book.cakephp.org/2.0/en/development/configuration.html#Configure::load
  */
@@ -332,7 +332,7 @@ class Configure {
  * @param string $config The name of the configured adapter to dump data with.
  * @param array $keys The name of the top-level keys you want to dump.
  *   This allows you save only some data stored in Configure.
- * @return boolean success
+ * @return bool success
  * @throws ConfigureException if the adapter does not implement a `dump` method.
  */
 	public static function dump($key, $config = 'default', $keys = array()) {
@@ -391,7 +391,7 @@ class Configure {
  * @param string $name The storage name for the saved configuration.
  * @param string $cacheConfig The cache configuration to save into. Defaults to 'default'
  * @param array $data Either an array of data to store, or leave empty to store all values.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function store($name, $cacheConfig = 'default', $data = null) {
 		if ($data === null) {
@@ -406,7 +406,7 @@ class Configure {
  *
  * @param string $name Name of the stored config file to load.
  * @param string $cacheConfig Name of the Cache configuration to read from.
- * @return boolean Success.
+ * @return bool Success.
  */
 	public static function restore($name, $cacheConfig = 'default') {
 		$values = Cache::read($name, $cacheConfig);
@@ -419,7 +419,7 @@ class Configure {
 /**
  * Clear all values stored in Configure.
  *
- * @return boolean success.
+ * @return bool success.
  */
 	public static function clear() {
 		self::$_values = array();

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -139,7 +139,7 @@ class Object {
  * Stop execution of the current script. Wraps exit() making
  * testing easier.
  *
- * @param integer|string $status see http://php.net/exit for values
+ * @param int|string $status see http://php.net/exit for values
  * @return void
  */
 	protected function _stop($status = 0) {
@@ -151,10 +151,10 @@ class Object {
  * for more information on writing to logs.
  *
  * @param string $msg Log message
- * @param integer $type Error type constant. Defined in app/Config/core.php.
+ * @param int $type Error type constant. Defined in app/Config/core.php.
  * @param null|string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success of log write
+ * @return bool Success of log write
  */
 	public function log($msg, $type = LOG_ERR, $scope = null) {
 		if (!is_string($msg)) {
@@ -191,7 +191,7 @@ class Object {
  *
  * @param array $properties The name of the properties to merge.
  * @param string $class The class to merge the property with.
- * @param boolean $normalize Set to true to run the properties through Hash::normalize() before merging.
+ * @param bool $normalize Set to true to run the properties through Hash::normalize() before merging.
  * @return void
  */
 	protected function _mergeVars($properties, $class, $normalize = true) {

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -24,7 +24,6 @@ App::uses('ExceptionRenderer', 'Error');
 App::uses('Router', 'Routing');
 
 /**
- *
  * Error Handler provides basic error and exception handling for your application. It captures and
  * handles all unhandled exceptions and errors. Displays helpful framework errors when debug > 1.
  *
@@ -162,7 +161,7 @@ class ErrorHandler {
  *
  * @param Exception $exception The exception to render.
  * @param array $config An array of configuration for logging.
- * @return boolean
+ * @return bool
  */
 	protected static function _log(Exception $exception, $config) {
 		if (empty($config['log'])) {
@@ -187,12 +186,12 @@ class ErrorHandler {
  * You can use Configure::write('Error.level', $value); to set what type of errors will be handled here.
  * Stack traces for errors can be enabled with Configure::write('Error.trace', true);
  *
- * @param integer $code Code of error
+ * @param int $code Code of error
  * @param string $description Error description
  * @param string $file File on which error occurred
- * @param integer $line Line that triggered the error
+ * @param int $line Line that triggered the error
  * @param array $context Context
- * @return boolean true if error was handled
+ * @return bool true if error was handled
  */
 	public static function handleError($code, $description, $file = null, $line = null, $context = null) {
 		if (error_reporting() === 0) {
@@ -230,11 +229,11 @@ class ErrorHandler {
 /**
  * Generate an error page when some fatal error happens.
  *
- * @param integer $code Code of error
+ * @param int $code Code of error
  * @param string $description Error description
  * @param string $file File on which error occurred
- * @param integer $line Line that triggered the error
- * @return boolean
+ * @param int $line Line that triggered the error
+ * @return bool
  */
 	public static function handleFatalError($code, $description, $file, $line) {
 		$logMessage = 'Fatal Error (' . $code . '): ' . $description . ' in [' . $file . ', line ' . $line . ']';
@@ -260,7 +259,7 @@ class ErrorHandler {
 /**
  * Map an error code into an Error word, and log location.
  *
- * @param integer $code Error code to map
+ * @param int $code Error code to map
  * @return array Array of error word, and log location.
  */
 	public static function mapErrorCode($code) {

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -76,7 +76,7 @@ class BadRequestException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Bad Request' will be the message
- * @param integer $code Status code, defaults to 400
+ * @param int $code Status code, defaults to 400
  */
 	public function __construct($message = null, $code = 400) {
 		if (empty($message)) {
@@ -98,7 +98,7 @@ class UnauthorizedException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Unauthorized' will be the message
- * @param integer $code Status code, defaults to 401
+ * @param int $code Status code, defaults to 401
  */
 	public function __construct($message = null, $code = 401) {
 		if (empty($message)) {
@@ -120,7 +120,7 @@ class ForbiddenException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Forbidden' will be the message
- * @param integer $code Status code, defaults to 403
+ * @param int $code Status code, defaults to 403
  */
 	public function __construct($message = null, $code = 403) {
 		if (empty($message)) {
@@ -142,7 +142,7 @@ class NotFoundException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Not Found' will be the message
- * @param integer $code Status code, defaults to 404
+ * @param int $code Status code, defaults to 404
  */
 	public function __construct($message = null, $code = 404) {
 		if (empty($message)) {
@@ -164,7 +164,7 @@ class MethodNotAllowedException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Method Not Allowed' will be the message
- * @param integer $code Status code, defaults to 405
+ * @param int $code Status code, defaults to 405
  */
 	public function __construct($message = null, $code = 405) {
 		if (empty($message)) {
@@ -186,7 +186,7 @@ class InternalErrorException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Internal Server Error' will be the message
- * @param integer $code Status code, defaults to 500
+ * @param int $code Status code, defaults to 500
  */
 	public function __construct($message = null, $code = 500) {
 		if (empty($message)) {
@@ -228,7 +228,7 @@ class CakeException extends CakeBaseException {
  *
  * @param string|array $message Either the string of the error message, or an array of attributes
  *   that are made available in the view, and sprintf()'d into CakeException::$_messageTemplate
- * @param integer $code The code of the error, is also the HTTP status code for the error.
+ * @param int $code The code of the error, is also the HTTP status code for the error.
  */
 	public function __construct($message, $code = 500) {
 		if (is_array($message)) {
@@ -594,9 +594,9 @@ class FatalErrorException extends CakeException {
  * Constructor
  *
  * @param string $message The error message.
- * @param integer $code The error code.
+ * @param int $code The error code.
  * @param string $file The file the error occurred in.
- * @param integer $line The line the error occurred on.
+ * @param int $line The line the error occurred on.
  */
 	public function __construct($message, $code = 500, $file = null, $line = null) {
 		parent::__construct($message, $code);

--- a/lib/Cake/Event/CakeEvent.php
+++ b/lib/Cake/Event/CakeEvent.php
@@ -26,7 +26,7 @@ class CakeEvent {
 /**
  * Name of the event
  *
- * @var string $name
+ * @var string
  */
 	protected $_name = null;
 
@@ -40,21 +40,21 @@ class CakeEvent {
 /**
  * Custom data for the method that receives the event
  *
- * @var mixed $data
+ * @var mixed
  */
 	public $data = null;
 
 /**
  * Property used to retain the result value of the event listeners
  *
- * @var mixed $result
+ * @var mixed
  */
 	public $result = null;
 
 /**
  * Flags an event as stopped or not, default is false
  *
- * @var boolean
+ * @var bool
  */
 	protected $_stopped = false;
 
@@ -121,7 +121,7 @@ class CakeEvent {
 /**
  * Check if the event is stopped
  *
- * @return boolean True if the event is stopped
+ * @return bool True if the event is stopped
  */
 	public function isStopped() {
 		return $this->_stopped;

--- a/lib/Cake/Event/CakeEventListener.php
+++ b/lib/Cake/Event/CakeEventListener.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -29,7 +29,7 @@ class CakeEventManager {
 /**
  * The default priority queue value for new, attached listeners
  *
- * @var integer
+ * @var int
  */
 	public static $defaultPriority = 10;
 
@@ -43,14 +43,14 @@ class CakeEventManager {
 /**
  * List of listener callbacks associated to
  *
- * @var object $Listeners
+ * @var object
  */
 	protected $_listeners = array();
 
 /**
  * Internal flag to distinguish a common manager from the singleton
  *
- * @var boolean
+ * @var bool
  */
 	protected $_isGlobal = false;
 

--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -74,7 +74,7 @@ class I18n {
  * Set to true when I18N::_bindTextDomain() is called for the first time.
  * If a translation file is found it is set to false again
  *
- * @var boolean
+ * @var bool
  */
 	protected $_noLocale = false;
 
@@ -185,7 +185,7 @@ class I18n {
  * @param string $domain Domain The domain of the translation. Domains are often used by plugin translations.
  *    If null, the default domain will be used.
  * @param string $category Category The integer value of the category to use.
- * @param integer $count Count Count is used with $plural to choose the correct plural form.
+ * @param int $count Count Count is used with $plural to choose the correct plural form.
  * @param string $language Language to translate string to.
  *    If null it checks for language in session followed by Config.language configuration variable.
  * @return string translated string.
@@ -309,8 +309,8 @@ class I18n {
  * Attempts to find the plural form of a string.
  *
  * @param string $header Type
- * @param integer $n Number
- * @return integer plural match
+ * @param int $n Number
+ * @return int plural match
  */
 	protected function _pluralGuess($header, $n) {
 		if (!is_string($header) || $header === "nplurals=1;plural=0;" || !isset($header[0])) {

--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -410,7 +410,7 @@ class L10n {
 /**
  * Attempts to find the locale settings based on the HTTP_ACCEPT_LANGUAGE variable
  *
- * @return boolean Success
+ * @return bool Success
  */
 	protected function _autoLanguage() {
 		$_detectableLanguages = CakeRequest::acceptLanguage();
@@ -434,7 +434,7 @@ class L10n {
  * Attempts to find locale for language, or language for locale
  *
  * @param string|array $mixed 2/3 char string (language/locale), array of those strings, or null
- * @return string|array|boolean string language/locale, array of those values, whole map as an array,
+ * @return string|array|bool string language/locale, array of those values, whole map as an array,
  *    or false when language/locale doesn't exist
  */
 	public function map($mixed = null) {
@@ -463,7 +463,7 @@ class L10n {
  * Attempts to find catalog record for requested language
  *
  * @param string|array $language string requested language, array of requested languages, or null for whole catalog
- * @return array|boolean array catalog record for requested language, array of catalog records, whole catalog,
+ * @return array|bool array catalog record for requested language, array of catalog records, whole catalog,
  *    or false when language doesn't exist
  */
 	public function catalog($language = null) {

--- a/lib/Cake/I18n/Multibyte.php
+++ b/lib/Cake/I18n/Multibyte.php
@@ -113,8 +113,8 @@ class Multibyte {
  *
  * @param string $haystack The string from which to get the position of the first occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param integer $offset The position in $haystack to start searching.
- * @return integer|boolean The numeric position of the first occurrence of $needle in the $haystack string,
+ * @param int $offset The position in $haystack to start searching.
+ * @return int|bool The numeric position of the first occurrence of $needle in the $haystack string,
  *    or false if $needle is not found.
  */
 	public static function stripos($haystack, $needle, $offset = 0) {
@@ -131,11 +131,11 @@ class Multibyte {
  *
  * @param string $haystack The string from which to get the first occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the first occurrence of $needle.
  *    If set to false, it returns all of $haystack from the first occurrence of $needle to the end,
  *    Default value is false.
- * @return integer|boolean The portion of $haystack, or false if $needle is not found.
+ * @return int|bool The portion of $haystack, or false if $needle is not found.
  */
 	public static function stristr($haystack, $needle, $part = false) {
 		$php = (PHP_VERSION < 5.3);
@@ -191,7 +191,7 @@ class Multibyte {
  * Get string length.
  *
  * @param string $string The string being checked for length.
- * @return integer The number of characters in string $string
+ * @return int The number of characters in string $string
  */
 	public static function strlen($string) {
 		if (Multibyte::checkMultibyte($string)) {
@@ -206,8 +206,8 @@ class Multibyte {
  *
  * @param string $haystack The string being checked.
  * @param string $needle The position counted from the beginning of haystack.
- * @param integer $offset The search offset. If it is not specified, 0 is used.
- * @return integer|boolean The numeric position of the first occurrence of $needle in the $haystack string.
+ * @param int $offset The search offset. If it is not specified, 0 is used.
+ * @return int|bool The numeric position of the first occurrence of $needle in the $haystack string.
  *    If $needle is not found, it returns false.
  */
 	public static function strpos($haystack, $needle, $offset = 0) {
@@ -249,11 +249,11 @@ class Multibyte {
  *
  * @param string $haystack The string from which to get the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the last occurrence of $needle.
  *    If set to false, it returns all of $haystack from the last occurrence of $needle to the end,
  *    Default value is false.
- * @return string|boolean The portion of $haystack. or false if $needle is not found.
+ * @return string|bool The portion of $haystack. or false if $needle is not found.
  */
 	public static function strrchr($haystack, $needle, $part = false) {
 		$check = Multibyte::utf8($haystack);
@@ -309,11 +309,11 @@ class Multibyte {
  *
  * @param string $haystack The string from which to get the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the last occurrence of $needle.
  *    If set to false, it returns all of $haystack from the last occurrence of $needle to the end,
  *    Default value is false.
- * @return string|boolean The portion of $haystack. or false if $needle is not found.
+ * @return string|bool The portion of $haystack. or false if $needle is not found.
  */
 	public static function strrichr($haystack, $needle, $part = false) {
 		$check = Multibyte::strtoupper($haystack);
@@ -371,8 +371,8 @@ class Multibyte {
  *
  * @param string $haystack The string from which to get the position of the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param integer $offset The position in $haystack to start searching.
- * @return integer|boolean The numeric position of the last occurrence of $needle in the $haystack string,
+ * @param int $offset The position in $haystack to start searching.
+ * @return int|bool The numeric position of the last occurrence of $needle in the $haystack string,
  *    or false if $needle is not found.
  */
 	public static function strripos($haystack, $needle, $offset = 0) {
@@ -421,9 +421,9 @@ class Multibyte {
  *
  * @param string $haystack The string being checked, for the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param integer $offset May be specified to begin searching an arbitrary number of characters into the string.
+ * @param int $offset May be specified to begin searching an arbitrary number of characters into the string.
  *    Negative values will stop searching at an arbitrary point prior to the end of the string.
- * @return integer|boolean The numeric position of the last occurrence of $needle in the $haystack string.
+ * @return int|bool The numeric position of the last occurrence of $needle in the $haystack string.
  *    If $needle is not found, it returns false.
  */
 	public static function strrpos($haystack, $needle, $offset = 0) {
@@ -471,11 +471,11 @@ class Multibyte {
  *
  * @param string $haystack The string from which to get the first occurrence of $needle.
  * @param string $needle The string to find in $haystack
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the first occurrence of $needle.
  *    If set to false, it returns all of $haystack from the first occurrence of $needle to the end,
  *    Default value is FALSE.
- * @return string|boolean The portion of $haystack, or true if $needle is not found.
+ * @return string|bool The portion of $haystack, or true if $needle is not found.
  */
 	public static function strstr($haystack, $needle, $part = false) {
 		$php = (PHP_VERSION < 5.3);
@@ -662,7 +662,7 @@ class Multibyte {
  *
  * @param string $haystack The string being checked.
  * @param string $needle The string being found.
- * @return integer The number of times the $needle substring occurs in the $haystack string.
+ * @return int The number of times the $needle substring occurs in the $haystack string.
  */
 	public static function substrCount($haystack, $needle) {
 		$count = 0;
@@ -696,8 +696,8 @@ class Multibyte {
  * Get part of string
  *
  * @param string $string The string being checked.
- * @param integer $start The first position used in $string.
- * @param integer $length The maximum length of the returned string.
+ * @param int $start The first position used in $string.
+ * @param int $length The maximum length of the returned string.
  * @return string The portion of $string specified by the $string and $length parameters.
  */
 	public static function substr($string, $start, $length = null) {
@@ -774,7 +774,7 @@ class Multibyte {
 /**
  * Return the Code points range for Unicode characters
  *
- * @param integer $decimal Decimal value.
+ * @param int $decimal Decimal value.
  * @return string
  */
 	protected static function _codepoint($decimal) {
@@ -822,7 +822,7 @@ class Multibyte {
 /**
  * Find the related code folding values for $char
  *
- * @param integer $char decimal value of character
+ * @param int $char decimal value of character
  * @param string $type Type 'lower' or 'upper'. Defaults to 'lower'.
  * @return array
  */
@@ -862,7 +862,7 @@ class Multibyte {
  * Check the $string for multibyte characters
  *
  * @param string $string Value to test.
- * @return boolean
+ * @return bool
  */
 	public static function checkMultibyte($string) {
 		$length = strlen($string);

--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -66,7 +66,6 @@ App::uses('LogEngineCollection', 'Log');
  * application. By using scopes you can control logging for each part
  * of your application and still keep standard log levels.
  *
- *
  * See CakeLog::config() and CakeLog::write() for more information
  * on scopes
  *
@@ -182,7 +181,7 @@ class CakeLog {
  * @param string $key The keyname for this logger, used to remove the
  *    logger later.
  * @param array $config Array of configuration information for the logger
- * @return boolean success of configuration.
+ * @return bool success of configuration.
  * @throws CakeLogException
  */
 	public static function config($key, $config) {
@@ -254,7 +253,7 @@ class CakeLog {
  * }}}
  *
  * @param array $levels array
- * @param boolean $append true to append, false to replace
+ * @param bool $append true to append, false to replace
  * @return array Active log levels
  */
 	public static function levels($levels = array(), $append = true) {
@@ -303,7 +302,7 @@ class CakeLog {
  * Checks whether $streamName is enabled
  *
  * @param string $streamName to check
- * @return boolean
+ * @return bool
  * @throws CakeLogException
  */
 	public static function enabled($streamName) {
@@ -392,13 +391,13 @@ class CakeLog {
  *
  * `CakeLog::write('warning', 'Stuff is broken here');`
  *
- * @param integer|string $type Type of message being written. When value is an integer
+ * @param int|string $type Type of message being written. When value is an integer
  *    or a string matching the recognized levels, then it will
  *    be treated log levels. Otherwise it's treated as scope.
  * @param string $message Message content to log
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function write($type, $message, $scope = array()) {
 		if (empty(self::$_Collection)) {
@@ -450,7 +449,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function emergency($message, $scope = array()) {
 		return self::write(self::$_levelMap['emergency'], $message, $scope);
@@ -462,7 +461,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function alert($message, $scope = array()) {
 		return self::write(self::$_levelMap['alert'], $message, $scope);
@@ -474,7 +473,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function critical($message, $scope = array()) {
 		return self::write(self::$_levelMap['critical'], $message, $scope);
@@ -486,7 +485,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function error($message, $scope = array()) {
 		return self::write(self::$_levelMap['error'], $message, $scope);
@@ -498,7 +497,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function warning($message, $scope = array()) {
 		return self::write(self::$_levelMap['warning'], $message, $scope);
@@ -510,7 +509,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function notice($message, $scope = array()) {
 		return self::write(self::$_levelMap['notice'], $message, $scope);
@@ -522,7 +521,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function debug($message, $scope = array()) {
 		return self::write(self::$_levelMap['debug'], $message, $scope);
@@ -534,7 +533,7 @@ class CakeLog {
  * @param string $message log message
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See CakeLog::config() for more information on logging scopes.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function info($message, $scope = array()) {
 		return self::write(self::$_levelMap['info'], $message, $scope);

--- a/lib/Cake/Log/Engine/ConsoleLog.php
+++ b/lib/Cake/Log/Engine/ConsoleLog.php
@@ -75,7 +75,7 @@ class ConsoleLog extends BaseLog {
  *
  * @param string $type The type of log you are making.
  * @param string $message The message you want to log.
- * @return boolean success of write.
+ * @return bool success of write.
  */
 	public function write($type, $message) {
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message . "\n";

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -61,7 +61,7 @@ class FileLog extends BaseLog {
 /**
  * Max file size, used for log file rotation.
  *
- * @var integer
+ * @var int
  */
 	protected $_size = null;
 
@@ -128,7 +128,7 @@ class FileLog extends BaseLog {
  *
  * @param string $type The type of log you are making.
  * @param string $message The message you want to log.
- * @return boolean success of write.
+ * @return bool success of write.
  */
 	public function write($type, $message) {
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message . "\n";

--- a/lib/Cake/Log/Engine/SyslogLog.php
+++ b/lib/Cake/Log/Engine/SyslogLog.php
@@ -26,7 +26,6 @@ App::uses('BaseLog', 'Log/Engine');
 class SyslogLog extends BaseLog {
 
 /**
- *
  * By default messages are formatted as:
  * 	type: message
  *
@@ -60,7 +59,6 @@ class SyslogLog extends BaseLog {
 	);
 
 /**
- *
  * Used to map the string names back to their LOG_* constants
  *
  * @var array
@@ -79,7 +77,7 @@ class SyslogLog extends BaseLog {
 /**
  * Whether the logger connection is open or not
  *
- * @var boolean
+ * @var bool
  */
 	protected $_open = false;
 
@@ -102,7 +100,7 @@ class SyslogLog extends BaseLog {
  *
  * @param string $type The type of log you are making.
  * @param string $message The message you want to log.
- * @return boolean success of write.
+ * @return bool success of write.
  */
 	public function write($type, $message) {
 		if (!$this->_open) {
@@ -130,8 +128,8 @@ class SyslogLog extends BaseLog {
  * will initialize the connection to the system logger
  *
  * @param string $ident the prefix to add to all messages logged
- * @param integer $options the options flags to be used for logged messages
- * @param integer $facility the stream or facility to log to
+ * @param int $options the options flags to be used for logged messages
+ * @param int $facility the stream or facility to log to
  * @return void
  */
 	protected function _open($ident, $options, $facility) {
@@ -142,9 +140,9 @@ class SyslogLog extends BaseLog {
  * Extracts the call to syslog() in order to run unit tests on it. This function
  * will perform the actual write in the system logger
  *
- * @param integer $priority Message priority.
+ * @param int $priority Message priority.
  * @param string $message Message to log.
- * @return boolean
+ * @return bool
  */
 	protected function _write($priority, $message) {
 		return syslog($priority, $message);

--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -28,7 +26,7 @@ class AclNode extends Model {
 /**
  * Explicitly disable in-memory query caching for ACL models
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 

--- a/lib/Cake/Model/Aco.php
+++ b/lib/Cake/Model/Aco.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/AcoAction.php
+++ b/lib/Cake/Model/AcoAction.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Aro.php
+++ b/lib/Cake/Model/Aro.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Behavior/AclBehavior.php
+++ b/lib/Cake/Model/Behavior/AclBehavior.php
@@ -94,7 +94,7 @@ class AclBehavior extends ModelBehavior {
  * Creates a new ARO/ACO node bound to this record
  *
  * @param Model $model Model using this behavior.
- * @param boolean $created True if this is a new record
+ * @param bool $created True if this is a new record
  * @param array $options Options passed from Model::save().
  * @return void
  */

--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -263,7 +263,7 @@ class ContainableBehavior extends ModelBehavior {
  * @param Model $Model Model on which binding restriction is being applied
  * @param array $contain Parameters to use for restricting this model
  * @param array $containments Current set of containments
- * @param boolean $throwErrors Whether non-existent bindings show throw errors
+ * @param bool $throwErrors Whether non-existent bindings show throw errors
  * @return array Containments
  */
 	public function containments(Model $Model, $contain, $containments = array(), $throwErrors = null) {
@@ -365,7 +365,7 @@ class ContainableBehavior extends ModelBehavior {
  *
  * @param Model $Model Model
  * @param array $map Map of relations for given model
- * @param array|boolean $fields If array, fields to initially load, if false use $Model as primary model
+ * @param array|bool $fields If array, fields to initially load, if false use $Model as primary model
  * @return array Fields
  */
 	public function fieldDependencies(Model $Model, $map, $fields = array()) {

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -274,7 +274,7 @@ class TranslateBehavior extends ModelBehavior {
  *
  * @param Model $Model Model find was run on
  * @param array $results Array of model results.
- * @param boolean $primary Did the find originate on $model.
+ * @param bool $primary Did the find originate on $model.
  * @return array Modified results
  */
 	public function afterFind(Model $Model, $results, $primary = false) {
@@ -329,7 +329,7 @@ class TranslateBehavior extends ModelBehavior {
  *
  * @param Model $Model Model invalidFields was called on.
  * @param array $options Options passed from Model::save().
- * @return boolean
+ * @return bool
  * @see Model::save()
  */
 	public function beforeValidate(Model $Model, $options = array()) {
@@ -346,7 +346,7 @@ class TranslateBehavior extends ModelBehavior {
  *
  * @param Model $Model Model save was called on.
  * @param array $options Options passed from Model::save().
- * @return boolean true.
+ * @return bool true.
  * @see Model::save()
  */
 	public function beforeSave(Model $Model, $options = array()) {
@@ -415,7 +415,7 @@ class TranslateBehavior extends ModelBehavior {
  * afterSave Callback
  *
  * @param Model $Model Model the callback is called on
- * @param boolean $created Whether or not the save created a record.
+ * @param bool $created Whether or not the save created a record.
  * @param array $options Options passed from Model::save().
  * @return void
  */
@@ -571,9 +571,9 @@ class TranslateBehavior extends ModelBehavior {
  *
  * @param Model $Model using this behavior of model
  * @param string|array $fields string with field or array(field1, field2=>AssocName, field3)
- * @param boolean $reset Leave true to have the fields only modified for the next operation.
+ * @param bool $reset Leave true to have the fields only modified for the next operation.
  *   if false the field will be added for all future queries.
- * @return boolean
+ * @return bool
  * @throws CakeException when attempting to bind a translating called name. This is not allowed
  *   as it shadows Model::$name.
  */
@@ -667,7 +667,7 @@ class TranslateBehavior extends ModelBehavior {
  * @param Model $Model using this behavior of model
  * @param string|array $fields string with field, or array(field1, field2=>AssocName, field3), or null for
  *    unbind all original translations
- * @return boolean
+ * @return bool
  */
 	public function unbindTranslation(Model $Model, $fields = null) {
 		if (empty($fields) && empty($this->settings[$Model->alias])) {

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -85,9 +85,9 @@ class TreeBehavior extends ModelBehavior {
  * parameters to be saved.
  *
  * @param Model $Model Model using this behavior.
- * @param boolean $created indicates whether the node just saved was created or updated
+ * @param bool $created indicates whether the node just saved was created or updated
  * @param array $options Options passed from Model::save().
- * @return boolean true on success, false on failure
+ * @return bool true on success, false on failure
  */
 	public function afterSave(Model $Model, $created, $options = array()) {
 		extract($this->settings[$Model->alias]);
@@ -121,8 +121,8 @@ class TreeBehavior extends ModelBehavior {
  * This is used to delete child nodes in the afterDelete.
  *
  * @param Model $Model Model using this behavior.
- * @param boolean $cascade If true records that depend on this record will also be deleted
- * @return boolean
+ * @param bool $cascade If true records that depend on this record will also be deleted
+ * @return bool
  */
 	public function beforeDelete(Model $Model, $cascade = true) {
 		extract($this->settings[$Model->alias]);
@@ -142,7 +142,7 @@ class TreeBehavior extends ModelBehavior {
  * Will delete the current node and all children using the deleteAll method and sync the table
  *
  * @param Model $Model Model using this behavior
- * @return boolean true to continue, false to abort the delete
+ * @return bool true to continue, false to abort the delete
  */
 	public function afterDelete(Model $Model) {
 		extract($this->settings[$Model->alias]);
@@ -174,7 +174,7 @@ class TreeBehavior extends ModelBehavior {
  *
  * @param Model $Model Model using this behavior
  * @param array $options Options passed from Model::save().
- * @return boolean true to continue, false to abort the save
+ * @return bool true to continue, false to abort the save
  * @see Model::save()
  */
 	public function beforeSave(Model $Model, $options = array()) {
@@ -243,9 +243,9 @@ class TreeBehavior extends ModelBehavior {
  * If false is passed for the id parameter, all top level nodes are counted, or all nodes are counted.
  *
  * @param Model $Model Model using this behavior
- * @param integer|string|boolean $id The ID of the record to read or false to read all top level nodes
- * @param boolean $direct whether to count direct, or all, children
- * @return integer number of child nodes
+ * @param int|string|bool $id The ID of the record to read or false to read all top level nodes
+ * @param bool $direct whether to count direct, or all, children
+ * @return int number of child nodes
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::childCount
  */
 	public function childCount(Model $Model, $id = null, $direct = false) {
@@ -284,13 +284,13 @@ class TreeBehavior extends ModelBehavior {
  * If false is passed for the id parameter, top level, or all (depending on direct parameter appropriate) are counted.
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $id The ID of the record to read
- * @param boolean $direct whether to return only the direct, or all, children
+ * @param int|string $id The ID of the record to read
+ * @param bool $direct whether to return only the direct, or all, children
  * @param string|array $fields Either a single string of a field name, or an array of field names
  * @param string $order SQL ORDER BY conditions (e.g. "price DESC" or "name ASC") defaults to the tree order
- * @param integer $limit SQL LIMIT clause, for calculating items per page.
- * @param integer $page Page number, for accessing paged data
- * @param integer $recursive The number of levels deep to fetch associated records
+ * @param int $limit SQL LIMIT clause, for calculating items per page.
+ * @param int $page Page number, for accessing paged data
+ * @param int $recursive The number of levels deep to fetch associated records
  * @return array Array of child nodes
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::children
  */
@@ -347,7 +347,7 @@ class TreeBehavior extends ModelBehavior {
  * @param string $keyPath A string path to the key, i.e. "{n}.Post.id"
  * @param string $valuePath A string path to the value, i.e. "{n}.Post.title"
  * @param string $spacer The character or characters which will be repeated
- * @param integer $recursive The number of levels deep to fetch associated records
+ * @param int $recursive The number of levels deep to fetch associated records
  * @return array An associative array of records, where the id is the key, and the display field is the value
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::generateTreeList
  */
@@ -407,10 +407,10 @@ class TreeBehavior extends ModelBehavior {
  * reads the parent id and returns this node
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $id The ID of the record to read
+ * @param int|string $id The ID of the record to read
  * @param string|array $fields Fields to get
- * @param integer $recursive The number of levels deep to fetch associated records
- * @return array|boolean Array of data for the parent node
+ * @param int $recursive The number of levels deep to fetch associated records
+ * @return array|bool Array of data for the parent node
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::getParentNode
  */
 	public function getParentNode(Model $Model, $id = null, $fields = null, $recursive = null) {
@@ -440,9 +440,9 @@ class TreeBehavior extends ModelBehavior {
  * Get the path to the given node
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $id The ID of the record to read
+ * @param int|string $id The ID of the record to read
  * @param string|array $fields Either a single string of a field name, or an array of field names
- * @param integer $recursive The number of levels deep to fetch associated records
+ * @param int $recursive The number of levels deep to fetch associated records
  * @return array Array of nodes from top most parent to current node
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::getPath
  */
@@ -478,9 +478,9 @@ class TreeBehavior extends ModelBehavior {
  * If the node is the last child, or is a top level node with no subsequent node this method will return false
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $id The ID of the record to move
- * @param integer|boolean $number how many places to move the node or true to move to last position
- * @return boolean true on success, false on failure
+ * @param int|string $id The ID of the record to move
+ * @param int|bool $number how many places to move the node or true to move to last position
+ * @return bool true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::moveDown
  */
 	public function moveDown(Model $Model, $id = null, $number = 1) {
@@ -536,9 +536,9 @@ class TreeBehavior extends ModelBehavior {
  * If the node is the first child, or is a top level node with no previous node this method will return false
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $id The ID of the record to move
- * @param integer|boolean $number how many places to move the node, or true to move to first position
- * @return boolean true on success, false on failure
+ * @param int|string $id The ID of the record to move
+ * @param int|bool $number how many places to move the node, or true to move to first position
+ * @return bool true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::moveUp
  */
 	public function moveUp(Model $Model, $id = null, $number = 1) {
@@ -599,9 +599,9 @@ class TreeBehavior extends ModelBehavior {
  *
  * @param Model $Model Model using this behavior
  * @param string $mode parent or tree
- * @param string|integer $missingParentAction 'return' to do nothing and return, 'delete' to
+ * @param string|int $missingParentAction 'return' to do nothing and return, 'delete' to
  * delete, or the id of the parent to set as the parent_id
- * @return boolean true on success, false on failure
+ * @return bool true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::recover
  */
 	public function recover(Model $Model, $mode = 'parent', $missingParentAction = null) {
@@ -657,9 +657,9 @@ class TreeBehavior extends ModelBehavior {
  * Recursive helper function used by recover
  *
  * @param Model $Model Model instance.
- * @param integer $counter Counter
+ * @param int $counter Counter
  * @param mixed $parentId Parent record Id
- * @return integer $counter
+ * @return int counter
  */
 	protected function _recoverByParentId(Model $Model, $counter = 1, $parentId = null) {
 		$params = array(
@@ -739,7 +739,7 @@ class TreeBehavior extends ModelBehavior {
  *
  * @param Model $Model Model using this behavior
  * @param array $options array of options to use in reordering.
- * @return boolean true on success, false on failure
+ * @return bool true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::reorder
  */
 	public function reorder(Model $Model, $options = array()) {
@@ -776,9 +776,9 @@ class TreeBehavior extends ModelBehavior {
  * after the children are reparented.
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $id The ID of the record to remove
- * @param boolean $delete whether to delete the node after reparenting children (if any)
- * @return boolean true on success, false on failure
+ * @param int|string $id The ID of the record to remove
+ * @param bool $delete whether to delete the node after reparenting children (if any)
+ * @return bool true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::removeFromTree
  */
 	public function removeFromTree(Model $Model, $id = null, $delete = false) {
@@ -918,9 +918,9 @@ class TreeBehavior extends ModelBehavior {
  * method could be private, since calling save with parent_id set also calls setParent
  *
  * @param Model $Model Model using this behavior
- * @param integer|string $parentId Parent record Id
- * @param boolean $created True if newly created record else false.
- * @return boolean true on success, false on failure
+ * @param int|string $parentId Parent record Id
+ * @param bool $created True if newly created record else false.
+ * @return bool true on success, false on failure
  */
 	protected function _setParent(Model $Model, $parentId = null, $created = false) {
 		extract($this->settings[$Model->alias]);
@@ -990,9 +990,9 @@ class TreeBehavior extends ModelBehavior {
  * @param Model $Model Model Instance.
  * @param string $scope Scoping conditions.
  * @param string $right Right value
- * @param integer $recursive Recursive find value.
- * @param boolean $created Whether it's a new record.
- * @return integer
+ * @param int $recursive Recursive find value.
+ * @param bool $created Whether it's a new record.
+ * @return int
  */
 	protected function _getMax(Model $Model, $scope, $right, $recursive = -1, $created = false) {
 		$db = ConnectionManager::getDataSource($Model->useDbConfig);
@@ -1020,8 +1020,8 @@ class TreeBehavior extends ModelBehavior {
  * @param Model $Model Model instance.
  * @param string $scope Scoping conditions.
  * @param string $left Left value.
- * @param integer $recursive Recurursive find value.
- * @return integer
+ * @param int $recursive Recurursive find value.
+ * @return int
  */
 	protected function _getMin(Model $Model, $scope, $left, $recursive = -1) {
 		$db = ConnectionManager::getDataSource($Model->useDbConfig);
@@ -1041,10 +1041,10 @@ class TreeBehavior extends ModelBehavior {
  * Handles table sync operations, Taking account of the behavior scope.
  *
  * @param Model $Model Model instance.
- * @param integer $shift Shift by.
+ * @param int $shift Shift by.
  * @param string $dir Direction.
  * @param array $conditions Conditions.
- * @param boolean $created Whether it's a new record.
+ * @param bool $created Whether it's a new record.
  * @param string $field Field type.
  * @return void
  */

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -97,7 +97,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
  *
  * @param string $behavior CamelCased name of the behavior to load
  * @param array $config Behavior configuration parameters
- * @return boolean True on success, false on failure
+ * @return bool True on success, false on failure
  * @throws MissingBehaviorException when a behavior could not be found.
  */
 	public function load($behavior, $config = array()) {
@@ -216,7 +216,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
  * @param Model $model The model the method was originally called on.
  * @param string $method The method called.
  * @param array $params Parameters for the called method.
- * @param boolean $strict If methods are not found, trigger an error.
+ * @param bool $strict If methods are not found, trigger an error.
  * @return array All methods for all behaviors attached to this object
  */
 	public function dispatchMethod($model, $method, $params = array(), $strict = false) {
@@ -254,7 +254,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
  * also check mappedMethods.
  *
  * @param string $method The method to find.
- * @param boolean $callback Return the callback for the method.
+ * @param bool $callback Return the callback for the method.
  * @return mixed If $callback is false, a boolean will be returned, if its true, an array
  *   containing callback information will be returned. For mapped methods the array will have 3 elements.
  */

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -132,7 +132,7 @@ class CakeSchema extends Object {
  * Before callback to be implemented in subclasses
  *
  * @param array $event schema object properties
- * @return boolean Should process continue
+ * @return bool Should process continue
  */
 	public function before($event = array()) {
 		return true;

--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -54,7 +54,7 @@ class ConnectionManager {
 /**
  * Indicates if the init code for this class has already been executed
  *
- * @var boolean
+ * @var bool
  */
 	protected static $_init = false;
 
@@ -147,7 +147,7 @@ class ConnectionManager {
  * @param string|array $connName A string name of the connection, as defined in app/Config/database.php,
  *                        or an array containing the filename (without extension) and class name of the object,
  *                        to be found in app/Model/Datasource/ or lib/Cake/Model/Datasource/.
- * @return boolean True on success, null on failure or false if the class is already loaded
+ * @return bool True on success, null on failure or false if the class is already loaded
  * @throws MissingDatasourceException
  */
 	public static function loadDataSource($connName) {
@@ -221,7 +221,7 @@ class ConnectionManager {
  * Removes a connection configuration at runtime given its name
  *
  * @param string $name the connection name as it was created
- * @return boolean success if connection was removed, false if it does not exist
+ * @return bool success if connection was removed, false if it does not exist
  */
 	public static function drop($name) {
 		if (empty(self::$_init)) {

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -37,7 +37,7 @@ class CakeSession {
 /**
  * True if the Session is still valid
  *
- * @var boolean
+ * @var bool
  */
 	public static $valid = false;
 
@@ -65,28 +65,28 @@ class CakeSession {
 /**
  * Error number of last occurred error
  *
- * @var integer
+ * @var int
  */
 	public static $lastError = null;
 
 /**
  * Start time for this session.
  *
- * @var integer
+ * @var int
  */
 	public static $time = false;
 
 /**
  * Cookie lifetime
  *
- * @var integer
+ * @var int
  */
 	public static $cookieLifeTime;
 
 /**
  * Time when this session becomes invalid.
  *
- * @var integer
+ * @var int
  */
 	public static $sessionTime = false;
 
@@ -107,7 +107,7 @@ class CakeSession {
 /**
  * Session timeout multiplier factor
  *
- * @var integer
+ * @var int
  */
 	public static $timeout = null;
 
@@ -115,7 +115,7 @@ class CakeSession {
  * Number of requests that can occur during a session time without the session being renewed.
  * This feature is only used when config value `Session.autoRegenerate` is set to true.
  *
- * @var integer
+ * @var int
  * @see CakeSession::_checkValid()
  */
 	public static $requestCountdown = 10;
@@ -123,7 +123,7 @@ class CakeSession {
 /**
  * Whether or not the init function in this class was already called
  *
- * @var boolean
+ * @var bool
  */
 	protected static $_initialized = false;
 
@@ -193,7 +193,7 @@ class CakeSession {
 /**
  * Starts the Session.
  *
- * @return boolean True if session was started
+ * @return bool True if session was started
  */
 	public static function start() {
 		if (self::started()) {
@@ -215,7 +215,7 @@ class CakeSession {
 /**
  * Determine if Session has been started.
  *
- * @return boolean True if session has been started.
+ * @return bool True if session has been started.
  */
 	public static function started() {
 		return isset($_SESSION) && session_id();
@@ -225,7 +225,7 @@ class CakeSession {
  * Returns true if given variable is set in session.
  *
  * @param string $name Variable name to check for
- * @return boolean True if variable is there
+ * @return bool True if variable is there
  */
 	public static function check($name = null) {
 		if (empty($name) || !self::_hasSession() || !self::start()) {
@@ -264,7 +264,7 @@ class CakeSession {
  * Removes a variable from session.
  *
  * @param string $name Session variable to remove
- * @return boolean Success
+ * @return bool Success
  */
 	public static function delete($name) {
 		if (self::check($name)) {
@@ -297,7 +297,7 @@ class CakeSession {
 /**
  * Return error description for given error number.
  *
- * @param integer $errorNumber Error to set
+ * @param int $errorNumber Error to set
  * @return string Error as string
  */
 	protected static function _error($errorNumber) {
@@ -322,7 +322,7 @@ class CakeSession {
 /**
  * Returns true if session is valid.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public static function valid() {
 		if (self::start() && self::read('Config')) {
@@ -342,7 +342,7 @@ class CakeSession {
  * against the time the session is set to expire. The User agent is only checked
  * if Session.checkAgent == true.
  *
- * @return boolean
+ * @return bool
  */
 	protected static function _validAgentAndTime() {
 		$config = self::read('Config');
@@ -412,7 +412,7 @@ class CakeSession {
  *
  * @param string|array $name Name of variable
  * @param string $value Value to write
- * @return boolean True if the write was successful, false if the write failed
+ * @return bool True if the write was successful, false if the write failed
  */
 	public static function write($name, $value = null) {
 		if (empty($name) || !self::start()) {
@@ -548,7 +548,7 @@ class CakeSession {
 /**
  * Returns whether a session exists
  *
- * @return boolean
+ * @return bool
  */
 	protected static function _hasSession() {
 		return self::started() || isset($_COOKIE[self::_cookieName()]);
@@ -578,7 +578,7 @@ class CakeSession {
  * Get one of the prebaked default session configurations.
  *
  * @param string $name Config name.
- * @return boolean|array
+ * @return bool|array
  */
 	protected static function _defaultConfig($name) {
 		$defaults = array(
@@ -644,7 +644,7 @@ class CakeSession {
 /**
  * Helper method to start a session
  *
- * @return boolean Success
+ * @return bool Success
  */
 	protected static function _startSession() {
 		self::init();
@@ -727,7 +727,7 @@ class CakeSession {
 /**
  * Helper method to set an internal error message.
  *
- * @param integer $errorNumber Number of the error
+ * @param int $errorNumber Number of the error
  * @param string $errorMessage Description of the error
  * @return void
  */

--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -29,7 +29,7 @@ class DataSource extends Object {
 /**
  * Are we connected to the DataSource?
  *
- * @var boolean
+ * @var bool
  */
 	public $connected = false;
 
@@ -64,7 +64,7 @@ class DataSource extends Object {
 /**
  * Whether or not this DataSource is in the middle of a transaction
  *
- * @var boolean
+ * @var bool
  */
 	protected $_transactionStarted = false;
 
@@ -72,7 +72,7 @@ class DataSource extends Object {
  * Whether or not source data like available tables and schema descriptions
  * should be cached
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheSources = true;
 
@@ -144,7 +144,7 @@ class DataSource extends Object {
 /**
  * Begin a transaction
  *
- * @return boolean Returns true if a transaction is not in progress
+ * @return bool Returns true if a transaction is not in progress
  */
 	public function begin() {
 		return !$this->_transactionStarted;
@@ -153,7 +153,7 @@ class DataSource extends Object {
 /**
  * Commit a transaction
  *
- * @return boolean Returns true if a transaction is in progress
+ * @return bool Returns true if a transaction is in progress
  */
 	public function commit() {
 		return $this->_transactionStarted;
@@ -162,7 +162,7 @@ class DataSource extends Object {
 /**
  * Rollback a transaction
  *
- * @return boolean Returns true if a transaction is in progress
+ * @return bool Returns true if a transaction is in progress
  */
 	public function rollback() {
 		return $this->_transactionStarted;
@@ -186,7 +186,7 @@ class DataSource extends Object {
  * @param Model $Model The Model to be created.
  * @param array $fields An Array of fields to be saved.
  * @param array $values An Array of values to save.
- * @return boolean success
+ * @return bool success
  */
 	public function create(Model $Model, $fields = null, $values = null) {
 		return false;
@@ -199,7 +199,7 @@ class DataSource extends Object {
  *
  * @param Model $Model The model being read.
  * @param array $queryData An array of query data used to find the data you want
- * @param integer $recursive Number of levels of association
+ * @param int $recursive Number of levels of association
  * @return mixed
  */
 	public function read(Model $Model, $queryData = array(), $recursive = null) {
@@ -215,7 +215,7 @@ class DataSource extends Object {
  * @param array $fields Array of fields to be updated
  * @param array $values Array of values to be update $fields to.
  * @param mixed $conditions The array of conditions to use.
- * @return boolean Success
+ * @return bool Success
  */
 	public function update(Model $Model, $fields = null, $values = null, $conditions = null) {
 		return false;
@@ -228,7 +228,7 @@ class DataSource extends Object {
  *
  * @param Model $Model The model class having record(s) deleted
  * @param mixed $conditions The conditions to use for deleting.
- * @return boolean Success
+ * @return bool Success
  */
 	public function delete(Model $Model, $conditions = null) {
 		return false;
@@ -248,7 +248,7 @@ class DataSource extends Object {
  * Returns the number of rows returned by last operation.
  *
  * @param mixed $source The source name.
- * @return integer Number of rows returned by last operation
+ * @return int Number of rows returned by last operation
  */
 	public function lastNumRows($source = null) {
 		return false;
@@ -258,7 +258,7 @@ class DataSource extends Object {
  * Returns the number of rows affected by last query.
  *
  * @param mixed $source The source name.
- * @return integer Number of rows affected by last query.
+ * @return int Number of rows affected by last query.
  */
 	public function lastAffected($source = null) {
 		return false;
@@ -269,7 +269,7 @@ class DataSource extends Object {
  * are satisfied. Often used from connect() to check for support
  * before establishing a connection.
  *
- * @return boolean Whether or not the Datasources conditions for use are met.
+ * @return bool Whether or not the Datasources conditions for use are met.
  */
 	public function enabled() {
 		return true;
@@ -416,7 +416,7 @@ class DataSource extends Object {
 /**
  * Closes a connection. Override in subclasses
  *
- * @return boolean
+ * @return bool
  */
 	public function close() {
 		return $this->connected = false;

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -52,7 +52,7 @@ class Mysql extends DboSource {
 /**
  * Reference to the PDO object connection
  *
- * @var PDO $_connection
+ * @var PDO
  */
 	protected $_connection = null;
 
@@ -73,7 +73,7 @@ class Mysql extends DboSource {
 /**
  * use alias for update and delete. Set to true if version >= 4.1
  *
- * @var boolean
+ * @var bool
  */
 	protected $_useAlias = true;
 
@@ -145,7 +145,7 @@ class Mysql extends DboSource {
  *   combined with `ssl_key`.
  * - `ssl_ca` The certificate authority for SSL connections.
  *
- * @return boolean True if the database could be connected, else false
+ * @return bool True if the database could be connected, else false
  * @throws MissingConnectionException
  */
 	public function connect() {
@@ -203,7 +203,7 @@ class Mysql extends DboSource {
 /**
  * Check whether the MySQL extension is installed/loaded
  *
- * @return boolean
+ * @return bool
  */
 	public function enabled() {
 		return in_array('mysql', PDO::getAvailableDrivers());
@@ -420,7 +420,7 @@ class Mysql extends DboSource {
  *
  * @param Model $model The model to delete from.
  * @param mixed $conditions The conditions to use.
- * @return boolean Success
+ * @return bool Success
  */
 	public function delete(Model $model, $conditions = null) {
 		if (!$this->_useAlias) {
@@ -459,7 +459,7 @@ class Mysql extends DboSource {
  * Sets the database encoding
  *
  * @param string $enc Database encoding
- * @return boolean
+ * @return bool
  */
 	public function setEncoding($enc) {
 		return $this->_execute('SET NAMES ' . $enc) !== false;
@@ -796,7 +796,7 @@ class Mysql extends DboSource {
 /**
  * Check if the server support nested transactions
  *
- * @return boolean
+ * @return bool
  */
 	public function nestedTransactionSupported() {
 		return $this->useNestedTransactions && version_compare($this->getVersion(), '4.1', '>=');

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -104,7 +104,7 @@ class Postgres extends DboSource {
 /**
  * Connects to the database using options in the given configuration array.
  *
- * @return boolean True if successfully connected.
+ * @return bool True if successfully connected.
  * @throws MissingConnectionException
  */
 	public function connect() {
@@ -149,7 +149,7 @@ class Postgres extends DboSource {
 /**
  * Check if PostgreSQL is enabled/loaded
  *
- * @return boolean
+ * @return bool
  */
 	public function enabled() {
 		return in_array('pgsql', PDO::getAvailableDrivers());
@@ -284,7 +284,7 @@ class Postgres extends DboSource {
  *
  * @param string $source Name of the database table
  * @param string $field Name of the ID database field. Defaults to "id"
- * @return integer
+ * @return int
  */
 	public function lastInsertId($source = null, $field = 'id') {
 		$seq = $this->getSequence($source, $field);
@@ -318,7 +318,7 @@ class Postgres extends DboSource {
  * @param string $table The name of the table to update.
  * @param string $column The column to use when resetting the sequence value,
  *   the sequence name will be fetched using Postgres::getSequence();
- * @return boolean success.
+ * @return bool success.
  */
 	public function resetSequence($table, $column) {
 		$tableName = $this->fullTableName($table, false, false);
@@ -334,9 +334,9 @@ class Postgres extends DboSource {
  * Deletes all the records in a table and drops all associated auto-increment sequences
  *
  * @param string|Model $table A string or model class representing the table to be truncated
- * @param boolean $reset true for resetting the sequence, false to leave it as is.
+ * @param bool $reset true for resetting the sequence, false to leave it as is.
  *    and if 1, sequences are not modified
- * @return boolean SQL TRUNCATE TABLE statement, false if not applicable.
+ * @return bool SQL TRUNCATE TABLE statement, false if not applicable.
  */
 	public function truncate($table, $reset = false) {
 		$table = $this->fullTableName($table, false, false);
@@ -377,7 +377,7 @@ class Postgres extends DboSource {
  * @param Model $model The model to get fields for.
  * @param string $alias Alias table name.
  * @param mixed $fields The list of fields to get.
- * @param boolean $quote Whether or not to quote identifiers.
+ * @param bool $quote Whether or not to quote identifiers.
  * @return array
  */
 	public function fields(Model $model, $alias = null, $fields = array(), $quote = true) {
@@ -640,8 +640,8 @@ class Postgres extends DboSource {
 /**
  * Returns a limit statement in the correct format for the particular database.
  *
- * @param integer $limit Limit of results returned
- * @param integer $offset Offset from which to start results
+ * @param int $limit Limit of results returned
+ * @param int $offset Offset from which to start results
  * @return string SQL limit/offset statement
  */
 	public function limit($limit, $offset = null) {
@@ -710,7 +710,7 @@ class Postgres extends DboSource {
  * Gets the length of a database-native column description, or null if no length
  *
  * @param string $real Real database-layer column type (i.e. "varchar(255)")
- * @return integer An integer representing the length of the column
+ * @return int An integer representing the length of the column
  */
 	public function length($real) {
 		$col = str_replace(array(')', 'unsigned'), '', $real);
@@ -786,8 +786,8 @@ class Postgres extends DboSource {
  * Translates between PHP boolean values and PostgreSQL boolean values
  *
  * @param mixed $data Value to be translated
- * @param boolean $quote true to quote a boolean to be used in a query, false to return the boolean value
- * @return boolean Converted boolean value
+ * @param bool $quote true to quote a boolean to be used in a query, false to return the boolean value
+ * @return bool Converted boolean value
  */
 	public function boolean($data, $quote = false) {
 		switch (true) {
@@ -817,7 +817,7 @@ class Postgres extends DboSource {
  * Sets the database encoding
  *
  * @param mixed $enc Database encoding
- * @return boolean True on success, false on failure
+ * @return bool True on success, false on failure
  */
 	public function setEncoding($enc) {
 		return $this->_execute('SET NAMES ' . $this->value($enc)) !== false;
@@ -959,7 +959,7 @@ class Postgres extends DboSource {
 /**
  * Check if the server support nested transactions
  *
- * @return boolean
+ * @return bool
  */
 	public function nestedTransactionSupported() {
 		return $this->useNestedTransactions && version_compare($this->getVersion(), '8.0', '>=');

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -102,7 +102,7 @@ class Sqlite extends DboSource {
 /**
  * Connects to the database using config['database'] as a filename.
  *
- * @return boolean
+ * @return bool
  * @throws MissingConnectionException
  */
 	public function connect() {
@@ -126,7 +126,7 @@ class Sqlite extends DboSource {
 /**
  * Check whether the SQLite extension is installed/loaded
  *
- * @return boolean
+ * @return bool
  */
 	public function enabled() {
 		return in_array('sqlite', PDO::getAvailableDrivers());
@@ -227,7 +227,7 @@ class Sqlite extends DboSource {
  * primary key, where applicable.
  *
  * @param string|Model $table A string or model class representing the table to be truncated
- * @return boolean SQL TRUNCATE TABLE statement, false if not applicable.
+ * @return bool SQL TRUNCATE TABLE statement, false if not applicable.
  */
 	public function truncate($table) {
 		if (in_array('sqlite_sequence', $this->listSources())) {
@@ -371,8 +371,8 @@ class Sqlite extends DboSource {
 /**
  * Returns a limit statement in the correct format for the particular database.
  *
- * @param integer $limit Limit of results returned
- * @param integer $offset Offset from which to start results
+ * @param int $limit Limit of results returned
+ * @param int $offset Offset from which to start results
  * @return string SQL limit/offset statement
  */
 	public function limit($limit, $offset = null) {
@@ -427,7 +427,7 @@ class Sqlite extends DboSource {
  * Sets the database encoding
  *
  * @param string $enc Database encoding
- * @return boolean
+ * @return bool
  */
 	public function setEncoding($enc) {
 		if (!in_array($enc, array("UTF-8", "UTF-16", "UTF-16le", "UTF-16be"))) {
@@ -549,7 +549,7 @@ class Sqlite extends DboSource {
 /**
  * PDO deals in objects, not resources, so overload accordingly.
  *
- * @return boolean
+ * @return bool
  */
 	public function hasResult() {
 		return is_object($this->_result);
@@ -577,7 +577,7 @@ class Sqlite extends DboSource {
 /**
  * Check if the server support nested transactions
  *
- * @return boolean
+ * @return bool
  */
 	public function nestedTransactionSupported() {
 		return $this->useNestedTransactions && version_compare($this->getVersion(), '3.6.8', '>=');

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -115,7 +115,7 @@ class Sqlserver extends DboSource {
 /**
  * Connects to the database using options in the given configuration array.
  *
- * @return boolean True if the database could be connected, else false
+ * @return bool True if the database could be connected, else false
  * @throws MissingConnectionException
  */
 	public function connect() {
@@ -157,7 +157,7 @@ class Sqlserver extends DboSource {
 /**
  * Check that PDO SQL Server is installed/loaded
  *
- * @return boolean
+ * @return bool
  */
 	public function enabled() {
 		return in_array('sqlsrv', PDO::getAvailableDrivers());
@@ -272,7 +272,7 @@ class Sqlserver extends DboSource {
  * @param Model $model The model to get fields for.
  * @param string $alias Alias table name
  * @param array $fields The fields so far.
- * @param boolean $quote Whether or not to quote identfiers.
+ * @param bool $quote Whether or not to quote identfiers.
  * @return array
  */
 	public function fields(Model $model, $alias = null, $fields = array(), $quote = true) {
@@ -389,8 +389,8 @@ class Sqlserver extends DboSource {
 /**
  * Returns a limit statement in the correct format for the particular database.
  *
- * @param integer $limit Limit of results returned
- * @param integer $offset Offset from which to start results
+ * @param int $limit Limit of results returned
+ * @param int $offset Offset from which to start results
  * @return string SQL limit/offset statement
  */
 	public function limit($limit, $offset = null) {
@@ -610,7 +610,7 @@ class Sqlserver extends DboSource {
  *
  * @param Model $model The model to read from
  * @param array $queryData The query data
- * @param integer $recursive How many layers to go.
+ * @param int $recursive How many layers to go.
  * @return array|false Array of resultset rows, or false if no rows matched
  */
 	public function read(Model $model, $queryData = array(), $recursive = null) {
@@ -745,7 +745,7 @@ class Sqlserver extends DboSource {
  * this returns false.
  *
  * @param mixed $source Unused
- * @return integer Number of affected rows
+ * @return int Number of affected rows
  */
 	public function lastAffected($source = null) {
 		$affected = parent::lastAffected();

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -63,7 +63,7 @@ class DboSource extends DataSource {
  * Whether or not to cache the results of DboSource::name() and DboSource::conditions()
  * into the memory cache. Set to false to disable the use of the memory cache.
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheMethods = true;
 
@@ -72,14 +72,14 @@ class DboSource extends DataSource {
  * the transaction methods (begin/commit/rollback), but just the global transaction will
  * be executed.
  *
- * @var boolean
+ * @var bool
  */
 	public $useNestedTransactions = false;
 
 /**
  * Print full query debug info?
  *
- * @var boolean
+ * @var bool
  */
 	public $fullDebug = false;
 
@@ -93,14 +93,14 @@ class DboSource extends DataSource {
 /**
  * Number of rows in current resultset
  *
- * @var integer
+ * @var int
  */
 	public $numRows = null;
 
 /**
  * Time the last query took
  *
- * @var integer
+ * @var int
  */
 	public $took = null;
 
@@ -114,14 +114,14 @@ class DboSource extends DataSource {
 /**
  * Queries count.
  *
- * @var integer
+ * @var int
  */
 	protected $_queriesCnt = 0;
 
 /**
  * Total duration of all queries.
  *
- * @var integer
+ * @var int
  */
 	protected $_queriesTime = null;
 
@@ -137,14 +137,14 @@ class DboSource extends DataSource {
  *
  * This is to prevent query log taking over too much memory.
  *
- * @var integer Maximum number of queries in the queries log.
+ * @var int
  */
 	protected $_queriesLogMax = 200;
 
 /**
  * Caches serialized results of executed queries
  *
- * @var array Cache of results from executed sql queries.
+ * @var array
  */
 	protected $_queryCache = array();
 
@@ -186,7 +186,7 @@ class DboSource extends DataSource {
 /**
  * Indicates the level of nested transactions
  *
- * @var integer
+ * @var int
  */
 	protected $_transactionNesting = 0;
 
@@ -232,7 +232,7 @@ class DboSource extends DataSource {
  * Indicates whether there was a change on the cached results on the methods of this class
  * This will be used for storing in a more persistent cache
  *
- * @var boolean
+ * @var bool
  */
 	protected $_methodCacheChange = false;
 
@@ -240,7 +240,7 @@ class DboSource extends DataSource {
  * Constructor
  *
  * @param array $config Array of configuration information for the Datasource.
- * @param boolean $autoConnect Whether or not the datasource should automatically connect.
+ * @param bool $autoConnect Whether or not the datasource should automatically connect.
  * @throws MissingConnectionException when a connection cannot be made.
  */
 	public function __construct($config = null, $autoConnect = true) {
@@ -265,7 +265,7 @@ class DboSource extends DataSource {
  * Reconnects to database server with optional new settings
  *
  * @param array $config An array defining the new configuration settings
- * @return boolean True on success, false on failure
+ * @return bool True on success, false on failure
  */
 	public function reconnect($config = array()) {
 		$this->disconnect();
@@ -278,7 +278,7 @@ class DboSource extends DataSource {
 /**
  * Disconnects from database.
  *
- * @return boolean Always true
+ * @return bool Always true
  */
 	public function disconnect() {
 		if ($this->_result instanceof PDOStatement) {
@@ -396,7 +396,7 @@ class DboSource extends DataSource {
  *
  * @param string $sql SQL statement
  * @param array $params Additional options for the query.
- * @return boolean
+ * @return bool
  */
 	public function rawQuery($sql, $params = array()) {
 		$this->took = $this->numRows = false;
@@ -500,7 +500,7 @@ class DboSource extends DataSource {
  * this returns false.
  *
  * @param mixed $source The source to check.
- * @return integer Number of affected rows
+ * @return int Number of affected rows
  */
 	public function lastAffected($source = null) {
 		if ($this->hasResult()) {
@@ -514,7 +514,7 @@ class DboSource extends DataSource {
  * this returns false.
  *
  * @param mixed $source Not used
- * @return integer Number of rows in resultset
+ * @return int Number of rows in resultset
  */
 	public function lastNumRows($source = null) {
 		return $this->lastAffected();
@@ -645,10 +645,10 @@ class DboSource extends DataSource {
  *   by setting $options to `false`
  *
  * @param string $sql SQL statement
- * @param array|boolean $params Either parameters to be bound as values for the SQL statement,
+ * @param array|bool $params Either parameters to be bound as values for the SQL statement,
  *  or a boolean to control query caching.
  * @param array $options additional options for the query.
- * @return boolean|array Array of resultset rows, or false if no rows matched
+ * @return bool|array Array of resultset rows, or false if no rows matched
  */
 	public function fetchAll($sql, $params = array(), $options = array()) {
 		if (is_string($options)) {
@@ -695,7 +695,7 @@ class DboSource extends DataSource {
 /**
  * Fetches the next row from the current result set
  *
- * @return boolean
+ * @return bool
  */
 	public function fetchResult() {
 		return false;
@@ -853,7 +853,7 @@ class DboSource extends DataSource {
 /**
  * Checks if the source is connected to the database.
  *
- * @return boolean True if the database is connected, else false
+ * @return bool True if the database is connected, else false
  */
 	public function isConnected() {
 		return $this->connected;
@@ -862,7 +862,7 @@ class DboSource extends DataSource {
 /**
  * Checks if the result is valid
  *
- * @return boolean True if the result is valid else false
+ * @return bool True if the result is valid else false
  */
 	public function hasResult() {
 		return $this->_result instanceof PDOStatement;
@@ -871,8 +871,8 @@ class DboSource extends DataSource {
 /**
  * Get the query log as an array.
  *
- * @param boolean $sorted Get the queries sorted by time taken, defaults to false.
- * @param boolean $clear If True the existing log will cleared.
+ * @param bool $sorted Get the queries sorted by time taken, defaults to false.
+ * @param bool $clear If True the existing log will cleared.
  * @return array Array of queries run as an array
  */
 	public function getLog($sorted = false, $clear = true) {
@@ -891,7 +891,7 @@ class DboSource extends DataSource {
  * Outputs the contents of the queries log. If in a non-CLI environment the sql_log element
  * will be rendered and output. If in a CLI environment, a plain text log is generated.
  *
- * @param boolean $sorted Get the queries sorted by time taken, defaults to false.
+ * @param bool $sorted Get the queries sorted by time taken, defaults to false.
  * @return void
  */
 	public function showLog($sorted = false) {
@@ -937,8 +937,8 @@ class DboSource extends DataSource {
  * Gets full table name including prefix
  *
  * @param Model|string $model Either a Model object or a string table name.
- * @param boolean $quote Whether you want the table name quoted.
- * @param boolean $schema Whether you want the schema name included.
+ * @param bool $quote Whether you want the table name quoted.
+ * @param bool $schema Whether you want the schema name included.
  * @return string Full quoted table name
  */
 	public function fullTableName($model, $quote = true, $schema = true) {
@@ -983,7 +983,7 @@ class DboSource extends DataSource {
  *   used to generate field names.
  * @param array $values An array of values with keys matching the fields. If null, $Model->data will
  *   be used to generate values.
- * @return boolean Success
+ * @return bool Success
  */
 	public function create(Model $Model, $fields = null, $values = null) {
 		$id = null;
@@ -1029,7 +1029,7 @@ class DboSource extends DataSource {
  *
  * @param Model $Model A Model object that the query is for.
  * @param array $queryData An array of queryData information containing keys similar to Model::find().
- * @param integer $recursive Number of levels of association
+ * @param int $recursive Number of levels of association
  * @return mixed boolean false on error/failure. An array of results on success.
  */
 	public function read(Model $Model, $queryData = array(), $recursive = null) {
@@ -1222,9 +1222,9 @@ class DboSource extends DataSource {
  * @param string $association Association name.
  * @param array $assocData Association data.
  * @param array &$queryData An array of queryData information containing keys similar to Model::find().
- * @param boolean $external Whether or not the association query is on an external datasource.
+ * @param bool $external Whether or not the association query is on an external datasource.
  * @param array &$resultSet Existing results.
- * @param integer $recursive Number of levels of association.
+ * @param int $recursive Number of levels of association.
  * @param array $stack A list with joined models.
  * @return mixed
  * @throws CakeException when results cannot be created.
@@ -1499,7 +1499,7 @@ class DboSource extends DataSource {
  * @param array &$merge The data to merge.
  * @param string $association The association name to merge.
  * @param string $type The type of association
- * @param boolean $selfJoin Whether or not this is a self join.
+ * @param bool $selfJoin Whether or not this is a self join.
  * @return void
  */
 	protected function _mergeAssociation(&$data, &$merge, $association, $type, $selfJoin = false) {
@@ -1644,7 +1644,7 @@ class DboSource extends DataSource {
  * @param string $association Association name.
  * @param array $assocData Association data.
  * @param array &$queryData An array of queryData information containing keys similar to Model::find().
- * @param boolean $external Whether or not the association query is on an external datasource.
+ * @param bool $external Whether or not the association query is on an external datasource.
  * @return mixed
  *   String representing a query.
  *   True, when $external is false and association $type is 'hasOne' or 'belongsTo'.
@@ -2003,7 +2003,7 @@ class DboSource extends DataSource {
  * @param array $fields The fields to update
  * @param array $values The values fo the fields.
  * @param mixed $conditions The conditions for the update. When non-empty $values will not be quoted.
- * @return boolean Success
+ * @return bool Success
  */
 	public function update(Model $Model, $fields = array(), $values = null, $conditions = null) {
 		if (!$values) {
@@ -2035,8 +2035,8 @@ class DboSource extends DataSource {
  *
  * @param Model $Model The model to prepare fields for.
  * @param array $fields The fields to update.
- * @param boolean $quoteValues If values should be quoted, or treated as SQL snippets
- * @param boolean $alias Include the model alias in the field name
+ * @param bool $quoteValues If values should be quoted, or treated as SQL snippets
+ * @param bool $alias Include the model alias in the field name
  * @return array Fields and values, quoted and prepared
  */
 	protected function _prepareUpdateFields(Model $Model, $fields, $quoteValues = true, $alias = false) {
@@ -2082,7 +2082,7 @@ class DboSource extends DataSource {
  *
  * @param Model $Model The model to delete from
  * @param mixed $conditions The conditions to use. If empty the model's primary key will be used.
- * @return boolean Success
+ * @return bool Success
  */
 	public function delete(Model $Model, $conditions = null) {
 		$alias = $joins = null;
@@ -2234,7 +2234,7 @@ class DboSource extends DataSource {
  * primary key, where applicable.
  *
  * @param Model|string $table A string or model class representing the table to be truncated
- * @return boolean SQL TRUNCATE TABLE statement, false if not applicable.
+ * @return bool SQL TRUNCATE TABLE statement, false if not applicable.
  */
 	public function truncate($table) {
 		return $this->execute('TRUNCATE TABLE ' . $this->fullTableName($table));
@@ -2243,7 +2243,7 @@ class DboSource extends DataSource {
 /**
  * Check if the server support nested transactions
  *
- * @return boolean
+ * @return bool
  */
 	public function nestedTransactionSupported() {
 		return false;
@@ -2252,7 +2252,7 @@ class DboSource extends DataSource {
 /**
  * Begin a transaction
  *
- * @return boolean True on success, false on fail
+ * @return bool True on success, false on fail
  * (i.e. if the database/model does not support transactions,
  * or a transaction has not started).
  */
@@ -2275,7 +2275,7 @@ class DboSource extends DataSource {
 /**
  * Begin a nested transaction
  *
- * @return boolean
+ * @return bool
  */
 	protected function _beginNested() {
 		$query = 'SAVEPOINT LEVEL' . ++$this->_transactionNesting;
@@ -2289,7 +2289,7 @@ class DboSource extends DataSource {
 /**
  * Commit a transaction
  *
- * @return boolean True on success, false on fail
+ * @return bool True on success, false on fail
  * (i.e. if the database/model does not support transactions,
  * or a transaction has not started).
  */
@@ -2317,7 +2317,7 @@ class DboSource extends DataSource {
 /**
  * Commit a nested transaction
  *
- * @return boolean
+ * @return bool
  */
 	protected function _commitNested() {
 		$query = 'RELEASE SAVEPOINT LEVEL' . $this->_transactionNesting--;
@@ -2331,7 +2331,7 @@ class DboSource extends DataSource {
 /**
  * Rollback a transaction
  *
- * @return boolean True on success, false on fail
+ * @return bool True on success, false on fail
  * (i.e. if the database/model does not support transactions,
  * or a transaction has not started).
  */
@@ -2359,7 +2359,7 @@ class DboSource extends DataSource {
 /**
  * Rollback a nested transaction
  *
- * @return boolean
+ * @return bool
  */
 	protected function _rollbackNested() {
 		$query = 'ROLLBACK TO SAVEPOINT LEVEL' . $this->_transactionNesting--;
@@ -2386,10 +2386,10 @@ class DboSource extends DataSource {
  * were provided either null or false will be returned based on what was input.
  *
  * @param Model $Model The model to get conditions for.
- * @param string|array|boolean $conditions Array of conditions, conditions string, null or false. If an array of conditions,
+ * @param string|array|bool $conditions Array of conditions, conditions string, null or false. If an array of conditions,
  *   or string conditions those conditions will be returned. With other values the model's existence will be checked.
  *   If the model doesn't exist a null or false will be returned depending on the input value.
- * @param boolean $useAlias Use model aliases rather than table names when generating conditions
+ * @param bool $useAlias Use model aliases rather than table names when generating conditions
  * @return mixed Either null, false, $conditions or an array of default conditions to use.
  * @see DboSource::update()
  * @see DboSource::conditions()
@@ -2466,7 +2466,7 @@ class DboSource extends DataSource {
  * @param Model $Model The model to get fields for.
  * @param string $alias Alias table name
  * @param mixed $fields The provided list of fields.
- * @param boolean $quote If false, returns fields array unquoted
+ * @param bool $quote If false, returns fields array unquoted
  * @return array
  */
 	public function fields(Model $Model, $alias = null, $fields = array(), $quote = true) {
@@ -2586,8 +2586,8 @@ class DboSource extends DataSource {
  * Setting DboSource::$cacheMethods to false will disable the memory cache.
  *
  * @param mixed $conditions Array or string of conditions, or any value.
- * @param boolean $quoteValues If true, values should be quoted
- * @param boolean $where If true, "WHERE " will be prepended to the return value
+ * @param bool $quoteValues If true, values should be quoted
+ * @param bool $where If true, "WHERE " will be prepended to the return value
  * @param Model $Model A reference to the Model instance making the query
  * @return string SQL fragment
  */
@@ -2630,7 +2630,7 @@ class DboSource extends DataSource {
  * Creates a WHERE clause by parsing given conditions array. Used by DboSource::conditions().
  *
  * @param array $conditions Array or string of conditions
- * @param boolean $quoteValues If true, values should be quoted
+ * @param bool $quoteValues If true, values should be quoted
  * @param Model $Model A reference to the Model instance making the query
  * @return string SQL fragment
  */
@@ -2874,8 +2874,8 @@ class DboSource extends DataSource {
 /**
  * Returns a limit statement in the correct format for the particular database.
  *
- * @param integer $limit Limit of results returned
- * @param integer $offset Offset from which to start results
+ * @param int $limit Limit of results returned
+ * @param int $offset Offset from which to start results
  * @return string SQL limit/offset statement
  */
 	public function limit($limit, $offset = null) {
@@ -3019,7 +3019,7 @@ class DboSource extends DataSource {
  *
  * @param Model $Model Model to search
  * @param string $sql SQL WHERE clause (condition only, not the "WHERE" part)
- * @return boolean True if the table has a matching record, else false
+ * @return bool True if the table has a matching record, else false
  */
 	public function hasAny(Model $Model, $sql) {
 		$sql = $this->conditions($sql);
@@ -3099,8 +3099,8 @@ class DboSource extends DataSource {
  * Translates between PHP boolean values and Database (faked) boolean values
  *
  * @param mixed $data Value to be translated
- * @param boolean $quote Whether or not the field should be cast to a string.
- * @return string|boolean Converted boolean value
+ * @param bool $quote Whether or not the field should be cast to a string.
+ * @return string|bool Converted boolean value
  */
 	public function boolean($data, $quote = false) {
 		if ($quote) {
@@ -3117,7 +3117,7 @@ class DboSource extends DataSource {
  * @param array $values The array of values to insert. The values should
  *   be an array of rows. Each row should have values keyed by the column name.
  *   Each row must have the values in the same order as $fields.
- * @return boolean
+ * @return bool
  */
 	public function insertMulti($table, $fields, $values) {
 		$table = $this->fullTableName($table);
@@ -3166,7 +3166,7 @@ class DboSource extends DataSource {
  *
  * @param string $table The name of the table to update.
  * @param string $column The column to use when resetting the sequence value.
- * @return boolean|void success.
+ * @return bool|void success.
  */
 	public function resetSequence($table, $column) {
 	}
@@ -3250,7 +3250,7 @@ class DboSource extends DataSource {
  *
  * @param mixed $compare The comparison data.
  * @param string $table The table name.
- * @return boolean
+ * @return bool
  */
 	public function alterSchema($compare, $table = null) {
 		return false;

--- a/lib/Cake/Model/Datasource/Session/CacheSession.php
+++ b/lib/Cake/Model/Datasource/Session/CacheSession.php
@@ -30,7 +30,7 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Method called on open of a database session.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function open() {
 		return true;
@@ -39,7 +39,7 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Method called on close of a database session.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function close() {
 		return true;
@@ -58,9 +58,9 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Helper function called on write for database sessions.
  *
- * @param integer $id ID that uniquely identifies session in database
+ * @param int $id ID that uniquely identifies session in database
  * @param mixed $data The value of the data to be saved.
- * @return boolean True for successful write, false otherwise.
+ * @return bool True for successful write, false otherwise.
  */
 	public function write($id, $data) {
 		return Cache::write($id, $data, Configure::read('Session.handler.config'));
@@ -69,8 +69,8 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Method called on the destruction of a database session.
  *
- * @param integer $id ID that uniquely identifies session in cache
- * @return boolean True for successful delete, false otherwise.
+ * @param int $id ID that uniquely identifies session in cache
+ * @return bool True for successful delete, false otherwise.
  */
 	public function destroy($id) {
 		return Cache::delete($id, Configure::read('Session.handler.config'));
@@ -79,8 +79,8 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Helper function called on gc for cache sessions.
  *
- * @param integer $expires Timestamp (defaults to current time)
- * @return boolean Success
+ * @param int $expires Timestamp (defaults to current time)
+ * @return bool Success
  */
 	public function gc($expires = null) {
 		return Cache::gc(Configure::read('Session.handler.config'), $expires);

--- a/lib/Cake/Model/Datasource/Session/CakeSessionHandlerInterface.php
+++ b/lib/Cake/Model/Datasource/Session/CakeSessionHandlerInterface.php
@@ -25,14 +25,14 @@ interface CakeSessionHandlerInterface {
 /**
  * Method called on open of a session.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function open();
 
 /**
  * Method called on close of a session.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function close();
 
@@ -47,17 +47,17 @@ interface CakeSessionHandlerInterface {
 /**
  * Helper function called on write for sessions.
  *
- * @param integer $id ID that uniquely identifies session in database
+ * @param int $id ID that uniquely identifies session in database
  * @param mixed $data The value of the data to be saved.
- * @return boolean True for successful write, false otherwise.
+ * @return bool True for successful write, false otherwise.
  */
 	public function write($id, $data);
 
 /**
  * Method called on the destruction of a session.
  *
- * @param integer $id ID that uniquely identifies session in database
- * @return boolean True for successful delete, false otherwise.
+ * @param int $id ID that uniquely identifies session in database
+ * @return bool True for successful delete, false otherwise.
  */
 	public function destroy($id);
 
@@ -65,8 +65,8 @@ interface CakeSessionHandlerInterface {
  * Run the Garbage collection on the session storage. This method should vacuum all
  * expired or dead sessions.
  *
- * @param integer $expires Timestamp (defaults to current time)
- * @return boolean Success
+ * @param int $expires Timestamp (defaults to current time)
+ * @return bool Success
  */
 	public function gc($expires = null);
 

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -36,7 +36,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Number of seconds to mark the session as expired
  *
- * @var integer
+ * @var int
  */
 	protected $_timeout;
 
@@ -67,7 +67,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Method called on open of a database session.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function open() {
 		return true;
@@ -76,7 +76,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Method called on close of a database session.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function close() {
 		return true;
@@ -85,7 +85,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Method used to read from a database session.
  *
- * @param integer|string $id The key of the value to read
+ * @param int|string $id The key of the value to read
  * @return mixed The value of the key or false if it does not exist
  */
 	public function read($id) {
@@ -103,9 +103,9 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Helper function called on write for database sessions.
  *
- * @param integer $id ID that uniquely identifies session in database
+ * @param int $id ID that uniquely identifies session in database
  * @param mixed $data The value of the data to be saved.
- * @return boolean True for successful write, false otherwise.
+ * @return bool True for successful write, false otherwise.
  */
 	public function write($id, $data) {
 		if (!$id) {
@@ -120,8 +120,8 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Method called on the destruction of a database session.
  *
- * @param integer $id ID that uniquely identifies session in database
- * @return boolean True for successful delete, false otherwise.
+ * @param int $id ID that uniquely identifies session in database
+ * @return bool True for successful delete, false otherwise.
  */
 	public function destroy($id) {
 		return $this->_model->delete($id);
@@ -130,8 +130,8 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Helper function called on gc for database sessions.
  *
- * @param integer $expires Timestamp (defaults to current time)
- * @return boolean Success
+ * @param int $expires Timestamp (defaults to current time)
+ * @return bool Success
  */
 	public function gc($expires = null) {
 		if (!$expires) {

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -266,7 +266,7 @@ class Model extends Object implements CakeEventListener {
  * Whether or not to cache queries for this model. This enables in-memory
  * caching only, the results are not stored beyond the current request.
  *
- * @var boolean
+ * @var bool
  * @link http://book.cakephp.org/2.0/en/models/model-attributes.html#cachequeries
  */
 	public $cacheQueries = false;
@@ -499,7 +499,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Whether or not to cache sources for this model.
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheSources = true;
 
@@ -514,7 +514,7 @@ class Model extends Object implements CakeEventListener {
  * Number of associations to recurse through during find calls. Fetches only
  * the first level by default.
  *
- * @var integer
+ * @var int
  * @link http://book.cakephp.org/2.0/en/models/model-attributes.html#recursive
  */
 	public $recursive = 1;
@@ -598,14 +598,14 @@ class Model extends Object implements CakeEventListener {
 /**
  * The ID of the model record that was last inserted.
  *
- * @var integer
+ * @var int
  */
 	protected $_insertID = null;
 
 /**
  * Has the datasource been configured.
  *
- * @var boolean
+ * @var bool
  * @see Model::getDataSource
  */
 	protected $_sourceConfigured = false;
@@ -663,7 +663,7 @@ class Model extends Object implements CakeEventListener {
  * Would create a model attached to the posts table on connection2. Dynamic model creation is useful
  * when you want a model object that contains no associations or attached behaviors.
  *
- * @param boolean|integer|string|array $id Set this ID for this model on startup,
+ * @param bool|int|string|array $id Set this ID for this model on startup,
  * can also be an array of options, see above.
  * @param string $table Name of database table to use.
  * @param string $ds DataSource connection name.
@@ -804,7 +804,7 @@ class Model extends Object implements CakeEventListener {
  * Handles the lazy loading of model associations by looking in the association arrays for the requested variable
  *
  * @param string $name variable tested for existence in class
- * @return boolean true if the variable exists (if is a not loaded model association it will be created), false otherwise
+ * @return bool true if the variable exists (if is a not loaded model association it will be created), false otherwise
  */
 	public function __isset($name) {
 		$className = false;
@@ -909,8 +909,8 @@ class Model extends Object implements CakeEventListener {
  * model.
  *
  * @param array $params Set of bindings (indexed by binding type)
- * @param boolean $reset Set to false to make the binding permanent
- * @return boolean Success
+ * @param bool $reset Set to false to make the binding permanent
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#creating-and-destroying-associations-on-the-fly
  */
 	public function bindModel($params, $reset = true) {
@@ -959,8 +959,8 @@ class Model extends Object implements CakeEventListener {
  * Unbound models that are not made permanent will reset with the next call to Model::find()
  *
  * @param array $params Set of bindings to unbind (indexed by binding type)
- * @param boolean $reset Set to false to make the unbinding permanent
- * @return boolean Success
+ * @param bool $reset Set to false to make the unbinding permanent
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/models/associations-linking-models-together.html#creating-and-destroying-associations-on-the-fly
  */
 	public function unbindModel($params, $reset = true) {
@@ -1349,7 +1349,7 @@ class Model extends Object implements CakeEventListener {
  * Returns an array of table metadata (column names and types) from the database.
  * $field => keys(type, null, default, key, length, extra)
  *
- * @param boolean|string $field Set to true to reload schema, or a string to return a specific field
+ * @param bool|string $field Set to true to reload schema, or a string to return a specific field
  * @return array Array of table metadata
  */
 	public function schema($field = false) {
@@ -1425,7 +1425,7 @@ class Model extends Object implements CakeEventListener {
  * Returns true if the supplied field exists in the model's database table.
  *
  * @param string|array $name Name of field to look for, or an array of names
- * @param boolean $checkVirtual checks if the field is declared as virtual
+ * @param bool $checkVirtual checks if the field is declared as virtual
  * @return mixed If $name is a string, returns a boolean indicating whether the field exists.
  *               If $name is an array of field names, returns the first field that exists,
  *               or false if none exist.
@@ -1461,7 +1461,7 @@ class Model extends Object implements CakeEventListener {
  * inherited methods and methods that could be callable through behaviors.
  *
  * @param string $method The method to be called.
- * @return boolean True on method being callable.
+ * @return bool True on method being callable.
  */
 	public function hasMethod($method) {
 		if (method_exists($this, $method)) {
@@ -1475,7 +1475,7 @@ class Model extends Object implements CakeEventListener {
  * Returns true if the supplied field is a model Virtual Field
  *
  * @param string $field Name of field to look for
- * @return boolean indicating whether the field exists as a model virtual field.
+ * @return bool indicating whether the field exists as a model virtual field.
  */
 	public function isVirtualField($field) {
 		if (empty($this->virtualFields) || !is_string($field)) {
@@ -1525,9 +1525,9 @@ class Model extends Object implements CakeEventListener {
  * for those fields that are not defined in $data, and clearing previous validation errors.
  * Especially helpful for saving data in loops.
  *
- * @param boolean|array $data Optional data array to assign to the model after it is created. If null or false,
+ * @param bool|array $data Optional data array to assign to the model after it is created. If null or false,
  *   schema data defaults are not merged.
- * @param boolean $filterKey If true, overwrites any primary key input with an empty value
+ * @param bool $filterKey If true, overwrites any primary key input with an empty value
  * @return array The current Model::data; after merging $data and/or defaults from database
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-create-array-data-array
  */
@@ -1559,7 +1559,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * This function is a convenient wrapper class to create(false) and, as the name suggests, clears the id, data, and validation errors.
  *
- * @return boolean Always true upon success
+ * @return bool Always true upon success
  * @see Model::create()
  */
 	public function clear() {
@@ -1572,7 +1572,7 @@ class Model extends Object implements CakeEventListener {
  * data (Model::$data) with the record found.
  *
  * @param string|array $fields String of single field name, or an array of field names.
- * @param integer|string $id The ID of the record to read
+ * @param int|string $id The ID of the record to read
  * @return array Array of database fields, or false if not found
  * @link http://book.cakephp.org/2.0/en/models/retrieving-your-data.html#model-read
  */
@@ -1649,11 +1649,11 @@ class Model extends Object implements CakeEventListener {
  *
  * @param string $name Name of the table field
  * @param mixed $value Value of the field
- * @param boolean|array $validate Either a boolean, or an array.
+ * @param bool|array $validate Either a boolean, or an array.
  *   If a boolean, indicates whether or not to validate before saving.
  *   If an array, allows control of 'validate', 'callbacks' and 'counterCache' options.
  *   See Model::save() for details of each options.
- * @return boolean See Model::save()
+ * @return bool See Model::save()
  * @see Model::save()
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-savefield-string-fieldname-string-fieldvalue-validate-false
  */
@@ -1674,7 +1674,7 @@ class Model extends Object implements CakeEventListener {
  * default, validation occurs before save.
  *
  * @param array $data Data to save.
- * @param boolean|array $validate Either a boolean, or an array.
+ * @param bool|array $validate Either a boolean, or an array.
  *   If a boolean, indicates whether or not to validate before saving.
  *   If an array, can have following keys:
  *
@@ -1880,7 +1880,7 @@ class Model extends Object implements CakeEventListener {
  * Check if the passed in field is a UUID field
  *
  * @param string $field the field to check
- * @return boolean
+ * @return bool
  */
 	protected function _isUUIDField($field) {
 		$field = $this->schema($field);
@@ -1891,7 +1891,7 @@ class Model extends Object implements CakeEventListener {
  * Saves model hasAndBelongsToMany data to the database.
  *
  * @param array $joined Data to save
- * @param integer|string $id ID of record in this model
+ * @param int|string $id ID of record in this model
  * @param DataSource $db Datasource instance.
  * @return void
  */
@@ -2023,7 +2023,7 @@ class Model extends Object implements CakeEventListener {
  * Updates the counter cache of belongsTo associations after a save or delete operation
  *
  * @param array $keys Optional foreign key data, defaults to the information $this->data
- * @param boolean $created True if a new record was created, otherwise only associations with
+ * @param bool $created True if a new record was created, otherwise only associations with
  *   'counterScope' defined get updated
  * @return void
  */
@@ -2287,7 +2287,7 @@ class Model extends Object implements CakeEventListener {
  *
  * @param array &$data Record data to validate. This should be a numerically-indexed array
  * @param array $options Options to use when validating record data (see above), See also $options of validates().
- * @return boolean|array If atomic: True on success, or false on failure.
+ * @return bool|array If atomic: True on success, or false on failure.
  *    Otherwise: array similar to the $data array passed, but values are set to true/false
  *    depending on whether each record validated successfully.
  */
@@ -2486,7 +2486,7 @@ class Model extends Object implements CakeEventListener {
  *
  * @param string $key fieldname to be added to list
  * @param array $options Options list
- * @return array $options
+ * @return array options
  */
 	protected function _addToWhiteList($key, $options) {
 		if (empty($options['fieldList']) && $this->whitelist && !in_array($key, $this->whitelist)) {
@@ -2522,7 +2522,7 @@ class Model extends Object implements CakeEventListener {
  *
  * @param array &$data Record data to validate. This should be an array indexed by association name.
  * @param array $options Options to use when validating record data (see above), See also $options of validates().
- * @return array|boolean If atomic: True on success, or false on failure.
+ * @return array|bool If atomic: True on success, or false on failure.
  *    Otherwise: array similar to the $data array passed, but values are set to true/false
  *    depending on whether each record validated successfully.
  */
@@ -2536,7 +2536,7 @@ class Model extends Object implements CakeEventListener {
  * @param array $fields Set of fields and values, indexed by fields.
  *    Fields are treated as SQL snippets, to insert literal values manually escape your data.
  * @param mixed $conditions Conditions to match, true for all records
- * @return boolean True on success, false on failure
+ * @return bool True on success, false on failure
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-updateall-array-fields-array-conditions
  */
 	public function updateAll($fields, $conditions = true) {
@@ -2546,9 +2546,9 @@ class Model extends Object implements CakeEventListener {
 /**
  * Removes record for given ID. If no ID is given, the current ID is used. Returns true on success.
  *
- * @param integer|string $id ID of record to delete
- * @param boolean $cascade Set to true to delete records that depend on this record
- * @return boolean True on success
+ * @param int|string $id ID of record to delete
+ * @param bool $cascade Set to true to delete records that depend on this record
+ * @return bool True on success
  * @link http://book.cakephp.org/2.0/en/models/deleting-data.html
  */
 	public function delete($id = null, $cascade = true) {
@@ -2608,7 +2608,7 @@ class Model extends Object implements CakeEventListener {
  * Cascades model deletes through associated hasMany and hasOne child records.
  *
  * @param string $id ID of record that was deleted
- * @param boolean $cascade Set to true to delete records that depend on this record
+ * @param bool $cascade Set to true to delete records that depend on this record
  * @return void
  */
 	protected function _deleteDependent($id, $cascade) {
@@ -2688,9 +2688,9 @@ class Model extends Object implements CakeEventListener {
  * Deletes multiple model records based on a set of conditions.
  *
  * @param mixed $conditions Conditions to match
- * @param boolean $cascade Set to true to delete records that depend on this record
- * @param boolean $callbacks Run callbacks
- * @return boolean True on success, false on failure
+ * @param bool $cascade Set to true to delete records that depend on this record
+ * @param bool $callbacks Run callbacks
+ * @return bool True on success, false on failure
  * @link http://book.cakephp.org/2.0/en/models/deleting-data.html#deleteall
  */
 	public function deleteAll($conditions, $cascade = true, $callbacks = false) {
@@ -2766,8 +2766,8 @@ class Model extends Object implements CakeEventListener {
  * and then performs a `Model::find('count')` on the currently configured datasource
  * to ascertain the existence of the record in persistent storage.
  *
- * @param integer|string $id ID of record to check for existence
- * @return boolean True if such a record exists
+ * @param int|string $id ID of record to check for existence
+ * @return bool True if such a record exists
  */
 	public function exists($id = null) {
 		if ($id === null) {
@@ -2791,7 +2791,7 @@ class Model extends Object implements CakeEventListener {
  * Returns true if a record that meets given conditions exists.
  *
  * @param array $conditions SQL conditions array
- * @return boolean True if such a record exists
+ * @return bool True if such a record exists
  */
 	public function hasAny($conditions = null) {
 		return (bool)$this->find('count', array('conditions' => $conditions, 'recursive' => -1));
@@ -3011,7 +3011,7 @@ class Model extends Object implements CakeEventListener {
  * @param string $state Either "before" or "after"
  * @param array $query Query.
  * @param array $results Results.
- * @return integer The number of records found, or false
+ * @return int The number of records found, or false
  * @see Model::find()
  */
 	protected function _findCount($state, $query, $results = array()) {
@@ -3208,7 +3208,7 @@ class Model extends Object implements CakeEventListener {
  * Passes query results through model and behavior afterFind() methods.
  *
  * @param array $results Results to filter
- * @param boolean $primary If this is the primary model results (results from model where the find operation was performed)
+ * @param bool $primary If this is the primary model results (results from model where the find operation was performed)
  * @return array Set of filtered results
  */
 	protected function _filterResults($results, $primary = true) {
@@ -3223,7 +3223,7 @@ class Model extends Object implements CakeEventListener {
  * to those originally defined in the model. Normally called at the end
  * of each call to Model::find()
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function resetAssociations() {
 		if (!empty($this->__backAssociation)) {
@@ -3252,8 +3252,8 @@ class Model extends Object implements CakeEventListener {
  * Returns false if any fields passed match any (by default, all if $or = false) of their matching values.
  *
  * @param array $fields Field/value pairs to search (if no values specified, they are pulled from $this->data)
- * @param boolean $or If false, all fields specified must match in order for a false return value
- * @return boolean False if any records matching any fields are found
+ * @param bool $or If false, all fields specified must match in order for a false return value
+ * @return bool False if any records matching any fields are found
  */
 	public function isUnique($fields, $or = true) {
 		if (!is_array($fields)) {
@@ -3319,7 +3319,7 @@ class Model extends Object implements CakeEventListener {
  * Will validate the currently set data. Use Model::set() or Model::create() to set the active data.
  *
  * @param array $options An optional array of custom options to be made available in the beforeValidate callback
- * @return boolean True if there are no errors
+ * @return bool True if there are no errors
  */
 	public function validates($options = array()) {
 		return $this->validator()->validates($options);
@@ -3355,7 +3355,7 @@ class Model extends Object implements CakeEventListener {
  * Returns true if given field name is a foreign key in this model.
  *
  * @param string $field Returns true if the input string ends in "_id"
- * @return boolean True if the field is a foreign key listed in the belongsTo array.
+ * @return bool True if the field is a foreign key listed in the belongsTo array.
  */
 	public function isForeignKey($field) {
 		$foreignKeys = array();
@@ -3396,7 +3396,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Returns the current record's ID
  *
- * @param integer $list Index on which the composed ID is located
+ * @param int $list Index on which the composed ID is located
  * @return mixed The ID of the current record, false if no ID
  */
 	public function getID($list = 0) {
@@ -3440,7 +3440,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Sets the ID of the last record this model inserted
  *
- * @param integer|string $id Last inserted ID
+ * @param int|string $id Last inserted ID
  * @return void
  */
 	public function setInsertID($id) {
@@ -3450,7 +3450,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Returns the number of rows returned from the last query.
  *
- * @return integer Number of rows
+ * @return int Number of rows
  */
 	public function getNumRows() {
 		return $this->getDataSource()->lastNumRows();
@@ -3459,7 +3459,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Returns the number of rows affected by the last query.
  *
- * @return integer Number of rows
+ * @return int Number of rows
  */
 	public function getAffectedRows() {
 		return $this->getDataSource()->lastAffected();
@@ -3609,7 +3609,7 @@ class Model extends Object implements CakeEventListener {
  * Return value should be the (modified) results.
  *
  * @param mixed $results The results of the find operation
- * @param boolean $primary Whether this model is being queried directly (vs. being queried as an association)
+ * @param bool $primary Whether this model is being queried directly (vs. being queried as an association)
  * @return mixed Result of the find operation
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#afterfind
  */
@@ -3622,7 +3622,7 @@ class Model extends Object implements CakeEventListener {
  * to halt the save.
  *
  * @param array $options Options passed from Model::save().
- * @return boolean True if the operation should continue, false if it should abort
+ * @return bool True if the operation should continue, false if it should abort
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforesave
  * @see Model::save()
  */
@@ -3633,7 +3633,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Called after each successful save operation.
  *
- * @param boolean $created True if this save created a new record
+ * @param bool $created True if this save created a new record
  * @param array $options Options passed from Model::save().
  * @return void
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#aftersave
@@ -3645,8 +3645,8 @@ class Model extends Object implements CakeEventListener {
 /**
  * Called before every deletion operation.
  *
- * @param boolean $cascade If true records that depend on this record will also be deleted
- * @return boolean True if the operation should continue, false if it should abort
+ * @param bool $cascade If true records that depend on this record will also be deleted
+ * @return bool True if the operation should continue, false if it should abort
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforedelete
  */
 	public function beforeDelete($cascade = true) {
@@ -3667,7 +3667,7 @@ class Model extends Object implements CakeEventListener {
  * validation rules can be defined in $validate.
  *
  * @param array $options Options passed from Model::save().
- * @return boolean True if validate operation should continue, false to abort
+ * @return bool True if validate operation should continue, false to abort
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforevalidate
  * @see Model::save()
  */

--- a/lib/Cake/Model/ModelBehavior.php
+++ b/lib/Cake/Model/ModelBehavior.php
@@ -115,7 +115,7 @@ class ModelBehavior extends Object {
  *
  * @param Model $model Model using this behavior
  * @param array $query Data used to execute this query, i.e. conditions, order, etc.
- * @return boolean|array False or null will abort the operation. You can return an array to replace the
+ * @return bool|array False or null will abort the operation. You can return an array to replace the
  *   $query that will be eventually run.
  */
 	public function beforeFind(Model $model, $query) {
@@ -127,7 +127,7 @@ class ModelBehavior extends Object {
  *
  * @param Model $model Model using this behavior
  * @param mixed $results The results of the find operation
- * @param boolean $primary Whether this model is being queried directly (vs. being queried as an association)
+ * @param bool $primary Whether this model is being queried directly (vs. being queried as an association)
  * @return mixed An array value will replace the value of $results - any other value will be ignored.
  */
 	public function afterFind(Model $model, $results, $primary = false) {
@@ -175,9 +175,9 @@ class ModelBehavior extends Object {
  * afterSave is called after a model is saved.
  *
  * @param Model $model Model using this behavior
- * @param boolean $created True if this save created a new record
+ * @param bool $created True if this save created a new record
  * @param array $options Options passed from Model::save().
- * @return boolean
+ * @return bool
  * @see Model::save()
  */
 	public function afterSave(Model $model, $created, $options = array()) {
@@ -189,7 +189,7 @@ class ModelBehavior extends Object {
  * beforeDelete is called. Returning false from a beforeDelete will abort the delete.
  *
  * @param Model $model Model using this behavior
- * @param boolean $cascade If true records that depend on this record will also be deleted
+ * @param bool $cascade If true records that depend on this record will also be deleted
  * @return mixed False if the operation should abort. Any other result will continue.
  */
 	public function beforeDelete(Model $model, $cascade = true) {

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -93,7 +93,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * Will validate the currently set data. Use `Model::set()` or `Model::create()` to set the active data.
  *
  * @param array $options An optional array of custom options to be made available in the beforeValidate callback
- * @return boolean True if there are no errors
+ * @return bool True if there are no errors
  */
 	public function validates($options = array()) {
 		$errors = $this->errors($options);
@@ -121,7 +121,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  *
  * @param array &$data Record data to validate. This should be an array indexed by association name.
  * @param array $options Options to use when validating record data (see above), See also $options of validates().
- * @return array|boolean If atomic: True on success, or false on failure.
+ * @return array|bool If atomic: True on success, or false on failure.
  *    Otherwise: array similar to the $data array passed, but values are set to true/false
  *    depending on whether each record validated successfully.
  */
@@ -335,7 +335,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * Sets the CakeValidationSet objects from the `Model::$validate` property
  * If `Model::$validate` is not set or empty, this method returns false. True otherwise.
  *
- * @return boolean true if `Model::$validate` was processed, false otherwise
+ * @return bool true if `Model::$validate` was processed, false otherwise
  */
 	protected function _parseRules() {
 		if ($this->_validate === $this->_model->validate) {
@@ -408,7 +408,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * set and data in the data set.
  *
  * @param array $options Array of options to use on Validation of with models
- * @return boolean Failure of validation on with models.
+ * @return bool Failure of validation on with models.
  * @see Model::validates()
  */
 	protected function _validateWithModels($options) {
@@ -443,7 +443,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * Propagates beforeValidate event
  *
  * @param array $options Options to pass to callback.
- * @return boolean
+ * @return bool
  */
 	protected function _triggerBeforeValidate($options = array()) {
 		$model = $this->getModel();
@@ -460,7 +460,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * Returns whether a rule set is defined for a field or not
  *
  * @param string $field name of the field to check
- * @return boolean
+ * @return bool
  */
 	public function offsetExists($field) {
 		$this->_parseRules();
@@ -519,7 +519,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Returns the number of fields having validation rules
  *
- * @return integer
+ * @return int
  */
 	public function count() {
 		$this->_parseRules();

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -28,7 +26,7 @@ class Permission extends AppModel {
 /**
  * Explicitly disable in-memory query caching
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 
@@ -71,7 +69,7 @@ class Permission extends AppModel {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $action Action (defaults to *)
- * @return boolean Success (true if ARO has access to action in ACO, false otherwise)
+ * @return bool Success (true if ARO has access to action in ACO, false otherwise)
  */
 	public function check($aro, $aco, $action = '*') {
 		if (!$aro || !$aco) {
@@ -166,8 +164,8 @@ class Permission extends AppModel {
  * @param string $aro ARO The requesting object identifier.
  * @param string $aco ACO The controlled object identifier.
  * @param string $actions Action (defaults to *) Invalid permissions will result in an exception
- * @param integer $value Value to indicate access type (1 to give access, -1 to deny, 0 to inherit)
- * @return boolean Success
+ * @param int $value Value to indicate access type (1 to give access, -1 to deny, 0 to inherit)
+ * @return bool Success
  * @throws AclException on Invalid permission key.
  */
 	public function allow($aro, $aco, $actions = '*', $value = 1) {

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -39,7 +39,7 @@ class CakeValidationRule {
 /**
  * Holds whether the record being validated exists in datasource or not
  *
- * @var boolean
+ * @var bool
  */
 	protected $_recordExists = false;
 
@@ -81,7 +81,7 @@ class CakeValidationRule {
 /**
  * The 'allowEmpty' key
  *
- * @var boolean
+ * @var bool
  */
 	public $allowEmpty = null;
 
@@ -95,7 +95,7 @@ class CakeValidationRule {
 /**
  * The 'last' key
  *
- * @var boolean
+ * @var bool
  */
 	public $last = true;
 
@@ -118,7 +118,7 @@ class CakeValidationRule {
 /**
  * Checks if the rule is valid
  *
- * @return boolean
+ * @return bool
  */
 	public function isValid() {
 		if (!$this->_valid || (is_string($this->_valid) && !empty($this->_valid))) {
@@ -131,7 +131,7 @@ class CakeValidationRule {
 /**
  * Returns whether the field can be left blank according to this rule
  *
- * @return boolean
+ * @return bool
  */
 	public function isEmptyAllowed() {
 		return $this->skip() || $this->allowEmpty === true;
@@ -140,7 +140,7 @@ class CakeValidationRule {
 /**
  * Checks if the field is required according to the `required` property
  *
- * @return boolean
+ * @return bool
  */
 	public function isRequired() {
 		if (in_array($this->required, array('create', 'update'), true)) {
@@ -158,7 +158,7 @@ class CakeValidationRule {
  *
  * @param string $field Field name
  * @param array &$data Data to check rule against
- * @return boolean
+ * @return bool
  */
 	public function checkRequired($field, &$data) {
 		return (
@@ -175,7 +175,7 @@ class CakeValidationRule {
  *
  * @param string $field Field name
  * @param array &$data data to check rule against
- * @return boolean
+ * @return bool
  */
 	public function checkEmpty($field, &$data) {
 		if (empty($data[$field]) && $data[$field] != '0' && $this->allowEmpty === true) {
@@ -187,7 +187,7 @@ class CakeValidationRule {
 /**
  * Checks if the validation rule should be skipped
  *
- * @return boolean True if the ValidationRule can be skipped
+ * @return bool True if the ValidationRule can be skipped
  */
 	public function skip() {
 		if (!empty($this->on)) {
@@ -202,7 +202,7 @@ class CakeValidationRule {
  * Returns whether this rule should break validation process for associated field
  * after it fails
  *
- * @return boolean
+ * @return bool
  */
 	public function isLast() {
 		return (bool)$this->last;
@@ -245,8 +245,8 @@ class CakeValidationRule {
  * If called with no parameters it will return whether this rule
  * is configured for update operations or not.
  *
- * @param boolean $exists Boolean to indicate if records exists
- * @return boolean
+ * @param bool $exists Boolean to indicate if records exists
+ * @return bool
  */
 	public function isUpdate($exists = null) {
 		if ($exists === null) {
@@ -261,7 +261,7 @@ class CakeValidationRule {
  * @param string $field Field name
  * @param array &$data Data array
  * @param array &$methods Methods list
- * @return boolean True if the rule could be dispatched, false otherwise
+ * @return bool True if the rule could be dispatched, false otherwise
  */
 	public function process($field, &$data, &$methods) {
 		$this->_valid = true;
@@ -299,7 +299,7 @@ class CakeValidationRule {
 /**
  * Returns passed options for this rule
  *
- * @param string|integer $key Array index
+ * @param string|int $key Array index
  * @return array
  */
 	public function getOptions($key) {

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -53,7 +53,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Whether the validation is stopped
  *
- * @var boolean
+ * @var bool
  */
 	public $isStopped = false;
 
@@ -115,7 +115,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * validation errors
  *
  * @param array $data Data array
- * @param boolean $isUpdate Is record being updated or created
+ * @param bool $isUpdate Is record being updated or created
  * @return array list of validation errors for this field
  */
 	public function validate($data, $isUpdate = false) {
@@ -233,7 +233,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * }}}
  *
  * @param array $rules The rules to be set
- * @param boolean $mergeVars [optional] If true, merges vars instead of replace. Defaults to true.
+ * @param bool $mergeVars [optional] If true, merges vars instead of replace. Defaults to true.
  * @return $this
  */
 	public function setRules($rules = array(), $mergeVars = true) {
@@ -308,7 +308,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * Returns whether an index exists in the rule set
  *
  * @param string $index name of the rule
- * @return boolean
+ * @return bool
  */
 	public function offsetExists($index) {
 		return isset($this->_rules[$index]);
@@ -361,7 +361,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Returns the number of rules in this set
  *
- * @return integer
+ * @return int
  */
 	public function count() {
 		return count($this->_rules);

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -126,7 +126,7 @@ class CakeRequest implements ArrayAccess {
  * Constructor
  *
  * @param string $url Trimmed URL string to use. Should not contain the application base path.
- * @param boolean $parseEnvironment Set to false to not auto parse the environment. ie. GET, POST and FILES.
+ * @param bool $parseEnvironment Set to false to not auto parse the environment. ie. GET, POST and FILES.
  */
 	public function __construct($url = null, $parseEnvironment = true) {
 		$this->_base();
@@ -386,7 +386,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Get the IP the client is using, or says they are using.
  *
- * @param boolean $safe Use safe = false when you think the user might manipulate their HTTP_CLIENT_IP
+ * @param bool $safe Use safe = false when you think the user might manipulate their HTTP_CLIENT_IP
  *   header. Setting $safe = false will also look at HTTP_X_FORWARDED_FOR
  * @return string The client IP.
  */
@@ -414,7 +414,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Returns the referer that referred this request.
  *
- * @param boolean $local Attempt to return a local address. Local addresses do not contain hostnames.
+ * @param bool $local Attempt to return a local address. Local addresses do not contain hostnames.
  * @return string The referring address for this request.
  */
 	public function referer($local = false) {
@@ -471,7 +471,7 @@ class CakeRequest implements ArrayAccess {
  * on routing parameters.
  *
  * @param string $name The property being accessed.
- * @return boolean Existence
+ * @return bool Existence
  */
 	public function __isset($name) {
 		return isset($this->params[$name]);
@@ -486,7 +486,7 @@ class CakeRequest implements ArrayAccess {
  *
  * @param string|array $type The type of request you want to check. If an array
  *   this method will return true if the request matches any type.
- * @return boolean Whether or not the request is the type you are checking.
+ * @return bool Whether or not the request is the type you are checking.
  */
 	public function is($type) {
 		if (is_array($type)) {
@@ -534,7 +534,7 @@ class CakeRequest implements ArrayAccess {
  * built-in types.
  *
  * @param array $types The types to check.
- * @return boolean Success.
+ * @return bool Success.
  * @see CakeRequest::is()
  */
 	public function isAll(array $types) {
@@ -628,7 +628,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Get the value of the current requests URL. Will include named parameters and querystring arguments.
  *
- * @param boolean $base Include the base path, set to false to trim the base path off.
+ * @param bool $base Include the base path, set to false to trim the base path off.
  * @return string the current request URL including query string args.
  */
 	public function here($base = true) {
@@ -676,7 +676,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Get the host that the request was handled on.
  *
- * @param boolean $trustProxy Whether or not to trust the proxy host.
+ * @param bool $trustProxy Whether or not to trust the proxy host.
  * @return string
  */
 	public function host($trustProxy = false) {
@@ -689,7 +689,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Get the domain name and include $tldLength segments of the tld.
  *
- * @param integer $tldLength Number of segments your tld contains. For example: `example.com` contains 1 tld.
+ * @param int $tldLength Number of segments your tld contains. For example: `example.com` contains 1 tld.
  *   While `example.co.uk` contains 2.
  * @return string Domain name without subdomains.
  */
@@ -702,7 +702,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Get the subdomains for a host.
  *
- * @param integer $tldLength Number of segments your tld contains. For example: `example.com` contains 1 tld.
+ * @param int $tldLength Number of segments your tld contains. For example: `example.com` contains 1 tld.
  *   While `example.co.uk` contains 2.
  * @return array An array of subdomains.
  */
@@ -924,7 +924,7 @@ class CakeRequest implements ArrayAccess {
  * and a 405 error will be returned.
  *
  * @param string|array $methods Allowed HTTP request methods.
- * @return boolean true
+ * @return bool true
  * @throws MethodNotAllowedException
  */
 	public function allowMethod($methods) {
@@ -946,7 +946,7 @@ class CakeRequest implements ArrayAccess {
  * Alias of CakeRequest::allowMethod() for backwards compatibility.
  *
  * @param string|array $methods Allowed HTTP request methods.
- * @return boolean true
+ * @return bool true
  * @throws MethodNotAllowedException
  * @see CakeRequest::allowMethod()
  * @deprecated 2.5 Use CakeRequest::allowMethod() instead.
@@ -1007,7 +1007,7 @@ class CakeRequest implements ArrayAccess {
  * Array access isset() implementation
  *
  * @param string $name thing to check.
- * @return boolean
+ * @return bool
  */
 	public function offsetExists($name) {
 		return isset($this->params[$name]);

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -312,7 +312,7 @@ class CakeResponse {
 /**
  * Status code to send to the client
  *
- * @var integer
+ * @var int
  */
 	protected $_status = 200;
 
@@ -320,7 +320,7 @@ class CakeResponse {
  * Content type to send. This can be an 'extension' that will be transformed using the $_mimetypes array
  * or a complete mime-type
  *
- * @var integer
+ * @var int
  */
 	protected $_contentType = 'text/html';
 
@@ -617,8 +617,8 @@ class CakeResponse {
  * Sets the HTTP status code to be sent
  * if $code is null the current code is returned
  *
- * @param integer $code the HTTP status code
- * @return integer current status code
+ * @param int $code the HTTP status code
+ * @return int current status code
  * @throws CakeException When an unknown status code is reached.
  */
 	public function statusCode($code = null) {
@@ -634,7 +634,7 @@ class CakeResponse {
 /**
  * Queries & sets valid HTTP response codes & messages.
  *
- * @param integer|array $code If $code is an integer, then the corresponding code/message is
+ * @param int|array $code If $code is an integer, then the corresponding code/message is
  *        returned if it exists, null if it does not exist. If $code is an array, then the
  *        keys are used as codes and the values as messages to add to the default HTTP
  *        codes. The codes must be integers greater than 99 and less than 1000. Keep in
@@ -814,11 +814,11 @@ class CakeResponse {
  * This method controls the `public` or `private` directive in the Cache-Control
  * header
  *
- * @param boolean $public If set to true, the Cache-Control header will be set as public
+ * @param bool $public If set to true, the Cache-Control header will be set as public
  *   if set to false, the response will be set to private
  *   if no value is provided, it will return whether the response is sharable or not
- * @param integer $time time in seconds after which the response should no longer be considered fresh
- * @return boolean
+ * @param int $time time in seconds after which the response should no longer be considered fresh
+ * @return bool
  */
 	public function sharable($public = null, $time = null) {
 		if ($public === null) {
@@ -852,8 +852,8 @@ class CakeResponse {
  * a good candidate to be fetched from a shared cache (like in a proxy server).
  * If called with no parameters, this function will return the current max-age value if any
  *
- * @param integer $seconds if null, the method will return the current s-maxage value
- * @return integer
+ * @param int $seconds if null, the method will return the current s-maxage value
+ * @return int
  */
 	public function sharedMaxAge($seconds = null) {
 		if ($seconds !== null) {
@@ -872,8 +872,8 @@ class CakeResponse {
  * a good candidate to be fetched from the local (client) cache.
  * If called with no parameters, this function will return the current max-age value if any
  *
- * @param integer $seconds if null, the method will return the current max-age value
- * @return integer
+ * @param int $seconds if null, the method will return the current max-age value
+ * @return int
  */
 	public function maxAge($seconds = null) {
 		if ($seconds !== null) {
@@ -893,9 +893,9 @@ class CakeResponse {
  * with the origin.
  * If called with no parameters, this function will return whether must-revalidate is present.
  *
- * @param boolean $enable If null returns whether directive is set, if boolean
+ * @param bool $enable If null returns whether directive is set, if boolean
  *   sets or unsets directive.
- * @return boolean
+ * @return bool
  */
 	public function mustRevalidate($enable = null) {
 		if ($enable !== null) {
@@ -1035,7 +1035,7 @@ class CakeResponse {
  * If no parameters are passed, current Etag header is returned.
  *
  * @param string $tag Tag to set.
- * @param boolean $weak whether the response is semantically the same as
+ * @param bool $weak whether the response is semantically the same as
  *   other with the same hash or not
  * @return string
  */
@@ -1072,7 +1072,7 @@ class CakeResponse {
  * Sets the correct output buffering handler to send a compressed response. Responses will
  * be compressed with zlib, if the extension is available.
  *
- * @return boolean false if client does not accept compressed responses or no handler is available, true otherwise
+ * @return bool false if client does not accept compressed responses or no handler is available, true otherwise
  */
 	public function compress() {
 		$compressionEnabled = ini_get("zlib.output_compression") !== '1' &&
@@ -1084,7 +1084,7 @@ class CakeResponse {
 /**
  * Returns whether the resulting output will be compressed by PHP
  *
- * @return boolean
+ * @return bool
  */
 	public function outputCompressed() {
 		return strpos(env('HTTP_ACCEPT_ENCODING'), 'gzip') !== false
@@ -1119,8 +1119,8 @@ class CakeResponse {
  * Sets the Content-Length header for the response
  * If called with no arguments returns the last Content-Length set
  *
- * @param integer $bytes Number of bytes
- * @return integer|null
+ * @param int $bytes Number of bytes
+ * @return int|null
  */
 	public function length($bytes = null) {
 		if ($bytes !== null) {
@@ -1143,7 +1143,7 @@ class CakeResponse {
  * a comparison will not be possible.
  *
  * @param CakeRequest $request Request object
- * @return boolean whether the response was marked as not modified or not.
+ * @return bool whether the response was marked as not modified or not.
  */
 	public function checkNotModified(CakeRequest $request) {
 		$etags = preg_split('/\s*,\s*/', $request->header('If-None-Match'), null, PREG_SPLIT_NO_EMPTY);
@@ -1289,7 +1289,7 @@ class CakeResponse {
  * Normalize the origin to regular expressions and put in an array format
  *
  * @param array $domains Domains to normalize
- * @param boolean $requestIsSSL Whether it's a SSL request.
+ * @param bool $requestIsSSL Whether it's a SSL request.
  * @return array
  */
 	protected function _normalizeCorsDomains($domains, $requestIsSSL = false) {
@@ -1440,7 +1440,7 @@ class CakeResponse {
  *
  * @param File $file File object
  * @param array $range The range to read out of the file.
- * @return boolean True is whole file is echoed successfully or false if client connection is lost in between
+ * @return bool True is whole file is echoed successfully or false if client connection is lost in between
  */
 	protected function _sendFile($file, $range) {
 		$compress = $this->outputCompressed();
@@ -1481,7 +1481,7 @@ class CakeResponse {
 /**
  * Returns true if connection is still active
  *
- * @return boolean
+ * @return bool
  */
 	protected function _isActive() {
 		return connection_status() === CONNECTION_NORMAL && !connection_aborted();
@@ -1490,7 +1490,7 @@ class CakeResponse {
 /**
  * Clears the contents of the topmost output buffer and discards them
  *
- * @return boolean
+ * @return bool
  */
 	protected function _clearBuffer() {
 		//@codingStandardsIgnoreStart

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -64,7 +64,7 @@ class CakeSocket {
 /**
  * This boolean contains the current state of the CakeSocket class
  *
- * @var boolean
+ * @var bool
  */
 	public $connected = false;
 
@@ -78,7 +78,7 @@ class CakeSocket {
 /**
  * True if the socket stream is encrypted after a CakeSocket::enableCrypto() call
  *
- * @var boolean
+ * @var bool
  */
 	public $encrypted = false;
 
@@ -124,7 +124,7 @@ class CakeSocket {
 /**
  * Connect the socket to the given host and port.
  *
- * @return boolean Success
+ * @return bool Success
  * @throws SocketException
  */
 	public function connect() {
@@ -182,7 +182,7 @@ class CakeSocket {
  *
  * Instead we need to handle those errors manually.
  *
- * @param integer $code Code.
+ * @param int $code Code.
  * @param string $message Message.
  * @return void
  */
@@ -253,7 +253,7 @@ class CakeSocket {
 /**
  * Set the last error.
  *
- * @param integer $errNum Error code
+ * @param int $errNum Error code
  * @param string $errStr Error string
  * @return void
  */
@@ -265,7 +265,7 @@ class CakeSocket {
  * Write data to the socket.
  *
  * @param string $data The data to write to the socket
- * @return boolean Success
+ * @return bool Success
  */
 	public function write($data) {
 		if (!$this->connected) {
@@ -287,7 +287,7 @@ class CakeSocket {
  * Read data from the socket. Returns false if no data is available or no connection could be
  * established.
  *
- * @param integer $length Optional buffer length to read; defaults to 1024
+ * @param int $length Optional buffer length to read; defaults to 1024
  * @return mixed Socket data
  */
 	public function read($length = 1024) {
@@ -312,7 +312,7 @@ class CakeSocket {
 /**
  * Disconnect the socket from the current connection.
  *
- * @return boolean Success
+ * @return bool Success
  */
 	public function disconnect() {
 		if (!is_resource($this->connection)) {
@@ -338,7 +338,7 @@ class CakeSocket {
  * Resets the state of this Socket instance to it's initial state (before Object::__construct got executed)
  *
  * @param array $state Array with key and values to reset
- * @return boolean True on success
+ * @return bool True on success
  */
 	public function reset($state = null) {
 		if (empty($state)) {
@@ -360,8 +360,8 @@ class CakeSocket {
  *
  * @param string $type can be one of 'ssl2', 'ssl3', 'ssl23' or 'tls'
  * @param string $clientOrServer can be one of 'client', 'server'. Default is 'client'
- * @param boolean $enable enable or disable encryption. Default is true (enable)
- * @return boolean True on success
+ * @param bool $enable enable or disable encryption. Default is true (enable)
+ * @return bool True on success
  * @throws InvalidArgumentException When an invalid encryption scheme is chosen.
  * @throws SocketException When attempting to enable SSL/TLS fails
  * @see stream_socket_enable_crypto

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -40,14 +40,14 @@ class CakeEmail {
 /**
  * Line length - no should more - RFC 2822 - 2.1.1
  *
- * @var integer
+ * @var int
  */
 	const LINE_LENGTH_SHOULD = 78;
 
 /**
  * Line length - no must more - RFC 2822 - 2.1.1
  *
- * @var integer
+ * @var int
  */
 	const LINE_LENGTH_MUST = 998;
 
@@ -133,7 +133,7 @@ class CakeEmail {
 /**
  * Message ID
  *
- * @var boolean|string True to generate, False to ignore, String with value
+ * @var bool|string
  */
 	protected $_messageId = true;
 
@@ -517,7 +517,7 @@ class CakeEmail {
  * Charset setter/getter
  *
  * @param string $charset Character set.
- * @return string $this->charset
+ * @return string this->charset
  */
 	public function charset($charset = null) {
 		if ($charset === null) {
@@ -534,7 +534,7 @@ class CakeEmail {
  * HeaderCharset setter/getter
  *
  * @param string $charset Character set.
- * @return string $this->charset
+ * @return string this->charset
  */
 	public function headerCharset($charset = null) {
 		if ($charset === null) {
@@ -819,8 +819,8 @@ class CakeEmail {
 /**
  * Template and layout
  *
- * @param boolean|string $template Template name or null to not use
- * @param boolean|string $layout Layout name or null to not use
+ * @param bool|string $template Template name or null to not use
+ * @param bool|string $layout Layout name or null to not use
  * @return array|$this
  */
 	public function template($template = false, $layout = false) {
@@ -951,8 +951,8 @@ class CakeEmail {
 /**
  * Message-ID
  *
- * @param boolean|string $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
- * @return boolean|string|$this
+ * @param bool|string $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
+ * @return bool|string|$this
  * @throws SocketException
  */
 	public function messageId($message = null) {
@@ -1175,7 +1175,7 @@ class CakeEmail {
  * @param string $subject String of subject or null to use 'subject' from transport config
  * @param string|array $message String with message or array with variables to be used in render
  * @param string|array $transportConfig String to use config from EmailConfig or array with configs
- * @param boolean $send Send the email or just return the instance pre-configured
+ * @param bool $send Send the email or just return the instance pre-configured
  * @return CakeEmail Instance of CakeEmail
  * @throws SocketException
  */
@@ -1335,7 +1335,7 @@ class CakeEmail {
  * Wrap the message to follow the RFC 2822 - 2.1.1
  *
  * @param string $message Message to wrap
- * @param integer $wrapLength The line length
+ * @param int $wrapLength The line length
  * @return array Wrapped message
  */
 	protected function _wrap($message, $wrapLength = CakeEmail::LINE_LENGTH_MUST) {

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -336,7 +336,7 @@ class SmtpTransport extends AbstractTransport {
  * Protected method for sending data to SMTP connection
  *
  * @param string $data data to be sent to SMTP server
- * @param string|boolean $checkCode code to check for in server response, false to skip
+ * @param string|bool $checkCode code to check for in server response, false to skip
  * @return void
  * @throws SocketException
  */

--- a/lib/Cake/Network/Http/DigestAuthentication.php
+++ b/lib/Cake/Network/Http/DigestAuthentication.php
@@ -45,7 +45,7 @@ class DigestAuthentication {
  *
  * @param HttpSocket $http Http socket instance.
  * @param array &$authInfo Authentication info.
- * @return boolean
+ * @return bool
  */
 	protected static function _getServerInformation(HttpSocket $http, &$authInfo) {
 		$originalRequest = $http->request;

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -35,7 +35,7 @@ class HttpSocket extends CakeSocket {
  * enforce RFC 2616 (HTTP/1.1 specs).
  * will be disabled and additional measures to deal with non-standard responses will be enabled.
  *
- * @var boolean
+ * @var bool
  */
 	public $quirksMode = false;
 
@@ -210,7 +210,7 @@ class HttpSocket extends CakeSocket {
  * Set proxy settings
  *
  * @param string|array $host Proxy host. Can be an array with settings to authentication class
- * @param integer $port Port. Default 3128.
+ * @param int $port Port. Default 3128.
  * @param string $method Proxy method (ie, Basic, Digest). If empty, disable proxy authentication
  * @param string $user Username if your proxy need authentication
  * @param string $pass Password to proxy authentication
@@ -231,7 +231,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Set the resource to receive the request content. This resource must support fwrite.
  *
- * @param resource|boolean $resource Resource or false to disable the resource use
+ * @param resource|bool $resource Resource or false to disable the resource use
  * @return void
  * @throws SocketException
  */
@@ -640,7 +640,7 @@ class HttpSocket extends CakeSocket {
  * Parses and sets the specified URI into current request configuration.
  *
  * @param string|array $uri URI, See HttpSocket::_parseUri()
- * @return boolean If uri has merged in config
+ * @return bool If uri has merged in config
  */
 	protected function _configUri($uri = null) {
 		if (empty($uri)) {
@@ -745,7 +745,7 @@ class HttpSocket extends CakeSocket {
  * such as 'scheme', 'port', 'query'.
  *
  * @param string|array $uri URI to parse
- * @param boolean|array $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
+ * @param bool|array $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
  * @return array Parsed URI
  */
 	protected function _parseUri($uri = null, $base = array()) {
@@ -984,7 +984,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Gets escape chars according to RFC 2616 (HTTP 1.1 specs).
  *
- * @param boolean $hex true to get them as HEX values, false otherwise
+ * @param bool $hex true to get them as HEX values, false otherwise
  * @param array $chars Characters to escape
  * @return array Escape chars
  */
@@ -1012,8 +1012,8 @@ class HttpSocket extends CakeSocket {
  * Resets the state of this HttpSocket instance to it's initial state (before Object::__construct got executed) or does
  * the same thing partially for the request and the response property only.
  *
- * @param boolean $full If set to false only HttpSocket::response and HttpSocket::request are reset
- * @return boolean True on success
+ * @param bool $full If set to false only HttpSocket::response and HttpSocket::request are reset
+ * @return bool True on success
  */
 	public function reset($full = true) {
 		static $initalState = array();

--- a/lib/Cake/Network/Http/HttpSocketResponse.php
+++ b/lib/Cake/Network/Http/HttpSocketResponse.php
@@ -53,7 +53,7 @@ class HttpSocketResponse implements ArrayAccess {
 /**
  * Response code
  *
- * @var integer
+ * @var int
  */
 	public $code = 0;
 
@@ -124,7 +124,7 @@ class HttpSocketResponse implements ArrayAccess {
 /**
  * If return is 200 (OK)
  *
- * @return boolean
+ * @return bool
  */
 	public function isOk() {
 		return in_array($this->code, array(200, 201, 202, 203, 204, 205, 206));
@@ -133,7 +133,7 @@ class HttpSocketResponse implements ArrayAccess {
 /**
  * If return is a valid 3xx (Redirection)
  *
- * @return boolean
+ * @return bool
  */
 	public function isRedirect() {
 		return in_array($this->code, array(301, 302, 303, 307)) && $this->getHeader('Location') !== null;
@@ -186,7 +186,7 @@ class HttpSocketResponse implements ArrayAccess {
  * 'body' and 'header' or false on failure.
  *
  * @param string $body A string containing the body to decode.
- * @param string|boolean $encoding Can be false in case no encoding is being used, or a string representing the encoding.
+ * @param string|bool $encoding Can be false in case no encoding is being used, or a string representing the encoding.
  * @return mixed Array of response headers and body or false.
  */
 	protected function _decodeBody($body, $encoding = 'chunked') {
@@ -344,7 +344,7 @@ class HttpSocketResponse implements ArrayAccess {
 /**
  * Gets escape chars according to RFC 2616 (HTTP 1.1 specs).
  *
- * @param boolean $hex True to get them as HEX values, false otherwise.
+ * @param bool $hex True to get them as HEX values, false otherwise.
  * @param array $chars Characters to uescape.
  * @return array Escape chars
  */
@@ -372,7 +372,7 @@ class HttpSocketResponse implements ArrayAccess {
  * ArrayAccess - Offset Exists
  *
  * @param string $offset Offset to check.
- * @return boolean
+ * @return bool
  */
 	public function offsetExists($offset) {
 		return in_array($offset, array('raw', 'status', 'header', 'body', 'cookies'));

--- a/lib/Cake/Routing/Dispatcher.php
+++ b/lib/Cake/Routing/Dispatcher.php
@@ -245,7 +245,7 @@ class Dispatcher implements CakeEventListener {
  * Load controller and return controller class name
  *
  * @param CakeRequest $request Request instance.
- * @return string|boolean Name of controller class name
+ * @return string|bool Name of controller class name
  */
 	protected function _loadController($request) {
 		$pluginName = $pluginPath = $controller = null;

--- a/lib/Cake/Routing/DispatcherFilter.php
+++ b/lib/Cake/Routing/DispatcherFilter.php
@@ -28,7 +28,7 @@ abstract class DispatcherFilter implements CakeEventListener {
 /**
  * Default priority for all methods in this filter
  *
- * @var integer
+ * @var int
  */
 	public $priority = 10;
 
@@ -78,7 +78,7 @@ abstract class DispatcherFilter implements CakeEventListener {
  *
  * @param CakeEvent $event container object having the `request`, `response` and `additionalParams`
  *	keys in the data property.
- * @return CakeResponse|boolean
+ * @return CakeResponse|bool
  */
 	public function beforeDispatch(CakeEvent $event) {
 	}

--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -28,7 +28,7 @@ class AssetDispatcher extends DispatcherFilter {
  * Default priority for all methods in this filter
  * This filter should run before the request gets parsed by router
  *
- * @var integer
+ * @var int
  */
 	public $priority = 9;
 

--- a/lib/Cake/Routing/Filter/CacheDispatcher.php
+++ b/lib/Cake/Routing/Filter/CacheDispatcher.php
@@ -27,7 +27,7 @@ class CacheDispatcher extends DispatcherFilter {
  * Default priority for all methods in this filter
  * This filter should run before the request gets parsed by router
  *
- * @var integer
+ * @var int
  */
 	public $priority = 9;
 

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -97,7 +97,7 @@ class CakeRoute {
 /**
  * Check if a Route has been compiled into a regular expression.
  *
- * @return boolean
+ * @return bool
  */
 	public function compiled() {
 		return !empty($this->_compiledRoute);
@@ -334,7 +334,7 @@ class CakeRoute {
  * @param string $val The value of the named parameter
  * @param array $rule The rule(s) to apply, can also be a match string
  * @param string $context An array with additional context information (controller / action)
- * @return boolean
+ * @return bool
  */
 	protected function _matchNamed($val, $rule, $context) {
 		if ($rule === true || $rule === false) {

--- a/lib/Cake/Routing/Route/RedirectRoute.php
+++ b/lib/Cake/Routing/Route/RedirectRoute.php
@@ -43,7 +43,7 @@ class RedirectRoute extends CakeRoute {
 /**
  * Flag for disabling exit() when this route parses a URL.
  *
- * @var boolean
+ * @var bool
  */
 	public $stop = true;
 
@@ -64,7 +64,7 @@ class RedirectRoute extends CakeRoute {
  * redirection
  *
  * @param string $url The URL to parse
- * @return boolean False on failure
+ * @return bool False on failure
  */
 	public function parse($url) {
 		$params = parent::parse($url);
@@ -113,7 +113,7 @@ class RedirectRoute extends CakeRoute {
  * Stop execution of the current script. Wraps exit() making
  * testing easier.
  *
- * @param integer|string $code See http://php.net/exit for values
+ * @param int|string $code See http://php.net/exit for values
  * @return void
  */
 	protected function _stop($code = 0) {

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -50,7 +50,7 @@ class Router {
 /**
  * Have routes been loaded
  *
- * @var boolean
+ * @var bool
  */
 	public static $initialized = false;
 
@@ -73,7 +73,7 @@ class Router {
 /**
  * Directive for Router to parse out file extensions for mapping to Content-types.
  *
- * @var boolean
+ * @var bool
  */
 	protected static $_parseExtensions = false;
 
@@ -702,7 +702,7 @@ class Router {
 /**
  * Gets the current request object, or the first one.
  *
- * @param boolean $current True to get the current request object, or false to get the first one.
+ * @param bool $current True to get the current request object, or false to get the first one.
  * @return CakeRequest|null Null if stack is empty.
  */
 	public static function getRequest($current = false) {
@@ -716,7 +716,7 @@ class Router {
 /**
  * Gets parameter information
  *
- * @param boolean $current Get current request parameter, useful when using requestAction
+ * @param bool $current Get current request parameter, useful when using requestAction
  * @return array Parameter information
  */
 	public static function getParams($current = false) {
@@ -733,7 +733,7 @@ class Router {
  * Gets URL parameter by name
  *
  * @param string $name Parameter name
- * @param boolean $current Current parameter, useful when using requestAction
+ * @param bool $current Current parameter, useful when using requestAction
  * @return string Parameter value
  */
 	public static function getParam($name = 'controller', $current = false) {
@@ -747,7 +747,7 @@ class Router {
 /**
  * Gets path information
  *
- * @param boolean $current Current parameter, useful when using requestAction
+ * @param bool $current Current parameter, useful when using requestAction
  * @return array
  */
 	public static function getPaths($current = false) {
@@ -783,9 +783,9 @@ class Router {
 /**
  * Promote a route (by default, the last one added) to the beginning of the list
  *
- * @param integer $which A zero-based array index representing the route to move. For example,
+ * @param int $which A zero-based array index representing the route to move. For example,
  *    if 3 routes have been added, the last route would be 2.
- * @return boolean Returns false if no route exists at the position specified by $which.
+ * @return bool Returns false if no route exists at the position specified by $which.
  */
 	public static function promote($which = null) {
 		if ($which === null) {
@@ -823,7 +823,7 @@ class Router {
  *   or an array specifying any of the following: 'controller', 'action',
  *   and/or 'plugin', in addition to named arguments (keyed array elements),
  *   and standard URL arguments (indexed array elements)
- * @param boolean|array $full If (bool) true, the full base URL will be prepended to the result.
+ * @param bool|array $full If (bool) true, the full base URL will be prepended to the result.
  *   If an array accepts the following keys
  *    - escape - used when making URLs embedded in html escapes query string '&'
  *    - full - if true the full base URL will be prepended.
@@ -1059,7 +1059,7 @@ class Router {
  * @param string|array $q Query string Either a string of already compiled query string arguments or
  *    an array of arguments to convert into a query string.
  * @param array $extra Extra querystring parameters.
- * @param boolean $escape Whether or not to use escaped &
+ * @param bool $escape Whether or not to use escaped &
  * @return array
  */
 	public static function queryString($q, $extra = array(), $escape = false) {
@@ -1103,7 +1103,7 @@ class Router {
  * are used for CakePHP internals and should not normally be part of an output URL.
  *
  * @param CakeRequest|array $params The params array or CakeRequest object that needs to be reversed.
- * @param boolean $full Set to true to include the full URL including the protocol when reversing
+ * @param bool $full Set to true to include the full URL including the protocol when reversing
  *     the URL.
  * @return string The string that is the reversed result of the array
  */
@@ -1249,7 +1249,7 @@ class Router {
  * To have the extensions parsed you still need to call `Router::parseExtensions()`
  *
  * @param array $extensions List of extensions to be added as valid extension
- * @param boolean $merge Default true will merge extensions. Set to false to override current extensions
+ * @param bool $merge Default true will merge extensions. Set to false to override current extensions
  * @return array
  */
 	public static function setExtensions($extensions, $merge = true) {

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -42,7 +42,7 @@ class FixtureTaskTest extends CakeTestCase {
 /**
  * Whether backup global state for each test method or not
  *
- * @var boolean
+ * @var bool
  */
 	public $backupGlobals = false;
 
@@ -244,7 +244,6 @@ class FixtureTaskTest extends CakeTestCase {
 
 /**
  * test that execute passes runs bake depending with named model.
- *
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -39,7 +39,7 @@ class ShellTestShell extends Shell {
 /**
  * stopped property
  *
- * @var integer
+ * @var int
  */
 	public $stopped;
 
@@ -53,7 +53,7 @@ class ShellTestShell extends Shell {
 /**
  * stop method
  *
- * @param integer $status
+ * @param int $status
  * @return void
  */
 	protected function _stop($status = 0) {

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -40,7 +40,7 @@ class AclNodeTwoTestBase extends AclNode {
 /**
  * cacheSources property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheSources = false;
 }
@@ -127,7 +127,7 @@ class PermissionTwoTest extends Permission {
 /**
  * cacheQueries property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 
@@ -141,7 +141,7 @@ class PermissionTwoTest extends Permission {
 /**
  * actsAs property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $actsAs = null;
 }
@@ -487,7 +487,7 @@ class DbAclTest extends CakeTestCase {
  * Generates a list of the current aro and aco structures and a grid dump of the permissions that are defined
  * Only designed to work with the db based ACL
  *
- * @param boolean $treesToo
+ * @param bool $treesToo
  * @return void
  */
 	protected function _debug($printTreesToo = false) {
@@ -534,7 +534,7 @@ class DbAclTest extends CakeTestCase {
  * Used by debug to format strings used in the data dump
  *
  * @param string $string
- * @param integer $len
+ * @param int $len
  * @return void
  */
 	protected function _pad($string = '', $len = 14) {

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -31,14 +31,14 @@ class TestAuthComponent extends AuthComponent {
 /**
  * testStop property
  *
- * @var boolean
+ * @var bool
  */
 	public $testStop = false;
 
 /**
  * Helper method to add/set an authenticate object instance
  *
- * @param integer $index The index at which to add/set the object
+ * @param int $index The index at which to add/set the object
  * @param Object $object The object to add/set
  * @return void
  */
@@ -49,7 +49,7 @@ class TestAuthComponent extends AuthComponent {
 /**
  * Helper method to add/set an authorize object instance
  *
- * @param integer $index The index at which to add/set the object
+ * @param int $index The index at which to add/set the object
  * @param Object $object The object to add/set
  * @return void
  */
@@ -112,7 +112,7 @@ class AuthTestController extends Controller {
 /**
  * testUrl property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $testUrl = null;
 
@@ -225,7 +225,7 @@ class AjaxAuthController extends Controller {
 /**
  * testUrl property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $testUrl = null;
 
@@ -290,7 +290,7 @@ class AuthComponentTest extends CakeTestCase {
 /**
  * initialized property
  *
- * @var boolean
+ * @var bool
  */
 	public $initialized = false;
 

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -58,7 +58,7 @@ class DebugCompTransport extends AbstractTransport {
  * Send mail
  *
  * @params object $email CakeEmail
- * @return boolean
+ * @return bool
  */
 	public function send(CakeEmail $email) {
 		$email->addHeaders(array('Date' => EmailComponentTest::$sentDate));
@@ -94,7 +94,7 @@ class EmailTestController extends Controller {
 /**
  * uses property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $uses = null;
 

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -118,7 +118,7 @@ class ControllerPaginateModel extends CakeTestModel {
 /**
  * paginate method
  *
- * @return boolean
+ * @return bool
  */
 	public function paginate($conditions, $fields, $order, $limit, $page, $recursive, $extra) {
 		$this->extra = $extra;
@@ -901,7 +901,6 @@ class PaginatorComponentTest extends CakeTestCase {
 
 /**
  * Test that a really REALLY large page number gets clamped to the max page size.
- *
  *
  * @expectedException NotFoundException
  * @return void

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -33,7 +33,7 @@ class RequestHandlerTestController extends Controller {
 /**
  * uses property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $uses = null;
 

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -30,7 +30,7 @@ class TestSecurityComponent extends SecurityComponent {
  * validatePost method
  *
  * @param Controller $controller
- * @return boolean
+ * @return bool
  */
 	public function validatePost(Controller $controller) {
 		return $this->_validatePost($controller);
@@ -55,7 +55,7 @@ class SecurityTestController extends Controller {
 /**
  * failed property
  *
- * @var boolean false
+ * @var bool
  */
 	public $failed = false;
 

--- a/lib/Cake/Test/Case/Controller/ComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentTest.php
@@ -67,7 +67,7 @@ class AppleComponent extends Component {
 /**
  * testName property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $testName = null;
 

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -74,7 +74,7 @@ class ControllerPost extends CakeTestModel {
 /**
  * lastQuery property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $lastQuery = null;
 

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -64,7 +64,7 @@ class ScaffoldMockControllerWithFields extends Controller {
  * function beforeScaffold
  *
  * @param string method
- * @return boolean true
+ * @return bool true
  */
 	public function beforeScaffold($method) {
 		$this->set('scaffoldFields', array('title'));

--- a/lib/Cake/Test/Case/Log/Engine/SyslogLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/SyslogLogTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/AclNodeTest.php
+++ b/lib/Cake/Test/Case/Model/AclNodeTest.php
@@ -36,7 +36,7 @@ class DbAclNodeTestBase extends AclNode {
 /**
  * cacheSources property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheSources = false;
 }
@@ -102,7 +102,7 @@ class DbPermissionTest extends CakeTestModel {
 /**
  * cacheQueries property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -28,7 +28,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
@@ -31,7 +31,7 @@ class TreeBehaviorAfterTest extends CakeTestCase {
 /**
  * Whether backup global state for each test method or not
  *
- * @var boolean
+ * @var bool
  */
 	public $backupGlobals = false;
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -33,7 +33,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 /**
  * Whether backup global state for each test method or not
  *
- * @var boolean
+ * @var bool
  */
 	public $backupGlobals = false;
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -33,7 +33,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 /**
  * Whether backup global state for each test method or not
  *
- * @var boolean
+ * @var bool
  */
 	public $backupGlobals = false;
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
@@ -34,7 +34,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 /**
  * Whether backup global state for each test method or not
  *
- * @var boolean
+ * @var bool
  */
 	public $backupGlobals = false;
 

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -80,7 +80,7 @@ class TestBehavior extends ModelBehavior {
  *
  * @param Model $model
  * @param array $results
- * @param boolean $primary
+ * @param bool $primary
  * @return void
  */
 	public function afterFind(Model $model, $results, $primary = false) {
@@ -128,7 +128,7 @@ class TestBehavior extends ModelBehavior {
  * afterSave method
  *
  * @param Model $model
- * @param boolean $created
+ * @param bool $created
  * @param array $options Options passed from Model::save().
  * @return void
  */
@@ -161,7 +161,7 @@ class TestBehavior extends ModelBehavior {
  *
  * @param Model $Model Model invalidFields was called on.
  * @param array $options Options passed from Model::save().
- * @return boolean
+ * @return bool
  * @see Model::save()
  */
 	public function beforeValidate(Model $model, $options = array()) {
@@ -188,7 +188,7 @@ class TestBehavior extends ModelBehavior {
  * afterValidate method
  *
  * @param Model $model
- * @param boolean $cascade
+ * @param bool $cascade
  * @return void
  */
 	public function afterValidate(Model $model) {
@@ -209,7 +209,7 @@ class TestBehavior extends ModelBehavior {
  * beforeDelete method
  *
  * @param Model $model
- * @param boolean $cascade
+ * @param bool $cascade
  * @return void
  */
 	public function beforeDelete(Model $model, $cascade = true) {
@@ -281,7 +281,7 @@ class TestBehavior extends ModelBehavior {
  * testMethod method
  *
  * @param Model $model
- * @param boolean $param
+ * @param bool $param
  * @return void
  */
 	public function testMethod(Model $model, $param = true) {

--- a/lib/Cake/Test/Case/Model/Datasource/DataSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DataSourceTest.php
@@ -57,7 +57,7 @@ class TestSource extends DataSource {
 /**
  * listSources
  *
- * @return boolean
+ * @return bool
  */
 	public function listSources() {
 		return null;

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -33,7 +33,7 @@ class MysqlTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 
@@ -196,7 +196,6 @@ class MysqlTest extends CakeTestCase {
 /**
  * testTinyintCasting method
  *
- *
  * @return void
  */
 	public function testTinyintCasting() {
@@ -235,7 +234,6 @@ class MysqlTest extends CakeTestCase {
 
 /**
  * testLastAffected method
- *
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -67,7 +67,7 @@ class PostgresTestModel extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -148,7 +148,7 @@ class PostgresClientTestModel extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -180,7 +180,7 @@ class PostgresTest extends CakeTestCase {
  * Do not automatically load fixtures for each test, they will be loaded manually
  * using CakeTestCase::loadFixtures
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -68,7 +68,7 @@ class SqliteTest extends CakeTestCase {
 /**
  * Do not automatically load fixtures for each test, they will be loaded manually using CakeTestCase::loadFixtures
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -116,7 +116,7 @@ class SqlserverTestModel extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -182,7 +182,7 @@ class SqlserverClientTestModel extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -248,7 +248,7 @@ class SqlserverTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -116,7 +116,7 @@ class DboSourceTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 
@@ -542,7 +542,6 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
- *
  * @expectedException PDOException
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
+++ b/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * Tests cross database HABTM. Requires $test and $test2 to both be set in DATABASE_CONFIG
  * NOTE: When testing on MySQL, you must set 'persistent' => false on *both* database connections,
  * or one connection will step on the other.
@@ -42,14 +40,14 @@ class ModelCrossSchemaHabtmTest extends BaseModelTest {
 /**
  * Don't drop tables if they exist
  *
- * @var boolean
+ * @var bool
  */
 	public $dropTables = false;
 
 /**
  * Don't auto load fixtures
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -39,7 +39,7 @@ class DboMock extends DboSource {
 /**
  * Returns true to fake a database connection
  *
- * @return boolean true
+ * @return bool true
  */
 	public function connect() {
 		return true;

--- a/lib/Cake/Test/Case/Model/ModelTestBase.php
+++ b/lib/Cake/Test/Case/Model/ModelTestBase.php
@@ -31,14 +31,14 @@ abstract class BaseModelTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 
 /**
  * Whether backup global state for each test method or not
  *
- * @var boolean
+ * @var bool
  */
 	public $backupGlobals = false;
 

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
@@ -28,7 +28,7 @@ class CakeValidationRuleTest extends CakeTestCase {
 /**
  * Auxiliary method to test custom validators
  *
- * @return boolean
+ * @return bool
  */
 	public function myTestRule() {
 		return false;
@@ -37,7 +37,7 @@ class CakeValidationRuleTest extends CakeTestCase {
 /**
  * Auxiliary method to test custom validators
  *
- * @return boolean
+ * @return bool
  */
 	public function myTestRule2() {
 		return true;

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -66,7 +66,7 @@ class Test extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -103,7 +103,7 @@ class TestAlias extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -139,7 +139,7 @@ class TestValidate extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -213,7 +213,7 @@ class User extends CakeTestModel {
 /**
  * beforeFind() callback used to run ContainableBehaviorTest::testLazyLoad()
  *
- * @return boolean
+ * @return bool
  * @throws Exception
  */
 	public function beforeFind($queryData) {
@@ -276,7 +276,7 @@ class Article extends CakeTestModel {
 /**
  * beforeSaveReturn property
  *
- * @var boolean
+ * @var bool
  */
 	public $beforeSaveReturn = true;
 
@@ -548,7 +548,7 @@ class ModifiedComment extends CakeTestModel {
 /**
  * Property used to toggle filtering of results
  *
- * @var boolean
+ * @var bool
  */
 	public $remove = false;
 
@@ -931,7 +931,7 @@ class Post extends CakeTestModel {
 
 /**
  * @param array $queryData
- * @return boolean true
+ * @return bool true
  */
 	public function beforeFind($queryData) {
 		if (isset($queryData['connection'])) {
@@ -942,8 +942,8 @@ class Post extends CakeTestModel {
 
 /**
  * @param array $results
- * @param boolean $primary
- * @return array $results
+ * @param bool $primary
+ * @return array results
  */
 	public function afterFind($results, $primary = false) {
 		$this->useDbConfig = 'test';
@@ -2050,28 +2050,28 @@ class CallbackPostTestModel extends CakeTestModel {
 /**
  * variable to control return of beforeValidate
  *
- * @var boolean
+ * @var bool
  */
 	public $beforeValidateReturn = true;
 
 /**
  * variable to control return of beforeSave
  *
- * @var boolean
+ * @var bool
  */
 	public $beforeSaveReturn = true;
 
 /**
  * variable to control return of beforeDelete
  *
- * @var boolean
+ * @var bool
  */
 	public $beforeDeleteReturn = true;
 
 /**
  * beforeSave callback
  *
- * @return boolean
+ * @return bool
  */
 	public function beforeSave($options = array()) {
 		return $this->beforeSaveReturn;
@@ -2081,7 +2081,7 @@ class CallbackPostTestModel extends CakeTestModel {
  * beforeValidate callback
  *
  * @param array $options Options passed from Model::save().
- * @return boolean True if validate operation should continue, false to abort
+ * @return bool True if validate operation should continue, false to abort
  * @see Model::save()
  */
 	public function beforeValidate($options = array()) {
@@ -2091,7 +2091,7 @@ class CallbackPostTestModel extends CakeTestModel {
 /**
  * beforeDelete callback
  *
- * @return boolean
+ * @return bool
  */
 	public function beforeDelete($cascade = true) {
 		return $this->beforeDeleteReturn;
@@ -2146,7 +2146,7 @@ class TheVoid extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 }
@@ -2168,7 +2168,7 @@ class ValidationTest1 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -2254,7 +2254,7 @@ class ValidationTest2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -2584,12 +2584,12 @@ class NumberTree extends CakeTestModel {
 /**
  * initialize method
  *
- * @param integer $levelLimit
- * @param integer $childLimit
+ * @param int $levelLimit
+ * @param int $childLimit
  * @param mixed $currentLevel
  * @param mixed $parent_id
  * @param string $prefix
- * @param boolean $hierarchal
+ * @param bool $hierarchal
  * @return void
  */
 	public function initialize($levelLimit = 3, $childLimit = 3, $currentLevel = null, $parentId = null, $prefix = '1', $hierarchal = true) {
@@ -2773,7 +2773,7 @@ class AfterTree extends NumberTree {
 	public $actsAs = array('Tree');
 
 /**
- * @param boolean $created
+ * @param bool $created
  * @param array $options
  * @return void
  */
@@ -3125,7 +3125,7 @@ class TranslatedItem extends CakeTestModel {
 /**
  * cacheQueries property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 
@@ -3162,7 +3162,7 @@ class TranslatedItem2 extends CakeTestModel {
 /**
  * cacheQueries property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 
@@ -3206,7 +3206,7 @@ class TranslatedItemWithTable extends CakeTestModel {
 /**
  * cacheQueries property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 
@@ -3280,7 +3280,7 @@ class TranslatedArticle extends CakeTestModel {
 /**
  * cacheQueries property
  *
- * @var boolean
+ * @var bool
  */
 	public $cacheQueries = false;
 
@@ -3582,7 +3582,7 @@ class TestModel extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -3657,7 +3657,7 @@ class TestModel2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 }
@@ -3679,7 +3679,7 @@ class TestModel3 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 }
@@ -3708,7 +3708,7 @@ class TestModel4 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -3792,7 +3792,7 @@ class TestModel4TestModel7 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -3837,7 +3837,7 @@ class TestModel5 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -3905,7 +3905,7 @@ class TestModel6 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -3965,7 +3965,7 @@ class TestModel7 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4012,7 +4012,7 @@ class TestModel8 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4073,7 +4073,7 @@ class TestModel9 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4134,7 +4134,7 @@ class Level extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4193,7 +4193,7 @@ class Group extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4253,7 +4253,7 @@ class User2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4325,7 +4325,7 @@ class Category2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4408,7 +4408,7 @@ class Article2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4480,7 +4480,7 @@ class CategoryFeatured2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4528,7 +4528,7 @@ class Featured2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4593,7 +4593,7 @@ class Comment2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4640,7 +4640,7 @@ class ArticleFeatured2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -4713,7 +4713,7 @@ class MysqlTestModel extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -5029,7 +5029,7 @@ class CustomArticle extends AppModel {
  * Alters title data
  *
  * @param array $options Options passed from Model::save().
- * @return boolean True if validate operation should continue, false to abort
+ * @return bool True if validate operation should continue, false to abort
  * @see Model::save()
  */
 	public function beforeValidate($options = array()) {

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -31,7 +31,7 @@ class TestCakeRequest extends CakeRequest {
  * reConstruct method
  *
  * @param string $url
- * @param boolean $parseEnvironment
+ * @param bool $parseEnvironment
  * @return void
  */
 	public function reConstruct($url = 'some/path', $parseEnvironment = true) {
@@ -1057,7 +1057,7 @@ class CakeRequestTest extends CakeTestCase {
  * Helper function for testing callbacks.
  *
  * @param $request
- * @return boolean
+ * @return bool
  */
 	public function detectCallback($request) {
 		return (bool)$request->return;

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -1088,9 +1088,9 @@ class CakeResponseTest extends CakeTestCase {
  * @param string|array $domains
  * @param string|array $methods
  * @param string|array $headers
- * @param string|boolean $expectedOrigin
- * @param string|boolean $expectedMethods
- * @param string|boolean $expectedHeaders
+ * @param string|bool $expectedOrigin
+ * @param string|bool $expectedMethods
+ * @param string|bool $expectedHeaders
  * @return void
  */
 	public function testCors($request, $origin, $domains, $methods, $headers, $expectedOrigin, $expectedMethods = false, $expectedHeaders = false) {

--- a/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
@@ -61,7 +61,7 @@ class DigestAuthenticationTest extends CakeTestCase {
 /**
  * Socket property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $HttpSocket = null;
 

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -39,7 +39,7 @@ class TestHttpResponse extends HttpResponse {
  * Convenience method for testing protected method
  *
  * @param string $body A string containing the body to decode
- * @param boolean|string $encoding Can be false in case no encoding is being used, or a string representing the encoding
+ * @param bool|string $encoding Can be false in case no encoding is being used, or a string representing the encoding
  * @return mixed Array or false
  */
 	public function decodeBody($body, $encoding = 'chunked') {
@@ -69,7 +69,7 @@ class TestHttpResponse extends HttpResponse {
 /**
  * Convenience method for testing protected method
  *
- * @param boolean $hex true to get them as HEX values, false otherwise
+ * @param bool $hex true to get them as HEX values, false otherwise
  * @return array Escape chars
  */
 	public function tokenEscapeChars($hex = true, $chars = null) {

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -93,7 +93,7 @@ class TestHttpSocket extends HttpSocket {
  * Convenience method for testing protected method
  *
  * @param string|array $uri URI to parse
- * @param boolean|array $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
+ * @param bool|array $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
  * @return array Parsed URI
  */
 	public function parseUri($uri = null, $base = array()) {
@@ -145,7 +145,7 @@ class TestHttpSocket extends HttpSocket {
 /**
  * Convenience method for testing protected method
  *
- * @param boolean $hex true to get them as HEX values, false otherwise
+ * @param bool $hex true to get them as HEX values, false otherwise
  * @return array Escape chars
  */
 	public function tokenEscapeChars($hex = true, $chars = null) {
@@ -174,14 +174,14 @@ class HttpSocketTest extends CakeTestCase {
 /**
  * Socket property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $Socket = null;
 
 /**
  * RequestSocket property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $RequestSocket = null;
 

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -339,7 +339,7 @@ class SomePostsController extends AppController {
 /**
  * autoRender property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoRender = false;
 
@@ -511,7 +511,7 @@ class TestFilterDispatcher extends DispatcherFilter {
  * TestFilterDispatcher::beforeDispatch()
  *
  * @param mixed $event
- * @return CakeResponse|boolean
+ * @return CakeResponse|bool
  */
 	public function beforeDispatch(CakeEvent $event) {
 		$event->stopPropagation();

--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -471,7 +471,7 @@ class CakeTestFixtureTest extends CakeTestCase {
  * @param string $table
  * @param string $fields
  * @param string $values
- * @return boolean true
+ * @return bool true
  */
 	public function insertCallback($table, $fields, $values) {
 		$this->insertMulti['table'] = $table;

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -28,7 +28,7 @@ class ClassRegisterModel extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 }

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -29,7 +29,7 @@ class FileTest extends CakeTestCase {
 /**
  * File property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $File = null;
 
@@ -543,7 +543,7 @@ class FileTest extends CakeTestCase {
 /**
  * getTmpFile method
  *
- * @param boolean $paintSkip
+ * @param bool $paintSkip
  * @return void
  */
 	protected function _getTmpFile($paintSkip = true) {

--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -58,7 +58,7 @@ class SanitizeTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -25,7 +25,7 @@ class SecurityTest extends CakeTestCase {
 /**
  * sut property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $sut = null;
 

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -29,7 +29,7 @@ class CustomValidator {
  * Makes sure that a given $email address is valid and unique
  *
  * @param string $email
- * @return boolean
+ * @return bool
  */
 	public static function customValidate($check) {
 		return (bool)preg_match('/^[0-9]{3}$/', $check);

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -82,7 +82,7 @@ class XmlTest extends CakeTestCase {
 /**
  * autoFixtures property
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -36,7 +36,7 @@ class ContactTestController extends Controller {
 /**
  * uses property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $uses = null;
 }
@@ -51,7 +51,7 @@ class Contact extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -142,7 +142,7 @@ class ContactTagsContact extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -207,7 +207,7 @@ class ContactTag extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -234,7 +234,7 @@ class UserForm extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -274,7 +274,7 @@ class OpenidUrl extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -329,7 +329,7 @@ class ValidateUser extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -381,7 +381,7 @@ class ValidateProfile extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -440,7 +440,7 @@ class ValidateItem extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -489,7 +489,7 @@ class TestMail extends CakeTestModel {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -513,7 +513,7 @@ class FormHelperTest extends CakeTestCase {
 /**
  * Do not load the fixtures by default
  *
- * @var boolean
+ * @var bool
  */
 	public $autoFixtures = false;
 
@@ -9826,7 +9826,6 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
- *
  * @expectedException CakeException
  * @return void
  */

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -46,7 +46,7 @@ class TheHtmlTestController extends Controller {
 /**
  * uses property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $uses = null;
 }

--- a/lib/Cake/Test/Case/View/HelperTest.php
+++ b/lib/Cake/Test/Case/View/HelperTest.php
@@ -31,7 +31,7 @@ class HelperTestPost extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -71,7 +71,7 @@ class HelperTestComment extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -105,7 +105,7 @@ class HelperTestTag extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 
@@ -136,7 +136,7 @@ class HelperTestPostsTag extends Model {
 /**
  * useTable property
  *
- * @var boolean
+ * @var bool
  */
 	public $useTable = false;
 

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -40,7 +40,7 @@ class ViewPostsController extends Controller {
 /**
  * uses property
  *
- * @var mixed null
+ * @var mixed
  */
 	public $uses = null;
 
@@ -163,7 +163,7 @@ class TestView extends View {
  * paths method
  *
  * @param string $plugin Optional plugin name to scan for view files.
- * @param boolean $cached Set to true to force a refresh of view paths.
+ * @param bool $cached Set to true to force a refresh of view paths.
  * @return array paths
  */
 	public function paths($plugin = null, $cached = true) {

--- a/lib/Cake/Test/Fixture/ArmorFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorFixture.php
@@ -28,7 +28,7 @@ class ArmorFixture extends CakeTestFixture {
  *
  * Used for Multi database fixture test
  *
- * @var string 'test2'
+ * @var string
  */
 	public $useDbConfig = 'test2';
 

--- a/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
@@ -28,7 +28,7 @@ class ArmorsPlayerFixture extends CakeTestFixture {
  *
  * Used for Multi database fixture test
  *
- * @var string 'test_database_three'
+ * @var string
  */
 	public $useDbConfig = 'test_database_three';
 

--- a/lib/Cake/Test/Fixture/JoinABFixture.php
+++ b/lib/Cake/Test/Fixture/JoinABFixture.php
@@ -26,7 +26,7 @@ class JoinABFixture extends CakeTestFixture {
 /**
  * name property
  *
- * @var string 'JoinAsJoinB'
+ * @var string
  */
 	public $name = 'JoinAsJoinB';
 

--- a/lib/Cake/Test/Fixture/JoinACFixture.php
+++ b/lib/Cake/Test/Fixture/JoinACFixture.php
@@ -26,7 +26,7 @@ class JoinACFixture extends CakeTestFixture {
 /**
  * name property
  *
- * @var string 'JoinAsJoinC'
+ * @var string
  */
 	public $name = 'JoinAsJoinC';
 

--- a/lib/Cake/Test/Fixture/TranslateArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateArticleFixture.php
@@ -26,7 +26,7 @@ class TranslateArticleFixture extends CakeTestFixture {
 /**
  * table property
  *
- * @var string 'i18n'
+ * @var string
  */
 	public $table = 'article_i18n';
 

--- a/lib/Cake/Test/Fixture/TranslateFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateFixture.php
@@ -26,7 +26,7 @@ class TranslateFixture extends CakeTestFixture {
 /**
  * table property
  *
- * @var string 'i18n'
+ * @var string
  */
 	public $table = 'i18n';
 

--- a/lib/Cake/Test/Fixture/TranslateTableFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateTableFixture.php
@@ -26,7 +26,7 @@ class TranslateTableFixture extends CakeTestFixture {
 /**
  * table property
  *
- * @var string 'another_i18n'
+ * @var string
  */
 	public $table = 'another_i18n';
 

--- a/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
@@ -30,7 +30,7 @@ class TranslateWithPrefixFixture extends CakeTestFixture {
 /**
  * table property
  *
- * @var string 'i18n'
+ * @var string
  */
 	public $table = 'i18n_translate_with_prefixes';
 

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/Test2DispatcherFilter.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/Test2DispatcherFilter.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/TestDispatcherFilter.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/TestDispatcherFilter.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthUser.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthUser.php
@@ -40,7 +40,7 @@ class TestPluginAuthUser extends TestPluginAppModel {
 /**
  * useDbConfig property
  *
- * @var string 'test'
+ * @var string
  */
 	public $useDbConfig = 'test';
 }

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -48,7 +48,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * between each test method. Tables will still be dropped at the
  * end of each test runner execution.
  *
- * @var boolean
+ * @var bool
  */
 	public $dropTables = true;
 
@@ -107,9 +107,9 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 /**
  * Overrides SimpleTestCase::skipIf to provide a boolean return value
  *
- * @param boolean $shouldSkip Whether or not the test should be skipped.
+ * @param bool $shouldSkip Whether or not the test should be skipped.
  * @param string $message The message to display.
- * @return boolean
+ * @return bool
  */
 	public function skipIf($shouldSkip, $message = '') {
 		if ($shouldSkip) {
@@ -219,7 +219,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $expected The expected value.
  * @param string $result The actual value.
  * @param string $message The message to use for failure.
- * @return boolean
+ * @return bool
  */
 	public function assertTextNotEquals($expected, $result, $message = '') {
 		$expected = str_replace(array("\r\n", "\r"), "\n", $expected);
@@ -234,7 +234,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $expected The expected value.
  * @param string $result The actual value.
  * @param string $message message The message to use for failure.
- * @return boolean
+ * @return bool
  */
 	public function assertTextEquals($expected, $result, $message = '') {
 		$expected = str_replace(array("\r\n", "\r"), "\n", $expected);
@@ -249,7 +249,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $prefix The prefix to check for.
  * @param string $string The string to search in.
  * @param string $message The message to use for failure.
- * @return boolean
+ * @return bool
  */
 	public function assertTextStartsWith($prefix, $string, $message = '') {
 		$prefix = str_replace(array("\r\n", "\r"), "\n", $prefix);
@@ -264,7 +264,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $prefix The prefix to not find.
  * @param string $string The string to search.
  * @param string $message The message to use for failure.
- * @return boolean
+ * @return bool
  */
 	public function assertTextStartsNotWith($prefix, $string, $message = '') {
 		$prefix = str_replace(array("\r\n", "\r"), "\n", $prefix);
@@ -279,7 +279,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $suffix The suffix to find.
  * @param string $string The string to search.
  * @param string $message The message to use for failure.
- * @return boolean
+ * @return bool
  */
 	public function assertTextEndsWith($suffix, $string, $message = '') {
 		$suffix = str_replace(array("\r\n", "\r"), "\n", $suffix);
@@ -294,7 +294,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $suffix The suffix to not find.
  * @param string $string The string to search.
  * @param string $message The message to use for failure.
- * @return boolean
+ * @return bool
  */
 	public function assertTextEndsNotWith($suffix, $string, $message = '') {
 		$suffix = str_replace(array("\r\n", "\r"), "\n", $suffix);
@@ -309,8 +309,8 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $needle The string to search for.
  * @param string $haystack The string to search through.
  * @param string $message The message to display on failure.
- * @param boolean $ignoreCase Whether or not the search should be case-sensitive.
- * @return boolean
+ * @param bool $ignoreCase Whether or not the search should be case-sensitive.
+ * @return bool
  */
 	public function assertTextContains($needle, $haystack, $message = '', $ignoreCase = false) {
 		$needle = str_replace(array("\r\n", "\r"), "\n", $needle);
@@ -325,8 +325,8 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $needle The string to search for.
  * @param string $haystack The string to search through.
  * @param string $message The message to display on failure.
- * @param boolean $ignoreCase Whether or not the search should be case-sensitive.
- * @return boolean
+ * @param bool $ignoreCase Whether or not the search should be case-sensitive.
+ * @return bool
  */
 	public function assertTextNotContains($needle, $haystack, $message = '', $ignoreCase = false) {
 		$needle = str_replace(array("\r\n", "\r"), "\n", $needle);
@@ -374,7 +374,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $string An HTML/XHTML/XML string
  * @param array $expected An array, see above
  * @param string $fullDebug Whether or not more verbose output should be used.
- * @return boolean
+ * @return bool
  */
 	public function assertTags($string, $expected, $fullDebug = false) {
 		$regex = array();
@@ -541,7 +541,6 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 /**
  * Compatibility wrapper function for assertEquals
  *
- *
  * @param mixed $result
  * @param mixed $expected
  * @param string $message the text to display if the assertion is not correct
@@ -697,9 +696,9 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 /**
  * Compatibility function for skipping.
  *
- * @param boolean $condition Condition to trigger skipping
+ * @param bool $condition Condition to trigger skipping
  * @param string $message Message for skip
- * @return boolean
+ * @return bool
  */
 	protected function skipUnless($condition, $message = '') {
 		if (!$condition) {

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -56,7 +56,7 @@ class CakeTestSuiteCommand extends PHPUnit_TextUI_Command {
  * Ugly hack to get around PHPUnit having a hard coded class name for the Runner. :(
  *
  * @param array $argv The command arguments
- * @param boolean $exit The exit mode.
+ * @param bool $exit The exit mode.
  * @return void
  */
 	public function run(array $argv, $exit = true) {

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -63,7 +63,7 @@ class CakeTestSuiteDispatcher {
 /**
  * boolean to set auto parsing of params.
  *
- * @var boolean
+ * @var bool
  */
 	protected $_paramsParsed = false;
 
@@ -130,7 +130,7 @@ class CakeTestSuiteDispatcher {
 /**
  * Checks for the existence of the test framework files
  *
- * @return boolean true if found, false otherwise
+ * @return bool true if found, false otherwise
  */
 	public function loadTestFramework() {
 		if (class_exists('PHPUnit_Framework_TestCase')) {
@@ -262,8 +262,8 @@ class CakeTestSuiteDispatcher {
 /**
  * Sets a static timestamp
  *
- * @param boolean $reset to set new static timestamp.
- * @return integer timestamp
+ * @param bool $reset to set new static timestamp.
+ * @return int timestamp
  */
 	public static function time($reset = false) {
 		static $now;

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -41,7 +41,7 @@ class ControllerTestDispatcher extends Dispatcher {
 /**
  * Use custom routes during tests
  *
- * @var boolean
+ * @var bool
  */
 	public $loadRoutes = true;
 
@@ -122,14 +122,14 @@ abstract class ControllerTestCase extends CakeTestCase {
 /**
  * Automatically mock controllers that aren't mocked
  *
- * @var boolean
+ * @var bool
  */
 	public $autoMock = true;
 
 /**
  * Use custom routes during tests
  *
- * @var boolean
+ * @var bool
  */
 	public $loadRoutes = true;
 
@@ -173,7 +173,7 @@ abstract class ControllerTestCase extends CakeTestCase {
  * Once a test has been run on a controller it should be rebuilt
  * to clean up properties.
  *
- * @var boolean
+ * @var bool
  */
 	protected $_dirtyController = false;
 

--- a/lib/Cake/TestSuite/Coverage/HtmlCoverageReport.php
+++ b/lib/Cake/TestSuite/Coverage/HtmlCoverageReport.php
@@ -28,14 +28,14 @@ class HtmlCoverageReport extends BaseCoverageReport {
 /**
  * Holds the total number of processed rows.
  *
- * @var integer
+ * @var int
  */
 	protected $_total = 0;
 
 /**
  * Holds the total number of covered rows.
  *
- * @var integer
+ * @var int
  */
 	protected $_covered = 0;
 
@@ -144,7 +144,7 @@ HTML;
  * Renders the HTML for a single line in the HTML diff.
  *
  * @param string $line The line content.
- * @param integer $linenumber The line number
+ * @param int $linenumber The line number
  * @param string $class The classname to use.
  * @param array $coveringTests The tests covering the line.
  * @return string

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -29,7 +29,7 @@ class CakeFixtureManager {
 /**
  * Was this class already initialized?
  *
- * @var boolean
+ * @var bool
  */
 	protected $_initialized = false;
 
@@ -179,7 +179,7 @@ class CakeFixtureManager {
  *
  * @param CakeTestFixture $fixture the fixture object to create
  * @param DataSource $db the datasource instance to use
- * @param boolean $drop whether drop the fixture if it is already created or not
+ * @param bool $drop whether drop the fixture if it is already created or not
  * @return void
  */
 	protected function _setupTable($fixture, $db = null, $drop = true) {
@@ -262,7 +262,7 @@ class CakeFixtureManager {
  *
  * @param string $name of the fixture
  * @param DataSource $db DataSource instance or leave null to get DataSource from the fixture
- * @param boolean $dropTables Whether or not tables should be dropped and re-created.
+ * @param bool $dropTables Whether or not tables should be dropped and re-created.
  * @return void
  * @throws UnexpectedValueException if $name is not a previously loaded class
  */

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -86,7 +86,7 @@ class CakeTestFixture {
  * When table is created for a fixture the MEMORY engine is used
  * where possible. Set $canUseMemory to false if you don't want this.
  *
- * @var boolean
+ * @var bool
  */
 	public $canUseMemory = true;
 
@@ -200,7 +200,7 @@ class CakeTestFixture {
  * Run before all tests execute, should return SQL statement to create table for this fixture could be executed successfully.
  *
  * @param DboSource $db An instance of the database object used to create the fixture table
- * @return boolean True on success, false on failure
+ * @return bool True on success, false on failure
  */
 	public function create($db) {
 		if (!isset($this->fields) || empty($this->fields)) {
@@ -251,7 +251,7 @@ class CakeTestFixture {
  * Run after all tests executed, should return SQL statement to drop table for this fixture.
  *
  * @param DboSource $db An instance of the database object used to create the fixture table
- * @return boolean True on success, false on failure
+ * @return bool True on success, false on failure
  */
 	public function drop($db) {
 		if (empty($this->fields)) {
@@ -273,7 +273,7 @@ class CakeTestFixture {
  * of this fixture could be executed successfully.
  *
  * @param DboSource $db An instance of the database into which the records will be inserted
- * @return boolean on success or if there are no records to insert, or false on failure
+ * @return bool on success or if there are no records to insert, or false on failure
  * @throws CakeException if counts of values and fields do not match.
  */
 	public function insert($db) {
@@ -315,7 +315,7 @@ class CakeTestFixture {
  * CakeFixture to trigger other events before / after truncate.
  *
  * @param DboSource $db A reference to a db instance
- * @return boolean
+ * @return bool
  */
 	public function truncate($db) {
 		$fullDebug = $db->fullDebug;

--- a/lib/Cake/TestSuite/Fixture/CakeTestModel.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestModel.php
@@ -32,7 +32,7 @@ class CakeTestModel extends Model {
  * incorrect order when no order has been defined in the finds.
  * Postgres can return the results in any order it considers appropriate if none is specified
  *
- * @param integer|string|array $id Set this ID for this model on startup, can also be an array of options, see above.
+ * @param int|string|array $id Set this ID for this model on startup, can also be an array of options, see above.
  * @param string $table Name of database table to use.
  * @param string $ds DataSource connection name.
  */
@@ -45,7 +45,7 @@ class CakeTestModel extends Model {
  * Overriding save() to set CakeTestSuiteDispatcher::date() as formatter for created, modified and updated fields
  *
  * @param array $data Data to save
- * @param boolean|array $validate Validate or options.
+ * @param bool|array $validate Validate or options.
  * @param array $fieldList Whitelist of fields
  * @return mixed
  */

--- a/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
@@ -27,7 +27,7 @@ class CakeBaseReporter extends PHPUnit_TextUI_ResultPrinter {
 /**
  * Headers sent
  *
- * @var boolean
+ * @var bool
  */
 	protected $_headerSent = false;
 

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -88,7 +88,7 @@ class CakeNumber {
 /**
  * If native number_format() should be used. If >= PHP5.4
  *
- * @var boolean
+ * @var bool
  */
 	protected static $_numberFormatSupport = null;
 
@@ -96,7 +96,7 @@ class CakeNumber {
  * Formats a number with a level of precision.
  *
  * @param float $value A floating point number.
- * @param integer $precision The precision of the returned number.
+ * @param int $precision The precision of the returned number.
  * @return float Formatted float.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::precision
  */
@@ -107,7 +107,7 @@ class CakeNumber {
 /**
  * Returns a formatted-for-humans file size.
  *
- * @param integer $size Size in bytes
+ * @param int $size Size in bytes
  * @return string Human readable size
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toReadableSize
  */
@@ -171,7 +171,7 @@ class CakeNumber {
  * - `multiply`: Multiply the input value by 100 for decimal percentages.
  *
  * @param float $value A floating point number
- * @param integer $precision The precision of the returned number
+ * @param int $precision The precision of the returned number
  * @param array $options Options
  * @return string Percentage string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toPercentage
@@ -188,7 +188,7 @@ class CakeNumber {
  * Formats a number into a currency format.
  *
  * @param float $value A floating point number
- * @param integer $options If integer then places, if string then before, if (,.-) then use it
+ * @param int $options If integer then places, if string then before, if (,.-) then use it
  *   or array with places and before keys
  * @return string formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
@@ -259,7 +259,7 @@ class CakeNumber {
  * Alternative number_format() to accommodate multibyte decimals and thousands < PHP 5.4
  *
  * @param float $value Value to format.
- * @param integer $places Decimal places to use.
+ * @param int $places Decimal places to use.
  * @param string $decimals Decimal position string.
  * @param string $thousands Thousands separator string.
  * @return string

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -85,7 +85,7 @@ class CakeTime {
 /**
  * Temporary variable containing the timestamp value, used internally in convertSpecifiers()
  *
- * @var integer
+ * @var int
  */
 	protected static $_time = null;
 
@@ -241,7 +241,7 @@ class CakeTime {
  *
  * @param string $serverTime UNIX timestamp
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return integer UNIX timestamp
+ * @return int UNIX timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::convert
  */
 	public static function convert($serverTime, $timezone) {
@@ -295,7 +295,7 @@ class CakeTime {
 /**
  * Returns server's offset from GMT in seconds.
  *
- * @return integer Offset
+ * @return int Offset
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::serverOffset
  */
 	public static function serverOffset() {
@@ -305,7 +305,7 @@ class CakeTime {
 /**
  * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Parsed timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::fromString
@@ -355,7 +355,7 @@ class CakeTime {
  * See http://php.net/manual/en/function.strftime.php for information on formatting
  * using locale strings.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @param string $format The format to use. If null, `TimeHelper::$niceFormat` is used
  * @return string Formatted date string
@@ -383,7 +383,7 @@ class CakeTime {
  * If $dateString's year is the current year, the returned string does not
  * include mention of the year.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Described, relative date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::niceShort
@@ -431,8 +431,8 @@ class CakeTime {
 /**
  * Returns a partial SQL string to search for all records between two dates.
  *
- * @param integer|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
- * @param integer|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -451,7 +451,7 @@ class CakeTime {
  * Returns a partial SQL string to search for all records between two times
  * occurring on the same day.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -464,9 +464,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is today.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string is today
+ * @return bool True if datetime string is today
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isToday
  */
 	public static function isToday($dateString, $timezone = null) {
@@ -478,9 +478,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is in the future.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string is in the future
+ * @return bool True if datetime string is in the future
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isFuture
  */
 	public static function isFuture($dateString, $timezone = null) {
@@ -491,9 +491,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is in the past.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string is in the past
+ * @return bool True if datetime string is in the past
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isPast
  */
 	public static function isPast($dateString, $timezone = null) {
@@ -504,9 +504,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is within this week.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string is within current week
+ * @return bool True if datetime string is within current week
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isThisWeek
  */
 	public static function isThisWeek($dateString, $timezone = null) {
@@ -518,9 +518,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is within this month
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string is within current month
+ * @return bool True if datetime string is within current month
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isThisMonth
  */
 	public static function isThisMonth($dateString, $timezone = null) {
@@ -532,9 +532,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is within current year.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string is within current year
+ * @return bool True if datetime string is within current year
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isThisYear
  */
 	public static function isThisYear($dateString, $timezone = null) {
@@ -546,9 +546,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string was yesterday.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string was yesterday
+ * @return bool True if datetime string was yesterday
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::wasYesterday
  */
 	public static function wasYesterday($dateString, $timezone = null) {
@@ -560,9 +560,9 @@ class CakeTime {
 /**
  * Returns true if given datetime string is tomorrow.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean True if datetime string was yesterday
+ * @return bool True if datetime string was yesterday
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::isTomorrow
  */
 	public static function isTomorrow($dateString, $timezone = null) {
@@ -574,8 +574,8 @@ class CakeTime {
 /**
  * Returns the quarter
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
- * @param boolean $range if true returns a range in Y-m-d format
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param bool $range if true returns a range in Y-m-d format
  * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::toQuarter
  */
@@ -602,9 +602,9 @@ class CakeTime {
 /**
  * Returns a UNIX timestamp from a textual datetime description. Wrapper for PHP function strtotime().
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return integer Unix timestamp
+ * @return int Unix timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::toUnix
  */
 	public static function toUnix($dateString, $timezone = null) {
@@ -620,7 +620,7 @@ class CakeTime {
  * If no timezone parameter is given and no DateTime object, the passed $dateString will be
  * considered to be in the UTC timezone.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @param string $format date format string
  * @return mixed Formatted date
@@ -665,7 +665,7 @@ class CakeTime {
 /**
  * Formats date for RSS feeds
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::toRSS
@@ -730,7 +730,7 @@ class CakeTime {
  *
  * NOTE: If the difference is one week or more, the lowest level of accuracy is day
  *
- * @param integer|string|DateTime $dateTime Datetime UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateTime Datetime UNIX timestamp, strtotime() valid string or DateTime object
  * @param array $options Default format if timestamp is used in $dateString
  * @return string Relative time string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::timeAgoInWords
@@ -939,11 +939,11 @@ class CakeTime {
 /**
  * Returns true if specified datetime was within the interval specified, else false.
  *
- * @param string|integer $timeInterval the numeric value with space then time type.
+ * @param string|int $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::wasWithinLast
  */
 	public static function wasWithinLast($timeInterval, $dateString, $timezone = null) {
@@ -962,11 +962,11 @@ class CakeTime {
 /**
  * Returns true if specified datetime is within the interval specified, else false.
  *
- * @param string|integer $timeInterval the numeric value with space then time type.
+ * @param string|int $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
- * @return boolean
+ * @return bool
  */
 	public static function isWithinNext($timeInterval, $dateString, $timezone = null) {
 		$tmp = str_replace(' ', '', $timeInterval);
@@ -984,8 +984,8 @@ class CakeTime {
 /**
  * Returns gmt as a UNIX timestamp.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
- * @return integer UNIX timestamp
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @return int UNIX timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::gmt
  */
 	public static function gmt($dateString = null) {
@@ -1019,9 +1019,9 @@ class CakeTime {
  *   CakeTime::format('2012-02-15 23:01:01', '%c', 'N/A', 'America/New_York'); // converts passed date to timezone
  * }}}
  *
- * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
- * @param integer|string|DateTime $format date format string (or UNIX timestamp, strtotime() valid string or DateTime object)
- * @param boolean|string $default if an invalid date is passed it will output supplied default value. Pass false if you want raw conversion value
+ * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
+ * @param int|string|DateTime $format date format string (or UNIX timestamp, strtotime() valid string or DateTime object)
+ * @param bool|string $default if an invalid date is passed it will output supplied default value. Pass false if you want raw conversion value
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::format
@@ -1041,9 +1041,9 @@ class CakeTime {
  * Returns a formatted date string, given either a UNIX timestamp or a valid strtotime() date string.
  * It takes into account the default date format for the current language if a LC_TIME file is used.
  *
- * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $format strftime format string.
- * @param boolean|string $default if an invalid date is passed it will output supplied default value. Pass false if you want raw conversion value
+ * @param bool|string $default if an invalid date is passed it will output supplied default value. Pass false if you want raw conversion value
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Formatted and translated date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::i18nFormat
@@ -1062,11 +1062,11 @@ class CakeTime {
 /**
  * Get list of timezone identifiers
  *
- * @param integer|string $filter A regex to filter identifier
+ * @param int|string $filter A regex to filter identifier
  * 	Or one of DateTimeZone class constants (PHP 5.3 and above)
  * @param string $country A two-letter ISO 3166-1 compatible country code.
  * 	This option is only used when $filter is set to DateTimeZone::PER_COUNTRY (available only in PHP 5.3 and above)
- * @param boolean $group If true (default value) groups the identifiers list by primary region
+ * @param bool $group If true (default value) groups the identifiers list by primary region
  * @return array List of timezone identifiers
  * @since 2.2
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::listTimezones
@@ -1118,7 +1118,7 @@ class CakeTime {
  * Handles utf8_encoding the result of strftime when necessary.
  *
  * @param string $format Format string.
- * @param integer $date Timestamp to format.
+ * @param int $date Timestamp to format.
  * @return string formatted string with correct encoding.
  */
 	protected static function _strftime($format, $date) {

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -89,7 +89,7 @@ class ClassRegistry {
  *
  * @param string|array $class as a string or a single key => value array instance will be created,
  *  stored in the registry and returned.
- * @param boolean $strict if set to true it will return false if the class was not found instead
+ * @param bool $strict if set to true it will return false if the class was not found instead
  *	of trying to create an AppModel
  * @return object instance of ClassName.
  * @throws CakeException when you try to construct an interface or abstract class.
@@ -206,7 +206,7 @@ class ClassRegistry {
  *
  * @param string $key Key for the object in registry
  * @param object $object Object to store
- * @return boolean True if the object was written, false if $key already exists
+ * @return bool True if the object was written, false if $key already exists
  */
 	public static function addObject($key, $object) {
 		$_this = ClassRegistry::getInstance();
@@ -236,7 +236,7 @@ class ClassRegistry {
  * Returns true if given key is present in the ClassRegistry.
  *
  * @param string $key Key to look for
- * @return boolean true if key exists in registry, false otherwise
+ * @return bool true if key exists in registry, false otherwise
  */
 	public static function isKeySet($key) {
 		$_this = ClassRegistry::getInstance();
@@ -306,7 +306,7 @@ class ClassRegistry {
  *
  * @param string $alias Alias to check.
  * @param string $class Class name.
- * @return boolean
+ * @return bool
  */
 	protected function &_duplicate($alias, $class) {
 		$duplicate = false;

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -182,7 +182,7 @@ class Debugger {
  * as well as export the variable using exportVar. By default the log is written to the debug log.
  *
  * @param mixed $var Variable or content to log
- * @param integer $level type of log to use. Defaults to LOG_DEBUG
+ * @param int $level type of log to use. Defaults to LOG_DEBUG
  * @param int $depth The depth to output to. Defaults to 3.
  * @return void
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#Debugger::log
@@ -195,12 +195,12 @@ class Debugger {
 /**
  * Overrides PHP's default error handling.
  *
- * @param integer $code Code of error
+ * @param int $code Code of error
  * @param string $description Error description
  * @param string $file File on which error occurred
- * @param integer $line Line that triggered the error
+ * @param int $line Line that triggered the error
  * @param array $context Context
- * @return boolean true if error was handled
+ * @return bool true if error was handled
  * @deprecated Will be removed in 3.0. This function is superseded by Debugger::outputError().
  */
 	public static function showError($code, $description, $file = null, $line = null, $context = null) {
@@ -383,8 +383,8 @@ class Debugger {
  * applied.
  *
  * @param string $file Absolute path to a PHP file
- * @param integer $line Line number to highlight
- * @param integer $context Number of lines of context to extract above and below $line
+ * @param int $line Line number to highlight
+ * @param int $context Number of lines of context to extract above and below $line
  * @return array Set of lines highlighted
  * @see http://php.net/highlight_string
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#Debugger::excerpt
@@ -463,7 +463,7 @@ class Debugger {
  * shown in an error message if CakePHP is deployed in development mode.
  *
  * @param string $var Variable to convert
- * @param integer $depth The depth to output to. Defaults to 3.
+ * @param int $depth The depth to output to. Defaults to 3.
  * @return string Variable as a formatted string
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#Debugger::exportVar
  */
@@ -475,8 +475,8 @@ class Debugger {
  * Protected export function used to keep track of indentation and recursion.
  *
  * @param mixed $var The variable to dump.
- * @param integer $depth The remaining depth.
- * @param integer $indent The current indentation level.
+ * @param int $depth The remaining depth.
+ * @param int $indent The current indentation level.
  * @return string The dumped variable.
  */
 	protected static function _export($var, $depth, $indent) {
@@ -519,8 +519,8 @@ class Debugger {
  * - schema
  *
  * @param array $var The array to export.
- * @param integer $depth The current depth, used for recursion tracking.
- * @param integer $indent The current indentation level.
+ * @param int $depth The current depth, used for recursion tracking.
+ * @param int $indent The current indentation level.
  * @return string Exported array.
  */
 	protected static function _array(array $var, $depth, $indent) {
@@ -566,8 +566,8 @@ class Debugger {
  * Handles object to string conversion.
  *
  * @param string $var Object to convert
- * @param integer $depth The current depth, used for tracking recursion.
- * @param integer $indent The current indentation level.
+ * @param int $depth The current depth, used for tracking recursion.
+ * @param int $indent The current indentation level.
  * @return string
  * @see Debugger::exportVar()
  */

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -60,7 +60,7 @@ class File {
 /**
  * Enable locking for file reading and writing
  *
- * @var boolean
+ * @var bool
  * http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::$lock
  */
 	public $lock = null;
@@ -70,7 +70,7 @@ class File {
  *
  * Current file's absolute path
  *
- * @var mixed null
+ * @var mixed
  * http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::$path
  */
 	public $path = null;
@@ -79,8 +79,8 @@ class File {
  * Constructor
  *
  * @param string $path Path to file
- * @param boolean $create Create file if it does not exist (if true)
- * @param integer $mode Mode to apply to the folder holding the file
+ * @param bool $create Create file if it does not exist (if true)
+ * @param int $mode Mode to apply to the folder holding the file
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File
  */
 	public function __construct($path, $create = false, $mode = 0755) {
@@ -102,7 +102,7 @@ class File {
 /**
  * Creates the file.
  *
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::create
  */
 	public function create() {
@@ -119,8 +119,8 @@ class File {
  * Opens the current file with a given $mode
  *
  * @param string $mode A valid 'fopen' mode string (r|w|a ...)
- * @param boolean $force If true then the file will be re-opened even if its already opened, otherwise it won't
- * @return boolean True on success, false on failure
+ * @param bool $force If true then the file will be re-opened even if its already opened, otherwise it won't
+ * @return bool True on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::open
  */
 	public function open($mode = 'r', $force = false) {
@@ -145,7 +145,7 @@ class File {
  *
  * @param string $bytes where to start
  * @param string $mode A `fread` compatible mode.
- * @param boolean $force If true then the file will be re-opened even if its already opened, otherwise it won't
+ * @param bool $force If true then the file will be re-opened even if its already opened, otherwise it won't
  * @return mixed string on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::read
  */
@@ -180,8 +180,8 @@ class File {
 /**
  * Sets or gets the offset for the currently opened file.
  *
- * @param integer|boolean $offset The $offset in bytes to seek. If set to false then the current offset is returned.
- * @param integer $seek PHP Constant SEEK_SET | SEEK_CUR | SEEK_END determining what the $offset is relative to
+ * @param int|bool $offset The $offset in bytes to seek. If set to false then the current offset is returned.
+ * @param int $seek PHP Constant SEEK_SET | SEEK_CUR | SEEK_END determining what the $offset is relative to
  * @return mixed True on success, false on failure (set mode), false on failure or integer offset on success (get mode)
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::offset
  */
@@ -202,7 +202,7 @@ class File {
  * all other platforms will use "\n"
  *
  * @param string $data Data to prepare for writing.
- * @param boolean $forceWindows If true forces usage Windows newline string.
+ * @param bool $forceWindows If true forces usage Windows newline string.
  * @return string The with converted line endings.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::prepare
  */
@@ -220,7 +220,7 @@ class File {
  * @param string $data Data to write to this File.
  * @param string $mode Mode of writing. {@link http://php.net/fwrite See fwrite()}.
  * @param string $force Force the file to open
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::write
  */
 	public function write($data, $mode = 'w', $force = false) {
@@ -247,7 +247,7 @@ class File {
  *
  * @param string $data Data to write
  * @param string $force Force the file to open
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::append
  */
 	public function append($data, $force = false) {
@@ -257,7 +257,7 @@ class File {
 /**
  * Closes the current file if it is opened.
  *
- * @return boolean True if closing was successful or file was already closed, otherwise false
+ * @return bool True if closing was successful or file was already closed, otherwise false
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::close
  */
 	public function close() {
@@ -270,7 +270,7 @@ class File {
 /**
  * Deletes the file.
  *
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::delete
  */
 	public function delete() {
@@ -352,7 +352,7 @@ class File {
  *
  * @param string $name The name of the file to make safe if different from $this->name
  * @param string $ext The name of the extension to make safe if different from $this->ext
- * @return string $ext The extension of the file
+ * @return string ext The extension of the file
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::safe
  */
 	public function safe($name = null, $ext = null) {
@@ -368,7 +368,7 @@ class File {
 /**
  * Get md5 Checksum of file with previous check of Filesize
  *
- * @param integer|boolean $maxsize in MB or true to force
+ * @param int|bool $maxsize in MB or true to force
  * @return string|false md5 Checksum {@link http://php.net/md5_file See md5_file()}, or false in case of an error
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::md5
  */
@@ -401,7 +401,7 @@ class File {
 /**
  * Returns true if the file exists.
  *
- * @return boolean True if it exists, false otherwise
+ * @return bool True if it exists, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::exists
  */
 	public function exists() {
@@ -425,7 +425,7 @@ class File {
 /**
  * Returns the file size
  *
- * @return integer|false Size of the file in bytes, or false in case of an error
+ * @return int|false Size of the file in bytes, or false in case of an error
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::size
  */
 	public function size() {
@@ -438,7 +438,7 @@ class File {
 /**
  * Returns true if the file is writable.
  *
- * @return boolean True if it's writable, false otherwise
+ * @return bool True if it's writable, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::writable
  */
 	public function writable() {
@@ -448,7 +448,7 @@ class File {
 /**
  * Returns true if the File is executable.
  *
- * @return boolean True if it's executable, false otherwise
+ * @return bool True if it's executable, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::executable
  */
 	public function executable() {
@@ -458,7 +458,7 @@ class File {
 /**
  * Returns true if the file is readable.
  *
- * @return boolean True if file is readable, false otherwise
+ * @return bool True if file is readable, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readable
  */
 	public function readable() {
@@ -468,7 +468,7 @@ class File {
 /**
  * Returns the file's owner.
  *
- * @return integer|false The file owner, or false in case of an error
+ * @return int|false The file owner, or false in case of an error
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::owner
  */
 	public function owner() {
@@ -481,7 +481,7 @@ class File {
 /**
  * Returns the file's group.
  *
- * @return integer|false The file group, or false in case of an error
+ * @return int|false The file group, or false in case of an error
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::group
  */
 	public function group() {
@@ -494,7 +494,7 @@ class File {
 /**
  * Returns last access time.
  *
- * @return integer|false Timestamp of last access time, or false in case of an error
+ * @return int|false Timestamp of last access time, or false in case of an error
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::lastAccess
  */
 	public function lastAccess() {
@@ -507,7 +507,7 @@ class File {
 /**
  * Returns last modified time.
  *
- * @return integer|false Timestamp of last modification, or false in case of an error
+ * @return int|false Timestamp of last modification, or false in case of an error
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::lastChange
  */
 	public function lastChange() {
@@ -531,8 +531,8 @@ class File {
  * Copy the File to $dest
  *
  * @param string $dest Destination for the copy
- * @param boolean $overwrite Overwrite $dest if exists
- * @return boolean Success
+ * @param bool $overwrite Overwrite $dest if exists
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::copy
  */
 	public function copy($dest, $overwrite = true) {
@@ -573,7 +573,7 @@ class File {
  * For 5.3 onwards it's possible to clear cache for just a single file. Passing true
  * will clear all the stat cache.
  *
- * @param boolean $all Clear all cache or not
+ * @param bool $all Clear all cache or not
  * @return void
  */
 	public function clearStatCache($all = false) {
@@ -589,7 +589,7 @@ class File {
  *
  * @param string|array $search Text(s) to search for.
  * @param string|array $replace Text(s) to replace with.
- * @return boolean Success
+ * @return bool Success
  */
 	public function replaceText($search, $replace) {
 		if (!$this->open('r+')) {

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -58,7 +58,7 @@ class Folder {
  * Sortedness. Whether or not list results
  * should be sorted by name.
  *
- * @var boolean
+ * @var bool
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::$sort
  */
 	public $sort = false;
@@ -66,7 +66,7 @@ class Folder {
 /**
  * Mode to be used on create. Does nothing on windows platforms.
  *
- * @var integer
+ * @var int
  * http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::$mode
  */
 	public $mode = 0755;
@@ -103,8 +103,8 @@ class Folder {
  * Constructor.
  *
  * @param string $path Path to folder
- * @param boolean $create Create folder if not found
- * @param string|boolean $mode Mode (CHMOD) to apply to created folder, false to ignore
+ * @param bool $create Create folder if not found
+ * @param string|bool $mode Mode (CHMOD) to apply to created folder, false to ignore
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder
  */
 	public function __construct($path = false, $create = false, $mode = false) {
@@ -155,10 +155,10 @@ class Folder {
  * Returns an array of the contents of the current directory.
  * The returned array holds two arrays: One of directories and one of files.
  *
- * @param boolean $sort Whether you want the results sorted, set this and the sort property
+ * @param bool $sort Whether you want the results sorted, set this and the sort property
  *   to false to get unsorted results.
- * @param array|boolean $exceptions Either an array or boolean true will not grab dot files
- * @param boolean $fullPath True returns the full path
+ * @param array|bool $exceptions Either an array or boolean true will not grab dot files
+ * @param bool $fullPath True returns the full path
  * @return mixed Contents of current directory as an array, an empty array on failure
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::read
  */
@@ -207,7 +207,7 @@ class Folder {
  * Returns an array of all matching files in current directory.
  *
  * @param string $regexpPattern Preg_match pattern (Defaults to: .*)
- * @param boolean $sort Whether results should be sorted.
+ * @param bool $sort Whether results should be sorted.
  * @return array Files that match given pattern
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::find
  */
@@ -220,7 +220,7 @@ class Folder {
  * Returns an array of all matching files in and below current directory.
  *
  * @param string $pattern Preg_match pattern (Defaults to: .*)
- * @param boolean $sort Whether results should be sorted.
+ * @param bool $sort Whether results should be sorted.
  * @return array Files matching $pattern
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::findRecursive
  */
@@ -238,7 +238,7 @@ class Folder {
  * Private helper function for findRecursive.
  *
  * @param string $pattern Pattern to match against
- * @param boolean $sort Whether results should be sorted.
+ * @param bool $sort Whether results should be sorted.
  * @return array Files matching pattern
  */
 	protected function _findRecursive($pattern, $sort = false) {
@@ -263,7 +263,7 @@ class Folder {
  * Returns true if given $path is a Windows path.
  *
  * @param string $path Path to check
- * @return boolean true if windows path, false otherwise
+ * @return bool true if windows path, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isWindowsPath
  */
 	public static function isWindowsPath($path) {
@@ -274,7 +274,7 @@ class Folder {
  * Returns true if given $path is an absolute path.
  *
  * @param string $path Path to check
- * @return boolean true if path is absolute.
+ * @return bool true if path is absolute.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isAbsolute
  */
 	public static function isAbsolute($path) {
@@ -335,7 +335,7 @@ class Folder {
  * Returns true if the File is in a given CakePath.
  *
  * @param string $path The path to check.
- * @return boolean
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::inCakePath
  */
 	public function inCakePath($path = '') {
@@ -349,8 +349,8 @@ class Folder {
  * Returns true if the File is in given path.
  *
  * @param string $path The path to check that the current pwd() resides with in.
- * @param boolean $reverse Reverse the search, check that pwd() resides within $path.
- * @return boolean
+ * @param bool $reverse Reverse the search, check that pwd() resides within $path.
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::inPath
  */
 	public function inPath($path = '', $reverse = false) {
@@ -369,10 +369,10 @@ class Folder {
  * Change the mode on a directory structure recursively. This includes changing the mode on files as well.
  *
  * @param string $path The path to chmod
- * @param integer $mode octal value 0755
- * @param boolean $recursive chmod recursively, set to false to only change the current directory.
+ * @param int $mode octal value 0755
+ * @param bool $recursive chmod recursively, set to false to only change the current directory.
  * @param array $exceptions array of files, directories to skip
- * @return boolean Returns TRUE on success, FALSE on failure
+ * @return bool Returns TRUE on success, FALSE on failure
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::chmod
  */
 	public function chmod($path, $mode = false, $recursive = true, $exceptions = array()) {
@@ -425,7 +425,7 @@ class Folder {
  * Returns an array of nested directories and files in each directory
  *
  * @param string $path the directory path to build the tree from
- * @param array|boolean $exceptions Either an array of files/folder to exclude
+ * @param array|bool $exceptions Either an array of files/folder to exclude
  *   or boolean true to not grab dot files/folders
  * @param string $type either 'file' or 'dir'. null returns both files and directories
  * @return mixed array of nested directories and files in each directory
@@ -491,8 +491,8 @@ class Folder {
  * deep path structures like `/foo/bar/baz/shoe/horn`
  *
  * @param string $pathname The directory structure to create
- * @param integer $mode octal value 0755
- * @return boolean Returns TRUE on success, FALSE on failure
+ * @param int $mode octal value 0755
+ * @return bool Returns TRUE on success, FALSE on failure
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::create
  */
 	public function create($pathname, $mode = false) {
@@ -530,7 +530,7 @@ class Folder {
 /**
  * Returns the size in bytes of this Folder and its contents.
  *
- * @return integer size in bytes of current folder
+ * @return int size in bytes of current folder
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::dirsize
  */
 	public function dirsize() {
@@ -567,7 +567,7 @@ class Folder {
  * Recursively Remove directories if the system allows.
  *
  * @param string $path Path of directory to delete
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::delete
  */
 	public function delete($path = null) {
@@ -633,7 +633,7 @@ class Folder {
  * - `scheme` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
  * @param array|string $options Either an array of options (see above) or a string of the destination directory.
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::copy
  */
 	public function copy($options) {
@@ -729,7 +729,7 @@ class Folder {
  * - `scheme` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
  * @param array $options (to, from, chmod, skip, scheme)
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::move
  */
 	public function move($options) {
@@ -751,7 +751,7 @@ class Folder {
 /**
  * get messages from latest method
  *
- * @param boolean $reset Reset message stack after reading
+ * @param bool $reset Reset message stack after reading
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::messages
  */
@@ -766,7 +766,7 @@ class Folder {
 /**
  * get error from latest method
  *
- * @param boolean $reset Reset error stack after reading
+ * @param bool $reset Reset error stack after reading
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::errors
  */
@@ -822,7 +822,7 @@ class Folder {
  * Returns true if given $path ends in a slash (i.e. is slash-terminated).
  *
  * @param string $path Path to check
- * @return boolean true if path ends with slash, false otherwise
+ * @return bool true if path ends with slash, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isSlashTerm
  */
 	public static function isSlashTerm($path) {

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -159,7 +159,7 @@ class Hash {
  *
  * @param string $key The key in the array being searched.
  * @param string $token The token being matched.
- * @return boolean
+ * @return bool
  */
 	protected static function _matchToken($key, $token) {
 		if ($token === '{n}') {
@@ -179,7 +179,7 @@ class Hash {
  *
  * @param array $data Array of data to match.
  * @param string $selector The patterns to match.
- * @return boolean Fitness of expression.
+ * @return bool Fitness of expression.
  */
 	protected static function _matches(array $data, $selector) {
 		preg_match_all(
@@ -282,7 +282,7 @@ class Hash {
  * @param array $data The data to operate on.
  * @param array $path The path to work on.
  * @param mixed $values The values to insert when doing inserts.
- * @return array $data.
+ * @return array data.
  */
 	protected static function _simpleOp($op, $data, $path, $values = null) {
 		$_list =& $data;
@@ -484,7 +484,7 @@ class Hash {
  *
  * @param array $data The data to search through.
  * @param array $needle The values to file in $data
- * @return boolean true if $data contains $needle, false otherwise
+ * @return bool true if $data contains $needle, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::contains
  */
 	public static function contains(array $data, array $needle) {
@@ -525,7 +525,7 @@ class Hash {
  *
  * @param array $data The data to check.
  * @param string $path The path to check for.
- * @return boolean Existence of path.
+ * @return bool Existence of path.
  * @see Hash::extract()
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::check
  */
@@ -559,7 +559,7 @@ class Hash {
  * Callback function for filtering.
  *
  * @param array $var Array to filter.
- * @return boolean
+ * @return bool
  */
 	protected static function _filter($var) {
 		if ($var === 0 || $var === '0' || !empty($var)) {
@@ -675,7 +675,7 @@ class Hash {
  * Checks to see if all the values in the array are numeric
  *
  * @param array $data The array to check.
- * @return boolean true if values are numeric, false otherwise
+ * @return bool true if values are numeric, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::numeric
  */
 	public static function numeric(array $data) {
@@ -693,7 +693,7 @@ class Hash {
  * to get the dimensions of the array.
  *
  * @param array $data Array to count dimensions on
- * @return integer The number of dimensions in $data
+ * @return int The number of dimensions in $data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::dimensions
  */
 	public static function dimensions(array $data) {
@@ -718,7 +718,7 @@ class Hash {
  * number of dimensions in a mixed array.
  *
  * @param array $data Array to count dimensions on
- * @return integer The maximum number of dimensions in $data
+ * @return int The maximum number of dimensions in $data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::maxDimensions
  */
 	public static function maxDimensions(array $data) {
@@ -949,7 +949,7 @@ class Hash {
  * Normalizes an array, and converts it to a standard format.
  *
  * @param array $data List to normalize
- * @param boolean $assoc If true, $data will be converted to an associative array.
+ * @param bool $assoc If true, $data will be converted to an associative array.
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::normalize
  */

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -314,7 +314,7 @@ class Inflector {
  *
  * @param string $type The type of inflection, either 'plural', 'singular' or 'transliteration'
  * @param array $rules Array of rules to be added.
- * @param boolean $reset If true, will unset default inflections for all
+ * @param bool $reset If true, will unset default inflections for all
  *        new rules that are being defined in $rules.
  * @return void
  */

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -44,7 +44,7 @@ abstract class ObjectCollection {
 /**
  * Default object priority. A non zero integer.
  *
- * @var integer
+ * @var int
  */
 	public $defaultPriority = 10;
 
@@ -161,7 +161,7 @@ abstract class ObjectCollection {
  * Provide isset access to _loaded
  *
  * @param string $name Name of object being checked.
- * @return boolean
+ * @return bool
  */
 	public function __isset($name) {
 		return isset($this->_loaded[$name]);
@@ -171,7 +171,7 @@ abstract class ObjectCollection {
  * Enables callbacks on an object or array of objects
  *
  * @param string|array $name CamelCased name of the object(s) to enable (string or array)
- * @param boolean $prioritize Prioritize enabled list after enabling object(s)
+ * @param bool $prioritize Prioritize enabled list after enabling object(s)
  * @return void
  */
 	public function enable($name, $prioritize = true) {
@@ -212,7 +212,7 @@ abstract class ObjectCollection {
  * @param string|array $name CamelCased name of the object(s) to enable (string or array)
  * 	If string the second param $priority is used else it should be an associative array
  * 	with keys as object names and values as priorities to set.
- * @param integer|null $priority Integer priority to set or null for default
+ * @param int|null $priority Integer priority to set or null for default
  * @return void
  */
 	public function setPriority($name, $priority = null) {

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -43,7 +43,7 @@ class Security {
  * Get allowed minutes of inactivity based on security level.
  *
  * @deprecated Exists for backwards compatibility only, not used by the core
- * @return integer Allowed inactivity in minutes
+ * @return int Allowed inactivity in minutes
  */
 	public static function inactiveMins() {
 		switch (Configure::read('Security.level')) {
@@ -70,7 +70,7 @@ class Security {
  * Validate authorization hash.
  *
  * @param string $authKey Authorization hash
- * @return boolean Success
+ * @return bool Success
  */
 	public static function validateAuthKey($authKey) {
 		return true;
@@ -151,7 +151,7 @@ class Security {
 /**
  * Sets the cost for they blowfish hash method.
  *
- * @param integer $cost Valid values are 4-31
+ * @param int $cost Valid values are 4-31
  * @return void
  */
 	public static function setCost($cost) {
@@ -252,7 +252,7 @@ class Security {
  * The salt length should not exceed 27. The salt will be composed of
  * [./0-9A-Za-z]{$length}.
  *
- * @param integer $length The length of the returned salt
+ * @param int $length The length of the returned salt
  * @return string The generated salt
  */
 	protected static function _salt($length = 22) {

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -122,7 +122,7 @@ class Set {
  *
  * @param array &$array Array to map
  * @param string $class Class name
- * @param boolean $primary whether to assign first array key as the _name_
+ * @param bool $primary whether to assign first array key as the _name_
  * @return mixed Mapped object
  */
 	protected static function _map(&$array, $class, $primary = false) {
@@ -186,7 +186,7 @@ class Set {
  * Checks to see if all the values in the array are numeric
  *
  * @param array $array The array to check. If null, the value of the current Set object
- * @return boolean true if values are numeric, false otherwise
+ * @return bool true if values are numeric, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::numeric
  */
 	public static function numeric($array = null) {
@@ -457,9 +457,9 @@ class Set {
  *
  * @param string|array $conditions An array of condition strings or an XPath expression
  * @param array $data An array of data to execute the match on
- * @param integer $i Optional: The 'nth'-number of the item being matched.
- * @param integer $length Length.
- * @return boolean
+ * @param int $i Optional: The 'nth'-number of the item being matched.
+ * @param int $length Length.
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::matches
  */
 	public static function matches($conditions, $data = array(), $i = null, $length = null) {
@@ -645,7 +645,7 @@ class Set {
  *
  * @param string|array $data Data to check on
  * @param string|array $path A dot-separated string.
- * @return boolean true if path is found, false otherwise
+ * @return bool true if path is found, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::check
  */
 	public static function check($data, $path = null) {
@@ -705,7 +705,7 @@ class Set {
  *
  * @param array $val1 First value
  * @param array $val2 Second value
- * @return boolean true if $val1 contains $val2, false otherwise
+ * @return bool true if $val1 contains $val2, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::contains
  */
 	public static function contains($val1, $val2 = null) {
@@ -730,9 +730,9 @@ class Set {
  * only consider the dimension of the first element in the array.
  *
  * @param array $array Array to count dimensions on
- * @param boolean $all Set to true to count the dimension considering all elements in array
- * @param integer $count Start the dimension count at this number
- * @return integer The number of dimensions in $array
+ * @param bool $all Set to true to count the dimension considering all elements in array
+ * @param int $count Start the dimension count at this number
+ * @return int The number of dimensions in $array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::countDim
  */
 	public static function countDim($array, $all = false, $count = 0) {
@@ -758,9 +758,9 @@ class Set {
  * Normalizes a string or array list.
  *
  * @param mixed $list List to normalize
- * @param boolean $assoc If true, $list will be converted to an associative array
+ * @param bool $assoc If true, $list will be converted to an associative array
  * @param string $sep If $list is a string, it will be split into an array with $sep
- * @param boolean $trim If true, separated strings will be trimmed
+ * @param bool $trim If true, separated strings will be trimmed
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::normalize
  */

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -19,7 +19,6 @@
 /**
  * String handling methods.
  *
- *
  * @package       Cake.Utility
  */
 class String {
@@ -323,7 +322,7 @@ class String {
  * - `indentAt` 0 based index to start indenting at. Defaults to 0.
  *
  * @param string $text The text to format.
- * @param array|integer $options Array of options to use, or an integer to wrap the text to.
+ * @param array|int $options Array of options to use, or an integer to wrap the text to.
  * @return string Formatted text.
  */
 	public static function wrap($text, $options = array()) {
@@ -350,9 +349,9 @@ class String {
  * Unicode aware version of wordwrap.
  *
  * @param string $text The text to format.
- * @param integer $width The width to wrap to. Defaults to 72.
+ * @param int $width The width to wrap to. Defaults to 72.
  * @param string $break The line is broken using the optional break parameter. Defaults to '\n'.
- * @param boolean $cut If the cut is set to true, the string is always wrapped at the specified width.
+ * @param bool $cut If the cut is set to true, the string is always wrapped at the specified width.
  * @return string Formatted text.
  */
 	public static function wordWrap($text, $width = 72, $break = "\n", $cut = false) {
@@ -472,7 +471,7 @@ class String {
  * - `exact` If false, $text will not be cut mid-word
  *
  * @param string $text String to truncate.
- * @param integer $length Length of returned string, including ellipsis.
+ * @param int $length Length of returned string, including ellipsis.
  * @param array $options An array of options.
  * @return string Trimmed string.
  */
@@ -513,7 +512,7 @@ class String {
  * - `html` If true, HTML tags would be handled correctly
  *
  * @param string $text String to truncate.
- * @param integer $length Length of returned string, including ellipsis.
+ * @param int $length Length of returned string, including ellipsis.
  * @param array $options An array of html attributes and options.
  * @return string Trimmed string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::truncate
@@ -633,7 +632,7 @@ class String {
  *
  * @param string $text String to search the phrase in
  * @param string $phrase Phrase that will be searched for
- * @param integer $radius The amount of characters that will be returned on each side of the founded phrase
+ * @param int $radius The amount of characters that will be returned on each side of the founded phrase
  * @param string $ellipsis Ending that will be appended
  * @return string Modified string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::excerpt

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -59,7 +57,7 @@ class Validation {
  * array('check' => 'valueToCheck');
  *
  * @param string|array $check Value to check
- * @return boolean Success
+ * @return bool Success
  */
 	public static function notEmpty($check) {
 		if (is_array($check)) {
@@ -81,7 +79,7 @@ class Validation {
  * array('check' => 'valueToCheck');
  *
  * @param string|array $check Value to check
- * @return boolean Success
+ * @return bool Success
  */
 	public static function alphaNumeric($check) {
 		if (is_array($check)) {
@@ -100,9 +98,9 @@ class Validation {
  * Returns true is string matches value min, max, or between min and max,
  *
  * @param string $check Value to check for length
- * @param integer $min Minimum value in range (inclusive)
- * @param integer $max Maximum value in range (inclusive)
- * @return boolean Success
+ * @param int $min Minimum value in range (inclusive)
+ * @param int $max Maximum value in range (inclusive)
+ * @return bool Success
  */
 	public static function between($check, $min, $max) {
 		$length = mb_strlen($check);
@@ -117,7 +115,7 @@ class Validation {
  * array('check' => 'valueToCheck');
  *
  * @param string|array $check Value to check
- * @return boolean Success
+ * @return bool Success
  */
 	public static function blank($check) {
 		if (is_array($check)) {
@@ -134,9 +132,9 @@ class Validation {
  * @param string|array $type 'all' may be passed as a sting, defaults to fast which checks format of most major credit cards
  *    if an array is used only the values of the array are checked.
  *    Example: array('amex', 'bankcard', 'maestro')
- * @param boolean $deep set to true this will check the Luhn algorithm of the credit card.
+ * @param bool $deep set to true this will check the Luhn algorithm of the credit card.
  * @param string $regex A custom regex can also be passed, this will be used instead of the defined regex values
- * @return boolean Success
+ * @return bool Success
  * @see Validation::luhn()
  */
 	public static function cc($check, $type = 'fast', $deep = false, $regex = null) {
@@ -207,8 +205,8 @@ class Validation {
  * @param string $operator Can be either a word or operand
  *    is greater >, is less <, greater or equal >=
  *    less or equal <=, is less <, equal to ==, not equal !=
- * @param integer $check2 only needed if $check1 is a string
- * @return boolean Success
+ * @param int $check2 only needed if $check1 is a string
+ * @return bool Success
  */
 	public static function comparison($check1, $operator = null, $check2 = null) {
 		if (is_array($check1)) {
@@ -265,7 +263,7 @@ class Validation {
  * @param string|array $check When used as a string, $regex must also be a valid regular expression.
  *    As and array: array('check' => value, 'regex' => 'valid regular expression')
  * @param string $regex If $check is passed as a string, $regex must also be set to valid regular expression
- * @return boolean Success
+ * @return bool Success
  */
 	public static function custom($check, $regex = null) {
 		if (is_array($check)) {
@@ -298,7 +296,7 @@ class Validation {
  * @param string|array $format Use a string or an array of the keys above.
  *    Arrays should be passed as array('dmy', 'mdy', etc)
  * @param string $regex If a custom regular expression is used this is the only validation that will occur.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function date($check, $format = 'ymd', $regex = null) {
 		if ($regex !== null) {
@@ -351,7 +349,7 @@ class Validation {
  * @param string $check Value to check
  * @param string|array $dateFormat Format of the date part. See Validation::date for more information.
  * @param string $regex Regex for the date part. If a custom regular expression is used this is the only validation that will occur.
- * @return boolean True if the value is valid, false otherwise
+ * @return bool True if the value is valid, false otherwise
  * @see Validation::date
  * @see Validation::time
  */
@@ -372,7 +370,7 @@ class Validation {
  * Does not allow/validate seconds.
  *
  * @param string $check a valid time string
- * @return boolean Success
+ * @return bool Success
  */
 	public static function time($check) {
 		return self::_check($check, '%^((0?[1-9]|1[012])(:[0-5]\d){0,2} ?([AP]M|[ap]m))$|^([01]\d|2[0-3])(:[0-5]\d){0,2}$%');
@@ -382,7 +380,7 @@ class Validation {
  * Boolean validation, determines if value passed is a boolean integer or true/false.
  *
  * @param string $check a valid boolean
- * @return boolean Success
+ * @return bool Success
  */
 	public static function boolean($check) {
 		$booleanList = array(0, 1, '0', '1', true, false);
@@ -399,9 +397,9 @@ class Validation {
  * - 1..N => Exactly that many number of decimal places. The '.' is required.
  *
  * @param float $check The value the test for decimal.
- * @param integer $places Decimal places.
+ * @param int $places Decimal places.
  * @param string $regex If a custom regular expression is used, this is the only validation that will occur.
- * @return boolean Success
+ * @return bool Success
  */
 	public static function decimal($check, $places = null, $regex = null) {
 		if ($regex === null) {
@@ -441,9 +439,9 @@ class Validation {
  * any PHP version on a non-windows distribution
  *
  * @param string $check Value to check
- * @param boolean $deep Perform a deeper validation (if true), by also checking availability of host
+ * @param bool $deep Perform a deeper validation (if true), by also checking availability of host
  * @param string $regex Regex to use (if none it will use built in regex)
- * @return boolean Success
+ * @return bool Success
  */
 	public static function email($check, $deep = false, $regex = null) {
 		if (is_array($check)) {
@@ -475,7 +473,7 @@ class Validation {
  *
  * @param mixed $check Value to check
  * @param mixed $comparedTo Value to compare
- * @return boolean Success
+ * @return bool Success
  */
 	public static function equalTo($check, $comparedTo) {
 		return ($check === $comparedTo);
@@ -486,7 +484,7 @@ class Validation {
  *
  * @param string|array $check Value to check
  * @param array $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
- * @return boolean Success
+ * @return bool Success
  */
 	public static function extension($check, $extensions = array('gif', 'jpeg', 'png', 'jpg')) {
 		if (is_array($check)) {
@@ -506,7 +504,7 @@ class Validation {
  *
  * @param string $check The string to test.
  * @param string $type The IP Protocol version to validate against
- * @return boolean Success
+ * @return bool Success
  */
 	public static function ip($check, $type = 'both') {
 		$type = strtolower($type);
@@ -524,8 +522,8 @@ class Validation {
  * Checks whether the length of a string is greater or equal to a minimal length.
  *
  * @param string $check The string to test
- * @param integer $min The minimal string length
- * @return boolean Success
+ * @param int $min The minimal string length
+ * @return bool Success
  */
 	public static function minLength($check, $min) {
 		return mb_strlen($check) >= $min;
@@ -535,8 +533,8 @@ class Validation {
  * Checks whether the length of a string is smaller or equal to a maximal length..
  *
  * @param string $check The string to test
- * @param integer $max The maximal string length
- * @return boolean Success
+ * @param int $max The maximal string length
+ * @return bool Success
  */
 	public static function maxLength($check, $max) {
 		return mb_strlen($check) <= $max;
@@ -547,7 +545,7 @@ class Validation {
  *
  * @param string $check Value to check
  * @param string $symbolPosition Where symbol is located (left/right)
- * @return boolean Success
+ * @return bool Success
  */
 	public static function money($check, $symbolPosition = 'left') {
 		$money = '(?!0,?\d)(?:\d{1,3}(?:([, .])\d{3})?(?:\1\d{3})*|(?:\d+))((?!\1)[,.]\d{1,2})?';
@@ -570,8 +568,8 @@ class Validation {
  *
  * @param array $check Value to check
  * @param array $options Options for the check.
- * @param boolean $caseInsensitive Set to true for case insensitive comparison.
- * @return boolean Success
+ * @param bool $caseInsensitive Set to true for case insensitive comparison.
+ * @return bool Success
  */
 	public static function multiple($check, $options = array(), $caseInsensitive = false) {
 		$defaults = array('in' => null, 'max' => null, 'min' => null);
@@ -608,7 +606,7 @@ class Validation {
  * Checks if a value is numeric.
  *
  * @param string $check Value to check
- * @return boolean Success
+ * @return bool Success
  */
 	public static function numeric($check) {
 		return is_numeric($check);
@@ -618,8 +616,8 @@ class Validation {
  * Checks if a value is a natural number.
  *
  * @param string $check Value to check
- * @param boolean $allowZero Set true to allow zero, defaults to false
- * @return boolean Success
+ * @param bool $allowZero Set true to allow zero, defaults to false
+ * @return bool Success
  * @see http://en.wikipedia.org/wiki/Natural_number
  */
 	public static function naturalNumber($check, $allowZero = false) {
@@ -633,7 +631,7 @@ class Validation {
  * @param string|array $check Value to check (string or array)
  * @param string $regex Regular expression to use
  * @param string $country Country code (defaults to 'all')
- * @return boolean Success
+ * @return bool Success
  */
 	public static function phone($check, $regex = null, $country = 'all') {
 		if (is_array($check)) {
@@ -678,7 +676,7 @@ class Validation {
  * @param string|array $check Value to check
  * @param string $regex Regular expression to use
  * @param string $country Country to use for formatting
- * @return boolean Success
+ * @return bool Success
  */
 	public static function postal($check, $regex = null, $country = 'us') {
 		if (is_array($check)) {
@@ -721,7 +719,7 @@ class Validation {
  * @param string $check Value to check
  * @param int|float $lower Lower limit
  * @param int|float $upper Upper limit
- * @return boolean Success
+ * @return bool Success
  */
 	public static function range($check, $lower = null, $upper = null) {
 		if (!is_numeric($check)) {
@@ -739,7 +737,7 @@ class Validation {
  * @param string|array $check Value to check
  * @param string $regex Regular expression to use
  * @param string $country Country
- * @return boolean Success
+ * @return bool Success
  */
 	public static function ssn($check, $regex = null, $country = null) {
 		if (is_array($check)) {
@@ -779,8 +777,8 @@ class Validation {
  * - an optional fragment (anchor tag)
  *
  * @param string $check Value to check
- * @param boolean $strict Require URL to be prefixed by a valid scheme (one of http(s)/ftp(s)/file/news/gopher)
- * @return boolean Success
+ * @param bool $strict Require URL to be prefixed by a valid scheme (one of http(s)/ftp(s)/file/news/gopher)
+ * @return bool Success
  */
 	public static function url($check, $strict = false) {
 		self::_populateIp();
@@ -798,8 +796,8 @@ class Validation {
  *
  * @param string $check Value to check.
  * @param array $list List to check against.
- * @param boolean $caseInsensitive Set to true for case insensitive comparison.
- * @return boolean Success.
+ * @param bool $caseInsensitive Set to true for case insensitive comparison.
+ * @return bool Success.
  */
 	public static function inList($check, $list, $caseInsensitive = false) {
 		$strict = !is_numeric($check);
@@ -829,7 +827,7 @@ class Validation {
  * Checks that a value is a valid UUID - http://tools.ietf.org/html/rfc4122
  *
  * @param string $check Value to check
- * @return boolean Success
+ * @return bool Success
  */
 	public static function uuid($check) {
 		$regex = '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[0-5][a-fA-F0-9]{3}-[089aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$/';
@@ -865,7 +863,7 @@ class Validation {
  *
  * @param string $check Value to check against the $regex expression
  * @param string $regex Regular expression
- * @return boolean Success of match
+ * @return bool Success of match
  */
 	protected static function _check($check, $regex) {
 		if (is_string($regex) && preg_match($regex, $check)) {
@@ -901,8 +899,8 @@ class Validation {
  * Luhn algorithm
  *
  * @param string|array $check Value to check.
- * @param boolean $deep If true performs deep check.
- * @return boolean Success
+ * @param bool $deep If true performs deep check.
+ * @return bool Success
  * @see http://en.wikipedia.org/wiki/Luhn_algorithm
  */
 	public static function luhn($check, $deep = false) {
@@ -935,7 +933,7 @@ class Validation {
  *
  * @param string|array $check Value to check.
  * @param array|string $mimeTypes Array of mime types or regex pattern to check.
- * @return boolean Success
+ * @return bool Success
  * @throws CakeException when mime type can not be determined.
  */
 	public static function mimeType($check, $mimeTypes = array()) {
@@ -965,8 +963,8 @@ class Validation {
  *
  * @param string|array $check Value to check.
  * @param string $operator See `Validation::comparison()`.
- * @param integer|string $size Size in bytes or human readable string like '5MB'.
- * @return boolean Success
+ * @param int|string $size Size in bytes or human readable string like '5MB'.
+ * @return bool Success
  */
 	public static function fileSize($check, $operator = null, $size = null) {
 		if (is_array($check) && isset($check['tmp_name'])) {
@@ -985,7 +983,7 @@ class Validation {
  * Checking for upload errors
  *
  * @param string|array $check Value to check.
- * @return boolean
+ * @return bool
  * @see http://www.php.net/manual/en/features.file-upload.errors.php
  */
 	public static function uploadError($check) {

--- a/lib/Cake/View/Errors/fatal_error.ctp
+++ b/lib/Cake/View/Errors/fatal_error.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_action.ctp
+++ b/lib/Cake/View/Errors/missing_action.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_behavior.ctp
+++ b/lib/Cake/View/Errors/missing_behavior.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_component.ctp
+++ b/lib/Cake/View/Errors/missing_component.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_connection.ctp
+++ b/lib/Cake/View/Errors/missing_connection.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_controller.ctp
+++ b/lib/Cake/View/Errors/missing_controller.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_database.ctp
+++ b/lib/Cake/View/Errors/missing_database.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_datasource.ctp
+++ b/lib/Cake/View/Errors/missing_datasource.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_datasource_config.ctp
+++ b/lib/Cake/View/Errors/missing_datasource_config.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_helper.ctp
+++ b/lib/Cake/View/Errors/missing_helper.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_plugin.ctp
+++ b/lib/Cake/View/Errors/missing_plugin.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_table.ctp
+++ b/lib/Cake/View/Errors/missing_table.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/pdo_error.ctp
+++ b/lib/Cake/View/Errors/pdo_error.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/private_action.ctp
+++ b/lib/Cake/View/Errors/private_action.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/scaffold_error.ctp
+++ b/lib/Cake/View/Errors/scaffold_error.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -251,7 +251,7 @@ class Helper extends Object {
  * @param string|array $url Either a relative string url like `/products/view/23` or
  *    an array of URL parameters. Using an array for URLs will allow you to leverage
  *    the reverse routing features of CakePHP.
- * @param boolean $full If true, the full base URL will be prepended to the result
+ * @param bool $full If true, the full base URL will be prepended to the result
  * @return string Full translated URL with base path.
  * @link http://book.cakephp.org/2.0/en/views/helpers.html
  */
@@ -481,7 +481,7 @@ class Helper extends Object {
  *
  * @param string $key The name of the attribute to create
  * @param string $value The value of the attribute to create.
- * @param boolean $escape Define if the value must be escaped
+ * @param bool $escape Define if the value must be escaped
  * @return string The composed attribute.
  * @deprecated This method will be moved to HtmlHelper in 3.0
  */
@@ -525,7 +525,7 @@ class Helper extends Object {
  * Sets this helper's model and field properties to the dot-separated value-pair in $entity.
  *
  * @param string $entity A field name, like "ModelName.fieldName" or "ModelName.ID.fieldName"
- * @param boolean $setScope Sets the view scope to the model specified in $tagValue
+ * @param bool $setScope Sets the view scope to the model specified in $tagValue
  * @return void
  */
 	public function setEntity($entity, $setScope = false) {

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -48,14 +48,14 @@ class CacheHelper extends AppHelper {
 /**
  * Counter used for counting nocache section tags.
  *
- * @var integer
+ * @var int
  */
 	protected $_counter = 0;
 
 /**
  * Is CacheHelper enabled? should files + output be parsed.
  *
- * @return boolean
+ * @return bool
  */
 	protected function _enabled() {
 		return $this->_View->cacheAction && (Configure::read('Cache.check') === true);
@@ -266,9 +266,9 @@ class CacheHelper extends AppHelper {
  *
  * @param string $content view content to write to a cache file.
  * @param string $timestamp Duration to set for cache file.
- * @param boolean $useCallbacks Whether to include statements in cached file which
+ * @param bool $useCallbacks Whether to include statements in cached file which
  *   run callbacks.
- * @return boolean success of caching view.
+ * @return bool success of caching view.
  */
 	protected function _writeFile($content, $timestamp, $useCallbacks = false) {
 		$now = time();

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -255,7 +255,7 @@ class FormHelper extends AppHelper {
  * Returns if a field is required to be filled based on validation properties from the validating object.
  *
  * @param CakeValidationSet $validationRules Validation rules set.
- * @return boolean true if field is required to be filled, false otherwise
+ * @return bool true if field is required to be filled, false otherwise
  */
 	protected function _isRequiredField($validationRules) {
 		if (empty($validationRules) || count($validationRules) === 0) {
@@ -635,7 +635,7 @@ class FormHelper extends AppHelper {
  * Determine which fields of a form should be used for hash.
  * Populates $this->fields
  *
- * @param boolean $lock Whether this field should be part of the validation
+ * @param bool $lock Whether this field should be part of the validation
  *     or excluded as part of the unlockedFields.
  * @param string|array $field Reference to field to be secured. Should be dot separated to indicate nesting.
  * @param mixed $value Field value, if value should not be tampered with.
@@ -674,7 +674,7 @@ class FormHelper extends AppHelper {
  * Returns true if there is an error for the given field, otherwise false
  *
  * @param string $field This should be "Modelname.fieldname"
- * @return boolean If there are errors this method returns true, else false.
+ * @return bool If there are errors this method returns true, else false.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::isFieldError
  */
 	public function isFieldError($field) {
@@ -1256,7 +1256,7 @@ class FormHelper extends AppHelper {
  *
  * @param string $fieldName Field name.
  * @param array $options Options list.
- * @return boolean|string false or Generated label element
+ * @return bool|string false or Generated label element
  */
 	protected function _getLabel($fieldName, $options) {
 		if ($options['type'] === 'radio') {
@@ -1789,7 +1789,7 @@ class FormHelper extends AppHelper {
  * @param string $title The content to be wrapped by <a> tags.
  * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
  * @param array $options Array of HTML attributes.
- * @param boolean|string $confirmMessage JavaScript confirmation message.
+ * @param bool|string $confirmMessage JavaScript confirmation message.
  * @return string An `<a />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postLink
  */
@@ -2204,8 +2204,8 @@ class FormHelper extends AppHelper {
  * - `value` The selected value of the input.
  *
  * @param string $fieldName Prefix name for the SELECT element
- * @param integer $minYear First year in sequence
- * @param integer $maxYear Last year in sequence
+ * @param int $minYear First year in sequence
+ * @param int $maxYear Last year in sequence
  * @param array $attributes Attribute array for the select elements.
  * @return string Completed year select input
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::year
@@ -2302,7 +2302,7 @@ class FormHelper extends AppHelper {
  * - `value` The selected value of the input.
  *
  * @param string $fieldName Prefix name for the SELECT element
- * @param boolean $format24Hours True for 24 hours format
+ * @param bool $format24Hours True for 24 hours format
  * @param array $attributes List of HTML attributes
  * @return string Completed hour select input
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::hour
@@ -2623,7 +2623,7 @@ class FormHelper extends AppHelper {
  * Parse the value for a datetime selected value
  *
  * @param string|array $value The selected value.
- * @param integer $timeFormat The time format
+ * @param int $timeFormat The time format
  * @return array Array of selected value.
  */
 	protected function _getDateTimeValue($value, $timeFormat) {
@@ -2713,7 +2713,7 @@ class FormHelper extends AppHelper {
  *
  * @param array $elements Elements to format.
  * @param array $parents Parents for OPTGROUP.
- * @param boolean $showParents Whether to show parents.
+ * @param bool $showParents Whether to show parents.
  * @param array $attributes HTML attributes.
  * @return array
  */
@@ -3013,7 +3013,7 @@ class FormHelper extends AppHelper {
  * Set/Get inputDefaults for form elements
  *
  * @param array $defaults New default values
- * @param boolean $merge Merge with current defaults
+ * @param bool $merge Merge with current defaults
  * @return array inputDefaults
  */
 	public function inputDefaults($defaults = null, $merge = false) {

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -481,7 +481,6 @@ class HtmlHelper extends AppHelper {
  * If the filename is prefixed with "/", the path will be relative to the base path of your
  * application. Otherwise, the path will be relative to your JavaScript path, usually webroot/js.
  *
- *
  * ### Usage
  *
  * Include one script file:
@@ -512,7 +511,7 @@ class HtmlHelper extends AppHelper {
  * - `fullBase` If true the url will get a full address for the script file.
  *
  * @param string|array $url String or array of javascript files to include
- * @param array|boolean $options Array of options, and html attributes see above. If boolean sets $options['inline'] = value
+ * @param array|bool $options Array of options, and html attributes see above. If boolean sets $options['inline'] = value
  * @return mixed String of `<script />` tags or null if $inline is false or if $once is true and the file has been
  *   included before.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::script
@@ -645,7 +644,7 @@ class HtmlHelper extends AppHelper {
  * }}}
  *
  * @param array $data Style data array, keys will be used as property names, values as property values.
- * @param boolean $oneline Whether or not the style block should be displayed on one line.
+ * @param bool $oneline Whether or not the style block should be displayed on one line.
  * @return string CSS styling data
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::style
  */
@@ -674,7 +673,7 @@ class HtmlHelper extends AppHelper {
  * All other keys will be passed to HtmlHelper::link() as the `$options` parameter.
  *
  * @param string $separator Text to separate crumbs.
- * @param string|array|boolean $startText This will be the first crumb, if false it defaults to first crumb in array. Can
+ * @param string|array|bool $startText This will be the first crumb, if false it defaults to first crumb in array. Can
  *   also be an array, see above for details.
  * @return string Composed bread crumbs
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
@@ -708,7 +707,7 @@ class HtmlHelper extends AppHelper {
  * - `lastClass` Class for wrapper tag on current active page, defaults to 'last'
  *
  * @param array $options Array of html attributes to apply to the generated list elements.
- * @param string|array|boolean $startText This will be the first crumb, if false it defaults to first crumb in array. Can
+ * @param string|array|bool $startText This will be the first crumb, if false it defaults to first crumb in array. Can
  *   also be an array, see `HtmlHelper::getCrumbs` for details.
  * @return string breadcrumbs html list
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
@@ -754,7 +753,7 @@ class HtmlHelper extends AppHelper {
  * Prepends startText to crumbs array if set
  *
  * @param string $startText Text to prepend
- * @param boolean $escape If the output should be escaped or not
+ * @param bool $escape If the output should be escaped or not
  * @return array Crumb list including startText (if provided)
  */
 	protected function _prepareCrumbs($startText, $escape = true) {
@@ -851,8 +850,8 @@ class HtmlHelper extends AppHelper {
  * @param array $data Array of table data
  * @param array $oddTrOptions HTML options for odd TR elements if true useCount is used
  * @param array $evenTrOptions HTML options for even TR elements
- * @param boolean $useCount adds class "column-$i"
- * @param boolean $continueOddEven If false, will use a non-static $count variable,
+ * @param bool $useCount adds class "column-$i"
+ * @param bool $continueOddEven If false, will use a non-static $count variable,
  *    so that the odd/even count is reset to zero just for that call.
  * @return string Formatted HTML
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::tableCells

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -137,7 +137,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
  * Converts a PHP-native variable of any type to a JSON-equivalent representation
  *
  * @param mixed $val A PHP variable to be converted to JSON
- * @param boolean $quoteString If false, leaves string values unquoted
+ * @param bool $quoteString If false, leaves string values unquoted
  * @param string $key Key name.
  * @return string a JavaScript-safe/JSON representation of $val
  */

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -35,7 +35,7 @@ class JsHelper extends AppHelper {
 /**
  * Whether or not you want scripts to be buffered or output.
  *
- * @var boolean
+ * @var bool
  */
 	public $bufferScripts = true;
 
@@ -157,7 +157,7 @@ class JsHelper extends AppHelper {
  * See JsBaseEngineHelper::value() for more information on this method.
  *
  * @param mixed $val A PHP variable to be converted to JSON
- * @param boolean $quoteString If false, leaves string values unquoted
+ * @param bool $quoteString If false, leaves string values unquoted
  * @param string $key Key name.
  * @return string a JavaScript-safe/JSON representation of $val
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::value
@@ -229,7 +229,7 @@ class JsHelper extends AppHelper {
  * Write a script to the buffered scripts.
  *
  * @param string $script Script string to add to the buffer.
- * @param boolean $top If true the script will be added to the top of the
+ * @param bool $top If true the script will be added to the top of the
  *   buffered scripts array. If false the bottom.
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::buffer
@@ -245,7 +245,7 @@ class JsHelper extends AppHelper {
 /**
  * Get all the buffered scripts
  *
- * @param boolean $clear Whether or not to clear the script caches (default true)
+ * @param bool $clear Whether or not to clear the script caches (default true)
  * @return array Array of scripts added to the request.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::getBuffer
  */

--- a/lib/Cake/View/Helper/NumberHelper.php
+++ b/lib/Cake/View/Helper/NumberHelper.php
@@ -79,7 +79,7 @@ class NumberHelper extends AppHelper {
  * Formats a number with a level of precision.
  *
  * @param float $number A floating point number.
- * @param integer $precision The precision of the returned number.
+ * @param int $precision The precision of the returned number.
  * @return float Formatted float.
  * @see CakeNumber::precision()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::precision
@@ -91,7 +91,7 @@ class NumberHelper extends AppHelper {
 /**
  * Returns a formatted-for-humans file size.
  *
- * @param integer $size Size in bytes
+ * @param int $size Size in bytes
  * @return string Human readable size
  * @see CakeNumber::toReadableSize()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toReadableSize
@@ -108,7 +108,7 @@ class NumberHelper extends AppHelper {
  * - `multiply`: Multiply the input value by 100 for decimal percentages.
  *
  * @param float $number A floating point number
- * @param integer $precision The precision of the returned number
+ * @param int $precision The precision of the returned number
  * @param array $options Options
  * @return string Percentage string
  * @see CakeNumber::toPercentage()
@@ -122,7 +122,7 @@ class NumberHelper extends AppHelper {
  * Formats a number into a currency format.
  *
  * @param float $number A floating point number
- * @param integer $options If integer then places, if string then before, if (,.-) then use it
+ * @param int $options If integer then places, if string then before, if (,.-) then use it
  *   or array with places and before keys
  * @return string formatted number
  * @see CakeNumber::format()

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -420,7 +420,7 @@ class PaginatorHelper extends AppHelper {
  * Merges passed URL options with current pagination state to generate a pagination URL.
  *
  * @param array $options Pagination/URL options array
- * @param boolean $asArray Return the URL as an array, or a URI string
+ * @param bool $asArray Return the URL as an array, or a URI string
  * @param string $model Which model to paginate on
  * @return mixed By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::url
@@ -544,7 +544,7 @@ class PaginatorHelper extends AppHelper {
  * Returns true if the given result set is not at the first page
  *
  * @param string $model Optional model name. Uses the default if none is specified.
- * @return boolean True if the result set is not at the first page.
+ * @return bool True if the result set is not at the first page.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::hasPrev
  */
 	public function hasPrev($model = null) {
@@ -555,7 +555,7 @@ class PaginatorHelper extends AppHelper {
  * Returns true if the given result set is not at the last page
  *
  * @param string $model Optional model name. Uses the default if none is specified.
- * @return boolean True if the result set is not at the last page.
+ * @return bool True if the result set is not at the last page.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::hasNext
  */
 	public function hasNext($model = null) {
@@ -566,8 +566,8 @@ class PaginatorHelper extends AppHelper {
  * Returns true if the given result set has the page number given by $page
  *
  * @param string $model Optional model name. Uses the default if none is specified.
- * @param integer $page The page number - if not set defaults to 1.
- * @return boolean True if the given result set has the specified page number.
+ * @param int $page The page number - if not set defaults to 1.
+ * @return bool True if the given result set has the specified page number.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::hasPage
  */
 	public function hasPage($model = null, $page = 1) {
@@ -583,8 +583,8 @@ class PaginatorHelper extends AppHelper {
  * Does $model have $page in its range?
  *
  * @param string $model Model name to get parameters for.
- * @param integer $page Page number you are checking.
- * @return boolean Whether model has $page
+ * @param int $page Page number you are checking.
+ * @return bool Whether model has $page
  */
 	protected function _hasPage($model, $page) {
 		$params = $this->params($model);
@@ -847,7 +847,7 @@ class PaginatorHelper extends AppHelper {
  * - `separator` Content between the generated links, defaults to ' | '
  * - `ellipsis` Content for ellipsis, defaults to '...'
  *
- * @param string|integer $first if string use as label for the link. If numeric, the number of page links
+ * @param string|int $first if string use as label for the link. If numeric, the number of page links
  *   you want at the beginning of the range.
  * @param array $options An array of options.
  * @return string numbers string.
@@ -911,7 +911,7 @@ class PaginatorHelper extends AppHelper {
  * - `separator` Content between the generated links, defaults to ' | '
  * - `ellipsis` Content for ellipsis, defaults to '...'
  *
- * @param string|integer $last if string use as label for the link, if numeric print page numbers
+ * @param string|int $last if string use as label for the link, if numeric print page numbers
  * @param array $options Array of options
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::last

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -34,7 +34,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
 /**
  * Is the current selection a multiple selection? or is it just a single element.
  *
- * @var boolean
+ * @var bool
  */
 	protected $_multiple = false;
 

--- a/lib/Cake/View/Helper/RssHelper.php
+++ b/lib/Cake/View/Helper/RssHelper.php
@@ -274,7 +274,7 @@ class RssHelper extends AppHelper {
 /**
  * Converts a time in any format to an RSS time
  *
- * @param integer|string|DateTime $time UNIX timestamp or valid time string or DateTime object.
+ * @param int|string|DateTime $time UNIX timestamp or valid time string or DateTime object.
  * @return string An RSS-formatted timestamp
  * @see TimeHelper::toRSS
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/rss.html#RssHelper::time
@@ -289,7 +289,7 @@ class RssHelper extends AppHelper {
  * @param string $name The name of the XML element
  * @param array $attrib The attributes of the XML element
  * @param string|array $content XML element content
- * @param boolean $endTag Whether the end tag of the element should be printed
+ * @param bool $endTag Whether the end tag of the element should be printed
  * @return string XML
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/rss.html#RssHelper::elem
  */

--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -49,7 +49,7 @@ class SessionHelper extends AppHelper {
  * In your view: `$this->Session->check('Controller.sessKey');`
  *
  * @param string $name Session key to check.
- * @return boolean
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::check
  */
 	public function check($name) {
@@ -152,7 +152,7 @@ class SessionHelper extends AppHelper {
 /**
  * Used to check is a session is valid in a view
  *
- * @return boolean
+ * @return bool
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::valid
  */
 	public function valid() {

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -280,7 +280,7 @@ class TextHelper extends AppHelper {
  * - `html` If true, HTML tags would be handled correctly
  *
  * @param string $text String to truncate.
- * @param integer $length Length of returned string, including ellipsis.
+ * @param int $length Length of returned string, including ellipsis.
  * @param array $options An array of html attributes and options.
  * @return string Trimmed string.
  * @see String::truncate()
@@ -302,7 +302,7 @@ class TextHelper extends AppHelper {
  * - `exact` If false, $text will not be cut mid-word
  *
  * @param string $text String to truncate.
- * @param integer $length Length of returned string, including ellipsis.
+ * @param int $length Length of returned string, including ellipsis.
  * @param array $options An array of html attributes and options.
  * @return string Trimmed string.
  * @see String::tail()
@@ -318,7 +318,7 @@ class TextHelper extends AppHelper {
  *
  * @param string $text String to search the phrase in
  * @param string $phrase Phrase that will be searched for
- * @param integer $radius The amount of characters that will be returned on each side of the founded phrase
+ * @param int $radius The amount of characters that will be returned on each side of the founded phrase
  * @param string $ending Ending that will be appended
  * @return string Modified string
  * @see String::excerpt()

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -83,7 +83,7 @@ class TimeHelper extends AppHelper {
  * Magic isset check for deprecated attributes.
  *
  * @param string $name Name of the attribute to check.
- * @return boolean
+ * @return bool
  */
 	public function __isset($name) {
 		if (isset($this->{$name})) {
@@ -144,7 +144,7 @@ class TimeHelper extends AppHelper {
  *
  * @param string $serverTime UNIX timestamp
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return integer UNIX timestamp
+ * @return int UNIX timestamp
  * @see CakeTime::convert()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -155,7 +155,7 @@ class TimeHelper extends AppHelper {
 /**
  * Returns server's offset
  *
- * @return integer Offset
+ * @return int Offset
  * @see CakeTime::serverOffset()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -166,7 +166,7 @@ class TimeHelper extends AppHelper {
 /**
  * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Parsed timestamp
  * @see CakeTime::fromString()
@@ -179,7 +179,7 @@ class TimeHelper extends AppHelper {
 /**
  * Returns a nicely formatted date string for given Datetime string.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @param string $format The format to use. If null, `CakeTime::$niceFormat` is used
  * @return string Formatted date string
@@ -193,7 +193,7 @@ class TimeHelper extends AppHelper {
 /**
  * Returns a formatted descriptive date string for given datetime string.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime objectp
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime objectp
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Described, relative date string
  * @see CakeTime::niceShort()
@@ -206,8 +206,8 @@ class TimeHelper extends AppHelper {
 /**
  * Returns a partial SQL string to search for all records between two dates.
  *
- * @param integer|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
- * @param integer|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -222,7 +222,7 @@ class TimeHelper extends AppHelper {
  * Returns a partial SQL string to search for all records between two times
  * occurring on the same day.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -236,9 +236,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if given datetime string is today.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean True if datetime string is today
+ * @return bool True if datetime string is today
  * @see CakeTime::isToday()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -249,9 +249,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if given datetime string is within this week.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean True if datetime string is within current week
+ * @return bool True if datetime string is within current week
  * @see CakeTime::isThisWeek()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -262,9 +262,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if given datetime string is within this month
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean True if datetime string is within current month
+ * @return bool True if datetime string is within current month
  * @see CakeTime::isThisMonth()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -275,9 +275,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if given datetime string is within current year.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean True if datetime string is within current year
+ * @return bool True if datetime string is within current year
  * @see CakeTime::isThisYear()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -288,9 +288,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if given datetime string was yesterday.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean True if datetime string was yesterday
+ * @return bool True if datetime string was yesterday
  * @see CakeTime::wasYesterday()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -301,9 +301,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if given datetime string is tomorrow.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean True if datetime string was yesterday
+ * @return bool True if datetime string was yesterday
  * @see CakeTime::isTomorrow()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -314,8 +314,8 @@ class TimeHelper extends AppHelper {
 /**
  * Returns the quarter
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
- * @param boolean $range if true returns a range in Y-m-d format
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param bool $range if true returns a range in Y-m-d format
  * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
  * @see CakeTime::toQuarter()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -327,9 +327,9 @@ class TimeHelper extends AppHelper {
 /**
  * Returns a UNIX timestamp from a textual datetime description. Wrapper for PHP function strtotime().
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return integer Unix timestamp
+ * @return int Unix timestamp
  * @see CakeTime::toUnix()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -340,7 +340,7 @@ class TimeHelper extends AppHelper {
 /**
  * Returns a date formatted for Atom RSS feeds.
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted date string
  * @see CakeTime::toAtom()
@@ -353,7 +353,7 @@ class TimeHelper extends AppHelper {
 /**
  * Formats date for RSS feeds
  *
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted date string
  * @see CakeTime::toRSS()
@@ -374,7 +374,7 @@ class TimeHelper extends AppHelper {
  *   - `class` - The class name to use, defaults to `time-ago-in-words`.
  *   - `title` - Defaults to the $dateTime input.
  *
- * @param integer|string|DateTime $dateTime UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateTime UNIX timestamp, strtotime() valid string or DateTime object
  * @param array $options Default format if timestamp is used in $dateString
  * @return string Relative time string.
  * @see CakeTime::timeAgoInWords()
@@ -414,11 +414,11 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if specified datetime was within the interval specified, else false.
  *
- * @param string|integer $timeInterval the numeric value with space then time type.
+ * @param string|int $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean
+ * @return bool
  * @see CakeTime::wasWithinLast()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -429,11 +429,11 @@ class TimeHelper extends AppHelper {
 /**
  * Returns true if specified datetime is within the interval specified, else false.
  *
- * @param string|integer $timeInterval the numeric value with space then time type.
+ * @param string|int $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return boolean
+ * @return bool
  * @see CakeTime::isWithinLast()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
  */
@@ -444,8 +444,8 @@ class TimeHelper extends AppHelper {
 /**
  * Returns gmt as a UNIX timestamp.
  *
- * @param integer|string|DateTime $string UNIX timestamp, strtotime() valid string or DateTime object
- * @return integer UNIX timestamp
+ * @param int|string|DateTime $string UNIX timestamp, strtotime() valid string or DateTime object
+ * @return int UNIX timestamp
  * @see CakeTime::gmt()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -469,9 +469,9 @@ class TimeHelper extends AppHelper {
  *   $this->Time->format('2012-02-15 23:01:01', '%c', 'N/A', 'America/New_York'); // converts passed date to timezone
  * }}}
  *
- * @param integer|string|DateTime $format date format string (or a UNIX timestamp, strtotime() valid string or DateTime object)
- * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
- * @param boolean $invalid flag to ignore results of fromString == false
+ * @param int|string|DateTime $format date format string (or a UNIX timestamp, strtotime() valid string or DateTime object)
+ * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
+ * @param bool $invalid flag to ignore results of fromString == false
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted date string
  * @see CakeTime::format()
@@ -485,9 +485,9 @@ class TimeHelper extends AppHelper {
  * Returns a formatted date string, given either a UNIX timestamp or a valid strtotime() date string.
  * It takes into account the default date format for the current language if a LC_TIME file is used.
  *
- * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
+ * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $format strftime format string.
- * @param boolean $invalid flag to ignore results of fromString == false
+ * @param bool $invalid flag to ignore results of fromString == false
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted and translated date string
  * @see CakeTime::i18nFormat()

--- a/lib/Cake/View/HelperCollection.php
+++ b/lib/Cake/View/HelperCollection.php
@@ -50,7 +50,7 @@ class HelperCollection extends ObjectCollection implements CakeEventListener {
  * if any
  *
  * @param string $helper The helper name to be loaded
- * @return boolean whether the helper could be loaded or not
+ * @return bool whether the helper could be loaded or not
  * @throws MissingHelperException When a helper could not be found.
  *    App helpers are searched, and then plugin helpers.
  */

--- a/lib/Cake/View/Scaffolds/form.ctp
+++ b/lib/Cake/View/Scaffolds/form.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Scaffolds/index.ctp
+++ b/lib/Cake/View/Scaffolds/index.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Scaffolds/view.ctp
+++ b/lib/Cake/View/Scaffolds/view.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -80,7 +80,7 @@ class View extends Object {
 /**
  * Name of the controller.
  *
- * @var string Name of controller
+ * @var string
  */
 	public $name = null;
 
@@ -94,14 +94,14 @@ class View extends Object {
 /**
  * An array of names of built-in helpers to include.
  *
- * @var mixed A single name as a string or a list of names as an array.
+ * @var mixed
  */
 	public $helpers = array();
 
 /**
  * Path to View.
  *
- * @var string Path to View
+ * @var string
  */
 	public $viewPath = null;
 
@@ -129,7 +129,7 @@ class View extends Object {
 /**
  * Path to Layout.
  *
- * @var string Path to Layout
+ * @var string
  */
 	public $layoutPath = null;
 
@@ -137,7 +137,7 @@ class View extends Object {
  * Turns on or off CakePHP's conventional mode of applying layout files. On by default.
  * Setting to off means that layouts will not be automatically applied to rendered views.
  *
- * @var boolean
+ * @var bool
  */
 	public $autoLayout = true;
 
@@ -181,7 +181,7 @@ class View extends Object {
 /**
  * True when the view has been rendered.
  *
- * @var boolean
+ * @var bool
  */
 	public $hasRendered = false;
 
@@ -300,7 +300,7 @@ class View extends Object {
 /**
  * Whether the event manager was already configured for this object
  *
- * @var boolean
+ * @var bool
  */
 	protected $_eventManagerConfigured = false;
 
@@ -432,7 +432,7 @@ class View extends Object {
  * @param string $name Name of template file in the /app/View/Elements/ folder,
  *   or `MyPlugin.template` to check the template element from MyPlugin. If the element
  *   is not found in the plugin, the normal view path cascade will be searched.
- * @return boolean Success
+ * @return bool Success
  */
 	public function elementExists($name) {
 		return (bool)$this->_getElementFilename($name);
@@ -551,7 +551,7 @@ class View extends Object {
  *
  * @param string $filename the cache file to include
  * @param string $timeStart the page render start time
- * @return boolean Success of rendering the cached file.
+ * @return bool Success of rendering the cached file.
  */
 	public function renderCache($filename, $timeStart) {
 		$response = $this->response;
@@ -687,7 +687,7 @@ class View extends Object {
  *
  * @param string $name Name of the block
  * @param string $default Default text
- * @return string $default The block content or $default if the block does not exist.
+ * @return string default The block content or $default if the block does not exist.
  * @see ViewBlock::get()
  */
 	public function fetch($name, $default = '') {
@@ -861,7 +861,7 @@ class View extends Object {
  * Magic isset check for deprecated attributes.
  *
  * @param string $name Name of the attribute to check.
- * @return boolean
+ * @return bool
  */
 	public function __isset($name) {
 		if (isset($this->{$name})) {
@@ -1028,7 +1028,7 @@ class View extends Object {
  * It checks if the plugin is loaded, else filename will stay unchanged for filenames containing dot
  *
  * @param string $name The name you want to plugin split.
- * @param boolean $fallback If true uses the plugin set in the current CakeRequest when parsed plugin is not loaded
+ * @param bool $fallback If true uses the plugin set in the current CakeRequest when parsed plugin is not loaded
  * @return array Array with 2 indexes. 0 => plugin name, 1 => filename
  */
 	public function pluginSplit($name, $fallback = true) {
@@ -1113,7 +1113,7 @@ class View extends Object {
  * Return all possible paths to find view files in order
  *
  * @param string $plugin Optional plugin name to scan for view files.
- * @param boolean $cached Set to false to force a refresh of view paths. Default true.
+ * @param bool $cached Set to false to force a refresh of view paths. Default true.
  * @return array paths
  */
 	protected function _paths($plugin = null, $cached = true) {

--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -56,7 +54,7 @@ class ViewBlock {
 /**
  * Should the currently captured content be discarded on ViewBlock::end()
  *
- * @var boolean
+ * @var bool
  * @see ViewBlock::end()
  * @see ViewBlock::startIfEmpty()
  */

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -38,7 +38,7 @@ if (!function_exists('config')) {
  *
  * `config('config1', 'config2');`
  *
- * @return boolean Success
+ * @return bool Success
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#config
  */
 	function config() {
@@ -64,8 +64,8 @@ if (!function_exists('debug')) {
  * Only runs if debug level is greater than zero.
  *
  * @param mixed $var Variable to show debug information for.
- * @param boolean $showHtml If set to true, the method prints the debug data in a browser-friendly way.
- * @param boolean $showFrom If set to true, the method prints from where the function was called.
+ * @param bool $showHtml If set to true, the method prints the debug data in a browser-friendly way.
+ * @param bool $showFrom If set to true, the method prints from where the function was called.
  * @return void
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#basic-debugging
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#debug
@@ -128,7 +128,7 @@ if (!function_exists('sortByKey')) {
  * @param array &$array Array to sort
  * @param string $sortBy Sort by this key
  * @param string $order Sort order asc/desc (ascending or descending).
- * @param integer $type Type of sorting to perform
+ * @param int $type Type of sorting to perform
  * @return mixed Sorted array
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#sortByKey
  */
@@ -163,7 +163,7 @@ if (!function_exists('h')) {
  * @param string|array|object $text Text to wrap through htmlspecialchars. Also works with arrays, and objects.
  *    Arrays will be mapped and have all their elements escaped. Objects will be string cast if they
  *    implement a `__toString` method. Otherwise the class name will be used.
- * @param boolean $double Encode existing html entities
+ * @param bool $double Encode existing html entities
  * @param string $charset Character set to use when escaping. Defaults to config value in 'App.encoding' or 'UTF-8'
  * @return string Wrapped text
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#h
@@ -209,7 +209,7 @@ if (!function_exists('pluginSplit')) {
  * Commonly used like `list($plugin, $name) = pluginSplit($name);`
  *
  * @param string $name The name you want to plugin split.
- * @param boolean $dotAppend Set to true if you want the plugin to have a '.' appended to it.
+ * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
  * @param string $plugin Optional default plugin to use if no plugin is found. Defaults to null.
  * @return array Array with 2 indexes. 0 => plugin name, 1 => class name
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#pluginSplit
@@ -572,7 +572,7 @@ if (!function_exists('__n')) {
  *
  * @param string $singular Singular text to translate
  * @param string $plural Plural text
- * @param integer $count Count
+ * @param int $count Count
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return mixed plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__n
@@ -635,7 +635,7 @@ if (!function_exists('__dn')) {
  * @param string $domain Domain
  * @param string $singular Singular string to translate
  * @param string $plural Plural
- * @param integer $count Count
+ * @param int $count Count
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dn
@@ -679,7 +679,7 @@ if (!function_exists('__dc')) {
  *
  * @param string $domain Domain
  * @param string $msg Message to translate
- * @param integer $category Category
+ * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dc
@@ -726,8 +726,8 @@ if (!function_exists('__dcn')) {
  * @param string $domain Domain
  * @param string $singular Singular string to translate
  * @param string $plural Plural
- * @param integer $count Count
- * @param integer $category Category
+ * @param int $count Count
+ * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dcn
@@ -767,7 +767,7 @@ if (!function_exists('__c')) {
  * - LC_MESSAGES  I18n::LC_MESSAGES
  *
  * @param string $msg String to translate
- * @param integer $category Category
+ * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__c

--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -191,9 +191,9 @@ if (!function_exists('mb_stripos')) {
  *
  * @param string $haystack The string from which to get the position of the first occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param integer $offset The position in $haystack to start searching.
+ * @param int $offset The position in $haystack to start searching.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return integer|boolean The numeric position of the first occurrence of $needle in the $haystack string, or false
+ * @return int|bool The numeric position of the first occurrence of $needle in the $haystack string, or false
  *    if $needle is not found.
  */
 	function mb_stripos($haystack, $needle, $offset = 0, $encoding = null) {
@@ -209,12 +209,12 @@ if (!function_exists('mb_stristr')) {
  *
  * @param string $haystack The string from which to get the first occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the first occurrence of $needle.
  *    If set to false, it returns all of $haystack from the first occurrence of $needle to the end,
  *    Default value is false.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return string|boolean The portion of $haystack, or false if $needle is not found.
+ * @return string|bool The portion of $haystack, or false if $needle is not found.
  */
 	function mb_stristr($haystack, $needle, $part = false, $encoding = null) {
 		return Multibyte::stristr($haystack, $needle, $part);
@@ -229,7 +229,7 @@ if (!function_exists('mb_strlen')) {
  *
  * @param string $string The string being checked for length.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return integer The number of characters in string $string having character encoding encoding.
+ * @return int The number of characters in string $string having character encoding encoding.
  *    A multi-byte character is counted as 1.
  */
 	function mb_strlen($string, $encoding = null) {
@@ -245,9 +245,9 @@ if (!function_exists('mb_strpos')) {
  *
  * @param string $haystack The string being checked.
  * @param string $needle The position counted from the beginning of haystack.
- * @param integer $offset The search offset. If it is not specified, 0 is used.
+ * @param int $offset The search offset. If it is not specified, 0 is used.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return integer|boolean The numeric position of the first occurrence of $needle in the $haystack string.
+ * @return int|bool The numeric position of the first occurrence of $needle in the $haystack string.
  *    If $needle is not found, it returns false.
  */
 	function mb_strpos($haystack, $needle, $offset = 0, $encoding = null) {
@@ -263,12 +263,12 @@ if (!function_exists('mb_strrchr')) {
  *
  * @param string $haystack The string from which to get the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the last occurrence of $needle.
  *    If set to false, it returns all of $haystack from the last occurrence of $needle to the end,
  *    Default value is false.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return string|boolean The portion of $haystack. or false if $needle is not found.
+ * @return string|bool The portion of $haystack. or false if $needle is not found.
  */
 	function mb_strrchr($haystack, $needle, $part = false, $encoding = null) {
 		return Multibyte::strrchr($haystack, $needle, $part);
@@ -283,12 +283,12 @@ if (!function_exists('mb_strrichr')) {
  *
  * @param string $haystack The string from which to get the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the last occurrence of $needle.
  *    If set to false, it returns all of $haystack from the last occurrence of $needle to the end,
  *    Default value is false.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return string|boolean The portion of $haystack. or false if $needle is not found.
+ * @return string|bool The portion of $haystack. or false if $needle is not found.
  */
 	function mb_strrichr($haystack, $needle, $part = false, $encoding = null) {
 		return Multibyte::strrichr($haystack, $needle, $part);
@@ -303,9 +303,9 @@ if (!function_exists('mb_strripos')) {
  *
  * @param string $haystack The string from which to get the position of the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param integer $offset The position in $haystack to start searching.
+ * @param int $offset The position in $haystack to start searching.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return integer|boolean The numeric position of the last occurrence of $needle in the $haystack string,
+ * @return int|bool The numeric position of the last occurrence of $needle in the $haystack string,
  *    or false if $needle is not found.
  */
 	function mb_strripos($haystack, $needle, $offset = 0, $encoding = null) {
@@ -321,10 +321,10 @@ if (!function_exists('mb_strrpos')) {
  *
  * @param string $haystack The string being checked, for the last occurrence of $needle.
  * @param string $needle The string to find in $haystack.
- * @param integer $offset May be specified to begin searching an arbitrary number of characters into the string.
+ * @param int $offset May be specified to begin searching an arbitrary number of characters into the string.
  *    Negative values will stop searching at an arbitrary point prior to the end of the string.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return integer|boolean The numeric position of the last occurrence of $needle in the $haystack string.
+ * @return int|bool The numeric position of the last occurrence of $needle in the $haystack string.
  *    If $needle is not found, it returns false.
  */
 	function mb_strrpos($haystack, $needle, $offset = 0, $encoding = null) {
@@ -340,12 +340,12 @@ if (!function_exists('mb_strstr')) {
  *
  * @param string $haystack The string from which to get the first occurrence of $needle.
  * @param string $needle The string to find in $haystack
- * @param boolean $part Determines which portion of $haystack this function returns.
+ * @param bool $part Determines which portion of $haystack this function returns.
  *    If set to true, it returns all of $haystack from the beginning to the first occurrence of $needle.
  *    If set to false, it returns all of $haystack from the first occurrence of $needle to the end,
  *    Default value is FALSE.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return string|boolean The portion of $haystack, or true if $needle is not found.
+ * @return string|bool The portion of $haystack, or true if $needle is not found.
  */
 	function mb_strstr($haystack, $needle, $part = false, $encoding = null) {
 		return Multibyte::strstr($haystack, $needle, $part);
@@ -391,7 +391,7 @@ if (!function_exists('mb_substr_count')) {
  * @param string $haystack The string being checked.
  * @param string $needle The string being found.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
- * @return integer The number of times the $needle substring occurs in the $haystack string.
+ * @return int The number of times the $needle substring occurs in the $haystack string.
  */
 	function mb_substr_count($haystack, $needle, $encoding = null) {
 		return Multibyte::substrCount($haystack, $needle);
@@ -405,8 +405,8 @@ if (!function_exists('mb_substr')) {
  * Get part of string
  *
  * @param string $string The string being checked.
- * @param integer $start The first position used in $string.
- * @param integer $length The maximum length of the returned string.
+ * @param int $start The first position used in $string.
+ * @param int $length The maximum length of the returned string.
  * @param string $encoding Character encoding name to use. If it is omitted, internal character encoding is used.
  * @return string The portion of $string specified by the $string and $length parameters.
  */
@@ -430,7 +430,7 @@ if (!function_exists('mb_encode_mimeheader')) {
  *    mb_encode_mimeheader() performs line-folding
  *    (a » RFC term, the act of breaking a line longer than a certain length into multiple lines.
  *    The length is currently hard-coded to 74 characters). Falls back to "\r\n" (CRLF) if not given.
- * @param integer $indent [definition unknown and appears to have no affect]
+ * @param int $indent [definition unknown and appears to have no affect]
  * @return string A converted version of the string represented in ASCII.
  */
 	function mb_encode_mimeheader($str, $charset = 'UTF-8', $transferEncoding = 'B', $linefeed = "\r\n", $indent = 1) {


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/issues/3307#issuecomment-47212456

Also removed empty lines at the beginning of doc blocks. And shortened redundant `@var foo ...`.

This would allow further merge conflicts in the future, as currently, the "former" way will be introduced again in 3.0 now otherwise.
For example https://github.com/cakephp/cakephp/pull/3855/files#diff-b3d2ec2bff2ae851eb8184dd1d4ab9b9R294

If done right after https://github.com/cakephp/cakephp/pull/3855 (and all other branch merges) now, the merge conflicts should be minimal and easy to resolve.
Please confirm.
