### PR TITLE
3.0 nest label

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -726,6 +726,12 @@ class FormHelper extends Helper {
 		return $this->widget('label', $attrs);
 	}
 
+/**
+ * Auto generates a label name for a given field
+ *
+ * @param string $fieldName The field name
+ * @return string The generated label text
+ */
 	protected function _labelText($fieldName) {
 		$text = $fieldName;
 		if (substr($text, -5) === '._ids') {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -100,7 +100,7 @@ class FormHelper extends Helper {
 			'select' => '<select name="{{name}}"{{attrs}}>{{content}}</select>',
 			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
 			'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>',
-			'radioWrapper' => '{{input}}{{label}}',
+			'radioWrapper' => '{{label}}',
 			'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
 			'submitContainer' => '<div class="submit">{{content}}</div>',
 		]
@@ -1182,7 +1182,7 @@ class FormHelper extends Helper {
 		}
 
 		$labelAttributes = [
-			'for' => isset($options['id']) ? $options['id'] : null,
+			'for' => isset($options['id']) ? $options['id'] : null
 		] + $labelAttributes;
 		return $this->label($fieldName, $labelText, $labelAttributes);
 	}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -917,7 +917,7 @@ class FormHelper extends Helper {
 		}
 
 		$label = $options['label'];
-		if (!in_array($options['type'], ['radio', 'checbox'], true)) {
+		if (!in_array($options['type'], ['radio', 'checkbox'], true)) {
 			unset($options['label']);
 		}
 
@@ -1215,7 +1215,11 @@ class FormHelper extends Helper {
 		$options = $this->_initInputField($fieldName, $options);
 		$options['value'] = $value;
 
-		if (!isset($options['label']) || $options['label'] === null) {
+		if (!array_key_exists('label', $options)) {
+			$options['label'] = false;
+		}
+
+		if ($options['label'] === null) {
 			$options['label']['text'] = $this->_labelText($fieldName);
 		}
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -78,7 +78,7 @@ class FormHelper extends Helper {
 		'templates' => [
 			'button' => '<button{{attrs}}>{{text}}</button>',
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
-			'checkboxWrapper' => '<div class="checkbox">{{input}}{{label}}</div>',
+			'checkboxWrapper' => '<div class="checkbox">{{input}}</div>',
 			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}',
 			'error' => '<div class="error-message">{{content}}</div>',
 			'errorList' => '<ul>{{content}}</ul>',

--- a/src/View/Widget/Checkbox.php
+++ b/src/View/Widget/Checkbox.php
@@ -30,12 +30,20 @@ class Checkbox implements WidgetInterface {
 	protected $_templates;
 
 /**
+ * Label instance.
+ *
+ * @var \Cake\View\Widget\Label
+ */
+	protected $_label;
+
+/**
  * Constructor
  *
  * @param \Cake\View\StringTemplate $templates Templates list.
  */
-	public function __construct($templates) {
+	public function __construct($templates, $label) {
 		$this->_templates = $templates;
+		$this->_label = $label;
 	}
 
 /**
@@ -46,6 +54,8 @@ class Checkbox implements WidgetInterface {
  * - `name` - The name of the input.
  * - `value` - The value attribute. Defaults to '1'.
  * - `val` - The current value. If it matches `value` the checkbox will be checked.
+ * - `label` - Either false to disable label generation, or
+ *   an array of attributes for the label template.
  *   You can also use the 'checked' attribute to make the checkbox checked.
  * - `disabled` - Whether or not the checkbox should be disabled.
  *
@@ -61,22 +71,59 @@ class Checkbox implements WidgetInterface {
 			'value' => 1,
 			'val' => null,
 			'disabled' => false,
+			'label' => null,
+			'escape' => true
 		];
+
+		$escape = $data['escape'];
+		$label = $data['label'];
+
 		if ($this->_isChecked($data)) {
 			$data['checked'] = true;
 		}
-		unset($data['val']);
+		unset($data['val'], $data['escape'], $data['label']);
 
 		$attrs = $this->_templates->formatAttributes(
 			$data,
 			['name', 'value']
 		);
 
-		return $this->_templates->format('checkbox', [
+		$input = $this->_templates->format('checkbox', [
 			'name' => $data['name'],
 			'value' => $data['value'],
 			'attrs' => $attrs
 		]);
+
+		return $this->_renderLabel(
+			$data,
+			$label,
+			$input,
+			$context,
+			$escape
+		);
+	}
+
+/**
+ * Renders a label element for the given checkbox.
+ *
+ * @param array $attrs The input properties.
+ * @param false|string|array $label The properties for a label.
+ * @param string $input The input widget.
+ * @param \Cake\View\Form\ContextInterface $context The form context.
+ * @param bool $escape Whether or not to HTML escape the label.
+ * @return string Generated label.
+ */
+	protected function _renderLabel($attrs, $label, $input, $context, $escape) {
+		if ($label === false) {
+			return false;
+		}
+		$labelAttrs = is_array($label) ? $label : ['text' => $label];
+		$labelAttrs += [
+			'for' => isset($attrs['id']) ? $attrs['id'] : null,
+			'escape' => $escape,
+			'input' => $input,
+		];
+		return $this->_label->render($labelAttrs, $context);
 	}
 
 /**

--- a/src/View/Widget/Checkbox.php
+++ b/src/View/Widget/Checkbox.php
@@ -100,7 +100,7 @@ class Checkbox implements WidgetInterface {
 			$input,
 			$context,
 			$escape
-		);
+		) ?: $input;
 	}
 
 /**

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -34,11 +34,11 @@ class MultiCheckbox implements WidgetInterface {
 	protected $_templates;
 
 /**
- * Label widget instance.
+ * Checkbox widget instance.
  *
- * @var \Cake\View\Widget\Label
+ * @var \Cake\View\Widget\Checkbox
  */
-	protected $_label;
+	protected $_checkbox;
 
 /**
  * Render multi-checkbox widget.
@@ -52,11 +52,11 @@ class MultiCheckbox implements WidgetInterface {
  *   variables.
  *
  * @param \Cake\View\StringTemplate $templates Templates list.
- * @param \Cake\View\Widget\Label $label Label widget instance.
+ * @param \Cake\View\Widget\Checkbox $checkbox Checkbox widget instance.
  */
-	public function __construct($templates, $label) {
+	public function __construct($templates, $checkbox) {
 		$this->_templates = $templates;
-		$this->_label = $label;
+		$this->_checkbox = $checkbox;
 	}
 
 /**
@@ -147,28 +147,26 @@ class MultiCheckbox implements WidgetInterface {
  * @return string
  */
 	protected function _renderInput($checkbox, $context) {
-		$input = $this->_templates->format('checkbox', [
-			'name' => $checkbox['name'] . '[]',
-			'value' => $checkbox['escape'] ? h($checkbox['value']) : $checkbox['value'],
-			'attrs' => $this->_templates->formatAttributes(
-				$checkbox,
-				['name', 'value', 'text']
-			)
-		]);
-
 		$labelAttrs = [
 			'for' => $checkbox['id'],
 			'escape' => $checkbox['escape'],
-			'text' => $checkbox['text'],
-			'input' => $input,
+			'text' => $checkbox['text']
 		];
+
 		if (!empty($checkbox['checked']) && empty($labelAttrs['class'])) {
 			$labelAttrs['class'] = 'selected';
 		}
-		$label = $this->_label->render($labelAttrs, $context);
+
+		$attrs = $checkbox;
+		unset($attrs['name'], $attrs['value'], $attrs['text']);
+
+		$input = $this->_checkbox->render([
+			'name' => $checkbox['name'] . '[]',
+			'value' => $checkbox['escape'] ? h($checkbox['value']) : $checkbox['value'],
+			'label' => $labelAttrs,
+		] + $attrs, $context);
 
 		return $this->_templates->format('checkboxWrapper', [
-			'label' => $label,
 			'input' => $input
 		]);
 	}

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -47,7 +47,7 @@ class WidgetRegistry {
 		'checkbox' => ['Cake\View\Widget\Checkbox', 'label'],
 		'file' => ['Cake\View\Widget\File'],
 		'label' => ['Cake\View\Widget\Label'],
-		'multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'label'],
+		'multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'checkbox'],
 		'radio' => ['Cake\View\Widget\Radio', 'label'],
 		'select' => ['Cake\View\Widget\SelectBox'],
 		'textarea' => ['Cake\View\Widget\Textarea'],

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -44,7 +44,7 @@ class WidgetRegistry {
  */
 	protected $_widgets = [
 		'button' => ['Cake\View\Widget\Button'],
-		'checkbox' => ['Cake\View\Widget\Checkbox'],
+		'checkbox' => ['Cake\View\Widget\Checkbox', 'label'],
 		'file' => ['Cake\View\Widget\File'],
 		'label' => ['Cake\View\Widget\Label'],
 		'multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'label'],

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3630,11 +3630,11 @@ class FormHelperTest extends TestCase {
 				'type' => 'hidden', 'name' => 'User[get_spam]',
 				'value' => '1'
 			)),
+			'label' => array('for' => 'user-get-spam'),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'User[get_spam]',
 				'value' => '0', 'id' => 'user-get-spam'
 			)),
-			'label' => array('for' => 'user-get-spam'),
 			'Get Spam',
 			'/label',
 			'/div'

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1377,13 +1377,13 @@ class FormHelperTest extends TestCase {
 				'name' => 'something',
 				'value' => '0'
 			)),
+			'label' => array('for' => 'something'),
 			array('input' => array(
 				'type' => 'checkbox',
 				'name' => 'something',
 				'value' => '1',
 				'id' => 'something'
 			)),
-			'label' => array('for' => 'something'),
 			'Something',
 			'/label',
 			'/div'
@@ -2176,12 +2176,6 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->radio('Model.field', ['option A', 'option']);
 		$expected = [
 			'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => ''],
-			['input' => [
-				'type' => 'radio',
-				'name' => 'Model[field]',
-				'value' => '0',
-				'id' => 'prefix-model-field-0'
-			]],
 			'label' => ['for' => 'prefix-model-field-0'],
 			'option A',
 			'/label'
@@ -2283,6 +2277,7 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'div' => array('class' => 'input checkbox'),
 			'input' => array('type' => 'hidden', 'name' => 'User[disabled]', 'value' => '0'),
+			'label' => array('for' => 'user-disabled'),
 			array('input' => array(
 				'type' => 'checkbox',
 				'name' => 'User[disabled]',
@@ -2290,7 +2285,6 @@ class FormHelperTest extends TestCase {
 				'id' => 'user-disabled',
 				'data-foo' => 'disabled'
 			)),
-			'label' => array('for' => 'user-disabled'),
 			'Disabled',
 			'/label',
 			'/div'
@@ -2423,20 +2417,20 @@ class FormHelperTest extends TestCase {
 			'/label',
 			array('input' => array('type' => 'hidden', 'name' => "Contact[multiple]", 'value' => '')),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 1, 'disabled' => 'disabled', 'id' => "contact-multiple-1")),
 			array('label' => array('for' => "contact-multiple-1")),
+			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 1, 'disabled' => 'disabled', 'id' => "contact-multiple-1")),
 			'One',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 2, 'disabled' => 'disabled', 'id' => "contact-multiple-2")),
 			array('label' => array('for' => "contact-multiple-2")),
+			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 2, 'disabled' => 'disabled', 'id' => "contact-multiple-2")),
 			'Two',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 3, 'disabled' => 'disabled', 'id' => "contact-multiple-3")),
 			array('label' => array('for' => "contact-multiple-3")),
+			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 3, 'disabled' => 'disabled', 'id' => "contact-multiple-3")),
 			'Three',
 			'/label',
 			'/div',
@@ -3740,29 +3734,29 @@ class FormHelperTest extends TestCase {
 				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-0')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => '0', 'id' => 'model-multi-field-0'
 			)),
-			array('label' => array('for' => 'model-multi-field-0')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-1')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => '1', 'id' => 'model-multi-field-1'
 			)),
-			array('label' => array('for' => 'model-multi-field-1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-2')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => '2', 'id' => 'model-multi-field-2'
 			)),
-			array('label' => array('for' => 'model-multi-field-2')),
 			'third',
 			'/label',
 			'/div'
@@ -3779,29 +3773,29 @@ class FormHelperTest extends TestCase {
 				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-a+')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => 'a+', 'id' => 'model-multi-field-a+'
 			)),
-			array('label' => array('for' => 'model-multi-field-a+')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-a++')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => 'a++', 'id' => 'model-multi-field-a++'
 			)),
-			array('label' => array('for' => 'model-multi-field-a++')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-a+++')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => 'a+++', 'id' => 'model-multi-field-a+++'
 			)),
-			array('label' => array('for' => 'model-multi-field-a+++')),
 			'third',
 			'/label',
 			'/div'
@@ -3818,29 +3812,29 @@ class FormHelperTest extends TestCase {
 				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-a-b')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => 'a&gt;b', 'id' => 'model-multi-field-a-b'
 			)),
-			array('label' => array('for' => 'model-multi-field-a-b')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-a-b1')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => 'a&lt;b', 'id' => 'model-multi-field-a-b1'
 			)),
-			array('label' => array('for' => 'model-multi-field-a-b1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-multi-field-a-b2')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => 'a&quot;b', 'id' => 'model-multi-field-a-b2'
 			)),
-			array('label' => array('for' => 'model-multi-field-a-b2')),
 			'third',
 			'/label',
 			'/div'
@@ -3863,21 +3857,21 @@ class FormHelperTest extends TestCase {
 				'type' => 'hidden', 'name' => 'Model[tags]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-tags-1', 'class' => 'selected')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[tags][]',
 				'value' => '1', 'id' => 'model-tags-1', 'checked' => 'checked'
 			)),
-			array('label' => array('for' => 'model-tags-1', 'class' => 'selected')),
 			'first',
 			'/label',
 			'/div',
 
 			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'model-tags-array')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[tags][]',
 				'value' => 'Array', 'id' => 'model-tags-array'
 			)),
-			array('label' => array('for' => 'model-tags-array')),
 			'Array',
 			'/label',
 			'/div'
@@ -3965,20 +3959,20 @@ class FormHelperTest extends TestCase {
 			'/label',
 			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '0', 'id' => 'model-multi-field-0')),
 			array('label' => array('for' => 'model-multi-field-0')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '0', 'id' => 'model-multi-field-0')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1', 'id' => 'model-multi-field-1')),
 			array('label' => array('for' => 'model-multi-field-1')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1', 'id' => 'model-multi-field-1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '2', 'id' => 'model-multi-field-2')),
 			array('label' => array('for' => 'model-multi-field-2')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '2', 'id' => 'model-multi-field-2')),
 			'third',
 			'/label',
 			'/div',
@@ -3997,20 +3991,20 @@ class FormHelperTest extends TestCase {
 			'/label',
 			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => 'a', 'id' => 'model-multi-field-a')),
 			array('label' => array('for' => 'model-multi-field-a')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => 'a', 'id' => 'model-multi-field-a')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => 'b', 'id' => 'model-multi-field-b')),
 			array('label' => array('for' => 'model-multi-field-b')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => 'b', 'id' => 'model-multi-field-b')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => 'c', 'id' => 'model-multi-field-c')),
 			array('label' => array('for' => 'model-multi-field-c')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => 'c', 'id' => 'model-multi-field-c')),
 			'third',
 			'/label',
 			'/div',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2161,12 +2161,6 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->radio('Model.field', ['option A']);
 		$expected = [
 			'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => ''],
-			['input' => [
-				'type' => 'radio',
-				'name' => 'Model[field]',
-				'value' => '0',
-				'id' => 'prefix-model-field-0'
-			]],
 			'label' => ['for' => 'prefix-model-field-0'],
 			'option A',
 			'/label'
@@ -2449,14 +2443,14 @@ class FormHelperTest extends TestCase {
 			'/label',
 			array('input' => array('type' => 'hidden', 'name' => "Contact[multiple]", 'value' => '')),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 50, 'disabled' => 'disabled', 'id' => "contact-multiple-50")),
 			array('label' => array('for' => "contact-multiple-50")),
+			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => 50, 'disabled' => 'disabled', 'id' => "contact-multiple-50")),
 			'Fifty',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => '50f5c0cf', 'id' => "contact-multiple-50f5c0cf")),
 			array('label' => array('for' => "contact-multiple-50f5c0cf")),
+			array('input' => array('type' => 'checkbox', 'name' => "Contact[multiple][]", 'value' => '50f5c0cf', 'id' => "contact-multiple-50f5c0cf")),
 			'Stringy',
 			'/label',
 			'/div',
@@ -2619,14 +2613,14 @@ class FormHelperTest extends TestCase {
 				'/label',
 				'input' => array('type' => 'hidden', 'name' => 'Publisher[id]', 'value' => ''),
 				array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 1', 'id' => 'publisher-id-value-1')),
 				array('label' => array('for' => 'publisher-id-value-1')),
+				array('input' => array('type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 1', 'id' => 'publisher-id-value-1')),
 				'Label 1',
 				'/label',
 				'/div',
 				array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 2', 'id' => 'publisher-id-value-2')),
 				array('label' => array('for' => 'publisher-id-value-2')),
+				array('input' => array('type' => 'checkbox', 'name' => 'Publisher[id][]', 'value' => 'Value 2', 'id' => 'publisher-id-value-2')),
 				'Label 2',
 				'/label',
 				'/div',
@@ -2710,13 +2704,14 @@ class FormHelperTest extends TestCase {
 				'name' => 'Model[user]',
 				'value' => 0,
 			)),
+			'label' => array('for' => 'model-user'),
 			array('input' => array(
 				'name' => 'Model[user]',
 				'type' => 'checkbox',
 				'id' => 'model-user',
 				'value' => 1
 			)),
-			'label' => array('for' => 'model-user'), 'User', '/label',
+			'User', '/label',
 			'/div'
 		);
 		$this->assertTags($result, $expected);
@@ -2956,20 +2951,20 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '0', 'id' => 'model-multi-field-0')),
 			array('label' => array('for' => 'model-multi-field-0', 'class' => 'selected')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '0', 'id' => 'model-multi-field-0')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '1', 'id' => 'model-multi-field-1')),
 			array('label' => array('for' => 'model-multi-field-1', 'class' => 'selected')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '1', 'id' => 'model-multi-field-1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '2', 'id' => 'model-multi-field-2')),
 			array('label' => array('for' => 'model-multi-field-2')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '2', 'id' => 'model-multi-field-2')),
 			'third',
 			'/label',
 			'/div',
@@ -2984,8 +2979,8 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1/2', 'id' => 'model-multi-field-1-2')),
 			array('label' => array('for' => 'model-multi-field-1-2')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1/2', 'id' => 'model-multi-field-1-2')),
 			'half',
 			'/label',
 			'/div',
@@ -4041,12 +4036,14 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'fish', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0')),
-				array('label' => array('for' => 'fish-0')), '1', '/label',
+			array('label' => array('for' => 'fish-0')),
+			array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0')),
+			'1', '/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1')),
-				array('label' => array('for' => 'fish-1')), '2', '/label',
+			array('label' => array('for' => 'fish-1')),
+			array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1')),
+			'2', '/label',
 			'/div'
 		);
 		$this->assertTags($result, $expected);
@@ -6147,8 +6144,8 @@ class FormHelperTest extends TestCase {
 		$expected = [
 			'div' => ['class' => 'check'],
 			['input' => ['type' => 'hidden', 'name' => 'accept', 'value' => 0]],
-			['input' => ['id' => 'accept', 'type' => 'checkbox', 'name' => 'accept', 'value' => 1]],
 			'label' => ['for' => 'accept'],
+			['input' => ['id' => 'accept', 'type' => 'checkbox', 'name' => 'accept', 'value' => 1]],
 			'Accept',
 			'/label',
 			'/div'

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3236,8 +3236,8 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->radio('Model.field', array('option A'));
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'Model[field]', 'value' => ''),
-			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0')),
 			'label' => array('for' => 'model-field-0'),
+			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0')),
 			'option A',
 			'/label'
 		);
@@ -3249,12 +3249,12 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->radio('Model.field', array('option A', 'option B'));
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'Model[field]', 'value' => ''),
-			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0')),
 			array('label' => array('for' => 'model-field-0')),
+			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0')),
 			'option A',
 			'/label',
-			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1')),
 			array('label' => array('for' => 'model-field-1')),
+			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1')),
 			'option B',
 			'/label',
 		);
@@ -3267,12 +3267,12 @@ class FormHelperTest extends TestCase {
 		);
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'Employee[gender]', 'value' => '', 'form' => 'my-form'),
-			array('input' => array('type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'male', 'id' => 'employee-gender-male', 'form' => 'my-form')),
 			array('label' => array('for' => 'employee-gender-male')),
+			array('input' => array('type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'male', 'id' => 'employee-gender-male', 'form' => 'my-form')),
 			'Male',
 			'/label',
-			array('input' => array('type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'female', 'id' => 'employee-gender-female', 'form' => 'my-form')),
 			array('label' => array('for' => 'employee-gender-female')),
+			array('input' => array('type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'female', 'id' => 'employee-gender-female', 'form' => 'my-form')),
 			'Female',
 			'/label',
 		);
@@ -3281,55 +3281,15 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->radio('Model.field', array('option A', 'option B'), array('name' => 'Model[custom]'));
 		$expected = array(
 			array('input' => array('type' => 'hidden', 'name' => 'Model[custom]', 'value' => '')),
-			array('input' => array('type' => 'radio', 'name' => 'Model[custom]', 'value' => '0', 'id' => 'model-custom-0')),
 			array('label' => array('for' => 'model-custom-0')),
+			array('input' => array('type' => 'radio', 'name' => 'Model[custom]', 'value' => '0', 'id' => 'model-custom-0')),
 			'option A',
 			'/label',
-			array('input' => array('type' => 'radio', 'name' => 'Model[custom]', 'value' => '1', 'id' => 'model-custom-1')),
 			array('label' => array('for' => 'model-custom-1')),
+			array('input' => array('type' => 'radio', 'name' => 'Model[custom]', 'value' => '1', 'id' => 'model-custom-1')),
 			'option B',
 			'/label',
 		);
-		$this->assertTags($result, $expected);
-	}
-
-/**
- * test generating radio input inside label ala twitter bootstrap
- *
- * @return void
- */
-	public function testRadioInputInsideLabel() {
-		$this->Form->templates([
-			'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
-			'radioWrapper' => '{{label}}'
-		]);
-
-		$result = $this->Form->radio('Model.field', ['option A', 'option B']);
-		$expected = [
-			['input' => [
-				'type' => 'hidden',
-				'name' => 'Model[field]',
-				'value' => ''
-			]],
-			['label' => ['for' => 'model-field-0']],
-				['input' => [
-					'type' => 'radio',
-					'name' => 'Model[field]',
-					'value' => '0',
-					'id' => 'model-field-0'
-				]],
-				'option A',
-			'/label',
-			['label' => ['for' => 'model-field-1']],
-				['input' => [
-					'type' => 'radio',
-					'name' => 'Model[field]',
-					'value' => '1',
-					'id' => 'model-field-1'
-				]],
-				'option B',
-			'/label',
-		];
 		$this->assertTags($result, $expected);
 	}
 
@@ -3341,8 +3301,8 @@ class FormHelperTest extends TestCase {
 	public function testRadioHiddenInputDisabling() {
 		$result = $this->Form->radio('Model.1.field', array('option A'), array('hiddenField' => false));
 		$expected = array(
-			'input' => array('type' => 'radio', 'name' => 'Model[1][field]', 'value' => '0', 'id' => 'model-1-field-0'),
 			'label' => array('for' => 'model-1-field-0'),
+			'input' => array('type' => 'radio', 'name' => 'Model[1][field]', 'value' => '0', 'id' => 'model-1-field-0'),
 			'option A',
 			'/label'
 		);
@@ -6096,28 +6056,6 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->input('body', ['required' => true]);
 		$this->assertContains('required', $result);
-	}
-
-/**
- * Tests that it is possible to nest inputs inside labels
- *
- * @return void
- */
-	public function testNestInputInLabel() {
-		$this->Form->templates([
-			'label' => '<label{{attrs}}>{{text}}{{input}}</label>',
-			'formGroup' => '{{label}}'
-		]);
-		$result = $this->Form->input('foo');
-		$expected = array(
-			'div' => array('class' => 'input text'),
-			'label' => array('for' => 'foo'),
-				'Foo',
-				'input' => array('type' => 'text', 'name' => 'foo', 'id' => 'foo'),
-			'/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2162,6 +2162,7 @@ class FormHelperTest extends TestCase {
 		$expected = [
 			'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => ''],
 			'label' => ['for' => 'prefix-model-field-0'],
+			['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'prefix-model-field-0']],
 			'option A',
 			'/label'
 		];
@@ -2171,6 +2172,7 @@ class FormHelperTest extends TestCase {
 		$expected = [
 			'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => ''],
 			'label' => ['for' => 'prefix-model-field-0'],
+			['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'prefix-model-field-0']],
 			'option A',
 			'/label'
 		];
@@ -2186,11 +2188,11 @@ class FormHelperTest extends TestCase {
 				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			],
 			['div' => ['class' => 'checkbox']],
+			['label' => ['for' => 'prefix-model-multi-field-0']],
 			['input' => [
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
 				'value' => '0', 'id' => 'prefix-model-multi-field-0'
 			]],
-			['label' => ['for' => 'prefix-model-multi-field-0']],
 			'first',
 			'/label',
 			'/div',

--- a/tests/TestCase/View/Widget/CheckboxTest.php
+++ b/tests/TestCase/View/Widget/CheckboxTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\View\Widget;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\Checkbox;
+use Cake\View\Widget\Label;
 
 /**
  * Checkbox test case
@@ -32,6 +33,8 @@ class CheckboxTest extends TestCase {
 		parent::setUp();
 		$templates = [
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
+			'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
+			'checkboxWrapper' => '{{input}}',
 		];
 		$this->templates = new StringTemplate($templates);
 		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
@@ -43,7 +46,8 @@ class CheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$checkbox = new Checkbox($this->templates);
+		$label = new Label($this->templates);
+		$checkbox = new Checkbox($this->templates, $label);
 		$data = [
 			'name' => 'Comment[spam]',
 		];


### PR DESCRIPTION
I'm opening this PR in an early state so that it can be discussed.

So far, I don't know anyone using cake 3 that has not tried making it work with twitter bootstrap. It is obvious for them that it quite a pain to make the form helper nest inputs inside labels. This makes nesting the default for radio and checkbox widgets.

The approach taken was to let checkboxes render their own label as radio widgets do. The downside of this is that it becomes a pain to do not nest inputs inside labels, and basically impossible to nest other type of inputs inside them. I'm no yet convinced of this, but making a decision before we hit the beta is important.

Once we make the decision I can fix the rest of the tests.
