### PR TITLE
Make the error message better for fixture errors

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -289,7 +289,7 @@ class CakeTestFixture {
 				foreach ($this->records as $record) {
 					$merge = array_values(array_merge($default, $record));
 					if (count($fields) !== count($merge)) {
-						throw new CakeException('Fixture invalid: Count of fields does not match count of values');
+						throw new CakeException('Fixture invalid: Count of fields does not match count of values in ' . get_class($this));
 					}
 					$values[] = $merge;
 				}


### PR DESCRIPTION
The stack trace has no details about which fixture is the actual problem.
