### PR TITLE
3.0 Replace 'Test' by 'tests' directory in bake

### DIFF
--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -462,7 +462,7 @@ class TestTask extends BakeTask {
  * @return string
  */
 	public function getPath() {
-		$dir = 'Test/TestCase/';
+		$dir = 'tests/TestCase/';
 		$path = ROOT . DS . $dir;
 		if (isset($this->plugin)) {
 			$path = $this->_pluginPath($this->plugin) . 'tests/TestCase/';

--- a/src/Console/Templates/default/test/phpunit.xml.ctp
+++ b/src/Console/Templates/default/test/phpunit.xml.ctp
@@ -4,7 +4,7 @@
 	processIsolation="false"
 	stopOnFailure="false"
 	syntaxCheck="false"
-	bootstrap="./Test/bootstrap.php"
+	bootstrap="./tests/bootstrap.php"
 	>
 	<php>
 		<ini name="memory_limit" value="-1"/>

--- a/src/Console/Templates/default/test/phpunit.xml.ctp
+++ b/src/Console/Templates/default/test/phpunit.xml.ctp
@@ -14,7 +14,7 @@
 	<!-- Add any additional test suites you want to run here -->
 	<testsuites>
 		<testsuite name="<?= $plugin ?> Test Suite">
-			<directory>./Test/TestCase</directory>
+			<directory>./tests/TestCase</directory>
 		</testsuite>
 	</testsuites>
 

--- a/tests/TestCase/Console/Command/Task/TestTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/TestTaskTest.php
@@ -630,7 +630,7 @@ class TestTaskTest extends TestCase {
  */
 	public function testTestCaseFileName($type, $class, $expected) {
 		$result = $this->Task->testCaseFileName($type, $class);
-		$expected = ROOT . DS . 'Test/' . $expected;
+		$expected = ROOT . DS . 'tests/' . $expected;
 		$this->assertPathEquals($expected, $result);
 	}
 


### PR DESCRIPTION
I add an issue while baking controller test, it went to the wrong directory _Test/TestCase_.
This should fix the problem and point to _/tests/TestsCase/_.

I hope I didn't make any mistake, it's my first intent to participate to you project.
regards
