### PR TITLE
Allow getting of Authorize and Authenticate objects

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -335,7 +335,7 @@ class AuthComponent extends Component {
 		if (empty($this->_authenticateObjects)) {
 			$this->constructAuthenticate();
 		}
-		$auth = $this->_authenticateObjects[count($this->_authenticateObjects) - 1];
+		$auth = end($this->_authenticateObjects);
 		$result = $auth->unauthenticated($this->request, $this->response);
 		if ($result !== null) {
 			return $result;

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -498,7 +498,7 @@ class AuthComponent extends Component {
 				unset($config['className']);
 			} else {
 				$class = $alias;
-			}			
+			}
 			$className = App::className($class, 'Auth', 'Authorize');
 			if (!class_exists($className)) {
 				throw new Exception(sprintf('Authorization adapter "%s" was not found.', $class));

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -513,21 +513,17 @@ class AuthComponent extends Component {
 	}
 
 /**
- * Getter for authorize objects. Will either return an array of all authorize objects, or a particular authorize object.
+ * Getter for authorize objects. Will return a particular authorize object.
  *
- * @param string|null $alias Alias for the authorize object
- * @return \Cake\Auth\BaseAuthorize|array|null
+ * @param string $alias Alias for the authorize object
+ * @return \Cake\Auth\BaseAuthorize|null
  */
-	public function getAuthorize($alias = null) {
+	public function getAuthorize($alias) {
 		if (empty($this->_authorizeObjects)) {
 			$this->constructAuthorize();
 		}
 
-		if ($alias !== null && isset($this->_authorizeObjects[$alias])) {
-			return $this->_authorizeObjects[$alias];
-		}
-
-		return $alias === null ? $this->_authorizeObjects : null;
+		return isset($this->_authorizeObjects[$alias]) ? $this->_authorizeObjects[$alias] : null;
 	}
 
 /**
@@ -778,22 +774,18 @@ class AuthComponent extends Component {
 	}
 
 /**
- * Getter for authenticate objects. Will either return an array of all authenticate objects, or a particular authenticate object.
+ * Getter for authenticate objects. Will return a particular authenticate object.
  *
- * @param string|null $alias Alias for the authenticate object
+ * @param string $alias Alias for the authenticate object
  *
- * @return \Cake\Auth\BaseAuthenticate|array|null
+ * @return \Cake\Auth\BaseAuthenticate|null
  */
-	public function getAuthenticate($alias = null) {
+	public function getAuthenticate($alias) {
 		if (empty($this->_authenticateObjects)) {
 			$this->constructAuthenticate();
 		}
 
-		if ($alias !== null && isset($this->_authenticateObjects[$alias])) {
-			return $this->_authenticateObjects[$alias];
-		}
-
-		return $alias === null ? $this->_authenticateObjects : null;
+		return isset($this->_authenticateObjects[$alias]) ? $this->_authenticateObjects[$alias] : null;
 	}
 
 /**

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -492,19 +492,19 @@ class AuthComponent extends Component {
 			$global = $authorize[AuthComponent::ALL];
 			unset($authorize[AuthComponent::ALL]);
 		}
-		foreach ($authorize as $class => $config) {
+		foreach ($authorize as $alias => $config) {
+			if (!empty($config['className'])) {
+				$class = $config['className'];
+				unset($config['className']);
+			} else {
+				$class = $alias;
+			}			
 			$className = App::className($class, 'Auth', 'Authorize');
 			if (!class_exists($className)) {
 				throw new Exception(sprintf('Authorization adapter "%s" was not found.', $class));
 			}
 			if (!method_exists($className, 'authorize')) {
 				throw new Exception('Authorization objects must implement an authorize() method.');
-			}
-			if (!empty($config['alias'])) {
-				$alias = $config['alias'];
-				unset($config['alias']);
-			} else {
-				$alias = $className;
 			}
 			$config = (array)$config + $global;
 			$this->_authorizeObjects[$alias] = new $className($this->_registry, $config);
@@ -749,10 +749,12 @@ class AuthComponent extends Component {
 			$global = $authenticate[AuthComponent::ALL];
 			unset($authenticate[AuthComponent::ALL]);
 		}
-		foreach ($authenticate as $class => $config) {
+		foreach ($authenticate as $alias => $config) {
 			if (!empty($config['className'])) {
 				$class = $config['className'];
 				unset($config['className']);
+			} else {
+				$class = $alias;
 			}
 			$className = App::className($class, 'Auth', 'Authenticate');
 			if (!class_exists($className)) {
@@ -760,12 +762,6 @@ class AuthComponent extends Component {
 			}
 			if (!method_exists($className, 'authenticate')) {
 				throw new Exception('Authentication objects must implement an authenticate() method.');
-			}
-			if (!empty($config['alias'])) {
-				$alias = $config['alias'];
-				unset($config['alias']);
-			} else {
-				$alias = $className;
 			}
 			$config = array_merge($global, (array)$config);
 			$this->_authenticateObjects[$alias] = new $className($this->_registry, $config);

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -500,10 +500,34 @@ class AuthComponent extends Component {
 			if (!method_exists($className, 'authorize')) {
 				throw new Exception('Authorization objects must implement an authorize() method.');
 			}
+			if (!empty($config['alias'])) {
+				$alias = $config['alias'];
+				unset($config['alias']);
+			} else {
+				$alias = $className;
+			}
 			$config = (array)$config + $global;
-			$this->_authorizeObjects[] = new $className($this->_registry, $config);
+			$this->_authorizeObjects[$alias] = new $className($this->_registry, $config);
 		}
 		return $this->_authorizeObjects;
+	}
+
+/**
+ * Getter for authorize objects. Will either return an array of all authorize objects, or a particular authorize object.
+ *
+ * @param string|null $alias Alias for the authorize object
+ * @return \Cake\Auth\BaseAuthorize|array|null
+ */
+	public function getAuthorize($alias = null) {
+		if (empty($this->_authorizeObjects)) {
+			$this->constructAuthorize();
+		}
+
+		if ($alias !== null && isset($this->_authorizeObjects[$alias])) {
+			return $this->_authorizeObjects[$alias];
+		}
+
+		return $alias === null ? $this->_authorizeObjects : null;
 	}
 
 /**
@@ -741,10 +765,35 @@ class AuthComponent extends Component {
 			if (!method_exists($className, 'authenticate')) {
 				throw new Exception('Authentication objects must implement an authenticate() method.');
 			}
+			if (!empty($config['alias'])) {
+				$alias = $config['alias'];
+				unset($config['alias']);
+			} else {
+				$alias = $className;
+			}
 			$config = array_merge($global, (array)$config);
-			$this->_authenticateObjects[] = new $className($this->_registry, $config);
+			$this->_authenticateObjects[$alias] = new $className($this->_registry, $config);
 		}
 		return $this->_authenticateObjects;
+	}
+
+/**
+ * Getter for authenticate objects. Will either return an array of all authenticate objects, or a particular authenticate object.
+ *
+ * @param string|null $alias Alias for the authenticate object
+ *
+ * @return \Cake\Auth\BaseAuthenticate|array|null
+ */
+	public function getAuthenticate($alias = null) {
+		if (empty($this->_authenticateObjects)) {
+			$this->constructAuthenticate();
+		}
+
+		if ($alias !== null && isset($this->_authenticateObjects[$alias])) {
+			return $this->_authenticateObjects[$alias];
+		}
+
+		return $alias === null ? $this->_authenticateObjects : null;
 	}
 
 /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -317,7 +317,7 @@ class AuthComponentTest extends TestCase {
 			AuthComponent::ALL => array('actionPath' => 'controllers/'),
 			'Controller',
 		]);
-		$objects = $this->Controller->Auth->constructAuthorize();
+		$objects = array_values($this->Controller->Auth->constructAuthorize());
 		$result = $objects[0];
 		$this->assertEquals('controllers/', $result->config('actionPath'));
 	}
@@ -346,7 +346,7 @@ class AuthComponentTest extends TestCase {
 			AuthComponent::ALL => array('userModel' => 'AuthUsers'),
 			'Form'
 		]);
-		$objects = $this->Controller->Auth->constructAuthenticate();
+		$objects = array_values($this->Controller->Auth->constructAuthenticate());
 		$result = $objects[0];
 		$this->assertEquals('AuthUsers', $result->config('userModel'));
 	}
@@ -365,11 +365,11 @@ class AuthComponentTest extends TestCase {
 		$objects = $this->Controller->Auth->constructAuthenticate();
 		$this->assertEquals(2, count($objects));
 
-		$this->assertInstanceOf('Cake\Auth\FormAuthenticate', $objects[0]);
-		$this->assertInstanceOf('Cake\Auth\FormAuthenticate', $objects[1]);
+		$this->assertInstanceOf('Cake\Auth\FormAuthenticate', $objects['FormSimple']);
+		$this->assertInstanceOf('Cake\Auth\FormAuthenticate', $objects['FormBlowfish']);
 
-		$this->assertInstanceOf('Cake\Auth\DefaultPasswordHasher', $objects[0]->passwordHasher());
-		$this->assertInstanceOf('Cake\Auth\FallbackPasswordHasher', $objects[1]->passwordHasher());
+		$this->assertInstanceOf('Cake\Auth\DefaultPasswordHasher', $objects['FormSimple']->passwordHasher());
+		$this->assertInstanceOf('Cake\Auth\FallbackPasswordHasher', $objects['FormBlowfish']->passwordHasher());
 	}
 
 /**


### PR DESCRIPTION
Current there is no way of getting an authorize or authenticate object in order to call a custom method on them. This adds a simple getter for authorize and authenticate objects.
