### PR TITLE
Ignore RuntimeException

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -275,7 +275,11 @@ class FileEngine extends CacheEngine {
 			if (!file_exists($filePath) || is_dir($filePath)) {
 				continue;
 			}
-			$file = new SplFileObject($path . $entry, 'r');
+			try {
+				$file = new SplFileObject($path . $entry, 'r');
+			} catch (RuntimeException $e) {
+				continue;
+			}
 
 			if ($threshold) {
 				$mtime = $file->getMTime();


### PR DESCRIPTION
RuntimeException is thrown at race condition.
However, since for the processing at Garbage Collection, other processes
is determined that the expired.
this process is acceptable to ignore the RuntimeException even if there is
missing file.
