### PR TITLE
Fix 0/'0' not being patched properly.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -285,7 +285,11 @@ class Marshaller {
 			} elseif ($columnType) {
 				$converter = Type::build($columnType);
 				$value = $converter->marshal($value);
-				if ($original == $value) {
+				$isObject = is_object($value);
+				if (
+					(!$isObject && $original === $value) ||
+					($isObject && $original == $value)
+				) {
 					continue;
 				}
 			}

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -550,6 +550,34 @@ class MarshallerTest extends TestCase {
 	}
 
 /**
+ * Provides empty values.
+ *
+ * @return array
+ */
+	public function emptyProvider() {
+		return [
+			[0],
+			['0'],
+		];
+	}
+
+/**
+ * Test merging empty values into an entity.
+ *
+ * @dataProvider emptyProvider
+ * @return void
+ */
+	public function testMergeFalseyValues($value) {
+		$marshall = new Marshaller($this->articles);
+		$entity = new Entity();
+		$entity->accessible('*', true);
+
+		$entity = $marshall->merge($entity, ['author_id' => $value]);
+		$this->assertTrue($entity->dirty('author_id'), 'Field should be dirty');
+		$this->assertSame(0, $entity->get('author_id'), 'Value should be zero');
+	}
+
+/**
  * Tests that merge respects the entity accessible methods
  *
  * @return void


### PR DESCRIPTION
Use strict equality when comparing scalar values. We don't want to use strict equality on object types as DateTime instances will _always_ be different, as will arrays holding associated entities.

Refs #4307
