### PR TITLE
Fix an issue with calling Request::method() in a test

### DIFF
--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -254,9 +254,13 @@ abstract class ControllerTestCase extends TestCase {
 
 		$request = $this->getMock(
 			'Cake\Network\Request',
-			array('_readInput'),
+			array('_readInput', 'method'),
 			array($requestData)
 		);
+
+		$request->expects($this->any())
+			->method('method')
+			->will($this->returnValue($method));
 
 		if (is_string($options['data'])) {
 			$request->expects($this->any())

--- a/tests/TestCase/TestSuite/ControllerTestCaseTest.php
+++ b/tests/TestCase/TestSuite/ControllerTestCaseTest.php
@@ -215,6 +215,24 @@ class ControllerTestCaseTest extends TestCase {
 	}
 
 /**
+ * Tests testAction with call to request::method()
+ *
+ * @return void
+ */
+	public function testTestActionWithRequestMethod() {
+		$Controller = $this->Case->generate('TestsApps');
+		$this->Case->testAction('/tests_apps/index', [
+			'method' => 'get'
+		]);
+		$this->assertSame('GET', $this->Case->controller->request->method());
+
+		$this->Case->testAction('/tests_apps/set_action', [
+			'method' => 'post'
+		]);
+		$this->assertSame('POST', $this->Case->controller->request->method());
+	}
+
+/**
  * Test testAction() with prefix routes.
  *
  * @return void


### PR DESCRIPTION
Trying to call Request::method() during a testAction request was throwing

```
Missing argument 1 for PHPUnit_Framework_MockObject_Builder_InvocationMocker::method()
```

 as it was trying to call the method() method for mocks.

This patch corrects that issue by mocking out the method() method in a testAction request
