### PR TITLE
Added a shorthand stackTrace() method

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -118,6 +118,33 @@ TEXT;
 
 }
 
+if (!function_exists('stackTrace')) {
+
+/**
+ * Outputs a stack trace based on the supplied options.
+ *
+ * ### Options
+ *
+ * - `depth` - The number of stack frames to return. Defaults to 999
+ * - `args` - Should arguments for functions be shown?  If true, the arguments for each method call
+ *   will be displayed.
+ * - `start` - The stack frame to start generating a trace from. Defaults to 1
+ *
+ * @param array $options Format for outputting stack trace
+ * @return mixed Formatted stack trace
+ * @see \Cake\Utility\Debugger::trace()
+ */
+	function stackTrace($options = []) {
+		if (!Configure::read('debug')) {
+			return;
+		}
+		$options += ['start' => 0];
+		$options['start']++;
+		echo Debugger::trace($options);
+	}
+
+}
+
 if (!function_exists('sortByKey')) {
 
 /**

--- a/src/basics.php
+++ b/src/basics.php
@@ -126,7 +126,7 @@ if (!function_exists('stackTrace')) {
  * ### Options
  *
  * - `depth` - The number of stack frames to return. Defaults to 999
- * - `args` - Should arguments for functions be shown?  If true, the arguments for each method call
+ * - `args` - Should arguments for functions be shown? If true, the arguments for each method call
  *   will be displayed.
  * - `start` - The stack frame to start generating a trace from. Defaults to 1
  *

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -1081,4 +1081,22 @@ EXPECTED;
 		$result = namespaceSplit('Cake\Test\Something');
 		$this->assertEquals(array('Cake\Test', 'Something'), $result);
 	}
+
+/**
+ * Tests that the stackTrace() method is a shortcut for Debugger::trace()
+ *
+ * @return void
+ */
+	public function testStackTrace() {
+		ob_start();
+		list($_, $expected) = [stackTrace(), \Cake\Utility\Debugger::trace()];
+		$result = ob_get_clean();
+		$this->assertEquals($expected, $result);
+
+		$opts = ['args' => true];
+		ob_start();
+		list($_, $expected) = [stackTrace($opts), \Cake\Utility\Debugger::trace($opts)];
+		$result = ob_get_clean();
+		$this->assertEquals($expected, $result);
+	}
 }


### PR DESCRIPTION
Since I got a bit tired of writing the full namespace for Debugger each time I wanted to use it, added a shortcut function.
