### PR TITLE
Fix issues with Validation::inList() and SecurityComponent

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -470,8 +470,8 @@ class SecurityComponent extends Component {
 		$multi = array();
 
 		foreach ($fieldList as $i => $key) {
-			if (preg_match('/(\.\d+)+$/', $key)) {
-				$multi[$i] = preg_replace('/(\.\d+)+$/', '', $key);
+			if (preg_match('/(\.\d{1,10})+$/', $key)) {
+				$multi[$i] = preg_replace('/(\.\d{1,10})+$/', '', $key);
 				unset($fieldList[$i]);
 			}
 		}

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1979,6 +1979,10 @@ class ValidationTest extends CakeTestCase {
 		$this->assertFalse(Validation::inList(2, array('1', '2x', '3')));
 		$this->assertFalse(Validation::inList('One', array('one', 'two')));
 
+		// No hexadecimal for numbers.
+		$this->assertFalse(Validation::inList('0x7B', array('ABC', '123')));
+		$this->assertFalse(Validation::inList('0x7B', array('ABC', 123)));
+
 		// case insensitive
 		$this->assertTrue(Validation::inList('one', array('One', 'Two'), true));
 		$this->assertTrue(Validation::inList('Two', array('one', 'two'), true));

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -800,14 +800,13 @@ class Validation {
  * @return bool Success.
  */
 	public static function inList($check, $list, $caseInsensitive = false) {
-		$strict = !is_numeric($check);
-
 		if ($caseInsensitive) {
 			$list = array_map('mb_strtolower', $list);
 			$check = mb_strtolower($check);
+		} else {
+			$list = array_map('strval', $list);
 		}
-
-		return in_array((string)$check, $list, $strict);
+		return in_array((string)$check, $list, true);
 	}
 
 /**


### PR DESCRIPTION
Fix a few issues with `Validation::inList()` being a little too forgiving, and SecurityComponent being too helpful with deeply nested POST data sets.
