### PR TITLE
Fix broken behavior configuration

### DIFF
--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -212,12 +212,12 @@ class Behavior implements EventListener {
  * @return array
  */
 	public function implementedFinders() {
-		if (isset($this->_config['implementedFinders'])) {
-			return $this->_config['implementedFinders'];
+		$methods = $this->config('implementedFinders');
+		if (isset($methods)) {
+			return $methods;
 		}
 
-		$reflectionMethods = $this->_reflectionCache();
-		return $reflectionMethods['finders'];
+		return $this->_reflectionCache()['finders'];
 	}
 
 /**
@@ -242,12 +242,12 @@ class Behavior implements EventListener {
  * @return array
  */
 	public function implementedMethods() {
-		if (isset($this->_config['implementedMethods'])) {
-			return $this->_config['implementedMethods'];
+		$methods = $this->config('implementedMethods');
+		if (isset($methods)) {
+			return $methods;
 		}
 
-		$reflectionMethods = $this->_reflectionCache();
-		return $reflectionMethods['methods'];
+		return $this->_reflectionCache()['methods'];
 	}
 
 /**

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -125,7 +125,47 @@ class Behavior implements EventListener {
  * @param array $config The config for this behavior.
  */
 	public function __construct(Table $table, array $config = []) {
+		$config = $this->_resolveMethodAliases(
+			'implementedFinders',
+			$this->_defaultConfig,
+			$config
+		);
+		$config = $this->_resolveMethodAliases(
+			'implementedMethods',
+			$this->_defaultConfig,
+			$config
+		);
 		$this->config($config);
+	}
+
+/**
+ * Removes aliased methods that would otherwise be duplicated by userland configuration.
+ *
+ * @param string $key The key to filter.
+ * @param array $defaults The default method mappings.
+ * @param array $config The customized method mappings.
+ * @return array A de-duped list of config data.
+ */
+	protected function _resolveMethodAliases($key, $defaults, $config) {
+		if (!isset($defaults[$key], $config[$key])) {
+			return $config;
+		}
+		if (isset($config[$key]) && $config[$key] === []) {
+			$this->config($key, [], false);
+			unset($config[$key]);
+			return $config;
+		}
+
+		$indexed = array_flip($defaults[$key]);
+		$indexedCustom = array_flip($config[$key]);
+		foreach ($indexed as $method => $alias) {
+			if (!isset($indexedCustom[$method])) {
+				$indexedCustom[$method] = $alias;
+			}
+		}
+		$this->config($key, array_flip($indexedCustom), false);
+		unset($config[$key]);
+		return $config;
 	}
 
 /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -129,6 +129,51 @@ class BehaviorRegistryTest extends TestCase {
 	}
 
 /**
+ * Test load() duplicate method aliasing
+ *
+ * @return void
+ */
+	public function testLoadDuplicateMethodAliasing() {
+		$this->Behaviors->load('Tree');
+		$this->Behaviors->load('Duplicate', [
+			'implementedFinders' => [
+				'renamed' => 'findChildren',
+			],
+			'implementedMethods' => [
+				'renamed' => 'slugify',
+			]
+		]);
+		$this->assertTrue($this->Behaviors->hasMethod('renamed'));
+	}
+
+/**
+ * Test load() duplicate finder error
+ *
+ * @expectedException \Cake\Error\Exception
+ * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"
+ * @return void
+ */
+	public function testLoadDuplicateFinderError() {
+		$this->Behaviors->load('Tree');
+		$this->Behaviors->load('Duplicate');
+	}
+
+/**
+ * Test load() duplicate finder aliasing
+ *
+ * @return void
+ */
+	public function testLoadDuplicateFinderAliasing() {
+		$this->Behaviors->load('Tree');
+		$this->Behaviors->load('Duplicate', [
+			'implementedFinders' => [
+				'renamed' => 'findChildren',
+			]
+		]);
+		$this->assertTrue($this->Behaviors->hasFinder('renamed'));
+	}
+
+/**
  * test hasMethod()
  *
  * @return void

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -34,6 +34,7 @@ class TestBehavior extends Behavior {
  * Test Stub.
  */
 class Test2Behavior extends Behavior {
+
 	protected $_defaultConfig = [
 		'implementedFinders' => [
 			'foo' => 'findFoo',

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -34,6 +34,14 @@ class TestBehavior extends Behavior {
  * Test Stub.
  */
 class Test2Behavior extends Behavior {
+	protected $_defaultConfig = [
+		'implementedFinders' => [
+			'foo' => 'findFoo',
+		],
+		'implementedMethods' => [
+			'doSomething' => 'doSomething',
+		]
+	];
 
 /**
  * Test for event bindings.
@@ -239,7 +247,7 @@ class BehaviorTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
 		$expected = [
-			'foo' => 'findFoo'
+			'foo' => 'findFoo',
 		];
 		$this->assertEquals($expected, $behavior->implementedFinders());
 	}
@@ -272,8 +280,7 @@ class BehaviorTest extends TestCase {
 		$behavior = new Test2Behavior($table, [
 			'implementedFinders' => []
 		]);
-		$expected = [];
-		$this->assertEquals($expected, $behavior->implementedFinders());
+		$this->assertEquals([], $behavior->implementedFinders());
 	}
 
 /**

--- a/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
@@ -20,6 +20,17 @@ use Cake\ORM\Behavior;
  * Test class for trigging duplicate method errors.
  */
 class DuplicateBehavior extends Behavior {
+	protected $_defaultConfig = [
+		'implementedFinders' => [
+			'children' => 'findChildren',
+		],
+		'implementedMethods' => [
+			'slugify' => 'slugify',
+		]
+	];
+
+	public function findChildren() {
+	}
 
 	public function slugify() {
 	}

--- a/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
@@ -20,6 +20,7 @@ use Cake\ORM\Behavior;
  * Test class for trigging duplicate method errors.
  */
 class DuplicateBehavior extends Behavior {
+
 	protected $_defaultConfig = [
 		'implementedFinders' => [
 			'children' => 'findChildren',


### PR DESCRIPTION
Because of how configuration is merged, and that the aliases are keys not values, it was effectively impossible to remap behaviour methods that were defined in `_defaultConfig`. I have fixed the code to behave as intended. It requires a few extra calls to config only in the case where methods are remapped, which I think is acceptable. If others don't agree, I think we will need to change the interface.

Refs #4414
