### PR TITLE
Add a more helpful error message when the transport is undefined.

### DIFF
--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1227,7 +1227,7 @@ class Email {
 		$transport = $this->transport();
 		if (!$transport) {
 			$msg = 'Cannot send email, transport was not defined. Did you call transport() or define ' .
-				 ' a transport in the set profile?';
+				' a transport in the set profile?';
 			throw new Error\SocketException($msg);
 		}
 		$contents = $transport->send($this);

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1224,25 +1224,42 @@ class Email {
 
 		$this->_message = $this->_render($this->_wrap($content));
 
-		$contents = $this->transport()->send($this);
-		if (!empty($this->_profile['log'])) {
-			$config = [
-				'level' => LOG_DEBUG,
-				'scope' => 'email'
-			];
-			if ($this->_profile['log'] !== true) {
-				if (!is_array($this->_profile['log'])) {
-					$this->_profile['log'] = ['level' => $this->_profile['log']];
-				}
-				$config = $this->_profile['log'] + $config;
-			}
-			Log::write(
-				$config['level'],
-				PHP_EOL . $contents['headers'] . PHP_EOL . $contents['message'],
-				$config['scope']
-			);
+		$transport = $this->transport();
+		if (!$transport) {
+			$msg = 'Cannot send email, transport was not defined. Did you call transport() or define ' .
+				 ' a transport in the set profile?';
+			throw new Error\SocketException($msg);
 		}
+		$contents = $transport->send($this);
+		$this->_logDelivery($contents);
 		return $contents;
+	}
+
+/**
+ * Log the email message delivery.
+ *
+ * @param array $contents The content with 'headers' and 'message' keys.
+ * @return void
+ */
+	protected function _logDelivery($contents) {
+		if (empty($this->_profile['log'])) {
+			return;
+		}
+		$config = [
+			'level' => LOG_DEBUG,
+			'scope' => 'email'
+		];
+		if ($this->_profile['log'] !== true) {
+			if (!is_array($this->_profile['log'])) {
+				$this->_profile['log'] = ['level' => $this->_profile['log']];
+			}
+			$config = $this->_profile['log'] + $config;
+		}
+		Log::write(
+			$config['level'],
+			PHP_EOL . $contents['headers'] . PHP_EOL . $contents['message'],
+			$config['scope']
+		);
 	}
 
 /**

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -1019,6 +1019,7 @@ class EmailTest extends TestCase {
 /**
  * testSendWithoutFrom method
  *
+ * @expectedException Cake\Network\Error\SocketException
  * @return void
  */
 	public function testSendWithoutFrom() {
@@ -1026,13 +1027,13 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
 		$this->CakeEmail->profile(array('empty'));
-		$this->setExpectedException('Cake\Network\Error\SocketException');
 		$this->CakeEmail->send("Forgot to set From");
 	}
 
 /**
  * testSendWithoutTo method
  *
+ * @expectedException Cake\Network\Error\SocketException
  * @return void
  */
 	public function testSendWithoutTo() {
@@ -1040,7 +1041,20 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
 		$this->CakeEmail->profile(array('empty'));
-		$this->setExpectedException('Cake\Network\Error\SocketException');
+		$this->CakeEmail->send("Forgot to set To");
+	}
+
+/**
+ * test send without a transport method
+ *
+ * @expectedException Cake\Network\Error\SocketException
+ * @expectedExceptionMessage Cannot send email, transport was not defined.
+ * @return void
+ */
+	public function testSendWithoutTransport() {
+		$this->CakeEmail->to('cake@cakephp.org');
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->subject('My title');
 		$this->CakeEmail->send("Forgot to set To");
 	}
 


### PR DESCRIPTION
When creating a profile with no transport, or just not setting a transport fatal errors were emitted. A proper exception seems nicer.

Refs #3982
