### PR TITLE
3.0 default table warn

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -226,7 +226,7 @@ class TableRegistry {
  * @return array
  */
 	public static function genericInstances() {
-		return $_fallbacked;
+		return static::$_fallbacked;
 	}
 
 }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -68,6 +68,14 @@ class TableRegistry {
 	protected static $_instances = [];
 
 /**
+ * Contains a list of Table objects that were created out of the
+ * built-in Table class. The list is indexed by table alias
+ *
+ * @var array
+ */
+	protected static $_fallbacked = [];
+
+/**
  * Stores a list of options to be used when instantiating an object
  * with a matching alias.
  *
@@ -163,7 +171,14 @@ class TableRegistry {
 			$connectionName = $options['className']::defaultConnectionName();
 			$options['connection'] = ConnectionManager::get($connectionName);
 		}
-		return static::$_instances[$alias] = new $options['className']($options);
+
+		static::$_instances[$alias] = new $options['className']($options);
+
+		if ($options['className'] === 'Cake\ORM\Table') {
+			static::$_fallbacked[$alias] = static::$_instances[$alias];
+		}
+
+		return static::$_instances[$alias];
 	}
 
 /**
@@ -199,6 +214,19 @@ class TableRegistry {
 	public static function clear() {
 		static::$_instances = [];
 		static::$_config = [];
+		static::$_fallbacked = [];
+	}
+
+/**
+ * Returns the list of tables that were created by this registry that could
+ * not be instantiated from a specific subclass. This method is useful for
+ * debugging common mistakes when setting up associations or created new table
+ * classes.
+ *
+ * @return array
+ */
+	public static function genericInstances() {
+		return $_fallbacked;
 	}
 
 }

--- a/src/Template/Element/auto_table_warning.ctp
+++ b/src/Template/Element/auto_table_warning.ctp
@@ -39,3 +39,4 @@ instead of any other specific subclass.
 	<li><strong><?= $alias ?></strong></li>
 <?php endforeach; ?>
 </ul>
+<br/>

--- a/src/Template/Element/auto_table_warning.ctp
+++ b/src/Template/Element/auto_table_warning.ctp
@@ -1,0 +1,41 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+use Cake\ORM\TableRegistry;
+$autoTables = TableRegistry::genericInstances();
+if (!$autoTables) {
+	return;
+}
+?>
+<h3>Could this be caused by using Auto-Tables?</h3>
+<p>
+Some of the Table objects in your application were created by instantiating "<strong>Cake\ORM\Table</strong>"
+instead of any other specific subclass.
+</p>
+<p>This could be the cause for this exception. Auto-Tables are created for you under the following circumstances:</p>
+<ul>
+	<li>The class for the specified table does not exist.</li>
+	<li>The Table was created with a typo: <strong><em>TableRegistry::get('Atricles');</em></strong></li>
+	<li>The class file has a typo in the name or incorrect namespace: <strong><em>class Atricles extends Table</em></strong></li>
+	<li>The file containing the class has a typo or incorrect casing: <strong><em>Atricles.php</em></strong></li>
+	<li>The Table was used using associations but the association has a typo: <strong><em>$this->belongsTo('Atricles')</em></strong></li>
+	<li>The table class resides in a Plugin but <strong><em>no plugin notation</em></strong> was used in the association definition.</li>
+</ul>
+<br/>
+<p>Please try correcting the issue for the following table aliases:</p>
+<ul>
+<?php foreach ($autoTables as $alias => $table) : ?>
+	<li><strong><?= $alias ?></strong></li>
+<?php endforeach; ?>
+</ul>

--- a/src/Template/Error/missing_connection.ctp
+++ b/src/Template/Error/missing_connection.ctp
@@ -34,6 +34,6 @@
 	<strong>Notice: </strong>
 	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . basename(__FILE__)); ?>
 </p>
-
+<?= $this->element('auto_table_warning'); ?>
 <?php
 echo $this->element('exception_stack_trace');

--- a/src/Template/Error/missing_table.ctp
+++ b/src/Template/Error/missing_table.ctp
@@ -23,5 +23,5 @@
 	<strong>Notice: </strong>
 	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_table.ctp'); ?>
 </p>
-
+<?= $this->element('auto_table_warning'); ?>
 <?= $this->element('exception_stack_trace'); ?>

--- a/src/Template/Error/pdo_error.ctp
+++ b/src/Template/Error/pdo_error.ctp
@@ -33,6 +33,7 @@ use Cake\Utility\Debugger;
 		<strong>SQL Query Params: </strong>
 		<?= Debugger::dump($error->params); ?>
 <?php endif; ?>
+<?= $this->element('auto_table_warning'); ?>
 <p class="notice">
 	<strong>Notice: </strong>
 	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'pdo_error.ctp'); ?>

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -284,4 +284,17 @@ class TableRegistryTest extends TestCase {
 		$this->assertSame($mock, TableRegistry::get('Articles'));
 	}
 
+/**
+ * Tests genericInstances
+ *
+ * @return void
+ */
+	public function testGenericInstances() {
+		$foos = TableRegistry::get('Foos');
+		$bars = TableRegistry::get('Bars');
+		TableRegistry::get('Articles');
+		$expected = ['Foos' => $foos, 'Bars' => $bars];
+		$this->assertEquals($expected, TableRegistry::genericInstances());
+	}
+
 }


### PR DESCRIPTION
This is the first step towards intellingent warnings when the default Table class is used.
Related to https://github.com/cakephp/cakephp/issues/3795
