### PR TITLE
3.0 accessible cascadeCallbacks in Association

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -210,7 +210,8 @@ abstract class Association {
 	}
 
 /**
- * Sets whether or not cascaded deletes should also fire callbacks.
+ * Sets whether or not cascaded deletes should also fire callbacks. If no
+ * arguments are passed, the current configured value is returned
  *
  * @param bool $cascadeCallbacks cascade callbacks switch value
  * @return bool

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -210,6 +210,19 @@ abstract class Association {
 	}
 
 /**
+ * Sets whether or not cascaded deletes should also fire callbacks.
+ *
+ * @param bool $cascadeCallbacks cascade callbacks switch value
+ * @return bool
+ */
+	public function cascadeCallbacks($cascadeCallbacks = null) {
+		if ($cascadeCallbacks !== null) {
+			$this->_cascadeCallbacks = $cascadeCallbacks;
+		}
+		return $this->_cascadeCallbacks;
+	}
+
+/**
  * Sets the table instance for the source side of the association. If no arguments
  * are passed, the current configured table instance is returned
  *

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -92,6 +92,17 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Tests that cascadeCallbacks() returns the correct configured value
+ *
+ * @return void
+ */
+	public function testCascadeCallbacks() {
+		$this->assertSame(false, $this->association->cascadeCallbacks());
+		$this->association->cascadeCallbacks(true);
+		$this->assertSame(true, $this->association->cascadeCallbacks());
+	}
+
+/**
  * Tests that name() returns the correct configured value
  *
  * @return void


### PR DESCRIPTION
I was working on a soft delete behavior which nicely replaces original delete. Came across an issue with protected _cascadeCallbacks value, so I made cascadeCallbacks accessible and mutable from outside Association.

This is my first ever pull request and first contribution to CakePHP development. Hope everything is correct :)
