### PR TITLE
Avoiding a call to session_regenerate_id() when there is no id

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -521,6 +521,7 @@ class Session {
 			return;
 		}
 
+		$this->start();
 		$params = session_get_cookie_params();
 		setcookie(
 			session_name(), '', time() - 42000,

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -527,7 +527,10 @@ class Session {
 			$params['path'], $params['domain'],
 			$params['secure'], $params['httponly']
 		);
-		session_regenerate_id(true);
+
+		if (session_id()) {
+			session_regenerate_id(true);
+		}
 	}
 
 /**


### PR DESCRIPTION
It makes no sense to regenerate the session id when there wasn't one previously

Fixes #4312
