### PR TITLE
Add insertData option to belongsToMany association to insert additional data to joinTable

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -114,6 +114,14 @@ class BelongsToMany extends Association {
 	protected $_through;
 
 /**
+ * Additional data to insert into the join table represented as
+ * $column=>$value
+ *
+ * @var array
+ */
+	protected $_insertData;
+
+/**
  * Sets the name of the field representing the foreign key to the target table.
  * If no parameters are passed current field is returned
  *
@@ -507,6 +515,13 @@ class BelongsToMany extends Association {
 				$sourceEntity->extract($sourcePrimaryKey)
 			), ['guard' => false]);
 			$joint->set(array_combine($assocForeignKey, $e->extract($targetPrimaryKey)), ['guard' => false]);
+
+			if (!empty($this->_insertData) && is_array($this->_insertData)) {
+				foreach ($this->_insertData as $col => $value) {
+					$joint->set($col,$value, ['guard'=>false]);
+				}
+			}
+
 			$saved = $junction->save($joint, $options);
 
 			if (!$saved && !empty($options['atomic'])) {
@@ -958,6 +973,9 @@ class BelongsToMany extends Association {
 		}
 		if (!empty($opts['saveStrategy'])) {
 			$this->saveStrategy($opts['saveStrategy']);
+		}
+		if (!empty($opts['insertData'])) {
+			$this->_insertData = $opts['insertData'];
 		}
 	}
 


### PR DESCRIPTION
 I've added an 'insertData' option to the belongsToMany relationship to insert additional data into the join table. 

'insertData' => ['Column'=>'Data']

This is useful when using a single join table for belongsToMany relationships.
IE:
Tags
-ID
-TagName

Posts
-ID
Name

TaggedModels
-ID
-tag_id
-foreign_key
-model

You can set your belongsToMany relationship as:
PostsTable.php
$this->belongsToMany('Tags',[
'joinTable'=>'tagged_models'
'foreignKey'=>'foreign_key'
'conditions'=>['model'=>'Posts']
'insertData'=>['model'=>'Posts']
]);

This could also be useful for other use-cases.
It's a simple addition, however, I'm not very comfortable with the frameworks TestSuite so I could use some help there if this additional is deemed worthy to be added.
