### PR TITLE
Not using dynamic getters in Entity::extract()

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -276,7 +276,7 @@ trait EntityTrait {
  * $entity->has('last_name'); // false
  * }}}
  *
- * When checking multiple properties. All properties must not be null 
+ * When checking multiple properties. All properties must not be null
  * in order for true to be returned.
  *
  * @param string|array $property The property or properties to check.
@@ -457,6 +457,10 @@ trait EntityTrait {
  * Returns an array with the requested properties
  * stored in this entity, indexed by property name
  *
+ * This function will only use dynamic getters for properties that have not been
+ * set before directly. That is, it will always return the original value as stored
+ * or modified by a dynamic setter.
+ *
  * @param array $properties list of properties to be returned
  * @param bool $onlyDirty Return the requested property only if it is dirty
  * @return array
@@ -465,7 +469,9 @@ trait EntityTrait {
 		$result = [];
 		foreach ($properties as $property) {
 			if (!$onlyDirty || $this->dirty($property)) {
-				$result[$property] = $this->get($property);
+				$result[$property] = isset($this->_properties[$property]) ?
+					$this->_properties[$property] :
+					$this->get($property);
 			}
 		}
 		return $result;

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -476,6 +476,33 @@ class EntityTest extends TestCase {
 	}
 
 /**
+ * Tests that when a value is already set, the extract() function will not use
+ * getters for building the resulting array
+ *
+ * @return void
+ */
+	public function testExtractNoGetters() {
+		$entity = $this->getMock('\Cake\ORM\Entity', ['_getName', '_getLastName']);
+		$entity->name = 'Mark';
+		$entity->expects($this->any())
+			->method('_getName')
+			->will($this->returnValue('Jose'));
+
+		$entity->expects($this->any())
+			->method('_getLastName')
+			->will($this->returnValue('Smith'));
+
+		$this->assertEquals('Jose', $entity->name);
+		$this->assertEquals(['name' => 'Mark'], $entity->extract(['name']));
+
+		$expected = [
+			'name' => 'Mark',
+			'last_name' => 'Smith'
+		];
+		$this->assertEquals($expected, $entity->extract(['name', 'last_name']));
+	}
+
+/**
  * Tests dirty() method on a newly created object
  *
  * @return void


### PR DESCRIPTION
Fixes #4395

Seems like people are using entities more like a data transfer object instead of
a real entity. Protecting us from a flood of future issues by accounting for
how they are being used so far.
