### PR TITLE
Refactor exception handling to return instead of echoing.

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -184,15 +184,11 @@ abstract class BaseErrorHandler {
 		];
 		$this->_logError(LOG_ERR, $data);
 
-		if (ob_get_level()) {
-			ob_end_clean();
-		}
-
 		if (Configure::read('debug')) {
 			$this->handleException(new FatalErrorException($description, 500, $file, $line));
-		} else {
-			$this->handleException(new InternalErrorException());
+			return true;
 		}
+		$this->handleException(new InternalErrorException());
 		return true;
 	}
 

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -135,7 +135,9 @@ class ErrorHandler extends BaseErrorHandler {
 				throw new \Exception("$renderer is an invalid class.");
 			}
 			$error = new $renderer($exception);
-			$error->render();
+			$response = $error->render();
+			$this->_clearOutput();
+			$this->_sendResponse($response);
 		} catch (\Exception $e) {
 			// Disable trace for internal errors.
 			$this->_options['trace'] = false;
@@ -146,6 +148,33 @@ class ErrorHandler extends BaseErrorHandler {
 			);
 			trigger_error($message, E_USER_ERROR);
 		}
+	}
+
+/**
+ * Clear output buffers so error pages display properly.
+ *
+ * Easily stubbed in testing.
+ *
+ * @return void
+ */
+	protected function _clearOutput() {
+		while (ob_get_level()) {
+			ob_end_clean();
+		}
+	}
+
+/**
+ * Method that can be easily stubbed in testing.
+ *
+ * @param string|Cake\Network\Response $response Either the message or response object.
+ * @return void
+ */
+	protected function _sendResponse($response) {
+		if (is_string($response)) {
+			echo $response;
+			return;
+		}
+		echo $response->send();
 	}
 
 }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ErrorHandlerTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -30,24 +28,34 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
 /**
- * Test exception renderer
+ * Testing stub.
  */
-class TestExceptionRenderer extends ExceptionRenderer {
+class TestErrorHandler extends ErrorHandler {
 
 /**
- * Constructor for mocking Response::_sendHeader()
+ * Access the response used.
  *
- * @param \Exception $exception
+ * @var \Cake\Network\Response
  */
-	public function __construct(\Exception $exception) {
-		parent::__construct($exception);
-		$testCase = new ErrorHandlerTest();
-		$this->controller->response = $testCase->getMock(
-			'Cake\Network\Response',
-			['_sendHeader']
-		);
+	public $response;
+
+/**
+ * Stub output clearing in tests.
+ *
+ * @return void
+ */
+	protected function _clearOutput() {
+		// noop
 	}
 
+/**
+ * Stub sending responses
+ *
+ * @return void
+ */
+	protected function _sendResponse($response) {
+		$this->response = $response;
+	}
 }
 
 /**
@@ -137,9 +145,9 @@ class ErrorHandlerTest extends TestCase {
 
 		ob_start();
 		trigger_error('Test error', $error);
-
 		$result = ob_get_clean();
-		$this->assertRegExp('/<b>' . $expected . '<\/b>/', $result);
+
+		$this->assertContains('<b>' . $expected . '</b>', $result);
 	}
 
 /**
@@ -213,14 +221,10 @@ class ErrorHandlerTest extends TestCase {
  */
 	public function testHandleException() {
 		$error = new Error\NotFoundException('Kaboom!');
-		$errorHandler = new ErrorHandler([
-			'exceptionRenderer' => 'Cake\Test\TestCase\Error\TestExceptionRenderer'
-		]);
+		$errorHandler = new TestErrorHandler();
 
-		ob_start();
 		$errorHandler->handleException($error);
-		$result = ob_get_clean();
-		$this->assertRegExp('/Kaboom!/', $result, 'message missing.');
+		$this->assertContains('Kaboom!', $errorHandler->response->body(), 'message missing.');
 	}
 
 /**
@@ -229,9 +233,8 @@ class ErrorHandlerTest extends TestCase {
  * @return void
  */
 	public function testHandleExceptionLog() {
-		$errorHandler = new ErrorHandler([
+		$errorHandler = new TestErrorHandler([
 			'log' => true,
-			'exceptionRenderer' => 'Cake\Test\TestCase\Error\TestExceptionRenderer'
 		]);
 
 		$error = new Error\NotFoundException('Kaboom!');
@@ -243,10 +246,8 @@ class ErrorHandlerTest extends TestCase {
 				$this->stringContains('ErrorHandlerTest->testHandleExceptionLog')
 			));
 
-		ob_start();
 		$errorHandler->handleException($error);
-		$result = ob_get_clean();
-		$this->assertRegExp('/Kaboom!/', $result, 'message missing.');
+		$this->assertContains('Kaboom!', $errorHandler->response->body(), 'message missing.');
 	}
 
 /**
@@ -265,21 +266,16 @@ class ErrorHandlerTest extends TestCase {
 				$this->stringContains('[Cake\Error\ForbiddenException] Fooled you!')
 			);
 
-		$errorHandler = new ErrorHandler([
+		$errorHandler = new TestErrorHandler([
 			'log' => true,
 			'skipLog' => ['Cake\Error\NotFoundException'],
-			'exceptionRenderer' => 'Cake\Test\TestCase\Error\TestExceptionRenderer'
 		]);
 
-		ob_start();
 		$errorHandler->handleException($notFound);
-		$result = ob_get_clean();
-		$this->assertRegExp('/Kaboom!/', $result, 'message missing.');
+		$this->assertContains('Kaboom!', $errorHandler->response->body(), 'message missing.');
 
-		ob_start();
 		$errorHandler->handleException($forbidden);
-		$result = ob_get_clean();
-		$this->assertRegExp('/Fooled you!/', $result, 'message missing.');
+		$this->assertContains('Fooled you!', $errorHandler->response->body(), 'message missing.');
 	}
 
 /**
@@ -289,16 +285,15 @@ class ErrorHandlerTest extends TestCase {
  */
 	public function testLoadPluginHandler() {
 		Plugin::load('TestPlugin');
-		$errorHandler = new ErrorHandler([
+		$errorHandler = new TestErrorHandler([
 			'exceptionRenderer' => 'TestPlugin.TestPluginExceptionRenderer',
 		]);
 
 		$error = new Error\NotFoundException('Kaboom!');
-		ob_start();
 		$errorHandler->handleException($error);
-		$result = ob_get_clean();
+
+		$result = $errorHandler->response;
 		$this->assertEquals('Rendered by test plugin', $result);
-		Plugin::unload();
 	}
 
 /**
@@ -310,23 +305,18 @@ class ErrorHandlerTest extends TestCase {
  */
 	public function testHandleFatalErrorPage() {
 		$line = __LINE__;
-		$errorHandler = new ErrorHandler([
-			'exceptionRenderer' => 'Cake\Test\TestCase\Error\TestExceptionRenderer'
-		]);
+		$errorHandler = new TestErrorHandler();
 		Configure::write('debug', true);
-		ob_start();
-		ob_start();
+
 		$errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, $line);
-		$result = ob_get_clean();
+		$result = $errorHandler->response->body();
 		$this->assertContains('Something wrong', $result, 'message missing.');
 		$this->assertContains(__FILE__, $result, 'filename missing.');
 		$this->assertContains((string)$line, $result, 'line missing.');
 
-		ob_start();
-		ob_start();
 		Configure::write('debug', false);
 		$errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, $line);
-		$result = ob_get_clean();
+		$result = $errorHandler->response->body();
 		$this->assertNotContains('Something wrong', $result, 'message must not appear.');
 		$this->assertNotContains(__FILE__, $result, 'filename must not appear.');
 		$this->assertContains('An Internal Error Has Occurred', $result);
@@ -341,7 +331,7 @@ class ErrorHandlerTest extends TestCase {
 		$this->_logger->expects($this->at(0))
 			->method('write')
 			->with('error', $this->logicalAnd(
-				$this->stringContains(__FILE__ . ', line ' . (__LINE__ + 13)),
+				$this->stringContains(__FILE__ . ', line ' . (__LINE__ + 9)),
 				$this->stringContains('Fatal Error (1)'),
 				$this->stringContains('Something wrong')
 			));
@@ -349,13 +339,8 @@ class ErrorHandlerTest extends TestCase {
 			->method('write')
 			->with('error', $this->stringContains('[Cake\Error\FatalErrorException] Something wrong'));
 
-		$errorHandler = new ErrorHandler([
-			'log' => true,
-			'exceptionRenderer' => 'Cake\Test\TestCase\Error\TestExceptionRenderer'
-		]);
-		ob_start();
+		$errorHandler = new TestErrorHandler(['log' => true]);
 		$errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, __LINE__);
-		ob_clean();
 	}
 
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Error/TestPluginExceptionRenderer.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Error/TestPluginExceptionRenderer.php
@@ -30,9 +30,9 @@ class TestPluginExceptionRenderer extends ExceptionRenderer {
 /**
  * Renders the response for the exception.
  *
- * @return void
+ * @return string
  */
 	public function render() {
-		echo 'Rendered by test plugin';
+		return 'Rendered by test plugin';
 	}
 }


### PR DESCRIPTION
By returning a response/string instead of directly echoing we get a few benefits:
1. We can more easily test the code without relying on ob_start().
2. Application exception handlers can have full control over the response headers.
3. We can fix issues related to nested error pages.

This is a **breaking change** as application exception renderers now **must** return either a string or a response object. I will update the docs once this has been discussed/merged.

Fixes #4130
