### PR TITLE
Fix exception in date time widget

### DIFF
--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -151,7 +151,7 @@ class DateTime implements WidgetInterface {
 				continue;
 			}
 			if (!is_array($data[$select])) {
-				throw \RuntimeException(sprintf(
+				throw new \RuntimeException(sprintf(
 					'Options for "%s" must be an array|false|null',
 					$select
 				));


### PR DESCRIPTION
Passing a string or an integer as an option for date time inputs
will error in `Call to undefined function RuntimeException`
