### PR TITLE
3.0 small typos correction

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -128,7 +128,7 @@ class Connection {
 	}
 
 /**
- * Sets the driver instance. If an string is passed it will be treated
+ * Sets the driver instance. If a string is passed it will be treated
  * as a class name and will be instantiated.
  *
  * If no params are passed it will return the current driver instance.

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -950,7 +950,7 @@ class Response {
 	}
 
 /**
- * Sets the Last-Modified header for the response by taking an modification time
+ * Sets the Last-Modified header for the response by taking a modification time
  * If called with no parameters it will return the current Last-Modified value
  *
  * ## Examples:

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -719,7 +719,7 @@ abstract class Association {
  * By default the subquery strategy is used, which requires a query on the source
  * When using the select strategy, the list of primary keys will be used.
  *
- * Returns a closure that should be run for each record returned in an specific
+ * Returns a closure that should be run for each record returned in a specific
  * Query. This callable will be responsible for injecting the fields that are
  * related to each specific passed row.
  *
@@ -763,7 +763,7 @@ abstract class Association {
 	public abstract function isOwningSide(Table $side);
 
 /**
- * Extract the target's associaiton data our from the passed entity and proxies
+ * Extract the target's association data our from the passed entity and proxies
  * the saving operation to the target table.
  *
  * @param \Cake\ORM\Entity $entity the data to be saved

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -298,7 +298,7 @@ class EagerLoader {
  * @param array $options list of extra options to use for this association
  * @param array $paths An array with to values, the first one is a list of dot
  * separated strings representing associations that lead to this `$alias` in the
- * chain of associaitons to be loaded. The second value is the path to follow in
+ * chain of associations to be loaded. The second value is the path to follow in
  * entities' properties to fetch a record of the corresponding association.
  * @return array normalized associations
  * @throws \InvalidArgumentException When containments refer to associations that do not exist.
@@ -474,7 +474,7 @@ class EagerLoader {
 	}
 
 /**
- * Helper function used to iterate an statement and extract the columns
+ * Helper function used to iterate a statement and extract the columns
  * defined in $collectKeys
  *
  * @param \Cake\Database\StatementInterface $statement The statement to read from.

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -23,7 +23,7 @@ use \JsonSerializable;
 use \Serializable;
 
 /**
- * Represents the results obtained after executing a query for an specific table
+ * Represents the results obtained after executing a query for a specific table
  * This object is responsible for correctly nesting result keys reported from
  * the query, casting each field to the correct type and executing the extra
  * queries required for eager loading external associations.

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1737,7 +1737,7 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that formatters cna be applied to deep associaitons that are fetched using
+ * Tests that formatters cna be applied to deep associations that are fetched using
  * additional queries
  *
  * @return void
@@ -1772,7 +1772,7 @@ class QueryTest extends TestCase {
 
 /**
  * Tests that it is possible to attach more association when using a query
- * builder for other associaitons
+ * builder for other associations
  *
  * @return void
  */

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3337,7 +3337,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  *
  * @return void
  */
-	public function testValidateManyDefaultAssociaion() {
+	public function testValidateManyDefaultAssociation() {
 		$table = $this->getMock('\Cake\ORM\Table', ['entityValidator']);
 		$table->belongsTo('users');
 		$table->hasMany('articles');


### PR DESCRIPTION
- typos in text used on API and test name method

I could undo the 'an'->'a' conversion if it's due to my english skills
