### PR TITLE
Remove the possibility to create an infinite loop in SessionHelper.

### DIFF
--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -120,6 +120,8 @@ class SessionHelper extends AppHelper {
 
 		if (CakeSession::check('Message.' . $key)) {
 			$flash = CakeSession::read('Message.' . $key);
+			CakeSession::delete('Message.' . $key);
+
 			$message = $flash['message'];
 			unset($flash['message']);
 
@@ -144,7 +146,6 @@ class SessionHelper extends AppHelper {
 				$tmpVars['message'] = $message;
 				$out = $this->_View->element($flash['element'], $tmpVars, $options);
 			}
-			CakeSession::delete('Message.' . $key);
 		}
 		return $out;
 	}


### PR DESCRIPTION
By removing the session data _before_ rendering the element, we avoid issues where the element will try to re-render the session flash causing an infinite loop.

Refs #4350
