### PR TITLE
Fix CURRENT_TIMESTAMP being stored as a default value.

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -351,6 +351,9 @@ class Mysql extends DboSource {
 			if (in_array($fields[$column->Field]['type'], $this->fieldParameters['unsigned']['types'], true)) {
 				$fields[$column->Field]['unsigned'] = $this->_unsigned($column->Type);
 			}
+			if ($fields[$column->Field]['type'] === 'timestamp' && strtoupper($column->Default) === 'CURRENT_TIMESTAMP') {
+				$fields[$column->Field]['default'] = '';
+			}
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {
 				$fields[$column->Field]['key'] = $this->index[$column->Key];
 			}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -885,6 +885,32 @@ class MysqlTest extends CakeTestCase {
 	}
 
 /**
+ * Test that describe() ignores `default current_timestamp` in timestamp columns.
+ *
+ * @return void
+ */
+	public function testDescribeHandleCurrentTimestamp() {
+		$name = $this->Dbo->fullTableName('timestamp_default_values');
+		$sql = <<<SQL
+CREATE TABLE $name (
+	id INT(11) NOT NULL AUTO_INCREMENT,
+	phone VARCHAR(10),
+	limit_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id)
+);
+SQL;
+		$this->Dbo->execute($sql); 
+		$model = new Model(array(
+			'table' => 'timestamp_default_values',
+			'ds' => 'test',
+			'alias' => 'TimestampDefaultValue'
+		));
+		$result = $this->Dbo->describe($model);
+		$this->assertEquals('', $result['limit_date']['default']);
+		$this->Dbo->execute('DROP TABLE ' . $name);
+	}
+
+/**
  * test that a describe() gets additional fieldParameters
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -899,7 +899,7 @@ CREATE TABLE $name (
 	PRIMARY KEY(id)
 );
 SQL;
-		$this->Dbo->execute($sql); 
+		$this->Dbo->execute($sql);
 		$model = new Model(array(
 			'table' => 'timestamp_default_values',
 			'ds' => 'test',


### PR DESCRIPTION
When reflecting timestamp columns in MySQL current_timestamp comes back as the default value. This causes insertion errors later on as 'current_timestamp' is an invalid value for timestamp columns.

Refs #4184
