### PR TITLE
3.0 Reflect options in schema reflection

### DIFF
--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -136,6 +136,17 @@ abstract class BaseSchema {
 	abstract public function describeForeignKeySql($table, $config);
 
 /**
+ * Generate the SQL to describe table options
+ *
+ * @param string $name Table name.
+ * @param array $config The connection configuration.
+ * @return array SQL statements to get options for a table.
+ */
+	public function describeOptionsSql($name, $config) {
+		return ['', ''];
+	}
+
+/**
  * Convert field description results into abstract schema fields.
  *
  * @param \Cake\Database\Schema\Table $table The table object to append fields to.
@@ -209,5 +220,15 @@ abstract class BaseSchema {
  * @return array SQL statements to truncate a table.
  */
 	abstract public function truncateTableSql(Table $table);
+
+/**
+ * Convert options data into table options.
+ *
+ * @param \Cake\Database\Schema\Table $table Table instance.
+ * @param array $row The row of data.
+ * @return void
+ */
+	public function convertOptions(Table $table, $row) {
+	}
 
 }

--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -115,7 +115,7 @@ abstract class BaseSchema {
  * @param array $config The connection configuration.
  * @return array An array of (sql, params) to execute.
  */
-	abstract public function describeTableSql($name, $config);
+	abstract public function describeColumnSql($name, $config);
 
 /**
  * Generate the SQL to describe the indexes in a table.
@@ -150,10 +150,10 @@ abstract class BaseSchema {
  * Convert field description results into abstract schema fields.
  *
  * @param \Cake\Database\Schema\Table $table The table object to append fields to.
- * @param array $row The row data from `describeTableSql`.
+ * @param array $row The row data from `describeColumnSql`.
  * @return void
  */
-	abstract public function convertFieldDescription(Table $table, $row);
+	abstract public function convertColumnDescription(Table $table, $row);
 
 /**
  * Convert an index description results into abstract schema indexes or constraints.
@@ -174,6 +174,16 @@ abstract class BaseSchema {
  * @return void
  */
 	abstract public function convertForeignKeyDescription(Table $table, $row);
+
+/**
+ * Convert options data into table options.
+ *
+ * @param \Cake\Database\Schema\Table $table Table instance.
+ * @param array $row The row of data.
+ * @return void
+ */
+	public function convertOptionsDescription(Table $table, $row) {
+	}
 
 /**
  * Generate the SQL to create a table.
@@ -220,15 +230,5 @@ abstract class BaseSchema {
  * @return array SQL statements to truncate a table.
  */
 	abstract public function truncateTableSql(Table $table);
-
-/**
- * Convert options data into table options.
- *
- * @param \Cake\Database\Schema\Table $table Table instance.
- * @param array $row The row of data.
- * @return void
- */
-	public function convertOptions(Table $table, $row) {
-	}
 
 }

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -107,47 +107,50 @@ class Collection {
 				return $cached;
 			}
 		}
-
+		$table = new Table($name);
 		$config = $this->_connection->config();
-		list($sql, $params) = $this->_dialect->describeTableSql($name, $config);
-		$statement = $this->_executeSql($sql, $params);
-		if (count($statement) === 0) {
+
+		$this->_reflect('Column', $name, $config, $table);
+		if (count($table->columns()) === 0) {
 			throw new Exception(sprintf('Cannot describe %s. It has 0 columns.', $name));
 		}
-
-		$table = new Table($name);
-		foreach ($statement->fetchAll('assoc') as $row) {
-			$this->_dialect->convertFieldDescription($table, $row);
-		}
-		$statement->closeCursor();
-
-		list($sql, $params) = $this->_dialect->describeIndexSql($name, $config);
-		$statement = $this->_executeSql($sql, $params);
-		foreach ($statement->fetchAll('assoc') as $row) {
-			$this->_dialect->convertIndexDescription($table, $row);
-		}
-		$statement->closeCursor();
-
-		list($sql, $params) = $this->_dialect->describeForeignKeySql($name, $config);
-		$statement = $this->_executeSql($sql, $params);
-		foreach ($statement->fetchAll('assoc') as $row) {
-			$this->_dialect->convertForeignKeyDescription($table, $row);
-		}
-		$statement->closeCursor();
-
-		list($sql, $params) = $this->_dialect->describeOptionsSql($name, $config);
-		if ($sql) {
-			$statement = $this->_executeSql($sql, $params);
-			foreach ($statement->fetchAll('assoc') as $row) {
-				$this->_dialect->convertOptions($table, $row);
-			}
-			$statement->closeCursor();
-		}
+		$this->_reflect('Index', $name, $config, $table);
+		$this->_reflect('ForeignKey', $name, $config, $table);
+		$this->_reflect('Options', $name, $config, $table);
 
 		if (!empty($cacheConfig)) {
 			Cache::write($cacheKey, $table, $cacheConfig);
 		}
 		return $table;
+	}
+
+/**
+ * Helper method for running each step of the reflection process.
+ *
+ * @param string $stage The stage name.
+ * @param string $name The talble name.
+ * @param array $config The config data.
+ * @param \Cake\Database\Schema\Table $table The table instance
+ * @return void
+ * @throws \Cake\Database\Exception on query failure.
+ */
+	protected function _reflect($stage, $name, $config, $table) {
+		$describeMethod = "describe{$stage}Sql";
+		$convertMethod = "convert{$stage}Description";
+
+		list($sql, $params) = $this->_dialect->{$describeMethod}($name, $config);
+		if (empty($sql)) {
+			return;
+		}
+		try {
+			$statement = $this->_connection->execute($sql, $params);
+		} catch (\PDOException $e) {
+			throw new Exception($e->getMessage(), 500, $e);
+		}
+		foreach ($statement->fetchAll('assoc') as $row) {
+			$this->_dialect->{$convertMethod}($table, $row);
+		}
+		$statement->closeCursor();
 	}
 
 /**
@@ -176,22 +179,6 @@ class Collection {
 			$enable = '_cake_model_';
 		}
 		return $this->_cache = $enable;
-	}
-
-/**
- * Helper method to run queries and convert Exceptions to the correct types.
- *
- * @param string $sql The sql to run.
- * @param array $params Parameters for the statement.
- * @return \Cake\Database\StatementInterface Prepared statement
- * @throws \Cake\Database\Exception on query failure.
- */
-	protected function _executeSql($sql, $params) {
-		try {
-			return $this->_connection->execute($sql, $params);
-		} catch (\PDOException $e) {
-			throw new Exception($e->getMessage(), 500, $e);
-		}
 	}
 
 }

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -135,6 +135,15 @@ class Collection {
 		}
 		$statement->closeCursor();
 
+		list($sql, $params) = $this->_dialect->describeOptionsSql($name, $config);
+		if ($sql) {
+			$statement = $this->_executeSql($sql, $params);
+			foreach ($statement->fetchAll('assoc') as $row) {
+				$this->_dialect->convertOptions($table, $row);
+			}
+			$statement->closeCursor();
+		}
+
 		if (!empty($cacheConfig)) {
 			Cache::write($cacheKey, $table, $cacheConfig);
 		}

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -119,12 +119,14 @@ class Collection {
 		foreach ($statement->fetchAll('assoc') as $row) {
 			$this->_dialect->convertFieldDescription($table, $row);
 		}
+		$statement->closeCursor();
 
 		list($sql, $params) = $this->_dialect->describeIndexSql($name, $config);
 		$statement = $this->_executeSql($sql, $params);
 		foreach ($statement->fetchAll('assoc') as $row) {
 			$this->_dialect->convertIndexDescription($table, $row);
 		}
+		$statement->closeCursor();
 
 		list($sql, $params) = $this->_dialect->describeForeignKeySql($name, $config);
 		$statement = $this->_executeSql($sql, $params);

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -128,7 +128,7 @@ class Collection {
  * Helper method for running each step of the reflection process.
  *
  * @param string $stage The stage name.
- * @param string $name The talble name.
+ * @param string $name The table name.
  * @param array $config The config data.
  * @param \Cake\Database\Schema\Table $table The table instance
  * @return void

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -55,7 +55,8 @@ class MysqlSchema extends BaseSchema {
  */
 	public function convertOptions(Table $table, $row) {
 		$table->options([
-			'engine' => $row['Engine']
+			'engine' => $row['Engine'],
+			'collation' => $row['Collation'],
 		]);
 	}
 

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -39,8 +39,24 @@ class MysqlSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeIndexSql($table, $config) {
-		return ['SHOW INDEXES FROM ' . $this->_driver->quoteIdentifier($table), []];
+	public function describeIndexSql($name, $config) {
+		return ['SHOW INDEXES FROM ' . $this->_driver->quoteIdentifier($name), []];
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function describeOptionsSql($name, $config) {
+		return ['SHOW TABLE STATUS WHERE Name = ?', [$name]];
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function convertOptions(Table $table, $row) {
+		$table->options([
+			'engine' => $row['Engine']
+		]);
 	}
 
 /**

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -32,7 +32,7 @@ class MysqlSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeTableSql($name, $config) {
+	public function describeColumnSql($name, $config) {
 		return ['SHOW FULL COLUMNS FROM ' . $this->_driver->quoteIdentifier($name), []];
 	}
 
@@ -53,7 +53,7 @@ class MysqlSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function convertOptions(Table $table, $row) {
+	public function convertOptionsDescription(Table $table, $row) {
 		$table->options([
 			'engine' => $row['Engine'],
 			'collation' => $row['Collation'],
@@ -137,7 +137,7 @@ class MysqlSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function convertFieldDescription(Table $table, $row) {
+	public function convertColumnDescription(Table $table, $row) {
 		$field = $this->_convertColumn($row['Type']);
 		$field += [
 			'null' => $row['Null'] === 'YES' ? true : false,

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -34,7 +34,7 @@ class PostgresSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeTableSql($name, $config) {
+	public function describeColumnSql($name, $config) {
 		$sql =
 		'SELECT DISTINCT table_schema AS schema, column_name AS name, data_type AS type,
 			is_nullable AS null, column_default AS default,
@@ -124,7 +124,7 @@ class PostgresSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function convertFieldDescription(Table $table, $row) {
+	public function convertColumnDescription(Table $table, $row) {
 		$field = $this->_convertColumn($row['type']);
 
 		if ($field['type'] === 'boolean') {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -100,7 +100,7 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeTableSql($name, $config) {
+	public function describeColumnSql($name, $config) {
 		$sql = sprintf(
 			'PRAGMA table_info(%s)',
 			$this->_driver->quoteIdentifier($name)
@@ -111,7 +111,7 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function convertFieldDescription(Table $table, $row) {
+	public function convertColumnDescription(Table $table, $row) {
 		$field = $this->_convertColumn($row['type']);
 		$field += [
 			'null' => !$row['notnull'],

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -40,7 +40,7 @@ class SqlserverSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeTableSql($name, $config) {
+	public function describeColumnSql($name, $config) {
 		$sql =
 		"SELECT DISTINCT TABLE_SCHEMA AS [schema], COLUMN_NAME AS [name], DATA_TYPE AS [type],
 			IS_NULLABLE AS [null], COLUMN_DEFAULT AS [default],
@@ -135,7 +135,7 @@ class SqlserverSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function convertFieldDescription(Table $table, $row) {
+	public function convertColumnDescription(Table $table, $row) {
 		$field = $this->_convertColumn(
 			$row['type'],
 			$row['char_length'],

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -174,7 +174,7 @@ class MysqlSchemaTest extends TestCase {
 		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
 		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
-		$dialect->convertFieldDescription($table, $field);
+		$dialect->convertColumnDescription($table, $field);
 	}
 
 /**
@@ -378,6 +378,7 @@ SQL;
 		$schema = new SchemaCollection($connection);
 		$result = $schema->describe('schema_articles');
 		$this->assertArrayHasKey('engine', $result->options());
+		$this->assertArrayHasKey('collation', $result->options());
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -367,6 +367,20 @@ SQL;
 	}
 
 /**
+ * Test describing a table creates options
+ *
+ * @return void
+ */
+	public function testDescribeTableOptions() {
+		$connection = ConnectionManager::get('test');
+		$this->_createTables($connection);
+
+		$schema = new SchemaCollection($connection);
+		$result = $schema->describe('schema_articles');
+		$this->assertArrayHasKey('engine', $result->options());
+	}
+
+/**
  * Column provider for creating column sql
  *
  * @return array

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -221,7 +221,7 @@ SQL;
 		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
 		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
-		$dialect->convertFieldDescription($table, $field);
+		$dialect->convertColumnDescription($table, $field);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -151,7 +151,7 @@ class SqliteSchemaTest extends TestCase {
 		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
 		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
-		$dialect->convertFieldDescription($table, $field);
+		$dialect->convertColumnDescription($table, $field);
 	}
 
 /**
@@ -180,8 +180,8 @@ class SqliteSchemaTest extends TestCase {
 		];
 
 		$table = new \Cake\Database\Schema\Table('table');
-		$dialect->convertFieldDescription($table, $field1);
-		$dialect->convertFieldDescription($table, $field2);
+		$dialect->convertColumnDescription($table, $field1);
+		$dialect->convertColumnDescription($table, $field2);
 		$this->assertEquals(['field1', 'field2'], $table->primaryKey());
 	}
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -254,7 +254,7 @@ SQL;
 		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
 		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
-		$dialect->convertFieldDescription($table, $field);
+		$dialect->convertColumnDescription($table, $field);
 	}
 
 /**


### PR DESCRIPTION
This adds engine/collation reflection to MySQL databases, which fixes #4263. I've also done a bit of refactoring and clean up to make schema reflection use less code and be have more consistent method names.
