### PR TITLE
3.0 - Using a simple string interpolation routine in QueryLogger

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -15,7 +15,6 @@
 namespace Cake\Database\Log;
 
 use Cake\Log\Log;
-use Cake\Utility\String;
 
 /**
  * This class is a bridge used to write LoggedQuery objects into a real log.
@@ -64,7 +63,12 @@ class QueryLogger {
 			return is_string($p) ? "'$p'" : $p;
 		}, $query->params);
 
-		return String::insert($query->query, $params);
+		$keys = [];
+		foreach ($params as $key => $param) {
+			$keys[] = is_string($key) ? "/:$key/" : '/[?]/';
+		}
+
+		return preg_replace($keys, $params, $query->query, 1);
 	}
 
 }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -53,7 +53,7 @@ class QueryLoggerTest extends \Cake\TestSuite\TestCase {
 		$logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
 		$query = new LoggedQuery;
 		$query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3';
-		$query->params = ['p1' => 'string', 'p2' => 3, 'p3' => null];
+		$query->params = ['p1' => 'string', 'p3' => null, 'p2' => 3];
 
 		$logger->expects($this->once())->method('_log')->with($query);
 		$logger->log($query);


### PR DESCRIPTION
The idea is to try to not depend on the String library inside Database lib.
Not using String::insert() would also make @markstory happy
