### PR TITLE
Optimize StringTemplate a bit

### DIFF
--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -64,7 +64,7 @@ trait StringTemplateTrait {
 	public function templater() {
 		if (empty($this->_templater)) {
 			$class = $this->config('templateClass') ?: 'Cake\View\StringTemplate';
-			$this->_templater = new $class([], str_replace('\\', '_', __CLASS__));
+			$this->_templater = new $class();
 
 			$templates = $this->config('templates');
 			if ($templates) {
@@ -74,10 +74,8 @@ trait StringTemplateTrait {
 				} else {
 					$this->_templater->add($templates);
 				}
-				$this->_templater->writeCache();
 			}
 		}
-
 		return $this->_templater;
 	}
 

--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -64,7 +64,7 @@ trait StringTemplateTrait {
 	public function templater() {
 		if (empty($this->_templater)) {
 			$class = $this->config('templateClass') ?: 'Cake\View\StringTemplate';
-			$this->_templater = new $class;
+			$this->_templater = new $class([], str_replace('\\', '_', __CLASS__));
 
 			$templates = $this->config('templates');
 			if ($templates) {
@@ -74,6 +74,7 @@ trait StringTemplateTrait {
 				} else {
 					$this->_templater->add($templates);
 				}
+				$this->_templater->writeCache();
 			}
 		}
 

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -47,8 +47,6 @@ class StringTemplate {
  * @var array
  */
 	protected $_defaultConfig = [
-		'attribute' => '{{name}}="{{value}}"',
-		'compactAttribute' => '{{name}}="{{value}}"',
 	];
 
 /**
@@ -251,26 +249,17 @@ class StringTemplate {
 			$value = implode(' ', $value);
 		}
 		if (is_numeric($key)) {
-			return $this->format('compactAttribute', [
-				'name' => $value,
-				'value' => $value
-			]);
+			return "$value=\"$value\"";
 		}
 		$truthy = [1, '1', true, 'true', $key];
 		$isMinimized = in_array($key, $this->_compactAttributes);
 		if ($isMinimized && in_array($value, $truthy, true)) {
-			return $this->format('compactAttribute', [
-				'name' => $key,
-				'value' => $key
-			]);
+			return "$key=\"$key\"";
 		}
 		if ($isMinimized) {
 			return '';
 		}
-		return $this->format('attribute', [
-			'name' => $key,
-			'value' => $escape ? h($value) : $value
-		]);
+		return $key . '="' . ($escape ? h($value) : $value) . '"';
 	}
 
 }

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\View;
 
-use Cake\Cache\Cache;
 use Cake\Configure\Engine\PhpConfig;
 use Cake\Core\InstanceConfigTrait;
 
@@ -65,57 +64,12 @@ class StringTemplate {
 	protected $_compiled = [];
 
 /**
- * The persistent cache key for templates.
- *
- * @var string
- */
-	protected $_cacheKey;
-
-/**
  * Constructor.
  *
  * @param array $config A set of templates to add.
- * @param string $cacheKey The cache key to load templates from
  */
-	public function __construct(array $config = [], $key = null) {
-		if ($key) {
-			$this->_cacheKey = $key;
-			$this->loadCache();
-		}
+	public function __construct(array $config = []) {
 		$this->add($config);
-	}
-
-/**
- * Loads templates and compiled results from the persistent cache.
- *
- * @return void
- */
-	public function loadCache() {
-		if (!$this->_cacheKey) {
-			return;
-		}
-		$results = Cache::read($this->_cacheKey, '_cake_core_');
-		if (!$results) {
-			return;
-		}
-		$this->_templates = $results['templates'];
-		$this->_compiled = $results['compiled'];
-	}
-
-/**
- * Save templates to the persistent cache.
- *
- * @return void
- */
-	public function writeCache() {
-		if (empty($this->_cacheKey)) {
-			return;
-		}
-		$data = [
-			'templates' => $this->_config,
-			'compiled' => $this->_compiled
-		];
-		Cache::write($this->_cacheKey, '_cake_core_');
 	}
 
 /**

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -36,9 +36,26 @@ class StringTemplate {
  * @var array
  */
 	protected $_compactAttributes = array(
-		'compact', 'checked', 'declare', 'readonly', 'disabled', 'selected',
-		'defer', 'ismap', 'nohref', 'noshade', 'nowrap', 'multiple', 'noresize',
-		'autoplay', 'controls', 'loop', 'muted', 'required', 'novalidate', 'formnovalidate'
+		'compact' => true,
+		'checked' => true,
+		'declare' => true,
+		'readonly' => true,
+		'disabled' => true,
+		'selected' => true,
+		'defer' => true,
+		'ismap' => true,
+		'nohref' => true,
+		'noshade' => true,
+		'nowrap' => true,
+		'multiple' => true,
+		'noresize' => true,
+		'autoplay' => true,
+		'controls' => true,
+		'loop' => true,
+		'muted' => true,
+		'required' => true,
+		'novalidate' => true,
+		'formnovalidate' => true,
 	);
 
 /**
@@ -253,7 +270,7 @@ class StringTemplate {
 			return "$value=\"$value\"";
 		}
 		$truthy = [1, '1', true, 'true', $key];
-		$isMinimized = in_array($key, $this->_compactAttributes);
+		$isMinimized = isset($this->_compactAttributes[$key]);
 		if ($isMinimized && in_array($value, $truthy, true)) {
 			return "$key=\"$key\"";
 		}

--- a/tests/TestCase/View/Helper/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/Helper/StringTemplateTraitTest.php
@@ -65,12 +65,10 @@ class StringTemplateTraitTest extends TestCase {
 
 		$this->assertEquals(
 			[
-				'attribute' => '{{name}}="{{value}}"',
-				'compactAttribute' => '{{name}}="{{value}}"',
 				'text' => '<p>{{text}}</p>'
 			],
 			$this->Template->templates(),
-			'newly added template should be inlcuded in template list'
+			'newly added template should be included in template list'
 		);
 	}
 
@@ -87,8 +85,6 @@ class StringTemplateTraitTest extends TestCase {
 
 		$this->assertEquals(
 			[
-				'attribute' => '{{name}}="{{value}}"',
-				'compactAttribute' => '{{name}}="{{value}}"',
 				'text' => '<p>{{text}}</p>'
 			],
 			$this->Template->templates(),

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -195,21 +195,6 @@ class StringTemplateTest extends TestCase {
 	}
 
 /**
- * Tests that compile information is refreshed on adds and removes
- *
- * @return void
- */
-	public function testCopiledInfoRefresh() {
-		$compilation = $this->template->compile('link');
-		$this->template->add([
-			'link' => '<a bar="{{foo}}">{{baz}}</a>'
-		]);
-		$this->assertNotEquals($compilation, $this->template->compile('link'));
-		$this->template->remove('link');
-		$this->assertEquals([null, null], $this->template->compile('link'));
-	}
-
-/**
  * test push/pop templates.
  *
  * @return void


### PR DESCRIPTION
@lorenzo did a profile run recently and found that StringTemplate was one of the heavier aspects of the page. It was spending a good amount of time compiling and formatting results. I tried to fix the compiling by adding a persistent cache, but that resulted in _slower_ response times as reading from the file cache was not cheap.

I ended up removing attribute formatting templates, and eagerly compiling all templates. This saves a few hundred function calls (~2.5ms) per request which helps a bit.

![profiler](http://cl.ly/image/1H1u1O35073R/Screen%20Shot%202014-08-06%20at%2011.36.21%20PM.png)
