### PR TITLE
3.0 Component, Behavior & Helper Configuration Improvement

### DIFF
--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -14,6 +14,9 @@
  */
 namespace Cake\Utility;
 
+use Cake\Core\Configure;
+use ReflectionClass;
+
 /**
  * Acts as a registry/factory for objects.
  *
@@ -76,6 +79,18 @@ abstract class ObjectRegistry {
 			list($plugin, $objectName) = pluginSplit($objectName);
 			$this->_throwMissingClassError($objectName, $plugin);
 		}
+
+		$shortName = (new ReflectionClass($this))->getShortName();
+		$registryType = str_replace('Registry', '', $shortName);
+		$allowedRegistries = array('Component', 'Behavior', 'Helper');
+
+		if (in_array($registryType, $allowedRegistries)) {
+			$shortName = (new ReflectionClass($className))->getShortName();
+			$registryName = str_replace($registryType, '', $shortName);
+			$appConfig = (array)Configure::read($registryType . '.' . $registryName);
+			$config += $appConfig;
+		}
+
 		$instance = $this->_create($className, $name, $config);
 		$this->_loaded[$name] = $instance;
 		return $instance;

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -20,6 +20,7 @@ use Cake\Controller\Component\CookieComponent;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Plugin;
+use Cake\Core\Configure;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
@@ -68,6 +69,24 @@ class ComponentRegistryTest extends TestCase {
 
 		$result = $this->Components->load('Cookie');
 		$this->assertSame($result, $this->Components->Cookie);
+	}
+
+/**
+ * testLoadWithConfiguration method
+ *
+ * @return void
+ */
+	public function testLoadWithConfiguration() {
+		Configure::write('Component.Flash', ['element' => 'test']);
+
+		$result = $this->Components->load('Flash');
+		$this->assertInstanceOf('Cake\Controller\Component\FlashComponent', $result);
+		$this->assertSame('test', $this->Components->Flash->config('element'));
+
+		$this->Components->unload('Flash');
+		$result = $this->Components->load('Flash', ['element' => 'overwrite']);
+		$this->assertInstanceOf('Cake\Controller\Component\FlashComponent', $result);
+		$this->assertSame('overwrite', $this->Components->Flash->config('element'));
 	}
 
 /**


### PR DESCRIPTION
With this approach it's also possible to configure Component, Behavoir & Helper in the app configuration. The configuration needs to look like the following:

```
'Component => [
    'Flash' => ['element' => 'Common.default']
]
```

Resolves https://github.com/cakephp/cakephp/issues/4296
