### PR TITLE
Fix in saveMany() in Model.php

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2220,7 +2220,7 @@ class Model extends Object implements CakeEventListener {
 
 		if ($options['validate'] === 'first') {
 			$validates = $this->validateMany($data, $options);
-			if ((!$validates && $options['atomic']) || (!$options['atomic'] && in_array(false, $validates, true))) {
+			if ((!$validates && $options['atomic']) || (!$options['atomic'] && !in_array(true, $validates, true))) {
 				return $validates;
 			}
 			$options['validate'] = false;


### PR DESCRIPTION
There are two ways of use the function saveMany(...) with the atomic variable.

If atomic is set to True, the $this->validateMany() returns a boolean indicating if the elements fulfill their validation requirements established in the Model (True if they do, False if there is at least someone not). In case they don't validate the restrictions the function saveMany will return, because of this condition:

if ((!$validates && $options['atomic']) || ...) {
    return $validates;
}

All is correct here. But

If atomic parameter is set to false, we are telling CakePHP that it should keep going in case there would be any record that was invalid. This is why, validateMany doesn't return a boolean but an array of booleans. It indicates which records fulfill the restrictions. Example:

$validates = Array(
    [0] => True
    [1] => False
    [2] => False
    [3] => False
);

In this case CakePHP should save the first record and ignore the following ones, but this is not what happened, because of the following:

if (... || (!$options['atomic'] && in_array(false, $validates, true))) {
    return $validates;
}

With this condition CakePHPis being told "If atomic is set to false and there is at least one invalid record" return without save.
What it should be is "If atomic is set to false and there is not any valid record" return.
Thus is the following condition

if (... || (!$options['atomic'] && !in_array(true, $validates, true))) {
    return $validates;
}
