### PR TITLE
3.0 - unify options for newEntity() and save()

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -146,11 +146,10 @@ interface RepositoryInterface {
  * is saved. Until the entity is saved, it will be a detached record.
  *
  * @param array $data The data to build an entity with.
- * @param array $associations A whitelist of associations
- *   to hydrate. Defaults to all associations
+ * @param array $options A list of options for the object hydration.
  * @return \Cake\Datasource\EntityInterface
  */
-	public function newEntity(array $data = [], $associations = null);
+	public function newEntity(array $data = [], array $options = []);
 
 /**
  * Create a list of entities + associated entities from an array.
@@ -165,11 +164,10 @@ interface RepositoryInterface {
  * The hydrated entities can then be iterated and saved.
  *
  * @param array $data The data to build an entity with.
- * @param array $associations A whitelist of associations
- *   to hydrate. Defaults to all associations
+ * @param array $options A list of options for the objects hydration.
  * @return array An array of hydrated records.
  */
-	public function newEntities(array $data, $associations = null);
+	public function newEntities(array $data, array $associations = []);
 
 /**
  * Merges the passed `$data` into `$entity` respecting the accessible
@@ -185,10 +183,10 @@ interface RepositoryInterface {
  * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
  * data merged in
  * @param array $data key value list of fields to be merged into the entity
- * @param array $associations The list of associations to be merged
+ * @param array $options A list of options for the object hydration.
  * @return \Cake\Datasource\EntityInterface
  */
-	public function patchEntity(EntityInterface $entity, array $data, $associations = null);
+	public function patchEntity(EntityInterface $entity, array $data, array $options = []);
 
 /**
  * Merges each of the elements passed in `$data` into the entities
@@ -205,9 +203,9 @@ interface RepositoryInterface {
  * @param array|\Traversable $entities the entities that will get the
  * data merged in
  * @param array $data list of arrays to be merged into the entities
- * @param array $associations The list of associations to be merged
+ * @param array $options A list of options for the objects hydration.
  * @return array
  */
-	public function patchEntities($entities, array $data, $associations = null);
+	public function patchEntities($entities, array $data, array $options = []);
 
 }

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -167,7 +167,7 @@ interface RepositoryInterface {
  * @param array $options A list of options for the objects hydration.
  * @return array An array of hydrated records.
  */
-	public function newEntities(array $data, array $associations = []);
+	public function newEntities(array $data, array $options = []);
 
 /**
  * Merges the passed `$data` into `$entity` respecting the accessible

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -37,13 +37,6 @@ class Marshaller {
 	use AssociationsNormalizerTrait;
 
 /**
- * Whether or not this marhshaller is in safe mode.
- *
- * @var bool
- */
-	protected $_safe;
-
-/**
  * The table instance this marshaller is for.
  *
  * @var \Cake\ORM\Table
@@ -54,11 +47,9 @@ class Marshaller {
  * Constructor.
  *
  * @param \Cake\ORM\Table $table
- * @param bool $safe Whether or not this marshaller is in safe mode
  */
-	public function __construct(Table $table, $safe = false) {
+	public function __construct(Table $table) {
 		$this->_table = $table;
-		$this->_safe = $safe;
 	}
 
 /**

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -110,7 +110,7 @@ class Marshaller {
 			$columnType = $schema->columnType($key);
 			if (isset($propertyMap[$key])) {
 				$assoc = $propertyMap[$key]['association'];
-				$nested = $propertyMap[$key]['nested'];
+				$nested = ['associated' => $propertyMap[$key]['nested']];
 				$value = $this->_marshalAssociation($assoc, $value, $nested);
 			} elseif ($columnType) {
 				$converter = Type::build($columnType);
@@ -172,6 +172,7 @@ class Marshaller {
  * @return array An array of built entities.
  */
 	protected function _belongsToMany(Association $assoc, array $data, $options = []) {
+		$associated = isset($options['associated']) ? $options['associated'] : [];
 		$hasIds = array_key_exists('_ids', $data);
 		if ($hasIds && is_array($data['_ids'])) {
 			return $this->_loadBelongsToMany($assoc, $data['_ids']);
@@ -185,8 +186,8 @@ class Marshaller {
 		$jointMarshaller = $joint->marshaller();
 
 		$nested = [];
-		if (isset($options['_joinData']['associated'])) {
-			$nested = (array)$options['_joinData']['associated'];
+		if (isset($associated['_joinData']['associated'])) {
+			$nested = ['associated' => (array)$associated['_joinData']['associated']];
 		}
 
 		foreach ($records as $i => $record) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -256,7 +256,7 @@ class Marshaller {
 
 			if (isset($propertyMap[$key])) {
 				$assoc = $propertyMap[$key]['association'];
-				$nested = $propertyMap[$key]['nested'];
+				$nested = ['associated' => $propertyMap[$key]['nested']];
 				$value = $this->_mergeAssociation($original, $assoc, $value, $nested);
 			} elseif ($columnType) {
 				$converter = Type::build($columnType);
@@ -363,6 +363,7 @@ class Marshaller {
  */
 	protected function _mergeBelongsToMany($original, $assoc, $value, $options) {
 		$hasIds = array_key_exists('_ids', $value);
+		$associated = isset($options['associated']) ? $options['associated'] : [];
 		if ($hasIds && is_array($value['_ids'])) {
 			return $this->_loadBelongsToMany($assoc, $value['_ids']);
 		}
@@ -370,7 +371,7 @@ class Marshaller {
 			return [];
 		}
 
-		if (!in_array('_joinData', $options) && !isset($options['_joinData'])) {
+		if (!in_array('_joinData', $associated) && !isset($associated['_joinData'])) {
 			return $this->mergeMany($original, $value, $options);
 		}
 
@@ -386,8 +387,8 @@ class Marshaller {
 		$marshaller = $joint->marshaller();
 
 		$nested = [];
-		if (isset($options['_joinData']['associated'])) {
-			$nested = (array)$options['_joinData']['associated'];
+		if (isset($associated['_joinData']['associated'])) {
+			$nested = ['associated' => (array)$associated['_joinData']['associated']];
 		}
 
 		$records = $this->mergeMany($original, $value, $options);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -59,9 +59,14 @@ class Marshaller {
  * @return array
  */
 	protected function _buildPropertyMap($options) {
+		if (empty($options['associated'])) {
+			return [];
+		}
+
+		$include = $options['associated'];
 		$map = [];
-		$options = $this->_normalizeAssociations($options);
-		foreach ($options as $key => $nested) {
+		$include = $this->_normalizeAssociations($include);
+		foreach ($include as $key => $nested) {
 			if (is_int($key) && is_scalar($nested)) {
 				$key = $nested;
 				$nested = [];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1550,13 +1550,11 @@ class Table implements RepositoryInterface, EventListener {
  * Override this method if you want a table object to use custom
  * marshalling logic.
  *
- * @param bool $safe Whether or not this marshaller
- *   should be in safe mode.
  * @return \Cake\ORM\Marshaller
  * @see \Cake\ORM\Marshaller
  */
-	public function marshaller($safe = false) {
-		return new Marshaller($this, $safe);
+	public function marshaller() {
+		return new Marshaller($this);
 	}
 
 /**
@@ -1576,22 +1574,22 @@ class Table implements RepositoryInterface, EventListener {
  *
  * By default all the associations on this table will be hydrated. You can
  * limit which associations are built, or include deeper associations
- * using the associations parameter:
+ * using the options parameter:
  *
  * {{{
  * $articles = $this->Articles->newEntity(
  *   $this->request->data(),
- *   ['Tags', 'Comments.Users']
+ *   ['associated' => ['Tags', 'Comments.Users']]
  * );
  * }}}
  *
  */
-	public function newEntity(array $data = [], $associations = null) {
-		if ($associations === null) {
-			$associations = $this->_associations->keys();
+	public function newEntity(array $data = [], array $options = []) {
+		if (!isset($options['associated'])) {
+			$options['associated'] = $this->_associations->keys();
 		}
 		$marshaller = $this->marshaller();
-		return $marshaller->one($data, $associations);
+		return $marshaller->one($data, $options);
 	}
 
 /**
@@ -1604,14 +1602,14 @@ class Table implements RepositoryInterface, EventListener {
  * {{{
  * $articles = $this->Articles->newEntities(
  *   $this->request->data(),
- *   ['Tags', 'Comments.Users']
+ *   ['associated' => ['Tags', 'Comments.Users']]
  * );
  * }}}
  *
  */
-	public function newEntities(array $data, $associations = null) {
-		if ($associations === null) {
-			$associations = $this->_associations->keys();
+	public function newEntities(array $data, array $options = []) {
+		if (!isset($options['associated'])) {
+			$options['associated'] = $this->_associations->keys();
 		}
 		$marshaller = $this->marshaller();
 		return $marshaller->many($data, $associations);
@@ -1624,9 +1622,9 @@ class Table implements RepositoryInterface, EventListener {
  * `$data` array will appear, those that can be matched by primary key will get
  * the data merged, but those that cannot, will be discarded.
  */
-	public function patchEntity(EntityInterface $entity, array $data, $associations = null) {
-		if ($associations === null) {
-			$associations = $this->_associations->keys();
+	public function patchEntity(EntityInterface $entity, array $data, array $options = []) {
+		if (!isset($options['associated'])) {
+			$options['associated'] = $this->_associations->keys();
 		}
 		$marshaller = $this->marshaller();
 		return $marshaller->merge($entity, $data, $associations);
@@ -1643,9 +1641,9 @@ class Table implements RepositoryInterface, EventListener {
  * `$data` array will appear, those that can be matched by primary key will get
  * the data merged, but those that cannot, will be discarded.
  */
-	public function patchEntities($entities, array $data, $associations = null) {
-		if ($associations === null) {
-			$associations = $this->_associations->keys();
+	public function patchEntities($entities, array $data, array $options = []) {
+		if (!isset($options['associated'])) {
+			$options['associated'] = $this->_associations->keys();
 		}
 		$marshaller = $this->marshaller();
 		return $marshaller->mergeMany($entities, $data, $associations);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1646,7 +1646,7 @@ class Table implements RepositoryInterface, EventListener {
 			$options['associated'] = $this->_associations->keys();
 		}
 		$marshaller = $this->marshaller();
-		return $marshaller->mergeMany($entities, $data, $associations);
+		return $marshaller->mergeMany($entities, $data, $options);
 	}
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1597,7 +1597,7 @@ class Table implements RepositoryInterface, EventListener {
  *
  * By default all the associations on this table will be hydrated. You can
  * limit which associations are built, or include deeper associations
- * using the associations parameter:
+ * using the options parameter:
  *
  * {{{
  * $articles = $this->Articles->newEntities(
@@ -1627,7 +1627,7 @@ class Table implements RepositoryInterface, EventListener {
 			$options['associated'] = $this->_associations->keys();
 		}
 		$marshaller = $this->marshaller();
-		return $marshaller->merge($entity, $data, $associations);
+		return $marshaller->merge($entity, $data, $options);
 	}
 
 /**

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -444,7 +444,7 @@ class CompositeKeyTest extends TestCase {
 			'tags' => ['_ids' => [[1, 1], [2, 2], [3, 1]]]
 		];
 		$marshall = new Marshaller($articles);
-		$result = $marshall->one($data, ['SiteTags']);
+		$result = $marshall->one($data, ['associated' => ['SiteTags']]);
 
 		$this->assertCount(3, $result->tags);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
@@ -457,7 +457,7 @@ class CompositeKeyTest extends TestCase {
 			'tags' => ['_ids' => [1, 2, 3]]
 		];
 		$marshall = new Marshaller($articles);
-		$result = $marshall->one($data, ['SiteTags']);
+		$result = $marshall->one($data, ['associated' => ['SiteTags']]);
 		$this->assertEmpty($result->tags);
 	}
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -202,7 +202,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Users']);
+		$result = $marshall->one($data, ['associated' => ['Users']]);
 
 		$this->assertInstanceOf('Cake\ORM\Entity', $result);
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
@@ -231,7 +231,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Users']);
+		$result = $marshall->one($data, ['associated' => ['Users']]);
 
 		$this->assertEquals($data['title'], $result->title);
 		$this->assertEquals($data['body'], $result->body);
@@ -265,7 +265,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Comments']);
+		$result = $marshall->one($data, ['associated' => ['Comments']]);
 
 		$this->assertEquals($data['title'], $result->title);
 		$this->assertEquals($data['body'], $result->body);
@@ -298,7 +298,7 @@ class MarshallerTest extends TestCase {
 		];
 		$marshall = new Marshaller($this->articles);
 		$result = $marshall->one($data, [
-			'Tags'
+			'associated' => ['Tags']
 		]);
 
 		$this->assertEquals($data['title'], $result->title);
@@ -352,7 +352,7 @@ class MarshallerTest extends TestCase {
 		$articlesTags->belongsTo('Users');
 
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Tags._joinData.Users']);
+		$result = $marshall->one($data, ['associated' => ['Tags._joinData.Users']]);
 		$this->assertInstanceOf(
 			'Cake\ORM\Entity',
 			$result->tags[0]->_joinData->user,
@@ -386,7 +386,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->comments);
-		$result = $marshall->one($data, ['Articles.Users']);
+		$result = $marshall->one($data, ['associated' => ['Articles.Users']]);
 
 		$this->assertEquals(
 			$data['article']['title'],
@@ -441,7 +441,7 @@ class MarshallerTest extends TestCase {
 			],
 		];
 		$marshall = new Marshaller($this->comments);
-		$result = $marshall->many($data, ['Users']);
+		$result = $marshall->many($data, ['associated' => ['Users']]);
 
 		$this->assertCount(2, $result);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result[0]);
@@ -468,7 +468,7 @@ class MarshallerTest extends TestCase {
 			'tags' => ['_ids' => '']
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Tags']);
+		$result = $marshall->one($data, ['associated' => ['Tags']]);
 		$this->assertCount(0, $result->tags);
 
 		$data = [
@@ -476,7 +476,7 @@ class MarshallerTest extends TestCase {
 			'body' => 'Some content here',
 			'tags' => ['_ids' => false]
 		];
-		$result = $marshall->one($data, ['Tags']);
+		$result = $marshall->one($data, ['associated' => ['Tags']]);
 		$this->assertCount(0, $result->tags);
 
 		$data = [
@@ -484,7 +484,7 @@ class MarshallerTest extends TestCase {
 			'body' => 'Some content here',
 			'tags' => ['_ids' => null]
 		];
-		$result = $marshall->one($data, ['Tags']);
+		$result = $marshall->one($data, ['associated' => ['Tags']]);
 		$this->assertCount(0, $result->tags);
 
 		$data = [
@@ -493,7 +493,7 @@ class MarshallerTest extends TestCase {
 			'tags' => ['_ids' => [1, 2, 3]]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Tags']);
+		$result = $marshall->one($data, ['associated' => ['Tags']]);
 
 		$this->assertCount(3, $result->tags);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
@@ -612,7 +612,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$marshall->merge($entity, $data, ['Users']);
+		$marshall->merge($entity, $data, ['associated' => ['Users']]);
 		$this->assertEquals('My Content', $entity->body);
 		$this->assertSame($user, $entity->user);
 		$this->assertEquals('mark', $entity->user->username);
@@ -639,7 +639,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$marshall->merge($entity, $data, ['Users']);
+		$marshall->merge($entity, $data, ['associated' => ['Users']]);
 		$this->assertEquals('My Content', $entity->body);
 		$this->assertInstanceOf('Cake\ORM\Entity', $entity->user);
 		$this->assertEquals('mark', $entity->user->username);
@@ -680,7 +680,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->merge($entity, $data, ['Users', 'Comments']);
+		$result = $marshall->merge($entity, $data, ['associated' => ['Users', 'Comments']]);
 		$this->assertSame($entity, $result);
 		$this->assertSame($user, $result->user);
 		$this->assertEquals('not so secret', $entity->user->password);
@@ -724,7 +724,7 @@ class MarshallerTest extends TestCase {
 		];
 		$entity->accessible('*', true);
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->merge($entity, $data, ['Tags']);
+		$result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
 
 		$this->assertCount(3, $result->tags);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
@@ -754,21 +754,21 @@ class MarshallerTest extends TestCase {
 		];
 		$entity->accessible('*', true);
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->merge($entity, $data, ['Tags']);
+		$result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
 		$this->assertCount(0, $result->tags);
 
 		$data = [
 			'title' => 'Haz moar tags',
 			'tags' => ['_ids' => false]
 		];
-		$result = $marshall->merge($entity, $data, ['Tags']);
+		$result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
 		$this->assertCount(0, $result->tags);
 
 		$data = [
 			'title' => 'Haz moar tags',
 			'tags' => ['_ids' => null]
 		];
-		$result = $marshall->merge($entity, $data, ['Tags']);
+		$result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
 		$this->assertCount(0, $result->tags);
 	}
 
@@ -864,7 +864,7 @@ class MarshallerTest extends TestCase {
 		$articlesTags = TableRegistry::get('ArticlesTags');
 		$articlesTags->belongsTo('Users');
 
-		$options = ['Tags._joinData.Users'];
+		$options = ['associated' => ['Tags._joinData.Users']];
 		$marshall = new Marshaller($this->articles);
 		$entity = $marshall->one($data, $options);
 		$entity->accessible('*', true);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -800,7 +800,7 @@ class MarshallerTest extends TestCase {
 			],
 		];
 
-		$options = ['Tags' => ['associated' => ['_joinData']]];
+		$options = ['associated' => ['Tags' => ['associated' => ['_joinData']]]];
 		$marshall = new Marshaller($this->articles);
 		$entity = $marshall->one($data, $options);
 		$entity->accessible('*', true);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -226,14 +226,13 @@ class QueryRegressionTest extends TestCase {
 				]
 			]
 		];
-		$entity = $articles->patchEntity($entity, $data, [
-			'Highlights._joinData.Authors', 'Highlights.Authors'
-		]);
-		$articles->save($entity, [
+		$options = [
 			'associated' => [
 				'Highlights._joinData.Authors', 'Highlights.Authors'
 			]
-		]);
+		];
+		$entity = $articles->patchEntity($entity, $data, $options);
+		$articles->save($entity, $options);
 		$entity = $articles->get(2, [
 			'contain' => [
 				'SpecialTags' => ['sort' => ['SpecialTags.id' => 'ASC']],

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3352,7 +3352,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$data = ['foo' => 'bar'];
 		$marshaller->expects($this->once())
 			->method('merge')
-			->with($entity, $data, ['users', 'articles'])
+			->with($entity, $data, ['associated' => ['users', 'articles']])
 			->will($this->returnValue($entity));
 		$table->patchEntity($entity, $data);
 	}
@@ -3375,7 +3375,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$data = [['foo' => 'bar']];
 		$marshaller->expects($this->once())
 			->method('mergeMany')
-			->with($entities, $data, ['users', 'articles'])
+			->with($entities, $data, ['associated' => ['users', 'articles']])
 			->will($this->returnValue($entities));
 		$table->patchEntities($entities, $data);
 	}


### PR DESCRIPTION
As the first step for https://github.com/cakephp/cakephp/issues/3831, I unified the options array accepted by both newEntity and save. This helps keep your controllers DRY

Before:

``` php
$entity = $this->Articles->newEntity($data, ['Author', 'Comments']);
$this->Articles->save($entity, ['validate' => 'custom', 'associated' => ['Author', 'Comments']])
```

Now:

``` php
$options = ['validate' => 'custom', 'associated' => ['Author', 'Comments']];
$entity = $this->Articles->newEntity($data, $options);
$this->Articles->save($entity, $options);
```

More importantly, this opens the way for passing more options to the marshaller, like the list of fields to marshal, for instance.
