### PR TITLE
Fix: Blackholed request when POSTing to a URL with space

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -207,7 +207,7 @@ class CakeRequest implements ArrayAccess {
 			$query = $_GET;
 		}
 
-		$unsetUrl = '/' . str_replace('.', '_', urldecode($this->url));
+		$unsetUrl = '/' . str_replace(array('.', ' '), '_', urldecode($this->url));
 		unset($query[$unsetUrl]);
 		unset($query[$this->base . $unsetUrl]);
 		if (strpos($this->url, '?') !== false) {

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2145,6 +2145,20 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test the here() with space in URL
+ *
+ * @return void
+ */
+	public function testHereWithSpaceInUrl() {
+		Configure::write('App.base', '');
+		$_GET = array('/admin/settings/settings/prefix/Access_Control' => '');
+		$request = new CakeRequest('/admin/settings/settings/prefix/Access%20Control');
+
+		$result = $request->here();
+		$this->assertEquals('/admin/settings/settings/prefix/Access%20Control', $result);
+	}
+
+/**
  * Test the input() method.
  *
  * @return void


### PR DESCRIPTION
Eg:

Actual Posted URL:
    `/admin/settings/settings/prefix/Access%20Control`
$_GET value:
    `/admin/settings/settings/prefix/Access_Control`

Since $unsetUrl differs, the $_GET value will get copied in to
CakeRequest::$query, causing CakeRequest::here() to return:

```
`/admin/settings/settings/prefix/Access%20Control?%2Fadmin%2Fsettings%2Fsettings%2Fprefix%2FAccess_Control=`
```

This confuses SecurityComponent in the following line:

```
https://github.com/cakephp/cakephp/blob/f23d811ff59c50ef278e98bb75f4ec1e7e54a5b3/lib/Cake/Controller/Component/SecurityComponent.php#L514
```
