### PR TITLE
Improve getting namespaced class name.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -27,7 +27,6 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
-use Cake\View\View;
 use Cake\View\ViewVarsTrait;
 
 /**

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -40,10 +40,11 @@ trait ViewVarsTrait {
 	public function createView($viewClass = null) {
 		if ($viewClass === null) {
 			$viewClass = $this->viewClass;
-			if ($this->viewClass !== 'View') {
-				list($plugin, $viewClass) = pluginSplit($viewClass, true);
-				$viewClass = App::className($viewClass, 'View', 'View');
-			}
+		}
+		if ($viewClass === 'View') {
+			$viewClass = App::className($viewClass, 'View');
+		} else {
+			$viewClass = App::className($viewClass, 'View', 'View');
 		}
 		$viewOptions = array_intersect_key(get_object_vars($this), array_flip($this->_validViewOptions));
 		return new $viewClass($this->request, $this->response, $this->eventManager(), $viewOptions);


### PR DESCRIPTION
Improvements over existing code:
- Currently if you pass `$viewClass` argument or have `$this->viewClass` set to `View` it skips calling `App::className()` which necessitates having a `use` statement for that class. This shouldn't be necessary. The method should have same behavior regardless of what the class is or how it's passed to it.
- The `pluginSplit()` call is not necessary since `App::className()` already does it internally.
