### PR TITLE
2.6: Added a shorthand stackTrace() method

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -20,6 +20,7 @@ require_once CAKE . 'basics.php';
 
 App::uses('Folder', 'Utility');
 App::uses('CakeResponse', 'Network');
+App::uses('Debugger', 'Utility');
 
 /**
  * BasicsTest class
@@ -1138,6 +1139,24 @@ EXPECTED;
 			'g' => "te'''st"
 			);
 		$this->assertEquals($expected, stripslashes_deep($nested));
+	}
+
+/**
+ * Tests that the stackTrace() method is a shortcut for Debugger::trace()
+ *
+ * @return void
+ */
+	public function testStackTrace() {
+		ob_start();
+		list(, $expected) = array(stackTrace(), Debugger::trace());
+		$result = ob_get_clean();
+		$this->assertEquals($expected, $result);
+
+		$opts = array('args' => true);
+		ob_start();
+		list(, $expected) = array(stackTrace($opts), Debugger::trace($opts));
+		$result = ob_get_clean();
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -71,17 +71,20 @@ if (!function_exists('debug')) {
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#debug
  */
 	function debug($var, $showHtml = null, $showFrom = true) {
-		if (Configure::read('debug') > 0) {
-			App::uses('Debugger', 'Utility');
-			$file = '';
-			$line = '';
-			$lineInfo = '';
-			if ($showFrom) {
-				$trace = Debugger::trace(array('start' => 1, 'depth' => 2, 'format' => 'array'));
-				$file = str_replace(array(CAKE_CORE_INCLUDE_PATH, ROOT), '', $trace[0]['file']);
-				$line = $trace[0]['line'];
-			}
-			$html = <<<HTML
+		if (!Configure::read('debug')) {
+			return;
+		}
+		App::uses('Debugger', 'Utility');
+
+		$file = '';
+		$line = '';
+		$lineInfo = '';
+		if ($showFrom) {
+			$trace = Debugger::trace(array('start' => 1, 'depth' => 2, 'format' => 'array'));
+			$file = str_replace(array(CAKE_CORE_INCLUDE_PATH, ROOT), '', $trace[0]['file']);
+			$line = $trace[0]['line'];
+		}
+		$html = <<<HTML
 <div class="cake-debug-output">
 %s
 <pre class="cake-debug">
@@ -89,33 +92,61 @@ if (!function_exists('debug')) {
 </pre>
 </div>
 HTML;
-			$text = <<<TEXT
+		$text = <<<TEXT
 %s
 ########## DEBUG ##########
 %s
 ###########################
 
 TEXT;
-			$template = $html;
-			if (php_sapi_name() === 'cli' || $showHtml === false) {
-				$template = $text;
-				if ($showFrom) {
-					$lineInfo = sprintf('%s (line %s)', $file, $line);
-				}
+		$template = $html;
+		if (php_sapi_name() === 'cli' || $showHtml === false) {
+			$template = $text;
+			if ($showFrom) {
+				$lineInfo = sprintf('%s (line %s)', $file, $line);
 			}
-			if ($showHtml === null && $template !== $text) {
-				$showHtml = true;
-			}
-			$var = Debugger::exportVar($var, 25);
-			if ($showHtml) {
-				$template = $html;
-				$var = h($var);
-				if ($showFrom) {
-					$lineInfo = sprintf('<span><strong>%s</strong> (line <strong>%s</strong>)</span>', $file, $line);
-				}
-			}
-			printf($template, $lineInfo, $var);
 		}
+		if ($showHtml === null && $template !== $text) {
+			$showHtml = true;
+		}
+		$var = Debugger::exportVar($var, 25);
+		if ($showHtml) {
+			$template = $html;
+			$var = h($var);
+			if ($showFrom) {
+				$lineInfo = sprintf('<span><strong>%s</strong> (line <strong>%s</strong>)</span>', $file, $line);
+			}
+		}
+		printf($template, $lineInfo, $var);
+	}
+
+}
+
+if (!function_exists('stackTrace')) {
+
+/**
+ * Outputs a stack trace based on the supplied options.
+ *
+ * ### Options
+ *
+ * - `depth` - The number of stack frames to return. Defaults to 999
+ * - `args` - Should arguments for functions be shown? If true, the arguments for each method call
+ *   will be displayed.
+ * - `start` - The stack frame to start generating a trace from. Defaults to 1
+ *
+ * @param array $options Format for outputting stack trace
+ * @return mixed Formatted stack trace
+ * @see Debugger::trace()
+ */
+	function stackTrace(array $options = array()) {
+		if (!Configure::read('debug')) {
+			return;
+		}
+		App::uses('Debugger', 'Utility');
+
+		$options += array('start' => 0);
+		$options['start']++;
+		echo Debugger::trace($options);
 	}
 
 }


### PR DESCRIPTION
2.6 version of 3.0 https://github.com/cakephp/cakephp/pull/3903

Also unified debug() to return early instead of additional nesting.
