### PR TITLE
Make year range validation less strict by default.

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1462,10 +1462,11 @@ class ValidationTest extends CakeTestCase {
 		$this->assertTrue(Validation::date('2008', array('y')));
 		$this->assertTrue(Validation::date('2013', array('y')));
 		$this->assertTrue(Validation::date('2104', array('y')));
+		$this->assertTrue(Validation::date('1899', array('y')));
 		$this->assertFalse(Validation::date('20009', array('y')));
 		$this->assertFalse(Validation::date(' 2012', array('y')));
 		$this->assertFalse(Validation::date('3000', array('y')));
-		$this->assertFalse(Validation::date('1899', array('y')));
+		$this->assertFalse(Validation::date('1799', array('y')));
 	}
 
 /**

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -278,7 +278,9 @@ class Validation {
 
 /**
  * Date validation, determines if the string passed is a valid date.
- * keys that expect full month, day and year will validate leap years
+ * keys that expect full month, day and year will validate leap years.
+ *
+ * Years are valid from 1800 to 2999.
  *
  * ### Formats:
  *
@@ -304,7 +306,7 @@ class Validation {
 		}
 		$month = '(0[123456789]|10|11|12)';
 		$separator = '([- /.])';
-		$fourDigitYear = '(([1][9][0-9][0-9])|([2][0-9][0-9][0-9]))';
+		$fourDigitYear = '(([1][8-9][0-9][0-9])|([2][0-9][0-9][0-9]))';
 		$twoDigitYear = '([0-9]{2})';
 		$year = '(?:' . $fourDigitYear . '|' . $twoDigitYear . ')';
 


### PR DESCRIPTION
Currently 1899 fails - which could be a valid date in some use cases.

Refs conversation around https://github.com/cakephp/cakephp/commit/33fbace4c77040acf2379bc1e9463e6f580feeef#commitcomment-7145913

Not sure if we should do that, though. But here is a better location for a discussion.

Anyway, since `2999` is the upper limit, it sounds silly to set the lower limit already at `1900`.
Especially as there is no use case for any such far away future dates, whereas years the distant past are quite important for a lot of use cases.
It should rather be `1000` then as lowest (4 digit) year possible.
But I did set it to `1800` now for 2.5, we can rediscuss it for 2.6 of course.
