### PR TITLE
Fix relative path resolution in View.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -850,19 +850,38 @@ class View {
 					return $name;
 				}
 				$name = trim($name, DS);
-			} elseif ($name[0] === '.') {
-				$name = $this->viewPath . DS . $subDir . $name;
 			} elseif (!$plugin || $this->viewPath !== $this->name) {
 				$name = $this->viewPath . DS . $subDir . $name;
 			}
 		}
-		$paths = $this->_paths($plugin);
-		foreach ($paths as $path) {
+
+		foreach ($this->_paths($plugin) as $path) {
 			if (file_exists($path . $name . $this->_ext)) {
-				return $path . $name . $this->_ext;
+				return $this->_checkFilePath($path . $name . $this->_ext, $path);
 			}
 		}
 		throw new Error\MissingViewException(array('file' => $name . $this->_ext));
+	}
+
+/**
+ * Check that a view file path does not go outside of the defined template paths.
+ *
+ * Only paths that contain `..` will be checked, as they are the ones most likely to
+ * have the ability to resolve to files outside of the template paths.
+ *
+ * @param string $file The path to the template file.
+ * @param string $path Base path that $file should be inside of.
+ * @return string The file path
+ */
+	protected function _checkFilePath($file, $path) {
+		if (strpos($file, '..') === false) {
+			return $file;
+		}
+		$absolute = realpath($file);
+		if (strpos($absolute, $path) !== 0) {
+			throw new Error\MissingViewException(array('file' => $file));
+		}
+		return $absolute;
 	}
 
 /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -923,7 +923,6 @@ class View {
 			$subDir = $this->layoutPath . DS;
 		}
 		list($plugin, $name) = $this->pluginSplit($name);
-		$paths = $this->_paths($plugin);
 
 		$layoutPaths = ['Layout' . DS . $subDir];
 		if (!empty($this->request->params['prefix'])) {
@@ -933,10 +932,11 @@ class View {
 			);
 		}
 
-		foreach ($paths as $path) {
+		foreach ($this->_paths($plugin) as $path) {
 			foreach ($layoutPaths as $layoutPath) {
-				if (file_exists($path . $layoutPath . $name . $this->_ext)) {
-					return $path . $layoutPath . $name . $this->_ext;
+				$currentPath = $path . $layoutPath;
+				if (file_exists($currentPath . $name . $this->_ext)) {
+					return $this->_checkFilePath($currentPath . $name . $this->_ext, $currentPath);
 				}
 			}
 		}

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -872,6 +872,7 @@ class View {
  * @param string $file The path to the template file.
  * @param string $path Base path that $file should be inside of.
  * @return string The file path
+ * @throws \Cake\Error\Exception
  */
 	protected function _checkFilePath($file, $path) {
 		if (strpos($file, '..') === false) {
@@ -879,7 +880,8 @@ class View {
 		}
 		$absolute = realpath($file);
 		if (strpos($absolute, $path) !== 0) {
-			throw new Error\MissingViewException(array('file' => $file));
+			$msg = sprintf('Cannot use "%s" as a template, it is not within any view template path.', $file);
+			throw new Exception($msg);
 		}
 		return $absolute;
 	}

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -851,7 +851,7 @@ class View {
 				}
 				$name = trim($name, DS);
 			} elseif ($name[0] === '.') {
-				$name = substr($name, 3);
+				$name = $this->viewPath . DS . $subDir . $name;
 			} elseif (!$plugin || $this->viewPath !== $this->name) {
 				$name = $this->viewPath . DS . $subDir . $name;
 			}

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -614,6 +614,26 @@ class ViewTest extends TestCase {
 	}
 
 /**
+ * Test that getLayoutFileName() protects against malicious directory traversal.
+ *
+ * @expectedException Cake\View\Error\MissingViewException
+ * @return void
+ */
+	public function testGetLayoutFileNameDirectoryTraversal() {
+		$viewOptions = [
+			'plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages',
+		];
+		$request = $this->getMock('Cake\Network\Request');
+		$response = $this->getMock('Cake\Network\Response');
+
+		$view = new TestView(null, null, null, $viewOptions);
+		$view->ext('.php');
+		$view->getLayoutFileName('../../../../bootstrap');
+	}
+
+/**
  * Test for missing views
  *
  * @expectedException \Cake\View\Error\MissingViewException

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -492,7 +492,7 @@ class ViewTest extends TestCase {
 		$result = $View->getViewFileName('/Posts/index');
 		$this->assertPathEquals($expected, $result);
 
-		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
+		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . '..' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
 		$this->assertPathEquals($expected, $result);
 
@@ -1127,7 +1127,7 @@ class ViewTest extends TestCase {
 		$result = $View->getViewFileName('../Element/test_element');
 		$this->assertRegExp('/Element(\/|\\\)test_element.ctp/', $result);
 
-		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
+		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . '..' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
 		$this->assertPathEquals($expected, $result);
 	}

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -132,12 +132,13 @@ class TestView extends View {
 	}
 
 /**
- * Test only function to return instance scripts.
+ * Setter for extension.
  *
- * @return array Scripts
+ * @param string $ext The extension
+ * @return void
  */
-	public function scripts() {
-		return $this->_scripts;
+	public function ext($ext) {
+		$this->_ext = $ext;
 	}
 
 }
@@ -475,7 +476,8 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testGetViewFileNames() {
-		$viewOptions = ['plugin' => null,
+		$viewOptions = [
+			'plugin' => null,
 			'name' => 'Pages',
 			'viewPath' => 'Pages'
 		];
@@ -492,7 +494,7 @@ class ViewTest extends TestCase {
 		$result = $View->getViewFileName('/Posts/index');
 		$this->assertPathEquals($expected, $result);
 
-		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . '..' . DS . 'Posts' . DS . 'index.ctp';
+		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
 		$this->assertPathEquals($expected, $result);
 
@@ -510,6 +512,26 @@ class ViewTest extends TestCase {
 			'Template' . DS . 'Tests' . DS . 'index.ctp';
 		$result = $View->getViewFileName('TestPlugin.index');
 		$this->assertPathEquals($expected, $result);
+	}
+
+/**
+ * Test that getViewFileName() protects against malicious directory traversal.
+ *
+ * @expectedException Cake\View\Error\MissingViewException
+ * @return void
+ */
+	public function testGetViewFileNameDirectoryTraversal() {
+		$viewOptions = [
+			'plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages',
+		];
+		$request = $this->getMock('Cake\Network\Request');
+		$response = $this->getMock('Cake\Network\Response');
+
+		$view = new TestView(null, null, null, $viewOptions);
+		$view->ext('.php');
+		$view->getViewFileName('../../../../bootstrap');
 	}
 
 /**
@@ -1127,7 +1149,7 @@ class ViewTest extends TestCase {
 		$result = $View->getViewFileName('../Element/test_element');
 		$this->assertRegExp('/Element(\/|\\\)test_element.ctp/', $result);
 
-		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . '..' . DS . 'Posts' . DS . 'index.ctp';
+		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
 		$this->assertPathEquals($expected, $result);
 	}

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -517,7 +517,7 @@ class ViewTest extends TestCase {
 /**
  * Test that getViewFileName() protects against malicious directory traversal.
  *
- * @expectedException Cake\View\Error\MissingViewException
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testGetViewFileNameDirectoryTraversal() {
@@ -616,7 +616,7 @@ class ViewTest extends TestCase {
 /**
  * Test that getLayoutFileName() protects against malicious directory traversal.
  *
- * @expectedException Cake\View\Error\MissingViewException
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testGetLayoutFileNameDirectoryTraversal() {


### PR DESCRIPTION
Relative paths in view file names where handled very poorly before when subdirectories were involved. This was not very important in 2.x but is more important for 3.x as we have Cells and relative paths should work
properly.

Refs #3945
