### PR TITLE
Fix exists() being called on every save() operation.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -270,10 +270,10 @@ trait EntityTrait {
  * ### Example:
  *
  * {{{
- *		$entity = new Entity(['id' => 1, 'name' => null]);
- *		$entity->has('id'); // true
- *		$entity->has('name'); // false
- *		$entity->has('last_name'); // false
+ * $entity = new Entity(['id' => 1, 'name' => null]);
+ * $entity->has('id'); // true
+ * $entity->has('name'); // false
+ * $entity->has('last_name'); // false
  * }}}
  *
  * @param string $property The property to check.
@@ -288,9 +288,10 @@ trait EntityTrait {
  *
  * ### Examples:
  *
- * ``$entity->unsetProperty('name');``
- *
- * ``$entity->unsetProperty(['name', 'last_name']);``
+ * {{{
+ * $entity->unsetProperty('name');
+ * $entity->unsetProperty(['name', 'last_name']);
+ * }}}
  *
  * @param string|array $property The property to unset.
  * @return \Cake\DataSource\EntityInterface

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -276,11 +276,19 @@ trait EntityTrait {
  * $entity->has('last_name'); // false
  * }}}
  *
- * @param string $property The property to check.
+ * When checking multiple properties. All properties must not be null 
+ * in order for true to be returned.
+ *
+ * @param string|array $property The property or properties to check.
  * @return bool
  */
 	public function has($property) {
-		return $this->get($property) !== null;
+		foreach ((array)$property as $prop) {
+			if ($this->get($prop) === null) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1148,7 +1148,7 @@ class Table implements RepositoryInterface, EventListener {
 		$primaryColumns = (array)$this->primaryKey();
 		$primary = $entity->extract($primaryColumns);
 
-		if ($primary && $entity->isNew()) {
+		if (array_filter($primary) !== [] && $entity->isNew()) {
 			$alias = $this->alias();
 			$conditions = [];
 			foreach ($primary as $k => $v) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1148,7 +1148,7 @@ class Table implements RepositoryInterface, EventListener {
 		$primaryColumns = (array)$this->primaryKey();
 		$primary = $entity->extract($primaryColumns);
 
-		if (array_filter($primary) !== [] && $entity->isNew()) {
+		if ($primaryColumns && $entity->isNew() && array_filter($primary, 'strlen') === $primary) {
 			$alias = $this->alias();
 			$conditions = [];
 			foreach ($primary as $k => $v) {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -262,6 +262,11 @@ class EntityTest extends TestCase {
 		$this->assertFalse($entity->has('foo'));
 		$this->assertFalse($entity->has('last_name'));
 
+		$this->assertTrue($entity->has(['id']));
+		$this->assertTrue($entity->has(['id', 'name']));
+		$this->assertFalse($entity->has(['id', 'foo']));
+		$this->assertFalse($entity->has(['id', 'nope']));
+
 		$entity = $this->getMock('\Cake\ORM\Entity', ['_getThings']);
 		$entity->expects($this->once())->method('_getThings')
 			->will($this->returnValue(0));

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1213,6 +1213,30 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test that saving a new empty entity does not call exists.
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveNewEntityNoExists() {
+		$table = $this->getMock(
+			'Cake\ORM\Table',
+			['exists'],
+			[[
+				'connection' => $this->connection,
+				'alias' => 'Users',
+				'table' => 'users',
+			]]
+		);
+		$entity = $table->newEntity(['username' => 'mark']);
+		$this->assertTrue($entity->isNew());
+
+		$table->expects($this->never())
+			->method('exists');
+		$this->assertSame($entity, $table->save($entity));
+	}
+
+/**
  * Tests that saving an entity will filter out properties that
  * are not present in the table schema when saving
  *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1372,7 +1372,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testAfterSaveNotCalled() {
 		$table = $this->getMock(
 			'\Cake\ORM\Table',
-			['query', 'exists'],
+			['query'],
 			[['table' => 'users', 'connection' => $this->connection]]
 		);
 		$query = $this->getMock(
@@ -1387,8 +1387,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'updated' => new Time('2013-10-10 00:00')
 		]);
 
-		$table->expects($this->once())->method('exists')
-			->will($this->returnValue(false));
 		$table->expects($this->once())->method('query')
 			->will($this->returnValue($query));
 
@@ -1416,7 +1414,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testSaveNewErrorOnNoPrimaryKey() {
-		$entity = new \Cake\ORM\Entity();
+		$entity = new \Cake\ORM\Entity(['username' => 'superuser']);
 		$table = TableRegistry::get('users', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
@@ -1472,7 +1470,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$connection->driver(ConnectionManager::get('test')->driver());
 		$table = $this->getMock(
 			'\Cake\ORM\Table',
-			['query', 'connection', 'exists'],
+			['query', 'connection'],
 			[['table' => 'users']]
 		);
 		$query = $this->getMock(
@@ -1480,10 +1478,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['execute', 'addDefaultTypes'],
 			[null, $table]
 		);
-
-		$table->expects($this->once())->method('exists')
-			->will($this->returnValue(false));
-
 		$table->expects($this->any())->method('connection')
 			->will($this->returnValue($connection));
 
@@ -1526,9 +1520,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['execute', 'addDefaultTypes'],
 			[null, $table]
 		);
-
-		$table->expects($this->once())->method('exists')
-			->will($this->returnValue(false));
 
 		$table->expects($this->any())->method('connection')
 			->will($this->returnValue($connection));


### PR DESCRIPTION
If an entity isNew and contains no primary key data we should not call exists() as there is no way for it to exist yet. Exists should continue to be called when the entity has a primary key value and is marked as new though as it may or may not exist in the database and we need to know.

Fixes #4260
