### PR TITLE
Updated plugin baking task folder list

### DIFF
--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -121,7 +121,6 @@ class PluginTask extends AppShell {
 				'Test' . DS . 'Case' . DS . 'Model' . DS . 'Datasource',
 				'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper',
 				'Test' . DS . 'Fixture',
-				'Vendor',
 				'View' . DS . 'Elements',
 				'View' . DS . 'Helper',
 				'View' . DS . 'Layout',

--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -108,18 +108,26 @@ class PluginTask extends AppShell {
 			$Folder = new Folder($this->path . $plugin);
 			$directories = array(
 				'Config' . DS . 'Schema',
-				'Model' . DS . 'Behavior',
-				'Model' . DS . 'Datasource',
 				'Console' . DS . 'Command' . DS . 'Task',
+				'Console' . DS . 'Templates',
 				'Controller' . DS . 'Component',
 				'Lib',
-				'View' . DS . 'Helper',
+				'Locale' . DS . 'eng' . DS . 'LC_MESSAGES',
+				'Model' . DS . 'Behavior',
+				'Model' . DS . 'Datasource',
 				'Test' . DS . 'Case' . DS . 'Controller' . DS . 'Component',
-				'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper',
+				'Test' . DS . 'Case' . DS . 'Lib',
 				'Test' . DS . 'Case' . DS . 'Model' . DS . 'Behavior',
+				'Test' . DS . 'Case' . DS . 'Model' . DS . 'Datasource',
+				'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper',
 				'Test' . DS . 'Fixture',
 				'Vendor',
-				'webroot'
+				'View' . DS . 'Elements',
+				'View' . DS . 'Helper',
+				'View' . DS . 'Layout',
+				'webroot' . DS . 'css',
+				'webroot' . DS . 'js',
+				'webroot' . DS . 'img',
 			);
 
 			foreach ($directories as $directory) {

--- a/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
@@ -100,18 +100,26 @@ class PluginTaskTest extends CakeTestCase {
 
 		$directories = array(
 			'Config' . DS . 'Schema',
-			'Model' . DS . 'Behavior',
-			'Model' . DS . 'Datasource',
 			'Console' . DS . 'Command' . DS . 'Task',
+			'Console' . DS . 'Templates',
 			'Controller' . DS . 'Component',
 			'Lib',
-			'View' . DS . 'Helper',
+			'Locale' . DS . 'eng' . DS . 'LC_MESSAGES',
+			'Model' . DS . 'Behavior',
+			'Model' . DS . 'Datasource',
 			'Test' . DS . 'Case' . DS . 'Controller' . DS . 'Component',
-			'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper',
+			'Test' . DS . 'Case' . DS . 'Lib',
 			'Test' . DS . 'Case' . DS . 'Model' . DS . 'Behavior',
+			'Test' . DS . 'Case' . DS . 'Model' . DS . 'Datasource',
+			'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper',
 			'Test' . DS . 'Fixture',
 			'Vendor',
-			'webroot'
+			'View' . DS . 'Elements',
+			'View' . DS . 'Helper',
+			'View' . DS . 'Layout',
+			'webroot' . DS . 'css',
+			'webroot' . DS . 'js',
+			'webroot' . DS . 'img',
 		);
 		foreach ($directories as $dir) {
 			$this->assertTrue(is_dir($path . DS . $dir), 'Missing directory for ' . $dir);

--- a/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
@@ -113,7 +113,6 @@ class PluginTaskTest extends CakeTestCase {
 			'Test' . DS . 'Case' . DS . 'Model' . DS . 'Datasource',
 			'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper',
 			'Test' . DS . 'Fixture',
-			'Vendor',
 			'View' . DS . 'Elements',
 			'View' . DS . 'Helper',
 			'View' . DS . 'Layout',


### PR DESCRIPTION
It's more convenient to remove unneeded folders.
Propagates the various possibilities of plugins.

I was thinking about adding `Locale`, too.
Any opinions about that?

I'm currently setting up a boilerplate repo for building new plugins, by going a bit beyond of what the plugin bake task provides (WIP!):
https://github.com/ravage84/cakephp-plugin-skel/

It's similar to https://github.com/FriendsOfCake/app-template

But the scope of my repo is beyond of what the core needs to provide.
