### PR TITLE
3.0 Fix an issue where plugin associations would be mishandled.

### DIFF
--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -175,7 +175,7 @@ class BelongsTo extends Association {
  */
 	protected function _linkField($options) {
 		$links = [];
-		$name = $this->name();
+		$name = $this->alias();
 
 		foreach ((array)$this->target()->primaryKey() as $key) {
 			$links[] = sprintf('%s.%s', $name, $key);

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -122,7 +122,7 @@ class HasMany extends Association {
  */
 	protected function _linkField($options) {
 		$links = [];
-		$name = $this->name();
+		$name = $this->alias();
 
 		foreach ((array)$options['foreignKey'] as $key) {
 			$links[] = sprintf('%s.%s', $name, $key);

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -128,7 +128,7 @@ class HasOne extends Association {
  */
 	protected function _linkField($options) {
 		$links = [];
-		$name = $this->name();
+		$name = $this->alias();
 
 		foreach ((array)$options['foreignKey'] as $key) {
 			$links[] = sprintf('%s.%s', $name, $key);

--- a/tests/TestCase/Console/Command/Task/TestTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/TestTaskTest.php
@@ -181,10 +181,13 @@ class TestTaskTest extends TestCase {
 			->with($this->stringContains('You must provide'));
 		$this->io->expects($this->at(1))
 			->method('out')
-			->with($this->stringContains('1. CommentsTable'));
+			->with($this->stringContains('1. AuthorsTable'));
 		$this->io->expects($this->at(2))
 			->method('out')
-			->with($this->stringContains('2. TestPluginCommentsTable'));
+			->with($this->stringContains('2. CommentsTable'));
+		$this->io->expects($this->at(3))
+			->method('out')
+			->with($this->stringContains('3. TestPluginCommentsTable'));
 
 		$this->Task->outputClassChoices('Table');
 	}

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Core\Plugin;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -34,6 +35,7 @@ class QueryRegressionTest extends TestCase {
 	public $fixtures = [
 		'core.user',
 		'core.article',
+		'core.comment',
 		'core.tag',
 		'core.articles_tag',
 		'core.author',
@@ -318,6 +320,33 @@ class QueryRegressionTest extends TestCase {
 		$this->assertEquals(
 			new Time('2014-06-01 10:10:00'),
 			$highlights->_joinData->highlighted_time
+		);
+	}
+
+/**
+ * An integration test that spot checks that associations use the
+ * correct alias names to generate queries.
+ *
+ * @return void
+ */
+	public function testPluginAssociationQueryGeneration() {
+		Plugin::load('TestPlugin');
+		$articles = TableRegistry::get('Articles');
+		$articles->hasMany('TestPlugin.Comments');
+		$articles->belongsTo('TestPlugin.Authors');
+
+		$result = $articles->find()
+			->where(['Articles.id' => 2])
+			->contain(['Comments', 'Authors'])
+			->first();
+
+		$this->assertNotEmpty(
+			$result->comments[0]->id,
+			'No SQL error and comment exists.'
+		);
+		$this->assertNotEmpty(
+			$result->author->id,
+			'No SQL error and author exists.'
 		);
 	}
 

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Table/AuthorsTable.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Table/AuthorsTable.php
@@ -17,8 +17,8 @@ namespace TestPlugin\Model\Table;
 use Cake\ORM\Table;
 
 /**
- * Class CommentsTable
+ * Class AuthorsTable
  */
-class CommentsTable extends Table {
+class AuthorsTable extends Table {
 
 }


### PR DESCRIPTION
When joining plugin models together, I ran into an issue when using `hasMany('Plugin.Model')`. The SQL conditions would be incorrectly generated as `Plugin.Model.foo_id` instead of `Model.foo_id`.

This change fixes the failing build for cakephp/debug_kit#192
