### PR TITLE
Optimize FileEngine::gc()

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -271,13 +271,10 @@ class FileEngine extends CacheEngine {
 			if (substr($entry, 0, $prefixLength) !== $this->settings['prefix']) {
 				continue;
 			}
-			$filePath = $path . $entry;
-			if (!file_exists($filePath) || is_dir($filePath)) {
-				continue;
-			}
+
 			try {
 				$file = new SplFileObject($path . $entry, 'r');
-			} catch (RuntimeException $e) {
+			} catch (Exception $e) {
 				continue;
 			}
 


### PR DESCRIPTION
SplFileObject constructor throws a RuntimeException if the file does not exist or LogicException for a directory. This means additional checks can be safely removed.
