### PR TITLE
Documentation fixes

### DIFF
--- a/src/Auth/DefaultPasswordHasher.php
+++ b/src/Auth/DefaultPasswordHasher.php
@@ -44,7 +44,7 @@ class DefaultPasswordHasher extends AbstractPasswordHasher {
  *
  * @param string $password Plain text password to hash.
  * @return string Password hash
- * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#hashing-passwords
+ * @link http://book.cakephp.org/3.0/en/core-libraries/components/authentication.html#hashing-passwords
  */
 	public function hash($password) {
 		return password_hash(

--- a/src/Console/Error/ConsoleException.php
+++ b/src/Console/Error/ConsoleException.php
@@ -7,7 +7,7 @@
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://book.cakephp.org/2.0/en/development/testing.html
+ * @link          http://book.cakephp.org/3.0/en/development/errors.html#error-exception-configuration
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -188,7 +188,7 @@ class Shell {
  * allows configuration of tasks prior to shell execution
  *
  * @return void
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::initialize
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#Cake\Console\ConsoleOptionParser::initialize
  */
 	public function initialize() {
 		$this->loadTasks();
@@ -202,7 +202,7 @@ class Shell {
  * or otherwise modify the pre-command flow.
  *
  * @return void
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::startup
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#Cake\Console\ConsoleOptionParser::startup
  */
 	public function startup() {
 		$this->_welcome();
@@ -241,7 +241,7 @@ class Shell {
  *
  * @param string $task The task name to check.
  * @return bool Success
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::hasTask
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#shell-tasks
  */
 	public function hasTask($task) {
 		return isset($this->_taskMap[Inflector::camelize($task)]);
@@ -252,7 +252,7 @@ class Shell {
  *
  * @param string $name The method name to check.
  * @return bool
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::hasMethod
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#shell-tasks
  */
 	public function hasMethod($name) {
 		try {
@@ -288,7 +288,7 @@ class Shell {
  * `return $this->dispatchShell('schema', 'create', 'i18n', '--dry');`
  *
  * @return mixed The return of the other shell.
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::dispatchShell
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#invoking-other-shells-from-your-shell
  */
 	public function dispatchShell() {
 		$args = func_get_args();
@@ -321,7 +321,7 @@ class Shell {
  * @param bool $autoMethod Set to true to allow any public method to be called even if it
  *   was not defined as a subcommand. This is used by ShellDispatcher to make building simple shells easy.
  * @return void
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::runCommand
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#the-cakephp-console
  */
 	public function runCommand($argv, $autoMethod = false) {
 		$command = isset($argv[0]) ? $argv[0] : null;
@@ -402,7 +402,7 @@ class Shell {
  * By overriding this method you can configure the ConsoleOptionParser before returning it.
  *
  * @return ConsoleOptionParser
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::getOptionParser
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
  */
 	public function getOptionParser() {
 		$name = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
@@ -543,7 +543,7 @@ class Shell {
  * @param string $title Title of the error
  * @param string $message An optional error message
  * @return void
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::error
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
  */
 	public function error($title, $message = null) {
 		$this->_io->err(sprintf('<error>Error:</error> %s', $title));
@@ -558,7 +558,7 @@ class Shell {
  * Clear the console
  *
  * @return void
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::clear
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#console-output
  */
 	public function clear() {
 		if (empty($this->params['noclear'])) {
@@ -576,7 +576,7 @@ class Shell {
  * @param string $path Where to put the file.
  * @param string $contents Content to put in the file.
  * @return bool Success
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::createFile
+ * @link http://book.cakephp.org/3.0/en/console-and-shells.html#creating-files
  */
 	public function createFile($path, $contents) {
 		$path = str_replace(DS . DS, DS, $path);

--- a/src/basics.php
+++ b/src/basics.php
@@ -40,8 +40,8 @@ if (!function_exists('debug')) {
  * @param bool $showHtml If set to true, the method prints the debug data in a browser-friendly way.
  * @param bool $showFrom If set to true, the method prints from where the function was called.
  * @return void
- * @link http://book.cakephp.org/2.0/en/development/debugging.html#basic-debugging
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#debug
+ * @link http://book.cakephp.org/3.0/en/development/debugging.html#basic-debugging
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#debug
  */
 	function debug($var, $showHtml = null, $showFrom = true) {
 		if (!Configure::read('debug')) {
@@ -133,7 +133,7 @@ if (!function_exists('h')) {
  * @param bool $double Encode existing html entities
  * @param string $charset Character set to use when escaping. Defaults to config value in 'App.encoding' or 'UTF-8'
  * @return string Wrapped text
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#h
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#h
  */
 	function h($text, $double = true, $charset = null) {
 		if (is_string($text)) {
@@ -181,7 +181,7 @@ if (!function_exists('pluginSplit')) {
  * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
  * @param string $plugin Optional default plugin to use if no plugin is found. Defaults to null.
  * @return array Array with 2 indexes. 0 => plugin name, 1 => class name
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#pluginSplit
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pluginSplit
  */
 	function pluginSplit($name, $dotAppend = false, $plugin = null) {
 		if (strpos($name, '.') !== false) {
@@ -227,7 +227,7 @@ if (!function_exists('pr')) {
  * @param mixed $var Variable to print out
  * @return void
  * @see debug()
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#pr
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pr
  * @see debug()
  */
 	function pr($var) {
@@ -249,7 +249,7 @@ if (!function_exists('env')) {
  *
  * @param string $key Environment variable name.
  * @return string Environment variable setting.
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#env
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#env
  */
 	function env($key) {
 		if ($key === 'HTTPS') {
@@ -351,7 +351,7 @@ if (!function_exists('__')) {
  * @param string $singular Text to translate
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return mixed translated string
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__
  */
 	function __($singular, $args = null) {
 		if (!$singular) {
@@ -375,7 +375,7 @@ if (!function_exists('__n')) {
  * @param int $count Count
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return mixed plural form of translated string
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__n
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__n
  */
 	function __n($singular, $plural, $count, $args = null) {
 		if (!$singular) {
@@ -400,7 +400,7 @@ if (!function_exists('__d')) {
  * @param string $msg String to translate
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return string translated string
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__d
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__d
  */
 	function __d($domain, $msg, $args = null) {
 		if (!$msg) {
@@ -425,7 +425,7 @@ if (!function_exists('__dn')) {
  * @param int $count Count
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return string plural form of translated string
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dn
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dn
  */
 	function __dn($domain, $singular, $plural, $count, $args = null) {
 		if (!$singular) {
@@ -450,7 +450,7 @@ if (!function_exists('__x')) {
  * @param string $singular Text to translate
  * @param mixed $args Array with arguments or multiple arguments in function
  * @return mixed translated string
- * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__
+ * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__
  */
 	function __x($context, $singular, $args = null) {
 		if (!$singular) {


### PR DESCRIPTION
Replacing 2.0 links for 3.0.
Methods with no documentation now point to the main section of the class they belong to.

More fixes to come...
