### PR TITLE
Cache test update

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -47,6 +47,11 @@ class CacheTest extends TestCase {
 		Cache::drop('tests');
 	}
 
+/**
+ * Configure cache settings for test
+ *
+ * @return void
+ */
 	protected function _configCache() {
 		Cache::config('tests', [
 			'engine' => 'File',

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -65,13 +65,13 @@ class CacheTest extends TestCase {
  *
  * @return void
  */
-	public function testNonFatalErrorsWithCachedisable() {
+	public function testNonFatalErrorsWithCacheDisable() {
 		Cache::disable();
 		$this->_configCache();
 
-		Cache::write('no_save', 'Noooo!', 'tests');
-		Cache::read('no_save', 'tests');
-		Cache::delete('no_save', 'tests');
+		$this->assertNull(Cache::write('no_save', 'Noooo!', 'tests'));
+		$this->assertFalse(Cache::read('no_save', 'tests'));
+		$this->assertNull(Cache::delete('no_save', 'tests'));
 	}
 
 /**


### PR DESCRIPTION
- Added docblock to `_configCache()`
- Made assertions in `testNonFatalErrorsWithCacheDisable`. (To avoid "R" (Risky)  in phpunit.)
- Renamed `testNonFatalErrorsWithCachedisable` to `testNonFatalErrorsWithCacheDisable`.

There is _apparently_ no way to tell PHPUnit there is no assertions in it :/ 
https://github.com/sebastianbergmann/phpunit-documentation/issues/171#issuecomment-38792136
