### PR TITLE
3.0 Routing resource improvements part 1

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -438,6 +438,12 @@ class Route {
 			unset($url['_ext']);
 		}
 
+		// Check the method first as it is special.
+		if (!$this->_matchMethod($url)) {
+			return false;
+		}
+		unset($url['[method]'], $defaults['[method]']);
+
 		// Missing defaults is a fail.
 		if (array_diff_key($defaults, $url) !== []) {
 			return false;
@@ -498,6 +504,24 @@ class Route {
 		}
 		$url += $hostOptions;
 		return $this->_writeUrl($url, $pass, $query);
+	}
+
+/**
+ * Check whether or not the URL's HTTP method matches.
+ *
+ * @param array $url The array for the URL being generated.
+ */
+	protected function _matchMethod($url) {
+		if (empty($this->defaults['[method]'])) {
+			return true;
+		}
+		if (empty($url['[method]'])) {
+			return false;
+		}
+		if (!in_array(strtoupper($url['[method]']), (array)$this->defaults['[method]'])) {
+			return false;
+		}
+		return true;
 	}
 
 /**

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -411,8 +411,8 @@ class Route {
 
 		$hostOptions = array_intersect_key($url, $context);
 
-		// Check for properties that will cause and
-		// absoulte url. Copy the other properties over.
+		// Check for properties that will cause an
+		// absolute url. Copy the other properties over.
 		if (
 			isset($hostOptions['_scheme']) ||
 			isset($hostOptions['_port']) ||
@@ -488,7 +488,7 @@ class Route {
 			return false;
 		}
 
-		//check patterns for routed params
+		// check patterns for routed params
 		if (!empty($this->options)) {
 			foreach ($this->options as $key => $pattern) {
 				if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#', $url[$key])) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -510,6 +510,7 @@ class Route {
  * Check whether or not the URL's HTTP method matches.
  *
  * @param array $url The array for the URL being generated.
+ * @return bool
  */
 	protected function _matchMethod($url) {
 		if (empty($this->defaults['[method]'])) {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -47,14 +47,13 @@ class RouteBuilder {
  *
  * @var array
  */
-	protected static $_resourceMap = array(
-		array('action' => 'index', 'method' => 'GET', 'id' => false),
-		array('action' => 'view', 'method' => 'GET', 'id' => true),
-		array('action' => 'add', 'method' => 'POST', 'id' => false),
-		array('action' => 'edit', 'method' => 'PUT', 'id' => true),
-		array('action' => 'delete', 'method' => 'DELETE', 'id' => true),
-		array('action' => 'edit', 'method' => 'POST', 'id' => true)
-	);
+	protected static $_resourceMap = [
+		'index' => ['action' => 'index', 'method' => 'GET', 'id' => false],
+		'create' => ['action' => 'add', 'method' => 'POST', 'id' => false],
+		'view' => ['action' => 'view', 'method' => 'GET', 'id' => true],
+		'update' => ['action' => 'edit', 'method' => ['PUT', 'PATCH'], 'id' => true],
+		'delete' => ['action' => 'delete', 'method' => 'DELETE', 'id' => true],
+	];
 
 /**
  * The extensions that should be set into the routes connected.
@@ -187,6 +186,8 @@ class RouteBuilder {
  *
  * - 'id' - The regular expression fragment to use when matching IDs. By default, matches
  *    integer values and UUIDs.
+ * - 'only' - Only connect the specific list of actions.
+ * - 'actions' - Override the method names used for connecting actions.
  *
  * @param string|array $name A controller name or array of controller names (i.e. "Posts" or "ListItems")
  * @param array $options Options to use when generating REST routes
@@ -201,10 +202,13 @@ class RouteBuilder {
 		}
 		$options += array(
 			'connectOptions' => [],
-			'id' => static::ID . '|' . static::UUID
+			'id' => static::ID . '|' . static::UUID,
+			'only' => ['index', 'update', 'create', 'view', 'delete'],
+			'actions' => [],
 		);
+		$options['only'] = (array)$options['only'];
+
 		$connectOptions = $options['connectOptions'];
-		unset($options['connectOptions']);
 
 		$urlName = Inflector::underscore($name);
 
@@ -213,12 +217,21 @@ class RouteBuilder {
 			$ext = $options['_ext'];
 		}
 
-		foreach (static::$_resourceMap as $params) {
+		foreach (static::$_resourceMap as $method => $params) {
+			if (!in_array($method, $options['only'], true)) {
+				continue;
+			}
+
+			$action = $params['action'];
+			if (isset($options['actions'][$method])) {
+				$action = $options['actions'][$method];
+			}
+
 			$id = $params['id'] ? ':id' : '';
 			$url = '/' . implode('/', array_filter(array($urlName, $id)));
 			$params = array(
 				'controller' => $name,
-				'action' => $params['action'],
+				'action' => $action,
 				'[method]' => $params['method'],
 				'_ext' => $ext
 			);

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -48,11 +48,11 @@ class RouteBuilder {
  * @var array
  */
 	protected static $_resourceMap = [
-		'index' => ['action' => 'index', 'method' => 'GET', 'id' => false],
-		'create' => ['action' => 'add', 'method' => 'POST', 'id' => false],
-		'view' => ['action' => 'view', 'method' => 'GET', 'id' => true],
-		'update' => ['action' => 'edit', 'method' => ['PUT', 'PATCH'], 'id' => true],
-		'delete' => ['action' => 'delete', 'method' => 'DELETE', 'id' => true],
+		'index' => ['action' => 'index', 'method' => 'GET', 'path' => ''],
+		'create' => ['action' => 'add', 'method' => 'POST', 'path' => ''],
+		'view' => ['action' => 'view', 'method' => 'GET', 'path' => ':id'],
+		'update' => ['action' => 'edit', 'method' => ['PUT', 'PATCH'], 'path' => ':id'],
+		'delete' => ['action' => 'delete', 'method' => 'DELETE', 'path' => ':id'],
 	];
 
 /**
@@ -207,7 +207,6 @@ class RouteBuilder {
 			'actions' => [],
 		);
 		$options['only'] = (array)$options['only'];
-
 		$connectOptions = $options['connectOptions'];
 
 		$urlName = Inflector::underscore($name);
@@ -227,8 +226,7 @@ class RouteBuilder {
 				$action = $options['actions'][$method];
 			}
 
-			$id = $params['id'] ? ':id' : '';
-			$url = '/' . implode('/', array_filter(array($urlName, $id)));
+			$url = '/' . implode('/', array_filter([$urlName, $params['path']]));
 			$params = array(
 				'controller' => $name,
 				'action' => $action,

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -125,20 +125,6 @@ class Router {
 	);
 
 /**
- * Default HTTP request method => controller action map.
- *
- * @var array
- */
-	protected static $_resourceMap = array(
-		array('action' => 'index', 'method' => 'GET', 'id' => false),
-		array('action' => 'view', 'method' => 'GET', 'id' => true),
-		array('action' => 'add', 'method' => 'POST', 'id' => false),
-		array('action' => 'edit', 'method' => 'PUT', 'id' => true),
-		array('action' => 'delete', 'method' => 'DELETE', 'id' => true),
-		array('action' => 'edit', 'method' => 'POST', 'id' => true)
-	);
-
-/**
  * Maintains the request object stack for the current request.
  * This will contain more than one request object when requestAction is used.
  *
@@ -174,82 +160,9 @@ class Router {
 	}
 
 /**
- * Resource map getter & setter.
- *
- * Allows you to define the default route configuration for REST routing and
- * Router::mapResources()
- *
- * @param array $resourceMap Resource map
- * @return mixed
- * @see Router::$_resourceMap
- */
-	public static function resourceMap($resourceMap = null) {
-		if ($resourceMap === null) {
-			return static::$_resourceMap;
-		}
-		static::$_resourceMap = $resourceMap;
-	}
-
-/**
  * Connects a new Route in the router.
  *
- * Routes are a way of connecting request URLs to objects in your application.
- * At their core routes are a set or regular expressions that are used to
- * match requests to destinations.
- *
- * Examples:
- *
- * `Router::connect('/:controller/:action/*');`
- *
- * The first parameter will be used as a controller name while the second is
- * used as the action name. The '/*' syntax makes this route greedy in that
- * it will match requests like `/posts/index` as well as requests
- * like `/posts/edit/1/foo/bar`.
- *
- * `Router::connect('/home-page', ['controller' => 'pages', 'action' => 'display', 'home']);`
- *
- * The above shows the use of route parameter defaults. And providing routing
- * parameters for a static route.
- *
- * {{{
- * Router::connect(
- *   '/:lang/:controller/:action/:id',
- *   [],
- *   ['id' => '[0-9]+', 'lang' => '[a-z]{3}']
- * );
- * }}}
- *
- * Shows connecting a route with custom route parameters as well as
- * providing patterns for those parameters. Patterns for routing parameters
- * do not need capturing groups, as one will be added for each route params.
- *
- * $options offers several 'special' keys that have special meaning
- * in the $options array.
- *
- * - `pass` is used to define which of the routed parameters should be shifted
- *   into the pass array. Adding a parameter to pass will remove it from the
- *   regular route array. Ex. `'pass' => array('slug')`.
- * - `routeClass` is used to extend and change how individual routes parse requests
- *   and handle reverse routing, via a custom routing class.
- *   Ex. `'routeClass' => 'SlugRoute'`
- * - `_name` is used to define a specific name for routes. This can be used to optimize
- *   reverse routing lookups. If undefined a name will be generated for each
- *   connected route.
- * - `_ext` is an array of filename extensions that will be parsed out of the url if present.
- *   See {@link Route::parseExtensions()}.
- *
- * You can also add additional conditions for matching routes to the $defaults array.
- * The following conditions can be used:
- *
- * - `[type]` Only match requests for specific content types.
- * - `[method]` Only match requests with specific HTTP verbs.
- * - `[server]` Only match when $_SERVER['SERVER_NAME'] matches the given value.
- *
- * Example of using the `[method]` condition:
- *
- * `Router::connect('/tasks', array('controller' => 'tasks', 'action' => 'index', '[method]' => 'GET'));`
- *
- * The above route will only be matched for GET requests. POST requests will fail to match this route.
+ * Compatibility proxy to \Cake\Routing\RouteBuilder::connect() in the `/` scope.
  *
  * @param string $route A string describing the template of the route
  * @param array $defaults An array describing the default route parameters. These parameters will be used by default
@@ -258,9 +171,10 @@ class Router {
  *   element should match. Also contains additional parameters such as which routed parameters should be
  *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
  *   custom routing class.
- * @see routes
  * @return void
  * @throws \Cake\Error\Exception
+ * @see \Cake\Routing\RouteBuilder::connect()
+ * @see \Cake\Routing\Router::scope()
  */
 	public static function connect($route, $defaults = [], $options = []) {
 		static::$initialized = true;
@@ -272,34 +186,15 @@ class Router {
 /**
  * Connects a new redirection Route in the router.
  *
- * Redirection routes are different from normal routes as they perform an actual
- * header redirection if a match is found. The redirection can occur within your
- * application or redirect to an outside location.
- *
- * Examples:
- *
- * `Router::redirect('/home/*', array('controller' => 'posts', 'action' => 'view'));`
- *
- * Redirects /home/* to /posts/view and passes the parameters to /posts/view. Using an array as the
- * redirect destination allows you to use other routes to define where an URL string should be redirected to.
- *
- * `Router::redirect('/posts/*', 'http://google.com', array('status' => 302));`
- *
- * Redirects /posts/* to http://google.com with a HTTP status of 302
- *
- * ### Options:
- *
- * - `status` Sets the HTTP status (default 301)
- * - `persist` Passes the params to the redirected route, if it can. This is useful with greedy routes,
- *   routes that end in `*` are greedy. As you can remap URLs and not loose any passed args.
+ * Compatibility proxy to \Cake\Routing\RouteBuilder::redirect() in the `/` scope.
  *
  * @param string $route A string describing the template of the route
  * @param array $url An URL to redirect to. Can be a string or a Cake array-based URL
  * @param array $options An array matching the named elements in the route to regular expressions which that
  *   element should match. Also contains additional parameters such as which routed parameters should be
  *   shifted into the passed arguments. As well as supplying patterns for routing parameters.
- * @see routes
  * @return array Array of routes
+ * @see \Cake\Routing\RouteBuilder::redirect()
  */
 	public static function redirect($route, $url, $options = []) {
 		$options['routeClass'] = 'Cake\Routing\Route\RedirectRoute';
@@ -311,6 +206,9 @@ class Router {
 
 /**
  * Generate REST resource routes for the given controller(s).
+ *
+ * Compatibility proxy to \Cake\Routing\RouteBuilder::resources(). Additional, compatibility
+ * around prefixes and plugins and prefixes is handled by this method.
  *
  * A quick way to generate a default routes to a set of REST resources (controller(s)).
  *
@@ -354,46 +252,36 @@ class Router {
  * @return void
  */
 	public static function mapResources($controller, $options = []) {
-		$options += array(
-			'connectOptions' => [],
-			'id' => static::ID . '|' . static::UUID
-		);
-
-		$connectOptions = $options['connectOptions'];
-		unset($options['connectOptions']);
-
 		foreach ((array)$controller as $name) {
 			list($plugin, $name) = pluginSplit($name);
-			$urlName = Inflector::underscore($name);
-			$pluginUrl = $plugin ? Inflector::underscore($plugin) : null;
-			$prefix = $ext = null;
 
+			$prefix = $pluginUrl = false;
 			if (!empty($options['prefix'])) {
 				$prefix = $options['prefix'];
 			}
-			if (!empty($options['_ext'])) {
-				$ext = $options['_ext'];
+			if ($plugin) {
+				$pluginUrl = Inflector::underscore($plugin);
 			}
 
-			foreach (static::$_resourceMap as $params) {
-				$id = $params['id'] ? ':id' : '';
-				$url = '/' . implode('/', array_filter(array($prefix, $pluginUrl, $urlName, $id)));
-				$params = array(
-					'plugin' => $plugin,
-					'controller' => $name,
-					'action' => $params['action'],
-					'[method]' => $params['method'],
-					'_ext' => $ext
-				);
-				if ($prefix) {
-					$params['prefix'] = $prefix;
-				}
-				$routeOptions = array_merge(array(
-					'id' => $options['id'],
-					'pass' => array('id')
-				), $connectOptions);
-				static::connect($url, $params, $routeOptions);
+			$callback = function($routes) use ($name, $options) {
+				$routes->resources($name, $options);
+			};
+
+			if ($plugin && $prefix) {
+				$path = '/' . implode('/', [$prefix, $pluginUrl]);
+				$params = ['prefix' => $prefix, 'plugin' => $plugin];
+				return static::scope($path, $params, $callback);
 			}
+
+			if ($prefix) {
+				return static::prefix($prefix, $callback);
+			}
+
+			if ($plugin) {
+				return static::plugin($plugin, $callback);
+			}
+
+			return static::scope('/', $callback);
 		}
 	}
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -681,6 +681,45 @@ class RouteTest extends TestCase {
 	}
 
 /**
+ * test that http header conditions can work with URL generation
+ *
+ * @return void
+ */
+	public function testMatchWithMultipleHttpMethodConditions() {
+		$route = new Route('/sample', [
+			'controller' => 'posts',
+			'action' => 'index',
+			'[method]' => ['PUT', 'POST']
+		]);
+		$url = [
+			'controller' => 'posts',
+			'action' => 'index',
+		];
+		$this->assertFalse($route->match($url));
+
+		$url = [
+			'controller' => 'posts',
+			'action' => 'index',
+			'[method]' => 'GET',
+		];
+		$this->assertFalse($route->match($url));
+
+		$url = [
+			'controller' => 'posts',
+			'action' => 'index',
+			'[method]' => 'PUT',
+		];
+		$this->assertEquals('/sample', $route->match($url));
+
+		$url = [
+			'controller' => 'posts',
+			'action' => 'index',
+			'[method]' => 'POST',
+		];
+		$this->assertEquals('/sample', $route->match($url));
+	}
+
+/**
  * Test that the [type] condition works.
  *
  * @return void

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -250,11 +250,66 @@ class RouteBuilderTest extends TestCase {
 		$routes->resources('Articles', ['_ext' => 'json']);
 
 		$all = $this->collection->routes();
-		$this->assertCount(6, $all);
+		$this->assertCount(5, $all);
 
 		$this->assertEquals('/api/articles', $all[0]->template);
 		$this->assertEquals('json', $all[0]->defaults['_ext']);
 		$this->assertEquals('Articles', $all[0]->defaults['controller']);
+	}
+
+/**
+ * Test the only option of RouteBuilder.
+ *
+ * @return void
+ */
+	public function testResourcesOnlyString() {
+		$routes = new RouteBuilder($this->collection, '/');
+		$routes->resources('Articles', ['only' => 'index']);
+
+		$result = $this->collection->routes();
+		$this->assertCount(1, $result);
+		$this->assertEquals('/articles', $result[0]->template);
+	}
+
+/**
+ * Test the only option of RouteBuilder.
+ *
+ * @return void
+ */
+	public function testResourcesOnlyArray() {
+		$routes = new RouteBuilder($this->collection, '/');
+		$routes->resources('Articles', ['only' => ['index', 'delete']]);
+
+		$result = $this->collection->routes();
+		$this->assertCount(2, $result);
+		$this->assertEquals('/articles', $result[0]->template);
+		$this->assertEquals('index', $result[0]->defaults['action']);
+		$this->assertEquals('GET', $result[0]->defaults['[method]']);
+
+		$this->assertEquals('/articles/:id', $result[1]->template);
+		$this->assertEquals('delete', $result[1]->defaults['action']);
+		$this->assertEquals('DELETE', $result[1]->defaults['[method]']);
+	}
+
+/**
+ * Test the actions option of RouteBuilder.
+ *
+ * @return void
+ */
+	public function testResourcesActions() {
+		$routes = new RouteBuilder($this->collection, '/');
+		$routes->resources('Articles', [
+			'only' => ['index', 'delete'],
+			'actions' => ['index' => 'showList']
+		]);
+
+		$result = $this->collection->routes();
+		$this->assertCount(2, $result);
+		$this->assertEquals('/articles', $result[0]->template);
+		$this->assertEquals('showList', $result[0]->defaults['action']);
+
+		$this->assertEquals('/articles/:id', $result[1]->template);
+		$this->assertEquals('delete', $result[1]->defaults['action']);
 	}
 
 /**

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -258,6 +258,45 @@ class RouteBuilderTest extends TestCase {
 	}
 
 /**
+ * Test resource parsing.
+ *
+ * @return void
+ */
+	public function testResourcesParsing() {
+		$routes = new RouteBuilder($this->collection, '/');
+		$routes->resources('Articles');
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$result = $this->collection->parse('/articles');
+		$this->assertEquals('Articles', $result['controller']);
+		$this->assertEquals('index', $result['action']);
+		$this->assertEquals([], $result['pass']);
+
+		$result = $this->collection->parse('/articles/1');
+		$this->assertEquals('Articles', $result['controller']);
+		$this->assertEquals('view', $result['action']);
+		$this->assertEquals([1], $result['pass']);
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$result = $this->collection->parse('/articles');
+		$this->assertEquals('Articles', $result['controller']);
+		$this->assertEquals('add', $result['action']);
+		$this->assertEquals([], $result['pass']);
+
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$result = $this->collection->parse('/articles/1');
+		$this->assertEquals('Articles', $result['controller']);
+		$this->assertEquals('edit', $result['action']);
+		$this->assertEquals([1], $result['pass']);
+
+		$_SERVER['REQUEST_METHOD'] = 'DELETE';
+		$result = $this->collection->parse('/articles/1');
+		$this->assertEquals('Articles', $result['controller']);
+		$this->assertEquals('delete', $result['action']);
+		$this->assertEquals([1], $result['pass']);
+	}
+
+/**
  * Test the only option of RouteBuilder.
  *
  * @return void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -154,7 +154,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'edit',
 			'id' => '13',
-			'[method]' => 'PUT',
+			'[method]' => ['PUT', 'PATCH'],
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/13');
@@ -166,7 +166,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'edit',
 			'id' => '475acc39-a328-44d3-95fb-015000000000',
-			'[method]' => 'PUT',
+			'[method]' => ['PUT', 'PATCH'],
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
@@ -208,7 +208,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'edit',
 			'id' => 'name',
-			'[method]' => 'PUT',
+			'[method]' => ['PUT', 'PATCH'],
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/name');
@@ -425,7 +425,7 @@ class RouterTest extends TestCase {
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(['controller' => 'Posts', 'action' => 'edit', '[method]' => 'POST', 'id' => 10]);
+		$result = Router::url(['controller' => 'Posts', 'action' => 'edit', '[method]' => 'PATCH', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 	}
@@ -2506,37 +2506,6 @@ class RouterTest extends TestCase {
 		$routes = Router::routes();
 		$route = $routes[0];
 		$this->assertInstanceOf('Cake\Routing\Route\RedirectRoute', $route);
-	}
-
-/**
- * Tests resourceMap as getter and setter.
- *
- * @return void
- */
-	public function testResourceMap() {
-		$default = Router::resourceMap();
-		$expected = array(
-			array('action' => 'index', 'method' => 'GET', 'id' => false),
-			array('action' => 'view', 'method' => 'GET', 'id' => true),
-			array('action' => 'add', 'method' => 'POST', 'id' => false),
-			array('action' => 'edit', 'method' => 'PUT', 'id' => true),
-			array('action' => 'delete', 'method' => 'DELETE', 'id' => true),
-			array('action' => 'edit', 'method' => 'POST', 'id' => true)
-		);
-		$this->assertEquals($expected, $default);
-
-		$custom = array(
-			array('action' => 'index', 'method' => 'GET', 'id' => false),
-			array('action' => 'view', 'method' => 'GET', 'id' => true),
-			array('action' => 'add', 'method' => 'POST', 'id' => false),
-			array('action' => 'edit', 'method' => 'PUT', 'id' => true),
-			array('action' => 'delete', 'method' => 'DELETE', 'id' => true),
-			array('action' => 'update', 'method' => 'POST', 'id' => true)
-		);
-		Router::resourceMap($custom);
-		$this->assertEquals(Router::resourceMap(), $custom);
-
-		Router::resourceMap($default);
 	}
 
 /**


### PR DESCRIPTION
This is the first set of changes for #3962. It adds the `only` and `actions` options to `resources()`. I've also removed the duplicated code between Router and RouteBuilder with these changes, and fixed a bug where routes matching multiple HTTP methods could never be reverse routed in a sane way.

I'm also considering renaming `[method]` to `_method` as it would be more consistent with other special routing options like `_ssl`. and `_host`.
