### PR TITLE
Executing multiple init commands rather than using PDO::MYSQL_ATTR_INIT_COMMAND

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -66,10 +66,6 @@ class Mysql extends \Cake\Database\Driver {
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
 		];
 
-		if ($config['init']) {
-			$config['flags'] += [PDO::MYSQL_ATTR_INIT_COMMAND => implode(';', (array)$config['init'])];
-		}
-
 		if (!empty($config['ssl_key']) && !empty($config['ssl_cert'])) {
 			$config['flags'][PDO::MYSQL_ATTR_SSL_KEY] = $config['ssl_key'];
 			$config['flags'][PDO::MYSQL_ATTR_SSL_CERT] = $config['ssl_cert'];
@@ -86,7 +82,14 @@ class Mysql extends \Cake\Database\Driver {
 			}
 		}
 
-		return $this->_connect($config);
+		$this->_connect($config);
+
+		if (!empty($config['init'])) {
+			foreach ((array)$config['init'] as $command) {
+				$this->connection()->exec($command);
+			}
+		}
+		return true;
 	}
 
 /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -88,7 +88,7 @@ class MysqlTest extends TestCase {
 		];
 		$driver = $this->getMock(
 			'Cake\Database\Driver\Mysql',
-			['_connect'],
+			['_connect', 'connection'],
 			[$config]
 		);
 		$expected = $config;
@@ -98,11 +98,19 @@ class MysqlTest extends TestCase {
 			PDO::ATTR_PERSISTENT => false,
 			PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-			PDO::MYSQL_ATTR_INIT_COMMAND => "Execute this;this too;SET time_zone = 'Antartica'"
 		];
+
+		$connection = $this->getMock('StdClass', ['exec']);
+		$connection->expects($this->at(0))->method('exec')->with('Execute this');
+		$connection->expects($this->at(1))->method('exec')->with('this too');
+		$connection->expects($this->at(2))->method('exec')->with("SET time_zone = 'Antartica'");
+		$connection->expects($this->exactly(3))->method('exec');
+
 		$driver->expects($this->once())->method('_connect')
 			->with($expected);
-		$driver->connect();
+		$driver->expects($this->any())->method('connection')
+			->will($this->returnValue($connection));
+		$driver->connect($config);
 	}
 
 }


### PR DESCRIPTION
`PDO::MYSQL_ATTR_INIT_COMMAND` does not support multiple commands as reported in https://bugs.php.net/bug.php?id=48859
