### PR TITLE
Fix afterFind() called twice with belongsTo and hasOne relationships

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1316,6 +1316,7 @@ class DboSource extends DataSource {
 		foreach ($resultSet as &$row) {
 			if ($type === 'hasOne' || $type === 'belongsTo' || $type === 'hasMany') {
 				$assocResultSet = array();
+				$prefetched = false;
 
 				if (
 					($type === 'hasOne' || $type === 'belongsTo') &&
@@ -1326,6 +1327,7 @@ class DboSource extends DataSource {
 					if (!empty($joinedData)) {
 						$assocResultSet[0] = array($LinkModel->alias => $row[$LinkModel->alias]);
 					}
+					$prefetched = true;
 				} else {
 					$query = $this->insertQueryData($queryTemplate, $row, $association, $Model, $stack);
 					if ($query !== false) {
@@ -1376,7 +1378,7 @@ class DboSource extends DataSource {
 					$this->_mergeAssociation($row, $assocResultSet, $association, $type, $selfJoin);
 				}
 
-				if ($type !== 'hasAndBelongsToMany' && isset($row[$association])) {
+				if ($type !== 'hasAndBelongsToMany' && isset($row[$association]) && !$prefetched) {
 					$row[$association] = $LinkModel->afterFind($row[$association], false);
 				}
 


### PR DESCRIPTION
Fixes #2268

I have pulled an all-nighter reading DboSrouce.php.
Now I know everything ;)

I think that it is not a complex thing.
Top-level hasOne/belongsTo associations are fetched at [L1106](https://github.com/cakephp/cakephp/blob/aa42b80a4d386913a0b83ec1b18f396851f24919/lib/Cake/Model/Datasource/DboSource.php#L1106) and filtered at [L1118](https://github.com/cakephp/cakephp/blob/aa42b80a4d386913a0b83ec1b18f396851f24919/lib/Cake/Model/Datasource/DboSource.php#L1118).
Deep hasOne/belongsTo associations are fetched at [L1332](https://github.com/cakephp/cakephp/blob/aa42b80a4d386913a0b83ec1b18f396851f24919/lib/Cake/Model/Datasource/DboSource.php#L1332) and filtered at [L1380](https://github.com/cakephp/cakephp/blob/aa42b80a4d386913a0b83ec1b18f396851f24919/lib/Cake/Model/Datasource/DboSource.php#L1380).
Logic is about simplicity.

However, if top-level hasOne/belongsTo associations have more deep associations,
they are not fetched doubly because of if check at [L1320-1324](https://github.com/cakephp/cakephp/blob/aa42b80a4d386913a0b83ec1b18f396851f24919/lib/Cake/Model/Datasource/DboSource.php#L1320-1324), but filtered doubly.
I have fixed this issue.

But an old enough bug may become a feature.
I am not sure it should be merged on to master.
