### PR TITLE
blacklist getOptionParser

### DIFF
--- a/src/Console/Command/Task/CommandTask.php
+++ b/src/Console/Command/Task/CommandTask.php
@@ -138,7 +138,7 @@ class CommandTask extends Shell {
 		$return = array_keys($taskMap);
 		$return = array_map('Cake\Utility\Inflector::underscore', $return);
 
-		$shellMethodNames = ['main', 'help'];
+		$shellMethodNames = ['main', 'help', 'getOptionParser'];
 
 		$baseClasses = ['Object', 'Shell', 'AppShell'];
 


### PR DESCRIPTION
This prevents any shell implementing `getOptionParser` (which all should) from having `getOptionPaser` show up as an autocomplete suggestion:

```
Console/cake orm_cache<tab>
build            clear            getOptionParser
```
