### PR TITLE
Updating RequestHandlerComponent to accept body of HTTP Delete requests

### DIFF
--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -506,7 +506,7 @@ class RequestHandlerComponent extends Component {
  *   in the request content type will be returned.
  */
 	public function requestedWith($type = null) {
-		if (!$this->request->is('post') && !$this->request->is('put')) {
+		if (!$this->request->is('post') && !$this->request->is('put') && !$this->request->is('delete')) {
 			return null;
 		}
 		if (is_array($type)) {

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -601,6 +601,9 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$result = $this->RequestHandler->requestedWith(array('rss', 'atom'));
 		$this->assertFalse($result);
 
+        $_SERVER['REQUEST_METHOD'] = 'DELETE';
+        $this->assertEquals('json', $this->RequestHandler->requestedWith());
+
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		unset($_SERVER['CONTENT_TYPE']);
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';


### PR DESCRIPTION
I was trying to use HTTP DELETE along with a JSON encoded body. CakePHP was ignoring the body content while it works for POST and PUT. I traced it down to this line of code.

During startup, the `RequestHandlerComponent` tries to set `$controller->request->data` if the `requestedType` is valid. This was not occurring for DELETE requests because of the checks in `requestedWith`
https://github.com/cakephp/cakephp/blob/master/lib/Cake/Controller/Component/RequestHandlerComponent.php#L216

I've patched `requestedWith` to allow DELETE. There are considerable arguments why the body of a DELETE request should be allowed, the strongest being that it the RFC allows it. Here is a stack overflow discussion of that issue at hand:

http://stackoverflow.com/questions/14323716/restful-alternatives-to-delete-request-body
