### PR TITLE
Fix validation callbacks without a provider

### DIFF
--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -180,7 +180,7 @@ class ValidationRule {
 			if (!isset($value) || empty($value)) {
 				continue;
 			}
-			if ($key === 'rule' && is_array($value)) {
+			if ($key === 'rule' && is_array($value) && !is_callable($value)) {
 				$this->_pass = array_slice($value, 1);
 				$value = array_shift($value);
 			}

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -415,17 +415,16 @@ EXPECTED;
  * @return void
  */
 	public function testPr() {
-		$this->skipIf(php_sapi_name() === 'cli', 'Skipping web test in cli mode');
 		ob_start();
 		pr('this is a test');
 		$result = ob_get_clean();
-		$expected = "<pre>this is a test</pre>";
+		$expected = "\nthis is a test\n";
 		$this->assertEquals($expected, $result);
 
 		ob_start();
 		pr(array('this' => 'is', 'a' => 'test'));
 		$result = ob_get_clean();
-		$expected = "<pre>Array\n(\n    [this] => is\n    [a] => test\n)\n</pre>";
+		$expected = "\nArray\n(\n    [this] => is\n    [a] => test\n)\n\n";
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -74,6 +74,22 @@ class ValidationRuleTest extends TestCase {
 	}
 
 /**
+ * Test using a custom validation method with no provider declared.
+ *
+ * @return void
+ */
+	public function testCustomMethodNoProvider() {
+		$data = 'some data';
+		$context = ['field' => 'custom', 'newRecord' => true];
+		$providers = ['default' => ''];
+
+		$rule = new ValidationRule([
+			'rule' => [$this, 'myTestRule']
+		]);
+		$this->assertFalse($rule->process($data, $providers, $context));
+	}
+
+/**
  * Make sure errors are triggered when validation is missing.
  *
  * @expectedException \InvalidArgumentException

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2361,7 +2361,7 @@ class ValidationTest extends TestCase {
  * @return void
  */
 	public function testMimeType() {
-		$image = CORE_PATH . 'Cake/Test/TestApp/webroot/img/cake.power.gif';
+		$image = CORE_TESTS . 'test_app/webroot/img/cake.power.gif';
 		$File = new File($image, false);
 
 		$this->skipIf(!$File->mime(), 'Cannot determine mimeType');

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -757,7 +757,6 @@ class HtmlHelperTest extends TestCase {
  */
 	public function testScriptTimestamping() {
 		$this->skipIf(!is_writable(WWW_ROOT . 'js'), 'webroot/js is not Writable, timestamp testing has been skipped.');
-
 		Configure::write('debug', true);
 		Configure::write('Asset.timestamp', true);
 


### PR DESCRIPTION
Fixes #4330 and unskips a few tests that were skipped.
