### PR TITLE
Fix routing for altered url

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -615,7 +615,9 @@ class Router {
 
 			if (($r = $route->parse($url)) !== false) {
 				self::$_currentRoute[] =& $route;
-				$out = $r;
+				$out = array_map(function($value) {
+					return is_string($value) ? strtolower($value) : $value;
+				}, $r);
 				break;
 			}
 		}


### PR DESCRIPTION
When I type in www.gooGLE.com, I will still get to the page I want.
The same should go for URLs in my routes.
When a user alters a link by using capital letters, it is considered wrong.
Even if a route is found.

This change makes sure that all string entries eg. controller, action, plugin are in lower case, when finding a route match.

So that my route will find /cakephp and /cakePHP

```
Router::connect('/', array('controller' => 'cakephp ', 'action' => 'index'));
```

So if a user enters
