### PR TITLE
Fix TableRegistry::get() behavior when called several times with the same option

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -156,7 +156,7 @@ class TableRegistry {
 		$exists = isset(static::$_instances[$alias]);
 
 		if ($exists && !empty($options)) {
-			if (static::$_options[$alias] != $options) {
+			if (static::$_options[$alias] !== $options) {
 				throw new RuntimeException(sprintf(
 					'You cannot configure "%s", it already exists in the registry.',
 					$alias

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -77,6 +77,7 @@ class TableRegistry {
 
 /**
  * Contains a list of options that were passed to get() method.
+ *
  * @var array
  */
 	protected static $_options = [];

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -76,6 +76,12 @@ class TableRegistry {
 	protected static $_fallbacked = [];
 
 /**
+ * Contains a list of options that were passed to get() method.
+ * @var array
+ */
+	protected static $_options = [];
+
+/**
  * Stores a list of options to be used when instantiating an object
  * with a matching alias.
  *
@@ -147,15 +153,19 @@ class TableRegistry {
 	public static function get($name, array $options = []) {
 		list($plugin, $alias) = pluginSplit($name);
 		$exists = isset(static::$_instances[$alias]);
+
 		if ($exists && !empty($options)) {
-			throw new RuntimeException(sprintf(
-				'You cannot configure "%s", it already exists in the registry.',
-				$alias
-			));
+			if (static::$_options[$alias] != $options) {
+				throw new RuntimeException(sprintf(
+					'You cannot configure "%s", it already exists in the registry.',
+					$alias
+				));
+			}
 		}
 		if ($exists) {
 			return static::$_instances[$alias];
 		}
+		static::$_options[$alias] = $options;
 		$options = ['alias' => $alias] + $options;
 
 		if (empty($options['className'])) {

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -151,6 +151,18 @@ class TableRegistryTest extends TestCase {
 	}
 
 /**
+ * Test get() can be called several times with the same option without
+ * throwing an exception.
+ *
+ * @return void
+ */
+	public function testGetWithSameOption() {
+		$result = TableRegistry::get('Users', ['className' => 'Cake\Test\TestCase\ORM\MyUsersTable']);
+		$result2 = TableRegistry::get('Users', ['className' => 'Cake\Test\TestCase\ORM\MyUsersTable']);
+		$this->assertEquals($result, $result2);
+	}
+
+/**
  * Tests that tables can be instantiated based on conventions
  * and using plugin notation
  *


### PR DESCRIPTION
Current implementation of TableRegistry does not allow call get() method 
with the same options more than one time.

This pull request is to address the problem.
