### PR TITLE
Initialize Time::$defaultLocale to 'en_US' during tests.

### DIFF
--- a/tests/TestCase/Utility/TimeTest.php
+++ b/tests/TestCase/Utility/TimeTest.php
@@ -34,6 +34,7 @@ class TimeTest extends TestCase {
 		parent::setUp();
 		$this->now = Time::getTestNow();
 		$this->locale = Time::$defaultLocale;
+		Time::$defaultLocale = 'en_US';
 	}
 
 /**

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * TimeHelperTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -20,6 +18,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Time;
 use Cake\View\Helper\TimeHelper;
 use Cake\View\View;
 
@@ -40,6 +39,7 @@ class TimeHelperTest extends TestCase {
 		parent::setUp();
 		$this->View = new View();
 		$this->Time = new TimeHelper($this->View);
+		Time::$defaultLocale = 'en_US';
 	}
 
 /**


### PR DESCRIPTION
The standard date formats used by IntDateFormatter are locale dependent. This
change prevents failures when tests are run in an environment where default
locale is not 'en_US'.
