### PR TITLE
Fix a fatal error occurs in combination with a scaffold error.

### DIFF
--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -63,12 +63,45 @@ class ScaffoldMockControllerWithFields extends Controller {
 /**
  * function beforeScaffold
  *
- * @param string method
+ * @param string $method Method name.
  * @return bool true
  */
 	public function beforeScaffold($method) {
 		$this->set('scaffoldFields', array('title'));
 		return true;
+	}
+
+}
+
+/**
+ * ScaffoldMockControllerWithError class
+ *
+ * @package       Cake.Test.Case.Controller
+ */
+class ScaffoldMockControllerWithError extends Controller {
+
+/**
+ * name property
+ *
+ * @var string
+ */
+	public $name = 'ScaffoldMock';
+
+/**
+ * scaffold property
+ *
+ * @var mixed
+ */
+	public $scaffold;
+
+/**
+ * function beforeScaffold
+ *
+ * @param string $method Method name.
+ * @return bool false
+ */
+	public function beforeScaffold($method) {
+		return false;
 	}
 
 }
@@ -83,7 +116,7 @@ class TestScaffoldMock extends Scaffold {
 /**
  * Overload _scaffold
  *
- * @param CakeRequest $request
+ * @param CakeRequest $request Request object for scaffolding
  * @return void
  */
 	protected function _scaffold(CakeRequest $request) {
@@ -344,4 +377,40 @@ class ScaffoldTest extends CakeTestCase {
 		$this->assertNotRegExp('/textarea name="data\[ScaffoldMock\]\[body\]" cols="30" rows="6" id="ScaffoldMockBody"/', $result);
 	}
 
+/**
+ * test in case of scaffold error
+ *
+ * @return void
+ */
+	public function testScaffoldError() {
+		$request = new CakeRequest(null, false);
+		$this->Controller = new ScaffoldMockControllerWithError($request);
+		$this->Controller->response = $this->getMock('CakeResponse', array('_sendHeader'));
+
+		$params = array(
+			'plugin' => null,
+			'pass' => array(1),
+			'form' => array(),
+			'named' => array(),
+			'url' => array('url' => 'scaffold_mock/edit'),
+			'controller' => 'scaffold_mock',
+			'action' => 'edit',
+		);
+		$this->Controller->request->base = '';
+		$this->Controller->request->webroot = '/';
+		$this->Controller->request->here = '/scaffold_mock/edit';
+		$this->Controller->request->addParams($params);
+
+		//set router.
+		Router::reload();
+		Router::setRequestInfo($this->Controller->request);
+
+		$this->Controller->constructClasses();
+		ob_start();
+		new Scaffold($this->Controller, $this->Controller->request);
+		$this->Controller->response->send();
+		$result = ob_get_clean();
+
+		$this->assertRegExp('/Scaffold Error/', $result);
+	}
 }

--- a/lib/Cake/View/Errors/scaffold_error.ctp
+++ b/lib/Cake/View/Errors/scaffold_error.ctp
@@ -31,4 +31,8 @@ function _scaffoldError() {<br />
 
 </pre>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+if (isset($error) && $error instanceof Exception) {
+	echo $this->element('exception_stack_trace'); 
+}
+?>


### PR DESCRIPTION
Rendering scaffold_error.ctp causes a fatal error.
To reproduce, create a controller such as the following.

<pre>
class ArticlesController extends AppController {
    public $scaffold;

    public function beforeScaffold() {
        return false;
    }
}
</pre>

I have fixed this issue. (Though scaffolding will be removed in 3.0)
