### PR TITLE
Use fallbacks() for generated routes.

### DIFF
--- a/src/Template/Bake/default/config/routes.ctp
+++ b/src/Template/Bake/default/config/routes.ctp
@@ -19,6 +19,5 @@ namespace <?= $plugin ?>\Config;
 use Cake\Routing\Router;
 
 Router::plugin('<?= $plugin ?>', function($routes) {
-	$routes->connect('/:controller', ['action' => 'index']);
-	$routes->connect('/:controller/:action/*');
+	$routes->fallbacks();
 });


### PR DESCRIPTION
This makes the routes stub shorter and fixes issues where error messages would have the incorrect controller inflection in them.

Refs #4188
