### PR TITLE
3.0 Possible solution to empty association objects

### DIFF
--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -286,7 +286,8 @@ class TranslateBehavior extends Behavior {
 				$name = $field . '_translation';
 				$translation = $row->get($name);
 
-				if (!$translation) {
+				if ($translation === null || $translation === false) {
+					$row->unsetProperty($name);
 					continue;
 				}
 

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -33,13 +33,6 @@ class HasOne extends Association {
 	use SelectableAssociationTrait;
 
 /**
- * The type of join to be used when adding the association to a query
- *
- * @var string
- */
-	protected $_joinType = 'INNER';
-
-/**
  * Sets the name of the field representing the foreign key to the target table.
  * If no parameters are passed current field is returned
  *

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -393,7 +393,7 @@ class EagerLoader {
 	}
 
 /**
- * Decorates the passed statement object in order to inject data form associations
+ * Decorates the passed statement object in order to inject data from associations
  * that cannot be joined directly.
  *
  * @param \Cake\ORM\Query $query The query for which to eager load external

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -400,6 +400,14 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 
 			if ($assoc['canBeJoined']) {
 				$results[$alias] = $this->_castValues($target, $results[$alias]);
+
+				$hasData = array_filter($results[$alias], function ($v) {
+					return $v !== null;
+				});
+
+				if (!$hasData) {
+					continue;
+				}
 			}
 
 			if ($this->_hydrate && $assoc['canBeJoined']) {
@@ -407,7 +415,6 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 				$entity->clean();
 				$results[$alias] = $entity;
 			}
-
 			$results = $instance->transformRow($results, $alias, $assoc['canBeJoined']);
 		}
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -401,9 +401,13 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			if ($assoc['canBeJoined']) {
 				$results[$alias] = $this->_castValues($target, $results[$alias]);
 
-				$hasData = array_filter($results[$alias], function ($v) {
-					return $v !== null;
-				});
+				$hasData = false;
+				foreach ($results[$alias] as $v) {
+					if ($v !== null) {
+						$hasData = true;
+						break;
+					}
+				}
 
 				if (!$hasData) {
 					continue;

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -410,11 +410,11 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 				}
 
 				if (!$hasData) {
-					continue;
+					$results[$alias] = null;
 				}
 			}
 
-			if ($this->_hydrate && $assoc['canBeJoined']) {
+			if ($this->_hydrate && $results[$alias] !== null && $assoc['canBeJoined']) {
 				$entity = new $assoc['entityClass']($results[$alias], $options);
 				$entity->clean();
 				$results[$alias] = $entity;

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -446,22 +446,4 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		}]);
 	}
 
-/**
- * Test that eagerLoader leaves empty associations unpopulated.
- *
- * @return void
- */
-	public function testEagerLoaderLeavesEmptyAssocation() {
-		$this->loadFixtures('Article', 'Comment');
-		$comments = TableRegistry::get('Comments');
-		$comments->belongsTo('Articles');
-
-		// Clear the articles table so we can trigger an empty belongsTo
-		$articles = TableRegistry::get('Articles');
-		$articles->deleteAll([]);
-
-		$comment = $comments->get(1, ['contain' => ['Articles']]);
-		$this->assertNull($comment->article);
-	}
-
 }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -30,6 +30,20 @@ use Cake\ORM\TableRegistry;
 class BelongsToTest extends \Cake\TestSuite\TestCase {
 
 /**
+ * Fixtures to use.
+ *
+ * @var array
+ */
+	public $fixtures = ['core.article', 'core.comment'];
+
+/**
+ * Don't autoload fixtures as most tests uses mocks.
+ *
+ * @var bool
+ */
+	public $autoFixture = false;
+
+/**
  * Set up
  *
  * @return void
@@ -430,6 +444,24 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$association->attachTo($query, ['queryBuilder' => function($q) {
 			return $q->applyOptions(['something' => 'more']);
 		}]);
+	}
+
+/**
+ * Test that eagerLoader leaves empty associations unpopulated.
+ *
+ * @return void
+ */
+	public function testEagerLoaderLeavesEmptyAssocation() {
+		$this->loadFixtures('Article', 'Comment');
+		$comments = TableRegistry::get('Comments');
+		$comments->belongsTo('Articles');
+
+		// Clear the articles table so we can trigger an empty belongsTo
+		$articles = TableRegistry::get('Articles');
+		$articles->deleteAll([]);
+
+		$comment = $comments->get(1, ['contain' => ['Articles']]);
+		$this->assertNull($comment->article);
 	}
 
 }

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -30,20 +30,6 @@ use Cake\ORM\TableRegistry;
 class HasOneTest extends \Cake\TestSuite\TestCase {
 
 /**
- * Fixtures to use.
- *
- * @var array
- */
-	public $fixtures = ['core.article', 'core.comment'];
-
-/**
- * Don't autoload fixtures as most tests uses mocks.
- *
- * @var bool
- */
-	public $autoFixture = false;
-
-/**
  * Set up
  *
  * @return void
@@ -390,24 +376,6 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$association->attachTo($query, ['queryBuilder' => function($q) {
 			return $q->applyOptions(['something' => 'more']);
 		}]);
-	}
-
-/**
- * Test that eagerLoader leaves empty associations unpopulated.
- *
- * @return void
- */
-	public function testEagerLoaderLeavesEmptyAssocation() {
-		$this->loadFixtures('Article', 'Comment');
-		$articles = TableRegistry::get('Articles');
-		$articles->hasOne('Comments');
-
-		// Clear the comments table so we can trigger an empty hasOne.
-		$comments = TableRegistry::get('Comments');
-		$comments->deleteAll([]);
-
-		$article = $articles->get(1, ['contain' => ['Comments']]);
-		$this->assertNull($article->comment);
 	}
 
 }

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -107,7 +107,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
 				], $this->profilesTypeMap),
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'table' => 'profiles'
 			]
 		]);
@@ -138,7 +138,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => false
 				], $this->profilesTypeMap),
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'table' => 'profiles'
 			]
 		]);
@@ -174,7 +174,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
 				], $this->profilesTypeMap),
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'table' => 'profiles'
 			]
 		]);
@@ -204,7 +204,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
 				], $this->profilesTypeMap),
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'table' => 'profiles'
 			]
 		]);
@@ -243,7 +243,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 					'Profiles.is_active' => true,
 					['Users.id' => $field1, 'Users.site_id' => $field2],
 				], $this->profilesTypeMap),
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'table' => 'profiles'
 			]
 		]);

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -30,6 +30,20 @@ use Cake\ORM\TableRegistry;
 class HasOneTest extends \Cake\TestSuite\TestCase {
 
 /**
+ * Fixtures to use.
+ *
+ * @var array
+ */
+	public $fixtures = ['core.article', 'core.comment'];
+
+/**
+ * Don't autoload fixtures as most tests uses mocks.
+ *
+ * @var bool
+ */
+	public $autoFixture = false;
+
+/**
  * Set up
  *
  * @return void
@@ -376,6 +390,24 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$association->attachTo($query, ['queryBuilder' => function($q) {
 			return $q->applyOptions(['something' => 'more']);
 		}]);
+	}
+
+/**
+ * Test that eagerLoader leaves empty associations unpopulated.
+ *
+ * @return void
+ */
+	public function testEagerLoaderLeavesEmptyAssocation() {
+		$this->loadFixtures('Article', 'Comment');
+		$articles = TableRegistry::get('Articles');
+		$articles->hasOne('Comments');
+
+		// Clear the comments table so we can trigger an empty hasOne.
+		$comments = TableRegistry::get('Comments');
+		$comments->deleteAll([]);
+
+		$article = $articles->get(1, ['contain' => ['Comments']]);
+		$this->assertNull($article->comment);
 	}
 
 }

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -162,7 +162,7 @@ class EagerLoaderTest extends TestCase {
 		$query->expects($this->at(1))->method('join')
 			->with(['orders' => [
 				'table' => 'orders',
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['clients.id' => new IdentifierExpression('orders.client_id')]
 				], $this->ordersTypeMap)
@@ -182,7 +182,7 @@ class EagerLoaderTest extends TestCase {
 		$query->expects($this->at(3))->method('join')
 			->with(['stuff' => [
 				'table' => 'things',
-				'type' => 'INNER',
+				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['orders.id' => new IdentifierExpression('stuff.order_id')]
 				], $this->stuffTypeMap)

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -126,7 +126,6 @@ class QueryRegressionTest extends TestCase {
 		$this->assertNull($entity->created);
 	}
 
-
 /**
  * Test for https://github.com/cakephp/cakephp/issues/3626
  *


### PR DESCRIPTION
While I'm not 100% complete on this, I think this is the start of a reasonable way to solve both #3806 and #3902. When an association has 0 non-null fields the association property is left as the default value.
### TODO
- [x] Add tests for belongsTo.
- [x] Add tests for no hydration.
