### PR TITLE
hasOne/belongsTo associations should contain associated records in afterFind

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1113,11 +1113,6 @@ class DboSource extends DataSource {
 
 		$filtered = array();
 
-		// Filter hasOne and belongsTo associations
-		if ($queryData['callbacks'] === true || $queryData['callbacks'] === 'after') {
-			$filtered = $this->_filterResults($resultSet, $Model);
-		}
-
 		// Deep associations
 		if ($Model->recursive > -1) {
 			$joined = array();

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1143,10 +1143,10 @@ class DboSource extends DataSource {
 					}
 				}
 			}
+		}
 
-			if ($queryData['callbacks'] === true || $queryData['callbacks'] === 'after') {
-				$this->_filterResults($resultSet, $Model, $filtered);
-			}
+		if ($queryData['callbacks'] === true || $queryData['callbacks'] === 'after') {
+			$this->_filterResults($resultSet, $Model, $filtered);
 		}
 
 		if ($recursive !== null) {

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1510,6 +1510,57 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * Test that afterFind is called correctly for 'joins'
+ *
+ * @return void
+ */
+	public function testJoinsAfterFind() {
+		$this->loadFixtures('Article', 'User');
+
+		$User = new User();
+		$User->bindModel(array('hasOne' => array('Article')));
+
+		$Article = $this->getMock('Article', array('afterFind'), array(), '', true);
+		$Article->expects($this->once())
+			->method('afterFind')
+			->with(
+				array(
+					0 => array(
+						'Article' => array(
+							'id' => '1',
+							'user_id' => '1',
+							'title' => 'First Article',
+							'body' => 'First Article Body',
+							'published' => 'Y',
+							'created' => '2007-03-18 10:39:23',
+							'updated' => '2007-03-18 10:41:31'
+						)
+					)
+				),
+				$this->isFalse()
+			)
+			->will($this->returnArgument(0));
+
+		$User->Article = $Article;
+		$User->find('first', array(
+			'fields' => '*',
+			'conditions' => array('User.id' => 1),
+			'recursive' => -1,
+			'joins' => array(
+				array(
+					'table' => 'articles',
+					'alias' => 'Article',
+					'type' => 'LEFT',
+					'conditions' => array(
+						'Article.user_id = User.id'
+					),
+				)
+			),
+			'order' => array('Article.id')
+		));
+	}
+
+/**
  * Test that afterFind is called correctly for 'hasOne' association.
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1543,7 +1543,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$User->Article = $Article;
 		$User->find('first', array(
-			'fields' => '*',
+			'fields' => array('User.*', 'Article.*'),
 			'conditions' => array('User.id' => 1),
 			'recursive' => -1,
 			'joins' => array(

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1543,7 +1543,15 @@ class DboSourceTest extends CakeTestCase {
 
 		$User->Article = $Article;
 		$User->find('first', array(
-			'fields' => array('User.*', 'Article.*'),
+			'fields' => array(
+				'Article.id',
+				'Article.user_id',
+				'Article.title',
+				'Article.body',
+				'Article.published',
+				'Article.created',
+				'Article.updated'
+			),
 			'conditions' => array('User.id' => 1),
 			'recursive' => -1,
 			'joins' => array(

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1508,4 +1508,59 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertCount(2, $result['Article']['Tag']);
 		$this->assertCount(2, $result['Article']['Comment']);
 	}
+
+/**
+ * Test that afterFind is called correctly for 'hasOne' association.
+ *
+ * @return void
+ */
+	public function testHasOneAfterFind() {
+		$this->loadFixtures('Article', 'User', 'Comment');
+
+		$User = new User();
+		$User->bindModel(array('hasOne' => array('Article')));
+
+		$Article = $this->getMock('Article', array('afterFind'), array(), '', true);
+		$Article->unbindModel(array(
+			'belongsTo' => array('User'),
+			'hasMany' => array('Comment'),
+			'hasAndBelongsToMany' => array('Tag')
+		));
+		$Article->bindModel(array(
+			'hasOne' => array('Comment'),
+		));
+		$Article->expects($this->once())
+			->method('afterFind')
+			->with(
+				$this->equalTo(
+					array(
+						0 => array(
+							'Article' => array(
+								'id' => '1',
+								'user_id' => '1',
+								'title' => 'First Article',
+								'body' => 'First Article Body',
+								'published' => 'Y',
+								'created' => '2007-03-18 10:39:23',
+								'updated' => '2007-03-18 10:41:31',
+								'Comment' => array(
+									'id' => '1',
+									'article_id' => '1',
+									'user_id' => '2',
+									'comment' => 'First Comment for First Article',
+									'published' => 'Y',
+									'created' => '2007-03-18 10:45:23',
+									'updated' => '2007-03-18 10:47:31',
+								)
+							)
+						)
+					)
+				),
+				$this->isFalse()
+			)
+			->will($this->returnArgument(0));
+
+		$User->Article = $Article;
+		$User->find('first', array('conditions' => array('User.id' => 1), 'recursive' => 2));
+	}
 }


### PR DESCRIPTION
It is my fault.
Before 1fe943d6f1814cd3756d71c035d2b69fc36ce066, afterFind() is called twice with belongsTo/hasOne associations.
Although $results also doesn't contain associated records on first time,
it contains them on second time.

<pre>
//First time
array(
    0 => array(
        'User' => array(
            'id' => 1,
            'name' => 'Jane Doe',
        )
    )
)

//Second time
array(
    'id' => 1,
    'name' => 'Jane Doe',
    'Role' => array(
        'id' => 1,
        'name' => 'Administrator'
    )
)
</pre>


I suppressed second calls on 1fe943d6f1814cd3756d71c035d2b69fc36ce066.
So after 1fe943d6f1814cd3756d71c035d2b69fc36ce066, it doesn't work if associated records are used in afterFind.
This commit fixes it.

<pre>
array(
    0 => array(
        'User' => array(
            'id' => 1,
            'name' => 'Jane Doe',
            'roel_id' => 1,
            'Role' => array(
                'id' => 1,
                'name' => 'Administrator',
            )
        )
    )
)
</pre>


(Unlimited hasMany and hasAndBelongsToMany associations don't contain them originally,
So I didn't fix them on this commit)

Please merge this or revert 1fe943d6f1814cd3756d71c035d2b69fc36ce066.
Anyway, I will fix all issues related to afterFInd in 2.6.
