### PR TITLE
Add "contributing" pointers to GitHub readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Our primary goal is to provide a structured framework that enables PHP users at 
 
 [CONTRIBUTING.md](CONTRIBUTING.md) - Quick pointers for contributing to the CakePHP project
 
-[CookBook "Contributing" Section (2.x)](http://book.cakephp.org/2.0/en/contributing.html) [(3.0)](http://book.cakephp.org/3.0/en/contributing.html) - Version-specific details about contributing to the project.
+[CookBook "Contributing" Section (2.x)](http://book.cakephp.org/2.0/en/contributing.html) [(3.0)](http://book.cakephp.org/3.0/en/contributing.html) - Version-specific details about contributing to the project

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Our primary goal is to provide a structured framework that enables PHP users at 
 
 [CONTRIBUTING.md](CONTRIBUTING.md) - Quick pointers for contributing to the CakePHP project
 
-[CookBook "Contributing" Section](http://book.cakephp.org/2.0/en/contributing.html) - Detailed information about contributing to the project.
+[CookBook "Contributing" Section (2.x)](http://book.cakephp.org/2.0/en/contributing.html) [(3.0)](http://book.cakephp.org/3.0/en/contributing.html) - Version-specific details about contributing to the project.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ Our primary goal is to provide a structured framework that enables PHP users at 
 
 [Roadmaps](https://github.com/cakephp/cakephp/wiki#roadmaps) - Want to contribute? Get involved!
 
+
+## Contributing
+
+[CONTRIBUTING.md](CONTRIBUTING.md) - Quick pointers for contributing to the CakePHP project
+
+[CookBook "Contributing" Section](http://book.cakephp.org/2.0/en/contributing.html) - Detailed information about contributing to the project.


### PR DESCRIPTION
During [my last PR](https://github.com/cakephp/cakephp/pull/4230#discussion_r16125518), I seem to have looked in all of the wrong places for information on submitting contributions. This PR adds links where I expected them with the hope that others might find the right places more readily as well.

Please close if this is deemed not useful enough to add.
