### PR TITLE
JsonView.php load Layouts/json/default.ctp

### DIFF
--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -105,7 +105,12 @@ class JsonView extends View {
 		if (isset($this->viewVars['_serialize'])) {
 			$return = $this->_serialize($this->viewVars['_serialize']);
 		} elseif ($view !== false && $this->_getViewFileName($view)) {
-			$return = parent::render($view, false);
+			/* default layout */
+			if($layout === null && file_exists(APP.DS.'View'.DS.'Layouts'.DS.'json'.DS.'default.ctp')) {
+				$return = parent::render($view, 'default');
+			} else {
+				$return = parent::render($view, false);
+			}
 		}
 
 		if (!empty($this->viewVars['_jsonp'])) {


### PR DESCRIPTION
Making `JsonView::render()` load `Layouts/json/default.ctp` if it exits and no layout has been passed. It used to be possible to define a `Layouts/json/default.ctp` now no layout is used, not even if it exits.

If approved, this probably will be needed in `XmlView.php` too.
