### PR TITLE
Cleanup AuthComponent and Authorize classes.

### DIFF
--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -17,7 +17,6 @@ namespace Cake\Auth;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Error;
 use Cake\Network\Request;
 use Cake\Utility\Inflector;
 
@@ -31,13 +30,6 @@ abstract class BaseAuthorize {
 	use InstanceConfigTrait;
 
 /**
- * Controller for the request.
- *
- * @var Controller
- */
-	protected $_Controller = null;
-
-/**
  * ComponentRegistry instance for getting more components.
  *
  * @var ComponentRegistry
@@ -47,25 +39,9 @@ abstract class BaseAuthorize {
 /**
  * Default config for authorize objects.
  *
- * - `actionPath` - The path to ACO nodes that contains the nodes for controllers. Used as a prefix
- *    when calling $this->action();
- * - `actionMap` - Action -> crud mappings. Used by authorization objects that want to map actions to CRUD roles.
- * - `userModel` - Model name that ARO records can be found under. Defaults to 'User'.
- *
  * @var array
  */
-	protected $_defaultConfig = [
-		'actionPath' => null,
-		'actionMap' => [
-			'index' => 'read',
-			'add' => 'create',
-			'edit' => 'update',
-			'view' => 'read',
-			'delete' => 'delete',
-			'remove' => 'delete'
-		],
-		'userModel' => 'Users'
-	];
+	protected $_defaultConfig = [];
 
 /**
  * Constructor
@@ -75,8 +51,6 @@ abstract class BaseAuthorize {
  */
 	public function __construct(ComponentRegistry $registry, array $config = array()) {
 		$this->_registry = $registry;
-		$controller = $registry->getController();
-		$this->controller($controller);
 		$this->config($config);
 	}
 
@@ -88,88 +62,5 @@ abstract class BaseAuthorize {
  * @return bool
  */
 	abstract public function authorize($user, Request $request);
-
-/**
- * Accessor to the controller object.
- *
- * @param Controller $controller null to get, a controller to set.
- * @return mixed
- * @throws \Cake\Error\Exception
- */
-	public function controller(Controller $controller = null) {
-		if ($controller) {
-			if (!$controller instanceof Controller) {
-				throw new Error\Exception('$controller needs to be an instance of Controller');
-			}
-			$this->_Controller = $controller;
-			return true;
-		}
-		return $this->_Controller;
-	}
-
-/**
- * Get the action path for a given request. Primarily used by authorize objects
- * that need to get information about the plugin, controller, and action being invoked.
- *
- * @param \Cake\Network\Request $request The request a path is needed for.
- * @param string $path Path
- * @return string The action path for the given request.
- */
-	public function action(Request $request, $path = '/:plugin/:controller/:action') {
-		$plugin = empty($request['plugin']) ? null : Inflector::camelize($request['plugin']) . '/';
-		$path = str_replace(
-			array(':controller', ':action', ':plugin/'),
-			array(Inflector::camelize($request['controller']), $request['action'], $plugin),
-			$this->_config['actionPath'] . $path
-		);
-		$path = str_replace('//', '/', $path);
-		return trim($path, '/');
-	}
-
-/**
- * Maps crud actions to actual action names. Used to modify or get the current mapped actions.
- *
- * Create additional mappings for a standard CRUD operation:
- *
- * {{{
- * $this->Auth->mapActions(array('create' => array('add', 'register'));
- * }}}
- *
- * Or equivalently:
- *
- * {{{
- * $this->Auth->mapActions(array('register' => 'create', 'add' => 'create'));
- * }}}
- *
- * Create mappings for custom CRUD operations:
- *
- * {{{
- * $this->Auth->mapActions(array('range' => 'search'));
- * }}}
- *
- * You can use the custom CRUD operations to create additional generic permissions
- * that behave like CRUD operations. Doing this will require additional columns on the
- * permissions lookup. For example if one wanted an additional search CRUD operation
- * one would create and additional column '_search' in the aros_acos table. One could
- * create a custom admin CRUD operation for administration functions similarly if needed.
- *
- * @param array $map Either an array of mappings, or undefined to get current values.
- * @return mixed Either the current mappings or null when setting.
- * @see AuthComponent::mapActions()
- */
-	public function mapActions(array $map = array()) {
-		if (empty($map)) {
-			return $this->_config['actionMap'];
-		}
-		foreach ($map as $action => $type) {
-			if (is_array($type)) {
-				foreach ($type as $typedAction) {
-					$this->_config['actionMap'][$typedAction] = $action;
-				}
-			} else {
-				$this->_config['actionMap'][$action] = $type;
-			}
-		}
-	}
 
 }

--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -14,44 +14,66 @@
  */
 namespace Cake\Auth;
 
+use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Error;
+use Cake\Error\Exception;
 use Cake\Network\Request;
 
 /**
- * An authorization adapter for AuthComponent. Provides the ability to authorize using a controller callback.
- * Your controller's isAuthorized() method should return a boolean to indicate whether or not the user is authorized.
+ * An authorization adapter for AuthComponent. Provides the ability to authorize
+ * using a controller callback. Your controller's isAuthorized() method should
+ * return a boolean to indicate whether or not the user is authorized.
  *
  * {{{
  *	public function isAuthorized($user) {
- *		if (!empty($this->request->params['admin'])) {
+ *		if ($this->request->param('admin')) {
  *			return $user['role'] === 'admin';
  *		}
  *		return !empty($user);
  *	}
  * }}}
  *
- * the above is simple implementation that would only authorize users of the 'admin' role to access
- * admin routing.
+ * The above is simple implementation that would only authorize users of the
+ * 'admin' role to access admin routing.
  *
  * @see AuthComponent::$authenticate
  */
 class ControllerAuthorize extends BaseAuthorize {
 
 /**
- * Get/set the controller this authorize object will be working with. Also checks that isAuthorized is implemented.
+ * Controller for the request.
+ *
+ * @var \Cake\Controller\Controller
+ */
+	protected $_Controller = null;
+
+/**
+ * {@inheritDoc}
+ */
+	public function __construct(ComponentRegistry $registry, array $config = array()) {
+		parent::__construct($registry, $config);
+		$this->controller($registry->getController());
+	}
+
+/**
+ * Get/set the controller this authorize object will be working with. Also
+ * checks that isAuthorized is implemented.
  *
  * @param Controller $controller null to get, a controller to set.
- * @return mixed
- * @throws \Cake\Error\Exception
+ * @return \Cake\Controller\Controller
+ * @throws \Cake\Error\Exception If controller does not have method `isAuthorized()`.
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {
 			if (!method_exists($controller, 'isAuthorized')) {
-				throw new Error\Exception(sprintf('%s does not implement an isAuthorized() method.', get_class($controller)));
+				throw new Exception(sprintf(
+					'%s does not implement an isAuthorized() method.',
+					get_class($controller)
+				));
 			}
+			$this->_Controller = $controller;
 		}
-		return parent::controller($controller);
+		return $this->_Controller;
 	}
 
 /**

--- a/src/Auth/WeakPasswordHasher.php
+++ b/src/Auth/WeakPasswordHasher.php
@@ -15,6 +15,8 @@
 namespace Cake\Auth;
 
 use Cake\Auth\AbstractPasswordHasher;
+use Cake\Core\Configure;
+use Cake\Utility\Debugger;
 use Cake\Utility\Security;
 
 /**
@@ -33,6 +35,16 @@ class WeakPasswordHasher extends AbstractPasswordHasher {
 	protected $_defaultConfig = [
 		'hashType' => null
 	];
+
+/**
+ * {@inheritDoc}
+ */
+	public function __construct(array $config = []) {
+		if (Configure::read('debug')) {
+			Debugger::checkSecurityKeys();
+		}
+		parent::config($config);
+	}
 
 /**
  * Generates password hash.

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -561,27 +561,6 @@ class AuthComponent extends Component {
 	}
 
 /**
- * Maps action names to CRUD operations.
- *
- * Used for controller-based authentication. Make sure
- * to configure the authorize property before calling this method. As it delegates $map to all the
- * attached authorize objects.
- *
- * @param array $map Actions to map
- * @return void
- * @see BaseAuthorize::mapActions()
- * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#mapping-actions-when-using-crudauthorize
- */
-	public function mapActions(array $map = array()) {
-		if (empty($this->_authorizeObjects)) {
-			$this->constructAuthorize();
-		}
-		foreach ($this->_authorizeObjects as $auth) {
-			$auth->mapActions($map);
-		}
-	}
-
-/**
  * Set provided user info to session as logged in user.
  *
  * The user record is written to the session key specified in AuthComponent::$sessionKey.

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -18,13 +18,11 @@ use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
-use Cake\Core\Configure;
 use Cake\Error;
 use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
-use Cake\Utility\Debugger;
 use Cake\Utility\Hash;
 
 /**
@@ -249,10 +247,6 @@ class AuthComponent extends Component {
 		$this->response = $controller->response;
 		$this->_methods = $controller->methods;
 		$this->session = $controller->request->session();
-
-		if (Configure::read('debug')) {
-			Debugger::checkSecurityKeys();
-		}
 	}
 
 /**

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -24,6 +24,17 @@ use Cake\TestSuite\TestCase;
 class WeakPasswordHasherTest extends TestCase {
 
 /**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+
+		Configure::write('Security.salt', 'YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
+	}
+
+/**
  * Tests that any password not produced by WeakPasswordHasher needs
  * to be rehashed
  *

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Auth;
 
 use Cake\Auth\WeakPasswordHasher;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1045,26 +1045,6 @@ class AuthComponentTest extends TestCase {
 	}
 
 /**
- * test mapActions loading and delegating to authorize objects.
- *
- * @return void
- */
-	public function testMapActionsDelegation() {
-		$MapActionMockAuthorize = $this->getMock(
-			'Cake\Controller\Component\Auth\BaseAuthorize',
-			array('authorize', 'mapActions'), array(), '', false
-		);
-
-		$this->Auth->authorize = array('MapActionMock');
-		$this->Auth->setAuthorizeObject(0, $MapActionMockAuthorize);
-		$MapActionMockAuthorize->expects($this->once())
-			->method('mapActions')
-			->with(array('create' => array('my_action')));
-
-		$this->Auth->mapActions(array('create' => array('my_action')));
-	}
-
-/**
  * test setting user info to session.
  *
  * @return void


### PR DESCRIPTION
mapActions(), action() methods were removed from BaseAuthorized. They should be
added to appropriate class in Acl plugin. BaseAuthorized::controller() has been
removed. ControllerAuthorize::controller() provides the required getter/setter.

I'll update tests once I get the :+1: to proposed pruning.
