### PR TITLE
Added support to Comparison expression for using Expressions as the field

### DIFF
--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -112,20 +112,15 @@ class Comparison extends QueryExpression {
 	public function sql(ValueBinder $generator) {
 		$field = $this->_field;
 
+		if ($field instanceof ExpressionInterface) {
+			$field = $field->sql($generator);
+		}
+
 		if ($this->_value instanceof ExpressionInterface) {
 			$template = '%s %s (%s)';
 			$value = $this->_value->sql($generator);
 		} else {
 			list($template, $value) = $this->_stringExpression($generator);
-		}
-
-		if ($field instanceof ExpressionInterface) {
-			$field = $field->sql($generator);
-
-			// SQL Server complains if you use an expression in the left hand side
-			// of a comparison. So, trying our best.
-			list($field, $value) = [$value, $field];
-			$template = str_replace('%s %s', '%s (%s)', $template);
 		}
 
 		return sprintf($template, $field, $this->_conjunction, $value);

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -112,15 +112,20 @@ class Comparison extends QueryExpression {
 	public function sql(ValueBinder $generator) {
 		$field = $this->_field;
 
-		if ($field instanceof ExpressionInterface) {
-			$field = $field->sql($generator);
-		}
-
 		if ($this->_value instanceof ExpressionInterface) {
 			$template = '%s %s (%s)';
 			$value = $this->_value->sql($generator);
 		} else {
 			list($template, $value) = $this->_stringExpression($generator);
+		}
+
+		if ($field instanceof ExpressionInterface) {
+			$field = $field->sql($generator);
+
+			// SQL Server complains if you use an expression in the left hand side
+			// of a comparison. So, trying our best.
+			list($field, $value) = [$value, $field];
+			$template = str_replace('%s %s', '%s (%s)', $template);
 		}
 
 		return sprintf($template, $field, $this->_conjunction, $value);

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -190,13 +190,12 @@ class IdentifierQuoter {
 			}
 			$expression->field($quoted);
 		} elseif ($field instanceof ExpressionInterface) {
-			$expression->field($this->quoteExpression($field));
+			$this->quoteExpression($field);
 		}
 
 		$value = $expression->getValue();
 		if ($value instanceof ExpressionInterface) {
 			$this->quoteExpression($value);
-			$expression->value($value);
 		}
 	}
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -871,7 +871,7 @@ class QueryTest extends TestCase {
 				$field = clone $exp;
 				$field->add('SELECT min(id) FROM comments');
 				return $exp
-					->eq($field, 100, 'integer');
+					->gt($field, 100, 'integer');
 			})
 			->execute();
 		$this->assertCount(0, $result);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -871,11 +871,9 @@ class QueryTest extends TestCase {
 				$field = clone $exp;
 				$field->add('SELECT min(id) FROM comments');
 				return $exp
-					->gt($field, 100, 'integer');
-			});
-
-		debug($result->sql());
-		$rsult = $result->execute();
+					->eq($field, 100, 'integer');
+			})
+			->execute();
 		$this->assertCount(0, $result);
 	}
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -857,7 +857,7 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that expression objects chan be used as the field in a comparison
+ * Tests that expression objects can be used as the field in a comparison
  * and the values will be bound correctly to the query
  *
  * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -857,7 +857,7 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that expression objects chan be used as the field in a comparison
+ * Tests that expression objects can be used as the field in a comparison
  * and the values will be bound correctly to the query
  *
  * @return void
@@ -869,10 +869,9 @@ class QueryTest extends TestCase {
 			->from('comments')
 			->where(function($exp) {
 				$field = clone $exp;
-				$field->add(['created' => new \DateTime('2021-12-30 15:00')], ['created' => 'datetime']);
+				$field->add('SELECT min(id) FROM comments');
 				return $exp
-					->eq('id', 1)
-					->eq($field, true, 'boolean');
+					->eq($field, 100, 'integer');
 			})
 			->execute();
 		$this->assertCount(0, $result);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -872,8 +872,10 @@ class QueryTest extends TestCase {
 				$field->add('SELECT min(id) FROM comments');
 				return $exp
 					->gt($field, 100, 'integer');
-			})
-			->execute();
+			});
+
+		debug($result->sql());
+		$rsult = $result->execute();
 		$this->assertCount(0, $result);
 	}
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -857,6 +857,28 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that expression objects chan be used as the field in a comparison
+ * and the values will be bound correctly to the query
+ *
+ * @return void
+ */
+	public function testSelectWhereUsingExpressionInField() {
+		$query = new Query($this->connection);
+		$result = $query
+			->select(['id'])
+			->from('comments')
+			->where(function($exp) {
+				$field = clone $exp;
+				$field->add(['created' => new \DateTime('2021-12-30 15:00')], ['created' => 'datetime']);
+				return $exp
+					->eq('id', 1)
+					->eq($field, true, 'boolean');
+			})
+			->execute();
+		$this->assertCount(0, $result);
+	}
+
+/**
  * Tests using where conditions with operator methods
  *
  * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -857,7 +857,7 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that expression objects can be used as the field in a comparison
+ * Tests that expression objects chan be used as the field in a comparison
  * and the values will be bound correctly to the query
  *
  * @return void


### PR DESCRIPTION
An example of using an expressions as the field part is passing a query object
