### PR TITLE
Provide session defaults.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -156,6 +156,7 @@ class Request implements \ArrayAccess {
  */
 	public static function createFromGlobals() {
 		list($base, $webroot) = static::_base();
+		$sessionConfig = (array)Configure::read('Session') + array('defaults' => 'php');
 		$config = array(
 			'query' => $_GET,
 			'post' => $_POST,
@@ -164,7 +165,7 @@ class Request implements \ArrayAccess {
 			'environment' => $_SERVER + $_ENV,
 			'base' => $base,
 			'webroot' => $webroot,
-			'session' => Session::create(Configure::read('Session'))
+			'session' => Session::create($sessionConfig)
 		);
 		$config['url'] = static::_url($config);
 		return new static($config);

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -156,7 +156,7 @@ class Request implements \ArrayAccess {
  */
 	public static function createFromGlobals() {
 		list($base, $webroot) = static::_base();
-		$sessionConfig = (array)Configure::read('Session') + array('defaults' => 'php');
+		$sessionConfig = (array)Configure::read('Session') + ['defaults' => 'php'];
 		$config = array(
 			'query' => $_GET,
 			'post' => $_POST,


### PR DESCRIPTION
Provide sane defaults to make testing easier.
Cake3 plugins would throw errors currently when trying to run phpunit testing:

```
ini_set(): session.name cannot be a numeric or empty ''
```

see [here](https://travis-ci.org/dereuromark/cakephp-tools/jobs/31455522) for example.

This is easily solvable by not requireing it in the bootstrap.
It should default to php on its own.
