### PR TITLE
3.0 - ORM select additional fields

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -656,7 +656,7 @@ trait CollectionTrait {
  * [
  *	1 => 'foo',
  *	2 => 'bar',
- *	3 => 'baz,
+ *	3 => 'baz',
  * ];
  *
  * $combined = (new Collection($items))->combine('id', 'name', 'parent');

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -594,22 +594,21 @@ abstract class Association {
  * @return void
  */
 	protected function _appendFields($query, $surrogate, $options) {
-		$options['fields'] = $surrogate->clause('select') ?: $options['fields'];
+		$fields = $surrogate->clause('select') ?: $options['fields'];
 		$target = $this->_targetTable;
 		$autoFields = $surrogate->autoFields();
-		if (empty($options['fields']) && !$autoFields) {
-			$f = isset($options['fields']) ? $options['fields'] : null;
-			if ($options['includeFields'] && ($f === null || $f !== false)) {
-				$options['fields'] = $target->schema()->columns();
+		if (empty($fields) && !$autoFields) {
+			if ($options['includeFields'] && ($fields === null || $fields !== false)) {
+				$fields = $target->schema()->columns();
 			}
 		}
 
 		if ($autoFields === true) {
-			$options['fields'] = array_merge((array)$options['fields'], $target->schema()->columns());
+			$fields = array_merge((array)$fields, $target->schema()->columns());
 		}
 
-		if (!empty($options['fields'])) {
-			$query->select($query->aliasFields($options['fields'], $target->alias()));
+		if (!empty($fields)) {
+			$query->select($query->aliasFields($fields, $target->alias()));
 		}
 	}
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -596,11 +596,16 @@ abstract class Association {
 	protected function _appendFields($query, $surrogate, $options) {
 		$options['fields'] = $surrogate->clause('select') ?: $options['fields'];
 		$target = $this->_targetTable;
-		if (empty($options['fields'])) {
+		$autoFields = $surrogate->autoFields();
+		if (empty($options['fields']) && !$autoFields) {
 			$f = isset($options['fields']) ? $options['fields'] : null;
 			if ($options['includeFields'] && ($f === null || $f !== false)) {
 				$options['fields'] = $target->schema()->columns();
 			}
+		}
+
+		if ($autoFields === true) {
+			$options['fields'] = array_merge((array)$options['fields'], $target->schema()->columns());
 		}
 
 		if (!empty($options['fields'])) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -68,7 +68,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 
 /**
  * Tracks whether or not the original query should include
- * fields from the top level model.
+ * fields from the top level table.
  *
  * @var bool
  */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -67,6 +67,14 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	protected $_hasFields;
 
 /**
+ * Tracks whether or not the original query should include
+ * fields from the top level model.
+ *
+ * @var bool
+ */
+	protected $_autoFields;
+
+/**
  * Boolean for tracking whether or not buffered results
  * are enabled.
  *
@@ -625,7 +633,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 		$select = $this->clause('select');
 		$this->_hasFields = true;
 
-		if (!count($select)) {
+		if (!count($select) || $this->_autoFields === true) {
 			$this->_hasFields = false;
 			$this->select($this->repository()->schema()->columns());
 			$select = $this->clause('select');
@@ -754,6 +762,23 @@ class Query extends DatabaseQuery implements JsonSerializable {
  */
 	public function jsonSerialize() {
 		return $this->all();
+	}
+
+/**
+ * Get/Set whether or not the ORM should automatically append fields.
+ *
+ * By default calling select() will disable auto-fields. You can re-enable
+ * auto-fields with this method.
+ *
+ * @param bool $value The value to set or null to read the current value.
+ * @return bool|$this Either the current value or the query object.
+ */
+	public function autoFields($value = null) {
+		if ($value === null) {
+			return $this->_autoFields;
+		}
+		$this->_autoFields = (bool)$value;
+		return $this;
 	}
 
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2060,7 +2060,7 @@ class QueryTest extends TestCase {
 			->autoFields(true)
 			->hydrate(false)
 			->contain(['Authors' => function($q) {
-				return $q->select(['compute' => '2 + 20'])
+				return $q->select(['compute' => '(SELECT 2 + 20)'])
 					->autoFields(true);
 			}])
 			->first();

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2013,7 +2013,7 @@ class QueryTest extends TestCase {
 	public function testAutoFields() {
 		$table = TableRegistry::get('Articles');
 		$result = $table->find('all')
-			->select(['myField' => 'id + 20'])
+			->select(['myField' => '(SELECT 20)'])
 			->autoFields(true)
 			->hydrate(false)
 			->first();


### PR DESCRIPTION
This solves #4360 and is an alternative to #4379.  I originally tried an approach similar to that taken in #4379, but found my solution wasn't very nice. Instead I decided to have a new accessor that allows a developer to indicate that they want the automatic fields in addition to the defined columns. This allows people to use computed fields and still get their model fields.

I've also taken care of making it work with `contain()` query builders.
