### PR TITLE
Mark fields as not dirty when they are unset.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -308,6 +308,7 @@ trait EntityTrait {
 		$property = (array)$property;
 		foreach ($property as $p) {
 			unset($this->_properties[$p]);
+			unset($this->_dirty[$p]);
 		}
 
 		return $this;

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -288,6 +288,18 @@ class EntityTest extends TestCase {
 	}
 
 /**
+ * Unsetting a property should not mark it as dirty.
+ *
+ * @return void
+ */
+	public function testUnsetMakesClean() {
+		$entity = new Entity(['id' => 1, 'name' => 'bar']);
+		$this->assertTrue($entity->dirty('name'));
+		$entity->unsetProperty('name');
+		$this->assertFalse($entity->dirty('name'), 'Removed properties are not dirty.');
+	}
+
+/**
  * Tests unsetProperty whith multiple properties
  *
  * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2493,7 +2493,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertTrue($entity->article->isNew());
 		$this->assertNull($entity->article->id);
 		$this->assertNull($entity->article->get('author_id'));
-		$this->assertTrue($entity->article->dirty('author_id'));
+		$this->assertFalse($entity->article->dirty('author_id'));
 		$this->assertNotEmpty($entity->article->errors('title'));
 	}
 
@@ -2637,7 +2637,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertTrue($entity->article->isNew());
 		$this->assertNull($entity->article->id);
 		$this->assertNull($entity->article->get('author_id'));
-		$this->assertTrue($entity->article->dirty('author_id'));
+		$this->assertFalse($entity->article->dirty('author_id'));
 		$this->assertNotEmpty($entity->article->errors('title'));
 	}
 


### PR DESCRIPTION
Leaving unset fields as dirty makes entity create null values when persisted.  This fixes #4288
