### PR TITLE
Be forward compatible to PHP 7's "Uniform Variable Syntax"

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -248,10 +248,10 @@ class ControllerTask extends BakeTask {
 		);
 
 		foreach ($properties as $var => $title) {
-			if (count($$var)) {
+			if (count(${$var})) {
 				$output = '';
-				$length = count($$var);
-				foreach ($$var as $i => $propElement) {
+				$length = count(${$var});
+				foreach (${$var} as $i => $propElement) {
 					if ($i != $length - 1) {
 						$output .= ucfirst($propElement) . ', ';
 					} else {


### PR DESCRIPTION
https://wiki.php.net/rfc/uniform_variable_syntax
https://wiki.php.net/rfc/uniform_variable_syntax#semantic_differences_in_existing_syntax
