### PR TITLE
Add test for missing datasource config template

### DIFF
--- a/src/Database/Error/MissingDriverException.php
+++ b/src/Database/Error/MissingDriverException.php
@@ -21,6 +21,6 @@ class MissingDriverException extends \Cake\Error\Exception {
 /**
  * {@inheritDoc}
  */
-	protected $_messageTemplate = 'Database driver "%s" could not be found.';
+	protected $_messageTemplate = 'Database driver %s could not be found.';
 
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -65,7 +65,7 @@ class ConnectionTest extends TestCase {
  * Tests creating a connection using no driver throws an exception
  *
  * @expectedException \Cake\Database\Error\MissingDriverException
- * @expectedExceptionMessage Database driver "" could not be found.
+ * @expectedExceptionMessage Database driver  could not be found.
  * @return void
  */
 	public function testNoDriver() {
@@ -76,7 +76,7 @@ class ConnectionTest extends TestCase {
  * Tests creating a connection using an invalid driver throws an exception
  *
  * @expectedException \Cake\Database\Error\MissingDriverException
- * @expectedExceptionMessage Database driver "" could not be found.
+ * @expectedExceptionMessage Database driver  could not be found.
  * @return void
  */
 	public function testEmptyDriver() {
@@ -87,7 +87,7 @@ class ConnectionTest extends TestCase {
  * Tests creating a connection using an invalid driver throws an exception
  *
  * @expectedException \Cake\Database\Error\MissingDriverException
- * @expectedExceptionMessage Database driver "\Foo\InvalidDriver" could not be found.
+ * @expectedExceptionMessage Database driver \Foo\InvalidDriver could not be found.
  * @return void
  */
 	public function testMissingDriver() {

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -24,6 +24,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Error\MissingPluginException;
 use Cake\Core\Plugin;
+use Cake\Datasource\Error\MissingDatasourceConfigException;
 use Cake\Error;
 use Cake\Error\ExceptionRenderer;
 use Cake\Event\Event;
@@ -561,6 +562,14 @@ class ExceptionRendererTest extends TestCase {
 					'/<h2>Missing Component<\/h2>/',
 					'/Create the class <em>SideboxComponent<\/em> below in file:/',
 					'/(\/|\\\)SideboxComponent.php/'
+				),
+				500
+			),
+			array(
+				new MissingDatasourceConfigException(array('name' => 'MyDatasourceConfig')),
+				array(
+					'/<h2>Missing Datasource Configuration<\/h2>/',
+					'/<em>MyDatasourceConfig<\/em> was not found/'
 				),
 				500
 			),


### PR DESCRIPTION
- Add test for `missing_datasource_config.ctp` to be rendered correctly
- Correct displayed message for MissingDriverException by removing `"`(see old result bellow)
  ![capture d ecran 2014-08-14 21 36 29](https://cloud.githubusercontent.com/assets/4977112/3925701/608ec00c-23ea-11e4-8d99-f0cc2356a583.png)
