### PR TITLE
3.0 move Configure namespace to Core\Configure

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,5 +17,7 @@ define('TIME_START', microtime(true));
 
 // Compatibility aliases. These will be removed for the first RC release.
 class_alias('Cake\Error\Debugger', 'Cake\Utility\Debugger');
+class_alias('Cake\Core\Configure\Engine\PhpConfig', 'Cake\Configure\Engine\PhpConfig');
+class_alias('Cake\Core\Configure\Engine\IniConfig', 'Cake\Configure\Engine\IniConfig');
 
 require CAKE . 'basics.php';

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -15,8 +15,8 @@
 namespace Cake\Core;
 
 use Cake\Cache\Cache;
-use Cake\Configure\ConfigEngineInterface;
-use Cake\Configure\Engine\PhpConfig;
+use Cake\Core\Configure\ConfigEngineInterface;
+use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Error\Exception;
 use Cake\Utility\Hash;
 

--- a/src/Core/Configure/ConfigEngineInterface.php
+++ b/src/Core/Configure/ConfigEngineInterface.php
@@ -12,7 +12,7 @@
  * @since         1.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Configure;
+namespace Cake\Core\Configure;
 
 /**
  * An interface for creating objects compatible with Configure::load()

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -12,9 +12,9 @@
  * @since         2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Configure\Engine;
+namespace Cake\Core\Configure\Engine;
 
-use Cake\Configure\ConfigEngineInterface;
+use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Plugin;
 use Cake\Error;
 use Cake\Utility\Hash;

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -12,9 +12,9 @@
  * @since         2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Configure\Engine;
+namespace Cake\Core\Configure\Engine;
 
-use Cake\Configure\ConfigEngineInterface;
+use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Plugin;
 use Cake\Error;
 

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View;
 
-use Cake\Configure\Engine\PhpConfig;
+use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\InstanceConfigTrait;
 
 /**

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -12,10 +12,10 @@
  * @since         2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Configure\Engine;
+namespace Cake\Test\TestCase\Core\Configure\Engine;
 
-use Cake\Configure\Engine\IniConfig;
 use Cake\Core\App;
+use Cake\Core\Configure\Engine\IniConfig;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -12,10 +12,10 @@
  * @since         2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Configure\Engine;
+namespace Cake\Test\TestCase\Core\Configure\Engine;
 
-use Cake\Configure\Engine\PhpConfig;
 use Cake\Core\App;
+use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -15,9 +15,9 @@
 namespace Cake\Test\TestCase\Core;
 
 use Cake\Cache\Cache;
-use Cake\Configure\Engine\PhpConfig;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 


### PR DESCRIPTION
refers to #4416

Move Cake\Configure to Cake\Core\Configure.

I'll update the docs if this is going to be merged
