### PR TITLE
Using mb_internal_encoding() in String instead of Configure.

### DIFF
--- a/src/Utility/String.php
+++ b/src/Utility/String.php
@@ -14,8 +14,6 @@
  */
 namespace Cake\Utility;
 
-use Cake\Core\Configure;
-
 /**
  * String handling methods.
  *
@@ -471,7 +469,7 @@ class String {
 		$default = array(
 			'ellipsis' => '...', 'exact' => true, 'html' => false
 		);
-		if (!empty($options['html']) && Configure::read('App.encoding') === 'UTF-8') {
+		if (!empty($options['html']) && strtolower(mb_internal_encoding()) === 'utf-8') {
 			$default['ellipsis'] = "\xe2\x80\xa6";
 		}
 		$options += $default;

--- a/src/basics.php
+++ b/src/basics.php
@@ -156,7 +156,7 @@ if (!function_exists('h')) {
 
 		static $defaultCharset = false;
 		if ($defaultCharset === false) {
-			$defaultCharset = Configure::read('App.encoding');
+			$defaultCharset = mb_internal_encoding();
 			if ($defaultCharset === null) {
 				$defaultCharset = 'UTF-8';
 			}

--- a/tests/TestCase/Utility/StringTest.php
+++ b/tests/TestCase/Utility/StringTest.php
@@ -13,7 +13,6 @@
  */
 namespace Cake\Test\TestCase\Utility;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\String;
 
@@ -25,11 +24,13 @@ class StringTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
+		$this->encoding = mb_internal_encoding();
 		$this->Text = new String();
 	}
 
 	public function tearDown() {
 		parent::tearDown();
+		mb_internal_encoding($this->encoding);
 		unset($this->Text);
 	}
 
@@ -508,7 +509,7 @@ podeís adquirirla.</span></p>
  * @return void
  */
 	public function testTruncateLegacy() {
-		Configure::write('App.encoding', 'ISO-8859-1');
+		mb_internal_encoding('ISO-8859-1');
 		$text = '<b>&copy; 2005-2007, Cake Software Foundation, Inc.</b><br />written by Alexander Wegener';
 		$result = $this->Text->truncate($text, 31, array(
 			'html' => true,


### PR DESCRIPTION
The value is already configure as part of the app's bootstrap process
and also offers a more accurate value of how PHP is working on the inside.
