### PR TITLE
3.0 - Consistent usage of short echo and sprintf

### DIFF
--- a/src/Console/Templates/default/views/form.ctp
+++ b/src/Console/Templates/default/views/form.ctp
@@ -17,7 +17,7 @@ use Cake\Utility\Inflector;
 <div class="<?= $pluralVar; ?> form">
 <?= "<?= \$this->Form->create(\${$singularVar}); ?>\n"; ?>
 	<fieldset>
-		<legend><?php printf("<?= __('%s %s'); ?>", Inflector::humanize($action), $singularHumanName); ?></legend>
+		<legend><?= sprintf("<?= __('%s %s'); ?>", Inflector::humanize($action), $singularHumanName) ?></legend>
 <?php
 		echo "\t<?php\n";
 		foreach ($fields as $field) {

--- a/src/Template/Error/missing_cell_view.ctp
+++ b/src/Template/Error/missing_cell_view.ctp
@@ -17,11 +17,11 @@ use Cake\Utility\Inflector;
 <h2>Missing Cell View</h2>
 <p class="error">
 	<strong>Error: </strong>
-	<?php printf('The view for <em>%sCell</em> was not found.', h(Inflector::camelize($name))); ?>
+	<?= sprintf('The view for <em>%sCell</em> was not found.', h(Inflector::camelize($name))) ?>
 </p>
 
 <p>
-	<?php printf('Confirm you have created the file: "%s"', h($file . $this->_ext)); ?>
+	<?= sprintf('Confirm you have created the file: "%s"', h($file . $this->_ext)) ?>
 	in one of the following paths:
 </p>
 <ul>

--- a/src/Template/Error/missing_view.ctp
+++ b/src/Template/Error/missing_view.ctp
@@ -17,11 +17,11 @@ use Cake\Utility\Inflector;
 <h2>Missing View</h2>
 <p class="error">
 	<strong>Error: </strong>
-	<?php printf('The view for <em>%sController::%s()</em> was not found.', h(Inflector::camelize($this->request->controller)), h($this->request->action)); ?>
+	<?= sprintf('The view for <em>%sController::%s()</em> was not found.', h(Inflector::camelize($this->request->controller)), h($this->request->action)) ?>
 </p>
 
 <p>
-	<?php printf('Confirm you have created the file: "%s"', h($file)); ?>
+	<?= sprintf('Confirm you have created the file: "%s"', h($file)) ?>
 	in one of the following paths:
 </p>
 <ul>
@@ -38,7 +38,7 @@ use Cake\Utility\Inflector;
 
 <p class="notice">
 	<strong>Notice: </strong>
-	<?php printf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_view.ctp'); ?>
+	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_view.ctp') ?>
 </p>
 
 <?= $this->element('exception_stack_trace'); ?>

--- a/tests/test_app/TestApp/Template/Error/error400.ctp
+++ b/tests/test_app/TestApp/Template/Error/error400.ctp
@@ -14,13 +14,13 @@
  */
 use Cake\Core\Configure;
 ?>
-<h2><?= $message; ?></h2>
+<h2><?= $message ?></h2>
 <p class="error">
 	<strong><?= __d('cake', 'Error'); ?>: </strong>
-	<?php printf(
+	<?= sprintf(
 		__d('cake', 'The requested address %s was not found on this server.'),
 		"<strong>'{$url}'</strong>"
-	); ?>
+	) ?>
 </p>
 <?php
 if (Configure::read('debug')):

--- a/tests/test_app/TestApp/Template/Error/error400.ctp
+++ b/tests/test_app/TestApp/Template/Error/error400.ctp
@@ -14,7 +14,7 @@
  */
 use Cake\Core\Configure;
 ?>
-<h2><?= $message ?></h2>
+<h2><?= h($message) ?></h2>
 <p class="error">
 	<strong><?= __d('cake', 'Error'); ?>: </strong>
 	<?= sprintf(

--- a/tests/test_app/TestApp/Template/Error/error500.ctp
+++ b/tests/test_app/TestApp/Template/Error/error500.ctp
@@ -14,7 +14,7 @@
  */
 use Cake\Core\Configure;
 ?>
-<h2><?= $message; ?></h2>
+<h2><?= h($message) ?></h2>
 <p class="error">
 	<strong><?= __d('cake', 'Error'); ?>: </strong>
 	<?= __d('cake', 'An Internal Error Has Occurred.'); ?>


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/4079.

Went with sprintf() since it does fall a little closer in line with CS (even though, yeah, the CS is about echo, and printf() is different) and the benchmarking difference between the two is minuscule.
