### PR TITLE
Solution to no div = false option

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -104,6 +104,7 @@ class FormHelper extends Helper {
 			'radioWrapper' => '{{input}}{{label}}',
 			'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
 			'submitContainer' => '<div class="submit">{{content}}</div>',
+			'raw' => '{{label}}{{input}}'
 		]
 	];
 
@@ -884,7 +885,8 @@ class FormHelper extends Helper {
 			'error' => null,
 			'required' => null,
 			'options' => null,
-			'templates' => []
+			'templates' => [],
+			'div' => true
 		];
 		$options = $this->_parseOptions($fieldName, $options);
 		$options += ['id' => $this->_domId($fieldName)];
@@ -922,16 +924,18 @@ class FormHelper extends Helper {
 		}
 
 		$label = $this->_getLabel($fieldName, compact('input', 'label', 'error') + $options);
-
-		$groupTemplate = $options['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
-		$result = $this->formatTemplate($groupTemplate, compact('input', 'label', 'error'));
-		$result = $this->formatTemplate($template, [
-			'content' => $result,
-			'error' => $error,
-			'required' => $options['required'] ? ' required' : '',
-			'type' => $options['type'],
-		]);
-
+		if($options['div']===true){
+			$groupTemplate = $options['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
+			$result = $this->formatTemplate($groupTemplate, compact('input', 'label', 'error'));
+			$result = $this->formatTemplate($template, [
+				'content' => $result,
+				'error' => $error,
+				'required' => $options['required'] ? ' required' : '',
+				'type' => $options['type'],
+			]);
+		} else {
+	            $result = $this->formatTemplate('raw', compact('input', 'label'));
+	        }
 		if ($newTemplates) {
 			$this->templates($originalTemplates);
 		}


### PR DESCRIPTION
The new template system is great but lacks the ability to return the raw input field since the group template is wrapped around the field inside the form helper. Changing the template changes all the inputs instead of just the one you need to modify. This makes it really complicated to omit the div of one element while retaining it on all the others. The proposed changes allows you to pass div = false as before to remove the wrapping div.
