### PR TITLE
Use plugin prefixes when generating models in prefixes.

### DIFF
--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -224,20 +224,30 @@ class ModelTask extends BakeTask {
 		$primary = (array)$schema->primaryKey();
 		foreach ($schema->columns() as $fieldName) {
 			$offset = strpos($fieldName, '_id');
+			$assoc = false;
 			if (!in_array($fieldName, $primary) && $fieldName !== 'parent_id' && $offset !== false) {
 				$tmpModelName = $this->_modelNameFromKey($fieldName);
-				$associations['belongsTo'][] = [
+				$assoc = [
 					'alias' => $tmpModelName,
 					'foreignKey' => $fieldName
 				];
 			} elseif ($fieldName === 'parent_id') {
 				$className = ($this->plugin) ? $this->plugin . '.' . $model->alias() : $model->alias();
-				$associations['belongsTo'][] = [
+				$assoc = [
 					'alias' => 'Parent' . $model->alias(),
 					'className' => $className,
 					'foreignKey' => $fieldName
 				];
 			}
+
+			if ($assoc === false) {
+				continue;
+			}
+
+			if ($this->plugin && empty($assoc['className'])) {
+				$assoc['className'] = $this->plugin . '.' . $assoc['alias'];
+			}
+			$associations['belongsTo'][] = $assoc;
 		}
 		return $associations;
 	}
@@ -281,6 +291,9 @@ class ModelTask extends BakeTask {
 						'foreignKey' => $fieldName
 					];
 				}
+				if ($assoc && $this->plugin && empty($assoc['className'])) {
+					$assoc['className'] = $this->plugin . '.' . $assoc['alias'];
+				}
 				if ($assoc) {
 					$associations['hasMany'][] = $assoc;
 				}
@@ -314,12 +327,16 @@ class ModelTask extends BakeTask {
 			}
 			if ($assocTable && in_array($assocTable, $tables)) {
 				$habtmName = $this->_modelName($assocTable);
-				$associations['belongsToMany'][] = [
+				$assoc = [
 					'alias' => $habtmName,
 					'foreignKey' => $foreignKey,
 					'targetForeignKey' => $this->_modelKey($habtmName),
 					'joinTable' => $otherTable
 				];
+				if ($assoc && $this->plugin) {
+					$assoc['className'] = $this->plugin . '.' . $assoc['alias'];
+				}
+				$associations['belongsToMany'][] = $assoc;
 			}
 		}
 		return $associations;

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -265,6 +265,44 @@ class ModelTaskTest extends TestCase {
 	}
 
 /**
+ * Test getAssociations in a plugin
+ *
+ * @return void
+ */
+	public function testGetAssociationsPlugin() {
+		$articles = TableRegistry::get('BakeArticles');
+		$this->Task->plugin = 'TestPlugin';
+
+		$result = $this->Task->getAssociations($articles);
+		$expected = [
+			'belongsTo' => [
+				[
+					'alias' => 'BakeUsers',
+					'className' => 'TestPlugin.BakeUsers',
+					'foreignKey' => 'bake_user_id'
+				],
+			],
+			'hasMany' => [
+				[
+					'alias' => 'BakeComments',
+					'className' => 'TestPlugin.BakeComments',
+					'foreignKey' => 'bake_article_id',
+				],
+			],
+			'belongsToMany' => [
+				[
+					'alias' => 'BakeTags',
+					'className' => 'TestPlugin.BakeTags',
+					'foreignKey' => 'bake_article_id',
+					'joinTable' => 'bake_articles_bake_tags',
+					'targetForeignKey' => 'bake_tag_id',
+				],
+			],
+		];
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * test that belongsTo generation works.
  *
  * @return void


### PR DESCRIPTION
After a bit of discussion in #4026 it sounded baking associations that default to using the plugin will result in less work instead of defaulting to app models.
