### PR TITLE
incorrect value for 'last' in validatio rules

### DIFF
--- a/cake/console/templates/default/classes/model.ctp
+++ b/cake/console/templates/default/classes/model.ctp
@@ -47,7 +47,7 @@ if (!empty($validate)):
 			echo "\t\t\t\t//'message' => 'Your custom message here',\n";
 			echo "\t\t\t\t//'allowEmpty' => false,\n";
 			echo "\t\t\t\t//'required' => false,\n";
-			echo "\t\t\t\t//'last' => false, // Stop validation after this rule\n";
+			echo "\t\t\t\t//'last' => true, // Stop validation after this rule\n";
 			echo "\t\t\t\t//'on' => 'create', // Limit validation to 'create' or 'update' operations\n";
 			echo "\t\t\t),\n";
 		endforeach;


### PR DESCRIPTION
As said in documentation:
"If set to true and the current rule does not validate, the current validation error message is then returned and all following rules for the current field will not be checked."
And:
"The default value for ‘last’ is false."
