### PR TITLE
Update TagFixture.php

### DIFF
--- a/lib/Cake/Test/Fixture/TagFixture.php
+++ b/lib/Cake/Test/Fixture/TagFixture.php
@@ -31,8 +31,8 @@ class TagFixture extends CakeTestFixture {
 	public $fields = array(
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'tag' => array('type' => 'string', 'null' => false),
-		'created' => 'datetime',
-		'updated' => 'datetime'
+		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
 	);
 
 /**


### PR DESCRIPTION
Updated the tag fixture so that it doesn't break `CakeSchema::_arrayDiffAssoc()`. As you can't compare an array to a string
