### PR TITLE
Add templates option to PaginatorHelper::numbers() and fix failing tests

### DIFF
--- a/src/Template/Error/missing_action.ctp
+++ b/src/Template/Error/missing_action.ctp
@@ -28,7 +28,7 @@ if (!empty($prefix)) {
 if (empty($plugin)) {
 	$path = APP_DIR . DS . 'Controller' . DS . $prefix . DS . h($controller) . '.php' ;
 } else {
-	$path = Plugin::classPath($plugin) . 'Controller' . DS . $prefix . DS . h($class) . '.php';
+	$path = Plugin::classPath($plugin) . 'Controller' . DS . $prefix . DS . h($controller) . '.php';
 }
 ?>
 <h2><?= sprintf('Missing Method in %s', h($controller)); ?></h2> <p class="error">

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -596,13 +596,19 @@ class PaginatorHelper extends Helper {
 		$options += $defaults;
 
 		$params = (array)$this->params($options['model']) + array('page' => 1);
-
 		if ($params['pageCount'] <= 1) {
 			return false;
 		}
 
+		$templater = $this->templater();
+		if (isset($options['templates'])) {
+			$templater->push();
+			$method = is_string($options['templates']) ? 'load' : 'add';
+			$templater->{$method}($options['templates']);
+		}
+
 		$out = '';
-		$ellipsis = $this->templater()->format('ellipsis', []);
+		$ellipsis = $templater->format('ellipsis', []);
 
 		if ($options['modulus'] && $params['pageCount'] > $options['modulus']) {
 			$half = intval($options['modulus'] / 2);
@@ -632,10 +638,10 @@ class PaginatorHelper extends Helper {
 					'text' => $i,
 					'url' => $this->generateUrl(['page' => $i], $options['model']),
 				];
-				$out .= $this->templater()->format('number', $vars);
+				$out .= $templater->format('number', $vars);
 			}
 
-			$out .= $this->templater()->format('current', [
+			$out .= $templater->format('current', [
 				'text' => $params['page'],
 				'url' => $this->generateUrl(['page' => $params['page']], $options['model']),
 			]);
@@ -646,7 +652,7 @@ class PaginatorHelper extends Helper {
 					'text' => $i,
 					'url' => $this->generateUrl(['page' => $i], $options['model']),
 				];
-				$out .= $this->templater()->format('number', $vars);
+				$out .= $templater->format('number', $vars);
 			}
 
 			if ($end != $params['page']) {
@@ -654,7 +660,7 @@ class PaginatorHelper extends Helper {
 					'text' => $i,
 					'url' => $this->generateUrl(['page' => $end], $options['model']),
 				];
-				$out .= $this->templater()->format('number', $vars);
+				$out .= $templater->format('number', $vars);
 			}
 
 			$out .= $options['after'];
@@ -672,7 +678,7 @@ class PaginatorHelper extends Helper {
 
 			for ($i = 1; $i <= $params['pageCount']; $i++) {
 				if ($i == $params['page']) {
-					$out .= $this->templater()->format('current', [
+					$out .= $templater->format('current', [
 						'text' => $params['page'],
 						'url' => $this->generateUrl(['page' => $params['page']], $options['model']),
 					]);
@@ -681,11 +687,14 @@ class PaginatorHelper extends Helper {
 						'text' => $i,
 						'url' => $this->generateUrl(['page' => $i], $options['model']),
 					];
-					$out .= $this->templater()->format('number', $vars);
+					$out .= $templater->format('number', $vars);
 				}
 			}
 
 			$out .= $options['after'];
+		}
+		if (isset($options['templates'])) {
+			$templater->pop();
 		}
 
 		return $out;

--- a/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
+++ b/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
@@ -26,13 +26,23 @@ use Locale;
 class LocaleSelectorFilterTest extends TestCase {
 
 /**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->locale = Locale::getDefault();
+	}
+
+/**
  * Resets the default locale
  *
  * @return void
  */
 	public function tearDown() {
 		parent::tearDown();
-		Locale::setDefault('');
+		Locale::setDefault($this->locale);
 	}
 
 /**
@@ -67,6 +77,7 @@ class LocaleSelectorFilterTest extends TestCase {
  * @return void
  */
 	public function testWithWhitelist() {
+		Locale::setDefault('en_US');
 		$filter = new LocaleSelectorFilter([
 			'locales' => ['en_CA', 'en_IN', 'es_VE']
 		]);
@@ -77,8 +88,8 @@ class LocaleSelectorFilterTest extends TestCase {
 		]);
 		$filter->beforeDispatch(new Event('name', null, ['request' => $request]));
 		$this->assertEquals('es_VE', Locale::getDefault());
-		Locale::setDefault('');
 
+		Locale::setDefault('en_US');
 		$request = new Request([
 			'environment' => [
 				'HTTP_ACCEPT_LANGUAGE' => 'en-GB;q=0.8,es-ES;q=0.9,da-DK;q=0.4'

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1254,6 +1254,45 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
+ * Test that numbers() lets you overwrite templates.
+ *
+ * The templates file has no li elements.
+ *
+ * @return void
+ */
+	public function testNumbersTemplates() {
+		$this->Paginator->request->params['paging'] = [
+			'Client' => [
+				'page' => 8,
+				'current' => 3,
+				'count' => 30,
+				'prevPage' => false,
+				'nextPage' => 2,
+				'pageCount' => 15,
+			]
+		];
+		$result = $this->Paginator->numbers(['templates' => 'htmlhelper_tags']);
+		$expected = [
+			['a' => ['href' => '/index?page=4']], '4', '/a',
+			['a' => ['href' => '/index?page=5']], '5', '/a',
+			['a' => ['href' => '/index?page=6']], '6', '/a',
+			['a' => ['href' => '/index?page=7']], '7', '/a',
+			'span' => ['class' => 'active'], '8', '/span',
+			['a' => ['href' => '/index?page=9']], '9', '/a',
+			['a' => ['href' => '/index?page=10']], '10', '/a',
+			['a' => ['href' => '/index?page=11']], '11', '/a',
+			['a' => ['href' => '/index?page=12']], '12', '/a',
+		];
+		$this->assertTags($result, $expected);
+
+		$this->assertContains(
+			'<li',
+			$this->Paginator->templater()->get('current'),
+			'Templates were not restored.'
+		);
+	}
+
+/**
  * Test modulus option for numbers()
  *
  * @return void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -133,3 +133,5 @@ Log::config([
 ]);
 
 Carbon\Carbon::setTestNow(Carbon\Carbon::now());
+
+ini_set('intl.default_locale', 'en_US');

--- a/tests/test_app/config/htmlhelper_tags.php
+++ b/tests/test_app/config/htmlhelper_tags.php
@@ -4,5 +4,7 @@ $config = [
 	'formstart' => 'start form',
 	'formend' => 'finish form',
 	'hiddenblock' => '<div class="hidden">{{content}}</div>',
-	'inputContainer' => '{{content}}'
+	'inputContainer' => '{{content}}',
+	'number' => '<a href="{{url}}">{{text}}</a>',
+	'current' => '<span class="active">{{text}}</span>',
 ];


### PR DESCRIPTION
As per #4171, I have added a templates option to numbers() making it easier to use custom templates for just that one method.

I also fixed a bunch of tests that were failing as my system's locale is not en_US.
