### PR TITLE
3.0 move exception

### DIFF
--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -16,8 +16,8 @@ namespace Cake\Auth;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
+use Cake\Core\Error\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Error;
 use Cake\Network\Request;
 use Cake\Utility\Inflector;
 
@@ -99,7 +99,7 @@ abstract class BaseAuthorize {
 	public function controller(Controller $controller = null) {
 		if ($controller) {
 			if (!$controller instanceof Controller) {
-				throw new Error\Exception('$controller needs to be an instance of Controller');
+				throw new Exception('$controller needs to be an instance of Controller');
 			}
 			$this->_Controller = $controller;
 			return true;

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -94,7 +94,7 @@ abstract class BaseAuthorize {
  *
  * @param Controller $controller null to get, a controller to set.
  * @return mixed
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -16,7 +16,7 @@ namespace Cake\Auth;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Network\Request;
 use Cake\Utility\Inflector;
@@ -94,7 +94,7 @@ abstract class BaseAuthorize {
  *
  * @param Controller $controller null to get, a controller to set.
  * @return mixed
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {

--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -43,7 +43,7 @@ class ControllerAuthorize extends BaseAuthorize {
  *
  * @param Controller $controller null to get, a controller to set.
  * @return mixed
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {

--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -15,7 +15,7 @@
 namespace Cake\Auth;
 
 use Cake\Controller\Controller;
-use Cake\Error;
+use Cake\Core\Error;
 use Cake\Network\Request;
 
 /**

--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -15,7 +15,7 @@
 namespace Cake\Auth;
 
 use Cake\Controller\Controller;
-use Cake\Core\Error;
+use Cake\Core\Error\Exception;
 use Cake\Network\Request;
 
 /**
@@ -48,7 +48,7 @@ class ControllerAuthorize extends BaseAuthorize {
 	public function controller(Controller $controller = null) {
 		if ($controller) {
 			if (!method_exists($controller, 'isAuthorized')) {
-				throw new Error\Exception(sprintf('%s does not implement an isAuthorized() method.', get_class($controller)));
+				throw new Exception(sprintf('%s does not implement an isAuthorized() method.', get_class($controller)));
 			}
 		}
 		return parent::controller($controller);

--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -15,7 +15,7 @@
 namespace Cake\Auth;
 
 use Cake\Controller\Controller;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Network\Request;
 
 /**
@@ -43,7 +43,7 @@ class ControllerAuthorize extends BaseAuthorize {
  *
  * @param Controller $controller null to get, a controller to set.
  * @return mixed
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -15,7 +15,7 @@
 namespace Cake\Cache;
 
 use Cake\Cache\Engine\NullEngine;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\StaticConfigTrait;
 
 /**
@@ -61,7 +61,7 @@ use Cake\Core\StaticConfigTrait;
  * @param string $name Name of the configuration
  * @param array $config Optional associative array of settings passed to the engine
  * @return array [engine, settings] on success, false on failure
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 class Cache {
 
@@ -100,7 +100,7 @@ class Cache {
  *
  * @param string $name Name of the config array that needs an engine instance built
  * @return void
- * @throws \Cake\Core\Error\Exception When a cache engine cannot be created.
+ * @throws \Cake\Core\Exception\Exception When a cache engine cannot be created.
  */
 	protected static function _buildEngine($name) {
 		if (empty(static::$_registry)) {
@@ -213,7 +213,7 @@ class Cache {
  * @param array $data An array of data to be stored in the cache
  * @param string $config Optional string configuration name to write to. Defaults to 'default'
  * @return array of bools for each key provided, indicating true for success or false for fail
- * @throws Cake\Core\Error\Exception
+ * @throws Cake\Core\Exception\Exception
  */
 	public static function writeMany($data, $config = 'default') {
 		$engine = static::engine($config);
@@ -394,7 +394,7 @@ class Cache {
  *
  * @param string $group group name or null to retrieve all group mappings
  * @return array map of group and all configuration that has the same group
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public static function groupConfigs($group = null) {
 		if ($group === null) {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Cache;
 
-use Cake\Core\StaticConfigTrait;
 use Cake\Cache\Engine\NullEngine;
-use Cake\Error;
+use Cake\Core\Error\Exception;
+use Cake\Core\StaticConfigTrait;
 
 /**
  * Cache provides a consistent interface to Caching in your application. It allows you
@@ -100,14 +100,14 @@ class Cache {
  *
  * @param string $name Name of the config array that needs an engine instance built
  * @return void
- * @throws \Cake\Error\Exception When a cache engine cannot be created.
+ * @throws \Cake\Core\Error\Exception When a cache engine cannot be created.
  */
 	protected static function _buildEngine($name) {
 		if (empty(static::$_registry)) {
 			static::$_registry = new CacheRegistry();
 		}
 		if (empty(static::$_config[$name]['className'])) {
-			throw new Error\Exception(sprintf('The "%s" cache configuration does not exist.', $name));
+			throw new Exception(sprintf('The "%s" cache configuration does not exist.', $name));
 		}
 
 		$config = static::$_config[$name];
@@ -213,14 +213,14 @@ class Cache {
  * @param array $data An array of data to be stored in the cache
  * @param string $config Optional string configuration name to write to. Defaults to 'default'
  * @return array of bools for each key provided, indicating true for success or false for fail
- * @throws \Cake\Core\Error\Exception
+ * @throws Cake\Core\Error\Exception
  */
 	public static function writeMany($data, $config = 'default') {
 		$engine = static::engine($config);
 		$return = $engine->writeMany($data);
 		foreach ($return as $key => $success) {
 			if ($success === false && !empty($data[$key])) {
-				throw new Error\Exception(sprintf(
+				throw new Exception(sprintf(
 					'%s cache was unable to write \'%s\' to %s cache',
 					$config,
 					$key,
@@ -405,7 +405,7 @@ class Cache {
 			return [$group => self::$_groups[$group]];
 		}
 
-		throw new Error\Exception(sprintf('Invalid cache group %s', $group));
+		throw new Exception(sprintf('Invalid cache group %s', $group));
 	}
 
 /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -61,7 +61,7 @@ use Cake\Error;
  * @param string $name Name of the configuration
  * @param array $config Optional associative array of settings passed to the engine
  * @return array [engine, settings] on success, false on failure
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 class Cache {
 
@@ -213,7 +213,7 @@ class Cache {
  * @param array $data An array of data to be stored in the cache
  * @param string $config Optional string configuration name to write to. Defaults to 'default'
  * @return array of bools for each key provided, indicating true for success or false for fail
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public static function writeMany($data, $config = 'default') {
 		$engine = static::engine($config);
@@ -394,7 +394,7 @@ class Cache {
  *
  * @param string $group group name or null to retrieve all group mappings
  * @return array map of group and all configuration that has the same group
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public static function groupConfigs($group = null) {
 		if ($group === null) {

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -15,7 +15,7 @@
 namespace Cake\Cache;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\ObjectRegistry;
 
 /**
@@ -48,7 +48,7 @@ class CacheRegistry extends ObjectRegistry {
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the cache is missing in.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Exception(sprintf('Cache engine %s is not available.', $class));
@@ -63,7 +63,7 @@ class CacheRegistry extends ObjectRegistry {
  * @param string $alias The alias of the object.
  * @param array $config An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
- * @throws \Cake\Core\Error\Exception when an object doesn't implement
+ * @throws \Cake\Core\Exception\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $alias, $config) {

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -48,7 +48,7 @@ class CacheRegistry extends ObjectRegistry {
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the cache is missing in.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\Exception(sprintf('Cache engine %s is not available.', $class));
@@ -63,7 +63,7 @@ class CacheRegistry extends ObjectRegistry {
  * @param string $alias The alias of the object.
  * @param array $config An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
- * @throws \Cake\Error\Exception when an object doesn't implement
+ * @throws \Cake\Core\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $alias, $config) {

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -15,7 +15,7 @@
 namespace Cake\Cache;
 
 use Cake\Core\App;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Utility\ObjectRegistry;
 
 /**
@@ -51,7 +51,7 @@ class CacheRegistry extends ObjectRegistry {
  * @throws \Cake\Core\Error\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
-		throw new Error\Exception(sprintf('Cache engine %s is not available.', $class));
+		throw new Exception(sprintf('Cache engine %s is not available.', $class));
 	}
 
 /**
@@ -77,13 +77,13 @@ class CacheRegistry extends ObjectRegistry {
 		}
 
 		if (!($instance instanceof CacheEngine)) {
-			throw new Error\Exception(
+			throw new Exception(
 				'Cache engines must use Cake\Cache\CacheEngine as a base class.'
 			);
 		}
 
 		if (!$instance->init($config)) {
-			throw new Error\Exception(
+			throw new Exception(
 				sprintf('Cache engine %s is not properly configured.', get_class($instance))
 			);
 		}

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -320,7 +320,7 @@ class FileEngine extends CacheEngine {
  * @param string $key The key to decrement
  * @param int $offset The number to offset
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function decrement($key, $offset = 1) {
 		throw new Error\Exception('Files cannot be atomically decremented.');
@@ -332,7 +332,7 @@ class FileEngine extends CacheEngine {
  * @param string $key The key to decrement
  * @param int $offset The number to offset
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function increment($key, $offset = 1) {
 		throw new Error\Exception('Files cannot be atomically incremented.');

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -16,7 +16,7 @@ namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\Inflector;
 
 /**
@@ -320,7 +320,7 @@ class FileEngine extends CacheEngine {
  * @param string $key The key to decrement
  * @param int $offset The number to offset
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function decrement($key, $offset = 1) {
 		throw new Exception('Files cannot be atomically decremented.');
@@ -332,7 +332,7 @@ class FileEngine extends CacheEngine {
  * @param string $key The key to decrement
  * @param int $offset The number to offset
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function increment($key, $offset = 1) {
 		throw new Exception('Files cannot be atomically incremented.');

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -16,7 +16,7 @@ namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
 use Cake\Core\Configure;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Utility\Inflector;
 
 /**
@@ -323,7 +323,7 @@ class FileEngine extends CacheEngine {
  * @throws \Cake\Core\Error\Exception
  */
 	public function decrement($key, $offset = 1) {
-		throw new Error\Exception('Files cannot be atomically decremented.');
+		throw new Exception('Files cannot be atomically decremented.');
 	}
 
 /**
@@ -335,7 +335,7 @@ class FileEngine extends CacheEngine {
  * @throws \Cake\Core\Error\Exception
  */
 	public function increment($key, $offset = 1) {
-		throw new Error\Exception('Files cannot be atomically incremented.');
+		throw new Exception('Files cannot be atomically incremented.');
 	}
 
 /**

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -15,7 +15,7 @@
 namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\Inflector;
 use \Memcached;
 
@@ -94,7 +94,7 @@ class MemcachedEngine extends CacheEngine {
  *
  * @param array $config array of setting for the engine
  * @return bool True if the engine has been successfully initialized, false if not
- * @throws \Cake\Core\Error\Exception when you try use authentication without Memcached compiled with SASL support
+ * @throws \Cake\Core\Exception\Exception when you try use authentication without Memcached compiled with SASL support
  */
 	public function init(array $config = []) {
 		if (!class_exists('Memcached')) {
@@ -166,7 +166,7 @@ class MemcachedEngine extends CacheEngine {
  * Settings the memcached instance
  *
  * @return void
- * @throws \Cake\Core\Error\Exception when the Memcached extension is not built with the desired serializer engine
+ * @throws \Cake\Core\Exception\Exception when the Memcached extension is not built with the desired serializer engine
  */
 	protected function _setOptions() {
 		$this->_Memcached->setOption(Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
@@ -303,7 +303,7 @@ class MemcachedEngine extends CacheEngine {
  * @param string $key Identifier for the data
  * @param int $offset How much to increment
  * @return bool|int New incremented value, false otherwise
- * @throws \Cake\Core\Error\Exception when you try to increment with compress = true
+ * @throws \Cake\Core\Exception\Exception when you try to increment with compress = true
  */
 	public function increment($key, $offset = 1) {
 		$key = $this->_key($key);
@@ -317,7 +317,7 @@ class MemcachedEngine extends CacheEngine {
  * @param string $key Identifier for the data
  * @param int $offset How much to subtract
  * @return bool|int New decremented value, false otherwise
- * @throws \Cake\Core\Error\Exception when you try to decrement with compress = true
+ * @throws \Cake\Core\Exception\Exception when you try to decrement with compress = true
  */
 	public function decrement($key, $offset = 1) {
 		$key = $this->_key($key);

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -15,7 +15,7 @@
 namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Utility\Inflector;
 use \Memcached;
 
@@ -152,7 +152,7 @@ class MemcachedEngine extends CacheEngine {
 
 		if ($this->_config['login'] !== null && $this->_config['password'] !== null) {
 			if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
-				throw new Error\Exception(
+				throw new Exception(
 					'Memcached extension is not build with SASL support'
 				);
 			}
@@ -173,13 +173,13 @@ class MemcachedEngine extends CacheEngine {
 
 		$serializer = strtolower($this->_config['serialize']);
 		if (!isset($this->_serializers[$serializer])) {
-			throw new Error\Exception(
+			throw new Exception(
 				sprintf('%s is not a valid serializer engine for Memcached', $serializer)
 			);
 		}
 
 		if ($serializer !== 'php' && !constant('Memcached::HAVE_' . strtoupper($serializer))) {
-			throw new Error\Exception(
+			throw new Exception(
 				sprintf('Memcached extension is not compiled with %s support', $serializer)
 			);
 		}

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -94,7 +94,7 @@ class MemcachedEngine extends CacheEngine {
  *
  * @param array $config array of setting for the engine
  * @return bool True if the engine has been successfully initialized, false if not
- * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
+ * @throws \Cake\Core\Error\Exception when you try use authentication without Memcached compiled with SASL support
  */
 	public function init(array $config = []) {
 		if (!class_exists('Memcached')) {
@@ -166,7 +166,7 @@ class MemcachedEngine extends CacheEngine {
  * Settings the memcached instance
  *
  * @return void
- * @throws \Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
+ * @throws \Cake\Core\Error\Exception when the Memcached extension is not built with the desired serializer engine
  */
 	protected function _setOptions() {
 		$this->_Memcached->setOption(Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
@@ -303,7 +303,7 @@ class MemcachedEngine extends CacheEngine {
  * @param string $key Identifier for the data
  * @param int $offset How much to increment
  * @return bool|int New incremented value, false otherwise
- * @throws \Cake\Error\Exception when you try to increment with compress = true
+ * @throws \Cake\Core\Error\Exception when you try to increment with compress = true
  */
 	public function increment($key, $offset = 1) {
 		$key = $this->_key($key);
@@ -317,7 +317,7 @@ class MemcachedEngine extends CacheEngine {
  * @param string $key Identifier for the data
  * @param int $offset How much to subtract
  * @return bool|int New decremented value, false otherwise
- * @throws \Cake\Error\Exception when you try to decrement with compress = true
+ * @throws \Cake\Core\Error\Exception when you try to decrement with compress = true
  */
 	public function decrement($key, $offset = 1) {
 		$key = $this->_key($key);

--- a/src/Configure/Engine/IniConfig.php
+++ b/src/Configure/Engine/IniConfig.php
@@ -92,7 +92,7 @@ class IniConfig implements ConfigEngineInterface {
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix. The chosen file must be on the engine's path.
  * @return array Parsed configuration values.
- * @throws \Cake\Error\Exception when files don't exist.
+ * @throws \Cake\Core\Error\Exception when files don't exist.
  *  Or when files contain '..' as this could lead to abusive reads.
  */
 	public function read($key) {

--- a/src/Configure/Engine/PhpConfig.php
+++ b/src/Configure/Engine/PhpConfig.php
@@ -55,7 +55,7 @@ class PhpConfig implements ConfigEngineInterface {
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix.
  * @return array Parsed configuration values.
- * @throws \Cake\Error\Exception when files don't exist or they don't contain `$config`.
+ * @throws \Cake\Core\Error\Exception when files don't exist or they don't contain `$config`.
  *  Or when files contain '..' as this could lead to abusive reads.
  */
 	public function read($key) {

--- a/src/Console/Error/ConsoleException.php
+++ b/src/Console/Error/ConsoleException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception class for Console libraries.  This exception will be thrown from Console library

--- a/src/Console/Error/ConsoleException.php
+++ b/src/Console/Error/ConsoleException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception class for Console libraries.  This exception will be thrown from Console library

--- a/src/Console/Error/MissingShellException.php
+++ b/src/Console/Error/MissingShellException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a shell cannot be found.

--- a/src/Console/Error/MissingShellException.php
+++ b/src/Console/Error/MissingShellException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a shell cannot be found.

--- a/src/Console/Error/MissingShellMethodException.php
+++ b/src/Console/Error/MissingShellMethodException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a shell method cannot be found.

--- a/src/Console/Error/MissingShellMethodException.php
+++ b/src/Console/Error/MissingShellMethodException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a shell method cannot be found.

--- a/src/Console/Error/MissingTaskException.php
+++ b/src/Console/Error/MissingTaskException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a Task cannot be found.

--- a/src/Console/Error/MissingTaskException.php
+++ b/src/Console/Error/MissingTaskException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Console\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a Task cannot be found.

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -16,7 +16,7 @@ namespace Cake\Console;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\Inflector;
 
 /**
@@ -100,7 +100,7 @@ class ShellDispatcher {
  * Defines current working environment.
  *
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	protected function _initEnvironment() {
 		if (!$this->_bootstrap()) {

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -16,7 +16,7 @@ namespace Cake\Console;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Utility\Inflector;
 
 /**
@@ -100,7 +100,7 @@ class ShellDispatcher {
  * Defines current working environment.
  *
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	protected function _initEnvironment() {
 		if (!$this->_bootstrap()) {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -19,6 +19,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\Error\Exception;
 use Cake\Error;
 use Cake\Error\Debugger;
 use Cake\Event\Event;
@@ -499,10 +500,10 @@ class AuthComponent extends Component {
 		foreach ($authorize as $class => $config) {
 			$className = App::className($class, 'Auth', 'Authorize');
 			if (!class_exists($className)) {
-				throw new Error\Exception(sprintf('Authorization adapter "%s" was not found.', $class));
+				throw new Exception(sprintf('Authorization adapter "%s" was not found.', $class));
 			}
 			if (!method_exists($className, 'authorize')) {
-				throw new Error\Exception('Authorization objects must implement an authorize() method.');
+				throw new Exception('Authorization objects must implement an authorize() method.');
 			}
 			$config = (array)$config + $global;
 			$this->_authorizeObjects[] = new $className($this->_registry, $config);
@@ -761,10 +762,10 @@ class AuthComponent extends Component {
 			}
 			$className = App::className($class, 'Auth', 'Authenticate');
 			if (!class_exists($className)) {
-				throw new Error\Exception(sprintf('Authentication adapter "%s" was not found.', $class));
+				throw new Exception(sprintf('Authentication adapter "%s" was not found.', $class));
 			}
 			if (!method_exists($className, 'authenticate')) {
-				throw new Error\Exception('Authentication objects must implement an authenticate() method.');
+				throw new Exception('Authentication objects must implement an authenticate() method.');
 			}
 			$config = array_merge($global, (array)$config);
 			$this->_authenticateObjects[] = new $className($this->_registry, $config);

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -19,7 +19,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Error;
 use Cake\Error\Debugger;
 use Cake\Event\Event;
@@ -484,7 +484,7 @@ class AuthComponent extends Component {
  * Loads the authorization objects configured.
  *
  * @return mixed Either null when authorize is empty, or the loaded authorization objects.
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function constructAuthorize() {
 		if (empty($this->_config['authorize'])) {
@@ -742,7 +742,7 @@ class AuthComponent extends Component {
  * Loads the configured authentication objects.
  *
  * @return mixed either null on empty authenticate value, or an array of loaded objects.
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function constructAuthenticate() {
 		if (empty($this->_config['authenticate'])) {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -483,7 +483,7 @@ class AuthComponent extends Component {
  * Loads the authorization objects configured.
  *
  * @return mixed Either null when authorize is empty, or the loaded authorization objects.
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function constructAuthorize() {
 		if (empty($this->_config['authorize'])) {
@@ -741,7 +741,7 @@ class AuthComponent extends Component {
  * Loads the configured authentication objects.
  *
  * @return mixed either null on empty authenticate value, or an array of loaded objects.
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function constructAuthenticate() {
 		if (empty($this->_config['authenticate'])) {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -19,7 +19,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\Network\Response;
 use Cake\Routing\Router;
@@ -636,7 +636,7 @@ class RequestHandlerComponent extends Component {
  *    be the handling callback, all other arguments should be additional parameters
  *    for the handler.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function addInputType($type, $handler) {
 		if (!is_array($handler) || !isset($handler[0]) || !is_callable($handler[0])) {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -19,7 +19,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Event\Event;
 use Cake\Network\Response;
 use Cake\Routing\Router;
@@ -636,7 +636,7 @@ class RequestHandlerComponent extends Component {
  *    be the handling callback, all other arguments should be additional parameters
  *    for the handler.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function addInputType($type, $handler) {
 		if (!is_array($handler) || !isset($handler[0]) || !is_callable($handler[0])) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Controller;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManagerTrait;
@@ -350,7 +350,7 @@ class Controller implements EventListener {
  * exists and isn't private.
  *
  * @return mixed The resulting response.
- * @throws \Cake\Error\Exception When request is not set.
+ * @throws \Cake\Core\Error\Exception When request is not set.
  * @throws \Cake\Controller\Error\PrivateActionException When actions are not public or prefixed by _
  * @throws \Cake\Controller\Error\MissingActionException When actions are not defined.
  */

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Controller;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManagerTrait;
@@ -350,7 +350,7 @@ class Controller implements EventListener {
  * exists and isn't private.
  *
  * @return mixed The resulting response.
- * @throws \Cake\Core\Error\Exception When request is not set.
+ * @throws \Cake\Core\Exception\Exception When request is not set.
  * @throws \Cake\Controller\Error\PrivateActionException When actions are not public or prefixed by _
  * @throws \Cake\Controller\Error\MissingActionException When actions are not defined.
  */

--- a/src/Controller/Error/MissingActionException.php
+++ b/src/Controller/Error/MissingActionException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Missing Action exception - used when a controller action

--- a/src/Controller/Error/MissingActionException.php
+++ b/src/Controller/Error/MissingActionException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Missing Action exception - used when a controller action

--- a/src/Controller/Error/MissingComponentException.php
+++ b/src/Controller/Error/MissingComponentException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a component cannot be found.

--- a/src/Controller/Error/MissingComponentException.php
+++ b/src/Controller/Error/MissingComponentException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a component cannot be found.

--- a/src/Controller/Error/MissingControllerException.php
+++ b/src/Controller/Error/MissingControllerException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Missing Controller exception - used when a controller

--- a/src/Controller/Error/MissingControllerException.php
+++ b/src/Controller/Error/MissingControllerException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Missing Controller exception - used when a controller

--- a/src/Controller/Error/PrivateActionException.php
+++ b/src/Controller/Error/PrivateActionException.php
@@ -15,7 +15,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Private Action exception - used when a controller action

--- a/src/Controller/Error/PrivateActionException.php
+++ b/src/Controller/Error/PrivateActionException.php
@@ -15,7 +15,7 @@
  */
 namespace Cake\Controller\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Private Action exception - used when a controller action

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -17,7 +17,7 @@ namespace Cake\Core;
 use Cake\Cache\Cache;
 use Cake\Configure\ConfigEngineInterface;
 use Cake\Configure\Engine\PhpConfig;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Utility\Hash;
 
 /**
@@ -281,7 +281,7 @@ class Configure {
  * @param array $keys The name of the top-level keys you want to dump.
  *   This allows you save only some data stored in Configure.
  * @return bool success
- * @throws \Cake\Error\Exception if the adapter does not implement a `dump` method.
+ * @throws \Cake\Core\Error\Exception if the adapter does not implement a `dump` method.
  */
 	public static function dump($key, $config = 'default', $keys = []) {
 		$engine = static::_getEngine($config);

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -17,7 +17,7 @@ namespace Cake\Core;
 use Cake\Cache\Cache;
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\Hash;
 
 /**
@@ -281,7 +281,7 @@ class Configure {
  * @param array $keys The name of the top-level keys you want to dump.
  *   This allows you save only some data stored in Configure.
  * @return bool success
- * @throws \Cake\Core\Error\Exception if the adapter does not implement a `dump` method.
+ * @throws \Cake\Core\Exception\Exception if the adapter does not implement a `dump` method.
  */
 	public static function dump($key, $config = 'default', $keys = []) {
 		$engine = static::_getEngine($config);

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -16,7 +16,7 @@ namespace Cake\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Plugin;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Utility\Hash;
 
 /**
@@ -97,12 +97,12 @@ class IniConfig implements ConfigEngineInterface {
  */
 	public function read($key) {
 		if (strpos($key, '..') !== false) {
-			throw new Error\Exception('Cannot load configuration files with ../ in them.');
+			throw new Exception('Cannot load configuration files with ../ in them.');
 		}
 
 		$file = $this->_getFilePath($key);
 		if (!is_file($file)) {
-			throw new Error\Exception(sprintf('Could not load configuration file: %s', $file));
+			throw new Exception(sprintf('Could not load configuration file: %s', $file));
 		}
 
 		$contents = parse_ini_file($file, true);

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -16,7 +16,7 @@ namespace Cake\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Plugin;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\Hash;
 
 /**
@@ -92,7 +92,7 @@ class IniConfig implements ConfigEngineInterface {
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix. The chosen file must be on the engine's path.
  * @return array Parsed configuration values.
- * @throws \Cake\Core\Error\Exception when files don't exist.
+ * @throws \Cake\Core\Exception\Exception when files don't exist.
  *  Or when files contain '..' as this could lead to abusive reads.
  */
 	public function read($key) {

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -15,8 +15,8 @@
 namespace Cake\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
+use Cake\Core\Error\Exception;
 use Cake\Core\Plugin;
-use Cake\Error;
 
 /**
  * PHP engine allows Configure to load configuration values from
@@ -60,17 +60,17 @@ class PhpConfig implements ConfigEngineInterface {
  */
 	public function read($key) {
 		if (strpos($key, '..') !== false) {
-			throw new Error\Exception('Cannot load configuration files with ../ in them.');
+			throw new Exception('Cannot load configuration files with ../ in them.');
 		}
 
 		$file = $this->_getFilePath($key);
 		if (!is_file($file)) {
-			throw new Error\Exception(sprintf('Could not load configuration file: %s', $file));
+			throw new Exception(sprintf('Could not load configuration file: %s', $file));
 		}
 
 		include $file;
 		if (!isset($config)) {
-			throw new Error\Exception(sprintf('No variable $config found in %s', $file));
+			throw new Exception(sprintf('No variable $config found in %s', $file));
 		}
 		return $config;
 	}

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -15,7 +15,7 @@
 namespace Cake\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\Plugin;
 
 /**
@@ -55,7 +55,7 @@ class PhpConfig implements ConfigEngineInterface {
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix.
  * @return array Parsed configuration values.
- * @throws \Cake\Core\Error\Exception when files don't exist or they don't contain `$config`.
+ * @throws \Cake\Core\Exception\Exception when files don't exist or they don't contain `$config`.
  *  Or when files contain '..' as this could lead to abusive reads.
  */
 	public function read($key) {

--- a/src/Core/Error/Exception.php
+++ b/src/Core/Error/Exception.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Error;
+namespace Cake\Core\Error;
 
 /**
  * Base class that all CakePHP Exceptions extend.
@@ -51,12 +51,12 @@ class Exception extends \RuntimeException {
  *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
  * @param int $code The code of the error, is also the HTTP status code for the error.
  */
-	public function __construct($message, $code = 500) {
+	public function __construct($message, $code = 500, $previous = null) {
 		if (is_array($message)) {
 			$this->_attributes = $message;
 			$message = vsprintf($this->_messageTemplate, $message);
 		}
-		parent::__construct($message, $code);
+		parent::__construct($message, $code, $previous);
 	}
 
 /**

--- a/src/Core/Error/Exception.php
+++ b/src/Core/Error/Exception.php
@@ -50,6 +50,7 @@ class Exception extends \RuntimeException {
  * @param string|array $message Either the string of the error message, or an array of attributes
  *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
  * @param int $code The code of the error, is also the HTTP status code for the error.
+ * @param \Exception $previous the previous exception.
  */
 	public function __construct($message, $code = 500, $previous = null) {
 		if (is_array($message)) {

--- a/src/Core/Error/MissingPluginException.php
+++ b/src/Core/Error/MissingPluginException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Core\Error;
 
-use Cake\Error\Exception;
+use Exception;
 
 /**
  * Exception raised when a plugin could not be found

--- a/src/Core/Error/MissingPluginException.php
+++ b/src/Core/Error/MissingPluginException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Core\Error;
 
-use Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception raised when a plugin could not be found

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Core\Error;
+namespace Cake\Core\Exception;
 
 /**
  * Base class that all CakePHP Exceptions extend.

--- a/src/Core/Exception/MissingPluginException.php
+++ b/src/Core/Exception/MissingPluginException.php
@@ -11,9 +11,9 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Core\Error;
+namespace Cake\Core\Exception;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when a plugin could not be found

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Core;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Utility\Hash;
 
 /**
@@ -69,7 +69,7 @@ trait InstanceConfigTrait {
  * @param mixed|null $value The value to set.
  * @param bool $merge Whether to merge or overwrite existing config, defaults to true.
  * @return mixed Config value being read, or the object itself on write operations.
- * @throws \Cake\Error\Exception When trying to set a key that is invalid.
+ * @throws \Cake\Core\Error\Exception When trying to set a key that is invalid.
  */
 	public function config($key = null, $value = null, $merge = true) {
 		if (!$this->_configInitialized) {
@@ -122,7 +122,7 @@ trait InstanceConfigTrait {
  * @param mixed $value Value to write.
  * @param bool $merge Whether to merge or overwrite value.
  * @return void
- * @throws Cake\Error\Exception if attempting to clobber existing config
+ * @throws Cake\Core\Error\Exception if attempting to clobber existing config
  */
 	protected function _configWrite($key, $value, $merge = false) {
 		if (is_string($key) && $value === null) {
@@ -174,7 +174,7 @@ trait InstanceConfigTrait {
  *
  * @param string $key Key to delete.
  * @return void
- * @throws Cake\Error\Exception if attempting to clobber existing config
+ * @throws Cake\Core\Error\Exception if attempting to clobber existing config
  */
 	protected function _configDelete($key) {
 		if (strpos($key, '.') === false) {

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Core;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\Hash;
 
 /**
@@ -69,7 +69,7 @@ trait InstanceConfigTrait {
  * @param mixed|null $value The value to set.
  * @param bool $merge Whether to merge or overwrite existing config, defaults to true.
  * @return mixed Config value being read, or the object itself on write operations.
- * @throws \Cake\Core\Error\Exception When trying to set a key that is invalid.
+ * @throws \Cake\Core\Exception\Exception When trying to set a key that is invalid.
  */
 	public function config($key = null, $value = null, $merge = true) {
 		if (!$this->_configInitialized) {
@@ -122,7 +122,7 @@ trait InstanceConfigTrait {
  * @param mixed $value Value to write.
  * @param bool $merge Whether to merge or overwrite value.
  * @return void
- * @throws Cake\Core\Error\Exception if attempting to clobber existing config
+ * @throws Cake\Core\Exception\Exception if attempting to clobber existing config
  */
 	protected function _configWrite($key, $value, $merge = false) {
 		if (is_string($key) && $value === null) {
@@ -174,7 +174,7 @@ trait InstanceConfigTrait {
  *
  * @param string $key Key to delete.
  * @return void
- * @throws Cake\Core\Error\Exception if attempting to clobber existing config
+ * @throws Cake\Core\Exception\Exception if attempting to clobber existing config
  */
 	protected function _configDelete($key) {
 		if (strpos($key, '.') === false) {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -95,7 +95,7 @@ abstract class ObjectRegistry {
  * @param string $class The class that is missing.
  * @param string $plugin The plugin $class is missing from.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	abstract protected function _throwMissingClassError($class, $plugin);
 

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -105,7 +105,7 @@ class Plugin {
  *
  * @param string|array $plugin name of the plugin to be loaded in CamelCase format or array or plugins to load
  * @param array $config configuration options for the plugin
- * @throws \Cake\Core\Error\MissingPluginException if the folder for the plugin to be loaded is not found
+ * @throws \Cake\Core\Exception\MissingPluginException if the folder for the plugin to be loaded is not found
  * @return void
  */
 	public static function load($plugin, array $config = []) {
@@ -137,7 +137,7 @@ class Plugin {
 		}
 
 		if (empty($config['path'])) {
-			throw new Error\MissingPluginException(['plugin' => $plugin]);
+			throw new Exception\MissingPluginException(['plugin' => $plugin]);
 		}
 
 		$config['classPath'] = $config['path'] . $config['classBase'] . DS;
@@ -219,11 +219,11 @@ class Plugin {
  *
  * @param string $plugin name of the plugin in CamelCase format
  * @return string path to the plugin folder
- * @throws \Cake\Core\Error\MissingPluginException if the folder for plugin was not found or plugin has not been loaded
+ * @throws \Cake\Core\Exception\MissingPluginException if the folder for plugin was not found or plugin has not been loaded
  */
 	public static function path($plugin) {
 		if (empty(static::$_plugins[$plugin])) {
-			throw new Error\MissingPluginException(['plugin' => $plugin]);
+			throw new Exception\MissingPluginException(['plugin' => $plugin]);
 		}
 		return static::$_plugins[$plugin]['path'];
 	}
@@ -233,11 +233,11 @@ class Plugin {
  *
  * @param string $plugin name of the plugin in CamelCase format.
  * @return string Path to the plugin folder container class folders.
- * @throws \Cake\Core\Error\MissingPluginException If plugin has not been loaded.
+ * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
  */
 	public static function classPath($plugin) {
 		if (empty(static::$_plugins[$plugin])) {
-			throw new Error\MissingPluginException(['plugin' => $plugin]);
+			throw new Exception\MissingPluginException(['plugin' => $plugin]);
 		}
 		return static::$_plugins[$plugin]['classPath'];
 	}
@@ -247,7 +247,7 @@ class Plugin {
  *
  * @param string $plugin name of the plugin in CamelCase format.
  * @return string Path to the plugin folder container config files.
- * @throws \Cake\Core\Error\MissingPluginException If plugin has not been loaded.
+ * @throws \Cake\Core\Exception\MissingPluginException If plugin has not been loaded.
  */
 	public static function configPath($plugin) {
 		if (empty(static::$_plugins[$plugin])) {

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Core;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * A trait that provides a set of static methods to manage configuration
@@ -65,7 +65,7 @@ trait StaticConfigTrait {
  * @param string|array $key The name of the configuration, or an array of multiple configs.
  * @param array $config An array of name => configuration data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws \Cake\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Core\Error\Exception When trying to modify an existing config.
  */
 	public static function config($key, $config = null) {
 		// Read config.

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Core;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * A trait that provides a set of static methods to manage configuration
@@ -65,7 +65,7 @@ trait StaticConfigTrait {
  * @param string|array $key The name of the configuration, or an array of multiple configs.
  * @param array $config An array of name => configuration data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws \Cake\Core\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
  */
 	public static function config($key, $config = null) {
 		// Read config.

--- a/src/Database/Error/MissingConnectionException.php
+++ b/src/Database/Error/MissingConnectionException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Database\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 class MissingConnectionException extends Exception {
 

--- a/src/Database/Error/MissingConnectionException.php
+++ b/src/Database/Error/MissingConnectionException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Database\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 class MissingConnectionException extends Exception {
 

--- a/src/Database/Error/MissingDriverException.php
+++ b/src/Database/Error/MissingDriverException.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Database\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
-class MissingDriverException extends \Cake\Core\Error\Exception {
+class MissingDriverException extends \Cake\Core\Exception\Exception {
 
 /**
  * {@inheritDoc}

--- a/src/Database/Error/MissingDriverException.php
+++ b/src/Database/Error/MissingDriverException.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Database\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
-class MissingDriverException extends \Cake\Error\Exception {
+class MissingDriverException extends \Cake\Core\Error\Exception {
 
 /**
  * {@inheritDoc}

--- a/src/Database/Error/MissingExtensionException.php
+++ b/src/Database/Error/MissingExtensionException.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Database\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
-class MissingExtensionException extends \Cake\Error\Exception {
+class MissingExtensionException extends \Cake\Core\Error\Exception {
 
 /**
  * {@inheritDoc}

--- a/src/Database/Error/MissingExtensionException.php
+++ b/src/Database/Error/MissingExtensionException.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Database\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
-class MissingExtensionException extends \Cake\Core\Error\Exception {
+class MissingExtensionException extends \Cake\Core\Exception\Exception {
 
 /**
  * {@inheritDoc}

--- a/src/Database/Exception.php
+++ b/src/Database/Exception.php
@@ -17,6 +17,6 @@ namespace Cake\Database;
 /**
  * Exception for the database package.
  */
-class Exception extends \Cake\Core\Error\Exception {
+class Exception extends \Cake\Core\Exception\Exception {
 
 }

--- a/src/Database/Exception.php
+++ b/src/Database/Exception.php
@@ -17,6 +17,6 @@ namespace Cake\Database;
 /**
  * Exception for the database package.
  */
-class Exception extends \Cake\Error\Exception {
+class Exception extends \Cake\Core\Error\Exception {
 
 }

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Database\Type;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Database\Driver;
 use PDO;
 
@@ -45,7 +45,7 @@ class BinaryType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Database\Type;
 
+use Cake\Core\Error\Exception;
 use Cake\Database\Driver;
-use Cake\Error;
 use PDO;
 
 /**
@@ -57,7 +57,7 @@ class BinaryType extends \Cake\Database\Type {
 		if (is_resource($value)) {
 			return $value;
 		}
-		throw new Error\Exception(sprintf('Unable to convert %s into binary.', gettype($value)));
+		throw new Exception(sprintf('Unable to convert %s into binary.', gettype($value)));
 	}
 
 /**

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -45,7 +45,7 @@ class BinaryType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -45,7 +45,7 @@ class FloatType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -45,7 +45,7 @@ class FloatType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -45,7 +45,7 @@ class IntegerType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -45,7 +45,7 @@ class IntegerType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -55,7 +55,7 @@ class ConnectionManager {
  * @param string|array $key The name of the connection config, or an array of multiple configs.
  * @param array $config An array of name => config data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws \Cake\Core\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
  * @see \Cake\Core\StaticConfigTrait::config()
  */
 	public static function config($key, $config = null) {

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -55,7 +55,7 @@ class ConnectionManager {
  * @param string|array $key The name of the connection config, or an array of multiple configs.
  * @param array $config An array of name => config data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws \Cake\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Core\Error\Exception When trying to modify an existing config.
  * @see \Cake\Core\StaticConfigTrait::config()
  */
 	public static function config($key, $config = null) {

--- a/src/Datasource/Error/MissingDatasourceConfigException.php
+++ b/src/Datasource/Error/MissingDatasourceConfigException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Datasource\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception class to be thrown when a datasource configuration is not found

--- a/src/Datasource/Error/MissingDatasourceConfigException.php
+++ b/src/Datasource/Error/MissingDatasourceConfigException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Datasource\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception class to be thrown when a datasource configuration is not found

--- a/src/Datasource/Error/MissingDatasourceException.php
+++ b/src/Datasource/Error/MissingDatasourceException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Datasource\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a datasource cannot be found.

--- a/src/Datasource/Error/MissingDatasourceException.php
+++ b/src/Datasource/Error/MissingDatasourceException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Datasource\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a datasource cannot be found.

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -15,7 +15,7 @@
 namespace Cake\Error;
 
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Cake\Utility\String;
@@ -625,7 +625,7 @@ class Debugger {
  * @param string $format The format you want errors to be output as.
  *   Leave null to get the current format.
  * @return mixed Returns null when setting. Returns the current format when getting.
- * @throws \Cake\Core\Error\Exception when choosing a format that doesn't exist.
+ * @throws \Cake\Core\Exception\Exception when choosing a format that doesn't exist.
  */
 	public static function outputAs($format = null) {
 		$self = Debugger::getInstance();

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -17,7 +17,7 @@ namespace Cake\Error;
 use Cake\Controller\Controller;
 use Cake\Controller\ErrorController;
 use Cake\Core\Configure;
-use Cake\Core\Error\MissingPluginException;
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Error;
 use Cake\Event\Event;
 use Cake\Network\Request;
@@ -53,7 +53,7 @@ class ExceptionRenderer {
 	public $controller = null;
 
 /**
- * Template to render for Cake\Core\Error\Exception
+ * Template to render for Cake\Core\Exception\Exception
  *
  * @var string
  */
@@ -75,7 +75,7 @@ class ExceptionRenderer {
 
 /**
  * Creates the controller to perform rendering on the error response.
- * If the error is a Cake\Core\Error\Exception it will be converted to either a 400 or a 500
+ * If the error is a Cake\Core\Exception\Exception it will be converted to either a 400 or a 500
  * code error depending on the code used to construct the error.
  *
  * @param \Exception $exception Exception

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -53,7 +53,7 @@ class ExceptionRenderer {
 	public $controller = null;
 
 /**
- * Template to render for Cake\Error\Exception
+ * Template to render for Cake\Core\Error\Exception
  *
  * @var string
  */
@@ -75,7 +75,7 @@ class ExceptionRenderer {
 
 /**
  * Creates the controller to perform rendering on the error response.
- * If the error is a Cake\Error\Exception it will be converted to either a 400 or a 500
+ * If the error is a Cake\Core\Error\Exception it will be converted to either a 400 or a 500
  * code error depending on the code used to construct the error.
  *
  * @param \Exception $exception Exception

--- a/src/Error/FatalErrorException.php
+++ b/src/Error/FatalErrorException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Represents a fatal error

--- a/src/Error/FatalErrorException.php
+++ b/src/Error/FatalErrorException.php
@@ -13,6 +13,8 @@
  */
 namespace Cake\Error;
 
+use Cake\Core\Error\Exception;
+
 /**
  * Represents a fatal error
  *

--- a/src/Error/HttpException.php
+++ b/src/Error/HttpException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Parent class for all of the HTTP related exceptions in CakePHP.

--- a/src/Error/HttpException.php
+++ b/src/Error/HttpException.php
@@ -13,11 +13,13 @@
  */
 namespace Cake\Error;
 
+use Cake\Core\Error\Exception;
+
 /**
  * Parent class for all of the HTTP related exceptions in CakePHP.
  * All HTTP status/error related exceptions should extend this class so
  * catch blocks can be specifically typed.
  *
  */
-class HttpException extends Exception {
+abstract class HttpException extends Exception {
 }

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -52,7 +52,7 @@ class ConsoleLog extends BaseLog {
  * - `outputAs` integer or ConsoleOutput::[RAW|PLAIN|COLOR]
  *
  * @param array $config Options for the FileLog, see above.
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function __construct(array $config = array()) {
 		if (DS === '\\' && !(bool)env('ANSICON')) {

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -15,7 +15,7 @@
 namespace Cake\Log\Engine;
 
 use Cake\Console\ConsoleOutput;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Console logging. Writes logs to console output.
@@ -52,7 +52,7 @@ class ConsoleLog extends BaseLog {
  * - `outputAs` integer or ConsoleOutput::[RAW|PLAIN|COLOR]
  *
  * @param array $config Options for the FileLog, see above.
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function __construct(array $config = array()) {
 		if (DS === '\\' && !(bool)env('ANSICON')) {

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -15,7 +15,7 @@
 namespace Cake\Log\Engine;
 
 use Cake\Console\ConsoleOutput;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 
 /**
  * Console logging. Writes logs to console output.
@@ -69,7 +69,7 @@ class ConsoleLog extends BaseLog {
 		} elseif (is_string($config['stream'])) {
 			$this->_output = new ConsoleOutput($config['stream']);
 		} else {
-			throw new Error\Exception('`stream` not a ConsoleOutput nor string');
+			throw new Exception('`stream` not a ConsoleOutput nor string');
 		}
 		$this->_output->outputAs($config['outputAs']);
 	}

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -14,7 +14,7 @@
 namespace Cake\Log;
 
 use Cake\Core\StaticConfigTrait;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Log\Engine\BaseLog;
 
 /**
@@ -246,7 +246,7 @@ class Log {
  * @param string|array $key The name of the logger config, or an array of multiple configs.
  * @param array $config An array of name => config data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws \Cake\Core\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
  */
 	public static function config($key, $config = null) {
 		$return = static::_config($key, $config);
@@ -316,7 +316,7 @@ class Log {
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
- * @throws \Cake\Core\Error\Exception If invalid level is passed.
+ * @throws \Cake\Core\Exception\Exception If invalid level is passed.
  */
 	public static function write($level, $message, $scope = array()) {
 		static::_init();

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -246,7 +246,7 @@ class Log {
  * @param string|array $key The name of the logger config, or an array of multiple configs.
  * @param array $config An array of name => config data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws \Cake\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Core\Error\Exception When trying to modify an existing config.
  */
 	public static function config($key, $config = null) {
 		$return = static::_config($key, $config);
@@ -316,7 +316,7 @@ class Log {
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
- * @throws \Cake\Error\Exception If invalid level is passed.
+ * @throws \Cake\Core\Error\Exception If invalid level is passed.
  */
 	public static function write($level, $message, $scope = array()) {
 		static::_init();

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -14,7 +14,7 @@
 namespace Cake\Log;
 
 use Cake\Core\StaticConfigTrait;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Log\Engine\BaseLog;
 
 /**
@@ -325,7 +325,7 @@ class Log {
 		}
 
 		if (!in_array($level, static::$_levels)) {
-			throw new Error\Exception(sprintf('Invalid log level "%s"', $level));
+			throw new Exception(sprintf('Invalid log level "%s"', $level));
 		}
 
 		$logged = false;

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -15,7 +15,7 @@
 namespace Cake\Log;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\ObjectRegistry;
 use Cake\Log\LogInterface;
 
@@ -48,7 +48,7 @@ class LogEngineRegistry extends ObjectRegistry {
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the logger is missing in.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Exception(sprintf('Could not load class %s', $class));
@@ -63,7 +63,7 @@ class LogEngineRegistry extends ObjectRegistry {
  * @param string $alias The alias of the object.
  * @param array $settings An array of settings to use for the logger.
  * @return \Cake\Log\LogInterface The constructed logger class.
- * @throws \Cake\Core\Error\Exception when an object doesn't implement
+ * @throws \Cake\Core\Exception\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $alias, $settings) {

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -15,9 +15,9 @@
 namespace Cake\Log;
 
 use Cake\Core\App;
-use Cake\Error;
-use Cake\Log\LogInterface;
+use Cake\Core\Error\Exception;
 use Cake\Core\ObjectRegistry;
+use Cake\Log\LogInterface;
 
 /**
  * Registry of loaded log engines
@@ -51,7 +51,7 @@ class LogEngineRegistry extends ObjectRegistry {
  * @throws \Cake\Core\Error\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
-		throw new Error\Exception(sprintf('Could not load class %s', $class));
+		throw new Exception(sprintf('Could not load class %s', $class));
 	}
 
 /**
@@ -79,7 +79,7 @@ class LogEngineRegistry extends ObjectRegistry {
 			return $instance;
 		}
 
-		throw new Error\Exception(
+		throw new Exception(
 			'Loggers must implement Cake\Log\LogInterface.'
 		);
 	}

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -48,7 +48,7 @@ class LogEngineRegistry extends ObjectRegistry {
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the logger is missing in.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\Exception(sprintf('Could not load class %s', $class));
@@ -63,7 +63,7 @@ class LogEngineRegistry extends ObjectRegistry {
  * @param string $alias The alias of the object.
  * @param array $settings An array of settings to use for the logger.
  * @return \Cake\Log\LogInterface The constructed logger class.
- * @throws \Cake\Error\Exception when an object doesn't implement
+ * @throws \Cake\Core\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $alias, $settings) {

--- a/src/Model/Error/MissingModelException.php
+++ b/src/Model/Error/MissingModelException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Model\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a model cannot be found.

--- a/src/Model/Error/MissingModelException.php
+++ b/src/Model/Error/MissingModelException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Model\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a model cannot be found.

--- a/src/Model/ModelAwareTrait.php
+++ b/src/Model/ModelAwareTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Model;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Provides functionality for loading table classes
@@ -72,7 +72,7 @@ trait ModelAwareTrait {
  *   delegates to Cake\ORM\TableRegistry.
  * @return bool True when single repository found and instance created.
  * @throws \Cake\Model\Error\MissingModelException If the model class cannot be found.
- * @throws \Cake\Core\Error\Exception When using a type that has not been registered.
+ * @throws \Cake\Core\Exception\Exception When using a type that has not been registered.
  */
 	public function loadModel($modelClass = null, $type = 'Table') {
 		if ($modelClass === null) {

--- a/src/Model/ModelAwareTrait.php
+++ b/src/Model/ModelAwareTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Model;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Provides functionality for loading table classes
@@ -72,7 +72,7 @@ trait ModelAwareTrait {
  *   delegates to Cake\ORM\TableRegistry.
  * @return bool True when single repository found and instance created.
  * @throws \Cake\Model\Error\MissingModelException If the model class cannot be found.
- * @throws \Cake\Error\Exception When using a type that has not been registered.
+ * @throws \Cake\Core\Error\Exception When using a type that has not been registered.
  */
 	public function loadModel($modelClass = null, $type = 'Table') {
 		if ($modelClass === null) {

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -17,7 +17,7 @@ namespace Cake\Network\Email;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\StaticConfigTrait;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Log\Log;
 use Cake\Network\Error;
 use Cake\Network\Http\FormData\Part;
@@ -961,7 +961,7 @@ class Email {
  *
  * @param string $name The transport configuration name to build.
  * @return \Cake\Network\Email\AbstractTransport
- * @throws \Cake\Core\Error\Exception When transport configuration is missing or invalid.
+ * @throws \Cake\Core\Exception\Exception When transport configuration is missing or invalid.
  */
 	protected function _constructTransport($name) {
 		if (!isset(static::$_transportConfig[$name]['className'])) {
@@ -1154,7 +1154,7 @@ class Email {
  * @param array|AbstractTransport $config Either an array of configuration
  *   data, or a transport instance.
  * @return mixed Either null when setting or an array of data when reading.
- * @throws \Cake\Core\Error\Exception When modifying an existing configuration.
+ * @throws \Cake\Core\Exception\Exception When modifying an existing configuration.
  */
 	public static function configTransport($key, $config = null) {
 		if ($config === null && is_string($key)) {
@@ -1301,7 +1301,7 @@ class Email {
  *
  * @param string|array $config Configuration options.
  * @return void
- * @throws \Cake\Core\Error\Exception When using a configuration that doesn't exist.
+ * @throws \Cake\Core\Exception\Exception When using a configuration that doesn't exist.
  */
 	protected function _applyConfig($config) {
 		if (is_string($config)) {

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -17,7 +17,7 @@ namespace Cake\Network\Email;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\StaticConfigTrait;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Log\Log;
 use Cake\Network\Error;
 use Cake\Network\Http\FormData\Part;
@@ -961,7 +961,7 @@ class Email {
  *
  * @param string $name The transport configuration name to build.
  * @return \Cake\Network\Email\AbstractTransport
- * @throws \Cake\Error\Exception When transport configuration is missing or invalid.
+ * @throws \Cake\Core\Error\Exception When transport configuration is missing or invalid.
  */
 	protected function _constructTransport($name) {
 		if (!isset(static::$_transportConfig[$name]['className'])) {
@@ -1154,7 +1154,7 @@ class Email {
  * @param array|AbstractTransport $config Either an array of configuration
  *   data, or a transport instance.
  * @return mixed Either null when setting or an array of data when reading.
- * @throws \Cake\Error\Exception When modifying an existing configuration.
+ * @throws \Cake\Core\Error\Exception When modifying an existing configuration.
  */
 	public static function configTransport($key, $config = null) {
 		if ($config === null && is_string($key)) {
@@ -1301,7 +1301,7 @@ class Email {
  *
  * @param string|array $config Configuration options.
  * @return void
- * @throws \Cake\Error\Exception When using a configuration that doesn't exist.
+ * @throws \Cake\Core\Error\Exception When using a configuration that doesn't exist.
  */
 	protected function _applyConfig($config) {
 		if (is_string($config)) {

--- a/src/Network/Error/SocketException.php
+++ b/src/Network/Error/SocketException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception class for Socket. This exception will be thrown from Socket, Email, HttpSocket

--- a/src/Network/Error/SocketException.php
+++ b/src/Network/Error/SocketException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception class for Socket. This exception will be thrown from Socket, Email, HttpSocket

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -231,7 +231,7 @@ class Stream {
  *
  * @param \Cake\Network\Request $request The request object.
  * @return array Array of populated Response objects
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	protected function _send(Request $request) {
 		$url = $request->url();
@@ -258,7 +258,7 @@ class Stream {
  *
  * @param string $url The url to connect to.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	protected function _open($url) {
 		set_error_handler([$this, '_connectionErrorHandler']);

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Http\Adapter;
 
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Network\Http\FormData;
 use Cake\Network\Http\Request;
 use Cake\Network\Http\Response;
@@ -244,7 +244,7 @@ class Stream {
 		fclose($this->_stream);
 
 		if ($meta['timed_out']) {
-			throw new Error\Exception('Connection timed out ' . $url);
+			throw new Exception('Connection timed out ' . $url);
 		}
 		$headers = $meta['wrapper_data'];
 		if (isset($meta['wrapper_type']) && $meta['wrapper_type'] === 'curl') {
@@ -266,7 +266,7 @@ class Stream {
 		restore_error_handler();
 
 		if (!$this->_stream || !empty($this->_connectionErrors)) {
-			throw new Error\Exception(implode("\n", $this->_connectionErrors));
+			throw new Exception(implode("\n", $this->_connectionErrors));
 		}
 	}
 

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Http\Adapter;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Network\Http\FormData;
 use Cake\Network\Http\Request;
 use Cake\Network\Http\Response;
@@ -231,7 +231,7 @@ class Stream {
  *
  * @param \Cake\Network\Request $request The request object.
  * @return array Array of populated Response objects
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	protected function _send(Request $request) {
 		$url = $request->url();
@@ -258,7 +258,7 @@ class Stream {
  *
  * @param string $url The url to connect to.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	protected function _open($url) {
 		set_error_handler([$this, '_connectionErrorHandler']);

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Http\Auth;
 
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Network\Http\Request;
 
 /**
@@ -60,7 +60,7 @@ class Oauth {
 				break;
 
 			default:
-				throw new Error\Exception(sprintf('Unknown Oauth signature method %s', $credentials['method']));
+				throw new Exception(sprintf('Unknown Oauth signature method %s', $credentials['method']));
 
 		}
 		$request->header('Authorization', $value);
@@ -166,7 +166,7 @@ class Oauth {
 	protected function _normalizedUrl($url) {
 		$parts = parse_url($url);
 		if (!$parts) {
-			throw new Error\Exception('Unable to parse URL');
+			throw new Exception('Unable to parse URL');
 		}
 		$scheme = strtolower($parts['scheme'] ?: 'http');
 		$defaultPorts = [

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -34,7 +34,7 @@ class Oauth {
  * @param \Cake\Network\Request $request The request object.
  * @param array $credentials Authentication credentials.
  * @return void
- * @throws \Cake\Error\Exception On invalid signature types.
+ * @throws \Cake\Core\Error\Exception On invalid signature types.
  */
 	public function authentication(Request $request, array $credentials) {
 		$hasKeys = isset(
@@ -161,7 +161,7 @@ class Oauth {
  *
  * @param string $url URL
  * @return string Normalized URL
- * @throws \Cake\Error\Exception On invalid URLs
+ * @throws \Cake\Core\Error\Exception On invalid URLs
  */
 	protected function _normalizedUrl($url) {
 		$parts = parse_url($url);

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Http\Auth;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Network\Http\Request;
 
 /**
@@ -34,7 +34,7 @@ class Oauth {
  * @param \Cake\Network\Request $request The request object.
  * @param array $credentials Authentication credentials.
  * @return void
- * @throws \Cake\Core\Error\Exception On invalid signature types.
+ * @throws \Cake\Core\Exception\Exception On invalid signature types.
  */
 	public function authentication(Request $request, array $credentials) {
 		$hasKeys = isset(
@@ -161,7 +161,7 @@ class Oauth {
  *
  * @param string $url URL
  * @return string Normalized URL
- * @throws \Cake\Core\Error\Exception On invalid URLs
+ * @throws \Cake\Core\Exception\Exception On invalid URLs
  */
 	protected function _normalizedUrl($url) {
 		$parts = parse_url($url);

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -14,7 +14,7 @@
 namespace Cake\Network\Http;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Network\Http\CookieCollection;
 use Cake\Network\Http\Request;
@@ -397,7 +397,7 @@ class Client {
  *
  * @param string $type short type alias or full mimetype.
  * @return array Headers to set on the request.
- * @throws \Cake\Core\Error\Exception When an unknown type alias is used.
+ * @throws \Cake\Core\Exception\Exception When an unknown type alias is used.
  */
 	protected function _typeHeaders($type) {
 		if (strpos($type, '/') !== false) {
@@ -460,7 +460,7 @@ class Client {
  * @param array $auth The authentication options to use.
  * @param array $options The overall request options to use.
  * @return mixed Authentication strategy instance.
- * @throws \Cake\Core\Error\Exception when an invalid stratgey is chosen.
+ * @throws \Cake\Core\Exception\Exception when an invalid stratgey is chosen.
  */
 	protected function _createAuth($auth, $options) {
 		if (empty($auth['type'])) {

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -14,8 +14,8 @@
 namespace Cake\Network\Http;
 
 use Cake\Core\App;
+use Cake\Core\Error\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Error;
 use Cake\Network\Http\CookieCollection;
 use Cake\Network\Http\Request;
 use Cake\Utility\Hash;
@@ -411,7 +411,7 @@ class Client {
 			'xml' => 'application/xml',
 		];
 		if (!isset($typeMap[$type])) {
-			throw new Error\Exception('Unknown type alias.');
+			throw new Exception('Unknown type alias.');
 		}
 		return [
 			'Accept' => $typeMap[$type],
@@ -469,7 +469,7 @@ class Client {
 		$name = ucfirst($auth['type']);
 		$class = App::className($name, 'Network/Http/Auth');
 		if (!$class) {
-			throw new Error\Exception(
+			throw new Exception(
 				sprintf('Invalid authentication type %s', $name)
 			);
 		}

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -397,7 +397,7 @@ class Client {
  *
  * @param string $type short type alias or full mimetype.
  * @return array Headers to set on the request.
- * @throws \Cake\Error\Exception When an unknown type alias is used.
+ * @throws \Cake\Core\Error\Exception When an unknown type alias is used.
  */
 	protected function _typeHeaders($type) {
 		if (strpos($type, '/') !== false) {
@@ -460,7 +460,7 @@ class Client {
  * @param array $auth The authentication options to use.
  * @param array $options The overall request options to use.
  * @return mixed Authentication strategy instance.
- * @throws \Cake\Error\Exception when an invalid stratgey is chosen.
+ * @throws \Cake\Core\Error\Exception when an invalid stratgey is chosen.
  */
 	protected function _createAuth($auth, $options) {
 		if (empty($auth['type'])) {

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -60,7 +60,7 @@ class Request extends Message {
  *
  * @param string|null $method The method for the request.
  * @return mixed Either this or the current method.
- * @throws \Cake\Error\Exception On invalid methods.
+ * @throws \Cake\Core\Error\Exception On invalid methods.
  */
 	public function method($method = null) {
 		if ($method === null) {

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Http;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Network\Http\Message;
 
 /**
@@ -60,7 +60,7 @@ class Request extends Message {
  *
  * @param string|null $method The method for the request.
  * @return mixed Either this or the current method.
- * @throws \Cake\Core\Error\Exception On invalid methods.
+ * @throws \Cake\Core\Exception\Exception On invalid methods.
  */
 	public function method($method = null) {
 		if ($method === null) {

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Network\Http;
 
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Network\Http\Message;
 
 /**
@@ -68,7 +68,7 @@ class Request extends Message {
 		}
 		$name = get_called_class() . '::METHOD_' . strtoupper($method);
 		if (!defined($name)) {
-			throw new Error\Exception('Invalid method type');
+			throw new Exception('Invalid method type');
 		}
 		$this->_method = $method;
 		return $this;

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -15,7 +15,7 @@
 namespace Cake\Network;
 
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Error;
 use Cake\Network\Session;
 use Cake\Utility\Hash;
@@ -525,7 +525,7 @@ class Request implements \ArrayAccess {
  * @param string $name The method called
  * @param array $params Array of parameters for the method call
  * @return mixed
- * @throws \Cake\Core\Error\Exception when an invalid method is called.
+ * @throws \Cake\Core\Exception\Exception when an invalid method is called.
  */
 	public function __call($name, $params) {
 		if (strpos($name, 'is') === 0) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -524,7 +524,7 @@ class Request implements \ArrayAccess {
  * @param string $name The method called
  * @param array $params Array of parameters for the method call
  * @return mixed
- * @throws \Cake\Error\Exception when an invalid method is called.
+ * @throws \Cake\Core\Error\Exception when an invalid method is called.
  */
 	public function __call($name, $params) {
 		if (strpos($name, 'is') === 0) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -15,6 +15,7 @@
 namespace Cake\Network;
 
 use Cake\Core\Configure;
+use Cake\Core\Error\Exception;
 use Cake\Error;
 use Cake\Network\Session;
 use Cake\Utility\Hash;
@@ -531,7 +532,7 @@ class Request implements \ArrayAccess {
 			$type = strtolower(substr($name, 2));
 			return $this->is($type);
 		}
-		throw new Error\Exception(sprintf('Method %s does not exist', $name));
+		throw new Exception(sprintf('Method %s does not exist', $name));
 	}
 
 /**

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -15,7 +15,7 @@
 namespace Cake\Network;
 
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Error;
 use Cake\Utility\File;
 
@@ -518,7 +518,7 @@ class Response {
  * @param string $name the header name
  * @param string $value the header value
  * @return void
- * @throws \Cake\Core\Error\Exception When headers have already been sent
+ * @throws \Cake\Core\Exception\Exception When headers have already been sent
  */
 	protected function _sendHeader($name, $value = null) {
 		if (headers_sent($filename, $linenum)) {
@@ -625,7 +625,7 @@ class Response {
  *
  * @param int $code the HTTP status code
  * @return int current status code
- * @throws \Cake\Core\Error\Exception When an unknown status code is reached.
+ * @throws \Cake\Core\Exception\Exception When an unknown status code is reached.
  */
 	public function statusCode($code = null) {
 		if ($code === null) {
@@ -666,7 +666,7 @@ class Response {
  *
  * @return mixed associative array of the HTTP codes as keys, and the message
  *    strings as values, or null of the given $code does not exist.
- * @throws \Cake\Core\Error\Exception If an attempt is made to add an invalid status code
+ * @throws \Cake\Core\Exception\Exception If an attempt is made to add an invalid status code
  */
 	public function httpCodes($code = null) {
 		if (empty($code)) {

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -15,6 +15,7 @@
 namespace Cake\Network;
 
 use Cake\Core\Configure;
+use Cake\Core\Error\Exception;
 use Cake\Error;
 use Cake\Utility\File;
 
@@ -521,7 +522,7 @@ class Response {
  */
 	protected function _sendHeader($name, $value = null) {
 		if (headers_sent($filename, $linenum)) {
-			throw new Error\Exception(
+			throw new Exception(
 				sprintf('Headers already sent in %d on line %s', $linenum, $filename)
 			);
 		}
@@ -631,7 +632,7 @@ class Response {
 			return $this->_status;
 		}
 		if (!isset($this->_statusCodes[$code])) {
-			throw new Error\Exception('Unknown status code');
+			throw new Exception('Unknown status code');
 		}
 		return $this->_status = $code;
 	}
@@ -675,7 +676,7 @@ class Response {
 			$codes = array_keys($code);
 			$min = min($codes);
 			if (!is_int($min) || $min < 100 || max($codes) > 999) {
-				throw new Error\Exception('Invalid status code');
+				throw new Exception('Invalid status code');
 			}
 			$this->_statusCodes = $code + $this->_statusCodes;
 			return true;

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -517,7 +517,7 @@ class Response {
  * @param string $name the header name
  * @param string $value the header value
  * @return void
- * @throws \Cake\Error\Exception When headers have already been sent
+ * @throws \Cake\Core\Error\Exception When headers have already been sent
  */
 	protected function _sendHeader($name, $value = null) {
 		if (headers_sent($filename, $linenum)) {
@@ -624,7 +624,7 @@ class Response {
  *
  * @param int $code the HTTP status code
  * @return int current status code
- * @throws \Cake\Error\Exception When an unknown status code is reached.
+ * @throws \Cake\Core\Error\Exception When an unknown status code is reached.
  */
 	public function statusCode($code = null) {
 		if ($code === null) {
@@ -665,7 +665,7 @@ class Response {
  *
  * @return mixed associative array of the HTTP codes as keys, and the message
  *    strings as values, or null of the given $code does not exist.
- * @throws \Cake\Error\Exception If an attempt is made to add an invalid status code
+ * @throws \Cake\Core\Error\Exception If an attempt is made to add an invalid status code
  */
 	public function httpCodes($code = null) {
 		if (empty($code)) {

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -15,7 +15,7 @@
 namespace Cake\ORM;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Event\EventListener;
 
 /**
@@ -174,7 +174,7 @@ class Behavior implements EventListener {
  * Check that implemented* keys contain values pointing at callable.
  *
  * @return void
- * @throws \Cake\Error\Exception if config are invalid
+ * @throws \Cake\Core\Error\Exception if config are invalid
  */
 	public function verifyConfig() {
 		$keys = ['implementedFinders', 'implementedMethods'];

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -15,7 +15,7 @@
 namespace Cake\ORM;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Event\EventListener;
 
 /**
@@ -174,7 +174,7 @@ class Behavior implements EventListener {
  * Check that implemented* keys contain values pointing at callable.
  *
  * @return void
- * @throws \Cake\Core\Error\Exception if config are invalid
+ * @throws \Cake\Core\Exception\Exception if config are invalid
  */
 	public function verifyConfig() {
 		$keys = ['implementedFinders', 'implementedMethods'];

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -15,7 +15,7 @@
 namespace Cake\ORM;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Event\EventManagerTrait;
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;
@@ -125,7 +125,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $class The classname that is missing.
  * @param string $alias The alias of the object.
  * @return void
- * @throws \Cake\Core\Error\Exception when duplicate methods are connected.
+ * @throws \Cake\Core\Exception\Exception when duplicate methods are connected.
  */
 	protected function _getMethods(Behavior $instance, $class, $alias) {
 		$finders = array_change_key_case($instance->implementedFinders());
@@ -196,7 +196,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $method The method to invoke.
  * @param array $args The arguments you want to invoke the method with.
  * @return mixed The return value depends on the underlying behavior method.
- * @throws \Cake\Core\Error\Exception When the method is unknown.
+ * @throws \Cake\Core\Exception\Exception When the method is unknown.
  */
 	public function call($method, array $args = []) {
 		$method = strtolower($method);
@@ -214,7 +214,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $type The finder type to invoke.
  * @param array $args The arguments you want to invoke the method with.
  * @return mixed The return value depends on the underlying behavior method.
- * @throws \Cake\Core\Error\Exception When the method is unknown.
+ * @throws \Cake\Core\Exception\Exception When the method is unknown.
  */
 	public function callFinder($type, array $args = []) {
 		$type = strtolower($type);

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -15,7 +15,7 @@
 namespace Cake\ORM;
 
 use Cake\Core\App;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Event\EventManagerTrait;
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;
@@ -125,7 +125,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $class The classname that is missing.
  * @param string $alias The alias of the object.
  * @return void
- * @throws \Cake\Error\Exception when duplicate methods are connected.
+ * @throws \Cake\Core\Error\Exception when duplicate methods are connected.
  */
 	protected function _getMethods(Behavior $instance, $class, $alias) {
 		$finders = array_change_key_case($instance->implementedFinders());
@@ -196,7 +196,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $method The method to invoke.
  * @param array $args The arguments you want to invoke the method with.
  * @return mixed The return value depends on the underlying behavior method.
- * @throws \Cake\Error\Exception When the method is unknown.
+ * @throws \Cake\Core\Error\Exception When the method is unknown.
  */
 	public function call($method, array $args = []) {
 		$method = strtolower($method);
@@ -214,7 +214,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $type The finder type to invoke.
  * @param array $args The arguments you want to invoke the method with.
  * @return mixed The return value depends on the underlying behavior method.
- * @throws \Cake\Error\Exception When the method is unknown.
+ * @throws \Cake\Core\Error\Exception When the method is unknown.
  */
 	public function callFinder($type, array $args = []) {
 		$type = strtolower($type);

--- a/src/ORM/Error/MissingBehaviorException.php
+++ b/src/ORM/Error/MissingBehaviorException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\ORM\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a behavior cannot be found.

--- a/src/ORM/Error/MissingBehaviorException.php
+++ b/src/ORM/Error/MissingBehaviorException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\ORM\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a behavior cannot be found.

--- a/src/ORM/Error/MissingEntityException.php
+++ b/src/ORM/Error/MissingEntityException.php
@@ -16,7 +16,7 @@
  */
 namespace Cake\ORM\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception raised when an Entity  could not be found.

--- a/src/ORM/Error/MissingEntityException.php
+++ b/src/ORM/Error/MissingEntityException.php
@@ -16,7 +16,7 @@
  */
 namespace Cake\ORM\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when an Entity  could not be found.

--- a/src/ORM/Error/MissingTableClassException.php
+++ b/src/ORM/Error/MissingTableClassException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\ORM\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception raised when a Table could not be found.

--- a/src/ORM/Error/MissingTableClassException.php
+++ b/src/ORM/Error/MissingTableClassException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\ORM\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when a Table could not be found.

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1461,7 +1461,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $method The method name that was fired.
  * @param array $args List of arguments passed to the function.
  * @return mixed
- * @throws \Cake\Error\Exception when there are missing arguments, or when
+ * @throws \Cake\Core\Error\Exception when there are missing arguments, or when
  *  and & or are combined.
  */
 	protected function _dynamicFinder($method, $args) {
@@ -1482,7 +1482,7 @@ class Table implements RepositoryInterface, EventListener {
 		$makeConditions = function($fields, $args) {
 			$conditions = [];
 			if (count($args) < count($fields)) {
-				throw new \Cake\Error\Exception(sprintf(
+				throw new \Cake\Core\Error\Exception(sprintf(
 					'Not enough arguments to magic finder. Got %s required %s',
 					count($args),
 					count($fields)
@@ -1495,7 +1495,7 @@ class Table implements RepositoryInterface, EventListener {
 		};
 
 		if ($hasOr !== false && $hasAnd !== false) {
-			throw new \Cake\Error\Exception(
+			throw new \Cake\Core\Error\Exception(
 				'Cannot mix "and" & "or" in a magic finder. Use find() instead.'
 			);
 		}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1461,7 +1461,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $method The method name that was fired.
  * @param array $args List of arguments passed to the function.
  * @return mixed
- * @throws \Cake\Core\Error\Exception when there are missing arguments, or when
+ * @throws \Cake\Core\Exception\Exception when there are missing arguments, or when
  *  and & or are combined.
  */
 	protected function _dynamicFinder($method, $args) {
@@ -1482,7 +1482,7 @@ class Table implements RepositoryInterface, EventListener {
 		$makeConditions = function($fields, $args) {
 			$conditions = [];
 			if (count($args) < count($fields)) {
-				throw new \Cake\Core\Error\Exception(sprintf(
+				throw new \Cake\Core\Exception\Exception(sprintf(
 					'Not enough arguments to magic finder. Got %s required %s',
 					count($args),
 					count($fields)
@@ -1495,7 +1495,7 @@ class Table implements RepositoryInterface, EventListener {
 		};
 
 		if ($hasOr !== false && $hasAnd !== false) {
-			throw new \Cake\Core\Error\Exception(
+			throw new \Cake\Core\Exception\Exception(
 				'Cannot mix "and" & "or" in a magic finder. Use find() instead.'
 			);
 		}

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -16,7 +16,7 @@ namespace Cake\Routing;
 
 use Cake\Controller\Controller;
 use Cake\Controller\Error\MissingControllerException;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManagerTrait;
@@ -102,7 +102,7 @@ class Dispatcher {
  *
  * @param Controller $controller Controller to invoke
  * @return \Cake\Network\Response The resulting response object
- * @throws \Cake\Error\Exception If data returned by controller action is not an
+ * @throws \Cake\Core\Error\Exception If data returned by controller action is not an
  *   instance of Response
  */
 	protected function _invoke(Controller $controller) {

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -16,7 +16,7 @@ namespace Cake\Routing;
 
 use Cake\Controller\Controller;
 use Cake\Controller\Error\MissingControllerException;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManagerTrait;
@@ -102,7 +102,7 @@ class Dispatcher {
  *
  * @param Controller $controller Controller to invoke
  * @return \Cake\Network\Response The resulting response object
- * @throws \Cake\Core\Error\Exception If data returned by controller action is not an
+ * @throws \Cake\Core\Exception\Exception If data returned by controller action is not an
  *   instance of Response
  */
 	protected function _invoke(Controller $controller) {

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Routing;
 
+use Cake\Core\Error\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Error;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 
@@ -102,7 +102,7 @@ class DispatcherFilter implements EventListener {
 		}
 		$this->config($config);
 		if (isset($config['when']) && !is_callable($config['when'])) {
-			throw new Error\Exception('"when" conditions must be a callable.');
+			throw new Exception('"when" conditions must be a callable.');
 		}
 	}
 

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -94,7 +94,7 @@ class DispatcherFilter implements EventListener {
  * Constructor.
  *
  * @param array $config Settings for the filter.
- * @throws \Cake\Error\Exception When 'when' conditions are not callable.
+ * @throws \Cake\Core\Error\Exception When 'when' conditions are not callable.
  */
 	public function __construct($config = []) {
 		if (!isset($config['priority'])) {

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Routing;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
@@ -94,7 +94,7 @@ class DispatcherFilter implements EventListener {
  * Constructor.
  *
  * @param array $config Settings for the filter.
- * @throws \Cake\Core\Error\Exception When 'when' conditions are not callable.
+ * @throws \Cake\Core\Exception\Exception When 'when' conditions are not callable.
  */
 	public function __construct($config = []) {
 		if (!isset($config['priority'])) {

--- a/src/Routing/Error/MissingDispatcherFilterException.php
+++ b/src/Routing/Error/MissingDispatcherFilterException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Routing\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when a Dispatcher filter could not be found

--- a/src/Routing/Error/MissingDispatcherFilterException.php
+++ b/src/Routing/Error/MissingDispatcherFilterException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Routing\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception raised when a Dispatcher filter could not be found

--- a/src/Routing/Error/MissingRouteException.php
+++ b/src/Routing/Error/MissingRouteException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Routing\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception raised when a URL cannot be reverse routed

--- a/src/Routing/Error/MissingRouteException.php
+++ b/src/Routing/Error/MissingRouteException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Routing\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when a URL cannot be reverse routed

--- a/src/Routing/Filter/LocaleSelectorFilter.php
+++ b/src/Routing/Filter/LocaleSelectorFilter.php
@@ -36,7 +36,7 @@ class LocaleSelectorFilter extends DispatcherFilter {
  * Constructor.
  *
  * @param array $config Settings for the filter.
- * @throws \Cake\Error\Exception When 'when' conditions are not callable.
+ * @throws \Cake\Core\Error\Exception When 'when' conditions are not callable.
  */
 	public function __construct($config = []) {
 		parent::__construct($config);

--- a/src/Routing/Filter/LocaleSelectorFilter.php
+++ b/src/Routing/Filter/LocaleSelectorFilter.php
@@ -36,7 +36,7 @@ class LocaleSelectorFilter extends DispatcherFilter {
  * Constructor.
  *
  * @param array $config Settings for the filter.
- * @throws \Cake\Core\Error\Exception When 'when' conditions are not callable.
+ * @throws \Cake\Core\Exception\Exception When 'when' conditions are not callable.
  */
 	public function __construct($config = []) {
 		parent::__construct($config);

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -15,7 +15,7 @@
 namespace Cake\Routing;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Routing\Router;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
@@ -310,7 +310,7 @@ class RouteBuilder {
  *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
  *   custom routing class.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	public function connect($route, array $defaults = [], $options = []) {
 		if (empty($options['action'])) {
@@ -332,7 +332,7 @@ class RouteBuilder {
  * @param array $defaults Default parameters.
  * @param array $options Additional options parameters.
  * @return \Cake\Routing\Route\Route
- * @throws \Cake\Core\Error\Exception when route class or route object is invalid.
+ * @throws \Cake\Core\Exception\Exception when route class or route object is invalid.
  */
 	protected function _makeRoute($route, $defaults, $options) {
 		if (is_string($route)) {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -310,7 +310,7 @@ class RouteBuilder {
  *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
  *   custom routing class.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	public function connect($route, array $defaults = [], $options = []) {
 		if (empty($options['action'])) {
@@ -332,7 +332,7 @@ class RouteBuilder {
  * @param array $defaults Default parameters.
  * @param array $options Additional options parameters.
  * @return \Cake\Routing\Route\Route
- * @throws \Cake\Error\Exception when route class or route object is invalid.
+ * @throws \Cake\Core\Error\Exception when route class or route object is invalid.
  */
 	protected function _makeRoute($route, $defaults, $options) {
 		if (is_string($route)) {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -15,7 +15,7 @@
 namespace Cake\Routing;
 
 use Cake\Core\App;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\Routing\Router;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
@@ -341,7 +341,7 @@ class RouteBuilder {
 				$routeClass = App::className($options['routeClass'], 'Routing/Route');
 			}
 			if ($routeClass === false) {
-				throw new Error\Exception(sprintf('Cannot find route class %s', $options['routeClass']));
+				throw new Exception(sprintf('Cannot find route class %s', $options['routeClass']));
 			}
 			unset($options['routeClass']);
 
@@ -352,7 +352,7 @@ class RouteBuilder {
 				if (isset($defaults[$param]) && $defaults[$param] !== $val) {
 					$msg = 'You cannot define routes that conflict with the scope. ' .
 						'Scope had %s = %s, while route had %s = %s';
-					throw new Error\Exception(sprintf(
+					throw new Exception(sprintf(
 						$msg,
 						$param,
 						$val,
@@ -370,7 +370,7 @@ class RouteBuilder {
 		if ($route instanceof Route) {
 			return $route;
 		}
-		throw new Error\Exception('Route class not found, or route class is not a subclass of Cake\Routing\Route\Route');
+		throw new Exception('Route class not found, or route class is not a subclass of Cake\Routing\Route\Route');
 	}
 
 /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -165,7 +165,7 @@ class Router {
  *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
  *   custom routing class.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  * @see \Cake\Routing\RouteBuilder::connect()
  * @see \Cake\Routing\Router::scope()
  */
@@ -488,7 +488,7 @@ class Router {
  * @param bool $full If true, the full base URL will be prepended to the result.
  *   Default is false.
  * @return string Full translated URL with base path.
- * @throws \Cake\Error\Exception When the route name is not found
+ * @throws \Cake\Core\Error\Exception When the route name is not found
  */
 	public static function url($url = null, $full = false) {
 		if (!static::$initialized) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -165,7 +165,7 @@ class Router {
  *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
  *   custom routing class.
  * @return void
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  * @see \Cake\Routing\RouteBuilder::connect()
  * @see \Cake\Routing\Router::scope()
  */
@@ -488,7 +488,7 @@ class Router {
  * @param bool $full If true, the full base URL will be prepended to the result.
  *   Default is false.
  * @return string Full translated URL with base path.
- * @throws \Cake\Core\Error\Exception When the route name is not found
+ * @throws \Cake\Core\Exception\Exception When the route name is not found
  */
 	public static function url($url = null, $full = false) {
 		if (!static::$initialized) {

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -277,7 +277,7 @@ class TestTask extends BakeTask {
  *
  * @param string $type The type of thing having a test generated.
  * @return string
- * @throws \Cake\Error\Exception When invalid object types are requested.
+ * @throws \Cake\Core\Error\Exception When invalid object types are requested.
  */
 	public function mapType($type) {
 		$type = ucfirst($type);

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -17,8 +17,8 @@ namespace Cake\Shell\Task;
 use Cake\Console\Shell;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Core\Error\Exception;
 use Cake\Core\Plugin;
-use Cake\Error;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\ORM\Association;
@@ -282,7 +282,7 @@ class TestTask extends BakeTask {
 	public function mapType($type) {
 		$type = ucfirst($type);
 		if (empty($this->classTypes[$type])) {
-			throw new Error\Exception('Invalid object type.');
+			throw new Exception('Invalid object type.');
 		}
 		return $this->classTypes[$type];
 	}

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -17,7 +17,7 @@ namespace Cake\Shell\Task;
 use Cake\Console\Shell;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Core\Plugin;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -277,7 +277,7 @@ class TestTask extends BakeTask {
  *
  * @param string $type The type of thing having a test generated.
  * @return string
- * @throws \Cake\Core\Error\Exception When invalid object types are requested.
+ * @throws \Cake\Core\Exception\Exception When invalid object types are requested.
  */
 	public function mapType($type) {
 		$type = ucfirst($type);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -18,7 +18,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\TestSuite\Fixture\TestFixture;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
@@ -220,7 +220,7 @@ class FixtureManager {
  *
  * @param \Cake\TestSuite\TestCase $test the test to inspect for fixture loading
  * @return void
- * @throws \Cake\Core\Error\Exception When fixture records cannot be inserted.
+ * @throws \Cake\Core\Exception\Exception When fixture records cannot be inserted.
  */
 	public function load($test) {
 		if (empty($test->fixtures)) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -18,7 +18,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\TestSuite\Fixture\TestFixture;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
@@ -256,7 +256,7 @@ class FixtureManager {
 			}
 		} catch (\PDOException $e) {
 			$msg = sprintf('Unable to insert fixtures for "%s" test case. %s', get_class($test), $e->getMessage());
-			throw new Error\Exception($msg);
+			throw new Exception($msg);
 		}
 	}
 

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -220,7 +220,7 @@ class FixtureManager {
  *
  * @param \Cake\TestSuite\TestCase $test the test to inspect for fixture loading
  * @return void
- * @throws \Cake\Error\Exception When fixture records cannot be inserted.
+ * @throws \Cake\Core\Error\Exception When fixture records cannot be inserted.
  */
 	public function load($test) {
 		if (empty($test->fixtures)) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -87,7 +87,7 @@ class TestFixture {
 /**
  * Instantiate the fixture.
  *
- * @throws \Cake\Error\Exception on invalid datasource usage.
+ * @throws \Cake\Core\Error\Exception on invalid datasource usage.
  */
 	public function __construct() {
 		$connection = 'test';
@@ -175,7 +175,7 @@ class TestFixture {
  * Build fixture schema from a table in another datasource.
  *
  * @return void
- * @throws \Cake\Error\Exception when trying to import from an empty table.
+ * @throws \Cake\Core\Error\Exception when trying to import from an empty table.
  */
 	protected function _schemaFromImport() {
 		if (!is_array($this->import)) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\TestSuite\Fixture;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Database\Connection;
 use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionManager;
@@ -87,7 +87,7 @@ class TestFixture {
 /**
  * Instantiate the fixture.
  *
- * @throws \Cake\Core\Error\Exception on invalid datasource usage.
+ * @throws \Cake\Core\Exception\Exception on invalid datasource usage.
  */
 	public function __construct() {
 		$connection = 'test';
@@ -175,7 +175,7 @@ class TestFixture {
  * Build fixture schema from a table in another datasource.
  *
  * @return void
- * @throws \Cake\Core\Error\Exception when trying to import from an empty table.
+ * @throws \Cake\Core\Exception\Exception when trying to import from an empty table.
  */
 	protected function _schemaFromImport() {
 		if (!is_array($this->import)) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\TestSuite\Fixture;
 
+use Cake\Core\Error\Exception;
 use Cake\Database\Connection;
 use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionManager;
-use Cake\Error;
 use Cake\Log\Log;
 use Cake\Utility\Inflector;
 
@@ -99,7 +99,7 @@ class TestFixture {
 					$connection,
 					$this->name
 				);
-				throw new Error\Exception($message);
+				throw new Exception($message);
 			}
 		}
 		$this->init();
@@ -187,7 +187,7 @@ class TestFixture {
 		);
 
 		if (empty($import['table'])) {
-			throw new Error\Exception('Cannot import from undefined table.');
+			throw new Exception('Cannot import from undefined table.');
 		} else {
 			$this->table = $import['table'];
 		}

--- a/src/Utility/Debugger.php
+++ b/src/Utility/Debugger.php
@@ -15,7 +15,7 @@
 namespace Cake\Utility;
 
 use Cake\Core\Configure;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Log\Log;
 
 /**
@@ -623,7 +623,7 @@ class Debugger {
  * @param string $format The format you want errors to be output as.
  *   Leave null to get the current format.
  * @return mixed Returns null when setting. Returns the current format when getting.
- * @throws \Cake\Error\Exception when choosing a format that doesn't exist.
+ * @throws \Cake\Core\Error\Exception when choosing a format that doesn't exist.
  */
 	public static function outputAs($format = null) {
 		$self = Debugger::getInstance();

--- a/src/Utility/Error/XmlException.php
+++ b/src/Utility/Error/XmlException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Utility\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Exception class for Xml.  This exception will be thrown from Xml when it

--- a/src/Utility/Error/XmlException.php
+++ b/src/Utility/Error/XmlException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Utility\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception class for Xml.  This exception will be thrown from Xml when it

--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Utility;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use NumberFormatter;
 
 /**
@@ -81,7 +81,7 @@ class Number {
  * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
  * @param mixed $default Value to be returned when invalid size was used, for example 'Unknown type'
  * @return mixed Number of bytes as integer on success, `$default` on failure if not false
- * @throws \Cake\Error\Exception On invalid Unit type.
+ * @throws \Cake\Core\Error\Exception On invalid Unit type.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::fromReadableSize
  */
 	public static function fromReadableSize($size, $default = false) {

--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Utility;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use NumberFormatter;
 
 /**
@@ -81,7 +81,7 @@ class Number {
  * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
  * @param mixed $default Value to be returned when invalid size was used, for example 'Unknown type'
  * @return mixed Number of bytes as integer on success, `$default` on failure if not false
- * @throws \Cake\Core\Error\Exception On invalid Unit type.
+ * @throws \Cake\Core\Exception\Exception On invalid Unit type.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::fromReadableSize
  */
 	public static function fromReadableSize($size, $default = false) {

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -95,7 +95,7 @@ abstract class ObjectRegistry {
  * @param string $class The class that is missing.
  * @param string $plugin The plugin $class is missing from.
  * @return void
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	abstract protected function _throwMissingClassError($class, $plugin);
 

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -15,7 +15,7 @@
 namespace Cake\Utility;
 
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Security Library contains utility methods related to security
@@ -86,7 +86,7 @@ class Security {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
- * @throws \Cake\Core\Error\Exception When there are errors.
+ * @throws \Cake\Core\Exception\Exception When there are errors.
  * @return string Encrypted/Decrypted string
  */
 	public static function rijndael($text, $key, $operation) {
@@ -125,7 +125,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Encrypted data.
- * @throws \Cake\Core\Error\Exception On invalid data or key.
+ * @throws \Cake\Core\Exception\Exception On invalid data or key.
  */
 	public static function encrypt($plain, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'encrypt()');
@@ -153,7 +153,7 @@ class Security {
  * @param string $key Key to check.
  * @param string $method The method the key is being checked for.
  * @return void
- * @throws \Cake\Core\Error\Exception When key length is not 256 bit/32 bytes
+ * @throws \Cake\Core\Exception\Exception When key length is not 256 bit/32 bytes
  */
 	protected static function _checkKey($key, $method) {
 		if (strlen($key) < 32) {
@@ -168,7 +168,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Decrypted data. Any trailing null bytes will be removed.
- * @throws \Cake\Core\Error\Exception On invalid data or key.
+ * @throws \Cake\Core\Exception\Exception On invalid data or key.
  */
 	public static function decrypt($cipher, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'decrypt()');

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -15,7 +15,7 @@
 namespace Cake\Utility;
 
 use Cake\Core\Configure;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Security Library contains utility methods related to security
@@ -86,7 +86,7 @@ class Security {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
- * @throws \Cake\Error\Exception When there are errors.
+ * @throws \Cake\Core\Error\Exception When there are errors.
  * @return string Encrypted/Decrypted string
  */
 	public static function rijndael($text, $key, $operation) {
@@ -125,7 +125,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Encrypted data.
- * @throws \Cake\Error\Exception On invalid data or key.
+ * @throws \Cake\Core\Error\Exception On invalid data or key.
  */
 	public static function encrypt($plain, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'encrypt()');
@@ -153,7 +153,7 @@ class Security {
  * @param string $key Key to check.
  * @param string $method The method the key is being checked for.
  * @return void
- * @throws \Cake\Error\Exception When key length is not 256 bit/32 bytes
+ * @throws \Cake\Core\Error\Exception When key length is not 256 bit/32 bytes
  */
 	protected static function _checkKey($key, $method) {
 		if (strlen($key) < 32) {
@@ -168,7 +168,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Decrypted data. Any trailing null bytes will be removed.
- * @throws \Cake\Error\Exception On invalid data or key.
+ * @throws \Cake\Core\Error\Exception On invalid data or key.
  */
 	public static function decrypt($cipher, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'decrypt()');

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -15,7 +15,7 @@
 namespace Cake\Validation;
 
 use Cake\Core\App;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Utility\File;
 use Cake\Utility\Number;
 
@@ -909,7 +909,7 @@ class Validation {
  * @param string|array $check Value to check.
  * @param array|string $mimeTypes Array of mime types or regex pattern to check.
  * @return bool Success
- * @throws \Cake\Error\Exception when mime type can not be determined.
+ * @throws \Cake\Core\Error\Exception when mime type can not be determined.
  */
 	public static function mimeType($check, $mimeTypes = array()) {
 		if (is_array($check) && isset($check['tmp_name'])) {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -15,7 +15,7 @@
 namespace Cake\Validation;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Utility\File;
 use Cake\Utility\Number;
 
@@ -909,7 +909,7 @@ class Validation {
  * @param string|array $check Value to check.
  * @param array|string $mimeTypes Array of mime types or regex pattern to check.
  * @return bool Success
- * @throws \Cake\Core\Error\Exception when mime type can not be determined.
+ * @throws \Cake\Core\Exception\Exception when mime type can not be determined.
  */
 	public static function mimeType($check, $mimeTypes = array()) {
 		if (is_array($check) && isset($check['tmp_name'])) {

--- a/src/View/Error/MissingCellException.php
+++ b/src/View/Error/MissingCellException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a cell class file cannot be found.

--- a/src/View/Error/MissingCellException.php
+++ b/src/View/Error/MissingCellException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a cell class file cannot be found.

--- a/src/View/Error/MissingCellViewException.php
+++ b/src/View/Error/MissingCellViewException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a view file for a cell cannot be found.

--- a/src/View/Error/MissingCellViewException.php
+++ b/src/View/Error/MissingCellViewException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a view file for a cell cannot be found.

--- a/src/View/Error/MissingElementException.php
+++ b/src/View/Error/MissingElementException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when an element file cannot be found.

--- a/src/View/Error/MissingElementException.php
+++ b/src/View/Error/MissingElementException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when an element file cannot be found.

--- a/src/View/Error/MissingHelperException.php
+++ b/src/View/Error/MissingHelperException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a helper cannot be found.

--- a/src/View/Error/MissingHelperException.php
+++ b/src/View/Error/MissingHelperException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a helper cannot be found.

--- a/src/View/Error/MissingLayoutException.php
+++ b/src/View/Error/MissingLayoutException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a layout file cannot be found.

--- a/src/View/Error/MissingLayoutException.php
+++ b/src/View/Error/MissingLayoutException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a layout file cannot be found.

--- a/src/View/Error/MissingViewException.php
+++ b/src/View/Error/MissingViewException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * Used when a view file cannot be found.

--- a/src/View/Error/MissingViewException.php
+++ b/src/View/Error/MissingViewException.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\View\Error;
 
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 
 /**
  * Used when a view file cannot be found.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Helper;
 
 use Cake\Core\Configure;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\ORM\Entity;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -1298,7 +1298,7 @@ class FormHelper extends Helper {
 	public function __call($method, $params) {
 		$options = [];
 		if (empty($params)) {
-			throw new Error\Exception(sprintf('Missing field name for FormHelper::%s', $method));
+			throw new Exception(sprintf('Missing field name for FormHelper::%s', $method));
 		}
 		if (isset($params[1])) {
 			$options = $params[1];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1293,7 +1293,7 @@ class FormHelper extends Helper {
  * @param string $method Method name / input type to make.
  * @param array $params Parameters for the method call
  * @return string Formatted input method.
- * @throws \Cake\Error\Exception When there are no params for the method call.
+ * @throws \Cake\Core\Error\Exception When there are no params for the method call.
  */
 	public function __call($method, $params) {
 		$options = [];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Helper;
 
 use Cake\Core\Configure;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\ORM\Entity;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -1293,7 +1293,7 @@ class FormHelper extends Helper {
  * @param string $method Method name / input type to make.
  * @param array $params Parameters for the method call
  * @return string Formatted input method.
- * @throws \Cake\Core\Error\Exception When there are no params for the method call.
+ * @throws \Cake\Core\Exception\Exception When there are no params for the method call.
  */
 	public function __call($method, $params) {
 		$options = [];

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Helper;
 
 use Cake\Core\App;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\View\Helper;
 use Cake\View\View;
 
@@ -66,7 +66,7 @@ class NumberHelper extends Helper {
 		if ($engineClass) {
 			$this->_engine = new $engineClass($config);
 		} else {
-			throw new Error\Exception(sprintf('Class for %s could not be found', $config['engine']));
+			throw new Exception(sprintf('Class for %s could not be found', $config['engine']));
 		}
 	}
 

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Helper;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\View\Helper;
 use Cake\View\View;
 
@@ -55,7 +55,7 @@ class NumberHelper extends Helper {
  *
  * @param View $View The View this helper is being attached to.
  * @param array $config Configuration settings for the helper
- * @throws \Cake\Core\Error\Exception When the engine class could not be found.
+ * @throws \Cake\Core\Exception\Exception When the engine class could not be found.
  */
 	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -55,7 +55,7 @@ class NumberHelper extends Helper {
  *
  * @param View $View The View this helper is being attached to.
  * @param array $config Configuration settings for the helper
- * @throws \Cake\Error\Exception When the engine class could not be found.
+ * @throws \Cake\Core\Error\Exception When the engine class could not be found.
  */
 	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -71,7 +71,7 @@ class TextHelper extends Helper {
  *
  * @param View $View the view object the helper is attached to.
  * @param array $config Settings array Settings array
- * @throws \Cake\Error\Exception when the engine class could not be found.
+ * @throws \Cake\Core\Error\Exception when the engine class could not be found.
  */
 	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Helper;
 
 use Cake\Core\App;
-use Cake\Error;
+use Cake\Core\Error\Exception;
 use Cake\View\Helper;
 use Cake\View\View;
 
@@ -81,7 +81,7 @@ class TextHelper extends Helper {
 		if ($engineClass) {
 			$this->_engine = new $engineClass($config);
 		} else {
-			throw new Error\Exception(sprintf('Class for %s could not be found', $config['engine']));
+			throw new Exception(sprintf('Class for %s could not be found', $config['engine']));
 		}
 	}
 

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Helper;
 
 use Cake\Core\App;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\View\Helper;
 use Cake\View\View;
 
@@ -71,7 +71,7 @@ class TextHelper extends Helper {
  *
  * @param View $View the view object the helper is attached to.
  * @param array $config Settings array Settings array
- * @throws \Cake\Core\Error\Exception when the engine class could not be found.
+ * @throws \Cake\Core\Exception\Exception when the engine class could not be found.
  */
 	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -18,7 +18,7 @@ use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
@@ -406,7 +406,7 @@ class View {
  * @param string $view Name of view file to use
  * @param string $layout Layout to use.
  * @return string|null Rendered content or null if content already rendered and returned earlier.
- * @throws \Cake\Core\Error\Exception If there is an error in the view.
+ * @throws \Cake\Core\Exception\Exception If there is an error in the view.
  */
 	public function render($view = null, $layout = null) {
 		if ($this->hasRendered) {
@@ -437,7 +437,7 @@ class View {
  * @param string $content Content to render in a view, wrapped by the surrounding layout.
  * @param string $layout Layout name
  * @return mixed Rendered output, or false on error
- * @throws \Cake\Core\Error\Exception if there is an error in the view.
+ * @throws \Cake\Core\Exception\Exception if there is an error in the view.
  */
 	public function renderLayout($content, $layout = null) {
 		$layoutFileName = $this->_getLayoutFileName($layout);
@@ -685,7 +685,7 @@ class View {
  * @param string $viewFile Filename of the view
  * @param array $data Data to include in rendered view. If empty the current View::$viewVars will be used.
  * @return string Rendered output
- * @throws \Cake\Core\Error\Exception when a block is left open.
+ * @throws \Cake\Core\Exception\Exception when a block is left open.
  */
 	protected function _render($viewFile, $data = array()) {
 		if (empty($data)) {
@@ -821,7 +821,7 @@ class View {
  * @param string $file The path to the template file.
  * @param string $path Base path that $file should be inside of.
  * @return string The file path
- * @throws \Cake\Core\Error\Exception
+ * @throws \Cake\Core\Exception\Exception
  */
 	protected function _checkFilePath($file, $path) {
 		if (strpos($file, '..') === false) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -18,7 +18,7 @@ use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Error\Exception;
+use Cake\Core\Error\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
@@ -406,7 +406,7 @@ class View {
  * @param string $view Name of view file to use
  * @param string $layout Layout to use.
  * @return string|null Rendered content or null if content already rendered and returned earlier.
- * @throws \Cake\Error\Exception If there is an error in the view.
+ * @throws \Cake\Core\Error\Exception If there is an error in the view.
  */
 	public function render($view = null, $layout = null) {
 		if ($this->hasRendered) {
@@ -437,7 +437,7 @@ class View {
  * @param string $content Content to render in a view, wrapped by the surrounding layout.
  * @param string $layout Layout name
  * @return mixed Rendered output, or false on error
- * @throws \Cake\Error\Exception if there is an error in the view.
+ * @throws \Cake\Core\Error\Exception if there is an error in the view.
  */
 	public function renderLayout($content, $layout = null) {
 		$layoutFileName = $this->_getLayoutFileName($layout);
@@ -685,7 +685,7 @@ class View {
  * @param string $viewFile Filename of the view
  * @param array $data Data to include in rendered view. If empty the current View::$viewVars will be used.
  * @return string Rendered output
- * @throws \Cake\Error\Exception when a block is left open.
+ * @throws \Cake\Core\Error\Exception when a block is left open.
  */
 	protected function _render($viewFile, $data = array()) {
 		if (empty($data)) {
@@ -821,7 +821,7 @@ class View {
  * @param string $file The path to the template file.
  * @param string $path Base path that $file should be inside of.
  * @return string The file path
- * @throws \Cake\Error\Exception
+ * @throws \Cake\Core\Error\Exception
  */
 	protected function _checkFilePath($file, $path) {
 		if (strpos($file, '..') === false) {

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View;
 
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 
 /**
  * ViewBlock implements the concept of Blocks or Slots in the View layer.
@@ -72,7 +72,7 @@ class ViewBlock {
  * using View::get();
  *
  * @param string $name The name of the block to capture for.
- * @throws \Cake\Core\Error\Exception When starting a block twice
+ * @throws \Cake\Core\Exception\Exception When starting a block twice
  * @return void
  */
 	public function start($name) {

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View;
 
-use Cake\Error;
+use Cake\Core\Error\Exception;
 
 /**
  * ViewBlock implements the concept of Blocks or Slots in the View layer.
@@ -77,7 +77,7 @@ class ViewBlock {
  */
 	public function start($name) {
 		if (in_array($name, $this->_active)) {
-			throw new Error\Exception(sprintf("A view block with the name '%s' is already/still open.", $name));
+			throw new Exception(sprintf("A view block with the name '%s' is already/still open.", $name));
 		}
 		$this->_active[] = $name;
 		ob_start();

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -72,7 +72,7 @@ class ViewBlock {
  * using View::get();
  *
  * @param string $name The name of the block to capture for.
- * @throws \Cake\Error\Exception When starting a block twice
+ * @throws \Cake\Core\Error\Exception When starting a block twice
  * @return void
  */
 	public function start($name) {

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -52,7 +52,7 @@ class ControllerAuthorizeTest extends TestCase {
 	}
 
 /**
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testControllerErrorOnMissingMethod() {

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -52,7 +52,7 @@ class ControllerAuthorizeTest extends TestCase {
 	}
 
 /**
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testControllerErrorOnMissingMethod() {

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -115,7 +115,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testWriteNonExistingConfig() {
@@ -125,7 +125,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testIncrementNonExistingConfig() {
@@ -135,7 +135,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testDecrementNonExistingConfig() {
@@ -181,7 +181,7 @@ class CacheTest extends TestCase {
 /**
  * testConfigInvalidEngine method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testConfigInvalidEngine() {
@@ -193,7 +193,7 @@ class CacheTest extends TestCase {
 /**
  * test that trying to configure classes that don't extend CacheEngine fail.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testConfigInvalidObject() {
@@ -207,7 +207,7 @@ class CacheTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a cache adapter.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {
@@ -285,7 +285,7 @@ class CacheTest extends TestCase {
 
 /**
  * testGroupConfigsThrowsException method
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  */
 	public function testGroupConfigsThrowsException() {
 		Cache::groupConfigs('bogus');

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -115,7 +115,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testWriteNonExistingConfig() {
@@ -125,7 +125,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testIncrementNonExistingConfig() {
@@ -135,7 +135,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testDecrementNonExistingConfig() {
@@ -181,7 +181,7 @@ class CacheTest extends TestCase {
 /**
  * testConfigInvalidEngine method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testConfigInvalidEngine() {
@@ -193,7 +193,7 @@ class CacheTest extends TestCase {
 /**
  * test that trying to configure classes that don't extend CacheEngine fail.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testConfigInvalidObject() {
@@ -207,7 +207,7 @@ class CacheTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a cache adapter.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {
@@ -285,7 +285,7 @@ class CacheTest extends TestCase {
 
 /**
  * testGroupConfigsThrowsException method
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  */
 	public function testGroupConfigsThrowsException() {
 		Cache::groupConfigs('bogus');

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -177,7 +177,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Core\Error\Exception', 'invalid_serializer is not a valid serializer engine for Memcached'
+			'Cake\Core\Exception\Exception', 'invalid_serializer is not a valid serializer engine for Memcached'
 		);
 		$Memcached->init($config);
 	}
@@ -289,7 +289,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Core\Error\Exception', 'Memcached extension is not compiled with json support'
+			'Cake\Core\Exception\Exception', 'Memcached extension is not compiled with json support'
 		);
 		$Memcached->init($config);
 	}
@@ -314,7 +314,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Core\Error\Exception', 'msgpack is not a valid serializer engine for Memcached'
+			'Cake\Core\Exception\Exception', 'msgpack is not a valid serializer engine for Memcached'
 		);
 		$Memcached->init($config);
 	}
@@ -339,7 +339,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Core\Error\Exception', 'Memcached extension is not compiled with igbinary support'
+			'Cake\Core\Exception\Exception', 'Memcached extension is not compiled with igbinary support'
 		);
 		$Memcached->init($config);
 	}
@@ -366,7 +366,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Core\Error\Exception', 'Memcached extension is not build with SASL support'
+			'Cake\Core\Exception\Exception', 'Memcached extension is not build with SASL support'
 		);
 		$Memcached->init($config);
 	}

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -177,7 +177,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Error\Exception', 'invalid_serializer is not a valid serializer engine for Memcached'
+			'Cake\Core\Error\Exception', 'invalid_serializer is not a valid serializer engine for Memcached'
 		);
 		$Memcached->init($config);
 	}
@@ -289,7 +289,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Error\Exception', 'Memcached extension is not compiled with json support'
+			'Cake\Core\Error\Exception', 'Memcached extension is not compiled with json support'
 		);
 		$Memcached->init($config);
 	}
@@ -314,7 +314,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Error\Exception', 'msgpack is not a valid serializer engine for Memcached'
+			'Cake\Core\Error\Exception', 'msgpack is not a valid serializer engine for Memcached'
 		);
 		$Memcached->init($config);
 	}
@@ -339,7 +339,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Error\Exception', 'Memcached extension is not compiled with igbinary support'
+			'Cake\Core\Error\Exception', 'Memcached extension is not compiled with igbinary support'
 		);
 		$Memcached->init($config);
 	}
@@ -366,7 +366,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$this->setExpectedException(
-			'Cake\Error\Exception', 'Memcached extension is not build with SASL support'
+			'Cake\Core\Error\Exception', 'Memcached extension is not build with SASL support'
 		);
 		$Memcached->init($config);
 	}

--- a/tests/TestCase/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Configure/Engine/IniConfigTest.php
@@ -166,7 +166,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that exist without .ini extension.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
@@ -177,7 +177,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that don't exist.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadWithNonExistentFile() {
@@ -199,7 +199,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test reading keys with ../ doesn't work.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadWithDots() {

--- a/tests/TestCase/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Configure/Engine/PhpConfigTest.php
@@ -73,7 +73,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that exist without .php extension.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
@@ -84,7 +84,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that don't exist.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadWithNonExistentFile() {
@@ -95,7 +95,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test reading an empty file.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadEmptyFile() {
@@ -106,7 +106,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test reading keys with ../ doesn't work.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testReadWithDots() {

--- a/tests/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -16,7 +16,7 @@ namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\ConsoleErrorHandler;
 use Cake\Controller\Error\MissingActionException;
-use Cake\Core\Error\Exception;
+use Cake\Core\Exception\Exception;
 use Cake\Error;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\ConsoleErrorHandler;
 use Cake\Controller\Error\MissingActionException;
+use Cake\Core\Error\Exception;
 use Cake\Error;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
@@ -141,7 +142,7 @@ class ConsoleErrorHandlerTest extends TestCase {
  * @return void
  */
 	public function testNonIntegerExceptionCode() {
-		$exception = new Error\Exception('Non-integer exception code');
+		$exception = new Exception('Non-integer exception code');
 
 		$class = new \ReflectionClass('Exception');
 		$property = $class->getProperty('code');

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -207,7 +207,7 @@ class AuthComponentTest extends TestCase {
 /**
  * testIsAuthorizedMissingFile function
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testIsAuthorizedMissingFile() {
@@ -298,7 +298,7 @@ class AuthComponentTest extends TestCase {
 /**
  * testLoadAuthenticateNoFile function
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testLoadAuthenticateNoFile() {

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -207,7 +207,7 @@ class AuthComponentTest extends TestCase {
 /**
  * testIsAuthorizedMissingFile function
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testIsAuthorizedMissingFile() {
@@ -298,7 +298,7 @@ class AuthComponentTest extends TestCase {
 /**
  * testLoadAuthenticateNoFile function
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testLoadAuthenticateNoFile() {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -841,7 +841,7 @@ class RequestHandlerComponentTest extends TestCase {
 /**
  * testAddInputTypeException method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testAddInputTypeException() {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -841,7 +841,7 @@ class RequestHandlerComponentTest extends TestCase {
 /**
  * testAddInputTypeException method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testAddInputTypeException() {

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -166,7 +166,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that exist without .ini extension.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
@@ -177,7 +177,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that don't exist.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadWithNonExistentFile() {
@@ -199,7 +199,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test reading keys with ../ doesn't work.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadWithDots() {

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -73,7 +73,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that exist without .php extension.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
@@ -84,7 +84,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that don't exist.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadWithNonExistentFile() {
@@ -95,7 +95,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test reading an empty file.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadEmptyFile() {
@@ -106,7 +106,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test reading keys with ../ doesn't work.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testReadWithDots() {

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -457,7 +457,7 @@ class ConfigureTest extends TestCase {
 	}
 
 /**
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testDumpNoAdapter() {

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -457,7 +457,7 @@ class ConfigureTest extends TestCase {
 	}
 
 /**
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testDumpNoAdapter() {

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -181,7 +181,7 @@ class PluginTest extends TestCase {
  * Tests that Plugin::load() throws an exception on unknown plugin
  *
  * @return void
- * @expectedException \Cake\Core\Error\MissingPluginException
+ * @expectedException \Cake\Core\Exception\MissingPluginException
  */
 	public function testLoadNotFound() {
 		Plugin::load('MissingPlugin');
@@ -208,7 +208,7 @@ class PluginTest extends TestCase {
  * Tests that Plugin::path() throws an exception on unknown plugin
  *
  * @return void
- * @expectedException \Cake\Core\Error\MissingPluginException
+ * @expectedException \Cake\Core\Exception\MissingPluginException
  */
 	public function testPathNotFound() {
 		Plugin::path('TestPlugin');
@@ -235,7 +235,7 @@ class PluginTest extends TestCase {
  * Tests that Plugin::classPath() throws an exception on unknown plugin
  *
  * @return void
- * @expectedException \Cake\Core\Error\MissingPluginException
+ * @expectedException \Cake\Core\Exception\MissingPluginException
  */
 	public function testClassPathNotFound() {
 		Plugin::classPath('TestPlugin');

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -55,7 +55,7 @@ class BinaryTypeTest extends TestCase {
 /**
  * Test exceptions on invalid data.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Unable to convert array into binary.
  */
 	public function testToPHPFailure() {

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -55,7 +55,7 @@ class BinaryTypeTest extends TestCase {
 /**
  * Test exceptions on invalid data.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Unable to convert array into binary.
  */
 	public function testToPHPFailure() {

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -83,7 +83,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test for errors on duplicate config.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Cannot reconfigure existing key "test_variant"
  * @return void
  */
@@ -99,7 +99,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test get() failing on missing config.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage The datasource configuration "test_variant" was not found.
  * @return void
  */
@@ -125,7 +125,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test loading connections without aliases
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage The datasource configuration "other_name" was not found.
  * @return void
  */

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -83,7 +83,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test for errors on duplicate config.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Cannot reconfigure existing key "test_variant"
  * @return void
  */
@@ -99,7 +99,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test get() failing on missing config.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage The datasource configuration "test_variant" was not found.
  * @return void
  */
@@ -125,7 +125,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test loading connections without aliases
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage The datasource configuration "other_name" was not found.
  * @return void
  */

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -220,7 +220,7 @@ class DebuggerTest extends TestCase {
 /**
  * Test that choosing a non-existent format causes an exception
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testOutputAsException() {

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -22,7 +22,7 @@ use Cake\Controller\Error\MissingControllerException;
 use Cake\Controller\Error\PrivateActionException;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Core\Error\MissingPluginException;
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
 use Cake\Datasource\Error\MissingDatasourceConfigException;
 use Cake\Datasource\Error\MissingDatasourceException;
@@ -567,7 +567,7 @@ class ExceptionRendererTest extends TestCase {
 				500
 			),
 			array(
-				new \Cake\Core\Error\Exception('base class'),
+				new \Cake\Core\Exception\Exception('base class'),
 				array('/Internal Error/'),
 				500
 			)

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -567,7 +567,7 @@ class ExceptionRendererTest extends TestCase {
 				500
 			),
 			array(
-				new Error\Exception('base class'),
+				new \Cake\Core\Error\Exception('base class'),
 				array('/Internal Error/'),
 				500
 			)

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -69,7 +69,7 @@ class LogTest extends TestCase {
 /**
  * test all the errors from failed logger imports
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testImportingLoggerFailure() {
@@ -91,7 +91,7 @@ class LogTest extends TestCase {
 /**
  * test that loggers have to implement the correct interface.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testNotImplementingInterface() {
@@ -122,7 +122,7 @@ class LogTest extends TestCase {
 /**
  * test config() with valid key name
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testInvalidLevel() {
@@ -166,7 +166,7 @@ class LogTest extends TestCase {
  * Test that config() throws an exception when adding an
  * adapter with the wrong type.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testConfigInjectErrorOnWrongType() {
@@ -195,7 +195,7 @@ class LogTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a log adapter.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -69,7 +69,7 @@ class LogTest extends TestCase {
 /**
  * test all the errors from failed logger imports
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testImportingLoggerFailure() {
@@ -91,7 +91,7 @@ class LogTest extends TestCase {
 /**
  * test that loggers have to implement the correct interface.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testNotImplementingInterface() {
@@ -122,7 +122,7 @@ class LogTest extends TestCase {
 /**
  * test config() with valid key name
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testInvalidLevel() {
@@ -166,7 +166,7 @@ class LogTest extends TestCase {
  * Test that config() throws an exception when adding an
  * adapter with the wrong type.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testConfigInjectErrorOnWrongType() {
@@ -195,7 +195,7 @@ class LogTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a log adapter.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -766,7 +766,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using unknown transports fails.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  */
 	public function testTransportInvalid() {
 		$this->CakeEmail->transport('Invalid');
@@ -775,7 +775,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using classes with no send method fails.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  */
 	public function testTransportInstanceInvalid() {
 		$this->CakeEmail->transport(new \StdClass());
@@ -824,7 +824,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised when duplicate transports are configured.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  */
 	public function testConfigTransportErrorOnDuplicate() {
 		Email::dropTransport('debug');
@@ -880,7 +880,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised on duplicate config set.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testConfigErrorOnDuplicate() {
@@ -911,7 +911,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using an invalid profile fails.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Unknown email configuration "derp".
  */
 	public function testProfileInvalid() {

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -766,7 +766,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using unknown transports fails.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  */
 	public function testTransportInvalid() {
 		$this->CakeEmail->transport('Invalid');
@@ -775,7 +775,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using classes with no send method fails.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  */
 	public function testTransportInstanceInvalid() {
 		$this->CakeEmail->transport(new \StdClass());
@@ -824,7 +824,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised when duplicate transports are configured.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  */
 	public function testConfigTransportErrorOnDuplicate() {
 		Email::dropTransport('debug');
@@ -880,7 +880,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised on duplicate config set.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testConfigErrorOnDuplicate() {
@@ -911,7 +911,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using an invalid profile fails.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Unknown email configuration "derp".
  */
 	public function testProfileInvalid() {

--- a/tests/TestCase/Network/Http/Auth/OauthTest.php
+++ b/tests/TestCase/Network/Http/Auth/OauthTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 class OauthTest extends TestCase {
 
 /**
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  */
 	public function testExceptionUnknownSigningMethod() {
 		$auth = new Oauth();

--- a/tests/TestCase/Network/Http/Auth/OauthTest.php
+++ b/tests/TestCase/Network/Http/Auth/OauthTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 class OauthTest extends TestCase {
 
 /**
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  */
 	public function testExceptionUnknownSigningMethod() {
 		$auth = new Oauth();

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -244,7 +244,7 @@ class ClientTest extends TestCase {
 /**
  * Test invalid authentication types throw exceptions.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testInvalidAuthenticationType() {
@@ -388,7 +388,7 @@ class ClientTest extends TestCase {
 /**
  * Test that exceptions are raised on invalid types.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testExceptionOnUnknownType() {

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -244,7 +244,7 @@ class ClientTest extends TestCase {
 /**
  * Test invalid authentication types throw exceptions.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testInvalidAuthenticationType() {
@@ -388,7 +388,7 @@ class ClientTest extends TestCase {
 /**
  * Test that exceptions are raised on invalid types.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testExceptionOnUnknownType() {

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -48,7 +48,7 @@ class RequestTest extends TestCase {
 /**
  * test invalid method.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testMethodInvalid() {

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -48,7 +48,7 @@ class RequestTest extends TestCase {
 /**
  * test invalid method.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testMethodInvalid() {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -684,7 +684,7 @@ class RequestTest extends TestCase {
 /**
  * Test __call exceptions
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testMagicCallExceptionOnUnknownMethod() {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -684,7 +684,7 @@ class RequestTest extends TestCase {
 /**
  * Test __call exceptions
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testMagicCallExceptionOnUnknownMethod() {

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -113,7 +113,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the statusCode method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testStatusCode() {
@@ -398,7 +398,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the httpCodes method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testHttpCodes() {

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -113,7 +113,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the statusCode method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testStatusCode() {
@@ -398,7 +398,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the httpCodes method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testHttpCodes() {

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -119,7 +119,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate method error
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"
  * @return void
  */
@@ -149,7 +149,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate finder error
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"
  * @return void
  */
@@ -243,7 +243,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Cannot call "nope"
  */
 	public function testCallError() {
@@ -280,7 +280,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Cannot call finder "nope"
  */
 	public function testCallFinderError() {
@@ -291,7 +291,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unloaded behavior methods.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Cannot call "slugify" it does not belong to any attached behavior.
  */
 	public function testUnloadBehaviorThenCall() {
@@ -304,7 +304,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unloaded behavior finders.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Cannot call finder "noslug" it does not belong to any attached behavior.
  */
 	public function testUnloadBehaviorThenCallFinder() {

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -119,7 +119,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate method error
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"
  * @return void
  */
@@ -149,7 +149,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate finder error
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"
  * @return void
  */
@@ -243,7 +243,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Cannot call "nope"
  */
 	public function testCallError() {
@@ -280,7 +280,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Cannot call finder "nope"
  */
 	public function testCallFinderError() {
@@ -291,7 +291,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unloaded behavior methods.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Cannot call "slugify" it does not belong to any attached behavior.
  */
 	public function testUnloadBehaviorThenCall() {
@@ -304,7 +304,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unloaded behavior finders.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Cannot call finder "noslug" it does not belong to any attached behavior.
  */
 	public function testUnloadBehaviorThenCallFinder() {

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -319,7 +319,7 @@ class BehaviorTest extends TestCase {
 /**
  * testVerifyImplementedFindersInvalid
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage The method findNotDefined is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void
@@ -356,7 +356,7 @@ class BehaviorTest extends TestCase {
 /**
  * testVerifyImplementedMethodsInvalid
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -319,7 +319,7 @@ class BehaviorTest extends TestCase {
 /**
  * testVerifyImplementedFindersInvalid
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage The method findNotDefined is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void
@@ -356,7 +356,7 @@ class BehaviorTest extends TestCase {
 /**
  * testVerifyImplementedMethodsInvalid
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2212,7 +2212,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 0 required 1
  * @return void
  */
@@ -2225,7 +2225,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 1 required 2
  * @return void
  */
@@ -2238,7 +2238,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors when there is a mix of or & and.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Cannot mix "and" & "or" in a magic finder. Use find() instead.
  * @return void
  */

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2212,7 +2212,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 0 required 1
  * @return void
  */
@@ -2225,7 +2225,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 1 required 2
  * @return void
  */
@@ -2238,7 +2238,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors when there is a mix of or & and.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Cannot mix "and" & "or" in a magic finder. Use find() instead.
  * @return void
  */

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -63,7 +63,7 @@ class DispatcherFilterTest extends TestCase {
 /**
  * Test constructor error invalid when
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Core\Error\Exception
  * @expectedExceptionMessage "when" conditions must be a callable.
  * @return void
  */

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -63,7 +63,7 @@ class DispatcherFilterTest extends TestCase {
 /**
  * Test constructor error invalid when
  *
- * @expectedException Cake\Core\Error\Exception
+ * @expectedException Cake\Core\Exception\Exception
  * @expectedExceptionMessage "when" conditions must be a callable.
  * @return void
  */

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -162,7 +162,7 @@ class RouteBuilderTest extends TestCase {
 /**
  * Test error on invalid route class
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Route class not found, or route class is not a subclass of
  * @return void
  */
@@ -174,7 +174,7 @@ class RouteBuilderTest extends TestCase {
 /**
  * Test conflicting parameters raises an exception.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage You cannot define routes that conflict with the scope.
  * @return void
  */

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -162,7 +162,7 @@ class RouteBuilderTest extends TestCase {
 /**
  * Test error on invalid route class
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Route class not found, or route class is not a subclass of
  * @return void
  */
@@ -174,7 +174,7 @@ class RouteBuilderTest extends TestCase {
 /**
  * Test conflicting parameters raises an exception.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage You cannot define routes that conflict with the scope.
  * @return void
  */

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2276,7 +2276,7 @@ class RouterTest extends TestCase {
 /**
  * test that route classes must extend \Cake\Routing\Route\Route
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testCustomRouteException() {

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2276,7 +2276,7 @@ class RouterTest extends TestCase {
 /**
  * test that route classes must extend \Cake\Routing\Route\Route
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testCustomRouteException() {

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -220,7 +220,7 @@ class DebuggerTest extends TestCase {
 /**
  * Test that choosing a non-existent format causes an exception
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testOutputAsException() {

--- a/tests/TestCase/Utility/NumberTest.php
+++ b/tests/TestCase/Utility/NumberTest.php
@@ -508,7 +508,7 @@ class NumberTest extends TestCase {
 /**
  * testFromReadableSize
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testFromReadableSizeException() {

--- a/tests/TestCase/Utility/NumberTest.php
+++ b/tests/TestCase/Utility/NumberTest.php
@@ -508,7 +508,7 @@ class NumberTest extends TestCase {
 /**
  * testFromReadableSize
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testFromReadableSizeException() {

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -103,7 +103,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidOperation method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testRijndaelInvalidOperation() {
@@ -115,7 +115,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidKey method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testRijndaelInvalidKey() {
@@ -186,7 +186,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -223,7 +223,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -236,7 +236,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that empty data cause errors
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage The data to decrypt cannot be empty.
  * @return void
  */

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -103,7 +103,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidOperation method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testRijndaelInvalidOperation() {
@@ -115,7 +115,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidKey method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testRijndaelInvalidKey() {
@@ -186,7 +186,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -223,7 +223,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -236,7 +236,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that empty data cause errors
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage The data to decrypt cannot be empty.
  * @return void
  */

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -168,7 +168,7 @@ class XmlTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidDataProvider
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testBuildInvalidData($value) {

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -168,7 +168,7 @@ class XmlTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidDataProvider
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testBuildInvalidData($value) {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2378,7 +2378,7 @@ class ValidationTest extends TestCase {
 /**
  * testMimeTypeFalse method
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testMimeTypeFalse() {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2378,7 +2378,7 @@ class ValidationTest extends TestCase {
 /**
  * testMimeTypeFalse method
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testMimeTypeFalse() {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6092,7 +6092,7 @@ class FormHelperTest extends TestCase {
 /**
  * Test errors when field name is missing.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testHtml5InputException() {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6092,7 +6092,7 @@ class FormHelperTest extends TestCase {
 /**
  * Test errors when field name is missing.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testHtml5InputException() {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -124,7 +124,7 @@ class StringTemplateTest extends TestCase {
 /**
  * Test that loading non-existing templates causes errors.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @expectedExceptionMessage Could not load configuration file
  */
 	public function testLoadErrorNoFile() {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -124,7 +124,7 @@ class StringTemplateTest extends TestCase {
 /**
  * Test that loading non-existing templates causes errors.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @expectedExceptionMessage Could not load configuration file
  */
 	public function testLoadErrorNoFile() {

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -543,7 +543,7 @@ class ViewTest extends TestCase {
 /**
  * Test that getViewFileName() protects against malicious directory traversal.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Core\Error\Exception
  * @return void
  */
 	public function testGetViewFileNameDirectoryTraversal() {
@@ -642,7 +642,7 @@ class ViewTest extends TestCase {
 /**
  * Test that getLayoutFileName() protects against malicious directory traversal.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Core\Error\Exception
  * @return void
  */
 	public function testGetLayoutFileNameDirectoryTraversal() {
@@ -1467,7 +1467,7 @@ class ViewTest extends TestCase {
 /**
  * Test that starting the same block twice throws an exception
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testStartBlocksTwice() {
@@ -1479,7 +1479,7 @@ class ViewTest extends TestCase {
  * Test that an exception gets thrown when you leave a block open at the end
  * of a view.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Core\Error\Exception
  * @return void
  */
 	public function testExceptionOnOpenBlock() {

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -543,7 +543,7 @@ class ViewTest extends TestCase {
 /**
  * Test that getViewFileName() protects against malicious directory traversal.
  *
- * @expectedException Cake\Core\Error\Exception
+ * @expectedException Cake\Core\Exception\Exception
  * @return void
  */
 	public function testGetViewFileNameDirectoryTraversal() {
@@ -642,7 +642,7 @@ class ViewTest extends TestCase {
 /**
  * Test that getLayoutFileName() protects against malicious directory traversal.
  *
- * @expectedException Cake\Core\Error\Exception
+ * @expectedException Cake\Core\Exception\Exception
  * @return void
  */
 	public function testGetLayoutFileNameDirectoryTraversal() {
@@ -1467,7 +1467,7 @@ class ViewTest extends TestCase {
 /**
  * Test that starting the same block twice throws an exception
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testStartBlocksTwice() {
@@ -1479,7 +1479,7 @@ class ViewTest extends TestCase {
  * Test that an exception gets thrown when you leave a block open at the end
  * of a view.
  *
- * @expectedException \Cake\Core\Error\Exception
+ * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testExceptionOnOpenBlock() {


### PR DESCRIPTION
This is the first step towards fixing the use of exceptions in cake. Refs #4416

Next step would be to use more relevant exceptions instead of just throwing the generic cake one. When not using the extra features of this exception type, there is no point in using it.
