### PR TITLE
3.0 typos for API

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -493,7 +493,7 @@ class Cache {
  * @param string $config The cache configuration to use for this operation.
  *   Defaults to default.
  * @return mixed If the key is found: the cached data, false if the data
- *   missing/expired, or an error.  If the key is not found: boolean of the
+ *   missing/expired, or an error. If the key is not found: boolean of the
  *   success of the write
  */
 	public static function remember($key, $callable, $config = 'default') {

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -250,7 +250,7 @@ class ViewTask extends BakeTask {
  * - 'keyFields'
  * - 'schema'
  *
- * @return array Returns an variables to be made available to a view template
+ * @return array Returns variables to be made available to a view template
  */
 	protected function _loadController() {
 		$modelObj = TableRegistry::get($this->modelName);

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -74,7 +74,7 @@ trait PostgresDialectTrait {
 	}
 
 /**
- * Returns an dictionary of expressions to be transformed when compiling a Query
+ * Returns a dictionary of expressions to be transformed when compiling a Query
  * to SQL. Array keys are method names to be called in this class
  *
  * @return array

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -51,7 +51,7 @@ trait SqliteDialectTrait {
 	protected $_schemaDialect;
 
 /**
- * Returns an dictionary of expressions to be transformed when compiling a Query
+ * Returns a dictionary of expressions to be transformed when compiling a Query
  * to SQL. Array keys are method names to be called in this class
  *
  * @return array

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -120,7 +120,7 @@ class Comparison extends QueryExpression {
 	}
 
 /**
- * Returns a template and an placeholder for the value after registering it
+ * Returns a template and a placeholder for the value after registering it
  * with the placeholder $generator
  *
  * @param \Cake\Database\ValueBinder $generator The value binder to use.

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -499,7 +499,7 @@ class Table {
 	}
 
 /**
- * Read information about an constraint based on name.
+ * Read information about a constraint based on name.
  *
  * @param string $name The name of the constraint.
  * @return array|null Array of constraint data, or null

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -35,7 +35,7 @@ class PDOStatement extends StatementDecorator {
 	}
 
 /**
- * Assign a value to an positional or named variable in prepared query. If using
+ * Assign a value to a positional or named variable in prepared query. If using
  * positional variables you need to start with index one, if using named params then
  * just use the name in any order.
  *

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -69,7 +69,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
 	}
 
 /**
- * Assign a value to an positional or named variable in prepared query. If using
+ * Assign a value to a positional or named variable in prepared query. If using
  * positional variables you need to start with index one, if using named params then
  * just use the name in any order.
  *

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -21,7 +21,7 @@ namespace Cake\Database;
 interface StatementInterface {
 
 /**
- * Assign a value to an positional or named variable in prepared query. If using
+ * Assign a value to a positional or named variable in prepared query. If using
  * positional variables you need to start with index one, if using named params then
  * just use the name in any order.
  *

--- a/src/Model/ModelAwareTrait.php
+++ b/src/Model/ModelAwareTrait.php
@@ -29,7 +29,7 @@ trait ModelAwareTrait {
  * This object's primary model class name. Should be a plural form.
  * CakePHP will not inflect the name.
  *
- * Example: For a object named 'Comments', the modelClass would be 'Comments'.
+ * Example: For an object named 'Comments', the modelClass would be 'Comments'.
  * Plugin classes should use `Plugin.Comments` style names to correctly load
  * models from the correct plugin.
  *

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -296,7 +296,7 @@ class EagerLoader {
  * @param Table $parent owning side of the association
  * @param string $alias name of the association to be loaded
  * @param array $options list of extra options to use for this association
- * @param array $paths An array with to values, the first one is a list of dot
+ * @param array $paths An array with two values, the first one is a list of dot
  * separated strings representing associations that lead to this `$alias` in the
  * chain of associations to be loaded. The second value is the path to follow in
  * entities' properties to fetch a record of the corresponding association.
@@ -348,7 +348,7 @@ class EagerLoader {
  *
  * @param string $alias the name of the association to evaluate
  * @param array $config The association config
- * @param string $root An string representing the root association that started
+ * @param string $root A string representing the root association that started
  * the direct chain this alias is in
  * @return array The modified association config
  * @throws \RuntimeException if a duplicate association in the same chain is detected

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -229,6 +229,7 @@ class Query extends DatabaseQuery {
  *		]
  *	]);
  * }}}
+ *
  * If called with no arguments, this function will return an array with
  * with the list of previously configured associations to be contained in the
  * result.

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -228,7 +228,7 @@ class Query extends DatabaseQuery {
  *			}
  *		]
  *	]);
- *
+ * }}}
  * If called with no arguments, this function will return an array with
  * with the list of previously configured associations to be contained in the
  * result.

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -713,7 +713,7 @@ class Router {
 
 /**
  * Set/add valid extensions. Instructs the router to parse out file extensions
- * from the URL. For example, http://example.com/posts.rss would yield an file
+ * from the URL. For example, http://example.com/posts.rss would yield a file
  * extension of "rss". The file extension itself is made available in the
  * controller as `$this->params['_ext']`, and is used by the RequestHandler
  * component to automatically switch to alternate layouts and templates, and

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -40,7 +40,7 @@ abstract class ObjectRegistry {
 	protected $_loaded = [];
 
 /**
- * Loads/constructs a object instance.
+ * Loads/constructs an object instance.
  *
  * Will return the instance in the registry if it already exists.
  * If a subclass provides event support, you can use `$config['enabled'] = false`

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2198,7 +2198,7 @@ class FormHelper extends Helper {
  *
  * @param string $type The type of context. This key
  *   can be used to overwrite existing providers.
- * @param callable $check A callable that returns a object
+ * @param callable $check A callable that returns an object
  *   when the form context is the correct type.
  * @return void
  */

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -761,7 +761,7 @@ class ExceptionRendererTest extends TestCase {
 	}
 
 /**
- * Test that exceptions can be rendered when an request hasn't been registered
+ * Test that exceptions can be rendered when a request hasn't been registered
  * with Router
  *
  * @return void


### PR DESCRIPTION
- fixes some 'a -> 'an' mistakes
- close an Example code block
