### PR TITLE
3.0 misc orm fixes

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -257,7 +257,8 @@ trait EntityTrait {
 		}
 
 		if ($this->_methodExists($method)) {
-			$value = $this->{$method}($value);
+			$result = $this->{$method}($value);
+			return $result;
 		}
 		return $value;
 	}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1199,7 +1199,7 @@ class Table implements RepositoryInterface, EventListener {
 				$this,
 				$entity,
 				$options['associated'],
-				$options->getArrayCopy()
+				['validate' => (bool)$validate] + $options->getArrayCopy()
 			);
 			if ($success || !$options['atomic']) {
 				$entity->clean();

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -191,7 +191,6 @@ class EntityTest extends TestCase {
 		$this->assertEquals('Dr. Jones', $entity->get('name'));
 	}
 
-
 /**
  * Test magic property setting with no custom setter
  *

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -180,7 +180,7 @@ class EntityTest extends TestCase {
  */
 	public function testGetCustomGetters() {
 		$entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
-		$entity->expects($this->once())->method('_getName')
+		$entity->expects($this->exactly(2))->method('_getName')
 			->with('Jones')
 			->will($this->returnCallback(function($name) {
 				$this->assertSame('Jones', $name);
@@ -188,7 +188,9 @@ class EntityTest extends TestCase {
 			}));
 		$entity->set('name', 'Jones');
 		$this->assertEquals('Dr. Jones', $entity->get('name'));
+		$this->assertEquals('Dr. Jones', $entity->get('name'));
 	}
+
 
 /**
  * Test magic property setting with no custom setter
@@ -244,20 +246,6 @@ class EntityTest extends TestCase {
  */
 	public function testIndirectModification() {
 		$entity = new Entity;
-		$entity->things = ['a', 'b'];
-		$entity->things[] = 'c';
-		$this->assertEquals(['a', 'b', 'c'], $entity->things);
-	}
-
-/**
- * Test indirectly modifying internal properties with a getter
- *
- * @return void
- */
-	public function testIndirectModificationWithGetter() {
-		$entity = $this->getMock('\Cake\ORM\Entity', ['_getThings']);
-		$entity->expects($this->atLeastOnce())->method('_getThings')
-			->will($this->returnArgument(0));
 		$entity->things = ['a', 'b'];
 		$entity->things[] = 'c';
 		$this->assertEquals(['a', 'b', 'c'], $entity->things);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2136,10 +2136,16 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'body' => 'bar',
 			'author' => new \Cake\ORM\Entity([
 				'name' => 'Susan'
-			])
+			]),
+			'articles_tags' => [
+				new \Cake\ORM\Entity([
+					'tag_id' => 100
+				])
+			]
 		]);
 		$table = TableRegistry::get('articles');
 		$table->belongsTo('authors');
+		$table->hasMany('ArticlesTags');
 		$validator = (new Validator)->validatePresence('body');
 		$table->validator('custom', $validator);
 
@@ -2147,6 +2153,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->authors->validator('default', $validator2);
 		$this->assertFalse($table->save($entity, ['validate' => 'custom']), 'default was not used');
 		$this->assertNotEmpty($entity->author->errors('thing'));
+
+		$validator3 = (new Validator)->validatePresence('thing');
+		$table->ArticlesTags->validator('default', $validator2);
+		unset($entity->author);
+		$this->assertFalse($table->save($entity, ['validate' => 'custom']), 'default was not used');
+		$this->assertNotEmpty($entity->articles_tags[0]->errors('thing'));
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2154,7 +2154,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertFalse($table->save($entity, ['validate' => 'custom']), 'default was not used');
 		$this->assertNotEmpty($entity->author->errors('thing'));
 
-		$validator3 = (new Validator)->validatePresence('thing');
 		$table->ArticlesTags->validator('default', $validator2);
 		unset($entity->author);
 		$this->assertFalse($table->save($entity, ['validate' => 'custom']), 'default was not used');


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/3873

Also fixes a bug that I came across while browsing the app containing the above issue. The fix comes at the cost of axing one feature in the Entity class, it will not be possible to use indirect modification on properties hidden by a `_get*` method. In hindsight I think that was  a bad idea to have.
