### PR TITLE
CakeSession::delete() bugfix

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -267,7 +267,7 @@ class CakeSession {
  * @return bool Success
  */
 	public static function delete($name) {
-		if (self::check($name)) {
+		if (self::start() && self::check($name)) {
 			self::_overwrite($_SESSION, Hash::remove($_SESSION, $name));
 			return !self::check($name);
 		}

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -366,6 +366,12 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testDelete() {
 		$this->assertTrue(TestCakeSession::write('Delete.me', 'Clearing out'));
+
+		session_write_close();
+		$this->assertTrue(TestCakeSession::delete('Delete.me'));
+		$this->assertFalse(TestCakeSession::check('Delete.me'));
+
+		$this->assertTrue(TestCakeSession::write('Delete.me', 'Clearing out'));
 		$this->assertTrue(TestCakeSession::delete('Delete.me'));
 		$this->assertFalse(TestCakeSession::check('Delete.me'));
 		$this->assertTrue(TestCakeSession::check('Delete'));


### PR DESCRIPTION
Previously it was impossible to delete something from the session before you start it through CakeSession::start(). It's a bug in my opinion, so here the fix for it.
