### PR TITLE
3.0 Add removeSubcommand in ConsoleOptionParser

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -413,6 +413,17 @@ class ConsoleOptionParser {
 	}
 
 /**
+ * Remove an subcommand from the option parser.
+ *
+ * @param string $name The subcommand name to remove.
+ * @return ConsoleOptionParser this
+ */
+    public function removeSubcommand($name) {
+        unset($this->_subcommands[$name]);
+        return $this;
+    }
+
+/**
  * Add multiple subcommands at once.
  *
  * @param array $commands Array of subcommands.

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -413,10 +413,10 @@ class ConsoleOptionParser {
 	}
 
 /**
- * Remove an subcommand from the option parser.
+ * Remove a subcommand from the option parser.
  *
  * @param string $name The subcommand name to remove.
- * @return ConsoleOptionParser this
+ * @return $this
  */
     public function removeSubcommand($name) {
         unset($this->_subcommands[$name]);

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -492,6 +492,21 @@ class ConsoleOptionParserTest extends TestCase {
 	}
 
 /**
+ * test removeSubcommand with an object.
+ *
+ * @return void
+ */
+    public function testRemoveSubcommand() {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addSubcommand(new ConsoleInputSubcommand('test'));
+        $result = $parser->subcommands();
+        $this->assertEquals(1, count($result));
+        $parser->removeSubcommand('test');
+        $result = $parser->subcommands();
+        $this->assertEquals(0, count($result), 'Remove a subcommand does not work');
+    }
+
+/**
  * test adding multiple subcommands
  *
  * @return void


### PR DESCRIPTION
Sometimes if Shell extends another shell some subcomands not needed and they сould be removed from the child shell like an option.
