### PR TITLE
3.0 - Router plugin bake

### DIFF
--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -141,6 +141,7 @@ class PluginTask extends BakeTask {
 			$this->createFile($this->path . $plugin . DS . $classBase . DS . 'Controller' . DS . $controllerFileName, $out);
 
 			$hasAutoloader = $this->_modifyAutoloader($plugin, $this->path);
+			$this->_generateRoutes($plugin, $this->path);
 			$this->_modifyBootstrap($plugin, $hasAutoloader);
 			$this->_generatePhpunitXml($plugin, $this->path);
 			$this->_generateTestBootstrap($plugin, $this->path);
@@ -166,13 +167,30 @@ class PluginTask extends BakeTask {
 		if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
 			$autoload = $hasAutoloader ? null : "'autoload' => true, ";
 			$bootstrap->append(sprintf(
-				"\nPlugin::load('%s', [%s'bootstrap' => false, 'routes' => false]);\n",
+				"\nPlugin::load('%s', [%s'bootstrap' => false, 'routes' => true]);\n",
 				$plugin,
 				$autoload
 			));
 			$this->out('');
 			$this->out(sprintf('%s modified', $this->bootstrap));
 		}
+	}
+
+/**
+ * Generate a routes file for the plugin being baked.
+ *
+ * @param string $plugin The plugin to generate routes for.
+ * @param string $path The path to save the routes.php file in.
+ * @return void
+ */
+	protected function _generateRoutes($plugin, $path) {
+		$this->Template->set([
+			'plugin' => $plugin,
+		]);
+		$this->out( __d('cake_console', 'Generating routes.php file...'));
+		$out = $this->Template->generate('config', 'routes');
+		$file = $path . $plugin . DS . 'Config' . DS . 'routes.php';
+		$this->createFile($file, $out);
 	}
 
 /**

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -300,6 +300,9 @@ class PluginTask extends BakeTask {
 			'Can create plugins in any of your bootstrapped plugin paths.'
 		))->addArgument('name', [
 			'help' => __d('cake_console', 'CamelCased name of the plugin to create.')
+		])->addOption('composer', [
+			'default' => ROOT . '/composer.phar',
+			'help' => __d('cake_console', 'The path to the composer executable.')
 		])->removeOption('plugin');
 
 		return $parser;

--- a/src/Console/Templates/default/config/routes.ctp
+++ b/src/Console/Templates/default/config/routes.ctp
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+echo "<?php\n";
+?>
+namespace <?= $plugin ?>\Config;
+
+use Cake\Routing\Router;
+
+Router::plugin('<?= $plugin ?>', function($routes) {
+	$routes->connect('/:controller', ['action' => 'index']);
+	$routes->connect('/:controller/:action/*');
+});

--- a/tests/TestCase/Console/Command/Task/PluginTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/PluginTaskTest.php
@@ -144,13 +144,17 @@ class PluginTaskTest extends TestCase {
 		$this->Task->expects($this->at(1))->method('createFile')
 			->with($file, $this->stringContains('class AppController extends BaseController {'));
 
-		$file = $path . DS . 'phpunit.xml';
+		$file = $path . DS . 'Config' . DS . 'routes.php';
 		$this->Task->expects($this->at(2))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
+			->with($file, $this->stringContains("Router::plugin('BakeTestPlugin', function(\$routes)"));
+
+		$file = $path . DS . 'phpunit.xml';
+		$this->Task->expects($this->at(3))->method('createFile')
+			->with($file, $this->anything());
 
 		$file = $path . DS . 'tests' . DS . 'bootstrap.php';
-		$this->Task->expects($this->at(3))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
+		$this->Task->expects($this->at(4))->method('createFile')
+			->with($file, $this->anything());
 
 		$this->Task->main('BakeTestPlugin');
 


### PR DESCRIPTION
When baking a plugin bake should generate a routes stub file and load the plugin routes by default. I think encouraging people to make plugins with the routes is helpful as plugins can be self-contained.

This also fixes an issue where PluginTask was missing the `--composer` option.
