### PR TITLE
Fix incorrect order of view paths for themed plugins

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -932,11 +932,9 @@ class View {
 		}
 		$paths = array();
 		$viewPaths = App::path('Template');
-		$corePaths = App::core('Template');
 
 		if (!empty($plugin)) {
-			$count = count($viewPaths);
-			for ($i = 0; $i < $count; $i++) {
+			for ($i = 0, $count = count($viewPaths); $i < $count; $i++) {
 				$paths[] = $viewPaths[$i] . 'Plugin' . DS . $plugin . DS;
 			}
 			$paths = array_merge($paths, App::path('Template', $plugin));
@@ -948,21 +946,17 @@ class View {
 			$themePaths = App::path('Template', $theme);
 
 			if ($plugin) {
-				$count = count($viewPaths);
-				for ($i = 0; $i < $count; $i++) {
-					$themePaths[] = $themePaths[$i] . 'Plugin' . DS . $plugin . DS;
+				for ($i = 0, $count = count($viewPaths); $i < $count; $i++) {
+					array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DS . $plugin . DS);
 				}
 			}
-
 			$paths = array_merge($themePaths, $paths);
 		}
-
-		$paths = array_merge($paths, $corePaths);
+		$paths = array_merge($paths, App::core('Template'));
 
 		if ($plugin !== null) {
 			return $this->_pathsForPlugin[$plugin] = $paths;
 		}
-
 		return $this->_paths = $paths;
 	}
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -930,29 +930,25 @@ class View {
 				return $this->_pathsForPlugin[$plugin];
 			}
 		}
-		$paths = array();
 		$viewPaths = App::path('Template');
-
+		$pluginPaths = $themePaths = [];
 		if (!empty($plugin)) {
 			for ($i = 0, $count = count($viewPaths); $i < $count; $i++) {
-				$paths[] = $viewPaths[$i] . 'Plugin' . DS . $plugin . DS;
+				$pluginPaths[] = $viewPaths[$i] . 'Plugin' . DS . $plugin . DS;
 			}
-			$paths = array_merge($paths, App::path('Template', $plugin));
+			$pluginPaths = array_merge($pluginPaths, App::path('Template', $plugin));
 		}
 
-		$paths = array_unique(array_merge($paths, $viewPaths));
 		if (!empty($this->theme)) {
-			$theme = Inflector::camelize($this->theme);
-			$themePaths = App::path('Template', $theme);
+			$themePaths = App::path('Template', Inflector::camelize($this->theme));
 
 			if ($plugin) {
 				for ($i = 0, $count = count($viewPaths); $i < $count; $i++) {
 					array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DS . $plugin . DS);
 				}
 			}
-			$paths = array_merge($themePaths, $paths);
 		}
-		$paths = array_merge($paths, App::core('Template'));
+		$paths = array_merge($themePaths, $pluginPaths, $viewPaths, App::core('Template'));
 
 		if ($plugin !== null) {
 			return $this->_pathsForPlugin[$plugin] = $paths;

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -422,7 +422,7 @@ class ViewTest extends TestCase {
  *
  * @return void
  */
-	public function testPluginPathGeneration() {
+	public function testPathPluginGeneration() {
 		$viewOptions = ['plugin' => 'TestPlugin',
 			'name' => 'TestPlugin',
 			'viewPath' => 'Tests',
@@ -437,6 +437,34 @@ class ViewTest extends TestCase {
 		$paths = $View->paths('TestPlugin');
 		$pluginPath = Plugin::path('TestPlugin');
 		$expected = array(
+			TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+			$pluginPath . 'src' . DS . 'Template' . DS,
+			TEST_APP . 'TestApp' . DS . 'Template' . DS,
+			CAKE . 'Template' . DS,
+		);
+		$this->assertPathEquals($expected, $paths);
+	}
+
+/**
+ * Test that themed plugin paths are generated correctly.
+ *
+ * @return void
+ */
+	public function testPathThemedPluginGeneration() {
+		$viewOptions = ['plugin' => 'TestPlugin',
+			'name' => 'TestPlugin',
+			'viewPath' => 'Tests',
+			'view' => 'index',
+			'theme' => 'TestTheme'
+		];
+
+		$View = new TestView(null, null, null, $viewOptions);
+		$paths = $View->paths('TestPlugin');
+		$pluginPath = Plugin::path('TestPlugin');
+		$themePath = Plugin::path('TestTheme');
+		$expected = array(
+			$themePath . 'src' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+			$themePath . 'src' . DS . 'Template' . DS,
 			TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
 			$pluginPath . 'src' . DS . 'Template' . DS,
 			TEST_APP . 'TestApp' . DS . 'Template' . DS,


### PR DESCRIPTION
Fix the order of view paths in themed plugins and also optimize View::_paths a bit as it uses fewer array_merge() calls now.

Refs #4064
