### PR TITLE
Fix serialization of request, helpers and viewVars when they contain a closure

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
@@ -646,4 +646,35 @@ class CacheHelperTest extends CakeTestCase {
 			'@', $contents);
 		unlink($filename);
 	}
+
+	/**
+	 * test serialization with closure callback
+	 *
+	 * @return void
+	 */
+	public function testCacheClosure() {
+		if (PHP_VERSION_ID < 50300) {
+			$this->markTestSkipped('Closures not available before PHP 5.3');
+		}
+
+		$this->Controller->cache_parsing();
+		$this->Controller->request->addParams(array(
+				'controller' => 'cache_test',
+				'action' => 'cache_parsing',
+				'pass' => array(),
+				'named' => array()
+			));
+		$this->Controller->request->here = '/cacheTest/cache_parsing';
+		$this->Controller->cacheAction = 21600;
+
+		$closure = eval('return function() {};'); // Closure causes syntax error in PHP < 5.3
+		$this->Controller->request->addDetector('json', array('callback' => $closure));
+
+		$View = new View($this->Controller);
+		$result = $View->render('index');
+
+		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
+		$this->assertTrue(file_exists($filename));
+		unlink($filename);
+	}
 }


### PR DESCRIPTION
`CacheHelper::_writeFile()` fails if you have a closure in any of `$this->request`, `$this->_View->helpers` or `$this->_View->viewVars`. An exception is thrown by the call to `serialize()`.

I think this issue would most commonly occur when using a callback custom detector in `CakeRequest`.
