### PR TITLE
Fix cookie reading.

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -284,7 +284,7 @@ class CookieComponent extends Component {
 			return null;
 		}
 
-		if (!empty($names[1])) {
+		if (!empty($names[1]) && is_array($this->_values[$this->name][$key])) {
 			return Hash::get($this->_values[$this->name][$key], $names[1]);
 		}
 		return $this->_values[$this->name][$key];


### PR DESCRIPTION
As per IRC this issue has been reported while trying to write and read cookies:

> Catchable fatal error: Argument 1 passed to Hash::get() must be an array, string given, called in /var/www/html/stage/lib/Cake/Controller/Component/CookieComponent.php on line 286 and defined in /var/www/html/stage/lib/Cake/Utility/Hash.php on line 43

So we should check on is_array() first, before trying to use Hash::merge() on it to avoid the fatal error.

Any idea about a test case, though?

@ziplizard Was that you on IRC?
