### PR TITLE
removes confusing language

### DIFF
--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -45,7 +45,7 @@ trait CellTrait {
  *
  * Cells are not rendered until they are echoed.
  *
- * @param string $cell You must indicate both cell name, and optionally a cell action. e.g.: `TagCloud::smallList`
+ * @param string $cell You must indicate cell name, and optionally a cell action. e.g.: `TagCloud::smallList`
  * will invoke `View\Cell\TagCloudCell::smallList()`, `display` action will be invoked by default when none is provided.
  * @param array $data Additional arguments for cell method. e.g.:
  *    `cell('TagCloud::smallList', ['a1' => 'v1', 'a2' => 'v2'])` maps to `View\Cell\TagCloud::smallList(v1, v2)`


### PR DESCRIPTION
 removes confusing language about if a cell action is required.
- Only a API Documentation update.
