### PR TITLE
3.0 api docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ services:
 
 matrix:
   allow_failures:
-    - php: 5.4
-      env: PHPCS=1
     - php: hhvm-nightly
     - php: 5.6
   fast_finish: true

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -355,14 +355,14 @@ class Table implements RepositoryInterface, EventListener {
  *
  * {{{
  * protected function _initializeSchema(\Cake\Database\Schema\Table $table) {
- *	$table->columnType('preferences', 'json');
- *	return $table;
+ *  $table->columnType('preferences', 'json');
+ *  return $table;
  * }
  * }}}
  *
- * @api
  * @param \Cake\Database\Schema\Table $table The table definition fetched from database.
  * @return \Cake\Database\Schema\Table the altered schema
+ * @api
  */
 	protected function _initializeSchema(Schema $table) {
 		return $table;

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -87,8 +87,10 @@ class RouteBuilder {
 /**
  * Constructor
  *
+ * @param \Cake\Routing\RouteCollection $collection The route collection to append routes into.
  * @param string $path The path prefix the scope is for.
  * @param array $params The scope's routing parameters.
+ * @param array $extensions The extensions to connect when adding routes.
  */
 	public function __construct($collection, $path, array $params = [], array $extensions = []) {
 		$this->_collection = $collection;
@@ -186,7 +188,7 @@ class RouteBuilder {
  * - 'id' - The regular expression fragment to use when matching IDs. By default, matches
  *    integer values and UUIDs.
  *
- * @param string|array $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
+ * @param string|array $name A controller name or array of controller names (i.e. "Posts" or "ListItems")
  * @param array $options Options to use when generating REST routes
  * @param callable $callback An optional callback to be executed in a nested scope. Nested
  *   scopes inherit the existing path and 'id' parameter.
@@ -229,8 +231,8 @@ class RouteBuilder {
 
 		if (is_callable($callback)) {
 			$idName = Inflector::singularize($urlName) . '_id';
-			$path = $this->_path . '/' . $urlName . '/:' . $idName;
-			$this->scope($path, $this->params(), $callback);
+			$path = '/' . $urlName . '/:' . $idName;
+			$this->scope($path, [], $callback);
 		}
 	}
 
@@ -423,11 +425,11 @@ class RouteBuilder {
  */
 	public function prefix($name, callable $callback) {
 		$name = Inflector::underscore($name);
-		$path = $this->_path . '/' . $name;
+		$path = '/' . $name;
 		if (isset($this->_params['prefix'])) {
 			$name = $this->_params['prefix'] . '/' . $name;
 		}
-		$params = ['prefix' => $name] + $this->_params;
+		$params = ['prefix' => $name];
 		$this->scope($path, $params, $callback);
 	}
 
@@ -443,9 +445,9 @@ class RouteBuilder {
  * Routes connected in the scoped collection will have the correct path segment
  * prepended, and have a matching plugin routing key set.
  *
- * @param string $path The path name to use for the prefix.
- * @param array|callable $options Either the options to use, or a callback.
- * @param callable $callback The callback to invoke that builds the plugin routes.
+ * @param string $name The plugin name to build routes for
+ * @param array|callable $options Either the options to use, or a callback
+ * @param callable $callback The callback to invoke that builds the plugin routes
  *   Only required when $options is defined.
  * @return void
  */
@@ -458,10 +460,22 @@ class RouteBuilder {
 		if (empty($options['path'])) {
 			$options['path'] = '/' . Inflector::underscore($name);
 		}
-		$options['path'] = $this->_path . $options['path'];
 		$this->scope($options['path'], $params, $callback);
 	}
 
+/**
+ * Create a new routing scope.
+ *
+ * Scopes created with this method will inherit the properties of the scope they are
+ * added to. This means that both the current path and parameters will be appended
+ * to the supplied parameters.
+ *
+ * @param string $path The path to create a scope for.
+ * @param array|callable $params Either the parameters to add to routes, or a callback
+ * @param callable $callback The callback to invoke that builds the plugin routes
+ *   Only required when $params is defined.
+ * @return void
+ */
 	public function scope($path, $params, $callback) {
 		if ($callback === null) {
 			$callback = $params;
@@ -472,6 +486,10 @@ class RouteBuilder {
 			throw new \InvalidArgumentException($msg);
 		}
 
+		if ($this->_path !== '/') {
+			$path = $this->_path . $path;
+		}
+		$params = $params + $this->_params;
 		$builder = new static($this->_collection, $path, $params, $this->_extensions);
 		$callback($builder);
 	}

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -475,6 +475,7 @@ class RouteBuilder {
  * @param callable $callback The callback to invoke that builds the plugin routes
  *   Only required when $params is defined.
  * @return void
+ * @throws \InvalidArgumentException when there is no callable parameter.
  */
 	public function scope($path, $params, $callback) {
 		if ($callback === null) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -58,6 +58,7 @@ class RouteCollection {
  * @param \Cake\Routing\Route\Route $route The route object to add.
  * @param array $options Addtional options for the route. Primarily for the
  *   `_name` option, which enables named routes.
+ * @return void
  */
 	public function add(Route $route, $options = []) {
 		$this->_routes[] = $route;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -997,10 +997,10 @@ class Router {
  * Routes connected in the scoped collection will have the correct path segment
  * prepended, and have a matching plugin routing key set.
  *
- * @param string $path The path name to use for the prefix.
- * @param array|callable $options Either the options to use, or a callback.
+ * @param string $name The plugin name to build routes for
+ * @param array|callable $options Either the options to use, or a callback
  * @param callable $callback The callback to invoke that builds the plugin routes.
- *   Only required when $options is defined.
+ *   Only required when $options is defined
  * @return void
  */
 	public static function plugin($name, $options = [], $callback = null) {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -375,7 +375,7 @@ class EntityContext implements ContextInterface {
  * Get the table instance from a property path
  *
  * @param array $parts Each one of the parts in a path for a field name
- * @param bool $rootFallback
+ * @param bool $rootFallback Whether or not to fallback to the root entity.
  * @return \Cake\ORM\Table|bool Table instance or false
  */
 	protected function _getTable($parts, $rootFallback = true) {

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -1089,13 +1089,13 @@ EXPECTED;
  */
 	public function testStackTrace() {
 		ob_start();
-		list($_, $expected) = [stackTrace(), \Cake\Utility\Debugger::trace()];
+		list($r, $expected) = [stackTrace(), \Cake\Utility\Debugger::trace()];
 		$result = ob_get_clean();
 		$this->assertEquals($expected, $result);
 
 		$opts = ['args' => true];
 		ob_start();
-		list($_, $expected) = [stackTrace($opts), \Cake\Utility\Debugger::trace($opts)];
+		list($r, $expected) = [stackTrace($opts), \Cake\Utility\Debugger::trace($opts)];
 		$result = ob_get_clean();
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -14,11 +14,11 @@
  */
 namespace Cake\Test\TestCase\Controller\Component;
 
-use Cake\Event\Event;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -14,18 +14,17 @@
  */
 namespace Cake\Test\TestCase\Controller\Component;
 
+use Cake\Event\Event;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Network\Request;
-use Cake\Event\Event;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
 
 /**
  * FlashComponentTest class
- *
  */
 class FlashComponentTest extends TestCase {
 

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Test\TestCase\Network;
 
-use Cake\Network\Socket;
 use Cake\Network\Error\SocketException;
+use Cake\Network\Socket;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -126,7 +126,6 @@ class QueryRegressionTest extends TestCase {
 		$this->assertNull($entity->created);
 	}
 
-
 /**
  * Test for https://github.com/cakephp/cakephp/issues/3626
  *

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\Test\TestCase\Routing;
 
-use Cake\Routing\Route\Route;
-use Cake\Routing\Router;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
+use Cake\Routing\Route\Route;
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -286,6 +286,19 @@ class RouteBuilderTest extends TestCase {
 		$all = $this->collection->routes();
 		$this->assertEquals('/api/:controller', $all[0]->template);
 		$this->assertEquals('/api/:controller/:action/*', $all[1]->template);
+	}
+
+/**
+ * Test adding a scope.
+ *
+ * @return void
+ */
+	public function testScope() {
+		$routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+		$routes->scope('/v1', ['version' => 1], function($routes) {
+			$this->assertEquals('/api/v1', $routes->path());
+			$this->assertEquals(['prefix' => 'api', 'version' => 1], $routes->params());
+		});
 	}
 
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -16,8 +16,8 @@ namespace Cake\Test\TestCase\Routing;
 
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
-use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
+use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\Test\TestCase\Routing;
 
-use Cake\Routing\Route\Route;
-use Cake\Routing\Router;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
+use Cake\Routing\Router;
+use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 
 class RouteCollectionTest extends TestCase {


### PR DESCRIPTION
Finish off the remaining API doc errors :clap: :tada:

I've also rolled in a bug fix for the new routing code I found when fixing the docs, scope() should extend the current scope like prefix() and plugin() do.
