### PR TITLE
3.0 - Remove remaining cake_dev domain

### DIFF
--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -616,7 +616,7 @@ class Email {
 		} elseif (preg_match($this->_emailPattern, $email)) {
 			return;
 		}
-		throw new Error\SocketException(__d('cake_dev', 'Invalid email: "%s"', $email));
+		throw new Error\SocketException(sprintf('Invalid email: "%s"', $email));
 	}
 
 /**

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1334,10 +1334,7 @@ class Response {
 		);
 
 		if (strpos($path, '..') !== false) {
-			throw new Error\NotFoundException(__d(
-				'cake_dev',
-				'The requested file contains `..` and will not be read.'
-			));
+			throw new Error\NotFoundException('The requested file contains `..` and will not be read.');
 		}
 
 		if (!is_file($path)) {

--- a/src/Template/Error/missing_layout.ctp
+++ b/src/Template/Error/missing_layout.ctp
@@ -20,7 +20,7 @@
 </p>
 
 <p>
-	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', h($file)); ?>
+	<?= sprintf('Confirm you have created the file: %s', h($file)); ?>
 	in one of the following paths:
 </p>
 <ul>

--- a/tests/TestCase/Network/Email/SmtpTransportTest.php
+++ b/tests/TestCase/Network/Email/SmtpTransportTest.php
@@ -511,7 +511,7 @@ class SmtpTransportTest extends TestCase {
  * @return void
  */
 	public function testExplicitDisconnectNotConnected() {
-		$callback = function($arg)  {
+		$callback = function($arg) {
 			$this->assertNotEquals("QUIT\r\n", $arg);
 		};
 		$this->socket->expects($this->any())->method('write')->will($this->returnCallback($callback));
@@ -532,7 +532,7 @@ class SmtpTransportTest extends TestCase {
 		$email->to('cake@cakephp.org', 'CakePHP');
 		$email->expects($this->exactly(2))->method('message')->will($this->returnValue(array('First Line')));
 
-		$callback = function($arg)  {
+		$callback = function($arg) {
 			$this->assertNotEquals("QUIT\r\n", $arg);
 		};
 		$this->socket->expects($this->any())->method('write')->will($this->returnCallback($callback));


### PR DESCRIPTION
Also: in light of this... do we want to make `<?php printf()` or `<?= sprintf()` consistent across the framework?
