### PR TITLE
Added missing return statement.

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -597,6 +597,7 @@ class CakeResponse {
 			return isset($headers['Location']) ? $headers['Location'] : null;
 		}
 		$this->header('Location', $url);
+		return null;
 	}
 
 /**


### PR DESCRIPTION
PhpStorm is flagging this function as missing a return statement. Using a return statement (instead of the default) makes the intent of the source code clearer.
