### PR TITLE
Comparison expressions need to traverse over their own _value property

### DIFF
--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -120,6 +120,17 @@ class Comparison extends QueryExpression {
 	}
 
 /**
+ * {@inheritDoc}
+ *
+ */
+	public function traverse(callable $callable) {
+		if ($this->_value instanceof ExpressionInterface) {
+			$callable($this->_value);
+			$this->_value->traverse($callable);
+		}
+	}
+
+/**
  * Returns a template and a placeholder for the value after registering it
  * with the placeholder $generator
  *


### PR DESCRIPTION
Comparisons were not traversing their `_value` property which was causing issues when comparing another expression.

Especially prevalent when using SqlServer since it requires transforming of function expressions. An example:

```
$age = $query->func()->dateDiff([
            'Jobs.date_queued' => 'literal',
            $query->func()->now('date'),
        ]);
$olderThan30Days = $query->newExpr()->lte(30, $age); //Needs to be this way round as Comparison only treats $value as an expression
```

This was not traversing into the DateDiff, which was causing the `CURRENT_DATE` to not be transformed into the equivalent TSQL statement.
