### PR TITLE
3.0 entity deep errors

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -610,8 +610,10 @@ trait EntityTrait {
 		}
 
 		$entity = $this;
-		while (count($path)) {
+		$len = count($path);
+		while ($len) {
 			$part = array_shift($path);
+			$len = count($path);
 			if ($entity instanceof static) {
 				$val = $entity->get($part);
 			} elseif (is_array($entity)) {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -831,7 +831,7 @@ class EntityTest extends TestCase {
  */
 	public function testErrorPathReading() {
 		$assoc = new Entity;
-		$entity= new Entity([
+		$entity = new Entity([
 			'field' => 'value',
 			'one' => $assoc,
 			'many' => [$assoc]

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -839,11 +839,12 @@ class EntityTest extends TestCase {
 		$entity->errors('wrong', 'Bad stuff');
 		$assoc->errors('nope', 'Terrible things');
 
-		$this->assertEquals('Bad stuff', $entity->errors('wrong'));
-		$this->assertEquals('Terrible things', $entity->errors('many.0.nope'));
-		$this->assertEquals('Terrible things', $entity->errors('one.nope'));
-		$this->assertEquals(['nope' => 'Terrible things'], $entity->errors('one'));
-		$this->assertEquals(['nope' => 'Terrible things'], $entity->errors('many.0'));
+		$this->assertEquals(['Bad stuff'], $entity->errors('wrong'));
+		$this->assertEquals(['Terrible things'], $entity->errors('many.0.nope'));
+		$this->assertEquals(['Terrible things'], $entity->errors('one.nope'));
+		$this->assertEquals(['nope' => ['Terrible things']], $entity->errors('one'));
+		$this->assertEquals([0 => ['nope' => ['Terrible things']]], $entity->errors('many'));
+		$this->assertEquals(['nope' => ['Terrible things']], $entity->errors('many.0'));
 
 		$this->assertEquals([], $entity->errors('many.0.mistake'));
 		$this->assertEquals([], $entity->errors('one.mistake'));

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -825,6 +825,33 @@ class EntityTest extends TestCase {
 	}
 
 /**
+ * Test that errors can be read with a path.
+ *
+ * @return void
+ */
+	public function testErrorPathReading() {
+		$assoc = new Entity;
+		$entity= new Entity([
+			'field' => 'value',
+			'one' => $assoc,
+			'many' => [$assoc]
+		]);
+		$entity->errors('wrong', 'Bad stuff');
+		$assoc->errors('nope', 'Terrible things');
+
+		$this->assertEquals('Bad stuff', $entity->errors('wrong'));
+		$this->assertEquals('Terrible things', $entity->errors('many.0.nope'));
+		$this->assertEquals('Terrible things', $entity->errors('one.nope'));
+		$this->assertEquals(['nope' => 'Terrible things'], $entity->errors('one'));
+		$this->assertEquals(['nope' => 'Terrible things'], $entity->errors('many.0'));
+
+		$this->assertEquals([], $entity->errors('many.0.mistake'));
+		$this->assertEquals([], $entity->errors('one.mistake'));
+		$this->assertEquals([], $entity->errors('one.1.mistake'));
+		$this->assertEquals([], $entity->errors('many.1.nope'));
+	}
+
+/**
  * Tests that changing the value of a property will remove errors
  * stored for it
  *


### PR DESCRIPTION
Implements the proposed API in #3807. I didn't build out `allErrors()` as I don't fully understand how it would be used.
