### PR TITLE
master - `a` / `an` typo fixes fot API

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -197,7 +197,7 @@ class Cache {
 
 /**
  * Drops a cache engine. Deletes the cache configuration information
- * If the deleted configuration is the last configuration using an certain engine,
+ * If the deleted configuration is the last configuration using a certain engine,
  * the Engine instance is also unset.
  *
  * @param string $name A currently configured cache config you wish to remove.

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -381,7 +381,7 @@ class FixtureTask extends BakeTask {
 	}
 
 /**
- * Convert a $records array into a a string.
+ * Convert a $records array into a string.
  *
  * @param array $records Array of records to be converted to string
  * @return string A string value of the $records array.

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -248,7 +248,7 @@ class ViewTask extends BakeTask {
  *	'singularHumanName', 'pluralHumanName', 'fields', 'foreignKeys',
  *	'belongsTo', 'hasOne', 'hasMany', 'hasAndBelongsToMany'
  *
- * @return array Returns an variables to be made available to a view template
+ * @return array Returns a variables to be made available to a view template
  */
 	protected function _loadController() {
 		if (!$this->controllerName) {

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -47,7 +47,7 @@ class ConsoleErrorHandler {
 	}
 
 /**
- * Handle a exception in the console environment. Prints a message to stderr.
+ * Handle an exception in the console environment. Prints a message to stderr.
  *
  * @param Exception $exception The exception to handle
  * @return void

--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -170,7 +170,7 @@ class ConsoleOutput {
  * Outputs a single or multiple messages to stdout. If no parameters
  * are passed, outputs just a newline.
  *
- * @param string|array $message A string or a an array of strings to output
+ * @param string|array $message A string or an array of strings to output
  * @param int $newlines Number of newlines to append
  * @return int Returns the number of bytes returned from writing to stdout.
  */

--- a/lib/Cake/Console/HelpFormatter.php
+++ b/lib/Cake/Console/HelpFormatter.php
@@ -45,7 +45,7 @@ class HelpFormatter {
 	protected $_maxOptions = 6;
 
 /**
- * Build the help formatter for a an OptionParser
+ * Build the help formatter for an OptionParser
  *
  * @param ConsoleOptionParser $parser The option parser help is being generated for.
  */

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -594,7 +594,7 @@ class Shell extends Object {
  * present in most shells. Using Shell::QUIET for a message means it will always display.
  * While using Shell::VERBOSE means it will only display when verbose output is toggled.
  *
- * @param string|array $message A string or a an array of strings to output
+ * @param string|array $message A string or an array of strings to output
  * @param int $newlines Number of newlines to append
  * @param int $level The message's output level, see above.
  * @return int|bool Returns the number of bytes returned from writing to stdout.
@@ -618,7 +618,7 @@ class Shell extends Object {
  * Outputs a single or multiple error messages to stderr. If no parameters
  * are passed outputs just a newline.
  *
- * @param string|array $message A string or a an array of strings to output
+ * @param string|array $message A string or an array of strings to output
  * @param int $newlines Number of newlines to append
  * @return void
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::err

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -590,7 +590,7 @@ class App {
  * not construct any classes contained in the files. It will only find and require() the file.
  *
  * @param string|array $type The type of Class if passed as a string, or all params can be passed as
- *   an single array to $type.
+ *   a single array to $type.
  * @param string $name Name of the Class or a unique name for the file
  * @param bool|array $parent boolean true if Class Parent should be searched, accepts key => value
  *   array('parent' => $parent, 'file' => $file, 'search' => $search, 'ext' => '$ext');

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -33,7 +33,7 @@ class CakePlugin {
 	protected static $_plugins = array();
 
 /**
- * Loads a plugin and optionally loads bootstrapping, routing files or loads a initialization function
+ * Loads a plugin and optionally loads bootstrapping, routing files or loads an initialization function
  *
  * Examples:
  *

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -35,7 +35,7 @@ App::uses('Controller', 'Controller');
  *
  * You can implement application specific exception handling in one of a few ways:
  *
- * - Create a AppController::appError();
+ * - Create an AppController::appError();
  * - Create a subclass of ExceptionRenderer and configure it to be the `Exception.renderer`
  *
  * #### Using AppController::appError();

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -696,7 +696,7 @@ class Mysql extends DboSource {
 	}
 
 /**
- * Returns an detailed array of sources (tables) in the database.
+ * Returns a detailed array of sources (tables) in the database.
  *
  * @param string $name Table name to get parameters
  * @return array Array of table names in the database

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3246,7 +3246,7 @@ class DboSource extends DataSource {
 	}
 
 /**
- * Generate a alter syntax from CakeSchema::compare()
+ * Generate an alter syntax from CakeSchema::compare()
  *
  * @param mixed $compare The comparison data.
  * @param string $table The table name.

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -950,7 +950,7 @@ class CakeResponse {
 	}
 
 /**
- * Sets the Last-Modified header for the response by taking an modification time
+ * Sets the Last-Modified header for the response by taking a modification time
  * If called with no parameters it will return the current Last-Modified value
  *
  * ## Examples:
@@ -1003,7 +1003,7 @@ class CakeResponse {
  * parameters are passed, then an array with the current Vary header
  * value is returned
  *
- * @param string|array $cacheVariances a single Vary string or a array
+ * @param string|array $cacheVariances a single Vary string or an array
  *   containing the list for variances.
  * @return array
  */

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -1206,7 +1206,7 @@ class Router {
 /**
  * Instructs the router to parse out file extensions from the URL.
  *
- * For example, http://example.com/posts.rss would yield an file extension of "rss".
+ * For example, http://example.com/posts.rss would yield a file extension of "rss".
  * The file extension itself is made available in the controller as
  * `$this->params['ext']`, and is used by the RequestHandler component to
  * automatically switch to alternate layouts and templates, and load helpers

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -197,7 +197,7 @@ class File {
 	}
 
 /**
- * Prepares a ASCII string for writing. Converts line endings to the
+ * Prepares an ASCII string for writing. Converts line endings to the
  * correct terminator for the current platform. If Windows, "\r\n" will be used,
  * all other platforms will use "\n"
  *

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -234,7 +234,7 @@ abstract class ObjectCollection {
 	}
 
 /**
- * Disables callbacks on a object or array of objects. Public object methods are still
+ * Disables callbacks on an object or array of objects. Public object methods are still
  * callable as normal.
  *
  * @param string|array $name CamelCased name of the objects(s) to disable (string or array)

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -910,7 +910,7 @@ class Set {
 	}
 
 /**
- * Expand/unflattens an string to an array
+ * Expand/unflattens a string to an array
  *
  * For example, unflattens an array that was collapsed with `Set::flatten()`
  * into a multi-dimensional array. So, `array('0.Foo.Bar' => 'Far')` becomes

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -325,7 +325,7 @@ class Xml {
 	}
 
 /**
- * Returns this XML structure as a array.
+ * Returns this XML structure as an array.
  *
  * @param SimpleXMLElement|DOMDocument|DOMNode $obj SimpleXMLElement, DOMDocument or DOMNode instance
  * @return array Array representation of the XML structure.

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -329,7 +329,7 @@ class FormHelper extends AppHelper {
  *   If an array is passed and $options argument is empty, the array will be used as options.
  *   If `false` no model is used.
  * @param array $options An array of html attributes and options.
- * @return string An formatted opening FORM tag.
+ * @return string A formatted opening FORM tag.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-create
  */
 	public function create($model = null, $options = array()) {
@@ -1483,7 +1483,7 @@ class FormHelper extends AppHelper {
  * - `hiddenField` - boolean to indicate if you want the results of radio() to include
  *    a hidden input with a value of ''. This is useful for creating radio sets that non-continuous
  * - `disabled` - Set to `true` or `disabled` to disable all the radio buttons.
- * - `empty` - Set to `true` to create a input with the value '' as the first option. When `true`
+ * - `empty` - Set to `true` to create an input with the value '' as the first option. When `true`
  *   the radio label will be 'empty'. Set this option to a string to control the label value.
  *
  * @param string $fieldName Name of a field, like this "Modelname.fieldname"
@@ -2257,7 +2257,7 @@ class FormHelper extends AppHelper {
  * ### Attributes:
  *
  * - `monthNames` - If false, 2 digit numbers will be used instead of text.
- *   If a array, the given array will be used.
+ *   If an array, the given array will be used.
  * - `empty` - If true, the empty select option is shown. If a string,
  *   that string is displayed as the empty element.
  * - `value` The selected value of the input.
@@ -2455,7 +2455,7 @@ class FormHelper extends AppHelper {
  * ### Attributes:
  *
  * - `monthNames` If false, 2 digit numbers will be used instead of text.
- *   If a array, the given array will be used.
+ *   If an array, the given array will be used.
  * - `minYear` The lowest year to use in the year select
  * - `maxYear` The maximum year to use in the year select
  * - `interval` The interval for the minutes select. Defaults to 1
@@ -2933,7 +2933,7 @@ class FormHelper extends AppHelper {
  *   Disabling the field using the `disabled` option, will also omit the field from being
  *   part of the hashed key.
  *
- * This method will convert a numerically indexed 'disabled' into a associative
+ * This method will convert a numerically indexed 'disabled' into an associative
  * value. FormHelper's internals expect associative options.
  *
  * @param string $field Name of the field to initialize options for.

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -476,7 +476,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 	abstract public function serializeForm($options = array());
 
 /**
- * Parse an options assoc array into an JavaScript object literal.
+ * Parse an options assoc array into a JavaScript object literal.
  * Similar to object() but treats any non-integer value as a string,
  * does not include `{ }`
  *

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -225,7 +225,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
 	}
 
 /**
- * Create an new Request.
+ * Create a new Request.
  *
  * Requires `Request`. If you wish to use 'update' key you must have ```Request.HTML```
  * if you wish to do Json requests you will need ```JSON``` and ```Request.JSON```.


### PR DESCRIPTION
following the proposed typos correction for 3.0, I did the check and correct some in master branch
