### PR TITLE
Fixed sending of headers when ajaxLogin is set

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -367,7 +367,8 @@ class AuthComponent extends Component {
 		if (!empty($this->ajaxLogin)) {
 			$controller->response->statusCode(403);
 			$controller->viewPath = 'Elements';
-			echo $controller->render($this->ajaxLogin, $this->RequestHandler->ajaxLayout);
+			$response = $controller->render($this->ajaxLogin, $this->RequestHandler->ajaxLayout);
+			$response->send();
 			$this->_stop();
 			return false;
 		}

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -1156,6 +1156,36 @@ class AuthComponentTest extends CakeTestCase {
 	}
 
 /**
+ * testAjaxLoginResponseCode
+ *
+ * @return void
+ */
+	public function testAjaxLoginResponseCode() {
+		App::build(array(
+			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
+		));
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+		$url = '/ajax_auth/add';
+		$this->Auth->request->addParams(Router::parse($url));
+		$this->Auth->request->query['url'] = ltrim($url, '/');
+		$this->Auth->request->base = '';
+		$this->Auth->ajaxLogin = 'test_element';
+
+		Router::setRequestInfo($this->Auth->request);
+
+		$this->Controller->response = $this->getMock('CakeResponse', array('send'));
+		$this->Controller->response->expects($this->once())->method('send');
+		$this->Auth->initialize($this->Controller);
+
+		$result = $this->Auth->startup($this->Controller);
+
+		$this->assertFalse($result);
+		$this->assertEquals('this is the test element', $this->Controller->response->body());
+		unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+	}
+
+/**
  * testLoginActionRedirect method
  *
  * @return void

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -1174,8 +1174,10 @@ class AuthComponentTest extends CakeTestCase {
 
 		Router::setRequestInfo($this->Auth->request);
 
-		$this->Controller->response = $this->getMock('CakeResponse', array('send'));
-		$this->Controller->response->expects($this->once())->method('send');
+		$this->Controller->response = $this->getMock('CakeResponse', array('_sendHeader'));
+		$this->Controller->response->expects($this->at(0))
+		->method('_sendHeader')
+		->with('HTTP/1.1 403 Forbidden', null);
 		$this->Auth->initialize($this->Controller);
 
 		$result = $this->Auth->startup($this->Controller);


### PR DESCRIPTION
The status code is never sent to browser, so the response code is always 200.
