### PR TITLE
Update ControllerTask.php

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -188,6 +188,7 @@ class ControllerTask extends BakeTask {
 				if (strtolower($wannaUseSession) === 'y') {
 					array_push($components, 'Session');
 				}
+				array_unique($components);
 			}
 		} else {
 			list($wannaBakeCrud, $wannaBakeAdminCrud) = $this->_askAboutMethods();


### PR DESCRIPTION
When specifying Session as a component, you end up with 'Paginator, Session, Session' which doesn't make sense. Added some wording to let users know that Paginator and Session are included by default.
