### PR TITLE
1.3 dbo source no crc32

### DIFF
--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -54,9 +54,8 @@ class DboSource extends DataSource {
 
 /**
  * Caches result from query parsing operations.  Cached results for both DboSource::name() and
- * DboSource::conditions() will be stored here.  Method caching uses `md5()` which is
- * fast but can collisions more easily than other hashing algorithms.  If you have problems
- * with collisions, set DboSource::$cacheMethods to false.
+ * DboSource::conditions() will be stored here.  Method caching uses `md5()`. If you have
+ * problems with collisions, set DboSource::$cacheMethods to false.
  *
  * @var array
  * @access public

--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -54,7 +54,7 @@ class DboSource extends DataSource {
 
 /**
  * Caches result from query parsing operations.  Cached results for both DboSource::name() and
- * DboSource::conditions() will be stored here.  Method caching uses `crc32()` which is
+ * DboSource::conditions() will be stored here.  Method caching uses `md5()` which is
  * fast but can collisions more easily than other hashing algorithms.  If you have problems
  * with collisions, set DboSource::$cacheMethods to false.
  *
@@ -538,7 +538,7 @@ class DboSource extends DataSource {
 			}
 			return $data;
 		}
-		$cacheKey = crc32($this->startQuote.$data.$this->endQuote);
+		$cacheKey = md5($this->startQuote.$data.$this->endQuote);
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}
@@ -1972,7 +1972,7 @@ class DboSource extends DataSource {
 			$fields,
 			$quote
 		);
-		$cacheKey = crc32(serialize($cacheKey));
+		$cacheKey = md5(serialize($cacheKey));
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}
@@ -2098,7 +2098,7 @@ class DboSource extends DataSource {
 		} else {
 			$cacheKey = array($conditions, $quoteValues, $where);
 		}
-		$cacheKey = crc32(serialize($cacheKey));
+		$cacheKey = md5(serialize($cacheKey));
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}


### PR DESCRIPTION
It is a bad idea to use crc32() as a cache key. This issue has been fixed in the 2.x branch already but hit me hard again. Please include in the next maintenance release for 1.3!
