### PR TITLE
Remove getAjaxVersion().

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -356,17 +356,6 @@ class RequestHandlerComponent extends Component {
 	}
 
 /**
- * Gets Prototype version if call is Ajax, otherwise empty string.
- * The Prototype library sets a special "Prototype version" HTTP header.
- *
- * @return string|bool When Ajax the prototype version of component making the call otherwise false
- */
-	public function getAjaxVersion() {
-		$httpX = $this->request->env('HTTP_X_PROTOTYPE_VERSION');
-		return ($httpX === null) ? false : $httpX;
-	}
-
-/**
  * Determines which content types the client accepts. Acceptance is based on
  * the file extension parsed by the Router (if present), and by the HTTP_ACCEPT
  * header. Unlike Cake\Network\Request::accepts() this method deals entirely with mapped content types.

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -605,20 +605,6 @@ class RequestHandlerComponentTest extends TestCase {
 	}
 
 /**
- * testRequestClientTypes method
- *
- * @return void
- */
-	public function testRequestClientTypes() {
-		$this->RequestHandler->request->env('HTTP_X_PROTOTYPE_VERSION', '1.5');
-		$this->assertEquals('1.5', $this->RequestHandler->getAjaxVersion());
-
-		$this->RequestHandler->request->env('HTTP_X_REQUESTED_WITH', false);
-		$this->RequestHandler->request->env('HTTP_X_PROTOTYPE_VERSION', false);
-		$this->assertFalse($this->RequestHandler->getAjaxVersion());
-	}
-
-/**
  * testRequestContentTypes method
  *
  * @return void


### PR DESCRIPTION
It was very specific to prototype, which has a very low adoption rate these days. I can deprecate this method in 2.6 as well.
