### PR TITLE
Add case expression class for simple SQL case statements

### DIFF
--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -44,19 +44,19 @@ class CaseExpression implements ExpressionInterface {
 /**
  * The value to be used if none of the conditions match
  *
- * @var array|QueryExpression|string
+ * @var array|ExpressionInterface|string
  */
 	protected $_defaultValue;
 
 /**
  * Constructs the case expression
  *
- * @param array|QueryExpression $conditions The conditions to test.
+ * @param array|ExpressionInterface $conditions The conditions to test.
  *                                          Must be a QueryExpression, or an array of QueryExpressions.
- * @param string|array|QueryExpression $trueValues Value of each condition if that condition is true
- * @param string|array|QueryExpression $defaultValue Default value if none of the conditiosn are true
+ * @param string|array|ExpressionInterface $trueValues Value of each condition if that condition is true
+ * @param string|array|ExpressionInterface $defaultValue Default value if none of the conditiosn are true
  */
-	public function __construct($conditions = [], $trueValues = [], $defaultValue = 0) {
+	public function __construct($conditions = [], $trueValues = [], $defaultValue = '0') {
 		if (!empty($conditions)) {
 			$this->add($conditions, $trueValues);
 		}
@@ -69,8 +69,8 @@ class CaseExpression implements ExpressionInterface {
  * Conditions must be a one dimensional array or a QueryExpression.
  * The trueValues must be a similar structure, but may contain a string value.
  *
- * @param array|QueryExpression $conditions Must be a QueryExpression, or an array of QueryExpressions.
- * @param string|array|QueryExpression $trueValues Values of each condition if that condition is true
+ * @param array|ExpressionInterface $conditions Must be a QueryExpression, or an array of QueryExpressions.
+ * @param string|array|ExpressionInterface $trueValues Values of each condition if that condition is true
  *
  * @return $this
  */
@@ -91,8 +91,8 @@ class CaseExpression implements ExpressionInterface {
  * Iterates over the passed in conditions and ensures that there is a matching true value for each.
  * If no matching true value, then it is defaulted to '1'.
  *
- * @param array|QueryExpression $conditions Must be a QueryExpression, or an array of QueryExpressions.
- * @param string|array|QueryExpression $trueValues Values of each condition if that condition is true
+ * @param array|ExpressionInterface $conditions Must be a QueryExpression, or an array of QueryExpressions.
+ * @param string|array|ExpressionInterface $trueValues Values of each condition if that condition is true
  *
  * @return void
  */
@@ -129,9 +129,9 @@ class CaseExpression implements ExpressionInterface {
 /**
  * Gets/sets the default value part
  *
- * @param array|string|QueryExpression $value Value to set
+ * @param array|string|ExpressionInterface $value Value to set
  *
- * @return array|string|QueryExpression
+ * @return array|string|ExpressionInterface
  */
 	public function defaultValue($value = null) {
 		if ($value !== null) {
@@ -144,9 +144,9 @@ class CaseExpression implements ExpressionInterface {
 /**
  * Parses the value into a understandable format
  *
- * @param array|string|QueryExpression $value The value to parse
+ * @param array|string|ExpressionInterface $value The value to parse
  *
- * @return array|string|QueryExpression
+ * @return array|string|ExpressionInterface
  */
 	protected function _parseValue($value) {
 		if (is_string($value)) {
@@ -164,7 +164,7 @@ class CaseExpression implements ExpressionInterface {
 /**
  * Compiles the relevant parts into sql
  *
- * @param array|string|QueryExpression $part The part to compile
+ * @param array|string|ExpressionInterface $part The part to compile
  * @param ValueBinder $generator Sql generator
  *
  * @return string

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
+
+/**
+ * This class represents a SQL Case statement
+ *
+ * @internal
+ */
+class CaseExpression implements ExpressionInterface {
+
+	protected $_expression;
+
+	protected $_isTrue;
+
+	protected $_isFalse;
+
+/**
+ * Constructs the case expression
+ *
+ * @param QueryExpression $expression The expression to test
+ * @param mixed           $isTrue Value if the expression is true
+ * @param mixed           $isFalse Value if the expression is false
+ */
+	public function __construct(QueryExpression $expression, $isTrue = 1, $isFalse = 0) {
+		$this->_expression = $expression;
+		$this->_isTrue = $this->_getValue($isTrue);
+		$this->_isFalse = $this->_getValue($isFalse);
+	}
+
+/**
+ * Gets/sets the isTrue part
+ *
+ * @param mixed $value Value to set
+ *
+ * @return array|mixed
+ */
+	public function isTrue($value = null) {
+		return $this->_part('isTrue', $value);
+	}
+
+/**
+ * Gets/sets the isFalse part
+ *
+ * @param mixed $value Value to set
+ *
+ * @return array|mixed
+ * @codeCoverageIgnore
+ */
+	public function isFalse($value = null) {
+		return $this->_part('isFalse', $value);
+	}
+
+/**
+ * Gets/sets the passed part
+ *
+ * @param string $part The part to get or set
+ * @param mixed $value Value to set
+ *
+ * @return array|mixed
+ */
+	protected function _part($part, $value) {
+		if ($value !== null) {
+			$this->{'_' . $part} = $this->_getValue($value);
+		}
+
+		return $this->{'_' . $part};
+	}
+
+/**
+ * Parses the value into a understandable format
+ *
+ * @param mixed $value The value to parse
+ *
+ * @return array|mixed
+ */
+	protected function _getValue($value) {
+		if (is_string($value)) {
+			$value = [
+				'value' => $value,
+				'type' => null
+			];
+		} elseif (is_array($value) && !isset($value['value'])) {
+			$value = array_keys($value);
+			$value = end($value);
+		}
+		return $value;
+	}
+
+/**
+ * Compiles the true or false part into sql
+ *
+ * @param mixed       $part The part to compile
+ * @param ValueBinder $generator Sql generator
+ *
+ * @return string
+ */
+	protected function _compile($part, ValueBinder $generator) {
+		$part = $this->{'_' . $part};
+		if ($part instanceof ExpressionInterface) {
+			$part = $part->sql($generator);
+		} elseif (is_array($part)) {
+			$placeholder = $generator->placeholder('param');
+			$generator->bind($placeholder, $part['value'], $part['type']);
+			$part = $placeholder;
+		}
+
+		return $part;
+	}
+
+/**
+ * Converts the Node into a SQL string fragment.
+ *
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
+ *
+ * @return string
+ */
+	public function sql(ValueBinder $generator) {
+		$parts = [];
+		$parts[] = 'CASE WHEN';
+		$parts[] = $this->_expression->sql($generator);
+		$parts[] = 'THEN';
+		$parts[] = $this->_compile('isTrue', $generator);
+		$parts[] = 'ELSE';
+		$parts[] = $this->_compile('isFalse', $generator);
+		$parts[] = 'END';
+
+		return implode(' ', $parts);
+	}
+
+/**
+ * {@inheritDoc}
+ *
+ */
+	public function traverse(callable $visitor) {
+		foreach (['_expression', '_isTrue', '_isFalse'] as $c) {
+			if ($this->{$c} instanceof ExpressionInterface) {
+				$visitor($this->{$c});
+				$this->{$c}->traverse($visitor);
+			}
+		}
+	}
+
+}

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -56,7 +56,7 @@ class CaseExpression implements ExpressionInterface {
  * @param string|array|ExpressionInterface $trueValues Value of each condition if that condition is true
  * @param string|array|ExpressionInterface $defaultValue Default value if none of the conditiosn are true
  */
-	public function __construct($conditions = [], $trueValues = [], $defaultValue = '0') {
+	public function __construct($conditions = [], $trueValues = [], $defaultValue = 0) {
 		if (!empty($conditions)) {
 			$this->add($conditions, $trueValues);
 		}
@@ -108,7 +108,7 @@ class CaseExpression implements ExpressionInterface {
 				continue;
 			}
 
-			$trueValue = isset($trueValues[$k]) ? $trueValues[$k] : 1;
+			$trueValue = !empty($trueValues[$k]) ? $trueValues[$k] : 1;
 
 			if ($trueValue === 'literal') {
 				$trueValue = $k;
@@ -117,8 +117,6 @@ class CaseExpression implements ExpressionInterface {
 					'value' => $trueValue,
 					'type' => null
 				];
-			} elseif (empty($trueValue)) {
-				$trueValue = 1;
 			}
 
 			$this->_conditions[] = $c;

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -125,6 +125,8 @@ class CaseExpression implements ExpressionInterface {
 				$value = $k;
 				array_push($this->_values, $value);
 				continue;
+			} elseif ($value instanceof ExpressionInterface) {
+				array_push($this->_values, $value);
 			}
 
 			$type = isset($types[$k]) ? $types[$k] : null;

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -112,7 +112,7 @@ class CaseExpression implements ExpressionInterface {
 
 			if ($trueValue === 'literal') {
 				$trueValue = $k;
-			} elseif (is_string($trueValue)) {
+			} elseif (is_string($trueValue) || is_numeric($trueValue)) {
 				$trueValue = [
 					'value' => $trueValue,
 					'type' => null
@@ -149,7 +149,7 @@ class CaseExpression implements ExpressionInterface {
  * @return array|string|ExpressionInterface
  */
 	protected function _parseValue($value) {
-		if (is_string($value)) {
+		if (is_string($value) || is_numeric($value)) {
 			$value = [
 				'value' => $value,
 				'type' => null

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -101,8 +101,9 @@ class CaseExpression implements ExpressionInterface {
  * Iterates over the passed in conditions and ensures that there is a matching true value for each.
  * If no matching true value, then it is defaulted to '1'.
  *
- * @param array|ExpressionInterface $conditions Must be a QueryExpression, or an array of QueryExpressions.
- * @param string|array|ExpressionInterface $trueValues Values of each condition if that condition is true
+ * @param array|ExpressionInterface $conditions Must be a ExpressionInterface instance, or an array of ExpressionInterface instances.
+ * @param array|ExpressionInterface $values associtative array of values of each condition
+ * @param array $types associative array of types to be associated with the values
  *
  * @return void
  */
@@ -138,8 +139,8 @@ class CaseExpression implements ExpressionInterface {
 /**
  * Sets the default value
  *
- * @param $value Value to set
- * @param $type Type of value
+ * @param string|ExpressionInterface|array $value Value to set
+ * @param string $type Type of value
  *
  * @return void
  */

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -113,10 +113,7 @@ class CaseExpression implements ExpressionInterface {
 			if ($trueValue === 'literal') {
 				$trueValue = $k;
 			} elseif (is_string($trueValue) || is_numeric($trueValue)) {
-				$trueValue = [
-					'value' => $trueValue,
-					'type' => null
-				];
+				$trueValue = $this->_parseValue($trueValue);
 			}
 
 			$this->_conditions[] = $c;
@@ -150,13 +147,30 @@ class CaseExpression implements ExpressionInterface {
 		if (is_string($value) || is_numeric($value)) {
 			$value = [
 				'value' => $value,
-				'type' => null
+				'type' => is_string($value) ? null : $this->_getType($value)
 			];
 		} elseif (is_array($value) && !isset($value['value'])) {
 			$value = array_keys($value);
 			$value = end($value);
 		}
 		return $value;
+	}
+
+/**
+ * Gets the correct type for the value
+ *
+ * @param mixed $value The value to test
+ *
+ * @return null|string
+ */
+	protected function _getType($value) {
+		if (is_integer($value)) {
+			return 'integer';
+		} elseif (is_float($value)) {
+			return 'float';
+		}
+
+		return null;
 	}
 
 /**

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -127,6 +127,7 @@ class CaseExpression implements ExpressionInterface {
 				continue;
 			} elseif ($value instanceof ExpressionInterface) {
 				array_push($this->_values, $value);
+				continue;
 			}
 
 			$type = isset($types[$k]) ? $types[$k] : null;

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -269,14 +269,17 @@ class QueryExpression implements ExpressionInterface, Countable {
 /**
  * Adds a new case expression to the expression object
  *
- * @param array|ExpressionInterface $conditions The conditions to test. Must be a QueryExpression, or an array of QueryExpressions.
- * @param string|array|ExpressionInterface $trueValues Value of each condition if that condition is true
- * @param string|array|ExpressionInterface $defaultValue Default value if none of the conditiosn are true
+ * @param array|ExpressionInterface $conditions The conditions to test. Must be a ExpressionInterface
+ * instance,or an array of ExpressionInterface instances.
+ * @param array|ExpressionInterface $values associative array of values to be associated with the conditions
+ * passed in $conditions. If there are more $values than $conditions, the last $value is used as the `ELSE` value
+ * @param array $types associative array of types to be associated with the values
+ * passed in $values
  *
  * @return QueryExpression
  */
-	public function addCase($conditions, $trueValues = [], $defaultValue = 0) {
-		return $this->add(new CaseExpression($conditions, $trueValues, $defaultValue));
+	public function addCase($conditions, $values = [], $types = []) {
+		return $this->add(new CaseExpression($conditions, $values, $types));
 	}
 
 /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -266,8 +266,18 @@ class QueryExpression implements ExpressionInterface, Countable {
 		return $this->add(new Comparison($field, $values, $type, 'IN'));
 	}
 
-	public function addCase(QueryExpression $expression, $isTrue = 1, $isFalse = 0) {
-		return $this->add(new CaseExpression($expression, $isTrue, $isFalse));
+/**
+ * Adds a new case expression to the expression object
+ *
+ * @param array|ExpressionInterface        $conditions   The conditions to test.
+ *                                                       Must be a QueryExpression, or an array of QueryExpressions.
+ * @param string|array|ExpressionInterface $trueValues   Value of each condition if that condition is true
+ * @param string|array|ExpressionInterface $defaultValue Default value if none of the conditiosn are true
+ *
+ * @return QueryExpression
+ */
+	public function addCase($conditions, $trueValues = [], $defaultValue = '0') {
+		return $this->add(new CaseExpression($conditions, $trueValues, $defaultValue));
 	}
 
 /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -276,7 +276,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  *
  * @return QueryExpression
  */
-	public function addCase($conditions, $trueValues = [], $defaultValue = '0') {
+	public function addCase($conditions, $trueValues = [], $defaultValue = 0) {
 		return $this->add(new CaseExpression($conditions, $trueValues, $defaultValue));
 	}
 

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -269,9 +269,8 @@ class QueryExpression implements ExpressionInterface, Countable {
 /**
  * Adds a new case expression to the expression object
  *
- * @param array|ExpressionInterface        $conditions   The conditions to test.
- *                                                       Must be a QueryExpression, or an array of QueryExpressions.
- * @param string|array|ExpressionInterface $trueValues   Value of each condition if that condition is true
+ * @param array|ExpressionInterface $conditions The conditions to test. Must be a QueryExpression, or an array of QueryExpressions.
+ * @param string|array|ExpressionInterface $trueValues Value of each condition if that condition is true
  * @param string|array|ExpressionInterface $defaultValue Default value if none of the conditiosn are true
  *
  * @return QueryExpression

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -266,6 +266,10 @@ class QueryExpression implements ExpressionInterface, Countable {
 		return $this->add(new Comparison($field, $values, $type, 'IN'));
 	}
 
+	public function addCase(QueryExpression $expression, $isTrue = 1, $isFalse = 0) {
+		return $this->add(new CaseExpression($expression, $isTrue, $isFalse));
+	}
+
 /**
  * Adds a new condition to the expression object in the form
  * "field NOT IN (value1, value2)".

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Project: hesa-mbit.
+ * User: walther
+ * Date: 2014/08/08
+ * Time: 9:37 AM
+ */
+
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+use Cake\Database\Expression\CaseExpression;
+
+/**
+ * Tests CaseExpression class
+ */
+class CaseExpressionTest extends TestCase {
+
+/**
+ * Test that the sql output works correctly
+ *
+ * @return void
+ */
+	public function testSqlOutput() {
+		$expr = new QueryExpression();
+		$expr->eq('test', 'true');
+		$caseExpression = new CaseExpression($expr);
+
+		$this->assertInstanceOf('Cake\Database\ExpressionInterface', $caseExpression);
+		$expected = 'CASE WHEN test = :c0 THEN 1 ELSE 0 END';
+		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
+	}
+
+/**
+ * Test that we can pass in things as the isTrue/isFalse part
+ *
+ * @return void
+ */
+	public function testSetTrue() {
+		$expr = new QueryExpression();
+		$expr->eq('test', 'true');
+		$caseExpression = new CaseExpression($expr);
+		$expr2 = new QueryExpression();
+
+		$caseExpression->isTrue($expr2);
+		$this->assertSame($expr2, $caseExpression->isTrue());
+
+		$caseExpression->isTrue('test_string');
+		$this->assertSame(['value' => 'test_string', 'type' => null], $caseExpression->isTrue());
+
+		$caseExpression->isTrue(['test_string' => 'literal']);
+		$this->assertSame('test_string', $caseExpression->isTrue());
+	}
+
+/**
+ * Test that things are compiled correctly
+ *
+ * @return void
+ */
+	public function testSqlCompiler() {
+		$expr = new QueryExpression();
+		$expr->eq('test', 'true');
+		$caseExpression = new CaseExpression($expr);
+		$expr2 = new QueryExpression();
+		$expr2->eq('test', 'false');
+
+		$caseExpression->isTrue($expr2);
+		$this->assertSame('CASE WHEN test = :c0 THEN test = :c1 ELSE 0 END', $caseExpression->sql(new ValueBinder()));
+
+		$caseExpression->isTrue('test_string');
+		$this->assertSame('CASE WHEN test = :c0 THEN :c1 ELSE 0 END', $caseExpression->sql(new ValueBinder()));
+
+		$caseExpression->isTrue(['test_string' => 'literal']);
+		$this->assertSame('CASE WHEN test = :c0 THEN test_string ELSE 0 END', $caseExpression->sql(new ValueBinder()));
+	}
+
+/**
+ * Tests that the expression is correctly traversed
+ *
+ * @return void
+ */
+	public function testTraverse() {
+		$count = 0;
+		$visitor = function() use (&$count) {
+			$count++;
+		};
+
+		$expr = new QueryExpression();
+		$expr->eq('test', 'true');
+		$caseExpression = new CaseExpression($expr);
+		$caseExpression->traverse($visitor);
+		$this->assertSame(2, $count);
+	}
+}

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -33,13 +33,13 @@ class CaseExpressionTest extends TestCase {
 		$expr->eq('test', 'true');
 		$caseExpression = new CaseExpression($expr, 'foobar');
 
-		$expected = 'CASE WHEN test = :c0 THEN :c1 ELSE 0 END';
+		$expected = 'CASE WHEN test = :c0 THEN :c1 ELSE :c2 END';
 		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
 		$expr2 = new QueryExpression();
 		$expr2->eq('test2', 'false');
 		$caseExpression->add($expr2);
-		$expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN 1 ELSE 0 END';
+		$expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN :c3 ELSE :c4 END';
 		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 	}
 

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -32,14 +32,17 @@ class CaseExpressionTest extends TestCase {
 		$expr = new QueryExpression();
 		$expr->eq('test', 'true');
 		$caseExpression = new CaseExpression($expr, 'foobar');
-
-		$expected = 'CASE WHEN test = :c0 THEN :c1 ELSE :c2 END';
+		$expected = 'CASE WHEN test = :c0 THEN :c1 END';
 		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
 		$expr2 = new QueryExpression();
 		$expr2->eq('test2', 'false');
 		$caseExpression->add($expr2);
-		$expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN :c3 ELSE :c4 END';
+		$expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN :c3 END';
+		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
+
+		$caseExpression = new CaseExpression([$expr], ['foobar', 'else']);
+		$expected = 'CASE WHEN test = :c0 THEN :c1 ELSE :c2 END';
 		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 	}
 

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -1,11 +1,16 @@
 <?php
 /**
- * Project: hesa-mbit.
- * User: walther
- * Date: 2014/08/08
- * Time: 9:37 AM
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The Open Group Test Suite License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2013, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\Database\Expression;
 
 use Cake\Database\Expression\QueryExpression;

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -31,54 +31,16 @@ class CaseExpressionTest extends TestCase {
 	public function testSqlOutput() {
 		$expr = new QueryExpression();
 		$expr->eq('test', 'true');
-		$caseExpression = new CaseExpression($expr);
+		$caseExpression = new CaseExpression($expr, 'foobar');
 
-		$this->assertInstanceOf('Cake\Database\ExpressionInterface', $caseExpression);
-		$expected = 'CASE WHEN test = :c0 THEN 1 ELSE 0 END';
+		$expected = 'CASE WHEN test = :c0 THEN :c1 ELSE 0 END';
 		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
-	}
 
-/**
- * Test that we can pass in things as the isTrue/isFalse part
- *
- * @return void
- */
-	public function testSetTrue() {
-		$expr = new QueryExpression();
-		$expr->eq('test', 'true');
-		$caseExpression = new CaseExpression($expr);
 		$expr2 = new QueryExpression();
-
-		$caseExpression->isTrue($expr2);
-		$this->assertSame($expr2, $caseExpression->isTrue());
-
-		$caseExpression->isTrue('test_string');
-		$this->assertSame(['value' => 'test_string', 'type' => null], $caseExpression->isTrue());
-
-		$caseExpression->isTrue(['test_string' => 'literal']);
-		$this->assertSame('test_string', $caseExpression->isTrue());
-	}
-
-/**
- * Test that things are compiled correctly
- *
- * @return void
- */
-	public function testSqlCompiler() {
-		$expr = new QueryExpression();
-		$expr->eq('test', 'true');
-		$caseExpression = new CaseExpression($expr);
-		$expr2 = new QueryExpression();
-		$expr2->eq('test', 'false');
-
-		$caseExpression->isTrue($expr2);
-		$this->assertSame('CASE WHEN test = :c0 THEN test = :c1 ELSE 0 END', $caseExpression->sql(new ValueBinder()));
-
-		$caseExpression->isTrue('test_string');
-		$this->assertSame('CASE WHEN test = :c0 THEN :c1 ELSE 0 END', $caseExpression->sql(new ValueBinder()));
-
-		$caseExpression->isTrue(['test_string' => 'literal']);
-		$this->assertSame('CASE WHEN test = :c0 THEN test_string ELSE 0 END', $caseExpression->sql(new ValueBinder()));
+		$expr2->eq('test2', 'false');
+		$caseExpression->add($expr2);
+		$expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN 1 ELSE 0 END';
+		$this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 	}
 
 /**
@@ -94,8 +56,10 @@ class CaseExpressionTest extends TestCase {
 
 		$expr = new QueryExpression();
 		$expr->eq('test', 'true');
-		$caseExpression = new CaseExpression($expr);
+		$expr2 = new QueryExpression();
+		$expr2->eq('test', 'false');
+		$caseExpression = new CaseExpression([$expr, $expr2]);
 		$caseExpression->traverse($visitor);
-		$this->assertSame(2, $count);
+		$this->assertSame(4, $count);
 	}
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2736,6 +2736,12 @@ class QueryTest extends TestCase {
 					->add(['published' => 'N']), 1, 'integer'
 			);
 
+		//Postgres requires the case statement to be cast to a integer
+		if ($this->connection->driver() instanceof \Cake\Database\Driver\Postgres) {
+			$publishedCase = $query->func()->cast([$publishedCase, 'integer' => 'literal'])->type(' AS ');
+			$notPublishedCase = $query->func()->cast([$notPublishedCase, 'integer' => 'literal'])->type(' AS ');
+		}
+
 		$results = $query
 			->select([
 				'published' => $query->func()->sum($publishedCase),

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2727,13 +2727,13 @@ class QueryTest extends TestCase {
 			->newExpr()
 			->addCase($query
 				->newExpr()
-				->add(['published' => 'Y'])
+				->add(['published' => 'Y']), 1, 'integer'
 			);
 		$notPublishedCase = $query
 			->newExpr()
 			->addCase($query
 					->newExpr()
-					->add(['published' => 'N'])
+					->add(['published' => 'N']), 1, 'integer'
 			);
 
 		$results = $query
@@ -2769,15 +2769,16 @@ class QueryTest extends TestCase {
 				->newExpr()
 				->add(['published' => 'N'])
 		];
-		$trueValues = [
+		$values = [
 			'Published',
-			'Not published'
+			'Not published',
+			'None'
 		];
 		$results = $query
 			->select([
 				'id',
 				'comment',
-				'status' => $query->newExpr()->addCase($conditions, $trueValues, 'None')
+				'status' => $query->newExpr()->addCase($conditions, $values)
 			])
 			->from(['comments'])
 			->execute()

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2722,8 +2722,6 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testSqlCaseStatement() {
-		$convert = $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver;
-
 		$query = new Query($this->connection);
 		$publishedCase = $query
 			->newExpr()
@@ -2737,20 +2735,6 @@ class QueryTest extends TestCase {
 					->newExpr()
 					->add(['published' => 'N'])
 			);
-
-		//SQLServer requires the case statements to be converted to int
-		if ($convert) {
-			$publishedCase = $query->func()
-				->convert([
-					'INT' => 'literal',
-					$publishedCase
-				]);
-			$notPublishedCase = $query->func()
-				->convert([
-					'INT' => 'literal',
-					$notPublishedCase
-				]);
-		}
 
 		$results = $query
 			->select([

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2717,6 +2717,77 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that case statements work correctly for various use-cases.
+ *
+ * @return void
+ */
+	public function testSqlCaseStatement() {
+		$query = new Query($this->connection);
+		$publishedCase = $query
+			->newExpr()
+			->addCase($query
+				->newExpr()
+				->add(['published' => 'Y'])
+			);
+		$notPublishedCase = $query
+			->newExpr()
+			->addCase($query
+					->newExpr()
+					->add(['published' => 'N'])
+			);
+		$results = $query
+			->select([
+				'published' => $query->func()->sum($publishedCase),
+				'not_published' => $query->func()->sum($notPublishedCase)
+			])
+			->from(['comments'])
+			->execute()
+			->fetchAll('assoc');
+
+		$this->assertEquals(5, $results[0]['published']);
+		$this->assertEquals(1, $results[0]['not_published']);
+
+		$query = new Query($this->connection);
+		$query
+			->insert(['article_id', 'user_id', 'comment', 'published'])
+			->into('comments')
+			->values([
+				'article_id' => 2,
+				'user_id' => 1,
+				'comment' => 'In limbo',
+				'published' => 'L'
+			])
+			->execute();
+
+		$query = new Query($this->connection);
+		$conditions = [
+			$query
+				->newExpr()
+				->add(['published' => 'Y']),
+			$query
+				->newExpr()
+				->add(['published' => 'N'])
+		];
+		$trueValues = [
+			'Published',
+			'Not published'
+		];
+		$results = $query
+			->select([
+				'id',
+				'comment',
+				'status' => $query->newExpr()->addCase($conditions, $trueValues, 'None')
+			])
+			->from(['comments'])
+			->execute()
+			->fetchAll('assoc');
+
+		$this->assertEquals('Published', $results[2]['status']);
+		$this->assertEquals('Not published', $results[3]['status']);
+		$this->assertEquals('None', $results[6]['status']);
+	}
+
+/**
  * Assertion for comparing a table's contents with what is in it.
  *
  * @param string $table

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2722,6 +2722,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testSqlCaseStatement() {
+		$convert = $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver;
+
 		$query = new Query($this->connection);
 		$publishedCase = $query
 			->newExpr()
@@ -2735,6 +2737,21 @@ class QueryTest extends TestCase {
 					->newExpr()
 					->add(['published' => 'N'])
 			);
+
+		//SQLServer requires the case statements to be converted to int
+		if ($convert) {
+			$publishedCase = $query->func()
+				->convert([
+					'INT' => 'literal',
+					$publishedCase
+				]);
+			$notPublishedCase = $query->func()
+				->convert([
+					'INT' => 'literal',
+					$notPublishedCase
+				]);
+		}
+
 		$results = $query
 			->select([
 				'published' => $query->func()->sum($publishedCase),


### PR DESCRIPTION
References #4202

Usage is:

```
$query->newExpr()->addCase($expression, $valueIfTrue, $valueIfFalse)
```

`$expression` must be a QueryExpression instance.
