### PR TITLE
3.0 avoid fatal error by throwing exception

### DIFF
--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -72,7 +72,7 @@ abstract class ObjectRegistry {
 			$objectName = $config['className'];
 		}
 		$className = $this->_resolveClassName($objectName);
-		if (!$className) {
+		if (!$className || (is_string($className) && !class_exists($className))) {
 			list($plugin, $objectName) = pluginSplit($objectName);
 			$this->_throwMissingClassError($objectName, $plugin);
 		}

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -75,7 +75,7 @@ class ConnectionManagerTest extends TestCase {
  */
 	public function testConfigInvalidOptions() {
 		ConnectionManager::config('test_variant', [
-			'className' => 'HerpDerp'
+			'className' => 'Herp\Derp'
 		]);
 		ConnectionManager::get('test_variant');
 	}


### PR DESCRIPTION
Throws an exception instead of a fatal error when the datasource classname contain a `\`, for example: 

``` php
'default' => [
            'className' => 'Cake\Database\Connectio',
            'driver' => 'Cake\Database\Driver\Mysql',
            'persistent' => false,
            'host' => 'localhost',
            'login' => 'root',
            'password' => 'root',
            'database' => 'cake3a2',
            'prefix' => false,
            'encoding' => 'utf8',
            'timezone' => 'UTC',
            'cacheMetadata' => true,
```

Without this modification, this happen : 
![image](https://cloud.githubusercontent.com/assets/4977112/4042624/12dead84-2d06-11e4-84b2-4bbfa3bcfada.png)

With this fix : 
![image](https://cloud.githubusercontent.com/assets/4977112/4042636/319f49e0-2d06-11e4-8203-65f7b066ffe2.png)
