### PR TITLE
3.0 Router cleanup

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -392,20 +392,11 @@ class Controller implements EventListener {
  * @return bool
  */
 	protected function _isPrivateAction(\ReflectionMethod $method, Request $request) {
-		$privateAction = (
+		return (
 			$method->name[0] === '_' ||
 			!$method->isPublic() ||
 			!in_array($method->name, $this->methods)
 		);
-		$prefixes = Router::prefixes();
-
-		if (!$privateAction && !empty($prefixes)) {
-			if (empty($request->params['prefix']) && strpos($request->params['action'], '_') > 0) {
-				list($prefix) = explode('_', $request->params['action']);
-				$privateAction = in_array($prefix, $prefixes);
-			}
-		}
-		return $privateAction;
 	}
 
 /**

--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -17,6 +17,7 @@ namespace Cake\Routing\Filter;
 use Cake\Core\App;
 use Cake\Event\Event;
 use Cake\Routing\DispatcherFilter;
+use Cake\Utility\Inflector;
 
 /**
  * A dispatcher filter that builds the controller to dispatch
@@ -64,7 +65,7 @@ class ControllerFactoryFilter extends DispatcherFilter {
 			$controller = $request->params['controller'];
 		}
 		if (!empty($request->params['prefix'])) {
-			$namespace .= '/' . $request->params['prefix'];
+			$namespace .= '/' . Inflector::camelize($request->params['prefix']);
 		}
 		$className = false;
 		if ($pluginPath . $controller) {

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -41,9 +41,6 @@ class InflectedRoute extends Route {
 		if (!empty($params['plugin'])) {
 			$params['plugin'] = Inflector::camelize($params['plugin']);
 		}
-		if (!empty($params['prefix'])) {
-			$params['prefix'] = Inflector::camelize($params['prefix']);
-		}
 		return $params;
 	}
 
@@ -63,9 +60,6 @@ class InflectedRoute extends Route {
 		}
 		if (!empty($url['plugin'])) {
 			$url['plugin'] = Inflector::underscore($url['plugin']);
-		}
-		if (!empty($url['prefix'])) {
-			$url['prefix'] = Inflector::underscore($url['prefix']);
 		}
 		return parent::match($url, $context);
 	}

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -227,22 +227,27 @@ class Route {
 			return $this->_name;
 		}
 		$name = '';
-		if (isset($this->defaults['plugin'])) {
-			$name = $this->defaults['plugin'] . '.';
-		}
-		if (strpos($this->template, ':plugin') !== false) {
-			$name = '_plugin.';
-		}
-		foreach (array('controller', 'action') as $key) {
-			if ($key === 'action') {
-				$name .= ':';
-			}
-			$var = ':' . $key;
-			if (strpos($this->template, $var) !== false) {
-				$name .= '_' . $key;
+		$keys = [
+			'prefix' => ':',
+			'plugin' => '.',
+			'controller' => ':',
+			'action' => ''
+		];
+		foreach ($keys as $key => $glue) {
+			$value = null;
+			if (strpos($this->template, ':' . $key) !== false) {
+				$value = '_' . $key;
 			} elseif (isset($this->defaults[$key])) {
-				$name .= $this->defaults[$key];
+				$value = $this->defaults[$key];
 			}
+
+			if ($value === null) {
+				continue;
+			}
+			if (is_bool($value)) {
+				$value = $value ? '1' : '0';
+			}
+			$name .= $value . $glue;
 		}
 		return $this->_name = strtolower($name);
 	}

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -571,4 +571,21 @@ class Route {
 		return $out;
 	}
 
+/**
+ * Get the static path portion for this route.
+ *
+ * @return string
+ */
+	public function staticPath() {
+		$routeKey = strpos($this->template, ':');
+		if ($routeKey !== false) {
+			return substr($this->template, 0, $routeKey);
+		}
+		$star = strpos($this->template, '*');
+		if ($star !== false) {
+			return substr($this->template, 0, $star);
+		}
+		return $this->template;
+	}
+
 }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -55,8 +55,11 @@ class RouteCollection {
 /**
  * Add a route to the collection.
  *
+ * @param \Cake\Routing\Route\Route $route The route object to add.
+ * @param array $options Addtional options for the route. Primarily for the
+ *   `_name` option, which enables named routes.
  */
-	public function add(Route $route, $options) {
+	public function add(Route $route, $options = []) {
 		$this->_routes[] = $route;
 
 		// Explicit names

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -128,7 +128,6 @@ class RouteCollection {
  * @return string The name of the url
  */
 	protected function _getNames($url) {
-		$name = false;
 		if (isset($url['_name'])) {
 			return [$url['_name']];
 		}
@@ -136,29 +135,26 @@ class RouteCollection {
 		if (isset($url['plugin'])) {
 			$plugin = $url['plugin'];
 		}
+		$controller = $url['controller'];
+		$action = $url['action'];
+
 		$fallbacks = [
-			'%2$s:%3$s',
-			'%2$s:_action',
-			'_controller:%3$s',
-			'_controller:_action'
+			"${controller}:${action}",
+			"${controller}:_action",
+			"_controller:${action}",
+			"_controller:_action"
 		];
 		if ($plugin) {
 			$fallbacks = [
-				'%1$s.%2$s:%3$s',
-				'%1$s.%2$s:_action',
-				'%1$s._controller:%3$s',
-				'%1$s._controller:_action',
-				'_plugin.%2$s:%3$s',
-				'_plugin._controller:%3$s',
-				'_plugin._controller:_action',
-				'_controller:_action'
+				"${plugin}.${controller}:${action}",
+				"${plugin}.${controller}:_action",
+				"${plugin}._controller:${action}",
+				"${plugin}._controller:_action",
+				"_plugin.${controller}:${action}",
+				"_plugin._controller:${action}",
+				"_plugin._controller:_action",
+				"_controller:_action"
 			];
-		}
-		foreach ($fallbacks as $i => $template) {
-			$fallbacks[$i] = strtolower(sprintf($template, $plugin, $url['controller'], $url['action']));
-		}
-		if ($name) {
-			array_unshift($fallbacks, $name);
 		}
 		return $fallbacks;
 	}
@@ -184,28 +180,6 @@ class RouteCollection {
 				return $route->match($url + $route->defaults, $context);
 			}
 		}
-
-		/*
-		// Check the scope that matches key params.
-		$plugin = isset($url['plugin']) ? $url['plugin'] : '';
-		$prefix = isset($url['prefix']) ? $url['prefix'] : '';
-
-		$collection = null;
-		$attempts = [[$plugin, $prefix], ['', '']];
-		foreach ($attempts as $attempt) {
-			if (isset($this->_byParams[$attempt[0]][$attempt[1]])) {
-				$collection = $this->_byParams[$attempt[0]][$attempt[1]];
-				break;
-			}
-		}
-
-		if ($collection) {
-			$match = $collection->match($url, static::$_requestContext);
-			if ($match !== false) {
-				return $match;
-			}
-		}
-		 */
 
 		foreach ($this->_getNames($url) as $name) {
 			if (empty($this->_routeTable[$name])) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -83,8 +83,9 @@ class RouteCollection {
 /**
  * Takes the URL string and iterates the routes until one is able to parse the route.
  *
- * @param string $url Url to parse.
- * @return array An array of request parameters parsed from the url.
+ * @param string $url URL to parse.
+ * @return array An array of request parameters parsed from the URL.
+ * @throws \Cake\Routing\Error\MissingRouteException When a URL has no matching route.
  */
 	public function parse($url) {
 		foreach (array_keys($this->_paths) as $path) {
@@ -200,9 +201,10 @@ class RouteCollection {
  * @param array $context The request context to use. Contains _base, _port,
  *    _host, and _scheme keys.
  * @return string|false Either a string on match, or false on failure.
+ * @throws \Cake\Routing\Error\MissingRouteException when a route cannot be matched.
  */
 	public function match($url, $context) {
-		// Named routes support hack.
+		// Named routes support optimization.
 		if (isset($url['_name'])) {
 			$name = $url['_name'];
 			unset($url['_name']);

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -120,31 +120,76 @@ class RouteCollection {
  */
 	protected function _getNames($url) {
 		$plugin = false;
-		if (isset($url['plugin'])) {
+		if (isset($url['plugin']) && $url['plugin'] !== false) {
 			$plugin = strtolower($url['plugin']);
+		}
+		$prefix = false;
+		if (isset($url['prefix']) && $url['prefix'] !== false) {
+			$prefix = strtolower($url['prefix']);
 		}
 		$controller = strtolower($url['controller']);
 		$action = strtolower($url['action']);
 
-		$fallbacks = [
+		$names = [
 			"${controller}:${action}",
 			"${controller}:_action",
 			"_controller:${action}",
 			"_controller:_action"
 		];
-		if ($plugin) {
-			$fallbacks = [
+
+		// No prefix, no plugin
+		if ($prefix === false && $plugin === false) {
+			return $names;
+		}
+
+		// Only a plugin
+		if ($prefix === false) {
+			return [
 				"${plugin}.${controller}:${action}",
 				"${plugin}.${controller}:_action",
 				"${plugin}._controller:${action}",
 				"${plugin}._controller:_action",
 				"_plugin.${controller}:${action}",
+				"_plugin.${controller}:_action",
 				"_plugin._controller:${action}",
 				"_plugin._controller:_action",
-				"_controller:_action"
 			];
 		}
-		return $fallbacks;
+
+		// Only a prefix
+		if ($plugin === false) {
+			return [
+				"${prefix}:${controller}:${action}",
+				"${prefix}:${controller}:_action",
+				"${prefix}:_controller:${action}",
+				"${prefix}:_controller:_action",
+				"_prefix:${controller}:${action}",
+				"_prefix:${controller}:_action",
+				"_prefix:_controller:${action}",
+				"_prefix:_controller:_action"
+			];
+		}
+
+		// Prefix and plugin has the most options
+		// as there are 4 factors.
+		return [
+			"${prefix}:${plugin}.${controller}:${action}",
+			"${prefix}:${plugin}.${controller}:_action",
+			"${prefix}:${plugin}._controller:${action}",
+			"${prefix}:${plugin}._controller:_action",
+			"${prefix}:_plugin.${controller}:${action}",
+			"${prefix}:_plugin.${controller}:_action",
+			"${prefix}:_plugin._controller:${action}",
+			"${prefix}:_plugin._controller:_action",
+			"_prefix:${plugin}.${controller}:${action}",
+			"_prefix:${plugin}.${controller}:_action",
+			"_prefix:${plugin}._controller:${action}",
+			"_prefix:${plugin}._controller:_action",
+			"_prefix:_plugin.${controller}:${action}",
+			"_prefix:_plugin.${controller}:_action",
+			"_prefix:_plugin._controller:${action}",
+			"_prefix:_plugin._controller:_action",
+		];
 	}
 
 /**

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Routing;
+
+use Cake\Core\App;
+use Cake\Error;
+use Cake\Routing\Error\MissingRouteException;
+use Cake\Routing\Router;
+use Cake\Routing\Route\Route;
+use Cake\Utility\Inflector;
+
+/**
+ * Contains a collection of routes.
+ *
+ * Provides an interface for adding/removing routes
+ * and parsing/generating URLs with the routes it contains.
+ */
+class RouteCollection {
+
+/**
+ * The routes connected to this collection.
+ *
+ * @var array
+ */
+	protected $_routeTable = [];
+
+/**
+ * The routes connected to this collection.
+ *
+ * @var array
+ */
+	protected $_routes = [];
+
+/**
+ * The hash map of named routes that are in this collection.
+ *
+ * @var array
+ */
+	protected $_named = [];
+
+/**
+ * Add a route to the collection.
+ *
+ */
+	public function add(Route $route, $options) {
+		$this->_routes[] = $route;
+
+		// Explicit names
+		if (isset($options['_name'])) {
+			$this->_named[$options['_name']] = $route;
+		}
+
+		// Generated names.
+		$name = $route->getName();
+		if (!isset($this->_routeTable[$name])) {
+			$this->_routeTable[$name] = [];
+		}
+		$this->_routeTable[$name][] = $route;
+
+		// Index path prefixes (for parsing)
+		$path = $route->staticPath();
+		if (empty($this->_paths[$path])) {
+			$this->_paths[$path] = [];
+			krsort($this->_paths);
+		}
+		$this->_paths[$path][] = $route;
+
+		/*
+		// Index scopes by path (for parsing)
+		if (empty(static::$_pathScopes[$path])) {
+			static::$_pathScopes[$path] = $collection;
+			krsort(static::$_pathScopes);
+		} else {
+			static::$_pathScopes[$path]->merge($collection);
+		}
+
+		// Index scopes by key params (for reverse routing).
+		$plugin = isset($params['plugin']) ? $params['plugin'] : '';
+		$prefix = isset($params['prefix']) ? $params['prefix'] : '';
+		if (!isset(static::$_paramScopes[$plugin][$prefix])) {
+			static::$_paramScopes[$plugin][$prefix] = $collection;
+		} else {
+			static::$_paramScopes[$plugin][$prefix]->merge($collection);
+		}
+		*/
+	}
+
+/**
+ * Takes the URL string and iterates the routes until one is able to parse the route.
+ *
+ * @param string $url Url to parse.
+ * @return array An array of request parameters parsed from the url.
+ */
+	public function parse($url) {
+		krsort($this->_paths);
+		foreach ($this->_paths as $path => $collection) {
+			if (strpos($url, $path) !== 0) {
+				continue;
+			}
+
+			$queryParameters = null;
+			if (strpos($url, '?') !== false) {
+				list($url, $queryParameters) = explode('?', $url, 2);
+				parse_str($queryParameters, $queryParameters);
+			}
+			foreach ($collection as $route) {
+				$r = $route->parse($url);
+				if ($r === false) {
+					continue;
+				}
+				if ($queryParameters) {
+					$r['?'] = $queryParameters;
+				}
+				return $r;
+			}
+		}
+		throw new MissingRouteException(['url' => $url]);
+	}
+
+/**
+ * Get the set of names from the $url.  Accepts both older style array urls,
+ * and newer style urls containing '_name'
+ *
+ * @param array $url The url to match.
+ * @return string The name of the url
+ */
+	protected function _getNames($url) {
+		$name = false;
+		if (isset($url['_name'])) {
+			return [$url['_name']];
+		}
+		$plugin = false;
+		if (isset($url['plugin'])) {
+			$plugin = $url['plugin'];
+		}
+		$fallbacks = [
+			'%2$s:%3$s',
+			'%2$s:_action',
+			'_controller:%3$s',
+			'_controller:_action'
+		];
+		if ($plugin) {
+			$fallbacks = [
+				'%1$s.%2$s:%3$s',
+				'%1$s.%2$s:_action',
+				'%1$s._controller:%3$s',
+				'%1$s._controller:_action',
+				'_plugin.%2$s:%3$s',
+				'_plugin._controller:%3$s',
+				'_plugin._controller:_action',
+				'_controller:_action'
+			];
+		}
+		foreach ($fallbacks as $i => $template) {
+			$fallbacks[$i] = strtolower(sprintf($template, $plugin, $url['controller'], $url['action']));
+		}
+		if ($name) {
+			array_unshift($fallbacks, $name);
+		}
+		return $fallbacks;
+	}
+
+/**
+ * Reverse route or match a $url array with the defined routes.
+ * Returns either the string URL generate by the route, or false on failure.
+ *
+ * @param array $url The url to match.
+ * @param array $context The request context to use. Contains _base, _port,
+ *    _host, and _scheme keys.
+ * @return string|false Either a string on match, or false on failure.
+ */
+	public function match($url, $context) {
+		// Named routes support hack.
+		if (isset($url['_name'])) {
+			$route = false;
+			if (isset($this->_named[$url['_name']])) {
+				$route = $this->_named[$url['_name']];
+			}
+			if ($route) {
+				unset($url['_name']);
+				return $route->match($url + $route->defaults, $context);
+			}
+		}
+
+		/*
+		// Check the scope that matches key params.
+		$plugin = isset($url['plugin']) ? $url['plugin'] : '';
+		$prefix = isset($url['prefix']) ? $url['prefix'] : '';
+
+		$collection = null;
+		$attempts = [[$plugin, $prefix], ['', '']];
+		foreach ($attempts as $attempt) {
+			if (isset($this->_byParams[$attempt[0]][$attempt[1]])) {
+				$collection = $this->_byParams[$attempt[0]][$attempt[1]];
+				break;
+			}
+		}
+
+		if ($collection) {
+			$match = $collection->match($url, static::$_requestContext);
+			if ($match !== false) {
+				return $match;
+			}
+		}
+		 */
+
+		foreach ($this->_getNames($url) as $name) {
+			if (empty($this->_routeTable[$name])) {
+				continue;
+			}
+			foreach ($this->_routeTable[$name] as $route) {
+				$match = $route->match($url, $context);
+				if ($match) {
+					return strlen($match) > 1 ? trim($match, '/') : $match;
+				}
+			}
+		}
+		throw new MissingRouteException(['url' => var_export($url, true)]);
+	}
+
+/**
+ * Get all the connected routes as a flat list.
+ *
+ * @return array
+ */
+	public function routes() {
+		return $this->_routes;
+	}
+
+	public function named() {
+		return $this->_named;
+	}
+
+}

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -164,18 +164,6 @@ class Router {
 	protected static $_urlFilters = [];
 
 /**
- * Sets the Routing prefixes.
- *
- * @return void
- */
-	protected static function _setPrefixes() {
-		$routing = Configure::read('Routing');
-		if (!empty($routing['prefixes'])) {
-			static::$_prefixes = array_merge(static::$_prefixes, (array)$routing['prefixes']);
-		}
-	}
-
-/**
  * Gets the named route patterns for use in app/Config/routes.php
  *
  * @return array Named route elements

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -53,14 +53,6 @@ class Router {
 	protected static $_fullBaseUrl;
 
 /**
- * List of action prefixes used in connected routes.
- * Includes admin prefix
- *
- * @var array
- */
-	protected static $_prefixes = [];
-
-/**
  * List of valid extensions to parse from a URL. If null, any extension is allowed.
  *
  * @var array
@@ -415,18 +407,6 @@ class Router {
 				static::connect($url, $params, $routeOptions);
 			}
 		}
-	}
-
-/**
- * Returns the list of prefixes used in connected routes
- *
- * @return array A list of prefixes used in connected routes
- */
-	public static function prefixes() {
-		if (empty(static::$_prefixes)) {
-			return (array)Configure::read('Routing.prefixes');
-		}
-		return static::$_prefixes;
 	}
 
 /**

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -27,25 +27,22 @@ use Cake\Utility\Debugger;
 Add a matching route to <?= APP_DIR . DS . 'Config' . DS . 'routes.php' ?></p>
 
 <h3>Connected Routes</h3>
+<table cellspacing="0" cellpadding="0">
+<tr><th>Template</th><th>Defaults</th><th>Options</th></tr>
 <?php
-foreach (Router::routes() as $scope):
-	printf('<h4>Scope: %s</h4>', $scope->path());
-	echo '<table cellspacing="0" cellpadding="0">';
-	echo '<tr><th>Template</th><th>Defaults</th><th>Options</th></tr>';
-
-	foreach ($scope->routes() as $route):
-		echo '<tr>';
-		printf(
-			'<th width="25%%">%s</th><th>%s</th><th width="20%%">%s</th>',
-			$route->template,
-			Debugger::exportVar($route->defaults),
-			Debugger::exportVar($route->options)
-		);
-		echo '</tr>';
-	endforeach;
-	echo '</table>';
+foreach (Router::routes() as $route):
+	echo '<tr>';
+	printf(
+		'<th width="25%%">%s</th><th>%s</th><th width="20%%">%s</th>',
+		$route->template,
+		Debugger::exportVar($route->defaults),
+		Debugger::exportVar($route->options)
+	);
+	echo '</tr>';
 endforeach;
 ?>
+</table>
+
 <p class="notice">
 	<strong>Notice: </strong>
 	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_route.ctp'); ?>

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -858,7 +858,11 @@ class AuthComponentTest extends TestCase {
  */
 	public function testAdminRoute() {
 		$event = new Event('Controller.startup', $this->Controller);
+		Router::reload();
 		Router::prefix('admin', function($routes) {
+			$routes->fallbacks();
+		});
+		Router::scope('/', function($routes) {
 			$routes->fallbacks();
 		});
 
@@ -912,7 +916,11 @@ class AuthComponentTest extends TestCase {
  */
 	public function testLoginActionRedirect() {
 		$event = new Event('Controller.startup', $this->Controller);
+		Router::reload();
 		Router::prefix('admin', function($routes) {
+			$routes->fallbacks();
+		});
+		Router::scope('/', function($routes) {
 			$routes->fallbacks();
 		});
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -803,26 +803,6 @@ class ControllerTest extends TestCase {
 /**
  * test invoking controller methods.
  *
- * @expectedException \Cake\Controller\Error\PrivateActionException
- * @expectedExceptionMessage Private Action TestController::admin_add() is not directly accessible.
- * @return void
- */
-	public function testInvokeActionPrefixProtection() {
-		Configure::write('Routing.prefixes', array('admin'));
-		Router::reload();
-		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-
-		$url = new Request('test/admin_add/');
-		$url->addParams(array('controller' => 'test_controller', 'action' => 'admin_add'));
-		$response = $this->getMock('Cake\Network\Response');
-
-		$Controller = new TestController($url, $response);
-		$Controller->invokeAction();
-	}
-
-/**
- * test invoking controller methods.
- *
  * @return void
  */
 	public function testInvokeActionReturnValue() {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * Test case for Route
- *
  */
 class RouteTest extends TestCase {
 
@@ -878,6 +877,37 @@ class RouteTest extends TestCase {
 			array('plugin' => 'asset', 'controller' => 'assets', 'action' => 'get')
 		);
 		$this->assertEquals('asset.assets:get', $route->getName());
+	}
+
+/**
+ * Test getName() with prefixes.
+ *
+ * @return void
+ */
+	public function testGetNamePrefix() {
+		$route = new Route(
+			'/admin/:controller/:action',
+			array('prefix' => 'admin')
+		);
+		$this->assertEquals('admin:_controller:_action', $route->getName());
+
+		$route = new Route(
+			'/:prefix/assets/:action',
+			array('controller' => 'assets')
+		);
+		$this->assertEquals('_prefix:assets:_action', $route->getName());
+
+		$route = new Route(
+			'/admin/assets/get',
+			array('prefix' => 'admin', 'plugin' => 'asset', 'controller' => 'assets', 'action' => 'get')
+		);
+		$this->assertEquals('admin:asset.assets:get', $route->getName());
+
+		$route = new Route(
+			'/:prefix/:plugin/:controller/:action/*',
+			[]
+		);
+		$this->assertEquals('_prefix:_plugin._controller:_action', $route->getName());
 	}
 
 /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -68,6 +68,7 @@ class RouteTest extends TestCase {
 		$this->assertRegExp($result, '/posts/super_delete');
 		$this->assertNotRegExp($result, '/posts');
 		$this->assertNotRegExp($result, '/posts/super_delete/1');
+		$this->assertSame($result, $route->compile());
 
 		$route = new Route('/posts/foo:id', array('controller' => 'posts', 'action' => 'view'));
 		$result = $route->compile();
@@ -932,6 +933,25 @@ class RouteTest extends TestCase {
 		$result = $route->parse('/weblog');
 		$expected = array('section' => 'weblog', 'plugin' => 'blogs', 'controller' => 'posts', 'action' => 'index', 'pass' => array());
 		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Test getting the static path for a route.
+ *
+ * @return void
+ */
+	public function testStaticPath() {
+		$route = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
+		$this->assertEquals('/pages/', $route->staticPath());
+
+		$route = new Route('/pages/:id/*', ['controller' => 'Pages', 'action' => 'display']);
+		$this->assertEquals('/pages/', $route->staticPath());
+
+		$route = new Route('/:controller/:action/*');
+		$this->assertEquals('/', $route->staticPath());
+
+		$route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
+		$this->assertEquals('/books/reviews', $route->staticPath());
 	}
 
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -280,10 +280,10 @@ class RouteBuilderTest extends TestCase {
  * @return void
  */
 	public function testFallbacks() {
-		$routes = new ScopedRouteCollection('/api', ['prefix' => 'api']);
+		$routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
 		$routes->fallbacks();
 
-		$all = $routes->routes();
+		$all = $this->collection->routes();
 		$this->assertEquals('/api/:controller', $all[0]->template);
 		$this->assertEquals('/api/:controller/:action/*', $all[1]->template);
 	}

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -81,22 +81,6 @@ class RouteBuilderTest extends TestCase {
 	}
 
 /**
- * Test getting named routes.
- *
- * @return void
- */
-	public function testNamed() {
-		$routes = new RouteBuilder($this->collection, '/l');
-		$routes->connect('/:controller', ['action' => 'index'], ['_name' => 'cntrl']);
-		$routes->connect('/:controller/:action/*');
-
-		$all = $this->collection->named();
-		$this->assertCount(1, $all);
-		$this->assertInstanceOf('Cake\Routing\Route\Route', $all['cntrl']);
-		$this->assertEquals('/l/:controller', $all['cntrl']->template);
-	}
-
-/**
  * Test connecting an instance routes.
  *
  * @return void

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -179,6 +179,42 @@ class RouteCollectionTest extends TestCase {
 	}
 
 /**
+ * Test that prefixes increase the specificity of a route match.
+ *
+ * Connect the admin route after the non prefixed version, this means
+ * the non-prefix route would have a more specific name (users:index)
+ *
+ * @return void
+ */
+	public function testMatchPrefixSpecificity() {
+		$context = [
+			'_base' => '/',
+			'_scheme' => 'http',
+			'_host' => 'example.org',
+		];
+		$routes = new RouteBuilder($this->collection, '/');
+		$routes->connect('/:action/*', ['controller' => 'Users']);
+		$routes->connect('/admin/:controller', ['prefix' => 'admin', 'action' => 'index']);
+
+		$url = [
+			'plugin' => null,
+			'prefix' => 'admin',
+			'controller' => 'Users',
+			'action' => 'index'
+		];
+		$result = $this->collection->match($url, $context);
+		$this->assertEquals('admin/Users', $result);
+
+		$url = [
+			'plugin' => null,
+			'controller' => 'Users',
+			'action' => 'index'
+		];
+		$result = $this->collection->match($url, $context);
+		$this->assertEquals('index', $result);
+	}
+
+/**
  * Test getting named routes.
  *
  * @return void

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -124,6 +124,43 @@ class RouteCollectionTest extends TestCase {
 	}
 
 /**
+ * Test matching routes with names
+ *
+ * @return void
+ */
+	public function testMatchNamed() {
+		$context = [
+			'_base' => '/',
+			'_scheme' => 'http',
+			'_host' => 'example.org',
+		];
+		$routes = new RouteBuilder($this->collection, '/b');
+		$routes->connect('/', ['controller' => 'Articles']);
+		$routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
+
+		$result = $this->collection->match(['_name' => 'article:view', 'id' => '2'], $context);
+		$this->assertEquals('/b/2', $result);
+	}
+
+/**
+ * Test matching routes with names and failing
+ *
+ * @expectedException Cake\Routing\Error\MissingRouteException
+ * @return void
+ */
+	public function testMatchNamedError() {
+		$context = [
+			'_base' => '/',
+			'_scheme' => 'http',
+			'_host' => 'example.org',
+		];
+		$routes = new RouteBuilder($this->collection, '/b');
+		$routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'article:view']);
+
+		$this->collection->match(['_name' => 'derp'], $context);
+	}
+
+/**
  * Test matching plugin routes.
  *
  * @return void
@@ -139,6 +176,36 @@ class RouteCollectionTest extends TestCase {
 
 		$result = $this->collection->match(['plugin' => 'Contacts', 'controller' => 'Contacts', 'action' => 'index'], $context);
 		$this->assertEquals('contacts', $result);
+	}
+
+/**
+ * Test getting named routes.
+ *
+ * @return void
+ */
+	public function testNamed() {
+		$routes = new RouteBuilder($this->collection, '/l');
+		$routes->connect('/:controller', ['action' => 'index'], ['_name' => 'cntrl']);
+		$routes->connect('/:controller/:action/*');
+
+		$all = $this->collection->named();
+		$this->assertCount(1, $all);
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $all['cntrl']);
+		$this->assertEquals('/l/:controller', $all['cntrl']->template);
+	}
+
+/**
+ * Test adding with an error
+ */
+	public function testAdd() {
+	}
+
+/**
+ * Test the routes() method.
+ *
+ * @return void
+ */
+	public function testRoutes() {
 	}
 
 }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -195,17 +195,20 @@ class RouteCollectionTest extends TestCase {
 	}
 
 /**
- * Test adding with an error
- */
-	public function testAdd() {
-	}
-
-/**
- * Test the routes() method.
+ * Test the add() and routes() method.
  *
  * @return void
  */
-	public function testRoutes() {
+	public function testAddingRoutes() {
+		$one = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
+		$two = new Route('/', ['controller' => 'Dashboards', 'action' => 'display']);
+		$this->collection->add($one);
+		$this->collection->add($two);
+
+		$routes = $this->collection->routes();
+		$this->assertCount(2, $routes);
+		$this->assertSame($one, $routes[0]);
+		$this->assertSame($two, $routes[1]);
 	}
 
 }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1880,9 +1880,9 @@ class RouterTest extends TestCase {
 		Router::connect('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 
-		// $result = Router::parse('/');
-		// $expected = array('pass' => array('home'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		// $this->assertEquals($expected, $result);
+		$result = Router::parse('/');
+		$expected = array('pass' => array('home'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/pages/home/');
 		$expected = array('pass' => array('home'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2055,10 +2055,6 @@ class RouterTest extends TestCase {
 		$expected = '/company/users/login';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'prefix' => 'company'));
-		$expected = '/company/users/login';
-		$this->assertEquals($expected, $result);
-
 		$request = new Request();
 		Router::setRequestInfo(
 			$request->addParams(array(

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1492,30 +1492,6 @@ class RouterTest extends TestCase {
 	}
 
 /**
- * Test that Routing.prefixes are used when a Router instance is created
- * or reset
- *
- * @return void
- */
-	public function testRoutingPrefixesSetting() {
-		$restore = Configure::read('Routing');
-
-		Configure::write('Routing.prefixes', array('admin', 'member', 'super_user'));
-		Router::reload();
-		$result = Router::prefixes();
-		$expected = array('admin', 'member', 'super_user');
-		$this->assertEquals($expected, $result);
-
-		Configure::write('Routing.prefixes', array('admin', 'member'));
-		Router::reload();
-		$result = Router::prefixes();
-		$expected = array('admin', 'member');
-		$this->assertEquals($expected, $result);
-
-		Configure::write('Routing', $restore);
-	}
-
-/**
  * testParseExtensions method
  *
  * @return void
@@ -2011,7 +1987,6 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testParsingWithLiteralPrefixes() {
-		Configure::write('Routing.prefixes', []);
 		Router::reload();
 		$adminParams = array('prefix' => 'admin');
 		Router::connect('/admin/:controller', $adminParams);
@@ -2038,10 +2013,6 @@ class RouterTest extends TestCase {
 
 		$result = Router::url(array('prefix' => 'admin', 'controller' => 'posts'));
 		$expected = '/base/admin/posts';
-		$this->assertEquals($expected, $result);
-
-		$result = Router::prefixes();
-		$expected = [];
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
@@ -2080,7 +2051,6 @@ class RouterTest extends TestCase {
 		Router::connect('/company/:controller/:action/*', array('prefix' => 'company'));
 		Router::connect('/:action', array('controller' => 'users'));
 
-		/*
 		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'prefix' => 'company'));
 		$expected = '/company/users/login';
 		$this->assertEquals($expected, $result);
@@ -2088,7 +2058,6 @@ class RouterTest extends TestCase {
 		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'prefix' => 'company'));
 		$expected = '/company/users/login';
 		$this->assertEquals($expected, $result);
-		 */
 
 		$request = new Request();
 		Router::setRequestInfo(

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -108,7 +108,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testMapResources() {
-		$resources = Router::mapResources('Posts');
+		Router::mapResources('Posts');
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$expected = [
@@ -121,7 +121,6 @@ class RouterTest extends TestCase {
 		];
 		$result = Router::parse('/posts');
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($resources, ['posts']);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$expected = [
@@ -187,8 +186,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		$result = Router::mapResources('Posts', ['id' => '[a-z0-9_]+']);
-		$this->assertEquals(['posts'], $result);
+		Router::mapResources('Posts', ['id' => '[a-z0-9_]+']);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$expected = [
@@ -223,7 +221,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testPluginMapResources() {
-		$resources = Router::mapResources('TestPlugin.TestPlugin');
+		Router::mapResources('TestPlugin.TestPlugin');
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/test_plugin/test_plugin');
@@ -236,7 +234,6 @@ class RouterTest extends TestCase {
 			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
-		$this->assertEquals(array('test_plugin'), $resources);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/test_plugin/test_plugin/13');
@@ -258,8 +255,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testMapResourcesWithPrefix() {
-		$resources = Router::mapResources('Posts', array('prefix' => 'api'));
-		$this->assertEquals(array('posts'), $resources);
+		Router::mapResources('Posts', array('prefix' => 'api'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/api/posts');
@@ -284,9 +280,7 @@ class RouterTest extends TestCase {
 	public function testMapResourcesWithExtension() {
 		Router::parseExtensions(['json', 'xml'], false);
 
-		$resources = Router::mapResources('Posts', ['_ext' => 'json']);
-		$this->assertEquals(['posts'], $resources);
-
+		Router::mapResources('Posts', ['_ext' => 'json']);
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		$expected = array(
@@ -320,8 +314,8 @@ class RouterTest extends TestCase {
 				'foo' => '^(bar)$',
 			),
 		));
-		$routes = Router::scope('/');
-		$route = $routes->routes()[0];
+		$routes = Router::routes();
+		$route = $routes[0];
 		$this->assertInstanceOf('TestPlugin\Routing\Route\TestRoute', $route);
 		$this->assertEquals('^(bar)$', $route->options['foo']);
 	}
@@ -332,7 +326,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testPluginMapResourcesWithPrefix() {
-		$resources = Router::mapResources('TestPlugin.TestPlugin', array('prefix' => 'api'));
+		Router::mapResources('TestPlugin.TestPlugin', array('prefix' => 'api'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/api/test_plugin/test_plugin');
@@ -346,7 +340,6 @@ class RouterTest extends TestCase {
 			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
-		$this->assertEquals(array('test_plugin'), $resources);
 
 		$resources = Router::mapResources('Posts', array('prefix' => 'api'));
 
@@ -1911,9 +1904,9 @@ class RouterTest extends TestCase {
 		Router::connect('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 
-		$result = Router::parse('/');
-		$expected = array('pass' => array('home'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEquals($expected, $result);
+		// $result = Router::parse('/');
+		// $expected = array('pass' => array('home'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
+		// $this->assertEquals($expected, $result);
 
 		$result = Router::parse('/pages/home/');
 		$expected = array('pass' => array('home'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
@@ -2546,8 +2539,8 @@ class RouterTest extends TestCase {
  */
 	public function testRedirect() {
 		Router::redirect('/mobile', '/', ['status' => 301]);
-		$scope = Router::scope('/');
-		$route = $scope->routes()[0];
+		$routes = Router::routes();
+		$route = $routes[0];
 		$this->assertInstanceOf('Cake\Routing\Route\RedirectRoute', $route);
 	}
 
@@ -2627,15 +2620,11 @@ class RouterTest extends TestCase {
  */
 	public function testScope() {
 		Router::scope('/path', ['param' => 'value'], function($routes) {
-			$this->assertInstanceOf('Cake\Routing\ScopedRouteCollection', $routes);
-			$this->assertCount(0, $routes->routes());
+			$this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
 			$this->assertEquals('/path', $routes->path());
 			$this->assertEquals(['param' => 'value'], $routes->params());
 
 			$routes->connect('/articles', ['controller' => 'Articles']);
-		});
-		Router::scope('/path', function($routes) {
-			$this->assertCount(0, $routes->routes());
 		});
 	}
 
@@ -2656,7 +2645,7 @@ class RouterTest extends TestCase {
  */
 	public function testPrefix() {
 		Router::prefix('admin', function($routes) {
-			$this->assertInstanceOf('Cake\Routing\ScopedRouteCollection', $routes);
+			$this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
 			$this->assertEquals('/admin', $routes->path());
 			$this->assertEquals(['prefix' => 'admin'], $routes->params());
 		});
@@ -2669,7 +2658,7 @@ class RouterTest extends TestCase {
  */
 	public function testPlugin() {
 		Router::plugin('DebugKit', function($routes) {
-			$this->assertInstanceOf('Cake\Routing\ScopedRouteCollection', $routes);
+			$this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
 			$this->assertEquals('/debug_kit', $routes->path());
 			$this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
 		});
@@ -2682,7 +2671,7 @@ class RouterTest extends TestCase {
  */
 	public function testPluginOptions() {
 		Router::plugin('DebugKit', ['path' => '/debugger'], function($routes) {
-			$this->assertInstanceOf('Cake\Routing\ScopedRouteCollection', $routes);
+			$this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
 			$this->assertEquals('/debugger', $routes->path());
 			$this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
 		});


### PR DESCRIPTION
The ScopedRouteCollection class felt a bit messy to me, so I decided to split its roles out into a RouteBuilder and RouteCollection. I also found a few vestigial pieces of code that I removed.

One notable change I did was to shuffle the inflection to for prefixes. I don't think it is expected that one would have to use `'prefix' => 'Admin'` in their reverse routing. I'm happy to revert this part of the change, but we will need to update the RouteBuilder and docs accordingly.
