### PR TITLE
Update HtmlHelper.php

### DIFF
--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -497,7 +497,7 @@ class HtmlHelper extends AppHelper {
  *
  * Add the script file to a custom block:
  *
- * `$this->Html->script('styles.js', null, array('block' => 'bodyScript'));`
+ * `$this->Html->script('styles.js', array('block' => 'bodyScript'));`
  *
  * ### Options
  *


### PR DESCRIPTION
No need to add `null` to `$options` param as mentioned in the docs section [Using blocks for script and CSS files](http://book.cakephp.org/2.0/en/views.html#using-blocks-for-script-and-css-files)
