### PR TITLE
3.0 - Missing DS for bootstrap file path in Console\Command\Task\PluginTask

### DIFF
--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -47,7 +47,7 @@ class PluginTask extends BakeTask {
  */
 	public function initialize() {
 		$this->path = current(App::path('Plugin'));
-		$this->bootstrap = ROOT . 'config' . DS . 'bootstrap.php';
+		$this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
 	}
 
 /**


### PR DESCRIPTION
Fixed path to bootstrap.php in PluginTask
