### PR TITLE
FlashComponent Bugfix

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -73,7 +73,7 @@ class FlashComponent extends Component {
  * @return void
  */
 	public function set($message, array $options = []) {
-		$opts = array_merge($this->_defaultConfig, $options);
+		$opts = array_merge($this->config(), $options);
 
 		if ($message instanceof \Exception) {
 			$opts['params'] += ['code' => $message->getCode()];

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -36,8 +36,8 @@ class FlashComponentTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('App.namespace', 'TestApp');
-		$controller = new Controller(new Request(['session' => new Session()]));
-		$this->ComponentRegistry = new ComponentRegistry($controller);
+		$this->Controller = new Controller(new Request(['session' => new Session()]));
+		$this->ComponentRegistry = new ComponentRegistry($this->Controller);
 		$this->Flash = new FlashComponent($this->ComponentRegistry);
 		$this->Session = new Session();
 	}
@@ -117,6 +117,26 @@ class FlashComponentTest extends TestCase {
 			'key' => 'flash',
 			'element' => 'Flash/default',
 			'params' => ['code' => 404]
+		];
+		$result = $this->Session->read('Flash.flash');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testSetWithComponentConfiguration method
+ *
+ * @return void
+ */
+	public function testSetWithComponentConfiguration() {
+		$this->assertNull($this->Session->read('Flash.flash'));
+
+		$this->Controller->addComponent('Flash', ['element' => 'test']);
+		$this->Controller->Flash->set('This is a test message');
+		$expected = [
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'Flash/test',
+			'params' => []
 		];
 		$result = $this->Session->read('Flash.flash');
 		$this->assertEquals($expected, $result);


### PR DESCRIPTION
It's necessary to merge also options from `ConfigTrait` otherwise it's not possible to configure the component through `public $components = ['element' => 'path/to/element']`.
