### PR TITLE
Ensure that the driver schema dialects use is connected.

### DIFF
--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -35,9 +35,13 @@ abstract class BaseSchema {
 /**
  * Constructor
  *
+ * This constructor will connect the driver so that methods like columnSql() and others
+ * will fail when the driver has not been connected.
+ *
  * @param \Cake\Database\Driver $driver The driver to use.
  */
 	public function __construct(Driver $driver) {
+		$driver->connect();
 		$this->_driver = $driver;
 	}
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -843,6 +843,18 @@ SQL;
 	}
 
 /**
+ * Test that constructing a schema dialect connects the driver.
+ *
+ * @return void
+ */
+	public function testConstructConnectsDriver() {
+		$driver = $this->getMock('Cake\Database\Driver');
+		$driver->expects($this->once())
+			->method('connect');
+		$schema = new MysqlSchema($driver);
+	}
+
+/**
  * Get a schema instance with a mocked driver/pdo instances
  *
  * @return MysqlSchema


### PR DESCRIPTION
Failing to connect the driver causes failures when identifiers are quoted using cached schema objects.

Fixes #4031
