### PR TITLE
3.0 - better join methods

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -485,6 +485,11 @@ class Query implements ExpressionInterface, IteratorAggregate {
 			if (!is_array($t)) {
 				$t = ['table' => $t, 'conditions' => $this->newExpr()];
 			}
+
+			if (is_callable($t['conditions'])) {
+				$t['conditions'] = $t['conditions']($this->newExpr(), $this);
+			}
+
 			if (!($t['conditions'] instanceof ExpressionInterface)) {
 				$t['conditions'] = $this->newExpr()->add($t['conditions'], $types);
 			}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -526,7 +526,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return $this
  */
 	public function leftJoin($table, $conditions = [], $types = []) {
-		return $this->join($this->_makeJoin($table + ['type' => 'LEFT'], $conditions), $types);
+		return $this->join($this->_makeJoin($table, $conditions, 'LEFT'), $types);
 	}
 
 /**
@@ -553,7 +553,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return $this
  */
 	public function rightJoin($table, $conditions = [], $types = []) {
-		return $this->join($this->_makeJoin($table + ['type' => 'RIGHT'], $conditions), $types);
+		return $this->join($this->_makeJoin($table, $conditions, 'RIGHT'), $types);
 	}
 
 /**
@@ -580,7 +580,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return $this
  */
 	public function innerJoin($table, $conditions = [], $types = []) {
-		return $this->join($this->_makeJoin($table + ['type' => 'INNER'], $conditions), $types);
+		return $this->join($this->_makeJoin($table, $conditions, 'INNER'), $types);
 	}
 
 /**
@@ -589,9 +589,10 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @param string|array $table The table to join with
  * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
  * to use for joining.
+ * @param string $type the join type to use
  * @return array
  */
-	protected function _makeJoin($table, $conditions) {
+	protected function _makeJoin($table, $conditions, $type) {
 		$alias = $table;
 
 		if (is_array($table)) {
@@ -600,9 +601,11 @@ class Query implements ExpressionInterface, IteratorAggregate {
 		}
 
 		return [
-			'table' => $table,
-			'alias' => $alias,
-			'conditions' => $conditions
+			$alias => [
+				'table' => $table,
+				'conditions' => $conditions,
+				'type' => $type
+			]
 		];
 	}
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1212,10 +1212,25 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * this function in subclasses to use a more specialized QueryExpression class
  * if required.
  *
+ * You can optionally pass a single raw SQL string or an array or expressions in
+ * any format accepted by \Cake\Database\QueryExpression:
+ *
+ * {{{
+ *
+ * $expression = $query->newExpression(); // Returns an empty expression object
+ * $expression = $query->newExpression('Table.column = Table2.column'); // Return a raw SQL expression
+ * }}}
+ *
  * @return \Cake\Database\QueryExpression
  */
-	public function newExpr() {
-		return new QueryExpression([], $this->typeMap());
+	public function newExpr($rawExpression = null) {
+		$expression = new QueryExpression([], $this->typeMap());
+
+		if ($rawExpression !== null) {
+			$expression->add($rawExpression);
+		}
+
+		return $expression;
 	}
 
 /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -485,7 +485,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 			if (!is_array($t)) {
 				$t = ['table' => $t, 'conditions' => $this->newExpr()];
 			}
-			if (!($t['conditions']) instanceof ExpressionInterface) {
+			if (!($t['conditions'] instanceof ExpressionInterface)) {
 				$t['conditions'] = $this->newExpr()->add($t['conditions'], $types);
 			}
 			$alias = is_string($alias) ? $alias : null;
@@ -500,6 +500,110 @@ class Query implements ExpressionInterface, IteratorAggregate {
 
 		$this->_dirty();
 		return $this;
+	}
+
+/**
+ * Adds a single LEFT JOIN clause to the query.
+ *
+ * {{{
+ * // LEFT JOIN authors ON posts.author_id' = authors.id
+ * $query->leftJoin('authors', ['posts.author_id' = authors.id']);
+ * }}}
+ *
+ * You can pass an array in the first parameter if you need to alias
+ * the table for the join:
+ *
+ * {{{
+ * // LEFT JOIN authors a ON posts.author_id' = a.id
+ * $query->leftJoin(['a' => 'authors'], ['posts.author_id' = 'a.id']);
+ * }}}
+ *
+ * @param string|array $table The table to join with
+ * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
+ * to use for joining.
+ * @param array $types a list of types associated to the conditions used for converting
+ * values to the corresponding database representation.
+ * @return $this
+ */
+	public function leftJoin($table, $conditions = [], $types = []) {
+		return $this->join($this->_makeJoin($table + ['type' => 'LEFT'], $conditions), $types);
+	}
+
+/**
+ * Adds a single RIGHT JOIN clause to the query.
+ *
+ * {{{
+ * // RIGHT JOIN authors ON posts.author_id' = authors.id
+ * $query->rightJoin('authors', ['posts.author_id' = authors.id']);
+ * }}}
+ *
+ * You can pass an array in the first parameter if you need to alias
+ * the table for the join:
+ *
+ * {{{
+ * // RIGHT JOIN authors a ON posts.author_id' = a.id
+ * $query->righJoin(['a' => 'authors'], ['posts.author_id' = 'a.id']);
+ * }}}
+ *
+ * @param string|array $table The table to join with
+ * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
+ * to use for joining.
+ * @param array $types a list of types associated to the conditions used for converting
+ * values to the corresponding database representation.
+ * @return $this
+ */
+	public function rightJoin($table, $conditions = [], $types = []) {
+		return $this->join($this->_makeJoin($table + ['type' => 'RIGHT'], $conditions), $types);
+	}
+
+/**
+ * Adds a single INNER JOIN clause to the query.
+ *
+ * {{{
+ * // INNER JOIN authors ON posts.author_id' = authors.id
+ * $query->innerJoin('authors', ['posts.author_id' = authors.id']);
+ * }}}
+ *
+ * You can pass an array in the first parameter if you need to alias
+ * the table for the join:
+ *
+ * {{{
+ * // INNER JOIN authors a ON posts.author_id' = a.id
+ * $query->innerJoin(['a' => 'authors'], ['posts.author_id' = 'a.id']);
+ * }}}
+ *
+ * @param string|array $table The table to join with
+ * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
+ * to use for joining.
+ * @param array $types a list of types associated to the conditions used for converting
+ * values to the corresponding database representation.
+ * @return $this
+ */
+	public function innerJoin($table, $conditions = [], $types = []) {
+		return $this->join($this->_makeJoin($table + ['type' => 'INNER'], $conditions), $types);
+	}
+
+/**
+ * Returns an array that can be passed to the join method describing a single join clause
+ *
+ * @param string|array $table The table to join with
+ * @param string|array|\Cake\Database\ExpressionInterface $conditions The conditions
+ * to use for joining.
+ * @return array
+ */
+	protected function _makeJoin($table, $conditions) {
+		$alias = $table;
+
+		if (is_array($table)) {
+			$alias = key($table);
+			$table = current($table);
+		}
+
+		return [
+			'table' => $table,
+			'alias' => $alias,
+			'conditions' => $conditions
+		];
 	}
 
 /**
@@ -1221,6 +1325,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * $expression = $query->newExpression('Table.column = Table2.column'); // Return a raw SQL expression
  * }}}
  *
+ * @param mixed $rawExpression A string, array or anything you want wrapped in a expression object
  * @return \Cake\Database\QueryExpression
  */
 	public function newExpr($rawExpression = null) {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -280,6 +280,31 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests the leftJoin method
+ *
+ * @return void
+ */
+	public function testSelectLeftJoin() {
+		$query = new Query($this->connection);
+		$time = new \DateTime('2007-03-18 10:45:23');
+		$types = ['created' => 'datetime'];
+		$result = $query
+			->select(['title', 'name' => 'c.comment'])
+			->from('articles')
+			->leftJoin(['c' => 'comments'], ['created <' => $time], $types)
+			->execute();
+		$this->assertEquals(array('title' => 'First Article', 'name' => null), $result->fetch('assoc'));
+
+		$query = new Query($this->connection);
+		$result = $query
+			->select(['title', 'name' => 'c.comment'])
+			->from('articles')
+			->leftJoin(['c' => 'comments'], ['created >' => $time], $types)
+			->execute();
+		$this->assertEquals(array('title' => 'First Article', 'name' => 'Second Comment for First Article'), $result->fetch('assoc'));
+	}
+
+/**
  * Tests it is possible to filter a query by using simple AND joined conditions
  *
  * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -140,8 +140,8 @@ class QueryTest extends TestCase {
 		$this->assertEquals(array('foo' => 'Second Article Body', 'text' => 'Second Article Body', 'author_id' => 3), $result->fetch('assoc'));
 
 		$query = new Query($this->connection);
-		$exp = $query->newExpr()->add('1 + 1');
-		$comp = $query->newExpr()->add(['author_id +' => 2]);
+		$exp = $query->newExpr('1 + 1');
+		$comp = $query->newExpr(['author_id +' => 2]);
 		$result = $query->select(['text' => 'body', 'two' => $exp, 'three' => $comp])
 			->from('articles')->execute();
 		$this->assertEquals(array('text' => 'First Article Body', 'two' => 2, 'three' => 3), $result->fetch('assoc'));
@@ -220,7 +220,7 @@ class QueryTest extends TestCase {
 		$this->assertEquals(array('title' => 'Second Article', 'name' => 'larry'), $result->fetch('assoc'));
 
 		$query = new Query($this->connection);
-		$conditions = $query->newExpr()->add('author_id = a.id');
+		$conditions = $query->newExpr('author_id = a.id');
 		$result = $query
 			->select(['title', 'name'])
 			->from('articles')
@@ -258,7 +258,7 @@ class QueryTest extends TestCase {
 		$this->assertEquals(array('title' => 'Second Article', 'name' => 'nate'), $result->fetch('assoc'));
 
 		$query = new Query($this->connection);
-		$conditions = $query->newExpr()->add('author_id = a.id');
+		$conditions = $query->newExpr('author_id = a.id');
 		$result = $query
 			->select(['title', 'name'])
 			->from('articles')
@@ -921,7 +921,7 @@ class QueryTest extends TestCase {
 			->where(function($exp, $q) {
 				return $exp->in(
 					'created',
-					$q->newExpr()->add("'2007-03-18 10:45:23'"),
+					$q->newExpr("'2007-03-18 10:45:23'"),
 					'datetime'
 				);
 			})
@@ -936,7 +936,7 @@ class QueryTest extends TestCase {
 			->where(function($exp, $q) {
 				return $exp->notIn(
 					'created',
-					$q->newExpr()->add("'2007-03-18 10:45:23'"),
+					$q->newExpr("'2007-03-18 10:45:23'"),
 					'datetime'
 				);
 			})
@@ -1124,8 +1124,7 @@ class QueryTest extends TestCase {
 		$this->assertEquals(['id' => 2], $result->fetch('assoc'));
 		$this->assertEquals(['id' => 3], $result->fetch('assoc'));
 
-		$expression = $query->newExpr()
-			->add(['(id + :offset) % 2']);
+		$expression = $query->newExpr(['(id + :offset) % 2']);
 		$result = $query
 			->order([$expression, 'id' => 'desc'], true)
 			->bind(':offset', 1, null)
@@ -1862,8 +1861,7 @@ class QueryTest extends TestCase {
 	public function testUpdateWithExpression() {
 		$query = new Query($this->connection);
 
-		$expr = $query->newExpr();
-		$expr->add('title = author_id');
+		$expr = $query->newExpr('title = author_id');
 
 		$query->update('articles')
 			->set($expr)
@@ -2334,7 +2332,7 @@ class QueryTest extends TestCase {
 		$this->assertQuotedQuery('SELECT <1 \+ 1> AS <foo>$', $sql);
 
 		$query = new Query($this->connection);
-		$sql = $query->select(['foo' => $query->newExpr()->add('1 + 1')])->sql();
+		$sql = $query->select(['foo' => $query->newExpr('1 + 1')])->sql();
 		$this->assertQuotedQuery('SELECT \(1 \+ 1\) AS <foo>$', $sql);
 
 		$query = new Query($this->connection);
@@ -2358,7 +2356,7 @@ class QueryTest extends TestCase {
 		$this->assertQuotedQuery('FROM <something> AS <foo>$', $sql);
 
 		$query = new Query($this->connection);
-		$sql = $query->select('*')->from(['foo' => $query->newExpr()->add('bar')])->sql();
+		$sql = $query->select('*')->from(['foo' => $query->newExpr('bar')])->sql();
 		$this->assertQuotedQuery('FROM \(bar\) AS <foo>$', $sql);
 	}
 
@@ -2390,7 +2388,7 @@ class QueryTest extends TestCase {
 		$this->assertQuotedQuery('JOIN <something> <foo>', $sql);
 
 		$query = new Query($this->connection);
-		$sql = $query->select('*')->join(['foo' => $query->newExpr()->add('bar')])->sql();
+		$sql = $query->select('*')->join(['foo' => $query->newExpr('bar')])->sql();
 		$this->assertQuotedQuery('JOIN \(bar\) <foo>', $sql);
 	}
 
@@ -2406,7 +2404,7 @@ class QueryTest extends TestCase {
 		$this->assertQuotedQuery('GROUP BY <something>', $sql);
 
 		$query = new Query($this->connection);
-		$sql = $query->select('*')->group([$query->newExpr()->add('bar')])->sql();
+		$sql = $query->select('*')->group([$query->newExpr('bar')])->sql();
 		$this->assertQuotedQuery('GROUP BY \(bar\)', $sql);
 
 		$query = new Query($this->connection);
@@ -2453,7 +2451,7 @@ class QueryTest extends TestCase {
 		$this->assertQuotedQuery('INSERT INTO <foo> \(<bar>, <baz>\)', $sql);
 
 		$query = new Query($this->connection);
-		$sql = $query->insert([$query->newExpr()->add('bar')])
+		$sql = $query->insert([$query->newExpr('bar')])
 			->into('foo')
 			->where(['something' => 'value'])
 			->sql();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -305,6 +305,53 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests the innerJoin method
+ *
+ * @return void
+ */
+	public function testSelectInnerJoin() {
+		$query = new Query($this->connection);
+		$time = new \DateTime('2007-03-18 10:45:23');
+		$types = ['created' => 'datetime'];
+		$result = $query
+			->select(['title', 'name' => 'c.comment'])
+			->from('articles')
+			->innerJoin(['c' => 'comments'], ['created <' => $time], $types)
+			->execute();
+		$this->assertCount(0, $result->fetchAll());
+
+		$query = new Query($this->connection);
+		$result = $query
+			->select(['title', 'name' => 'c.comment'])
+			->from('articles')
+			->leftJoin(['c' => 'comments'], ['created >' => $time], $types)
+			->execute();
+		$this->assertEquals(array('title' => 'First Article', 'name' => 'Second Comment for First Article'), $result->fetch('assoc'));
+	}
+
+/**
+ * Tests the rightJoin method
+ *
+ * @return void
+ */
+	public function testSelectRightJoin() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlite,
+			'SQLite does not support RIGHT joins'
+		);
+		$query = new Query($this->connection);
+		$time = new \DateTime('2007-03-18 10:45:23');
+		$types = ['created' => 'datetime'];
+		$result = $query
+			->select(['title', 'name' => 'c.comment'])
+			->from('articles')
+			->rightJoin(['c' => 'comments'], ['created <' => $time], $types)
+			->execute();
+		$this->assertCount(0, $result->fetchAll());
+		$this->assertEquals(array('title' => null, 'name' => 'First Comment for First Article'), $result->fetch('assoc'));
+	}
+
+/**
  * Tests it is possible to filter a query by using simple AND joined conditions
  *
  * @return void


### PR DESCRIPTION
This adds a couple things I felt were missing in the query object by helping some people around:
- An easy way to construct raw SQL (now `newExpr()` can take the expression directly)
- Better method for constructing joins (added innerJoin, leftJoin and rightJoin methods)
- Added a way to pass a callback for constructing join conditions
