### PR TITLE
Change findType to finder in PaginatorComponent.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -107,7 +107,7 @@ class PaginatorComponent extends Component {
  * {{{
  * $settings = [
  *   'Articles' => [
- *     'findType' => 'custom',
+ *     'finder' => 'custom',
  *     'sortWhitelist' => ['title', 'author_id', 'comment_count'],
  *   ]
  * ];
@@ -115,12 +115,12 @@ class PaginatorComponent extends Component {
  *
  * ### Paginating with custom finders
  *
- * You can paginate with any find type defined on your table using the `findType` option.
+ * You can paginate with any find type defined on your table using the `finder` option.
  *
  * {{{
  *  $settings = array(
  *    'Articles' => array(
- *      'findType' => 'popular'
+ *      'finder' => 'popular'
  *    )
  *  );
  *  $results = $paginator->paginate($table, $settings);
@@ -156,8 +156,12 @@ class PaginatorComponent extends Component {
 		$options += ['page' => 1];
 		$options['page'] = intval($options['page']) < 1 ? 1 : (int)$options['page'];
 
-		$type = !empty($options['findType']) ? $options['findType'] : 'all';
-		unset($options['findType'], $options['maxLimit']);
+		if (!isset($options['finder']) && isset($options['findType'])) {
+			trigger_error('You should use finder instead of findType', E_USER_DEPRECATED);
+			$options['finder'] = $options['findType'];
+		}
+		$type = !empty($options['finder']) ? $options['finder'] : 'all';
+		unset($options['finder'], $options['maxLimit']);
 
 		if (empty($query)) {
 			$query = $object->find($type);
@@ -186,7 +190,7 @@ class PaginatorComponent extends Component {
 		}
 
 		$paging = array(
-			'findType' => $type,
+			'finder' => $type,
 			'page' => $page,
 			'current' => $numResults,
 			'count' => $count,

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -149,7 +149,7 @@ class PaginatorComponentTest extends TestCase {
 	public function testPaginateCustomFinder() {
 		$settings = array(
 			'PaginatorPosts' => array(
-				'findType' => 'popular',
+				'finder' => 'popular',
 				'fields' => array('id', 'title'),
 				'maxLimit' => 10,
 			)
@@ -163,7 +163,7 @@ class PaginatorComponentTest extends TestCase {
 			->will($this->returnValue($query));
 
 		$this->Paginator->paginate($table, $settings);
-		$this->assertEquals('popular', $this->request->params['paging']['PaginatorPosts']['findType']);
+		$this->assertEquals('popular', $this->request->params['paging']['PaginatorPosts']['finder']);
 	}
 
 /**
@@ -267,14 +267,14 @@ class PaginatorComponentTest extends TestCase {
 			'page' => 1,
 			'limit' => 20,
 			'maxLimit' => 100,
-			'findType' => 'myCustomFind'
+			'finder' => 'myCustomFind'
 		];
 		$result = $this->Paginator->mergeOptions('Post', $settings);
 		$expected = array(
 			'page' => 10,
 			'limit' => 10,
 			'maxLimit' => 100,
-			'findType' => 'myCustomFind',
+			'finder' => 'myCustomFind',
 			'whitelist' => ['limit', 'sort', 'page', 'direction'],
 		);
 		$this->assertEquals($expected, $result);
@@ -683,7 +683,7 @@ class PaginatorComponentTest extends TestCase {
 		$this->assertEquals(4, $result['current']);
 		$this->assertEquals(4, $result['count']);
 
-		$settings = array('findType' => 'published');
+		$settings = array('finder' => 'published');
 		$result = $this->Paginator->paginate($table, $settings);
 		$this->assertCount(3, $result, '3 rows should come back');
 		$this->assertEquals(array(1, 2, 3), $idExtractor($result));
@@ -692,7 +692,7 @@ class PaginatorComponentTest extends TestCase {
 		$this->assertEquals(3, $result['current']);
 		$this->assertEquals(3, $result['count']);
 
-		$settings = array('findType' => 'published', 'limit' => 2);
+		$settings = array('finder' => 'published', 'limit' => 2);
 		$result = $this->Paginator->paginate($table, $settings);
 		$this->assertCount(2, $result, '2 rows should come back');
 		$this->assertEquals(array(1, 2), $idExtractor($result));
@@ -708,6 +708,18 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
+ * test paginate() and custom find with deprecated option.
+ *
+ * @expectedException PHPUnit_Framework_Error_Deprecated
+ * @return void
+ */
+	public function testPaginateCustomFindOldOption() {
+		$this->loadFixtures('Post');
+		$table = TableRegistry::get('PaginatorPosts');
+		$this->Paginator->paginate($table, ['findType' => 'published']);
+	}
+
+/**
  * test paginate() and custom find with fields array, to make sure the correct count is returned.
  *
  * @return void
@@ -719,7 +731,7 @@ class PaginatorComponentTest extends TestCase {
 		$table->save(new \Cake\ORM\Entity($data));
 
 		$settings = [
-			'findType' => 'list',
+			'finder' => 'list',
 			'conditions' => array('PaginatorPosts.published' => 'Y'),
 			'limit' => 2
 		];
@@ -748,7 +760,7 @@ class PaginatorComponentTest extends TestCase {
  */
 	public function testPaginateCustomFindCount() {
 		$settings = array(
-			'findType' => 'published',
+			'finder' => 'published',
 			'limit' => 2
 		);
 		$table = $this->_getMockPosts(['find']);


### PR DESCRIPTION
Having everything be consistent is good and nice. I've left behind compatibility with `findType` as unlike CounterCache and Associated finders, PaginatorComponent is a bit more widely used and is harder to change.
