### PR TITLE
3.0 treebehavior fixes

### DIFF
--- a/src/Console/Templates/default/classes/table.ctp
+++ b/src/Console/Templates/default/classes/table.ctp
@@ -43,7 +43,11 @@ class <?= $name ?>Table extends Table {
 <?php
 $key = array_map(function($el) { return "'$el'"; }, (array)$primaryKey);
 ?>
+<?php if (count($primaryKey) > 1): ?>
 		$this->primaryKey([<?= implode(', ', $key) ?>]);
+<?php else: ?>
+		$this->primaryKey(<?= current($key) ?>);
+<?php endif ?>
 <?php endif ?>
 <?php foreach ($behaviors as $behavior => $behaviorData): ?>
 		$this->addBehavior('<?= $behavior ?>'<?= $behaviorData ? ", [" . implode(', ', $behaviorData) . ']' : '' ?>);

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -41,6 +41,8 @@ class TreeBehavior extends Behavior {
  */
 	protected $_table;
 
+	protected $_primaryKey;
+
 /**
  * Default config
  *
@@ -92,7 +94,7 @@ class TreeBehavior extends Behavior {
 		$isNew = $entity->isNew();
 		$config = $this->config();
 		$parent = $entity->get($config['parent']);
-		$primaryKey = (array)$this->_table->primaryKey();
+		$primaryKey = $this->_getPrimaryKey();
 		$dirty = $entity->dirty($config['parent']);
 
 		if ($isNew && $parent) {
@@ -169,7 +171,7 @@ class TreeBehavior extends Behavior {
 			throw new \RuntimeException(sprintf(
 				'Cannot use node "%s" as parent for entity "%s"',
 				$parent,
-				$entity->get($this->_table->primaryKey())
+				$entity->get($this->_getPrimaryKey())
 			));
 		}
 
@@ -296,7 +298,7 @@ class TreeBehavior extends Behavior {
 
 		if ($direct) {
 			return $this->_scope($this->_table->find())
-				->where([$parent => $node->get($this->_table->primaryKey())])
+				->where([$parent => $node->get($this->_getPrimaryKey())])
 				->count();
 		}
 
@@ -368,7 +370,7 @@ class TreeBehavior extends Behavior {
 			->find('threaded', ['parentField' => $this->config()['parent']])
 			->formatResults(function($results) use ($options) {
 				$options += [
-					'keyPath' => $this->_table->primaryKey(),
+					'keyPath' => $this->_getPrimaryKey(),
 					'valuePath' => $this->_table->displayField(),
 					'spacer' => '_'
 				];
@@ -415,7 +417,7 @@ class TreeBehavior extends Behavior {
 			return $this->_table->save($node);
 		}
 
-		$primary = $this->_table->primaryKey();
+		$primary = $this->_getPrimaryKey();
 		$this->_table->updateAll(
 			[$config['parent'] => $parent],
 			[$config['parent'] => $node->get($primary)]
@@ -599,7 +601,7 @@ class TreeBehavior extends Behavior {
 	protected function _getNode($id) {
 		$config = $this->config();
 		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
-		$primaryKey = $this->_table->primaryKey();
+		$primaryKey = $this->_getPrimaryKey();
 
 		$node = $this->_scope($this->_table->find())
 			->select([$parent, $left, $right])
@@ -746,12 +748,20 @@ class TreeBehavior extends Behavior {
 			return;
 		}
 
-		$fresh = $this->_table->get($entity->get($this->_table->primaryKey()), $fields);
+		$fresh = $this->_table->get($entity->get($this->_getPrimaryKey()), $fields);
 		$entity->set($fresh->extract($fields), ['guard' => false]);
 
 		foreach ($fields as $field) {
 			$entity->dirty($field, false);
 		}
+	}
+
+	protected function _getPrimaryKey() {
+		if (!$this->_primaryKey) {
+			$this->_primaryKey = (array)$this->_table->primaryKey();
+			$this->_primaryKey = $this->_primaryKey[0];
+		}
+		return $this->_primaryKey;
 	}
 
 }

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -756,6 +756,11 @@ class TreeBehavior extends Behavior {
 		}
 	}
 
+/**
+ * Returns a single string value representing the primary key of the attached table
+ *
+ * @return string
+ */
 	protected function _getPrimaryKey() {
 		if (!$this->_primaryKey) {
 			$this->_primaryKey = (array)$this->_table->primaryKey();

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -738,7 +738,7 @@ class ModelTaskTest extends TestCase {
 		$result = $this->Task->bakeTable($model, $config);
 
 		$this->assertContains('public function initialize(array $config) {', $result);
-		$this->assertContains("this->primaryKey(['id']);\n", $result);
+		$this->assertContains("this->primaryKey('id');\n", $result);
 		$this->assertContains("this->displayField('title');\n", $result);
 		$this->assertContains("this->addBehavior('Timestamp');\n", $result);
 		$this->assertContains("this->table('articles');\n", $result);

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -39,6 +39,7 @@ class TreeBehaviorTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->table = TableRegistry::get('NumberTrees');
+		$this->table->primaryKey(['id']);
 		$this->table->addBehavior('Tree');
 	}
 
@@ -385,8 +386,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testRecover() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$expected = $table->find()->order('lft')->hydrate(false)->toArray();
 		$table->updateAll(['lft' => null, 'rght' => null], []);
 		$table->recover();
@@ -437,8 +437,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testAddOrphan() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = new Entity(
 			['name' => 'New Orphan', 'parent_id' => null],
 			['markNew' => true]
@@ -459,8 +458,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testAddMiddle() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = new Entity(
 			['name' => 'laptops', 'parent_id' => 1],
 			['markNew' => true]
@@ -481,8 +479,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testAddLeaf() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = new Entity(
 			['name' => 'laptops', 'parent_id' => 2],
 			['markNew' => true]
@@ -503,8 +500,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testReParentSubTreeRight() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(2);
 		$entity->parent_id = 6;
 		$this->assertSame($entity, $table->save($entity));
@@ -522,8 +518,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testReParentSubTreeLeft() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(6);
 		$entity->parent_id = 2;
 		$this->assertSame($entity, $table->save($entity));
@@ -542,8 +537,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testReParentLeafLeft() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(10);
 		$entity->parent_id = 2;
 		$this->assertSame($entity, $table->save($entity));
@@ -562,8 +556,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testReParentLeafRight() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(5);
 		$entity->parent_id = 6;
 		$this->assertSame($entity, $table->save($entity));
@@ -581,8 +574,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testReParentNoTreeColumns() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(6);
 		$entity->unsetProperty('lft');
 		$entity->unsetProperty('rght');
@@ -603,8 +595,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testRootingSubTree() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(2);
 		$entity->parent_id = null;
 		$this->assertSame($entity, $table->save($entity));
@@ -622,8 +613,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testRootingNoTreeColumns() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(2);
 		$entity->unsetProperty('lft');
 		$entity->unsetProperty('rght');
@@ -645,8 +635,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testReparentCycle() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(2);
 		$entity->parent_id = 5;
 		$table->save($entity);
@@ -658,8 +647,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testDeleteLeaf() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(4);
 		$this->assertTrue($table->delete($entity));
 		$result = $table->find()->order('lft')->hydrate(false)->toArray();
@@ -674,8 +662,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testDeleteSubTree() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(6);
 		$this->assertTrue($table->delete($entity));
 		$result = $table->find()->order('lft')->hydrate(false)->toArray();
@@ -690,8 +677,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testDeleteRoot() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(1);
 		$this->assertTrue($table->delete($entity));
 		$result = $table->find()->order('lft')->hydrate(false)->toArray();
@@ -706,8 +692,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testDeleteRootNoTreeColumns() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(1);
 		$entity->unsetProperty('lft');
 		$entity->unsetProperty('rght');
@@ -724,8 +709,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testRemoveFromLeafFromTree() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(10);
 		$this->assertSame($entity, $table->removeFromTree($entity));
 		$this->assertEquals(21, $entity->lft);
@@ -742,8 +726,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testRemoveMiddleNodeFromTree() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(6);
 		$this->assertSame($entity, $table->removeFromTree($entity));
 		$result = $table->find('threaded')->order('lft')->hydrate(false)->toArray();
@@ -761,8 +744,7 @@ class TreeBehaviorTest extends TestCase {
  * @return void
  */
 	public function testRemoveRootFromTree() {
-		$table = TableRegistry::get('NumberTrees');
-		$table->addBehavior('Tree');
+		$table = $this->table;
 		$entity = $table->get(1);
 		$this->assertSame($entity, $table->removeFromTree($entity));
 		$result = $table->find('threaded')->order('lft')->hydrate(false)->toArray();


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/3951

Also, changed the Table bake template to not use arrays for `primaryKey()` when there is only a single value. This will be the case in the majority of cases so using arrays from the user perspective is just a big hassle.
