### PR TITLE
Rename [method] to _method.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -79,16 +79,6 @@ class Route {
 	protected $_name = null;
 
 /**
- * HTTP header shortcut map. Used for evaluating header-based route expressions.
- *
- * @var array
- */
-	protected $_headerMap = [
-		'type' => 'content_type',
-		'server' => 'server_name'
-	];
-
-/**
  * List of connected extensions for this route.
  *
  * @var array
@@ -283,29 +273,6 @@ class Route {
 			}
 		}
 
-		foreach ($this->defaults as $key => $val) {
-			$key = (string)$key;
-			if ($key[0] === '[' && preg_match('/^\[(\w+)\]$/', $key, $header)) {
-				if (isset($this->_headerMap[$header[1]])) {
-					$header = $this->_headerMap[$header[1]];
-				} else {
-					$header = 'http_' . $header[1];
-				}
-				$header = strtoupper($header);
-
-				$val = (array)$val;
-				$h = false;
-
-				foreach ($val as $v) {
-					if ($request->env($header) === $v) {
-						$h = true;
-					}
-				}
-				if (!$h) {
-					return false;
-				}
-			}
-		}
 		array_shift($route);
 		$count = count($this->keys);
 		for ($i = 0; $i <= $count; $i++) {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -230,7 +230,7 @@ class RouteBuilder {
 			$params = array(
 				'controller' => $name,
 				'action' => $action,
-				'[method]' => $params['method'],
+				'_method' => $params['method'],
 				'_ext' => $ext
 			);
 			$routeOptions = $connectOptions + [
@@ -294,17 +294,17 @@ class RouteBuilder {
  *   connected route.
  * - `_ext` is an array of filename extensions that will be parsed out of the url if present.
  *   See {@link ScopedRouteCollection::extensions()}.
+ * - `_method` Only match requests with specific HTTP verbs.
  *
  * You can also add additional conditions for matching routes to the $defaults array.
  * The following conditions can be used:
  *
  * - `[type]` Only match requests for specific content types.
- * - `[method]` Only match requests with specific HTTP verbs.
  * - `[server]` Only match when $_SERVER['SERVER_NAME'] matches the given value.
  *
- * Example of using the `[method]` condition:
+ * Example of using the `_method` condition:
  *
- * `$routes->connect('/tasks', array('controller' => 'Tasks', 'action' => 'index', '[method]' => 'GET'));`
+ * `$routes->connect('/tasks', array('controller' => 'Tasks', 'action' => 'index', '_method' => 'GET'));`
  *
  * The above route will only be matched for GET requests. POST requests will fail to match this route.
  *

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -296,12 +296,6 @@ class RouteBuilder {
  *   See {@link ScopedRouteCollection::extensions()}.
  * - `_method` Only match requests with specific HTTP verbs.
  *
- * You can also add additional conditions for matching routes to the $defaults array.
- * The following conditions can be used:
- *
- * - `[type]` Only match requests for specific content types.
- * - `[server]` Only match when $_SERVER['SERVER_NAME'] matches the given value.
- *
  * Example of using the `_method` condition:
  *
  * `$routes->connect('/tasks', array('controller' => 'Tasks', 'action' => 'index', '_method' => 'GET'));`

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -720,38 +720,6 @@ class RouteTest extends TestCase {
 	}
 
 /**
- * Test that the [type] condition works.
- *
- * @return void
- */
-	public function testParseWithContentTypeCondition() {
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		unset($_SERVER['CONTENT_TYPE']);
-		$route = new Route('/sample', [
-			'controller' => 'posts',
-			'action' => 'index',
-			'_method' => 'POST',
-			'[type]' => 'application/xml'
-		]);
-		$this->assertFalse($route->parse('/sample'), 'No content type set.');
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['CONTENT_TYPE'] = 'application/json';
-		$this->assertFalse($route->parse('/sample'), 'Wrong content type set.');
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['CONTENT_TYPE'] = 'application/xml';
-		$expected = [
-			'controller' => 'posts',
-			'action' => 'index',
-			'pass' => [],
-			'_method' => 'POST',
-			'[type]' => 'application/xml',
-		];
-		$this->assertEquals($expected, $route->parse('/sample'));
-	}
-
-/**
  * Check [method] compatibility.
  *
  * @return void

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -643,7 +643,7 @@ class RouteTest extends TestCase {
  */
 	public function testParseWithHttpHeaderConditions() {
 		$_SERVER['REQUEST_METHOD'] = 'GET';
-		$route = new Route('/sample', ['controller' => 'posts', 'action' => 'index', '[method]' => 'POST']);
+		$route = new Route('/sample', ['controller' => 'posts', 'action' => 'index', '_method' => 'POST']);
 		$this->assertFalse($route->parse('/sample'));
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
@@ -651,7 +651,7 @@ class RouteTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'index',
 			'pass' => [],
-			'[method]' => 'POST',
+			'_method' => 'POST',
 		];
 		$this->assertEquals($expected, $route->parse('/sample'));
 	}
@@ -666,7 +666,7 @@ class RouteTest extends TestCase {
 		$route = new Route('/sample', [
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => ['PUT', 'POST']
+			'_method' => ['PUT', 'POST']
 		]);
 		$this->assertFalse($route->parse('/sample'));
 
@@ -675,7 +675,7 @@ class RouteTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'index',
 			'pass' => [],
-			'[method]' => ['PUT', 'POST'],
+			'_method' => ['PUT', 'POST'],
 		];
 		$this->assertEquals($expected, $route->parse('/sample'));
 	}
@@ -689,7 +689,7 @@ class RouteTest extends TestCase {
 		$route = new Route('/sample', [
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => ['PUT', 'POST']
+			'_method' => ['PUT', 'POST']
 		]);
 		$url = [
 			'controller' => 'posts',
@@ -700,21 +700,21 @@ class RouteTest extends TestCase {
 		$url = [
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 		];
 		$this->assertFalse($route->match($url));
 
 		$url = [
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => 'PUT',
+			'_method' => 'PUT',
 		];
 		$this->assertEquals('/sample', $route->match($url));
 
 		$url = [
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => 'POST',
+			'_method' => 'POST',
 		];
 		$this->assertEquals('/sample', $route->match($url));
 	}
@@ -730,7 +730,7 @@ class RouteTest extends TestCase {
 		$route = new Route('/sample', [
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => 'POST',
+			'_method' => 'POST',
 			'[type]' => 'application/xml'
 		]);
 		$this->assertFalse($route->parse('/sample'), 'No content type set.');
@@ -745,10 +745,37 @@ class RouteTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'index',
 			'pass' => [],
-			'[method]' => 'POST',
+			'_method' => 'POST',
 			'[type]' => 'application/xml',
 		];
 		$this->assertEquals($expected, $route->parse('/sample'));
+	}
+
+/**
+ * Check [method] compatibility.
+ *
+ * @return void
+ */
+	public function testMethodCompatibility() {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$route = new Route('/sample', [
+			'controller' => 'Articles',
+			'action' => 'index',
+			'[method]' => 'POST',
+		]);
+		$url = [
+			'controller' => 'Articles',
+			'action' => 'index',
+			'_method' => 'POST',
+		];
+		$this->assertEquals('/sample', $route->match($url));
+
+		$url = [
+			'controller' => 'Articles',
+			'action' => 'index',
+			'[method]' => 'POST',
+		];
+		$this->assertEquals('/sample', $route->match($url));
 	}
 
 /**

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -323,11 +323,11 @@ class RouteBuilderTest extends TestCase {
 		$this->assertCount(2, $result);
 		$this->assertEquals('/articles', $result[0]->template);
 		$this->assertEquals('index', $result[0]->defaults['action']);
-		$this->assertEquals('GET', $result[0]->defaults['[method]']);
+		$this->assertEquals('GET', $result[0]->defaults['_method']);
 
 		$this->assertEquals('/articles/:id', $result[1]->template);
 		$this->assertEquals('delete', $result[1]->defaults['action']);
-		$this->assertEquals('DELETE', $result[1]->defaults['[method]']);
+		$this->assertEquals('DELETE', $result[1]->defaults['_method']);
 	}
 
 /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -116,7 +116,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'Posts',
 			'action' => 'index',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		];
 		$result = Router::parse('/posts');
@@ -129,7 +129,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'view',
 			'id' => '13',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/13');
@@ -141,7 +141,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'Posts',
 			'action' => 'add',
-			'[method]' => 'POST',
+			'_method' => 'POST',
 			'_ext' => null
 		];
 		$result = Router::parse('/posts');
@@ -154,7 +154,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'edit',
 			'id' => '13',
-			'[method]' => ['PUT', 'PATCH'],
+			'_method' => ['PUT', 'PATCH'],
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/13');
@@ -166,7 +166,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'edit',
 			'id' => '475acc39-a328-44d3-95fb-015000000000',
-			'[method]' => ['PUT', 'PATCH'],
+			'_method' => ['PUT', 'PATCH'],
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
@@ -179,7 +179,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'delete',
 			'id' => '13',
-			'[method]' => 'DELETE',
+			'_method' => 'DELETE',
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/13');
@@ -195,7 +195,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'view',
 			'id' => 'add',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/add');
@@ -208,7 +208,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'edit',
 			'id' => 'name',
-			'[method]' => ['PUT', 'PATCH'],
+			'_method' => ['PUT', 'PATCH'],
 			'_ext' => null
 		];
 		$result = Router::parse('/posts/name');
@@ -230,7 +230,7 @@ class RouterTest extends TestCase {
 			'plugin' => 'TestPlugin',
 			'controller' => 'TestPlugin',
 			'action' => 'index',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
@@ -243,7 +243,7 @@ class RouterTest extends TestCase {
 			'controller' => 'TestPlugin',
 			'action' => 'view',
 			'id' => '13',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
@@ -266,7 +266,7 @@ class RouterTest extends TestCase {
 			'action' => 'index',
 			'pass' => [],
 			'prefix' => 'api',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
@@ -288,7 +288,7 @@ class RouterTest extends TestCase {
 			'controller' => 'Posts',
 			'action' => 'index',
 			'pass' => [],
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => 'json',
 		);
 
@@ -336,7 +336,7 @@ class RouterTest extends TestCase {
 			'controller' => 'TestPlugin',
 			'prefix' => 'api',
 			'action' => 'index',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
@@ -350,7 +350,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'Posts',
 			'action' => 'index',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'prefix' => 'api',
 			'_ext' => null
 		);
@@ -363,7 +363,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testMultipleResourceRoute() {
-		Router::connect('/:controller', array('action' => 'index', '[method]' => array('GET', 'POST')));
+		Router::connect('/:controller', array('action' => 'index', '_method' => array('GET', 'POST')));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
@@ -372,7 +372,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => array('GET', 'POST')
+			'_method' => array('GET', 'POST')
 		);
 		$this->assertEquals($expected, $result);
 
@@ -383,7 +383,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
-			'[method]' => array('GET', 'POST')
+			'_method' => array('GET', 'POST')
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -399,7 +399,7 @@ class RouterTest extends TestCase {
 		$result = Router::url([
 			'controller' => 'Posts',
 			'action' => 'index',
-			'[method]' => 'GET'
+			'_method' => 'GET'
 		]);
 		$expected = '/posts';
 		$this->assertEquals($expected, $result);
@@ -407,25 +407,25 @@ class RouterTest extends TestCase {
 		$result = Router::url([
 			'controller' => 'Posts',
 			'action' => 'view',
-			'[method]' => 'GET',
+			'_method' => 'GET',
 			'id' => 10
 		]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(['controller' => 'Posts', 'action' => 'add', '[method]' => 'POST']);
+		$result = Router::url(['controller' => 'Posts', 'action' => 'add', '_method' => 'POST']);
 		$expected = '/posts';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(['controller' => 'Posts', 'action' => 'edit', '[method]' => 'PUT', 'id' => 10]);
+		$result = Router::url(['controller' => 'Posts', 'action' => 'edit', '_method' => 'PUT', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(['controller' => 'Posts', 'action' => 'delete', '[method]' => 'DELETE', 'id' => 10]);
+		$result = Router::url(['controller' => 'Posts', 'action' => 'delete', '_method' => 'DELETE', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(['controller' => 'Posts', 'action' => 'edit', '[method]' => 'PATCH', 'id' => 10]);
+		$result = Router::url(['controller' => 'Posts', 'action' => 'edit', '_method' => 'PATCH', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
This makes the more commonly used `_method` option congruent with other 'special keys' like _ssl and _host.

Include some backwards compatibility for creating routes, and generating URLs. Part of #3962.
