### PR TITLE
Fix error where routes would be incorrectly parsed.

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -93,25 +93,25 @@ class RouteCollection {
  */
 	public function parse($url) {
 		foreach (array_keys($this->_paths) as $path) {
-			if (strpos($url, $path) === 0) {
-				break;
-			}
-		}
-
-		$queryParameters = null;
-		if (strpos($url, '?') !== false) {
-			list($url, $queryParameters) = explode('?', $url, 2);
-			parse_str($queryParameters, $queryParameters);
-		}
-		foreach ($this->_paths[$path] as $route) {
-			$r = $route->parse($url);
-			if ($r === false) {
+			if (strpos($url, $path) !== 0) {
 				continue;
 			}
-			if ($queryParameters) {
-				$r['?'] = $queryParameters;
+
+			$queryParameters = null;
+			if (strpos($url, '?') !== false) {
+				list($url, $queryParameters) = explode('?', $url, 2);
+				parse_str($queryParameters, $queryParameters);
 			}
-			return $r;
+			foreach ($this->_paths[$path] as $route) {
+				$r = $route->parse($url);
+				if ($r === false) {
+					continue;
+				}
+				if ($queryParameters) {
+					$r['?'] = $queryParameters;
+				}
+				return $r;
+			}
 		}
 		throw new MissingRouteException(['url' => $url]);
 	}

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -102,6 +102,28 @@ class RouteCollectionTest extends TestCase {
 	}
 
 /**
+ * Test that parsing checks all the related path scopes.
+ *
+ * @return void
+ */
+	public function testParseFallback() {
+		$routes = new RouteBuilder($this->collection, '/', []);
+
+		$routes->resources('Articles');
+		$routes->connect('/:controller', ['action' => 'index'], [], ['routeClass' => 'InflectedRoute']);
+		$routes->connect('/:controller/:action', [], ['routeClass' => 'InflectedRoute']);
+
+		$result = $this->collection->parse('/articles/add');
+		$expected = [
+			'controller' => 'Articles',
+			'action' => 'add',
+			'plugin' => null,
+			'pass' => []
+		];
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Test match() throws an error on unknown routes.
  *
  * @expectedException Cake\Routing\Error\MissingRouteException


### PR DESCRIPTION
Instead of only trying the first path partition, we should check each
matching prefix slice until all path prefixes have been exhausted.

Fixes #3954
