### PR TITLE
Update JqueryEngineHelper.php

### DIFF
--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -261,7 +261,13 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
 			if (isset($options['success']) && !empty($options['success'])) {
 				$success .= $options['success'];
 			}
-			$success .= $this->jQueryObject . '("' . $options['update'] . '").html(data);';
+			if( is_array($options['update']) ){
+				foreach( $options['update'] as $elem ){
+					$success .= $this->jQueryObject . '("' . $elem . '").html(data);';
+				}
+			} else {
+				$success .= $this->jQueryObject . '("' . $options['update'] . '").html(data);';
+			}
 			if (!$wrapCallbacks) {
 				$success = 'function (data, textStatus) {' . $success . '}';
 			}


### PR DESCRIPTION
I would like being able to specify more then one id to be called when updated after an ajax request.
I know it is also possible accomplish this, wrapping all tags with and external tag, but I want to have both options.

Due compatibility with apps already coded it checks if parameter is not an array
