### PR TITLE
Add a simpler way to get column values

### DIFF
--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -335,6 +335,21 @@ class Table {
 	}
 
 /**
+ * Get a hash of columns and their default values.
+ *
+ * @return array
+ */
+	public function defaultValues() {
+		$defaults = [];
+		foreach ($this->_columns as $name => $data) {
+			if (isset($data['default'])) {
+				$defaults[$name] = $data['default'];
+			}
+		}
+		return $defaults;
+	}
+
+/**
  * Add an index.
  *
  * Used to add indexes, and full text indexes in platforms that support

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -51,9 +51,9 @@ class PostgresSchemaTest extends TestCase {
 		$table = <<<SQL
 CREATE TABLE schema_authors (
 id SERIAL,
-name VARCHAR(50),
+name VARCHAR(50) DEFAULT 'bob',
 bio DATE,
-position INT,
+position INT DEFAULT 1,
 created TIMESTAMP,
 PRIMARY KEY (id),
 CONSTRAINT "unique_position" UNIQUE ("position")
@@ -334,6 +334,70 @@ SQL;
 		$this->assertEquals(['id'], $result->primaryKey());
 		foreach ($expected as $field => $definition) {
 			$this->assertEquals($definition, $result->column($field));
+		}
+	}
+
+/**
+ * Test describing a table containing defaults with Postgres
+ *
+ * @return void
+ */
+	public function testDescribeTableWithDefaults() {
+		$connection = ConnectionManager::get('test');
+		$this->_createTables($connection);
+
+		$schema = new SchemaCollection($connection);
+		$result = $schema->describe('schema_authors');
+		$expected = [
+			'id' => [
+				'type' => 'integer',
+				'null' => false,
+				'default' => null,
+				'length' => 10,
+				'precision' => null,
+				'unsigned' => null,
+				'comment' => null,
+				'autoIncrement' => true,
+			],
+			'name' => [
+				'type' => 'string',
+				'null' => true,
+				'default' => 'bob',
+				'length' => 50,
+				'precision' => null,
+				'comment' => null,
+				'fixed' => null,
+			],
+			'bio' => [
+				'type' => 'date',
+				'null' => true,
+				'default' => null,
+				'length' => null,
+				'precision' => null,
+				'comment' => null,
+			],
+			'position' => [
+				'type' => 'integer',
+				'null' => true,
+				'default' => '1',
+				'length' => 10,
+				'precision' => null,
+				'comment' => null,
+				'unsigned' => null,
+				'autoIncrement' => null,
+			],
+			'created' => [
+				'type' => 'timestamp',
+				'null' => true,
+				'default' => null,
+				'length' => null,
+				'precision' => null,
+				'comment' => null,
+			],
+		];
+		$this->assertEquals(['id'], $result->primaryKey());
+		foreach ($expected as $field => $definition) {
+			$this->assertEquals($definition, $result->column($field), "Mismatch in $field column");
 		}
 	}
 

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -150,8 +150,32 @@ class TableTest extends TestCase {
 	}
 
 /**
- * Test adding an constraint.
+ * Test reading default values.
  *
+ * @return void
+ */
+	public function testDefaultValues() {
+		$table = new Table('articles');
+		$table->addColumn('id', [
+			'type' => 'integer',
+			'default' => 0
+		])->addColumn('title', [
+			'type' => 'string',
+			'default' => 'A title'
+		])->addColumn('body', [
+			'type' => 'text',
+		]);
+		$result = $table->defaultValues();
+		$expected = [
+			'id' => 0,
+			'title' => 'A title'
+		];
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Test adding an constraint.
+ *>
  * @return void
  */
 	public function testAddConstraint() {


### PR DESCRIPTION
To solve #4398 I've added a new method to Database\Schema\Table, and fixed a few bugs in Postgres' schema handling.
