### PR TITLE
Add getter mode for logQueries.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -542,10 +542,14 @@ class Connection {
 /**
  * Enables or disables query logging for this connection.
  *
- * @param bool $enable whether to turn logging on or disable it
- * @return void
+ * @param bool $enable whether to turn logging on or disable it.
+ *   Use null to read current value.
+ * @return bool
  */
-	public function logQueries($enable) {
+	public function logQueries($enable = null) {
+		if ($enable === null) {
+			return $this->_logQueries;
+		}
 		$this->_logQueries = $enable;
 	}
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -655,6 +655,19 @@ class ConnectionTest extends TestCase {
 	}
 
 /**
+ * test logQueries method
+ *
+ * @return void
+ */
+	public function testLogQueries() {
+		$this->connection->logQueries(true);
+		$this->assertTrue($this->connection->logQueries());
+
+		$this->connection->logQueries(false);
+		$this->assertFalse($this->connection->logQueries());
+	}
+
+/**
  * Tests that log() function logs to the configured query logger
  *
  * @return void


### PR DESCRIPTION
This is useful if you want to know whether or not a connection is  currently logging queries. The actual use case for this will be in DebugKit where I need to know whether a connection already has logging enabled so I can enable it and get the existing logger or not.
