### PR TITLE
Set default cookie path to app's base path instead of "/".

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -44,7 +44,7 @@ class CookieComponent extends Component {
  * - `path` - The path on the server in which the cookie will be available on.
  *   If path is set to '/foo/', the cookie will only be available within the
  *   /foo/ directory and all sub-directories such as /foo/bar/ of domain.
- *   The default value is the entire domain.
+ *   The default value is base path of app.
  * - `domain` - The domain that the cookie is available. To make the cookie
  *   available on all subdomains of example.com set domain to '.example.com'.
  * - `secure` - Indicates that the cookie should only be transmitted over a
@@ -58,7 +58,7 @@ class CookieComponent extends Component {
  * @var array
  */
 	protected $_defaultConfig = [
-		'path' => '/',
+		'path' => null,
 		'domain' => '',
 		'secure' => false,
 		'key' => null,
@@ -136,6 +136,10 @@ class CookieComponent extends Component {
 			$this->_request = $controller->request;
 		} else {
 			$this->_request = Request::createFromGlobals();
+		}
+
+		if (empty($this->_config['path'])) {
+			$this->config('path', $this->_request->base ?: '/');
 		}
 
 		if ($controller && isset($controller->response)) {

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -44,7 +44,9 @@ class CookieComponent extends Component {
  * - `path` - The path on the server in which the cookie will be available on.
  *   If path is set to '/foo/', the cookie will only be available within the
  *   /foo/ directory and all sub-directories such as /foo/bar/ of domain.
- *   The default value is base path of app.
+ *   The default value is base path of app. For e.g. if your app is running
+ *   under a subfolder "cakeapp" of document root the path would be "/cakeapp"
+ *   else it would be "/".
  * - `domain` - The domain that the cookie is available. To make the cookie
  *   available on all subdomains of example.com set domain to '.example.com'.
  * - `secure` - Indicates that the cookie should only be transmitted over a

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -159,7 +159,7 @@ class Request implements \ArrayAccess {
 		$sessionConfig = Hash::merge(
 			[
 				'defaults' => 'php',
-				'ini' => ['session.cookie_path' => $base ?: '/']
+				'cookie_path' => $base ?: '/'
 			],
 			(array)Configure::read('Session')
 		);
@@ -231,7 +231,7 @@ class Request implements \ArrayAccess {
 
 		if (empty($config['session'])) {
 			$config['session'] = new Session([
-				'ini' => ['session.cookie_path' => $config['base'] ?: '/']
+				'cookie_path' => $config['base'] ?: '/'
 			]);
 		}
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -159,7 +159,7 @@ class Request implements \ArrayAccess {
 		$sessionConfig = Hash::merge(
 			[
 				'defaults' => 'php',
-				'cookie_path' => $base ?: '/'
+				'cookiePath' => $base ?: '/'
 			],
 			(array)Configure::read('Session')
 		);
@@ -231,7 +231,7 @@ class Request implements \ArrayAccess {
 
 		if (empty($config['session'])) {
 			$config['session'] = new Session([
-				'cookie_path' => $config['base'] ?: '/'
+				'cookiePath' => $config['base'] ?: '/'
 			]);
 		}
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -156,7 +156,13 @@ class Request implements \ArrayAccess {
  */
 	public static function createFromGlobals() {
 		list($base, $webroot) = static::_base();
-		$sessionConfig = (array)Configure::read('Session') + ['defaults' => 'php'];
+		$sessionConfig = Hash::merge(
+			[
+				'defaults' => 'php',
+				'ini' => ['session.cookie_path' => $base ?: '/']
+			],
+			(array)Configure::read('Session')
+		);
 		$config = array(
 			'query' => $_GET,
 			'post' => $_POST,
@@ -209,10 +215,6 @@ class Request implements \ArrayAccess {
 			'input' => null,
 		);
 
-		if (empty($config['session'])) {
-			$config['session'] = new Session();
-		}
-
 		$this->_setConfig($config);
 	}
 
@@ -225,6 +227,12 @@ class Request implements \ArrayAccess {
 	protected function _setConfig($config) {
 		if (!empty($config['url']) && $config['url'][0] === '/') {
 			$config['url'] = substr($config['url'], 1);
+		}
+
+		if (empty($config['session'])) {
+			$config['session'] = new Session([
+				'ini' => ['session.cookie_path' => $config['base'] ?: '/']
+			]);
 		}
 
 		$this->url = $config['url'];

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -156,13 +156,11 @@ class Request implements \ArrayAccess {
  */
 	public static function createFromGlobals() {
 		list($base, $webroot) = static::_base();
-		$sessionConfig = Hash::merge(
-			[
-				'defaults' => 'php',
-				'cookiePath' => $base ?: '/'
-			],
-			(array)Configure::read('Session')
-		);
+		$sessionConfig = (array)Configure::read('Session') + [
+			'defaults' => 'php',
+			'cookiePath' => $base ?: '/'
+		];
+
 		$config = array(
 			'query' => $_GET,
 			'post' => $_POST,

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -181,7 +181,7 @@ class Session {
  * ### Configuration:
  *
  * - timeout: The time in minutes the session should be valid for.
- * - cookie_path: The url path for which session cookie is set. Maps to the
+ * - cookiePath: The url path for which session cookie is set. Maps to the
  *   `session.cookie_path` php.ini config. Defaults to base path of app.
  * - ini: A list of php.ini directives to change before the session start.
  * - handler: An array containing at least the `class` key. To be used as the session
@@ -200,10 +200,10 @@ class Session {
 			$config['ini']['session.name'] = $config['cookie'];
 		}
 
-		if (isset($config['cookie_path']) &&
+		if (isset($config['cookiePath']) &&
 			!isset($config['ini']['session.cookie_path'])
 		) {
-			$config['ini']['session.cookie_path'] = $config['cookie_path'];
+			$config['ini']['session.cookie_path'] = $config['cookiePath'];
 		}
 
 		if (!empty($config['ini']) && is_array($config['ini'])) {

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -182,7 +182,7 @@ class Session {
  *
  * - timeout: The time in minutes the session should be valid for.
  * - cookie_path: The url path for which session cookie is set. Maps to the
- *   `session.cookie_path` php.ini config.
+ *   `session.cookie_path` php.ini config. Defaults to base path of app.
  * - ini: A list of php.ini directives to change before the session start.
  * - handler: An array containing at least the `class` key. To be used as the session
  *   engine for persisting data. The rest of the keys in the array will be passed as

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -180,8 +180,10 @@ class Session {
  *
  * ### Configuration:
  *
- * - timeout: The time in minutes the session should be valid for
- * - ini: A list of ini directives to change before the session start.
+ * - timeout: The time in minutes the session should be valid for.
+ * - cookie_path: The url path for which session cookie is set. Maps to the
+ *   `session.cookie_path` php.ini config.
+ * - ini: A list of php.ini directives to change before the session start.
  * - handler: An array containing at least the `class` key. To be used as the session
  *   engine for persisting data. The rest of the keys in the array will be passed as
  *   the configuration array for the engine. You can set the `class` key to an already
@@ -196,6 +198,12 @@ class Session {
 
 		if (!empty($config['cookie'])) {
 			$config['ini']['session.name'] = $config['cookie'];
+		}
+
+		if (isset($config['cookie_path']) &&
+			!isset($config['ini']['session.cookie_path'])
+		) {
+			$config['ini']['session.cookie_path'] = $config['cookie_path'];
 		}
 
 		if (!empty($config['ini']) && is_array($config['ini'])) {

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -113,6 +113,7 @@ class SessionTest extends TestCase {
 		$_SESSION = null;
 
 		$config = array(
+			'cookie_path' => '/base',
 			'cookie' => 'test',
 			'checkAgent' => false,
 			'timeout' => 86400,
@@ -126,6 +127,7 @@ class SessionTest extends TestCase {
 		$this->assertEquals('', ini_get('session.use_trans_sid'), 'Ini value is incorrect');
 		$this->assertEquals('example.com', ini_get('session.referer_check'), 'Ini value is incorrect');
 		$this->assertEquals('test', ini_get('session.name'), 'Ini value is incorrect');
+		$this->assertEquals('/base', ini_get('session.cookie_path'), 'Ini value is incorrect');
 	}
 
 /**

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -111,7 +111,7 @@ class SessionTest extends TestCase {
 		$_SESSION = null;
 
 		$config = array(
-			'cookie_path' => '/base',
+			'cookiePath' => '/base',
 			'cookie' => 'test',
 			'checkAgent' => false,
 			'timeout' => 86400,

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * SessionTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *


### PR DESCRIPTION
This allows running multiple apps in subfolders under document root, without
interfering with each other or potentially other non-cake apps on same domain.
