### PR TITLE
Improve template handling in FormHelper

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -260,8 +260,7 @@ class FormHelper extends Helper {
  * - `encoding` Set the accept-charset encoding for the form. Defaults to `Configure::read('App.encoding')`
  * - `templates` The templates you want to use for this form. Any templates will be merged on top of
  *   the already loaded templates. This option can either be a filename in App/Config that contains
- *   the templates you want to load, or an array of templates to use. You can use
- *   resetTemplates() to restore the original templates.
+ *   the templates you want to load, or an array of templates to use.
  * - `context` Additional options for the context class. For example the EntityContext accepts a 'table'
  *   option that allows you to set the specific Table class the form should be based on.
  * - `idPrefix` Prefix for generated ID attributes.
@@ -297,10 +296,10 @@ class FormHelper extends Helper {
 		$this->_idPrefix = $options['idPrefix'];
 		$templater = $this->templater();
 
-		if (!empty($options['templates']) && is_array($options['templates'])) {
-			$templater->add($options['templates']);
-		} elseif (!empty($options['templates']) && is_string($options['templates'])) {
-			$templater->load($options['templates']);
+		if (!empty($options['templates'])) {
+			$templater->push();
+			$method = is_string($options['templates']) ? 'load' : 'add';
+			$templater->{$method}($options['templates']);
 		}
 		unset($options['templates']);
 
@@ -439,7 +438,6 @@ class FormHelper extends Helper {
  */
 	public function end($secureAttributes = []) {
 		$out = '';
-
 		if (
 			$this->requestType !== 'get' &&
 			!empty($this->request['_Token'])
@@ -447,9 +445,10 @@ class FormHelper extends Helper {
 			$out .= $this->secure($this->fields, $secureAttributes);
 			$this->fields = array();
 		}
+		$templater = $this->templater();
+		$out .= $templater->format('formend', []);
 
-		$out .= $this->formatTemplate('formend', []);
-
+		$templater->pop();
 		$this->requestType = null;
 		$this->_context = null;
 		$this->_idPrefix = null;
@@ -889,11 +888,12 @@ class FormHelper extends Helper {
 		$options = $this->_parseOptions($fieldName, $options);
 		$options += ['id' => $this->_domId($fieldName)];
 
-		$originalTemplates = $this->templates();
+		$templater = $this->templater();
 		$newTemplates = $options['templates'];
 
 		if ($newTemplates) {
-			$this->templates($options['templates']);
+			$templater->push();
+			$templater->add($options['templates']);
 		}
 		unset($options['templates']);
 
@@ -906,7 +906,7 @@ class FormHelper extends Helper {
 		}
 
 		$template = $options['type'] . 'Container' . $errorSuffix;
-		if (!$this->templates($template)) {
+		if (!$templater->get($template)) {
 			$template = 'inputContainer' . $errorSuffix;
 		}
 
@@ -917,15 +917,17 @@ class FormHelper extends Helper {
 
 		$input = $this->_getInput($fieldName, $options);
 		if ($options['type'] === 'hidden') {
-			$this->templates($originalTemplates);
+			if ($newTemplates) {
+				$templater->pop();
+			}
 			return $input;
 		}
 
 		$label = $this->_getLabel($fieldName, compact('input', 'label', 'error') + $options);
 
 		$groupTemplate = $options['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
-		$result = $this->formatTemplate($groupTemplate, compact('input', 'label', 'error'));
-		$result = $this->formatTemplate($template, [
+		$result = $templater->format($groupTemplate, compact('input', 'label', 'error'));
+		$result = $templater->format($template, [
 			'content' => $result,
 			'error' => $error,
 			'required' => $options['required'] ? ' required' : '',
@@ -933,7 +935,7 @@ class FormHelper extends Helper {
 		]);
 
 		if ($newTemplates) {
-			$this->templates($originalTemplates);
+			$templater->pop();
 		}
 
 		return $result;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -893,7 +893,8 @@ class FormHelper extends Helper {
 
 		if ($newTemplates) {
 			$templater->push();
-			$templater->add($options['templates']);
+			$templateMethod = is_string($options['templates']) ? 'load' : 'add';
+			$templater->{$templateMethod}($options['templates']);
 		}
 		unset($options['templates']);
 

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -52,6 +52,13 @@ class StringTemplate {
 	];
 
 /**
+ * A stack of template sets that have been stashed temporarily.
+ *
+ * @var
+ */
+	protected $_configStack = [];
+
+/**
  * Contains the list of compiled templates
  *
  * @var array
@@ -68,14 +75,38 @@ class StringTemplate {
 	}
 
 /**
+ * Push the current templates onto the template stack.
+ *
+ * @return void
+ */
+	public function push() {
+		$this->_configStack[] = $this->_config;
+	}
+
+/**
+ * Restore the most recently pushed set of templates.
+ *
+ * Restoring templates will invalidate all compiled templates.
+ *
+ * @return void
+ */
+	public function pop() {
+		if (empty($this->_configStack)) {
+			return;
+		}
+		$this->_config = array_pop($this->_configStack);
+		$this->_compiled = [];
+	}
+
+/**
  * Registers a list of templates by name
  *
  * ### Example:
  *
  * {{{
  * $templater->add([
- *	'link' => '<a href="{{url}}">{{title}}</a>'
- *	'button' => '<button>{{text}}</button>'
+ *   'link' => '<a href="{{url}}">{{title}}</a>'
+ *   'button' => '<button>{{text}}</button>'
  * ]);
  * }}}
  *

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -75,7 +75,7 @@ class StringTemplate {
 	}
 
 /**
- * Push the current templates onto the template stack.
+ * Push the current templates into the template stack.
  *
  * @return void
  */

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -54,7 +54,7 @@ class StringTemplate {
 /**
  * A stack of template sets that have been stashed temporarily.
  *
- * @var
+ * @var array
  */
 	protected $_configStack = [];
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2108,6 +2108,28 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that input() accepts a template file.
+ *
+ * @return void
+ */
+	public function testInputWithTemplateFile() {
+		$result = $this->Form->input('field', array(
+			'templates' => 'htmlhelper_tags'
+		));
+		$expected = array(
+			'label' => array('for' => 'field'),
+			'Field',
+			'/label',
+			'input' => array(
+				'type' => 'text', 'name' => 'field',
+				'id' => 'field'
+			),
+		);
+		$this->assertTags($result, $expected);
+
+	}
+
+/**
  * Test id prefix
  *
  * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2126,7 +2126,6 @@ class FormHelperTest extends TestCase {
 			),
 		);
 		$this->assertTags($result, $expected);
-
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -389,6 +389,19 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that create() and end() restore templates.
+ *
+ * @return void
+ */
+	public function testCreateEndRestoreTemplates() {
+		$this->Form->create($this->article, [
+			'templates' => ['input' => 'custom input element']
+		]);
+		$this->Form->end();
+		$this->assertNotEquals('custom input element', $this->Form->templater()->get('input'));
+	}
+
+/**
  * test the create() method
  *
  * @dataProvider requestTypeProvider

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -209,4 +209,23 @@ class StringTemplateTest extends TestCase {
 		$this->assertEquals([null, null], $this->template->compile('link'));
 	}
 
+/**
+ * test push/pop templates.
+ *
+ * @return void
+ */
+	public function testPushPopTemplates() {
+		$this->template->add(['name' => '{{name}} is my name']);
+		$this->assertNull($this->template->push());
+
+		$this->template->add(['name' => 'my name']);
+		$this->assertEquals('my name', $this->template->get('name'));
+
+		$this->assertNull($this->template->pop());
+		$this->assertEquals('{{name}} is my name', $this->template->get('name'));
+
+		$this->assertNull($this->template->pop());
+		$this->assertNull($this->template->pop());
+	}
+
 }

--- a/tests/test_app/TestApp/Config/htmlhelper_tags.php
+++ b/tests/test_app/TestApp/Config/htmlhelper_tags.php
@@ -3,5 +3,6 @@
 $config = [
 	'formstart' => 'start form',
 	'formend' => 'finish form',
-	'hiddenblock' => '<div class="hidden">{{content}}</div>'
+	'hiddenblock' => '<div class="hidden">{{content}}</div>',
+	'inputContainer' => '{{content}}'
 ];


### PR DESCRIPTION
These changes introduce an internal template stack in `StringTemplate` which allows for both `create()`/`end()` to push/pop the template stack solving #3124. It also cleans up the internals of `input()` and allows a templates file to be used there as well solving #4015.
