### PR TITLE
Add missing sprintf in shell.php

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -215,7 +215,7 @@ class Shell {
  */
 	protected function _welcome() {
 		$this->out();
-		$this->out('<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version());
+		$this->out(sprintf('<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version()));
 		$this->hr();
 		$this->out(sprintf('App : %s', APP_DIR));
 		$this->out(sprintf('Path: %s', APP));


### PR DESCRIPTION
One sprintf was missed in the removal of translation methods from the shell.
