### PR TITLE
Improve errors for cells

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -83,6 +83,7 @@ class ExceptionRenderer {
 	public function __construct(\Exception $exception) {
 		$this->error = $exception;
 		$this->controller = $this->_getController();
+
 	}
 
 /**
@@ -152,11 +153,6 @@ class ExceptionRenderer {
 		if ($exception instanceof Error\Exception && $isDebug) {
 			$this->controller->set($this->error->getAttributes());
 		}
-
-		while (ob_get_level() > 0) {
-			ob_end_clean();
-		}
-
 		$this->_outputMessage($template);
 	}
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -83,7 +83,6 @@ class ExceptionRenderer {
 	public function __construct(\Exception $exception) {
 		$this->error = $exception;
 		$this->controller = $this->_getController();
-
 	}
 
 /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -153,6 +153,10 @@ class ExceptionRenderer {
 			$this->controller->set($this->error->getAttributes());
 		}
 
+		while (ob_get_level() > 0) {
+			ob_end_clean();
+		}
+
 		$this->_outputMessage($template);
 	}
 

--- a/src/Template/Error/missing_cell_view.ctp
+++ b/src/Template/Error/missing_cell_view.ctp
@@ -14,14 +14,14 @@
  */
 use Cake\Utility\Inflector;
 ?>
-<h2>Missing View</h2>
+<h2>Missing Cell View</h2>
 <p class="error">
 	<strong>Error: </strong>
-	<?= sprintf('The view for <em>%sController::%s()</em> was not found.', h(Inflector::camelize($this->request->controller)), h($this->request->action)); ?>
+	<?= sprintf('The view for <em>%sCell</em> was not found.', h(Inflector::camelize($name))); ?>
 </p>
 
 <p>
-	<?php echo __d('cake_dev', 'Confirm you have created the file: "%s"', h($file)); ?>
+	<?php echo __d('cake_dev', 'Confirm you have created the file: "%s"', h($file . $this->_ext)); ?>
 	in one of the following paths:
 </p>
 <ul>
@@ -31,7 +31,7 @@ use Cake\Utility\Inflector;
 		if (strpos($path, CORE_PATH) !== false) {
 			continue;
 		}
-		echo sprintf('<li>%s%s</li>', h($path), h($file));
+		echo sprintf('<li>%sCell/%s/%s</li>', h($path), h($name), h($file . $this->_ext));
 	endforeach;
 ?>
 </ul>

--- a/src/Template/Error/missing_cell_view.ctp
+++ b/src/Template/Error/missing_cell_view.ctp
@@ -17,11 +17,11 @@ use Cake\Utility\Inflector;
 <h2>Missing Cell View</h2>
 <p class="error">
 	<strong>Error: </strong>
-	<?= sprintf('The view for <em>%sCell</em> was not found.', h(Inflector::camelize($name))); ?>
+	<?php printf('The view for <em>%sCell</em> was not found.', h(Inflector::camelize($name))); ?>
 </p>
 
 <p>
-	<?php echo __d('cake_dev', 'Confirm you have created the file: "%s"', h($file . $this->_ext)); ?>
+	<?php printf('Confirm you have created the file: "%s"', h($file . $this->_ext)); ?>
 	in one of the following paths:
 </p>
 <ul>

--- a/src/Template/Error/missing_cell_view.ctp
+++ b/src/Template/Error/missing_cell_view.ctp
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         0.10.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 use Cake\Utility\Inflector;

--- a/src/Template/Error/missing_view.ctp
+++ b/src/Template/Error/missing_view.ctp
@@ -17,11 +17,11 @@ use Cake\Utility\Inflector;
 <h2>Missing View</h2>
 <p class="error">
 	<strong>Error: </strong>
-	<?= sprintf('The view for <em>%sController::%s()</em> was not found.', h(Inflector::camelize($this->request->controller)), h($this->request->action)); ?>
+	<?php printf('The view for <em>%sController::%s()</em> was not found.', h(Inflector::camelize($this->request->controller)), h($this->request->action)); ?>
 </p>
 
 <p>
-	<?php echo __d('cake_dev', 'Confirm you have created the file: "%s"', h($file)); ?>
+	<?php printf('Confirm you have created the file: "%s"', h($file)); ?>
 	in one of the following paths:
 </p>
 <ul>
@@ -38,7 +38,7 @@ use Cake\Utility\Inflector;
 
 <p class="notice">
 	<strong>Notice: </strong>
-	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_view.ctp'); ?>
+	<?php printf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_view.ctp'); ?>
 </p>
 
 <?= $this->element('exception_stack_trace'); ?>

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -149,12 +149,13 @@ abstract class Cell {
 		$this->View->layout = false;
 		$className = explode('\\', get_class($this));
 		$className = array_pop($className);
-		$this->View->subDir = 'Cell' . DS . substr($className, 0, strpos($className, 'Cell'));
+		$name = substr($className, 0, strpos($className, 'Cell'));
+		$this->View->subDir = 'Cell' . DS . $name;
 
 		try {
 			return $this->View->render($template);
 		} catch (MissingViewException $e) {
-			throw new MissingCellViewException(['file' => $template]);
+			throw new MissingCellViewException(['file' => $template, 'name' => $name]);
 		}
 	}
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -20,6 +20,8 @@ use Cake\Model\ModelAwareTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Inflector;
+use Cake\View\Error\MissingCellViewException;
+use Cake\View\Error\MissingViewException;
 use Cake\View\ViewVarsTrait;
 
 /**
@@ -132,6 +134,7 @@ abstract class Cell {
  * @param string $template Custom template name to render. If not provided (null), the last
  * value will be used. This value is automatically set by `CellTrait::cell()`.
  * @return void
+ * @throws \Cake\Error\MissingCellViewException When a MissingViewException is raised during rendering.
  */
 	public function render($template = null) {
 		if ($template !== null && strpos($template, '/') === false) {
@@ -148,7 +151,11 @@ abstract class Cell {
 		$className = array_pop($className);
 		$this->View->subDir = 'Cell' . DS . substr($className, 0, strpos($className, 'Cell'));
 
-		return $this->View->render($template);
+		try {
+			return $this->View->render($template);
+		} catch (MissingViewException $e) {
+			throw new MissingCellViewException(['file' => $template]);
+		}
 	}
 
 /**

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -134,10 +134,10 @@ abstract class Cell {
  * @return void
  */
 	public function render($template = null) {
-		if ($template !== null) {
+		if ($template !== null && strpos($template, '/') === false) {
 			$template = Inflector::underscore($template);
 		}
-		if (empty($template)) {
+		if ($template === null) {
 			$template = $this->template;
 		}
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -134,7 +134,7 @@ abstract class Cell {
  * @param string $template Custom template name to render. If not provided (null), the last
  * value will be used. This value is automatically set by `CellTrait::cell()`.
  * @return void
- * @throws \Cake\Error\MissingCellViewException When a MissingViewException is raised during rendering.
+ * @throws \Cake\View\Error\MissingCellViewException When a MissingViewException is raised during rendering.
  */
 	public function render($template = null) {
 		if ($template !== null && strpos($template, '/') === false) {

--- a/src/View/Error/MissingCellViewException.php
+++ b/src/View/Error/MissingCellViewException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Error;
+
+use Cake\Error\Exception;
+
+/**
+ * Used when a view file for a cell cannot be found.
+ */
+class MissingCellViewException extends Exception {
+
+	protected $_messageTemplate = 'Cell view file "%s" is missing.';
+
+}

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ExceptionRendererTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -81,7 +81,7 @@ class CellTest extends TestCase {
 		$capture = function ($errno, $msg) {
 			restore_error_handler();
 			$this->assertEquals(E_USER_WARNING, $errno);
-			$this->assertContains('Could not render cell - View file', $msg);
+			$this->assertContains('Could not render cell - Cell view file', $msg);
 		};
 		set_error_handler($capture);
 
@@ -131,6 +131,17 @@ class CellTest extends TestCase {
 
 		$cell->teaserList();
 		$this->assertContains('<h2>Lorem ipsum</h2>', $cell->render('teaser_list'));
+	}
+
+/**
+ * Tests manual render() invocation with error
+ *
+ * @expectedException \Cake\View\Error\MissingCellViewException
+ * @return void
+ */
+	public function testCellManualRenderError() {
+		$cell = $this->View->cell('Articles');
+		$cell->render('derp');
 	}
 
 /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -169,6 +169,17 @@ class CellTest extends TestCase {
 	}
 
 /**
+ * Test that plugin cells can render other view templates.
+ *
+ * @return void
+ */
+	public function testPluginCellAlternateTemplateRenderParam() {
+		$cell = $this->View->cell('TestPlugin.Dummy::echoThis', ['msg' => 'hello world!']);
+		$result = $cell->render('../../Element/translate');
+		$this->assertContains('This is a translatable string', $result);
+	}
+
+/**
  * Tests that using an unexisting cell throws an exception.
  *
  * @expectedException \Cake\View\Error\MissingCellException


### PR DESCRIPTION
This set of changes resolve #3945 I think.  I've added a new framework for missing cell views as the MissingViewException references a controller which is total lies.

This also fixes an issue where relative paths would be inflected incorrectly, and solves broken layouts when missing cell/element exceptions are raised mid page.
