### PR TITLE
rename validation method ssn to personId

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -738,14 +738,15 @@ class Validation {
 	}
 
 /**
- * Checks that a value is a valid Social Security Number.
+ * Checks that a value is a valid identification number.
+ * In the case of US this would be the Social Security Number (SSN).
  *
  * @param string|array $check Value to check
  * @param string $regex Regular expression to use
  * @param string $country Country
  * @return bool Success
  */
-	public static function ssn($check, $regex = null, $country = null) {
+	public static function personId($check, $regex = null, $country = null) {
 		if (is_array($check)) {
 			extract(static::_defaults($check));
 		}
@@ -764,7 +765,7 @@ class Validation {
 			}
 		}
 		if (empty($regex)) {
-			return static::_pass('ssn', $check, $country);
+			return static::_pass('personId', $check, $country);
 		}
 		return static::_check($check, $regex);
 	}

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -58,12 +58,12 @@ class TestNlValidation {
 	}
 
 /**
- * ssn function for testing ssn pass through
+ * personId function for testing identification pass through.
  *
  * @param string $check
  * @return void
  */
-	public static function ssn($check) {
+	public static function personId($check) {
 		return true;
 	}
 
@@ -2285,14 +2285,14 @@ class ValidationTest extends TestCase {
 	}
 
 /**
- * test that phone and postal pass to other classes.
+ * test that phone, postal and personId pass to other classes.
  *
  * @return void
  */
-	public function testPhonePostalSsnPass() {
+	public function testPhonePostalPhonePersonIdPass() {
 		$this->assertTrue(Validation::postal('text', null, __NAMESPACE__ . '\TestNlValidation'));
 		$this->assertTrue(Validation::phone('text', null, __NAMESPACE__ . '\TestDeValidation'));
-		$this->assertTrue(Validation::ssn('text', null, __NAMESPACE__ . '\TestNlValidation'));
+		$this->assertTrue(Validation::personId('text', null, __NAMESPACE__ . '\TestNlValidation'));
 	}
 
 /**
@@ -2325,24 +2325,24 @@ class ValidationTest extends TestCase {
 	}
 
 /**
- * testSsn method
+ * testPersonId method
  *
  * @return void
  */
-	public function testSsn() {
-		$this->assertFalse(Validation::ssn('111-333', null, 'dk'));
-		$this->assertFalse(Validation::ssn('111111-333', null, 'dk'));
-		$this->assertTrue(Validation::ssn('111111-3334', null, 'dk'));
+	public function testPersonId() {
+		$this->assertFalse(Validation::personId('111-333', null, 'dk'));
+		$this->assertFalse(Validation::personId('111111-333', null, 'dk'));
+		$this->assertTrue(Validation::personId('111111-3334', null, 'dk'));
 
-		$this->assertFalse(Validation::ssn('1118333', null, 'nl'));
-		$this->assertFalse(Validation::ssn('1234567890', null, 'nl'));
-		$this->assertFalse(Validation::ssn('12345A789', null, 'nl'));
-		$this->assertTrue(Validation::ssn('123456789', null, 'nl'));
+		$this->assertFalse(Validation::personId('1118333', null, 'nl'));
+		$this->assertFalse(Validation::personId('1234567890', null, 'nl'));
+		$this->assertFalse(Validation::personId('12345A789', null, 'nl'));
+		$this->assertTrue(Validation::personId('123456789', null, 'nl'));
 
-		$this->assertFalse(Validation::ssn('11-33-4333', null, 'us'));
-		$this->assertFalse(Validation::ssn('113-3-4333', null, 'us'));
-		$this->assertFalse(Validation::ssn('111-33-333', null, 'us'));
-		$this->assertTrue(Validation::ssn('111-33-4333', null, 'us'));
+		$this->assertFalse(Validation::personId('11-33-4333', null, 'us'));
+		$this->assertFalse(Validation::personId('113-3-4333', null, 'us'));
+		$this->assertFalse(Validation::personId('111-33-333', null, 'us'));
+		$this->assertTrue(Validation::personId('111-33-4333', null, 'us'));
 	}
 
 /**


### PR DESCRIPTION
Preparation for https://github.com/cakephp/localized/issues/84

For Localized ssn() is too country specific and has been renamed to personId().
This should also be reflected in the CakePHP3.x core.

I will update the migration guide afterwards.
Should we also backport this to 2.6 with the deprecation of the ssn() method?
That would ease migration.
