### PR TITLE
Only add 'day' once with SqlServer DATEDIFF

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -155,7 +155,18 @@ trait SqlserverDialectTrait {
 				$expression->name('')->type(' +');
 				break;
 			case 'DATEDIFF':
-				$expression->add(['day' => 'literal'], [], true);
+				$hasDay = false;
+				$visitor = function($value) use (&$hasDay){
+					if ($value === 'day') {
+						$hasDay = true;
+					}
+					return $value;
+				};
+				$expression->iterateParts($visitor);
+
+				if (!$hasDay) {
+					$expression->add(['day' => 'literal'], [], true);
+				}
 				break;
 			case 'CURRENT_DATE':
 				$time = new FunctionExpression('GETUTCDATE');


### PR DESCRIPTION
If a single instance of a DATEDIFF Expression was used more than once, 'day' would be added multiple times (Once be usage). This threw an SQLServer error.

A simplistic example:

```
$age = $query->func()->dateDiff([
            'Jobs.date_queued' => 'literal',
            $functionBuilder->now('date'),
        ]);
        $between30And60 = $query->newExpr()
            ->lte(30, $age)
            ->gt(60, $age);
```

This PR, in conjunction with PR #4200 allows for this use case.
