### PR TITLE
Update JqueryEngineHelper.php

### DIFF
--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -261,12 +261,9 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
 			if (isset($options['success']) && !empty($options['success'])) {
 				$success .= $options['success'];
 			}
-			if (is_array($options['update'])) {
-				foreach ($options['update'] as $elem) {
-					$success .= $this->jQueryObject . '("' . $elem . '").html(data);';
-				}
-			} else {
-				$success .= $this->jQueryObject . '("' . $options['update'] . '").html(data);';
+			$elements = (array)$options['update'];
+			foreach ($elements as $elem) {
+				$success .= $this->jQueryObject . '("' . $elem . '").html(data);';
 			}
 			if (!$wrapCallbacks) {
 				$success = 'function (data, textStatus) {' . $success . '}';

--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -261,7 +261,13 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
 			if (isset($options['success']) && !empty($options['success'])) {
 				$success .= $options['success'];
 			}
-			$success .= $this->jQueryObject . '("' . $options['update'] . '").html(data);';
+			if (is_array($options['update'])) {
+				foreach ($options['update'] as $elem) {
+					$success .= $this->jQueryObject . '("' . $elem . '").html(data);';
+				}
+			} else {
+				$success .= $this->jQueryObject . '("' . $options['update'] . '").html(data);';
+			}
 			if (!$wrapCallbacks) {
 				$success = 'function (data, textStatus) {' . $success . '}';
 			}


### PR DESCRIPTION
 I hope this one is correct.
Because this a feature request it should go on cakephp 2.6 branch.

I would like being able to specify more then one id to be called when updated after an ajax request.
I know it is also possible accomplish this, wrapping all tags with and external tag, but I want to have both options.

Due compatibility with apps already coded it checks if parameter is not an array

I was asked to build a Test case to back my change, so instead of using an string to indicate the following call that we want to update just the tag whose have the specified id we do this:

``` php
<?=
    $this->Js->submit(
        __('Update'),
        array(
            'async'             =>  true,
            'class'             =>  'btn btn-default',
            'div'               =>  array(
                'class'         =>  'form-group'
            ),
            'method'            =>  'get',
            'update'            =>  array('#id_1', '#id_2'),
            'url' => array(
                'controller'    =>  'players',
                'action'        =>  'get_player/' . $name
            )
        )
    );
?>
```

Please let me know if I should improve any part of my pull. Thanks for your patience.
