### PR TITLE
3.0 - correct paths in missing_layout suggestions

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -892,7 +892,7 @@ class View {
 			}
 		}
 		throw new Error\MissingLayoutException(array(
-			'file' => $layoutPath[0] . $name . $this->_ext
+			'file' => $layoutPaths[0] . $name . $this->_ext
 		));
 	}
 


### PR DESCRIPTION
wrong (please note Layout/ missing part and L character before docs.ctp):

``` php
Missing Layout
Error: The layout file Ldocs.ctp can not be found or does not exist.

Confirm you have created the file: Ldocs.ctp    in one of the following paths:

[..]/src/Template/Plugin/Oven/Ldocs.ctp
[..]/plugins/Oven/src/Template/Ldocs.ctp
[..]/src/Template/Ldocs.ctp
```

correct:

``` php
Missing Layout
Error: The layout file Layout/docs.ctp can not be found or does not exist.

Confirm you have created the file: Layout/docs.ctp  in one of the following paths:

[..]/src/Template/Plugin/Oven/Layout/docs.ctp
[..]/plugins/Oven/src/Template/Layout/docs.ctp
[..]/src/Template/Layout/docs.ctp
```
