### PR TITLE
Supporting multiple SET commands during MySQL initialization

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -57,7 +57,7 @@ class Mysql extends \Cake\Database\Driver {
 		}
 
 		if (!empty($config['timezone'])) {
-			$config['init'][] = sprintf("SET time_zone = '%s'", $config['timezone']);
+			$config['init'][] = sprintf("LOCAL time_zone = '%s'", $config['timezone']);
 		}
 
 		$config['flags'] += [
@@ -67,7 +67,7 @@ class Mysql extends \Cake\Database\Driver {
 		];
 
 		if ($config['init']) {
-			$config['flags'] += [PDO::MYSQL_ATTR_INIT_COMMAND => implode(';', (array)$config['init'])];
+			$config['flags'] += [PDO::MYSQL_ATTR_INIT_COMMAND => 'SET ' . implode(', ', (array)$config['init'])];
 		}
 
 		if (!empty($config['ssl_key']) && !empty($config['ssl_cert'])) {

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -84,7 +84,7 @@ class MysqlTest extends TestCase {
 			'flags' => [1 => true, 2 => false],
 			'encoding' => 'a-language',
 			'timezone' => 'Antartica',
-			'init' => ['Execute this', 'this too']
+			'init' => ['LOCAL property=value', 'GLOBAL property=value']
 		];
 		$driver = $this->getMock(
 			'Cake\Database\Driver\Mysql',
@@ -93,12 +93,12 @@ class MysqlTest extends TestCase {
 		);
 		$expected = $config;
 		$expected['dsn'] = 'mysql:host=foo;port=3440;dbname=bar;charset=a-language';
-		$expected['init'][] = "SET time_zone = 'Antartica'";
+		$expected['init'][] = "LOCAL time_zone = 'Antartica'";
 		$expected['flags'] += [
 			PDO::ATTR_PERSISTENT => false,
 			PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-			PDO::MYSQL_ATTR_INIT_COMMAND => "Execute this;this too;SET time_zone = 'Antartica'"
+			PDO::MYSQL_ATTR_INIT_COMMAND => "SET LOCAL property=value, GLOBAL property=value, LOCAL time_zone = 'Antartica'"
 		];
 		$driver->expects($this->once())->method('_connect')
 			->with($expected);


### PR DESCRIPTION
Changing `SET GLOBAL innodb_stats_on_metadata = 0` to `GLOBAL innodb_stats_on_metadata = 0` would also be needed on https://github.com/cakephp/app/blob/master/config/app.default.php#L235

Maybe this is the only way to have multiple SET commands during initialization?
