### PR TITLE
Add note about identifier quoting in pdo error template.

### DIFF
--- a/src/Template/Error/pdo_error.ctp
+++ b/src/Template/Error/pdo_error.ctp
@@ -19,6 +19,10 @@ use Cake\Utility\Debugger;
 	<strong>Error: </strong>
 	<?= $message; ?>
 </p>
+<p class="notice">
+	If you are using SQL keywords as table column names, you can enable identifier
+	quoting for your database connection in src/Config/app.php.
+</p>
 <?php if (!empty($error->queryString)) : ?>
 	<p class="notice">
 		<strong>SQL Query: </strong>


### PR DESCRIPTION
Hopefully this should avoid a few unnecessary tickets like #4028.
