### PR TITLE
Fixes argument order for assertEquals in RouterTest

### DIFF
--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2216,7 +2216,7 @@ class RouterTest extends TestCase {
 			'slug' => 'the-best',
 			'pass' => [],
 		];
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
Fixes argument order for assertEquals in RouterTest
