### PR TITLE
3.0 - Persistent SMTP connections

### DIFF
--- a/src/Network/Email/SmtpTransport.php
+++ b/src/Network/Email/SmtpTransport.php
@@ -35,7 +35,6 @@ class SmtpTransport extends AbstractTransport {
 		'password' => null,
 		'client' => null,
 		'tls' => false,
-		'autoDisconnect' => true,
 		'keepAlive' => false
 	];
 
@@ -70,15 +69,13 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Destructor
  *
- * Tries to disconnect in case `autoDisconnect` is enabled.
+ * Tries to disconnect to ensure that the connection is being
+ * terminated properly before the socket gets closed.
  */
 	public function __destruct() {
 		try {
-			if ($this->_config['autoDisconnect']) {
-				$this->disconnect();
-			}
-		}
-		catch (\Exception $e) { // avoid fatal error on script termination
+			$this->disconnect();
+		} catch (\Exception $e) { // avoid fatal error on script termination
 		}
 	}
 

--- a/src/Network/Email/SmtpTransport.php
+++ b/src/Network/Email/SmtpTransport.php
@@ -90,6 +90,7 @@ class SmtpTransport extends AbstractTransport {
 	public function connect() {
 		if (!$this->connected()) {
 			$this->_connect();
+			$this->_auth();
 		}
 	}
 

--- a/tests/TestCase/Network/Email/SmtpTransportTest.php
+++ b/tests/TestCase/Network/Email/SmtpTransportTest.php
@@ -464,7 +464,6 @@ class SmtpTransportTest extends TestCase {
  * @return void
  */
 	public function testAutoDisconnect() {
-		$this->SmtpTransport->config(array('autoDisconnect' => true));
 		$this->socket->expects($this->at(0))->method('write')->with("QUIT\r\n");
 		$this->socket->connected = true;
 		unset($this->SmtpTransport);
@@ -476,34 +475,12 @@ class SmtpTransportTest extends TestCase {
  * @return void
  */
 	public function testKeepAlive() {
-		$this->SmtpTransport->config(array('keepAlive' => true, 'autoDisconnect' => false));
+		$this->SmtpTransport->config(array('keepAlive' => true));
 
 		$email = $this->getMock('Cake\Network\Email\Email', array('message'));
 		$email->from('noreply@cakephp.org', 'CakePHP Test');
 		$email->to('cake@cakephp.org', 'CakePHP');
-		$email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
-		$email->subject('Testing SMTP');
-		$date = date(DATE_RFC2822);
-		$email->setHeaders(array('X-Mailer' => Email::EMAIL_CLIENT, 'Date' => $date));
-		$email->expects($this->exactly(2))
-			->method('message')
-			->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
-
-		$data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
-		$data .= "To: CakePHP <cake@cakephp.org>\r\n";
-		$data .= "X-Mailer: CakePHP Email\r\n";
-		$data .= "Date: " . $date . "\r\n";
-		$data .= "Message-ID: <4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>\r\n";
-		$data .= "Subject: Testing SMTP\r\n";
-		$data .= "MIME-Version: 1.0\r\n";
-		$data .= "Content-Type: text/plain; charset=UTF-8\r\n";
-		$data .= "Content-Transfer-Encoding: 8bit\r\n";
-		$data .= "\r\n";
-		$data .= "First Line\r\n";
-		$data .= "Second Line\r\n";
-		$data .= "..Third Line\r\n"; // RFC5321 4.5.2.Transparency
-		$data .= "\r\n";
-		$data .= "\r\n\r\n.\r\n";
+		$email->expects($this->exactly(2))->method('message')->will($this->returnValue(array('First Line')));
 
 		$this->socket->expects($this->never())->method('disconnect');
 
@@ -524,7 +501,7 @@ class SmtpTransportTest extends TestCase {
 		$this->socket->expects($this->at(12))->method('write')->with("DATA\r\n");
 		$this->socket->expects($this->at(13))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(14))->method('read')->will($this->returnValue("354 OK\r\n"));
-		$this->socket->expects($this->at(15))->method('write')->with($data);
+		$this->socket->expects($this->at(15))->method('write')->with($this->stringContains('First Line'));
 		$this->socket->expects($this->at(16))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(17))->method('read')->will($this->returnValue("250 OK\r\n"));
 
@@ -542,7 +519,7 @@ class SmtpTransportTest extends TestCase {
 		$this->socket->expects($this->at(27))->method('write')->with("DATA\r\n");
 		$this->socket->expects($this->at(28))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(29))->method('read')->will($this->returnValue("354 OK\r\n"));
-		$this->socket->expects($this->at(30))->method('write')->with($data);
+		$this->socket->expects($this->at(15))->method('write')->with($this->stringContains('First Line'));
 		$this->socket->expects($this->at(31))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(32))->method('read')->will($this->returnValue("250 OK\r\n"));
 
@@ -560,29 +537,7 @@ class SmtpTransportTest extends TestCase {
 		$email = $this->getMock('Cake\Network\Email\Email', array('message'));
 		$email->from('noreply@cakephp.org', 'CakePHP Test');
 		$email->to('cake@cakephp.org', 'CakePHP');
-		$email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
-		$email->subject('Testing SMTP');
-		$date = date(DATE_RFC2822);
-		$email->setHeaders(array('X-Mailer' => Email::EMAIL_CLIENT, 'Date' => $date));
-		$email->expects($this->once())
-			->method('message')
-			->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
-
-		$data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
-		$data .= "To: CakePHP <cake@cakephp.org>\r\n";
-		$data .= "X-Mailer: CakePHP Email\r\n";
-		$data .= "Date: " . $date . "\r\n";
-		$data .= "Message-ID: <4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>\r\n";
-		$data .= "Subject: Testing SMTP\r\n";
-		$data .= "MIME-Version: 1.0\r\n";
-		$data .= "Content-Type: text/plain; charset=UTF-8\r\n";
-		$data .= "Content-Transfer-Encoding: 8bit\r\n";
-		$data .= "\r\n";
-		$data .= "First Line\r\n";
-		$data .= "Second Line\r\n";
-		$data .= "..Third Line\r\n"; // RFC5321 4.5.2.Transparency
-		$data .= "\r\n";
-		$data .= "\r\n\r\n.\r\n";
+		$email->expects($this->once())->method('message')->will($this->returnValue(array('First Line')));
 
 		$this->socket->expects($this->at(0))->method('connect')->will($this->returnValue(true));
 
@@ -602,7 +557,7 @@ class SmtpTransportTest extends TestCase {
 		$this->socket->expects($this->at(12))->method('write')->with("DATA\r\n");
 		$this->socket->expects($this->at(13))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(14))->method('read')->will($this->returnValue("354 OK\r\n"));
-		$this->socket->expects($this->at(15))->method('write')->with($data);
+		$this->socket->expects($this->at(15))->method('write')->with($this->stringContains('First Line'));
 		$this->socket->expects($this->at(16))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(17))->method('read')->will($this->returnValue("250 OK\r\n"));
 
@@ -610,4 +565,5 @@ class SmtpTransportTest extends TestCase {
 
 		$this->SmtpTransport->send($email);
 	}
+
 }


### PR DESCRIPTION
As already mentioned in #3013, I'd like to suggest support for persistent SMTP connections. They are especially useful when batch sending mails (newsletters, mailing lists, notifications, etc...), as most hosters do apply certain rate limiting like a maximum of x connections per y time.

Contrary to how it's done in the `Socket` class, this patch introduces a `connected()` method to test for an active connection. I think it's cleaner and easier to test/mock if necessary, and I'm wondering if it would be a good idea to expose something similar on the `Socket` class too, ie wrap `$connected` into a method?

I'm not sure if there are any conventions regarding this, but it would allow mocking and using expectations instead of making use of `Socket::$connected` (as can be seen in this patch's tests), also there seems to be no reason why the outside world should be able to change the exposed connection state without actually affecting the connection.

This is kind of a question for a new ticket, but since it would affect this patch's tests I thought I'd ask right here.
