### PR TITLE
3.0 helper

### DIFF
--- a/src/Console/Templates/default/views/form.ctp
+++ b/src/Console/Templates/default/views/form.ctp
@@ -49,7 +49,7 @@ use Cake\Utility\Inflector;
 	<h3><?= "<?= __('Actions'); ?>"; ?></h3>
 	<ul>
 <?php if (strpos($action, 'add') === false): ?>
-		<li><?= "<?= \$this->Form->postLink(__('Delete'), ['action' => 'delete', \${$singularVar}->{$primaryKey[0]}], [], __('Are you sure you want to delete # %s?', \${$singularVar}->{$primaryKey[0]})); ?>"; ?></li>
+		<li><?= "<?= \$this->Form->postLink(__('Delete'), ['action' => 'delete', \${$singularVar}->{$primaryKey[0]}], ['confirm' => __('Are you sure you want to delete # %s?', \${$singularVar}->{$primaryKey[0]})]); ?>"; ?></li>
 <?php endif; ?>
 		<li><?= "<?= \$this->Html->link(__('List " . $pluralHumanName . "'), ['action' => 'index']); ?>"; ?></li>
 <?php

--- a/src/Console/Templates/default/views/index.ctp
+++ b/src/Console/Templates/default/views/index.ctp
@@ -47,7 +47,7 @@ use Cake\Utility\Inflector;
 		echo "\t\t<td class=\"actions\">\n";
 		echo "\t\t\t<?= \$this->Html->link(__('View'), ['action' => 'view', {$pk}]); ?>\n";
 		echo "\t\t\t<?= \$this->Html->link(__('Edit'), ['action' => 'edit', {$pk}]); ?>\n";
-		echo "\t\t\t<?= \$this->Form->postLink(__('Delete'), ['action' => 'delete', {$pk}], [], __('Are you sure you want to delete # %s?', {$pk})); ?>\n";
+		echo "\t\t\t<?= \$this->Form->postLink(__('Delete'), ['action' => 'delete', {$pk}], ['confirm' => __('Are you sure you want to delete # %s?', {$pk})]); ?>\n";
 		echo "\t\t</td>\n";
 	echo "\t</tr>\n";
 

--- a/src/Console/Templates/default/views/view.ctp
+++ b/src/Console/Templates/default/views/view.ctp
@@ -45,7 +45,7 @@ foreach ($fields as $field) {
 	$pk = "\${$singularVar}->{$primaryKey[0]}";
 
 	echo "\t\t<li><?= \$this->Html->link(__('Edit " . $singularHumanName ."'), ['action' => 'edit', {$pk}]); ?> </li>\n";
-	echo "\t\t<li><?= \$this->Form->postLink(__('Delete " . $singularHumanName . "'), ['action' => 'delete', {$pk}], [], __('Are you sure you want to delete # %s?', {$pk})); ?> </li>\n";
+	echo "\t\t<li><?= \$this->Form->postLink(__('Delete " . $singularHumanName . "'), ['action' => 'delete', {$pk}], ['confirm' => __('Are you sure you want to delete # %s?', {$pk})]); ?> </li>\n";
 	echo "\t\t<li><?= \$this->Html->link(__('List " . $pluralHumanName . "'), ['action' => 'index']); ?> </li>\n";
 	echo "\t\t<li><?= \$this->Html->link(__('New " . $singularHumanName . "'), ['action' => 'add']); ?> </li>\n";
 
@@ -123,7 +123,7 @@ echo "\t\t<?php foreach (\${$singularVar}->{$details['property']} as \${$otherSi
 			echo "\t\t\t<td class=\"actions\">\n";
 			echo "\t\t\t\t<?= \$this->Html->link(__('View'), ['controller' => '{$details['controller']}', 'action' => 'view', {$otherPk}]); ?>\n";
 			echo "\t\t\t\t<?= \$this->Html->link(__('Edit'), ['controller' => '{$details['controller']}', 'action' => 'edit', {$otherPk}]); ?>\n";
-			echo "\t\t\t\t<?= \$this->Form->postLink(__('Delete'), ['controller' => '{$details['controller']}', 'action' => 'delete', {$otherPk}], [], __('Are you sure you want to delete # %s?', {$otherPk})); ?>\n";
+			echo "\t\t\t\t<?= \$this->Form->postLink(__('Delete'), ['controller' => '{$details['controller']}', 'action' => 'delete', {$otherPk}], ['confirm' => __('Are you sure you want to delete # %s?', {$otherPk})]); ?>\n";
 			echo "\t\t\t</td>\n";
 		echo "\t\t</tr>\n";
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1416,41 +1416,41 @@ class FormHelper extends Helper {
 	}
 
 /**
- * Creates an HTML link, but access the URL using the method you specify (defaults to POST).
- * Requires javascript to be enabled in browser.
+ * Creates an HTML link, but access the URL using the method you specify
+ * (defaults to POST). Requires javascript to be enabled in browser.
  *
- * This method creates a `<form>` element. So do not use this method inside an existing form.
- * Instead you should add a submit button using FormHelper::submit()
+ * This method creates a `<form>` element. So do not use this method inside an
+ * existing form. Instead you should add a submit button using FormHelper::submit()
  *
  * ### Options:
  *
  * - `data` - Array with key/value to pass in input hidden
- * - `method` - Request method to use. Set to 'delete' to simulate HTTP/1.1 DELETE request. Defaults to 'post'.
- * - `confirm` - Can be used instead of $confirmMessage.
+ * - `method` - Request method to use. Set to 'delete' to simulate
+ *   HTTP/1.1 DELETE request. Defaults to 'post'.
+ * - `confirm` - Confirm message to show.
  * - `block` - Set to true to append form to view block "postLink" or provide
  *   custom block name.
  * - Other options are the same of HtmlHelper::link() method.
  * - The option `onclick` will be replaced.
  *
  * @param string $title The content to be wrapped by <a> tags.
- * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
+ * @param string|array $url Cake-relative URL or array of URL parameters, or
+ *   external URL (starts with http://)
  * @param array $options Array of HTML attributes.
- * @param bool|string $confirmMessage JavaScript confirmation message.
  * @return string An `<a />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postLink
  */
-	public function postLink($title, $url = null, array $options = array(), $confirmMessage = false) {
-		$options += array('block' => null);
+	public function postLink($title, $url = null, array $options = array()) {
+		$options += array('block' => null, 'confirm' => null);
 
 		$requestMethod = 'POST';
 		if (!empty($options['method'])) {
 			$requestMethod = strtoupper($options['method']);
 			unset($options['method']);
 		}
-		if (!empty($options['confirm'])) {
-			$confirmMessage = $options['confirm'];
-			unset($options['confirm']);
-		}
+
+		$confirmMessage = $options['confirm'];
+		unset($options['confirm']);
 
 		$formName = str_replace('.', '', uniqid('post_', true));
 		$formOptions = array(

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -299,11 +299,10 @@ class HtmlHelper extends Helper {
  * @param string $title The content to be wrapped by <a> tags.
  * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
  * @param array $options Array of options and HTML attributes.
- * @param string $confirmMessage JavaScript confirmation message.
  * @return string An `<a />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::link
  */
-	public function link($title, $url = null, array $options = array(), $confirmMessage = false) {
+	public function link($title, $url = null, array $options = array()) {
 		$escapeTitle = true;
 		if ($url !== null) {
 			$url = $this->url($url);
@@ -327,7 +326,8 @@ class HtmlHelper extends Helper {
 			$title = htmlentities($title, ENT_QUOTES, $escapeTitle);
 		}
 
-		if (!empty($options['confirm'])) {
+		$confirmMessage = null;
+		if (isset($options['confirm'])) {
 			$confirmMessage = $options['confirm'];
 			unset($options['confirm']);
 		}

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -293,11 +293,15 @@ class HtmlHelper extends Helper {
  * ### Options
  *
  * - `escape` Set to false to disable escaping of title and attributes.
- * - `escapeTitle` Set to false to disable escaping of title. (Takes precedence over value of `escape`)
+ * - `escapeTitle` Set to false to disable escaping of title. Takes precedence
+ *   over value of `escape`)
  * - `confirm` JavaScript confirmation message.
+ * - `default` If set to false the default redirection behavior of link will be
+ *   prevented using javascript.
  *
  * @param string $title The content to be wrapped by <a> tags.
- * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
+ * @param string|array $url Cake-relative URL or array of URL parameters, or
+ *   external URL (starts with http://)
  * @param array $options Array of options and HTML attributes.
  * @return string An `<a />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::link

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -296,8 +296,6 @@ class HtmlHelper extends Helper {
  * - `escapeTitle` Set to false to disable escaping of title. Takes precedence
  *   over value of `escape`)
  * - `confirm` JavaScript confirmation message.
- * - `default` If set to false the default redirection behavior of link will be
- *   prevented using javascript.
  *
  * @param string $title The content to be wrapped by <a> tags.
  * @param string|array $url Cake-relative URL or array of URL parameters, or
@@ -337,15 +335,8 @@ class HtmlHelper extends Helper {
 		}
 		if ($confirmMessage) {
 			$options['onclick'] = $this->_confirm($confirmMessage, 'return true;', 'return false;', $options);
-		} elseif (isset($options['default']) && !$options['default']) {
-			if (isset($options['onclick'])) {
-				$options['onclick'] .= ' ';
-			} else {
-				$options['onclick'] = '';
-			}
-			$options['onclick'] .= 'event.returnValue = false; return false;';
-			unset($options['default']);
 		}
+
 		return $this->formatTemplate('link', [
 			'url' => $url,
 			'attrs' => $this->templater()->formatAttributes($options),

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5356,7 +5356,7 @@ class FormHelperTest extends TestCase {
 			'/a'
 		));
 
-		$result = $this->Form->postLink('Delete', '/posts/delete/1', array(), 'Confirm?');
+		$result = $this->Form->postLink('Delete', '/posts/delete/1', array('confirm' => 'Confirm?'));
 		$this->assertTags($result, array(
 			'form' => array(
 				'method' => 'post', 'action' => '/posts/delete/1',
@@ -5369,7 +5369,11 @@ class FormHelperTest extends TestCase {
 			'/a'
 		));
 
-		$result = $this->Form->postLink('Delete', '/posts/delete/1', array('escape' => false), '\'Confirm\' this "deletion"?');
+		$result = $this->Form->postLink(
+			'Delete',
+			'/posts/delete/1',
+			array('escape' => false, 'confirm' => '\'Confirm\' this "deletion"?')
+		);
 		$this->assertTags($result, array(
 			'form' => array(
 				'method' => 'post', 'action' => '/posts/delete/1',
@@ -5401,8 +5405,7 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->postLink(
 			'',
 			array('controller' => 'items', 'action' => 'delete', 10),
-			array('class' => 'btn btn-danger', 'escape' => false),
-			'Confirm thing'
+			array('class' => 'btn btn-danger', 'escape' => false, 'confirm' => 'Confirm thing')
 		);
 		$this->assertTags($result, array(
 			'form' => array(

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -148,17 +148,9 @@ class HtmlHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Html->link('Home', '/home', array('default' => false));
+		$result = $this->Html->link('Home', '/home', array('onclick' => 'someFunction();'));
 		$expected = array(
-			'a' => array('href' => '/home', 'onclick' => 'event.returnValue = false; return false;'),
-			'Home',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Html->link('Home', '/home', array('default' => false, 'onclick' => 'someFunction();'));
-		$expected = array(
-			'a' => array('href' => '/home', 'onclick' => 'someFunction(); event.returnValue = false; return false;'),
+			'a' => array('href' => '/home', 'onclick' => 'someFunction();'),
 			'Home',
 			'/a'
 		);


### PR DESCRIPTION
- Removed $confirmMessage param from FormHelper::postLink() and HtmlHelper::link(). It can be set using "confirm" key in $options.
- Documented "default" option for HtmlHelper::link(). Though personally I would like to get rid of it. Preventing the default redirection behavior of link by itself isn't very useful. You would have some associated js to do something useful in which case the default behavior preventing can be taken care of by the extra js code itself.
