### PR TITLE
3.0 inflector

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -599,12 +599,12 @@ class Inflector {
 	}
 
 /**
- * Returns the given CamelCasedWordGroup as an hyphenated-word-group.
+ * Returns the given CamelCasedWordGroup as an dashed-word-group.
  *
- * @param string $wordGroup The string to hyphenate.
- * @return string Hyphenated version of the word group
+ * @param string $wordGroup The string to dasherize.
+ * @return string Dashed version of the word group
  */
-	public static function hyphenate($wordGroup) {
+	public static function dasherize($wordGroup) {
 		$result = static::_cache(__FUNCTION__, $wordGroup);
 		if ($result !== null) {
 			return $result;

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -418,7 +418,7 @@ class Inflector {
  * @param string $type Inflection type
  * @param string $key Original value
  * @param string $value Inflected value
- * @return string Inflected value, from cache
+ * @return string|null Inflected value on cache hit or null on cache miss.
  */
 	protected static function _cache($type, $key, $value = false) {
 		$key = '_' . $key;
@@ -428,7 +428,7 @@ class Inflector {
 			return $value;
 		}
 		if (!isset(static::$_cache[$type][$key])) {
-			return false;
+			return null;
 		}
 		return static::$_cache[$type][$key];
 	}
@@ -606,7 +606,7 @@ class Inflector {
  */
 	public static function hyphenate($word) {
 		$result = static::_cache(__FUNCTION__, $word);
-		if ($result !== false) {
+		if ($result !== null) {
 			return $result;
 		}
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -640,7 +640,7 @@ class Inflector {
  */
 	public static function tableize($className) {
 		if (!($result = static::_cache(__FUNCTION__, $className))) {
-			$result = static::pluralize(Inflector::underscore($className));
+			$result = static::pluralize(static::underscore($className));
 			static::_cache(__FUNCTION__, $className, $result);
 		}
 		return $result;

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -577,7 +577,7 @@ class Inflector {
  */
 	public static function camelize($lowerCaseAndUnderscoredWord) {
 		if (!($result = static::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord))) {
-			$result = str_replace(' ', '', Inflector::humanize($lowerCaseAndUnderscoredWord));
+			$result = str_replace(' ', '', static::humanize($lowerCaseAndUnderscoredWord));
 			static::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord, $result);
 		}
 		return $result;
@@ -640,7 +640,7 @@ class Inflector {
  */
 	public static function tableize($className) {
 		if (!($result = static::_cache(__FUNCTION__, $className))) {
-			$result = Inflector::pluralize(Inflector::underscore($className));
+			$result = static::pluralize(Inflector::underscore($className));
 			static::_cache(__FUNCTION__, $className, $result);
 		}
 		return $result;
@@ -655,7 +655,7 @@ class Inflector {
  */
 	public static function classify($tableName) {
 		if (!($result = static::_cache(__FUNCTION__, $tableName))) {
-			$result = Inflector::camelize(Inflector::singularize($tableName));
+			$result = static::camelize(static::singularize($tableName));
 			static::_cache(__FUNCTION__, $tableName, $result);
 		}
 		return $result;
@@ -670,7 +670,7 @@ class Inflector {
  */
 	public static function variable($string) {
 		if (!($result = static::_cache(__FUNCTION__, $string))) {
-			$camelized = Inflector::camelize(Inflector::underscore($string));
+			$camelized = static::camelize(static::underscore($string));
 			$replace = strtolower(substr($camelized, 0, 1));
 			$result = preg_replace('/\\w/', $replace, $camelized, 1);
 			static::_cache(__FUNCTION__, $string, $result);

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -599,19 +599,19 @@ class Inflector {
 	}
 
 /**
- * Returns the given underscored_word or CamelCasedWord as an hyphenated-word.
+ * Returns the given CamelCasedWordGroup as an hyphenated-word-group.
  *
- * @param string $word The word to hyphenate.
- * @return string Hyphenated version of the word.
+ * @param string $wordGroup The string to hyphenate.
+ * @return string Hyphenated version of the word group
  */
-	public static function hyphenate($word) {
-		$result = static::_cache(__FUNCTION__, $word);
+	public static function hyphenate($wordGroup) {
+		$result = static::_cache(__FUNCTION__, $wordGroup);
 		if ($result !== null) {
 			return $result;
 		}
 
-		$result = str_replace('_', '-', static::underscore($word));
-		static::_cache(__FUNCTION__, $word, $result);
+		$result = str_replace('_', '-', static::underscore($wordGroup));
+		static::_cache(__FUNCTION__, $wordGroup, $result);
 		return $result;
 	}
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -428,7 +428,7 @@ class Inflector {
 			return $value;
 		}
 		if (!isset(static::$_cache[$type][$key])) {
-			return null;
+			return false;
 		}
 		return static::$_cache[$type][$key];
 	}
@@ -606,7 +606,7 @@ class Inflector {
  */
 	public static function dasherize($wordGroup) {
 		$result = static::_cache(__FUNCTION__, $wordGroup);
-		if ($result !== null) {
+		if ($result !== false) {
 			return $result;
 		}
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -599,6 +599,23 @@ class Inflector {
 	}
 
 /**
+ * Returns the given underscored_word or CamelCasedWord as an hyphenated-word.
+ *
+ * @param string $word The word to hyphenate.
+ * @return string Hyphenated version of the word.
+ */
+	public static function hyphenate($word) {
+		$result = static::_cache(__FUNCTION__, $word);
+		if ($result !== false) {
+			return $result;
+		}
+
+		$result = str_replace('_', '-', static::underscore($word));
+		static::_cache(__FUNCTION__, $word, $result);
+		return $result;
+	}
+
+/**
  * Returns the given underscored_word_group as a Human Readable Word Group.
  * (Underscores are replaced by spaces and capitalized following words.)
  *

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -388,6 +388,7 @@ class InflectorTest extends TestCase {
 		$this->assertSame('test-this-thing', Inflector::hyphenate('test_this_thing'));
 
 		// Test stupid values
+		$this->assertSame('', Inflector::hyphenate(null));
 		$this->assertSame('', Inflector::hyphenate(''));
 		$this->assertSame('0', Inflector::hyphenate(0));
 		$this->assertSame('', Inflector::hyphenate(false));
@@ -438,6 +439,8 @@ class InflectorTest extends TestCase {
 		$this->assertEquals(Inflector::humanize('posts'), 'Posts');
 		$this->assertEquals(Inflector::humanize('posts_tags'), 'Posts Tags');
 		$this->assertEquals(Inflector::humanize('file_systems'), 'File Systems');
+		$this->assertSame('', Inflector::humanize(null));
+		$this->assertSame('', Inflector::humanize(false));
 	}
 
 /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -376,6 +376,24 @@ class InflectorTest extends TestCase {
 	}
 
 /**
+ * testInflectorHyphenate method
+ *
+ * @return void
+ */
+	public function testInflectorHyphenate() {
+		$this->assertSame('test-thing', Inflector::hyphenate('TestThing'));
+		$this->assertSame('test-thing', Inflector::hyphenate('testThing'));
+		$this->assertSame('test-thing-extra', Inflector::hyphenate('TestThingExtra'));
+		$this->assertSame('test-thing-extra', Inflector::hyphenate('testThingExtra'));
+		$this->assertSame('test-this-thing', Inflector::hyphenate('test_this_thing'));
+
+		// Test stupid values
+		$this->assertSame('', Inflector::hyphenate(''));
+		$this->assertSame('0', Inflector::hyphenate(0));
+		$this->assertSame('', Inflector::hyphenate(false));
+	}
+
+/**
  * testVariableNaming method
  *
  * @return void

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * InflectorTest
- *
- * InflectorTest is used to test cases on the Inflector class
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -376,22 +372,22 @@ class InflectorTest extends TestCase {
 	}
 
 /**
- * testInflectorHyphenate method
+ * testDasherized method
  *
  * @return void
  */
-	public function testInflectorHyphenate() {
-		$this->assertSame('test-thing', Inflector::hyphenate('TestThing'));
-		$this->assertSame('test-thing', Inflector::hyphenate('testThing'));
-		$this->assertSame('test-thing-extra', Inflector::hyphenate('TestThingExtra'));
-		$this->assertSame('test-thing-extra', Inflector::hyphenate('testThingExtra'));
-		$this->assertSame('test-this-thing', Inflector::hyphenate('test_this_thing'));
+	public function testDasherized() {
+		$this->assertSame('test-thing', Inflector::dasherize('TestThing'));
+		$this->assertSame('test-thing', Inflector::dasherize('testThing'));
+		$this->assertSame('test-thing-extra', Inflector::dasherize('TestThingExtra'));
+		$this->assertSame('test-thing-extra', Inflector::dasherize('testThingExtra'));
+		$this->assertSame('test-this-thing', Inflector::dasherize('test_this_thing'));
 
 		// Test stupid values
-		$this->assertSame('', Inflector::hyphenate(null));
-		$this->assertSame('', Inflector::hyphenate(''));
-		$this->assertSame('0', Inflector::hyphenate(0));
-		$this->assertSame('', Inflector::hyphenate(false));
+		$this->assertSame('', Inflector::dasherize(null));
+		$this->assertSame('', Inflector::dasherize(''));
+		$this->assertSame('0', Inflector::dasherize(0));
+		$this->assertSame('', Inflector::dasherize(false));
 	}
 
 /**


### PR DESCRIPTION
`hyphenate()` can be useful for e.g. in a custom inflected route which generates hyphenated instead of underscored words.
