### PR TITLE
Add Shell::param()

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -429,6 +429,19 @@ class Shell {
 	}
 
 /**
+ * Safely access the values in $this->params.
+ *
+ * @param string $name The name of the parameter to get.
+ * @return string|bool|null Value. Will return null if it doesn't exist.
+ */
+	public function param($name) {
+		if (!isset($this->params[$name])) {
+			return null;
+		}
+		return $this->params[$name];
+	}
+
+/**
  * Prompts the user for input, and returns it.
  *
  * @param string $prompt Prompt text.

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -813,7 +813,7 @@ TEXT;
 		return array(
 			array(
 				'key',
-				'index',
+				'value',
 			),
 			array(
 				'help',

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -788,6 +788,52 @@ TEXT;
 		$this->assertEquals($expected, $this->Shell->TestApple->name);
 	}
 
+
+/**
+ * Test reading params
+ *
+ * @dataProvider paramReadingDataProvider
+ */
+	public function testParamReading($toRead, $expected) {
+		$this->Shell->params = array(
+			'key' => 'value',
+			'help' => false,
+			'emptykey' => '',
+			'truthy' => true
+		);
+		$this->assertSame($expected, $this->Shell->param($toRead));
+	}
+
+/**
+ * Data provider for testing reading values with Shell::param()
+ *
+ * @return array
+ */
+	public function paramReadingDataProvider() {
+		return array(
+			array(
+				'key',
+				'index',
+			),
+			array(
+				'help',
+				false,
+			),
+			array(
+				'emptykey',
+				'',
+			),
+			array(
+				'truthy',
+				true,
+			),
+			array(
+				'does_not_exist',
+				null,
+			)
+		);
+	}
+
 /**
  * Test that option parsers are created with the correct name/command.
  *

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1927,7 +1927,7 @@ class RequestTest extends TestCase {
 			'truthy' => 1,
 			'zero' => '0',
 		));
-		$this->assertEquals($expected, $request->param($toRead));
+		$this->assertSame($expected, $request->param($toRead));
 	}
 
 /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/4249

I had the same issues with the cakephp/upgrade repo and params access in it. So I thought it should be fixed ASAP in order for me to continue there.

It is pretty much the same method as in Request::param().
Only difference: not exists => null (instead of false) returned. This makes more sense here IMO.
