### PR TITLE
Fix for CakeResponse::sharable() header to include private caches

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -834,12 +834,11 @@ class CakeResponse {
 		if ($public) {
 			$this->_cacheDirectives['public'] = true;
 			unset($this->_cacheDirectives['private']);
-			$this->sharedMaxAge($time);
 		} else {
 			$this->_cacheDirectives['private'] = true;
 			unset($this->_cacheDirectives['public']);
-			$this->maxAge($time);
 		}
+		$this->maxAge($time);
 		if (!$time) {
 			$this->_setCacheControl();
 		}

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -838,6 +838,7 @@ class CakeResponse {
 			$this->_cacheDirectives['private'] = true;
 			unset($this->_cacheDirectives['public']);
 		}
+		
 		$this->maxAge($time);
 		if (!$time) {
 			$this->_setCacheControl();

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -838,7 +838,7 @@ class CakeResponse {
 			$this->_cacheDirectives['private'] = true;
 			unset($this->_cacheDirectives['public']);
 		}
-		
+
 		$this->maxAge($time);
 		if (!$time) {
 			$this->_setCacheControl();

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -751,7 +751,7 @@ class CakeResponseTest extends CakeTestCase {
 		$response = new CakeResponse;
 		$response->sharable(true, 3600);
 		$headers = $response->header();
-		$this->assertEquals('public, s-maxage=3600', $headers['Cache-Control']);
+		$this->assertEquals('public, max-age=3600', $headers['Cache-Control']);
 
 		$response = new CakeResponse;
 		$response->sharable(false, 3600);


### PR DESCRIPTION
$public = true would set only "s-maxage" header which is respected by proxies but ignored by browsers. Changed to set "max-age" header which is respected by both proxies and browsers (irrespective of value of  $public).
#3858
