### PR TITLE
Add `fullBase` option to `HtmlHelper::link()`

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -212,6 +212,26 @@ class HtmlHelperTest extends CakeTestCase {
 		$expected = array('a' => array('href' => Router::fullBaseUrl() . '/posts'), 'Posts', '/a');
 		$this->assertTags($result, $expected);
 
+		$result = $this->Html->link('Posts', array('controller' => 'posts', 'action' => 'index'), array('fullBase' => true));
+		$expected = array('a' => array('href' => Router::fullBaseUrl() . '/posts'), 'Posts', '/a');
+		$this->assertTags($result, $expected);
+
+		$result = $this->Html->link('/posts', null, array('fullBase' => true));
+		$expected = array('a' => array('href' => Router::fullBaseUrl() . '/posts'), Router::fullBaseUrl() . '/posts', '/a');
+		$this->assertTags($result, $expected);
+
+		$result = $this->Html->link('Posts', array('controller' => 'posts', 'action' => 'index', 'full_base' => true), array('fullBase' => false));
+		$expected = array('a' => array('href' => '/posts'), 'Posts', '/a');
+		$this->assertTags($result, $expected);
+
+		$result = $this->Html->link(array('controller' => 'posts', 'action' => 'index', 'full_base' => true), null, array('fullBase' => false));
+		$expected = '<a href="/posts">/posts</a>';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Html->link('Both strings', 'http://www.example.org', array('fullBase' => true));
+		$expected = array('a' => array('href' => 'http://www.example.org'), 'Both strings', '/a');
+		$this->assertTags($result, $expected);
+
 		$result = $this->Html->link('Home', '/home', array('confirm' => 'Are you sure you want to do this?'));
 		$expected = array(
 			'a' => array('href' => '/home', 'onclick' => 'if (confirm(&quot;Are you sure you want to do this?&quot;)) { return true; } return false;'),

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -322,6 +322,7 @@ class HtmlHelper extends AppHelper {
  * - `escape` Set to false to disable escaping of title and attributes.
  * - `escapeTitle` Set to false to disable escaping of title. (Takes precedence over value of `escape`)
  * - `confirm` JavaScript confirmation message.
+ * - `fullBase` If true the full base URL will be prepended to the generated URL
  *
  * @param string $title The content to be wrapped by <a> tags.
  * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
@@ -333,10 +334,23 @@ class HtmlHelper extends AppHelper {
  */
 	public function link($title, $url = null, $options = array(), $confirmMessage = false) {
 		$escapeTitle = true;
+
+		$fullBase = false;
+		if (isset($options['fullBase'])) {
+			$fullBase = $options['fullBase'];
+			unset($options['fullBase']);
+
+			if ($url !== null && is_array($url)) {
+				unset($url['full_base']);
+			} else if ($url === null && is_array($title)) {
+				unset($title['full_base']);
+			}
+		}
+
 		if ($url !== null) {
-			$url = $this->url($url);
+			$url = $this->url($url, $fullBase);
 		} else {
-			$url = $this->url($title);
+			$url = $this->url($title, $fullBase);
 			$title = htmlspecialchars_decode($url, ENT_QUOTES);
 			$title = h(urldecode($title));
 			$escapeTitle = false;

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -342,7 +342,7 @@ class HtmlHelper extends AppHelper {
 
 			if ($url !== null && is_array($url)) {
 				unset($url['full_base']);
-			} else if ($url === null && is_array($title)) {
+			} elseif ($url === null && is_array($title)) {
 				unset($title['full_base']);
 			}
 		}


### PR DESCRIPTION
Contrary to the other helper methods, `link()` was only accepting an option named `full_base` that had to be passed in the URL array.

I think having this functionality to work uniformly across the helper would be nice, though it seems to be still the same in 3.x, so I'm not sure whether this is considered to be useful, maybe I've overlooked some drawbacks.

Note that the last test uses `assertEquals()` because the `/posts` content of the `a` tag seems to break `assertTags()`, not sure whether this is a bug or just not supported.
