### PR TITLE
3.0 Update API Cake\Utility\Number::precision()

### DIFF
--- a/src/ORM/Exception/MissingEntityException.php
+++ b/src/ORM/Exception/MissingEntityException.php
@@ -19,7 +19,7 @@ namespace Cake\ORM\Exception;
 use Cake\Core\Exception\Exception;
 
 /**
- * Exception raised when an Entity  could not be found.
+ * Exception raised when an Entity could not be found.
  *
  */
 class MissingEntityException extends Exception {

--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -45,7 +45,7 @@ class Number {
  *
  * @param float $value A floating point number.
  * @param int $precision The precision of the returned number.
- * @return float Formatted float.
+ * @return string Formatted float.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::precision
  */
 	public static function precision($value, $precision = 3) {

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -244,7 +244,7 @@ class ErrorHandlerTest extends TestCase {
 		$this->_logger->expects($this->once())
 			->method('write')
 			->with('error', $this->logicalAnd(
-				$this->stringContains('[Cake\NEtwork\Exception\NotFoundException] Kaboom!'),
+				$this->stringContains('[Cake\Network\Exception\NotFoundException] Kaboom!'),
 				$this->stringContains('ErrorHandlerTest->testHandleExceptionLog')
 			));
 


### PR DESCRIPTION
This function now return a string and not a float anymore.

Additionally correct few typos
