### PR TITLE
Router extensions fix

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -113,7 +113,7 @@ class Route {
 /**
  * Get/Set the supported extensions for this route.
  *
- * @param null|array $extensions The extensions to set. Use null to get.
+ * @param null|string|array $extensions The extensions to set. Use null to get.
  * @return array|void The extensions or null.
  */
 	public function extensions($extensions = null) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -111,13 +111,16 @@ class Route {
 	}
 
 /**
- * Sets the supported extensions for this route.
+ * Get/Set the supported extensions for this route.
  *
- * @param array $extensions The extensions to set.
- * @return void
+ * @param null|array $extensions The extensions to set. Use null to get.
+ * @return array|void The extensions or null.
  */
-	public function parseExtensions(array $extensions) {
-		$this->_extensions = $extensions;
+	public function extensions($extensions = null) {
+		if ($extensions === null) {
+			return $this->_extensions;
+		}
+		$this->_extensions = (array)$extensions;
 	}
 
 /**

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -484,7 +484,7 @@ class RouteBuilder {
  * @return void
  * @throws \InvalidArgumentException when there is no callable parameter.
  */
-	public function scope($path, $params, $callback) {
+	public function scope($path, $params, $callback = null) {
 		if ($callback === null) {
 			$callback = $params;
 			$params = [];

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -287,7 +287,7 @@ class RouteCollection {
 /**
  * Get/set the extensions that the route collection could handle.
  *
- * @param null|array $extensions Either the list of extensions to set, or null to get.
+ * @param null|string|array $extensions Either the list of extensions to set, or null to get.
  * @return array The valid extensions.
  */
 	public function extensions($extensions = null) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -60,6 +60,13 @@ class RouteCollection {
 	protected $_paths = [];
 
 /**
+ * Route extensions
+ *
+ * @var array
+ */
+	protected $_extensions = [];
+
+/**
  * Add a route to the collection.
  *
  * @param \Cake\Routing\Route\Route $route The route object to add.
@@ -89,6 +96,11 @@ class RouteCollection {
 			krsort($this->_paths);
 		}
 		$this->_paths[$path][] = $route;
+
+		$extensions = $route->extensions();
+		if ($extensions) {
+			$this->addExtensions($extensions);
+		}
 	}
 
 /**
@@ -260,6 +272,29 @@ class RouteCollection {
  */
 	public function named() {
 		return $this->_named;
+	}
+
+/**
+ * Add one or more extensions.
+ *
+ * @param array $extensions The extensions to add.
+ * @return void
+ */
+	public function addExtensions(array $extensions) {
+		$this->_extensions = array_unique(array_merge($this->_extensions, $extensions));
+	}
+
+/**
+ * Get/set the extensions that the route collection could handle.
+ *
+ * @param null|array $extensions Either the list of extensions to set, or null to get.
+ * @return array The valid extensions.
+ */
+	public function extensions($extensions = null) {
+		if ($extensions === null) {
+			return array_unique($this->_extensions);
+		}
+		$this->_extensions = (array)$extensions;
 	}
 
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -53,13 +53,6 @@ class Router {
 	protected static $_fullBaseUrl;
 
 /**
- * List of valid extensions to parse from a URL. If null, any extension is allowed.
- *
- * @var array
- */
-	protected static $_validExtensions = [];
-
-/**
  * Regular expression for action names
  *
  * @var string
@@ -714,14 +707,15 @@ class Router {
  * @return array
  */
 	public static function parseExtensions($extensions = null, $merge = true) {
+		$collection = static::$_collection;
 		if ($extensions === null) {
-			return static::$_validExtensions;
+			return $collection->extensions();
 		}
 		$extensions = (array)$extensions;
 		if ($merge) {
-			$extensions = array_merge(static::$_validExtensions, $extensions);
+			$extensions = array_merge($collection->extensions(), $extensions);
 		}
-		return static::$_validExtensions = $extensions;
+		return $collection->extensions($extensions);
 	}
 
 /**
@@ -735,8 +729,7 @@ class Router {
 		if (!static::$initialized) {
 			static::_loadRoutes();
 		}
-
-		return static::$_validExtensions;
+		return static::$_collection->extensions();
 	}
 
 /**
@@ -829,7 +822,7 @@ class Router {
  *   was created/used.
  */
 	public static function scope($path, $params = [], $callback = null) {
-		$builder = new RouteBuilder(static::$_collection, '/', [], static::$_validExtensions);
+		$builder = new RouteBuilder(static::$_collection, '/', [], static::$_collection->extensions());
 		$builder->scope($path, $params, $callback);
 	}
 

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -70,7 +70,11 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->Controller = new RequestHandlerTestController($request, $response);
 		$this->Controller->constructClasses();
 		$this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
-		$this->_extensions = Router::extensions();
+
+		Router::scope('/', function($routes) {
+			$routes->extensions('json');
+			$routes->fallbacks();
+		});
 	}
 
 /**
@@ -83,10 +87,6 @@ class RequestHandlerComponentTest extends TestCase {
 		DispatcherFactory::clear();
 		$this->_init();
 		unset($this->RequestHandler, $this->Controller);
-		if (!headers_sent()) {
-			header('Content-type: text/html'); //reset content type.
-		}
-		call_user_func_array('Cake\Routing\Router::parseExtensions', [$this->_extensions, false]);
 	}
 
 /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -105,7 +105,7 @@ class RouteTest extends TestCase {
 		$result = $route->parse('/posts/index.pdf');
 		$this->assertFalse(isset($result['_ext']));
 
-		$route->parseExtensions(array('pdf', 'json', 'xml'));
+		$route->extensions(array('pdf', 'json', 'xml'));
 		$result = $route->parse('/posts/index.pdf');
 		$this->assertEquals('pdf', $result['_ext']);
 

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -419,6 +419,12 @@ class RouteBuilderTest extends TestCase {
 			$this->assertEquals('/api/v1', $routes->path());
 			$this->assertEquals(['prefix' => 'api', 'version' => 1], $routes->params());
 		});
+
+		$routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+		$routes->scope('/v1', function($routes) {
+			$this->assertEquals('/api/v1', $routes->path());
+			$this->assertEquals(['prefix' => 'api'], $routes->params());
+		});
 	}
 
 }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -293,4 +293,22 @@ class RouteCollectionTest extends TestCase {
 		$this->assertSame($two, $routes[1]);
 	}
 
+/**
+ * Test basic get/set of extensions.
+ *
+ * @return void
+ */
+	public function testExtensions() {
+		$this->assertEquals([], $this->collection->extensions());
+
+		$this->collection->extensions('json');
+		$this->assertEquals(['json'], $this->collection->extensions());
+
+		$this->collection->extensions(['rss', 'xml']);
+		$this->assertEquals(['rss', 'xml'], $this->collection->extensions());
+
+		$this->collection->addExtensions(['json']);
+		$this->assertEquals(['rss', 'xml', 'json'], $this->collection->extensions());
+	}
+
 }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1557,6 +1557,26 @@ class RouterTest extends TestCase {
 	}
 
 /**
+ * Test that route builders propagate extensions to the top.
+ *
+ * @return void
+ */
+	public function testExtensionsWithScopedRoutes() {
+		Router::scope('/', function($routes) {
+			$routes->extensions('rss');
+			$routes->connect('/', ['controller' => 'Pages', 'action' => 'index']);
+
+			$routes->scope('/api', function($routes) {
+				$routes->extensions('xml');
+				$routes->connect('/docs', ['controller' => 'ApiDocs', 'action' => 'index']);
+			});
+		});
+
+		// json is added by routes in test_app/config/routes.php
+		$this->assertEquals(['rss', 'xml', 'json'], Router::extensions());
+	}
+
+/**
  * testExtensionParsing method
  *
  * @return void


### PR DESCRIPTION
Fix `Router::extensions()` being incorrect after scoped routes are connected. By storing and propagating the extensions in the RouteCollection, we can correctly handle Accept header based content-type negotiation.
