### PR TITLE
3.0 - Fix issue where conditions that are valid global methods get treated as callables

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -293,7 +293,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @return \Cake\Database\Expression\QueryExpression
  */
 	public function and_($conditions, $types = []) {
-		if (is_callable($conditions)) {
+		if (!is_string($conditions) && is_callable($conditions)) {
 			return $conditions(new self([], $this->typeMap()->types($types)));
 		}
 		return new self($conditions, $this->typeMap()->types($types));
@@ -309,7 +309,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @return \Cake\Database\Expression\QueryExpression
  */
 	public function or_($conditions, $types = []) {
-		if (is_callable($conditions)) {
+		if (!is_string($conditions) && is_callable($conditions)) {
 			return $conditions(new self([], $this->typeMap()->types($types), 'OR'));
 		}
 		return new self($conditions, $this->typeMap()->types($types), 'OR');

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -434,7 +434,7 @@ class QueryExpression implements ExpressionInterface, Countable {
 				continue;
 			}
 
-			if (is_callable($c)) {
+			if (!is_string($c) && is_callable($c)) {
 				$expr = new QueryExpression([], $typeMap);
 				$c = $c($expr, $this);
 			}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -245,7 +245,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return $this
  */
 	public function select($fields = [], $overwrite = false) {
-		if (is_callable($fields)) {
+		if (!is_string($fields) && is_callable($fields)) {
 			$fields = $fields($this);
 		}
 
@@ -486,7 +486,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 				$t = ['table' => $t, 'conditions' => $this->newExpr()];
 			}
 
-			if (is_callable($t['conditions'])) {
+			if (!is_string($t['conditions']) && is_callable($t['conditions'])) {
 				$t['conditions'] = $t['conditions']($this->newExpr(), $this);
 			}
 
@@ -1557,7 +1557,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 	protected function _conjugate($part, $append, $conjunction, $types) {
 		$expression = $this->_parts[$part] ?: $this->newExpr();
 
-		if (is_callable($append)) {
+		if (!is_string($append) && is_callable($append)) {
 			$append = $append($this->newExpr(), $this);
 		}
 

--- a/src/Model/Behavior/CounterCacheBehavior.php
+++ b/src/Model/Behavior/CounterCacheBehavior.php
@@ -159,7 +159,7 @@ class CounterCacheBehavior extends Behavior {
 				$config = [];
 			}
 
-			if (is_callable($config)) {
+			if (!is_string($config) && is_callable($config)) {
 				$count = $config($event, $entity, $this->_table);
 			} else {
 				$count = $this->_getCount($config, $countConditions);

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -155,7 +155,7 @@ class ValidationRule {
  * @return bool True if the ValidationRule should be skipped
  */
 	protected function _skip($context) {
-		if (is_callable($this->_on)) {
+		if (!is_string($this->_on) && is_callable($this->_on)) {
 			$function = $this->_on;
 			return !$function($context);
 		}


### PR DESCRIPTION
I encountered an issue where certain query conditions where being treated as a callable by Cake\Database\Expression\QueryExpression.

A simple example:

```
$query = $Table->find('all')
->where([
    'my_field' => 'h'
]);
```

would throw

```
Warning Error: htmlspecialchars() expects parameter 4 to be boolean, object given in [vendor\cakephp\cakephp\src\basics.php, line 255]                                                    

2014-07-22 07:56:10 Warning: Warning (2): htmlspecialchars() expects parameter 4 to be boolean, object given in [vendor\cakephp\cakephp\src\basics.php, line 255]                         
Trace:                                                                                                                                                                                       
Cake\Error\BaseErrorHandler::handleError() - ROOTvendor\cakephp\cakephp\src\Error\BaseErrorHandler.php, line 135                                                                             
htmlspecialchars - [internal], line ??                                                                                                                                                       
h - ROOTvendor\cakephp\cakephp\src\basics.php, line 255                                                                                                                                      
Cake\Database\Expression\QueryExpression::_addConditions() - ROOTvendor\cakephp\cakephp\src\Database\Expression\QueryExpression.php, line 440                                                
Cake\Database\Expression\QueryExpression::add() - ROOTvendor\cakephp\cakephp\src\Database\Expression\QueryExpression.php, line 121                                                           
Cake\Database\Query::_conjugate() - ROOTvendor\cakephp\cakephp\src\Database\Query.php, line 1565                                                                                             
Cake\Database\Query::where() - ROOTvendor\cakephp\cakephp\src\Database\Query.php, line 735                                                                                        
```

I'm unsure if this may adversely affect other components or use-cases?
