### PR TITLE
Remove autoFields from count method

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -474,6 +474,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
  */
 	public function count() {
 		$query = clone $this;
+		$query->autoFields(false);
 		$query->limit(null);
 		$query->order([], true);
 		$query->offset(null);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2072,5 +2072,32 @@ class QueryTest extends TestCase {
 		$this->assertArrayHasKey('name', $result['author']);
 		$this->assertArrayHasKey('compute', $result);
 	}
+	
+/**
+ * Test count with autoFields
+ *
+ * @return void
+ */
+	public function testAutoFieldsCount() {
+		$table = TableRegistry::get('Articles');
+		$table->belongsTo('Authors');
+
+		$resultNormal = $table->find()
+			->select(['myField' => '(SELECT RAND())'])
+			->hydrate(false)
+			->contain('Authors')
+			->count();
+
+		$resultAutoFields = $table->find()
+			->select(['myField' => '(SELECT RAND())'])
+			->autoFields(true)
+			->hydrate(false)
+			->contain('Authors')
+			->count();
+
+		$this->assertNotNull($resultNormal);
+		$this->assertNotNull($resultAutoFields);
+		$this->assertEquals($resultNormal, $resultAutoFields);
+	}
 
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2072,7 +2072,7 @@ class QueryTest extends TestCase {
 		$this->assertArrayHasKey('name', $result['author']);
 		$this->assertArrayHasKey('compute', $result);
 	}
-	
+
 /**
  * Test that autofields works with count()
  *

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2074,30 +2074,19 @@ class QueryTest extends TestCase {
 	}
 	
 /**
- * Test count with autoFields
+ * Test that autofields works with count()
  *
  * @return void
  */
 	public function testAutoFieldsCount() {
 		$table = TableRegistry::get('Articles');
-		$table->belongsTo('Authors');
 
-		$resultNormal = $table->find()
-			->select(['myField' => '(SELECT RAND())'])
-			->hydrate(false)
-			->contain('Authors')
-			->count();
-
-		$resultAutoFields = $table->find()
-			->select(['myField' => '(SELECT RAND())'])
+		$result = $table->find()
+			->select(['myField' => '(SELECT (2 + 2))'])
 			->autoFields(true)
-			->hydrate(false)
-			->contain('Authors')
 			->count();
 
-		$this->assertNotNull($resultNormal);
-		$this->assertNotNull($resultAutoFields);
-		$this->assertEquals($resultNormal, $resultAutoFields);
+		$this->assertEquals(3, $result);
 	}
 
 }


### PR DESCRIPTION
When autoFields was set to true and count method was triggered, autofields were added to the query and SQL failed due to wrong format.

This solves `count()` problem in https://github.com/cakephp/cakephp/pull/4381
