### PR TITLE
Use an array for translation options to simplify the code

### DIFF
--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -181,7 +181,7 @@ class I18n {
  * Returns a translated string based on current language and translation files stored in locale folder
  *
  * @param string $singular String to translate
- * @param string $plural Plural string (if any)
+ * @param string|array $pluralOrOptions Plural string (if any) or options
  * @param string $domain Domain The domain of the translation. Domains are often used by plugin translations.
  *    If null, the default domain will be used.
  * @param string $category Category The integer value of the category to use.
@@ -192,9 +192,26 @@ class I18n {
  * @return string translated string.
  * @throws CakeException When '' is provided as a domain.
  */
-	public static function translate($singular, $plural = null, $domain = null, $category = self::LC_MESSAGES,
+	public static function translate($singular, $pluralOrOptions = null, $domain = null, $category = self::LC_MESSAGES,
 		$count = null, $language = null, $context = null
 	) {
+		if (is_array($pluralOrOptions)) {
+			$defaults = array(
+				'plural' => null,
+				'domain' => null,
+				'category' => self::LC_MESSAGES,
+				'count' => null,
+				'language' => null,
+				'context' => null
+			);
+
+			$options = $pluralOrOptions;
+
+			extract(array_merge($defaults, $options));
+		} else {
+			$plural = $pluralOrOptions;
+		}
+
 		$_this = I18n::getInstance();
 
 		if (strpos($singular, "\r\n") !== false) {

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -610,7 +610,11 @@ if (!function_exists('__n')) {
 		}
 
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($singular, $plural, null, I18n::LC_MESSAGES, $count);
+		$translated = I18n::translate($singular, array(
+			'plural' => $plural,
+			'category' => I18n::LC_MESSAGES,
+			'count' => $count
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 3));
 	}
@@ -633,7 +637,9 @@ if (!function_exists('__d')) {
 			return;
 		}
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($msg, null, $domain);
+		$translated = I18n::translate($msg, array(
+			'domain' => $domain
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 2));
 	}
@@ -660,7 +666,12 @@ if (!function_exists('__dn')) {
 			return;
 		}
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($singular, $plural, $domain, I18n::LC_MESSAGES, $count);
+		$translated = I18n::translate($singular, array(
+			'plural' => $plural,
+			'domain' => $domain,
+			'category' => I18n::LC_MESSAGES,
+			'count' => $count
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 4));
 	}
@@ -698,7 +709,10 @@ if (!function_exists('__dc')) {
 			return;
 		}
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($msg, null, $domain, $category);
+		$translated = I18n::translate($msg, array(
+			'domain' => $domain,
+			'category' => $category
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 3));
 	}
@@ -740,7 +754,12 @@ if (!function_exists('__dcn')) {
 			return;
 		}
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($singular, $plural, $domain, $category, $count);
+		$translated = I18n::translate($singular, array(
+			'plural' => $plural,
+			'domain' => $domain,
+			'category' => $category,
+			'count' => $count
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 5));
 	}
@@ -774,7 +793,9 @@ if (!function_exists('__c')) {
 			return;
 		}
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($msg, null, null, $category);
+		$translated = I18n::translate($msg, array(
+			'category' => $category
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 2));
 	}
@@ -798,7 +819,9 @@ if (!function_exists('__x')) {
 		}
 
 		App::uses('I18n', 'I18n');
-		$translated = I18n::translate($singular, null, null, null, null, null, $context);
+		$translated = I18n::translate($singular, array(
+			'context' => $context
+		));
 		$arguments = func_get_args();
 		return I18n::insertArgs($translated, array_slice($arguments, 1));
 	}


### PR DESCRIPTION
This actually adds some lines of code but it does make reading the basics file a lot easier.

This was inspired by @dereuromark 's comment on my context support pull request. (https://github.com/cakephp/cakephp/pull/3703#discussion_r14988680)
