### PR TITLE
Fix missing behavior class name

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -86,7 +86,7 @@ class BehaviorRegistry extends ObjectRegistry {
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\MissingBehaviorException([
-			'class' => $class,
+			'class' => $class . 'Behavior',
 			'plugin' => $plugin
 		]);
 	}


### PR DESCRIPTION
Before:

```
Error: Create the class Foo below in file: src\Model\Behavior\Foo.php
class Foo extends ModelBehavior
```

After

```
Error: Create the class FooBehavior below in file: src\Model\Behavior\FooBehavior.php
class FooBehavior extends ModelBehavior
```
