### PR TITLE
Add a null caching engine.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -15,6 +15,7 @@
 namespace Cake\Cache;
 
 use Cake\Core\StaticConfigTrait;
+use Cake\Cache\Engine\NullEngine;
 use Cake\Error;
 
 /**
@@ -128,11 +129,11 @@ class Cache {
  * triggered.
  *
  * @param string $config The configuration name you want an engine for.
- * @return \Cake\Cache\CacheEngine
+ * @return \Cake\Cache\CacheEngine When caching is diabled a null engine will be returned.
  */
 	public static function engine($config) {
 		if (!static::$_enabled) {
-			return false;
+			return new NullEngine();
 		}
 
 		if (isset(static::$_registry->{$config})) {
@@ -154,10 +155,6 @@ class Cache {
  */
 	public static function gc($config = 'default', $expires = null) {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return;
-		}
-
 		$engine->gc($expires);
 	}
 
@@ -181,7 +178,7 @@ class Cache {
  */
 	public static function write($key, $value, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine || is_resource($value)) {
+		if (is_resource($value)) {
 			return false;
 		}
 
@@ -220,10 +217,6 @@ class Cache {
  */
 	public static function writeMany($data, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		$return = $engine->writeMany($data);
 		foreach ($return as $key => $success) {
 			if ($success === false && !empty($data[$key])) {
@@ -257,10 +250,6 @@ class Cache {
  */
 	public static function read($key, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		return $engine->read($key);
 	}
 
@@ -284,10 +273,6 @@ class Cache {
  */
 	public static function readMany($keys, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		return $engine->readMany($keys);
 	}
 
@@ -302,7 +287,7 @@ class Cache {
  */
 	public static function increment($key, $offset = 1, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine || !is_int($offset) || $offset < 0) {
+		if (!is_int($offset) || $offset < 0) {
 			return false;
 		}
 
@@ -320,7 +305,7 @@ class Cache {
  */
 	public static function decrement($key, $offset = 1, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine || !is_int($offset) || $offset < 0) {
+		if (!is_int($offset) || $offset < 0) {
 			return false;
 		}
 
@@ -346,10 +331,6 @@ class Cache {
  */
 	public static function delete($key, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		return $engine->delete($key);
 	}
 
@@ -373,10 +354,6 @@ class Cache {
  */
 	public static function deleteMany($keys, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		return $engine->deleteMany($keys);
 	}
 
@@ -389,10 +366,6 @@ class Cache {
  */
 	public static function clear($check = false, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		return $engine->clear($check);
 	}
 
@@ -405,10 +378,6 @@ class Cache {
  */
 	public static function clearGroup($group, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
 		return $engine->clearGroup($group);
 	}
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -129,7 +129,7 @@ class Cache {
  * triggered.
  *
  * @param string $config The configuration name you want an engine for.
- * @return \Cake\Cache\CacheEngine When caching is diabled a null engine will be returned.
+ * @return \Cake\Cache\CacheEngine When caching is disabled a null engine will be returned.
  */
 	public static function engine($config) {
 		if (!static::$_enabled) {

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache\Engine;
+
+use Cake\Cache\CacheEngine;
+
+/**
+ * Null cache engine, all operations return false.
+ *
+ * This is used internally for when Cache::disable() has been called.
+ */
+class NullEngine extends CacheEngine {
+
+/**
+ * {@inheritDoc}
+ */
+	public function init(array $config = []) {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function gc($expires = null) {
+		return false;
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function write($key, $value) {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function writeMany($data) {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function read($key) {
+		return false;
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function readMany($keys) {
+		return false;
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function increment($key, $offset = 1) {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function decrement($key, $offset = 1) {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function delete($key) {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function deleteMany($keys) {
+		return false;
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function clear($check) {
+		return false;
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function clearGroup($group) {
+		return false;
+	}
+
+}

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -70,6 +70,19 @@ class CacheTest extends TestCase {
 	}
 
 /**
+ * Check that a null instance is returned from engine() when caching is disabled.
+ *
+ * @return void
+ */
+	public function testNullEngineWhenCacheDisable() {
+		$this->_configCache();
+		Cache::disable();
+
+		$result = Cache::engine('tests');
+		$this->assertInstanceOf('Cake\Cache\Engine\NullEngine', $result);
+	}
+
+/**
  * test configuring CacheEngines in App/libs
  *
  * @return void
@@ -436,7 +449,7 @@ class CacheTest extends TestCase {
 
 		Cache::disable();
 
-		$this->assertFalse(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
+		$this->assertNull(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
 		$this->assertFalse(Cache::read('key_2', 'test_cache_disable_1'));
 
 		Cache::enable();
@@ -451,7 +464,7 @@ class CacheTest extends TestCase {
 			'path' => TMP . 'tests'
 		]);
 
-		$this->assertFalse(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
+		$this->assertNull(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
 		$this->assertFalse(Cache::read('key_4', 'test_cache_disable_2'));
 
 		Cache::enable();
@@ -460,7 +473,7 @@ class CacheTest extends TestCase {
 		$this->assertSame(Cache::read('key_5', 'test_cache_disable_2'), 'hello');
 
 		Cache::disable();
-		$this->assertFalse(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
+		$this->assertNull(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
 		$this->assertFalse(Cache::read('key_6', 'test_cache_disable_2'));
 
 		Cache::enable();


### PR DESCRIPTION
Having a NullEngine makes a bunch of internal operations simpler as we don't have to check whether or not the engine() method returned an instance or not. It also makes it easy to use a null adapter in testing without having to generate mocks.

Fixes #4281
