### PR TITLE
Update all @deprecated annotations

### DIFF
--- a/lib/Cake/Cache/Engine/MemcacheEngine.php
+++ b/lib/Cake/Cache/Engine/MemcacheEngine.php
@@ -22,7 +22,7 @@
  * more information.
  *
  * @package Cake.Cache.Engine
- * @deprecated You should use the Memcached adapter instead.
+ * @deprecated 3.0.0 You should use the Memcached adapter instead.
  */
 class MemcacheEngine extends CacheEngine {
 

--- a/lib/Cake/Console/Command/ConsoleShell.php
+++ b/lib/Cake/Console/Command/ConsoleShell.php
@@ -19,7 +19,7 @@ App::uses('AppShell', 'Console/Command');
  * Provides a very basic 'interactive' console for CakePHP apps.
  *
  * @package       Cake.Console.Command
- * @deprecated Deprecated since version 2.4, will be removed in 3.0
+ * @deprecated 3.0.0 Deprecated since version 2.4, will be removed in 3.0
  */
 class ConsoleShell extends AppShell {
 

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -156,7 +156,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return bool Success
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	public function grant($aro, $aco, $action = "*") {
 		trigger_error(__d('cake_dev', '%s is deprecated, use %s instead', 'AclComponent::grant()', 'allow()'), E_USER_WARNING);
@@ -170,7 +170,7 @@ class AclComponent extends Component {
  * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return bool Success
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	public function revoke($aro, $aco, $action = "*") {
 		trigger_error(__d('cake_dev', '%s is deprecated, use %s instead', 'AclComponent::revoke()', 'deny()'), E_USER_WARNING);

--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -166,7 +166,7 @@ abstract class BaseAuthenticate {
  *
  * @param string $password The plain text password.
  * @return string The hashed form of the password.
- * @deprecated Since 2.4. Use a PasswordHasher class instead.
+ * @deprecated 3.0.0 Since 2.4. Use a PasswordHasher class instead.
  */
 	protected function _password($password) {
 		return Security::hash($password, null, true);

--- a/lib/Cake/Controller/Component/Auth/BlowfishAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishAuthenticate.php
@@ -35,7 +35,7 @@ App::uses('FormAuthenticate', 'Controller/Component/Auth');
  * @package	Cake.Controller.Component.Auth
  * @since CakePHP(tm) v 2.3
  * @see	AuthComponent::$authenticate
- * @deprecated Since 2.4. Just use FormAuthenticate with 'passwordHasher' setting set to 'Blowfish'
+ * @deprecated 3.0.0 Since 2.4. Just use FormAuthenticate with 'passwordHasher' setting set to 'Blowfish'
  */
 class BlowfishAuthenticate extends FormAuthenticate {
 

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -692,7 +692,7 @@ class AuthComponent extends Component {
  *
  * @param string|array $url Optional URL to write as the login redirect URL.
  * @return string Redirect URL
- * @deprecated 2.3 Use AuthComponent::redirectUrl() instead
+ * @deprecated 3.0.0 Since 2.3.0, use AuthComponent::redirectUrl() instead
  */
 	public function redirect($url = null) {
 		return $this->redirectUrl($url);
@@ -804,7 +804,7 @@ class AuthComponent extends Component {
  *
  * @param string $password Password to hash
  * @return string Hashed password
- * @deprecated Since 2.4. Use Security::hash() directly or a password hasher object.
+ * @deprecated 3.0.0 Since 2.4. Use Security::hash() directly or a password hasher object.
  */
 	public static function password($password) {
 		return Security::hash($password, null, true);
@@ -814,7 +814,7 @@ class AuthComponent extends Component {
  * Check whether or not the current user has data in the session, and is considered logged in.
  *
  * @return bool true if the user is logged in, false otherwise
- * @deprecated Since 2.5. Use AuthComponent::user() directly.
+ * @deprecated 3.0.0 Since 2.5. Use AuthComponent::user() directly.
  */
 	public function loggedIn() {
 		return (bool)$this->user();

--- a/lib/Cake/Controller/Component/EmailComponent.php
+++ b/lib/Cake/Controller/Component/EmailComponent.php
@@ -29,7 +29,7 @@ App::uses('CakeEmail', 'Network/Email');
  * @package       Cake.Controller.Component
  * @link          http://book.cakephp.org/2.0/en/core-libraries/components/email.html
  * @link          http://book.cakephp.org/2.0/en/core-utility-libraries/email.html
- * @deprecated    Will be removed in 3.0. Use Network/CakeEmail instead
+ * @deprecated    3.0.0 Will be removed in 3.0. Use Network/CakeEmail instead
  */
 class EmailComponent extends Component {
 

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -292,7 +292,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current HTTP request is Ajax, false otherwise
  *
  * @return bool True if call is Ajax
- * @deprecated use `$this->request->is('ajax')` instead.
+ * @deprecated 3.0.0 Use `$this->request->is('ajax')` instead.
  */
 	public function isAjax() {
 		return $this->request->is('ajax');
@@ -302,7 +302,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current HTTP request is coming from a Flash-based client
  *
  * @return bool True if call is from Flash
- * @deprecated use `$this->request->is('flash')` instead.
+ * @deprecated 3.0.0 Use `$this->request->is('flash')` instead.
  */
 	public function isFlash() {
 		return $this->request->is('flash');
@@ -312,7 +312,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current request is over HTTPS, false otherwise.
  *
  * @return bool True if call is over HTTPS
- * @deprecated use `$this->request->is('ssl')` instead.
+ * @deprecated 3.0.0 Use `$this->request->is('ssl')` instead.
  */
 	public function isSSL() {
 		return $this->request->is('ssl');
@@ -368,7 +368,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current call a POST request
  *
  * @return bool True if call is a POST
- * @deprecated Use $this->request->is('post'); from your controller.
+ * @deprecated 3.0.0 Use $this->request->is('post'); from your controller.
  */
 	public function isPost() {
 		return $this->request->is('post');
@@ -378,7 +378,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current call a PUT request
  *
  * @return bool True if call is a PUT
- * @deprecated Use $this->request->is('put'); from your controller.
+ * @deprecated 3.0.0 Use $this->request->is('put'); from your controller.
  */
 	public function isPut() {
 		return $this->request->is('put');
@@ -388,7 +388,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current call a GET request
  *
  * @return bool True if call is a GET
- * @deprecated Use $this->request->is('get'); from your controller.
+ * @deprecated 3.0.0 Use $this->request->is('get'); from your controller.
  */
 	public function isGet() {
 		return $this->request->is('get');
@@ -398,7 +398,7 @@ class RequestHandlerComponent extends Component {
  * Returns true if the current call a DELETE request
  *
  * @return bool True if call is a DELETE
- * @deprecated Use $this->request->is('delete'); from your controller.
+ * @deprecated 3.0.0 Use $this->request->is('delete'); from your controller.
  */
 	public function isDelete() {
 		return $this->request->is('delete');
@@ -425,7 +425,7 @@ class RequestHandlerComponent extends Component {
  * @param string|array $type The Content-type or array of Content-types assigned to the name,
  *    i.e. "text/html", or "application/xml"
  * @return void
- * @deprecated use `$this->response->type()` instead.
+ * @deprecated 3.0.0 Use `$this->response->type()` instead.
  */
 	public function setContent($name, $type = null) {
 		$this->response->type(array($name => $type));
@@ -435,7 +435,7 @@ class RequestHandlerComponent extends Component {
  * Gets the server name from which this request was referred
  *
  * @return string Server address
- * @deprecated use $this->request->referer() from your controller instead
+ * @deprecated 3.0.0 Use $this->request->referer() from your controller instead
  */
 	public function getReferer() {
 		return $this->request->referer(false);
@@ -447,7 +447,7 @@ class RequestHandlerComponent extends Component {
  * @param bool $safe Use safe = false when you think the user might manipulate
  *   their HTTP_CLIENT_IP header. Setting $safe = false will also look at HTTP_X_FORWARDED_FOR
  * @return string Client IP address
- * @deprecated use $this->request->clientIp() from your, controller instead.
+ * @deprecated 3.0.0 Use $this->request->clientIp() from your, controller instead.
  */
 	public function getClientIP($safe = true) {
 		return $this->request->clientIp($safe);
@@ -714,7 +714,7 @@ class RequestHandlerComponent extends Component {
  *
  * @param string|array $cType Either a string content type to map, or an array of types.
  * @return string|array Aliases for the types provided.
- * @deprecated Use $this->response->mapType() in your controller instead.
+ * @deprecated 3.0.0 Use $this->response->mapType() in your controller instead.
  */
 	public function mapType($cType) {
 		return $this->response->mapType($cType);

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -47,7 +47,7 @@ class SecurityComponent extends Component {
  * List of controller actions for which a POST request is required
  *
  * @var array
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @see SecurityComponent::requirePost()
  */
 	public $requirePost = array();
@@ -56,7 +56,7 @@ class SecurityComponent extends Component {
  * List of controller actions for which a GET request is required
  *
  * @var array
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @see SecurityComponent::requireGet()
  */
 	public $requireGet = array();
@@ -65,7 +65,7 @@ class SecurityComponent extends Component {
  * List of controller actions for which a PUT request is required
  *
  * @var array
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @see SecurityComponent::requirePut()
  */
 	public $requirePut = array();
@@ -74,7 +74,7 @@ class SecurityComponent extends Component {
  * List of controller actions for which a DELETE request is required
  *
  * @var array
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @see SecurityComponent::requireDelete()
  */
 	public $requireDelete = array();
@@ -117,7 +117,7 @@ class SecurityComponent extends Component {
  * Deprecated property, superseded by unlockedFields.
  *
  * @var array
- * @deprecated
+ * @deprecated 3.0.0 Superseded by unlockedFields.
  * @see SecurityComponent::$unlockedFields
  */
 	public $disabledFields = array();
@@ -252,7 +252,7 @@ class SecurityComponent extends Component {
  * Sets the actions that require a POST request, or empty for all actions
  *
  * @return void
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#SecurityComponent::requirePost
  */
 	public function requirePost() {
@@ -263,7 +263,7 @@ class SecurityComponent extends Component {
 /**
  * Sets the actions that require a GET request, or empty for all actions
  *
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @return void
  */
 	public function requireGet() {
@@ -274,7 +274,7 @@ class SecurityComponent extends Component {
 /**
  * Sets the actions that require a PUT request, or empty for all actions
  *
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @return void
  */
 	public function requirePut() {
@@ -285,7 +285,7 @@ class SecurityComponent extends Component {
 /**
  * Sets the actions that require a DELETE request, or empty for all actions
  *
- * @deprecated Use CakeRequest::onlyAllow() instead.
+ * @deprecated 3.0.0 Use CakeRequest::onlyAllow() instead.
  * @return void
  */
 	public function requireDelete() {

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -705,7 +705,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @return array Associative array of the HTTP codes as keys, and the message
  *    strings as values, or null of the given $code does not exist.
- * @deprecated Since 2.4. Will be removed in 3.0. Use CakeResponse::httpCodes().
+ * @deprecated 3.0.0 Since 2.4. Will be removed in 3.0. Use CakeResponse::httpCodes().
  */
 	public function httpCodes($code = null) {
 		return $this->response->httpCodes($code);
@@ -820,7 +820,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param string $status The header message that is being set.
  * @return void
- * @deprecated Will be removed in 3.0. Use CakeResponse::header().
+ * @deprecated 3.0.0 Will be removed in 3.0. Use CakeResponse::header().
  */
 	public function header($status) {
 		$this->response->header($status);
@@ -874,7 +874,7 @@ class Controller extends Object implements CakeEventListener {
  * Returns number of errors in a submitted FORM.
  *
  * @return int Number of errors
- * @deprecated This method will be removed in 3.0
+ * @deprecated 3.0.0 This method will be removed in 3.0
  */
 	public function validate() {
 		$args = func_get_args();
@@ -893,7 +893,7 @@ class Controller extends Object implements CakeEventListener {
  * `$errors = $this->validateErrors($this->Article, $this->User);`
  *
  * @return array Validation errors, or false if none
- * @deprecated This method will be removed in 3.0
+ * @deprecated 3.0.0 This method will be removed in 3.0
  */
 	public function validateErrors() {
 		$objects = func_get_args();
@@ -980,7 +980,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::disableCache
- * @deprecated Will be removed in 3.0. Use CakeResponse::disableCache().
+ * @deprecated 3.0.0 Will be removed in 3.0. Use CakeResponse::disableCache().
  */
 	public function disableCache() {
 		$this->response->disableCache();
@@ -997,7 +997,7 @@ class Controller extends Object implements CakeEventListener {
  * @param string $layout Layout you want to use, defaults to 'flash'
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::flash
- * @deprecated Will be removed in 3.0. Use Session::setFlash().
+ * @deprecated 3.0.0 Will be removed in 3.0. Use Session::setFlash().
  */
 	public function flash($message, $url, $pause = 1, $layout = 'flash') {
 		$this->autoRender = false;
@@ -1018,7 +1018,7 @@ class Controller extends Object implements CakeEventListener {
  * @param bool $exclusive If true, and $op is an array, fields not included in $op will not be
  *        included in the returned conditions
  * @return array An array of model conditions
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	public function postConditions($data = array(), $op = null, $bool = 'AND', $exclusive = false) {
 		if (!is_array($data) || empty($data)) {
@@ -1148,7 +1148,7 @@ class Controller extends Object implements CakeEventListener {
  * @param string $method Method name.
  * @return bool
  * @see Controller::beforeScaffold()
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	protected function _beforeScaffold($method) {
 		return $this->beforeScaffold($method);
@@ -1171,7 +1171,7 @@ class Controller extends Object implements CakeEventListener {
  * @param string $method Method name.
  * @return bool
  * @see Controller::afterScaffoldSave()
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	protected function _afterScaffoldSave($method) {
 		return $this->afterScaffoldSave($method);
@@ -1194,7 +1194,7 @@ class Controller extends Object implements CakeEventListener {
  * @param string $method Method name.
  * @return bool
  * @see Controller::afterScaffoldSaveError()
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	protected function _afterScaffoldSaveError($method) {
 		return $this->afterScaffoldSaveError($method);
@@ -1219,7 +1219,7 @@ class Controller extends Object implements CakeEventListener {
  * @param string $method Method name.
  * @return bool
  * @see Controller::scaffoldError()
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	protected function _scaffoldError($method) {
 		return $this->scaffoldError($method);

--- a/lib/Cake/Controller/Scaffold.php
+++ b/lib/Cake/Controller/Scaffold.php
@@ -27,7 +27,7 @@
  * scaffolded actions with custom-made ones.
  *
  * @package Cake.Controller
- * @deprecated Dynamic scaffolding will be removed and replaced in 3.0
+ * @deprecated 3.0.0 Dynamic scaffolding will be removed and replaced in 3.0
  */
 class Scaffold {
 

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -361,7 +361,7 @@ class App {
  * @param string $plugin CamelCased/lower_cased plugin name to find the path of.
  * @return string full path to the plugin.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::pluginPath
- * @deprecated Use CakePlugin::path() instead.
+ * @deprecated 3.0.0 Use CakePlugin::path() instead.
  */
 	public static function pluginPath($plugin) {
 		return CakePlugin::path($plugin);

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -74,7 +74,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
  * @param string $behavior Behavior name.
  * @param array $config Configuration options.
  * @return void
- * @deprecated Will be removed in 3.0. Replaced with load().
+ * @deprecated 3.0.0 Will be removed in 3.0. Replaced with load().
  */
 	public function attach($behavior, $config = array()) {
 		return $this->load($behavior, $config);
@@ -201,7 +201,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
  *
  * @param string $name Name of behavior
  * @return void
- * @deprecated Will be removed in 3.0. Use unload instead.
+ * @deprecated 3.0.0 Will be removed in 3.0. Use unload instead.
  */
 	public function detach($name) {
 		return $this->unload($name);

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -949,7 +949,7 @@ class CakeRequest implements ArrayAccess {
  * @return bool true
  * @throws MethodNotAllowedException
  * @see CakeRequest::allowMethod()
- * @deprecated 2.5 Use CakeRequest::allowMethod() instead.
+ * @deprecated 3.0.0 Since 2.5, use CakeRequest::allowMethod() instead.
  */
 	public function onlyAllow($methods) {
 		if (!is_array($methods)) {

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -28,7 +28,7 @@ if (class_exists('HttpResponse')) {
  * HTTP Response from HttpSocket.
  *
  * @package       Cake.Network.Http
- * @deprecated This class is deprecated as it has naming conflicts with pecl/http
+ * @deprecated 3.0.0 This class is deprecated as it has naming conflicts with pecl/http
  */
 class HttpResponse extends HttpSocketResponse {
 

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -544,7 +544,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $result
  * @param mixed $expected
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertEqual($result, $expected, $message = '') {
@@ -557,7 +557,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $result
  * @param mixed $expected
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertNotEqual($result, $expected, $message = '') {
@@ -570,7 +570,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $pattern a regular expression
  * @param string $string the text to be matched
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertPattern($pattern, $string, $message = '') {
@@ -583,7 +583,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $actual
  * @param mixed $expected
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertIdentical($actual, $expected, $message = '') {
@@ -596,7 +596,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $actual
  * @param mixed $expected
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertNotIdentical($actual, $expected, $message = '') {
@@ -609,7 +609,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $pattern a regular expression
  * @param string $string the text to be matched
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertNoPattern($pattern, $string, $message = '') {
@@ -619,7 +619,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 /**
  * assert no errors
  *
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected function assertNoErrors() {
@@ -630,7 +630,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  *
  * @param mixed $expected the name of the Exception or error
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected function expectError($expected = false, $message = '') {
@@ -645,7 +645,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  *
  * @param mixed $expected the name of the Exception
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected function expectException($name = 'Exception', $message = '') {
@@ -658,7 +658,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param mixed $first
  * @param mixed $second
  * @param string $message the text to display if the assertion is not correct
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertReference(&$first, &$second, $message = '') {
@@ -671,7 +671,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $object
  * @param string $type
  * @param string $message
- * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
+ * @deprecated 3.0.0 This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void
  */
 	protected static function assertIsA($object, $type, $message = '') {

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -201,7 +201,7 @@ class Debugger {
  * @param int $line Line that triggered the error
  * @param array $context Context
  * @return bool true if error was handled
- * @deprecated Will be removed in 3.0. This function is superseded by Debugger::outputError().
+ * @deprecated 3.0.0 Will be removed in 3.0. This function is superseded by Debugger::outputError().
  */
 	public static function showError($code, $description, $file = null, $line = null, $context = null) {
 		$self = Debugger::getInstance();
@@ -696,7 +696,7 @@ class Debugger {
  *    straight HTML output, or 'txt' for unformatted text.
  * @param array $strings Template strings to be used for the output format.
  * @return string
- * @deprecated Use Debugger::outputAs() and Debugger::addFormat(). Will be removed
+ * @deprecated 3.0.0 Use Debugger::outputAs() and Debugger::addFormat(). Will be removed
  *   in 3.0
  */
 	public static function output($format = null, $strings = array()) {

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -268,7 +268,7 @@ abstract class ObjectCollection {
  *   returns an array of currently-attached objects
  * @return mixed If $name is specified, returns the boolean status of the corresponding object.
  *    Otherwise, returns an array of all attached objects.
- * @deprecated Will be removed in 3.0. Use loaded instead.
+ * @deprecated 3.0.0 Will be removed in 3.0. Use loaded instead.
  */
 	public function attached($name = null) {
 		return $this->loaded($name);

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -27,7 +27,7 @@ App::uses('ConnectionManager', 'Model');
  * and all of the above on arrays.
  *
  * @package       Cake.Utility
- * @deprecated    Deprecated since version 2.4
+ * @deprecated    3.0.0 Deprecated since version 2.4
  */
 class Sanitize {
 

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -42,7 +42,7 @@ class Security {
 /**
  * Get allowed minutes of inactivity based on security level.
  *
- * @deprecated Exists for backwards compatibility only, not used by the core
+ * @deprecated 3.0.0 Exists for backwards compatibility only, not used by the core
  * @return int Allowed inactivity in minutes
  */
 	public static function inactiveMins() {
@@ -179,7 +179,7 @@ class Security {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use
  * @return string Encrypted/Decrypted string
- * @deprecated Will be removed in 3.0.
+ * @deprecated 3.0.0 Will be removed in 3.0.
  */
 	public static function cipher($text, $key) {
 		if (empty($key)) {

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -23,7 +23,7 @@ App::uses('Hash', 'Utility');
  * Class used for manipulation of arrays.
  *
  * @package       Cake.Utility
- * @deprecated Will be removed in 3.0. Use Hash instead.
+ * @deprecated 3.0.0 Will be removed in 3.0. Use Hash instead.
  */
 class Set {
 

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -197,7 +197,7 @@ class Helper extends Object {
  *
  * @param string $name Name of the property being accessed.
  * @return mixed Helper or property found at $name
- * @deprecated Accessing request properties through this method is deprecated and will be removed in 3.0.
+ * @deprecated 3.0.0 Accessing request properties through this method is deprecated and will be removed in 3.0.
  */
 	public function __get($name) {
 		if (isset($this->_helperMap[$name]) && !isset($this->{$name})) {
@@ -226,7 +226,7 @@ class Helper extends Object {
  * @param string $name Name of the property being accessed.
  * @param mixed $value Value to set.
  * @return void
- * @deprecated This method will be removed in 3.0
+ * @deprecated 3.0.0 This method will be removed in 3.0
  */
 	public function __set($name, $value) {
 		switch ($name) {
@@ -407,7 +407,7 @@ class Helper extends Object {
  *
  * @param string|array $output Either an array of strings to clean or a single string to clean.
  * @return string|array cleaned content for output
- * @deprecated This method will be removed in 3.0
+ * @deprecated 3.0.0 This method will be removed in 3.0
  */
 	public function clean($output) {
 		$this->_reset();
@@ -449,7 +449,7 @@ class Helper extends Object {
  * @param string $insertBefore String to be inserted before options.
  * @param string $insertAfter String to be inserted after options.
  * @return string Composed attributes.
- * @deprecated This method will be moved to HtmlHelper in 3.0
+ * @deprecated 3.0.0 This method will be moved to HtmlHelper in 3.0
  */
 	protected function _parseAttributes($options, $exclude = null, $insertBefore = ' ', $insertAfter = null) {
 		if (!is_string($options)) {
@@ -483,7 +483,7 @@ class Helper extends Object {
  * @param string $value The value of the attribute to create.
  * @param bool $escape Define if the value must be escaped
  * @return string The composed attribute.
- * @deprecated This method will be moved to HtmlHelper in 3.0
+ * @deprecated 3.0.0 This method will be moved to HtmlHelper in 3.0
  */
 	protected function _formatAttribute($key, $value, $escape = true) {
 		if (is_array($value)) {
@@ -801,7 +801,7 @@ class Helper extends Object {
  *
  * @param string $str String to be output.
  * @return string
- * @deprecated This method will be removed in future versions.
+ * @deprecated 3.0.0 This method will be removed in future versions.
  */
 	public function output($str) {
 		return $str;

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -624,7 +624,6 @@ class PaginatorHelper extends AppHelper {
  *
  * @param array $options Options for the counter string. See #options for list of keys.
  * @return string Counter string.
- * @deprecated The %page% style placeholders are deprecated.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::counter
  */
 	public function counter($options = array()) {

--- a/lib/Cake/View/MediaView.php
+++ b/lib/Cake/View/MediaView.php
@@ -53,7 +53,7 @@ App::uses('CakeRequest', 'Network');
  * }}}
  *
  * @package       Cake.View
- * @deprecated Deprecated since version 2.3, use CakeResponse::file() instead
+ * @deprecated 3.0.0 Deprecated since version 2.3, use CakeResponse::file() instead
  */
 class MediaView extends View {
 

--- a/lib/Cake/View/ScaffoldView.php
+++ b/lib/Cake/View/ScaffoldView.php
@@ -24,7 +24,7 @@ App::uses('View', 'View');
  * ScaffoldView provides specific view file loading features for scaffolded views.
  *
  * @package Cake.View
- * @deprecated Dynamic scaffolding will be removed and replaced in 3.0
+ * @deprecated 3.0.0 Dynamic scaffolding will be removed and replaced in 3.0
  */
 class ScaffoldView extends View {
 

--- a/lib/Cake/View/ThemeView.php
+++ b/lib/Cake/View/ThemeView.php
@@ -24,7 +24,7 @@ App::uses('View', 'View');
  * Stub class for 2.1 Compatibility
  *
  * @package       Cake.View
- * @deprecated Deprecated since 2.1, use View class instead
+ * @deprecated 3.0.0 Deprecated since 2.1, use View class instead
  */
 class ThemeView extends View {
 

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -590,7 +590,7 @@ class View extends Object {
  *
  * @param string $var The view var you want the contents of.
  * @return mixed The content of the named var if its set, otherwise null.
- * @deprecated Will be removed in 3.0. Use View::get() instead.
+ * @deprecated 3.0.0 Will be removed in 3.0. Use View::get() instead.
  */
 	public function getVar($var) {
 		return $this->get($var);
@@ -756,7 +756,7 @@ class View extends Object {
  *   update/replace a script element.
  * @param string $content The content of the script being added, optional.
  * @return void
- * @deprecated Will be removed in 3.0. Superseded by blocks functionality.
+ * @deprecated 3.0.0 Will be removed in 3.0. Superseded by blocks functionality.
  * @see View::start()
  */
 	public function addScript($name, $content = null) {

--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -164,7 +164,7 @@ class ViewBlock {
  * @param string $name Name of the block
  * @param string $value The content for the block.
  * @return void
- * @deprecated As of 2.3 use ViewBlock::concat() instead.
+ * @deprecated 3.0.0 As of 2.3 use ViewBlock::concat() instead.
  */
 	public function append($name, $value = null) {
 		$this->concat($name, $value);

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -389,7 +389,7 @@ if (!function_exists('cache')) {
  * @param mixed $expires A valid strtotime string when the data expires.
  * @param string $target The target of the cached data; either 'cache' or 'public'.
  * @return mixed The contents of the temporary file.
- * @deprecated Will be removed in 3.0. Please use Cache::write() instead.
+ * @deprecated 3.0.0 Will be removed in 3.0. Please use Cache::write() instead.
  */
 	function cache($path, $data = null, $expires = '+1 day', $target = 'cache') {
 		if (Configure::read('Cache.disable')) {


### PR DESCRIPTION
to adhere to the `@deprecated <version> <description>` format, where version and description are mandatory.

Inspired by the discussion https://github.com/cakephp/cakephp/pull/4417#discussion_r16957099

Related specs:
http://phpdoc.org/docs/latest/references/phpdoc/tags/deprecated.html
http://phpdoc.org/docs/latest/references/phpdoc/tags/version.html
