### PR TITLE
3.0 Update missing_behavior.ctp

### DIFF
--- a/src/Template/Error/missing_behavior.ctp
+++ b/src/Template/Error/missing_behavior.ctp
@@ -44,7 +44,7 @@ if (!empty($plugin) && !Plugin::loaded($plugin)) {
 </p>
 <pre>
 &lt;?php
-class <?= h($class); ?> extends ModelBehavior {
+class <?= h($class); ?> extends Behavior {
 
 }
 </pre>


### PR DESCRIPTION
The class needs to extend `Behavior` as that's the name of the class.
