### PR TITLE
Make Entity::isNew() only support true/false

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -72,11 +72,12 @@ trait EntityTrait {
 
 /**
  * Indicates whether or not this entity is yet to be persisted.
- * A null value indicates an unknown persistence status
+ * Entities default to assuming they are new. You can use Table::persisted()
+ * to set the new flag on an entity based on records in the database.
  *
  * @var bool
  */
-	protected $_new = null;
+	protected $_new = true;
 
 /**
  * List of errors per field as stored in this object
@@ -514,8 +515,7 @@ trait EntityTrait {
  * that it already is.
  *
  * @param bool $new true if it is known this instance was persisted
- * @return bool if it is known whether the entity was already persisted
- * null otherwise
+ * @return bool Whether or not the entity has been persisted.
  */
 	public function isNew($new = null) {
 		if ($new === null) {

--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -128,7 +128,10 @@ class DatabaseSession implements SessionHandlerInterface {
  * @return bool True for successful delete, false otherwise.
  */
 	public function destroy($id) {
-		return $this->_table->delete(new Entity([$this->_table->primaryKey() => $id]));
+		return $this->_table->delete(new Entity(
+			[$this->_table->primaryKey() => $id],
+			['markNew' => false]
+		));
 	}
 
 /**

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -786,13 +786,13 @@ class BelongsToMany extends Association {
  * @throws \InvalidArgumentException
  */
 	protected function _checkPersistenceStatus($sourceEntity, array $targetEntities) {
-		if ($sourceEntity->isNew() !== false) {
+		if ($sourceEntity->isNew()) {
 			$error = 'Source entity needs to be persisted before proceeding';
 			throw new \InvalidArgumentException($error);
 		}
 
 		foreach ($targetEntities as $entity) {
-			if ($entity->isNew() !== false) {
+			if ($entity->isNew()) {
 				$error = 'Cannot link not persisted entities';
 				throw new \InvalidArgumentException($error);
 			}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1084,8 +1084,7 @@ class Table implements RepositoryInterface, EventListener {
  *
  * This method will determine whether the passed entity needs to be
  * inserted or updated in the database. It does that by checking the `isNew`
- * method on the entity, if no information can be found there, it will go
- * directly to the database to check the entity's status.
+ * method on the entity.
  *
  * ### Saving on associated tables
  *
@@ -1147,17 +1146,13 @@ class Table implements RepositoryInterface, EventListener {
 	protected function _processSave($entity, $options) {
 		$primary = $entity->extract((array)$this->primaryKey());
 
-		if ($primary && $entity->isNew() === null) {
+		if ($primary && $entity->isNew()) {
 			$alias = $this->alias();
 			$keys = array_keys($primary);
 			foreach ($keys as &$pk) {
 				$pk = "$alias.$pk";
 			}
 			$entity->isNew(!$this->exists(array_combine($keys, $primary)));
-		}
-
-		if ($entity->isNew() === null) {
-			$entity->isNew(true);
 		}
 
 		$associated = $options['associated'];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1142,9 +1142,11 @@ class Table implements RepositoryInterface, EventListener {
  * @param \Cake\Datasource\EntityInterface $entity the entity to be saved
  * @param array $options the options to use for the save operation
  * @return \Cake\Datasource\EntityInterface|bool
+ * @throws \RuntimeException When an entity is missing some of the primary keys.
  */
 	protected function _processSave($entity, $options) {
-		$primary = $entity->extract((array)$this->primaryKey());
+		$primaryColumns = (array)$this->primaryKey();
+		$primary = $entity->extract($primaryColumns);
 
 		if ($primary && $entity->isNew()) {
 			$alias = $this->alias();
@@ -1232,7 +1234,7 @@ class Table implements RepositoryInterface, EventListener {
 		$primary = (array)$this->primaryKey();
 		if (empty($primary)) {
 			$msg = sprintf(
-				'Cannot insert row in "%s", it has no primary key.',
+				'Cannot insert row in "%s" table, it has no primary key.',
 				$this->table()
 			);
 			throw new \RuntimeException($msg);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -571,9 +571,14 @@ class EntityTest extends TestCase {
 			'title' => 'Foo',
 			'author_id' => 3
 		]);
-		$this->assertNull($entity->isNew());
+		$this->assertTrue($entity->isNew());
+
 		$entity->isNew(true);
 		$this->assertTrue($entity->isNew());
+
+		$entity->isNew('derpy');
+		$this->assertTrue($entity->isNew());
+
 		$entity->isNew(false);
 		$this->assertFalse($entity->isNew());
 	}
@@ -1042,7 +1047,7 @@ class EntityTest extends TestCase {
 		$entity->source('foos');
 		$result = $entity->__debugInfo();
 		$expected = [
-			'new' => null,
+			'new' => true,
 			'accessible' => ['*' => true, 'name' => true],
 			'properties' => ['foo' => 'bar'],
 			'dirty' => ['foo' => true],

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -110,7 +110,7 @@ class MarshallerTest extends TestCase {
 		$this->assertInstanceOf('Cake\ORM\Entity', $result);
 		$this->assertEquals($data, $result->toArray());
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
-		$this->assertNull($result->isNew(), 'Should be detached');
+		$this->assertTrue($result->isNew(), 'Should be new');
 		$this->assertEquals('Articles', $result->source());
 	}
 
@@ -206,7 +206,7 @@ class MarshallerTest extends TestCase {
 
 		$this->assertInstanceOf('Cake\ORM\Entity', $result);
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
-		$this->assertNull($result->isNew(), 'Should be detached');
+		$this->assertTrue($result->isNew(), 'Should be new');
 		$this->assertEquals($data['Articles']['title'], $result->title);
 		$this->assertEquals($data['Articles']['user']['username'], $result->user->username);
 	}
@@ -645,7 +645,7 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals('mark', $entity->user->username);
 		$this->assertEquals('not a secret', $entity->user->password);
 		$this->assertTrue($entity->dirty('user'));
-		$this->assertNull($entity->user->isNew());
+		$this->assertTrue($entity->user->isNew());
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2515,8 +2515,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$this->assertFalse($table->save($entity));
 		$this->assertTrue($entity->isNew());
-		$this->assertNull($entity->articles[0]->isNew());
-		$this->assertNull($entity->articles[1]->isNew());
+		$this->assertTrue($entity->articles[0]->isNew());
+		$this->assertTrue($entity->articles[1]->isNew());
 		$this->assertNull($entity->articles[0]->id);
 		$this->assertNull($entity->articles[1]->id);
 		$this->assertNull($entity->articles[0]->author_id);
@@ -2741,8 +2741,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$this->assertFalse($table->save($entity));
 		$this->assertTrue($entity->isNew());
-		$this->assertNull($entity->tags[0]->isNew());
-		$this->assertNull($entity->tags[1]->isNew());
+		$this->assertTrue($entity->tags[0]->isNew());
+		$this->assertTrue($entity->tags[1]->isNew());
 		$this->assertNull($entity->tags[0]->id);
 		$this->assertNull($entity->tags[1]->id);
 		$this->assertNull($entity->tags[0]->_joinData);
@@ -2817,8 +2817,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$this->assertFalse($table->save($entity));
 		$this->assertTrue($entity->isNew());
-		$this->assertNull($entity->tags[0]->isNew());
-		$this->assertNull($entity->tags[1]->isNew());
+		$this->assertTrue($entity->tags[0]->isNew());
+		$this->assertTrue($entity->tags[1]->isNew());
 		$this->assertNull($entity->tags[0]->id);
 		$this->assertNull($entity->tags[1]->id);
 		$this->assertNull($entity->tags[0]->_joinData);
@@ -3093,7 +3093,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tags[1]->_joinData = new \Cake\ORM\Entity([
 			'article_id' => 1,
 			'tag_id' => 2
-		]);
+		], $options);
 
 		$table->association('tags')->unlink($article, $tags);
 		$left = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1369,7 +1369,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  *
  * @group save
  * @expectedException \RuntimeException
- * @expectedExceptionMessage Cannot insert row in "users", it has no primary key
+ * @expectedExceptionMessage Cannot insert row in "users" table, it has no primary key
  * @return void
  */
 	public function testSaveNewErrorOnNoPrimaryKey() {


### PR DESCRIPTION
Having an indeterminate state complicates life. Having only true/false makes interacting with the ORM a bit simpler. Table::save() will still determine if an entity is truely new when saving and the primary key is
present. Delete operations assume you know what you are doing, and don't try to help as destroying data is generally more dangerous/difficult to recover vs. having too much data.

Refs #4050
