### PR TITLE
3.0 - Do not hinder fatal error causes when debug = false.

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -17,8 +17,8 @@ namespace Cake\Error;
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\Log\Log;
-use Cake\Routing\Router;
 use Cake\Network\Exception\InternalErrorException;
+use Cake\Routing\Router;
 
 /**
  * Base error handler that provides logic common to the CLI + web
@@ -184,6 +184,7 @@ abstract class BaseErrorHandler {
 			'error' => 'Fatal Error',
 		];
 		$this->_logError(LOG_ERR, $data);
+
 		$this->handleException(new FatalErrorException($description, 500, $file, $line));
 		return true;
 	}

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -184,12 +184,7 @@ abstract class BaseErrorHandler {
 			'error' => 'Fatal Error',
 		];
 		$this->_logError(LOG_ERR, $data);
-
-		if (Configure::read('debug')) {
-			$this->handleException(new FatalErrorException($description, 500, $file, $line));
-			return true;
-		}
-		$this->handleException(new InternalErrorException());
+		$this->handleException(new FatalErrorException($description, 500, $file, $line));
 		return true;
 	}
 


### PR DESCRIPTION
In the past it was impossible to use custom exception handlers to
log the cause of fatal errors. Removing this hindrance makes for
happier reporting tools
