### PR TITLE
Fix entity saving when '' is used as a primary key value.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -106,12 +106,16 @@ class Marshaller {
 			$data = $data[$tableName];
 		}
 
+		$primaryKey = $schema->primaryKey();
 		$properties = [];
 		foreach ($data as $key => $value) {
 			$columnType = $schema->columnType($key);
 			if (isset($propertyMap[$key])) {
 				$assoc = $propertyMap[$key]['association'];
 				$value = $this->_marshalAssociation($assoc, $value, $propertyMap[$key]);
+			} elseif ($value === '' && in_array($key, $primaryKey, true)) {
+				// Skip marshalling '' for pk fields.
+				continue;
 			} elseif ($columnType) {
 				$converter = Type::build($columnType);
 				$value = $converter->marshal($value);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1152,9 +1152,6 @@ class Table implements RepositoryInterface, EventListener {
 			$alias = $this->alias();
 			$conditions = [];
 			foreach ($primary as $k => $v) {
-				if ($v === '') {
-					$entity->unsetProperty($k);
-				}
 				$conditions["$alias.$k"] = $v;
 			}
 			$entity->isNew(!$this->exists($conditions));

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1150,11 +1150,14 @@ class Table implements RepositoryInterface, EventListener {
 
 		if ($primary && $entity->isNew()) {
 			$alias = $this->alias();
-			$keys = array_keys($primary);
-			foreach ($keys as &$pk) {
-				$pk = "$alias.$pk";
+			$conditions = [];
+			foreach ($primary as $k => $v) {
+				if ($v === '') {
+					$entity->unsetProperty($k);
+				}
+				$conditions["$alias.$k"] = $v;
 			}
-			$entity->isNew(!$this->exists(array_combine($keys, $primary)));
+			$entity->isNew(!$this->exists($conditions));
 		}
 
 		$associated = $options['associated'];

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -115,6 +115,27 @@ class MarshallerTest extends TestCase {
 	}
 
 /**
+ * Test that marshalling an entity with '' for pk values results
+ * in no pk value being set.
+ *
+ * @return void
+ */
+	public function testOneEmptyStringPrimaryKey() {
+		$data = [
+			'id' => '',
+			'username' => 'superuser',
+			'password' => 'root',
+			'created' => new Time('2013-10-10 00:00'),
+			'updated' => new Time('2013-10-10 00:00')
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, []);
+
+		$this->assertFalse($result->dirty('id'));
+		$this->assertNull($result->id);
+	}
+
+/**
  * Test marshalling datetime/date field.
  *
  * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1213,6 +1213,26 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test that saving a new entity with an empty id populates
+ * the entity's id field.
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveNewEntityEmptyIdField() {
+		$entity = new \Cake\ORM\Entity([
+			'id' => '',
+			'username' => 'superuser',
+			'password' => 'root',
+			'created' => new Time('2013-10-10 00:00'),
+			'updated' => new Time('2013-10-10 00:00')
+		]);
+		$table = TableRegistry::get('users');
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertEquals($entity->id, self::$nextUserId);
+	}
+
+/**
  * Tests that saving an entity will filter out properties that
  * are not present in the table schema when saving
  *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1213,26 +1213,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test that saving a new entity with an empty id populates
- * the entity's id field.
- *
- * @group save
- * @return void
- */
-	public function testSaveNewEntityEmptyIdField() {
-		$entity = new \Cake\ORM\Entity([
-			'id' => '',
-			'username' => 'superuser',
-			'password' => 'root',
-			'created' => new Time('2013-10-10 00:00'),
-			'updated' => new Time('2013-10-10 00:00')
-		]);
-		$table = TableRegistry::get('users');
-		$this->assertSame($entity, $table->save($entity));
-		$this->assertEquals($entity->id, self::$nextUserId);
-	}
-
-/**
  * Tests that saving an entity will filter out properties that
  * are not present in the table schema when saving
  *


### PR DESCRIPTION
Having '' as the primary key value is almost never wanted as '' is cast to null or 0. Instead filter out this value and treat it as a mistake.

Refs #4152
