### PR TITLE
3.0 - small fix on bake controller

### DIFF
--- a/src/Console/Templates/default/actions/controller_actions.ctp
+++ b/src/Console/Templates/default/actions/controller_actions.ctp
@@ -51,9 +51,9 @@ $allAssociations = array_merge(
 /**
  * View method
  *
- * @throws NotFoundException
  * @param string $id
  * @return void
+ * @throws NotFoundException
  */
 	public function view($id = null) {
 		$<?= $singularName?> = $this-><?= $currentModelName ?>->get($id, [
@@ -94,9 +94,9 @@ $allAssociations = array_merge(
 /**
  * Edit method
  *
- * @throws NotFoundException
  * @param string $id
  * @return void
+ * @throws NotFoundException
  */
 	public function edit($id = null) {
 		$<?= $singularName ?> = $this-><?= $currentModelName ?>->get($id, [
@@ -126,9 +126,9 @@ $allAssociations = array_merge(
 /**
  * Delete method
  *
- * @throws NotFoundException
  * @param string $id
  * @return void
+ * @throws NotFoundException
  */
 	public function delete($id = null) {
 		$<?= $singularName ?> = $this-><?= $currentModelName ?>->get($id);

--- a/tests/bake_compare/Controller/Actions.ctp
+++ b/tests/bake_compare/Controller/Actions.ctp
@@ -14,9 +14,9 @@
 /**
  * View method
  *
- * @throws NotFoundException
  * @param string $id
  * @return void
+ * @throws NotFoundException
  */
 	public function view($id = null) {
 		$bakeArticle = $this->BakeArticles->get($id, [
@@ -48,9 +48,9 @@
 /**
  * Edit method
  *
- * @throws NotFoundException
  * @param string $id
  * @return void
+ * @throws NotFoundException
  */
 	public function edit($id = null) {
 		$bakeArticle = $this->BakeArticles->get($id, [
@@ -73,9 +73,9 @@
 /**
  * Delete method
  *
- * @throws NotFoundException
  * @param string $id
  * @return void
+ * @throws NotFoundException
  */
 	public function delete($id = null) {
 		$bakeArticle = $this->BakeArticles->get($id);


### PR DESCRIPTION
avoid the `ERROR | Parameters must appear immediately after the comment` with phpcs --standard=CakePHP on baked controller and keep for consistency with the framework
