### PR TITLE
3.0 Make MemcachedEngine more friendly without php extension

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -31,397 +31,397 @@ use Cake\Utility\Inflector;
  */
 class MemcachedEngine extends CacheEngine {
 
-    /**
-     * memcached wrapper.
-     *
-     * @var Memcache
-     */
-    protected $_Memcached = null;
+/**
+ * memcached wrapper.
+ *
+ * @var Memcache
+ */
+	protected $_Memcached = null;
 
-    /**
-     * The default config used unless overriden by runtime configuration
-     *
-     * - `compress` Whether to compress data
-     * - `duration` Specify how long items in this cache configuration last.
-     * - `groups` List of groups or 'tags' associated to every key stored in this config.
-     *    handy for deleting a complete group from cache.
-     * - `login` Login to access the Memcache server
-     * - `password` Password to access the Memcache server
-     * - `persistent` The name of the persistent connection. All configurations using
-     *    the same persistent value will share a single underlying connection.
-     * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
-     *    with either another cache config or another application.
-     * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
-     *    cache::gc from ever being called automatically.
-     * - `serialize` The serializer engine used to serialize data. Available engines are php,
-     *    igbinary and json. Beside php, the memcached extension must be compiled with the
-     *    appropriate serializer support.
-     * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
-     *    them as a pool.
-     * - `options` - Additional options for the memcached client. Should be an array of option => value.
-     *    Use the \Memcached::OPT_* constants as keys.
-     *
-     * @var array
-     */
-    protected $_defaultConfig = [
-        'compress' => false,
-        'duration' => 3600,
-        'groups' => [],
-        'login' => null,
-        'password' => null,
-        'persistent' => false,
-        'prefix' => 'cake_',
-        'probability' => 100,
-        'serialize' => 'php',
-        'servers' => ['127.0.0.1'],
-        'options' => [],
-    ];
+/**
+ * The default config used unless overriden by runtime configuration
+ *
+ * - `compress` Whether to compress data
+ * - `duration` Specify how long items in this cache configuration last.
+ * - `groups` List of groups or 'tags' associated to every key stored in this config.
+ *    handy for deleting a complete group from cache.
+ * - `login` Login to access the Memcache server
+ * - `password` Password to access the Memcache server
+ * - `persistent` The name of the persistent connection. All configurations using
+ *    the same persistent value will share a single underlying connection.
+ * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
+ *    with either another cache config or another application.
+ * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+ *    cache::gc from ever being called automatically.
+ * - `serialize` The serializer engine used to serialize data. Available engines are php,
+ *    igbinary and json. Beside php, the memcached extension must be compiled with the
+ *    appropriate serializer support.
+ * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
+ *    them as a pool.
+ * - `options` - Additional options for the memcached client. Should be an array of option => value.
+ *    Use the \Memcached::OPT_* constants as keys.
+ *
+ * @var array
+ */
+	protected $_defaultConfig = [
+		'compress' => false,
+		'duration' => 3600,
+		'groups' => [],
+		'login' => null,
+		'password' => null,
+		'persistent' => false,
+		'prefix' => 'cake_',
+		'probability' => 100,
+		'serialize' => 'php',
+		'servers' => ['127.0.0.1'],
+		'options' => [],
+	];
 
-    /**
-     * List of available serializer engines
-     *
-     * Memcached must be compiled with json and igbinary support to use these engines
-     *
-     * @var array
-     */
-    protected $_serializers = [];
+/**
+ * List of available serializer engines
+ *
+ * Memcached must be compiled with json and igbinary support to use these engines
+ *
+ * @var array
+ */
+	protected $_serializers = [];
 
-    /**
-     * Initialize the Cache Engine
-     *
-     * Called automatically by the cache frontend
-     *
-     * @param array $config array of setting for the engine
-     * @return bool True if the engine has been successfully initialized, false if not
-     * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
-     */
-    public function init(array $config = []) {
-        if (!class_exists('Memcached')) {
-            return false;
-        }
+/**
+ * Initialize the Cache Engine
+ *
+ * Called automatically by the cache frontend
+ *
+ * @param array $config array of setting for the engine
+ * @return bool True if the engine has been successfully initialized, false if not
+ * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
+ */
+	public function init(array $config = []) {
+		if (!class_exists('Memcached')) {
+			return false;
+		}
 
-        if (!isset($config['prefix'])) {
-            $config['prefix'] = Inflector::slug(APP_DIR) . '_';
-        }
+		if (!isset($config['prefix'])) {
+			$config['prefix'] = Inflector::slug(APP_DIR) . '_';
+		}
 
-        $this->_serializers = [
-            'igbinary' => \Memcached::SERIALIZER_IGBINARY,
-            'json' => \Memcached::SERIALIZER_JSON,
-            'php' => \Memcached::SERIALIZER_PHP
-        ];
-        if (defined('Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
-            $this->_serializers['msgpack'] = \Memcached::SERIALIZER_MSGPACK;
-        }
+		$this->_serializers = [
+			'igbinary' => \Memcached::SERIALIZER_IGBINARY,
+			'json' => \Memcached::SERIALIZER_JSON,
+			'php' => \Memcached::SERIALIZER_PHP
+		];
+		if (defined('\\Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
+			$this->_serializers['msgpack'] = \Memcached::SERIALIZER_MSGPACK;
+		}
 
-        parent::init($config);
+		parent::init($config);
 
-        if (isset($config['servers'])) {
-            $this->config('servers', $config['servers'], false);
-        }
+		if (isset($config['servers'])) {
+			$this->config('servers', $config['servers'], false);
+		}
 
-        if (!is_array($this->_config['servers'])) {
-            $this->_config['servers'] = [$this->_config['servers']];
-        }
+		if (!is_array($this->_config['servers'])) {
+			$this->_config['servers'] = [$this->_config['servers']];
+		}
 
-        if (isset($this->_Memcached)) {
-            return true;
-        }
+		if (isset($this->_Memcached)) {
+			return true;
+		}
 
-        $this->_Memcached = new \Memcached($this->_config['persistent'] ? (string)$this->_config['persistent'] : null);
-        $this->_setOptions();
+		$this->_Memcached = new \Memcached($this->_config['persistent'] ? (string)$this->_config['persistent'] : null);
+		$this->_setOptions();
 
-        if (count($this->_Memcached->getServerList())) {
-            return true;
-        }
+		if (count($this->_Memcached->getServerList())) {
+			return true;
+		}
 
-        $servers = [];
-        foreach ($this->_config['servers'] as $server) {
-            $servers[] = $this->_parseServerString($server);
-        }
+		$servers = [];
+		foreach ($this->_config['servers'] as $server) {
+			$servers[] = $this->_parseServerString($server);
+		}
 
-        if (!$this->_Memcached->addServers($servers)) {
-            return false;
-        }
+		if (!$this->_Memcached->addServers($servers)) {
+			return false;
+		}
 
-        if (is_array($this->_config['options'])) {
-            foreach ($this->_config['options'] as $opt => $value) {
-                $this->_Memcached->setOption($opt, $value);
-            }
-        }
+		if (is_array($this->_config['options'])) {
+			foreach ($this->_config['options'] as $opt => $value) {
+				$this->_Memcached->setOption($opt, $value);
+			}
+		}
 
-        if ($this->_config['login'] !== null && $this->_config['password'] !== null) {
-            if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
-                throw new Error\Exception(
-                    'Memcached extension is not build with SASL support'
-                );
-            }
-            $this->_Memcached->setSaslAuthData($this->_config['login'], $this->_config['password']);
-        }
+		if ($this->_config['login'] !== null && $this->_config['password'] !== null) {
+			if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
+				throw new Error\Exception(
+					'Memcached extension is not build with SASL support'
+				);
+			}
+			$this->_Memcached->setSaslAuthData($this->_config['login'], $this->_config['password']);
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Settings the memcached instance
-     *
-     * @return void
-     * @throws \Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
-     */
-    protected function _setOptions() {
-        $this->_Memcached->setOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
+/**
+ * Settings the memcached instance
+ *
+ * @return void
+ * @throws \Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
+ */
+	protected function _setOptions() {
+		$this->_Memcached->setOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
 
-        $serializer = strtolower($this->_config['serialize']);
-        if (!isset($this->_serializers[$serializer])) {
-            throw new Error\Exception(
-                sprintf('%s is not a valid serializer engine for Memcached', $serializer)
-            );
-        }
+		$serializer = strtolower($this->_config['serialize']);
+		if (!isset($this->_serializers[$serializer])) {
+			throw new Error\Exception(
+				sprintf('%s is not a valid serializer engine for Memcached', $serializer)
+			);
+		}
 
-        if ($serializer !== 'php' && !constant('Memcached::HAVE_' . strtoupper($serializer))) {
-            throw new Error\Exception(
-                sprintf('Memcached extension is not compiled with %s support', $serializer)
-            );
-        }
+		if ($serializer !== 'php' && !constant('\\Memcached::HAVE_' . strtoupper($serializer))) {
+			throw new Error\Exception(
+				sprintf('Memcached extension is not compiled with %s support', $serializer)
+			);
+		}
 
-        $this->_Memcached->setOption(\Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
+		$this->_Memcached->setOption(\Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
 
-        // Check for Amazon ElastiCache instance
-        if (defined('Memcached::OPT_CLIENT_MODE') && defined('Memcached::DYNAMIC_CLIENT_MODE')) {
-            $this->_Memcached->setOption(\Memcached::OPT_CLIENT_MODE, \Memcached::DYNAMIC_CLIENT_MODE);
-        }
+		// Check for Amazon ElastiCache instance
+		if (defined('\\Memcached::OPT_CLIENT_MODE') && defined('\\Memcached::DYNAMIC_CLIENT_MODE')) {
+			$this->_Memcached->setOption(\Memcached::OPT_CLIENT_MODE, \Memcached::DYNAMIC_CLIENT_MODE);
+		}
 
-        $this->_Memcached->setOption(\Memcached::OPT_COMPRESSION, (bool)$this->_config['compress']);
-    }
+		$this->_Memcached->setOption(\Memcached::OPT_COMPRESSION, (bool)$this->_config['compress']);
+	}
 
-    /**
-     * Parses the server address into the host/port. Handles both IPv6 and IPv4
-     * addresses and Unix sockets
-     *
-     * @param string $server The server address string.
-     * @return array Array containing host, port
-     */
-    protected function _parseServerString($server) {
-        if ($server[0] === 'u') {
-            return [$server, 0];
-        }
-        if (substr($server, 0, 1) === '[') {
-            $position = strpos($server, ']:');
-            if ($position !== false) {
-                $position++;
-            }
-        } else {
-            $position = strpos($server, ':');
-        }
-        $port = 11211;
-        $host = $server;
-        if ($position !== false) {
-            $host = substr($server, 0, $position);
-            $port = substr($server, $position + 1);
-        }
-        return [$host, (int)$port];
-    }
+/**
+ * Parses the server address into the host/port. Handles both IPv6 and IPv4
+ * addresses and Unix sockets
+ *
+ * @param string $server The server address string.
+ * @return array Array containing host, port
+ */
+	protected function _parseServerString($server) {
+		if ($server[0] === 'u') {
+			return [$server, 0];
+		}
+		if (substr($server, 0, 1) === '[') {
+			$position = strpos($server, ']:');
+			if ($position !== false) {
+				$position++;
+			}
+		} else {
+			$position = strpos($server, ':');
+		}
+		$port = 11211;
+		$host = $server;
+		if ($position !== false) {
+			$host = substr($server, 0, $position);
+			$port = substr($server, $position + 1);
+		}
+		return [$host, (int)$port];
+	}
 
-    /**
-     * Write data for key into cache. When using memcached as your cache engine
-     * remember that the Memcached pecl extension does not support cache expiry times greater
-     * than 30 days in the future. Any duration greater than 30 days will be treated as never expiring.
-     *
-     * @param string $key Identifier for the data
-     * @param mixed $value Data to be cached
-     * @return bool True if the data was successfully cached, false on failure
-     * @see http://php.net/manual/en/memcache.set.php
-     */
-    public function write($key, $value) {
-        $duration = $this->_config['duration'];
-        if ($duration > 30 * DAY) {
-            $duration = 0;
-        }
+/**
+ * Write data for key into cache. When using memcached as your cache engine
+ * remember that the Memcached pecl extension does not support cache expiry times greater
+ * than 30 days in the future. Any duration greater than 30 days will be treated as never expiring.
+ *
+ * @param string $key Identifier for the data
+ * @param mixed $value Data to be cached
+ * @return bool True if the data was successfully cached, false on failure
+ * @see http://php.net/manual/en/memcache.set.php
+ */
+	public function write($key, $value) {
+		$duration = $this->_config['duration'];
+		if ($duration > 30 * DAY) {
+			$duration = 0;
+		}
 
-        $key = $this->_key($key);
+		$key = $this->_key($key);
 
-        return $this->_Memcached->set($key, $value, $duration);
-    }
+		return $this->_Memcached->set($key, $value, $duration);
+	}
 
-    /**
-     * Write many cache entries to the cache at once
-     *
-     * @param array $data An array of data to be stored in the cache
-     * @return array of bools for each key provided, true if the data was successfully cached, false on failure
-     */
-    public function writeMany($data) {
-        $cacheData = array();
-        foreach ($data as $key => $value) {
-            $cacheData[$this->_key($key)] = $value;
-        }
+/**
+ * Write many cache entries to the cache at once
+ *
+ * @param array $data An array of data to be stored in the cache
+ * @return array of bools for each key provided, true if the data was successfully cached, false on failure
+ */
+	public function writeMany($data) {
+		$cacheData = array();
+		foreach ($data as $key => $value) {
+			$cacheData[$this->_key($key)] = $value;
+		}
 
-        $success = $this->_Memcached->setMulti($cacheData);
+		$success = $this->_Memcached->setMulti($cacheData);
 
-        $return = array();
-        foreach (array_keys($data) as $key) {
-            $return[$key] = $success;
-        }
-        return $return;
-    }
+		$return = array();
+		foreach (array_keys($data) as $key) {
+			$return[$key] = $success;
+		}
+		return $return;
+	}
 
-    /**
-     * Read a key from the cache
-     *
-     * @param string $key Identifier for the data
-     * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
-     */
-    public function read($key) {
-        $key = $this->_key($key);
+/**
+ * Read a key from the cache
+ *
+ * @param string $key Identifier for the data
+ * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
+ */
+	public function read($key) {
+		$key = $this->_key($key);
 
-        return $this->_Memcached->get($key);
-    }
+		return $this->_Memcached->get($key);
+	}
 
-    /**
-     * Read many keys from the cache at once
-     *
-     * @param array $keys An array of identifiers for the data
-     * @return An array containing, for each of the given $keys, the cached data or false if cached data could not be
-     * retreived
-     */
-    public function readMany($keys) {
-        $cacheKeys = array();
-        foreach ($keys as $key) {
-            $cacheKeys[] = $this->_key($key);
-        }
+/**
+ * Read many keys from the cache at once
+ *
+ * @param array $keys An array of identifiers for the data
+ * @return An array containing, for each of the given $keys, the cached data or false if cached data could not be
+ * retreived
+ */
+	public function readMany($keys) {
+		$cacheKeys = array();
+		foreach ($keys as $key) {
+			$cacheKeys[] = $this->_key($key);
+		}
 
-        $values = $this->_Memcached->getMulti($cacheKeys);
-        $return = array();
-        foreach ($keys as &$key) {
-            $return[$key] = array_key_exists($this->_key($key), $values) ? $values[$this->_key($key)] : false;
-        }
-        return $return;
-    }
+		$values = $this->_Memcached->getMulti($cacheKeys);
+		$return = array();
+		foreach ($keys as &$key) {
+			$return[$key] = array_key_exists($this->_key($key), $values) ? $values[$this->_key($key)] : false;
+		}
+		return $return;
+	}
 
-    /**
-     * Increments the value of an integer cached key
-     *
-     * @param string $key Identifier for the data
-     * @param int $offset How much to increment
-     * @return bool|int New incremented value, false otherwise
-     * @throws \Cake\Error\Exception when you try to increment with compress = true
-     */
-    public function increment($key, $offset = 1) {
-        $key = $this->_key($key);
+/**
+ * Increments the value of an integer cached key
+ *
+ * @param string $key Identifier for the data
+ * @param int $offset How much to increment
+ * @return bool|int New incremented value, false otherwise
+ * @throws \Cake\Error\Exception when you try to increment with compress = true
+ */
+	public function increment($key, $offset = 1) {
+		$key = $this->_key($key);
 
-        return $this->_Memcached->increment($key, $offset);
-    }
+		return $this->_Memcached->increment($key, $offset);
+	}
 
-    /**
-     * Decrements the value of an integer cached key
-     *
-     * @param string $key Identifier for the data
-     * @param int $offset How much to subtract
-     * @return bool|int New decremented value, false otherwise
-     * @throws \Cake\Error\Exception when you try to decrement with compress = true
-     */
-    public function decrement($key, $offset = 1) {
-        $key = $this->_key($key);
+/**
+ * Decrements the value of an integer cached key
+ *
+ * @param string $key Identifier for the data
+ * @param int $offset How much to subtract
+ * @return bool|int New decremented value, false otherwise
+ * @throws \Cake\Error\Exception when you try to decrement with compress = true
+ */
+	public function decrement($key, $offset = 1) {
+		$key = $this->_key($key);
 
-        return $this->_Memcached->decrement($key, $offset);
-    }
+		return $this->_Memcached->decrement($key, $offset);
+	}
 
-    /**
-     * Delete a key from the cache
-     *
-     * @param string $key Identifier for the data
-     * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
-     */
-    public function delete($key) {
-        $key = $this->_key($key);
+/**
+ * Delete a key from the cache
+ *
+ * @param string $key Identifier for the data
+ * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+ */
+	public function delete($key) {
+		$key = $this->_key($key);
 
-        return $this->_Memcached->delete($key);
-    }
+		return $this->_Memcached->delete($key);
+	}
 
-    /**
-     * Delete many keys from the cache at once
-     *
-     * @param array $keys An array of identifiers for the data
-     * @return array of boolean values that are true if the key was successfully deleted, false if it didn't exist or
-     * couldn't be removed
-     */
-    public function deleteMany($keys) {
-        $cacheKeys = array();
-        foreach ($keys as $key) {
-            $cacheKeys[] = $this->_key($key);
-        }
+/**
+ * Delete many keys from the cache at once
+ *
+ * @param array $keys An array of identifiers for the data
+ * @return array of boolean values that are true if the key was successfully deleted, false if it didn't exist or
+ * couldn't be removed
+ */
+	public function deleteMany($keys) {
+		$cacheKeys = array();
+		foreach ($keys as $key) {
+			$cacheKeys[] = $this->_key($key);
+		}
 
-        $success = $this->_Memcached->deleteMulti($cacheKeys);
+		$success = $this->_Memcached->deleteMulti($cacheKeys);
 
-        $return = array();
-        foreach ($keys as $key) {
-            $return[$key] = $success;
-        }
-        return $return;
-    }
+		$return = array();
+		foreach ($keys as $key) {
+			$return[$key] = $success;
+		}
+		return $return;
+	}
 
-    /**
-     * Delete all keys from the cache
-     *
-     * @param bool $check If true will check expiration, otherwise delete all.
-     * @return bool True if the cache was successfully cleared, false otherwise
-     */
-    public function clear($check) {
-        if ($check) {
-            return true;
-        }
+/**
+ * Delete all keys from the cache
+ *
+ * @param bool $check If true will check expiration, otherwise delete all.
+ * @return bool True if the cache was successfully cleared, false otherwise
+ */
+	public function clear($check) {
+		if ($check) {
+			return true;
+		}
 
-        $keys = $this->_Memcached->getAllKeys();
+		$keys = $this->_Memcached->getAllKeys();
 
-        foreach ($keys as $key) {
-            if (strpos($key, $this->_config['prefix']) === 0) {
-                $this->_Memcached->delete($key);
-            }
-        }
+		foreach ($keys as $key) {
+			if (strpos($key, $this->_config['prefix']) === 0) {
+				$this->_Memcached->delete($key);
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Returns the `group value` for each of the configured groups
-     * If the group initial value was not found, then it initializes
-     * the group accordingly.
-     *
-     * @return array
-     */
-    public function groups() {
-        if (empty($this->_compiledGroupNames)) {
-            foreach ($this->_config['groups'] as $group) {
-                $this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
-            }
-        }
+/**
+ * Returns the `group value` for each of the configured groups
+ * If the group initial value was not found, then it initializes
+ * the group accordingly.
+ *
+ * @return array
+ */
+	public function groups() {
+		if (empty($this->_compiledGroupNames)) {
+			foreach ($this->_config['groups'] as $group) {
+				$this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
+			}
+		}
 
-        $groups = $this->_Memcached->getMulti($this->_compiledGroupNames);
-        if (count($groups) !== count($this->_config['groups'])) {
-            foreach ($this->_compiledGroupNames as $group) {
-                if (!isset($groups[$group])) {
-                    $this->_Memcached->set($group, 1, 0);
-                    $groups[$group] = 1;
-                }
-            }
-            ksort($groups);
-        }
+		$groups = $this->_Memcached->getMulti($this->_compiledGroupNames);
+		if (count($groups) !== count($this->_config['groups'])) {
+			foreach ($this->_compiledGroupNames as $group) {
+				if (!isset($groups[$group])) {
+					$this->_Memcached->set($group, 1, 0);
+					$groups[$group] = 1;
+				}
+			}
+			ksort($groups);
+		}
 
-        $result = [];
-        $groups = array_values($groups);
-        foreach ($this->_config['groups'] as $i => $group) {
-            $result[] = $group . $groups[$i];
-        }
+		$result = [];
+		$groups = array_values($groups);
+		foreach ($this->_config['groups'] as $i => $group) {
+			$result[] = $group . $groups[$i];
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    /**
-     * Increments the group value to simulate deletion of all keys under a group
-     * old values will remain in storage until they expire.
-     *
-     * @param string $group name of the group to be cleared
-     * @return bool success
-     */
-    public function clearGroup($group) {
-        return (bool)$this->_Memcached->increment($this->_config['prefix'] . $group);
-    }
+/**
+ * Increments the group value to simulate deletion of all keys under a group
+ * old values will remain in storage until they expire.
+ *
+ * @param string $group name of the group to be cleared
+ * @return bool success
+ */
+	public function clearGroup($group) {
+		return (bool)$this->_Memcached->increment($this->_config['prefix'] . $group);
+	}
 }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -31,397 +31,397 @@ use Cake\Utility\Inflector;
  */
 class MemcachedEngine extends CacheEngine {
 
-/**
- * memcached wrapper.
- *
- * @var Memcache
- */
-	protected $_Memcached = null;
+    /**
+     * memcached wrapper.
+     *
+     * @var Memcache
+     */
+    protected $_Memcached = null;
 
-/**
- * The default config used unless overriden by runtime configuration
- *
- * - `compress` Whether to compress data
- * - `duration` Specify how long items in this cache configuration last.
- * - `groups` List of groups or 'tags' associated to every key stored in this config.
- *    handy for deleting a complete group from cache.
- * - `login` Login to access the Memcache server
- * - `password` Password to access the Memcache server
- * - `persistent` The name of the persistent connection. All configurations using
- *    the same persistent value will share a single underlying connection.
- * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
- *    with either another cache config or another application.
- * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
- *    cache::gc from ever being called automatically.
- * - `serialize` The serializer engine used to serialize data. Available engines are php,
- *    igbinary and json. Beside php, the memcached extension must be compiled with the
- *    appropriate serializer support.
- * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
- *    them as a pool.
- * - `options` - Additional options for the memcached client. Should be an array of option => value.
- *    Use the \Memcached::OPT_* constants as keys.
- *
- * @var array
- */
-	protected $_defaultConfig = [
-		'compress' => false,
-		'duration' => 3600,
-		'groups' => [],
-		'login' => null,
-		'password' => null,
-		'persistent' => false,
-		'prefix' => 'cake_',
-		'probability' => 100,
-		'serialize' => 'php',
-		'servers' => ['127.0.0.1'],
-		'options' => [],
-	];
+    /**
+     * The default config used unless overriden by runtime configuration
+     *
+     * - `compress` Whether to compress data
+     * - `duration` Specify how long items in this cache configuration last.
+     * - `groups` List of groups or 'tags' associated to every key stored in this config.
+     *    handy for deleting a complete group from cache.
+     * - `login` Login to access the Memcache server
+     * - `password` Password to access the Memcache server
+     * - `persistent` The name of the persistent connection. All configurations using
+     *    the same persistent value will share a single underlying connection.
+     * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
+     *    with either another cache config or another application.
+     * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+     *    cache::gc from ever being called automatically.
+     * - `serialize` The serializer engine used to serialize data. Available engines are php,
+     *    igbinary and json. Beside php, the memcached extension must be compiled with the
+     *    appropriate serializer support.
+     * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
+     *    them as a pool.
+     * - `options` - Additional options for the memcached client. Should be an array of option => value.
+     *    Use the \Memcached::OPT_* constants as keys.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'compress' => false,
+        'duration' => 3600,
+        'groups' => [],
+        'login' => null,
+        'password' => null,
+        'persistent' => false,
+        'prefix' => 'cake_',
+        'probability' => 100,
+        'serialize' => 'php',
+        'servers' => ['127.0.0.1'],
+        'options' => [],
+    ];
 
-/**
- * List of available serializer engines
- *
- * Memcached must be compiled with json and igbinary support to use these engines
- *
- * @var array
- */
-	protected $_serializers = [];
+    /**
+     * List of available serializer engines
+     *
+     * Memcached must be compiled with json and igbinary support to use these engines
+     *
+     * @var array
+     */
+    protected $_serializers = [];
 
-/**
- * Initialize the Cache Engine
- *
- * Called automatically by the cache frontend
- *
- * @param array $config array of setting for the engine
- * @return bool True if the engine has been successfully initialized, false if not
- * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
- */
-	public function init(array $config = []) {
-		if (!class_exists('\\Memcached')) {
-			return false;
-		}
+    /**
+     * Initialize the Cache Engine
+     *
+     * Called automatically by the cache frontend
+     *
+     * @param array $config array of setting for the engine
+     * @return bool True if the engine has been successfully initialized, false if not
+     * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
+     */
+    public function init(array $config = []) {
+        if (!class_exists('Memcached')) {
+            return false;
+        }
 
-		if (!isset($config['prefix'])) {
-			$config['prefix'] = Inflector::slug(APP_DIR) . '_';
-		}
+        if (!isset($config['prefix'])) {
+            $config['prefix'] = Inflector::slug(APP_DIR) . '_';
+        }
 
-		$this->_serializers = [
-			'igbinary' => \Memcached::SERIALIZER_IGBINARY,
-			'json' => \Memcached::SERIALIZER_JSON,
-			'php' => \Memcached::SERIALIZER_PHP
-		];
-		if (defined('\\Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
-			$this->_serializers['msgpack'] = \Memcached::SERIALIZER_MSGPACK;
-		}
+        $this->_serializers = [
+            'igbinary' => \Memcached::SERIALIZER_IGBINARY,
+            'json' => \Memcached::SERIALIZER_JSON,
+            'php' => \Memcached::SERIALIZER_PHP
+        ];
+        if (defined('Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
+            $this->_serializers['msgpack'] = \Memcached::SERIALIZER_MSGPACK;
+        }
 
-		parent::init($config);
+        parent::init($config);
 
-		if (isset($config['servers'])) {
-			$this->config('servers', $config['servers'], false);
-		}
+        if (isset($config['servers'])) {
+            $this->config('servers', $config['servers'], false);
+        }
 
-		if (!is_array($this->_config['servers'])) {
-			$this->_config['servers'] = [$this->_config['servers']];
-		}
+        if (!is_array($this->_config['servers'])) {
+            $this->_config['servers'] = [$this->_config['servers']];
+        }
 
-		if (isset($this->_Memcached)) {
-			return true;
-		}
+        if (isset($this->_Memcached)) {
+            return true;
+        }
 
-		$this->_Memcached = new \Memcached($this->_config['persistent'] ? (string)$this->_config['persistent'] : null);
-		$this->_setOptions();
+        $this->_Memcached = new \Memcached($this->_config['persistent'] ? (string)$this->_config['persistent'] : null);
+        $this->_setOptions();
 
-		if (count($this->_Memcached->getServerList())) {
-			return true;
-		}
+        if (count($this->_Memcached->getServerList())) {
+            return true;
+        }
 
-		$servers = [];
-		foreach ($this->_config['servers'] as $server) {
-			$servers[] = $this->_parseServerString($server);
-		}
+        $servers = [];
+        foreach ($this->_config['servers'] as $server) {
+            $servers[] = $this->_parseServerString($server);
+        }
 
-		if (!$this->_Memcached->addServers($servers)) {
-			return false;
-		}
+        if (!$this->_Memcached->addServers($servers)) {
+            return false;
+        }
 
-		if (is_array($this->_config['options'])) {
-			foreach ($this->_config['options'] as $opt => $value) {
-				$this->_Memcached->setOption($opt, $value);
-			}
-		}
+        if (is_array($this->_config['options'])) {
+            foreach ($this->_config['options'] as $opt => $value) {
+                $this->_Memcached->setOption($opt, $value);
+            }
+        }
 
-		if ($this->_config['login'] !== null && $this->_config['password'] !== null) {
-			if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
-				throw new Error\Exception(
-					'Memcached extension is not build with SASL support'
-				);
-			}
-			$this->_Memcached->setSaslAuthData($this->_config['login'], $this->_config['password']);
-		}
+        if ($this->_config['login'] !== null && $this->_config['password'] !== null) {
+            if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
+                throw new Error\Exception(
+                    'Memcached extension is not build with SASL support'
+                );
+            }
+            $this->_Memcached->setSaslAuthData($this->_config['login'], $this->_config['password']);
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-/**
- * Settings the memcached instance
- *
- * @return void
- * @throws \Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
- */
-	protected function _setOptions() {
-		$this->_Memcached->setOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
+    /**
+     * Settings the memcached instance
+     *
+     * @return void
+     * @throws \Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
+     */
+    protected function _setOptions() {
+        $this->_Memcached->setOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
 
-		$serializer = strtolower($this->_config['serialize']);
-		if (!isset($this->_serializers[$serializer])) {
-			throw new Error\Exception(
-				sprintf('%s is not a valid serializer engine for Memcached', $serializer)
-			);
-		}
+        $serializer = strtolower($this->_config['serialize']);
+        if (!isset($this->_serializers[$serializer])) {
+            throw new Error\Exception(
+                sprintf('%s is not a valid serializer engine for Memcached', $serializer)
+            );
+        }
 
-		if ($serializer !== 'php' && !constant('\\Memcached::HAVE_' . strtoupper($serializer))) {
-			throw new Error\Exception(
-				sprintf('Memcached extension is not compiled with %s support', $serializer)
-			);
-		}
+        if ($serializer !== 'php' && !constant('Memcached::HAVE_' . strtoupper($serializer))) {
+            throw new Error\Exception(
+                sprintf('Memcached extension is not compiled with %s support', $serializer)
+            );
+        }
 
-		$this->_Memcached->setOption(\Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
+        $this->_Memcached->setOption(\Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
 
-		// Check for Amazon ElastiCache instance
-		if (defined('\\Memcached::OPT_CLIENT_MODE') && defined('\\Memcached::DYNAMIC_CLIENT_MODE')) {
-			$this->_Memcached->setOption(\Memcached::OPT_CLIENT_MODE, \Memcached::DYNAMIC_CLIENT_MODE);
-		}
+        // Check for Amazon ElastiCache instance
+        if (defined('Memcached::OPT_CLIENT_MODE') && defined('Memcached::DYNAMIC_CLIENT_MODE')) {
+            $this->_Memcached->setOption(\Memcached::OPT_CLIENT_MODE, \Memcached::DYNAMIC_CLIENT_MODE);
+        }
 
-		$this->_Memcached->setOption(\Memcached::OPT_COMPRESSION, (bool)$this->_config['compress']);
-	}
+        $this->_Memcached->setOption(\Memcached::OPT_COMPRESSION, (bool)$this->_config['compress']);
+    }
 
-/**
- * Parses the server address into the host/port. Handles both IPv6 and IPv4
- * addresses and Unix sockets
- *
- * @param string $server The server address string.
- * @return array Array containing host, port
- */
-	protected function _parseServerString($server) {
-		if ($server[0] === 'u') {
-			return [$server, 0];
-		}
-		if (substr($server, 0, 1) === '[') {
-			$position = strpos($server, ']:');
-			if ($position !== false) {
-				$position++;
-			}
-		} else {
-			$position = strpos($server, ':');
-		}
-		$port = 11211;
-		$host = $server;
-		if ($position !== false) {
-			$host = substr($server, 0, $position);
-			$port = substr($server, $position + 1);
-		}
-		return [$host, (int)$port];
-	}
+    /**
+     * Parses the server address into the host/port. Handles both IPv6 and IPv4
+     * addresses and Unix sockets
+     *
+     * @param string $server The server address string.
+     * @return array Array containing host, port
+     */
+    protected function _parseServerString($server) {
+        if ($server[0] === 'u') {
+            return [$server, 0];
+        }
+        if (substr($server, 0, 1) === '[') {
+            $position = strpos($server, ']:');
+            if ($position !== false) {
+                $position++;
+            }
+        } else {
+            $position = strpos($server, ':');
+        }
+        $port = 11211;
+        $host = $server;
+        if ($position !== false) {
+            $host = substr($server, 0, $position);
+            $port = substr($server, $position + 1);
+        }
+        return [$host, (int)$port];
+    }
 
-/**
- * Write data for key into cache. When using memcached as your cache engine
- * remember that the Memcached pecl extension does not support cache expiry times greater
- * than 30 days in the future. Any duration greater than 30 days will be treated as never expiring.
- *
- * @param string $key Identifier for the data
- * @param mixed $value Data to be cached
- * @return bool True if the data was successfully cached, false on failure
- * @see http://php.net/manual/en/memcache.set.php
- */
-	public function write($key, $value) {
-		$duration = $this->_config['duration'];
-		if ($duration > 30 * DAY) {
-			$duration = 0;
-		}
+    /**
+     * Write data for key into cache. When using memcached as your cache engine
+     * remember that the Memcached pecl extension does not support cache expiry times greater
+     * than 30 days in the future. Any duration greater than 30 days will be treated as never expiring.
+     *
+     * @param string $key Identifier for the data
+     * @param mixed $value Data to be cached
+     * @return bool True if the data was successfully cached, false on failure
+     * @see http://php.net/manual/en/memcache.set.php
+     */
+    public function write($key, $value) {
+        $duration = $this->_config['duration'];
+        if ($duration > 30 * DAY) {
+            $duration = 0;
+        }
 
-		$key = $this->_key($key);
+        $key = $this->_key($key);
 
-		return $this->_Memcached->set($key, $value, $duration);
-	}
+        return $this->_Memcached->set($key, $value, $duration);
+    }
 
-/**
- * Write many cache entries to the cache at once
- *
- * @param array $data An array of data to be stored in the cache
- * @return array of bools for each key provided, true if the data was successfully cached, false on failure
- */
-	public function writeMany($data) {
-		$cacheData = array();
-		foreach ($data as $key => $value) {
-			$cacheData[$this->_key($key)] = $value;
-		}
+    /**
+     * Write many cache entries to the cache at once
+     *
+     * @param array $data An array of data to be stored in the cache
+     * @return array of bools for each key provided, true if the data was successfully cached, false on failure
+     */
+    public function writeMany($data) {
+        $cacheData = array();
+        foreach ($data as $key => $value) {
+            $cacheData[$this->_key($key)] = $value;
+        }
 
-		$success = $this->_Memcached->setMulti($cacheData);
+        $success = $this->_Memcached->setMulti($cacheData);
 
-		$return = array();
-		foreach (array_keys($data) as $key) {
-			$return[$key] = $success;
-		}
-		return $return;
-	}
+        $return = array();
+        foreach (array_keys($data) as $key) {
+            $return[$key] = $success;
+        }
+        return $return;
+    }
 
-/**
- * Read a key from the cache
- *
- * @param string $key Identifier for the data
- * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
- */
-	public function read($key) {
-		$key = $this->_key($key);
+    /**
+     * Read a key from the cache
+     *
+     * @param string $key Identifier for the data
+     * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
+     */
+    public function read($key) {
+        $key = $this->_key($key);
 
-		return $this->_Memcached->get($key);
-	}
+        return $this->_Memcached->get($key);
+    }
 
-/**
- * Read many keys from the cache at once
- *
- * @param array $keys An array of identifiers for the data
- * @return An array containing, for each of the given $keys, the cached data or false if cached data could not be
- * retreived
- */
-	public function readMany($keys) {
-		$cacheKeys = array();
-		foreach ($keys as $key) {
-			$cacheKeys[] = $this->_key($key);
-		}
+    /**
+     * Read many keys from the cache at once
+     *
+     * @param array $keys An array of identifiers for the data
+     * @return An array containing, for each of the given $keys, the cached data or false if cached data could not be
+     * retreived
+     */
+    public function readMany($keys) {
+        $cacheKeys = array();
+        foreach ($keys as $key) {
+            $cacheKeys[] = $this->_key($key);
+        }
 
-		$values = $this->_Memcached->getMulti($cacheKeys);
-		$return = array();
-		foreach ($keys as &$key) {
-			$return[$key] = array_key_exists($this->_key($key), $values) ? $values[$this->_key($key)] : false;
-		}
-		return $return;
-	}
+        $values = $this->_Memcached->getMulti($cacheKeys);
+        $return = array();
+        foreach ($keys as &$key) {
+            $return[$key] = array_key_exists($this->_key($key), $values) ? $values[$this->_key($key)] : false;
+        }
+        return $return;
+    }
 
-/**
- * Increments the value of an integer cached key
- *
- * @param string $key Identifier for the data
- * @param int $offset How much to increment
- * @return bool|int New incremented value, false otherwise
- * @throws \Cake\Error\Exception when you try to increment with compress = true
- */
-	public function increment($key, $offset = 1) {
-		$key = $this->_key($key);
+    /**
+     * Increments the value of an integer cached key
+     *
+     * @param string $key Identifier for the data
+     * @param int $offset How much to increment
+     * @return bool|int New incremented value, false otherwise
+     * @throws \Cake\Error\Exception when you try to increment with compress = true
+     */
+    public function increment($key, $offset = 1) {
+        $key = $this->_key($key);
 
-		return $this->_Memcached->increment($key, $offset);
-	}
+        return $this->_Memcached->increment($key, $offset);
+    }
 
-/**
- * Decrements the value of an integer cached key
- *
- * @param string $key Identifier for the data
- * @param int $offset How much to subtract
- * @return bool|int New decremented value, false otherwise
- * @throws \Cake\Error\Exception when you try to decrement with compress = true
- */
-	public function decrement($key, $offset = 1) {
-		$key = $this->_key($key);
+    /**
+     * Decrements the value of an integer cached key
+     *
+     * @param string $key Identifier for the data
+     * @param int $offset How much to subtract
+     * @return bool|int New decremented value, false otherwise
+     * @throws \Cake\Error\Exception when you try to decrement with compress = true
+     */
+    public function decrement($key, $offset = 1) {
+        $key = $this->_key($key);
 
-		return $this->_Memcached->decrement($key, $offset);
-	}
+        return $this->_Memcached->decrement($key, $offset);
+    }
 
-/**
- * Delete a key from the cache
- *
- * @param string $key Identifier for the data
- * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
- */
-	public function delete($key) {
-		$key = $this->_key($key);
+    /**
+     * Delete a key from the cache
+     *
+     * @param string $key Identifier for the data
+     * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+     */
+    public function delete($key) {
+        $key = $this->_key($key);
 
-		return $this->_Memcached->delete($key);
-	}
+        return $this->_Memcached->delete($key);
+    }
 
-/**
- * Delete many keys from the cache at once
- *
- * @param array $keys An array of identifiers for the data
- * @return array of boolean values that are true if the key was successfully deleted, false if it didn't exist or
- * couldn't be removed
- */
-	public function deleteMany($keys) {
-		$cacheKeys = array();
-		foreach ($keys as $key) {
-			$cacheKeys[] = $this->_key($key);
-		}
+    /**
+     * Delete many keys from the cache at once
+     *
+     * @param array $keys An array of identifiers for the data
+     * @return array of boolean values that are true if the key was successfully deleted, false if it didn't exist or
+     * couldn't be removed
+     */
+    public function deleteMany($keys) {
+        $cacheKeys = array();
+        foreach ($keys as $key) {
+            $cacheKeys[] = $this->_key($key);
+        }
 
-		$success = $this->_Memcached->deleteMulti($cacheKeys);
+        $success = $this->_Memcached->deleteMulti($cacheKeys);
 
-		$return = array();
-		foreach ($keys as $key) {
-			$return[$key] = $success;
-		}
-		return $return;
-	}
+        $return = array();
+        foreach ($keys as $key) {
+            $return[$key] = $success;
+        }
+        return $return;
+    }
 
-/**
- * Delete all keys from the cache
- *
- * @param bool $check If true will check expiration, otherwise delete all.
- * @return bool True if the cache was successfully cleared, false otherwise
- */
-	public function clear($check) {
-		if ($check) {
-			return true;
-		}
+    /**
+     * Delete all keys from the cache
+     *
+     * @param bool $check If true will check expiration, otherwise delete all.
+     * @return bool True if the cache was successfully cleared, false otherwise
+     */
+    public function clear($check) {
+        if ($check) {
+            return true;
+        }
 
-		$keys = $this->_Memcached->getAllKeys();
+        $keys = $this->_Memcached->getAllKeys();
 
-		foreach ($keys as $key) {
-			if (strpos($key, $this->_config['prefix']) === 0) {
-				$this->_Memcached->delete($key);
-			}
-		}
+        foreach ($keys as $key) {
+            if (strpos($key, $this->_config['prefix']) === 0) {
+                $this->_Memcached->delete($key);
+            }
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-/**
- * Returns the `group value` for each of the configured groups
- * If the group initial value was not found, then it initializes
- * the group accordingly.
- *
- * @return array
- */
-	public function groups() {
-		if (empty($this->_compiledGroupNames)) {
-			foreach ($this->_config['groups'] as $group) {
-				$this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
-			}
-		}
+    /**
+     * Returns the `group value` for each of the configured groups
+     * If the group initial value was not found, then it initializes
+     * the group accordingly.
+     *
+     * @return array
+     */
+    public function groups() {
+        if (empty($this->_compiledGroupNames)) {
+            foreach ($this->_config['groups'] as $group) {
+                $this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
+            }
+        }
 
-		$groups = $this->_Memcached->getMulti($this->_compiledGroupNames);
-		if (count($groups) !== count($this->_config['groups'])) {
-			foreach ($this->_compiledGroupNames as $group) {
-				if (!isset($groups[$group])) {
-					$this->_Memcached->set($group, 1, 0);
-					$groups[$group] = 1;
-				}
-			}
-			ksort($groups);
-		}
+        $groups = $this->_Memcached->getMulti($this->_compiledGroupNames);
+        if (count($groups) !== count($this->_config['groups'])) {
+            foreach ($this->_compiledGroupNames as $group) {
+                if (!isset($groups[$group])) {
+                    $this->_Memcached->set($group, 1, 0);
+                    $groups[$group] = 1;
+                }
+            }
+            ksort($groups);
+        }
 
-		$result = [];
-		$groups = array_values($groups);
-		foreach ($this->_config['groups'] as $i => $group) {
-			$result[] = $group . $groups[$i];
-		}
+        $result = [];
+        $groups = array_values($groups);
+        foreach ($this->_config['groups'] as $i => $group) {
+            $result[] = $group . $groups[$i];
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-/**
- * Increments the group value to simulate deletion of all keys under a group
- * old values will remain in storage until they expire.
- *
- * @param string $group name of the group to be cleared
- * @return bool success
- */
-	public function clearGroup($group) {
-		return (bool)$this->_Memcached->increment($this->_config['prefix'] . $group);
-	}
+    /**
+     * Increments the group value to simulate deletion of all keys under a group
+     * old values will remain in storage until they expire.
+     *
+     * @param string $group name of the group to be cleared
+     * @return bool success
+     */
+    public function clearGroup($group) {
+        return (bool)$this->_Memcached->increment($this->_config['prefix'] . $group);
+    }
 }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -109,7 +109,7 @@ class MemcachedEngine extends CacheEngine {
 			'json' => \Memcached::SERIALIZER_JSON,
 			'php' => \Memcached::SERIALIZER_PHP
 		];
-		if (defined('\\Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
+		if (defined('Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
 			$this->_serializers['msgpack'] = \Memcached::SERIALIZER_MSGPACK;
 		}
 
@@ -177,7 +177,7 @@ class MemcachedEngine extends CacheEngine {
 			);
 		}
 
-		if ($serializer !== 'php' && !constant('\\Memcached::HAVE_' . strtoupper($serializer))) {
+		if ($serializer !== 'php' && !constant('Memcached::HAVE_' . strtoupper($serializer))) {
 			throw new Error\Exception(
 				sprintf('Memcached extension is not compiled with %s support', $serializer)
 			);
@@ -186,7 +186,7 @@ class MemcachedEngine extends CacheEngine {
 		$this->_Memcached->setOption(\Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
 
 		// Check for Amazon ElastiCache instance
-		if (defined('\\Memcached::OPT_CLIENT_MODE') && defined('\\Memcached::DYNAMIC_CLIENT_MODE')) {
+		if (defined('Memcached::OPT_CLIENT_MODE') && defined('Memcached::DYNAMIC_CLIENT_MODE')) {
 			$this->_Memcached->setOption(\Memcached::OPT_CLIENT_MODE, \Memcached::DYNAMIC_CLIENT_MODE);
 		}
 

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -17,7 +17,6 @@ namespace Cake\Cache\Engine;
 use Cake\Cache\CacheEngine;
 use Cake\Error;
 use Cake\Utility\Inflector;
-use \Memcached;
 
 /**
  * Memcached storage engine for cache. Memcached has some limitations in the amount of
@@ -60,7 +59,7 @@ class MemcachedEngine extends CacheEngine {
  * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
  *    them as a pool.
  * - `options` - Additional options for the memcached client. Should be an array of option => value.
- *    Use the Memcached::OPT_* constants as keys.
+ *    Use the \Memcached::OPT_* constants as keys.
  *
  * @var array
  */
@@ -85,11 +84,7 @@ class MemcachedEngine extends CacheEngine {
  *
  * @var array
  */
-	protected $_serializers = [
-		'igbinary' => Memcached::SERIALIZER_IGBINARY,
-		'json' => Memcached::SERIALIZER_JSON,
-		'php' => Memcached::SERIALIZER_PHP
-	];
+	protected $_serializers = [];
 
 /**
  * Initialize the Cache Engine
@@ -101,7 +96,7 @@ class MemcachedEngine extends CacheEngine {
  * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
  */
 	public function init(array $config = []) {
-		if (!class_exists('Memcached')) {
+		if (!class_exists('\\Memcached')) {
 			return false;
 		}
 
@@ -109,8 +104,13 @@ class MemcachedEngine extends CacheEngine {
 			$config['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
 
-		if (defined('Memcached::HAVE_MSGPACK') && Memcached::HAVE_MSGPACK) {
-			$this->_serializers['msgpack'] = Memcached::SERIALIZER_MSGPACK;
+		$this->_serializers = [
+			'igbinary' => \Memcached::SERIALIZER_IGBINARY,
+			'json' => \Memcached::SERIALIZER_JSON,
+			'php' => \Memcached::SERIALIZER_PHP
+		];
+		if (defined('\\Memcached::HAVE_MSGPACK') && \Memcached::HAVE_MSGPACK) {
+			$this->_serializers['msgpack'] = \Memcached::SERIALIZER_MSGPACK;
 		}
 
 		parent::init($config);
@@ -177,16 +177,16 @@ class MemcachedEngine extends CacheEngine {
 			);
 		}
 
-		if ($serializer !== 'php' && !constant('Memcached::HAVE_' . strtoupper($serializer))) {
+		if ($serializer !== 'php' && !constant('\\Memcached::HAVE_' . strtoupper($serializer))) {
 			throw new Error\Exception(
 				sprintf('Memcached extension is not compiled with %s support', $serializer)
 			);
 		}
 
-		$this->_Memcached->setOption(Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
+		$this->_Memcached->setOption(\Memcached::OPT_SERIALIZER, $this->_serializers[$serializer]);
 
 		// Check for Amazon ElastiCache instance
-		if (defined('Memcached::OPT_CLIENT_MODE') && defined('Memcached::DYNAMIC_CLIENT_MODE')) {
+		if (defined('\\Memcached::OPT_CLIENT_MODE') && defined('\\Memcached::DYNAMIC_CLIENT_MODE')) {
 			$this->_Memcached->setOption(\Memcached::OPT_CLIENT_MODE, \Memcached::DYNAMIC_CLIENT_MODE);
 		}
 


### PR DESCRIPTION
When memcached extension doesn't installed Cake can't verify its safely by init method and generates fatal error.

```
use \Memcached;
```

This piece of code breaks it all when i try to verify this engine.
