### PR TITLE
console: don't use colored output if there's no TTY

### DIFF
--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -161,7 +161,10 @@ class ConsoleOutput {
 	public function __construct($stream = 'php://stdout') {
 		$this->_output = fopen($stream, 'w');
 
-		if (DS === '\\' && !(bool)env('ANSICON')) {
+		if (
+			(DS === '\\' && !(bool)env('ANSICON')) ||
+			(function_exists('posix_isatty') && !posix_isatty($this->_output))
+		) {
 			$this->_outputAs = self::PLAIN;
 		}
 	}

--- a/lib/Cake/Log/Engine/ConsoleLog.php
+++ b/lib/Cake/Log/Engine/ConsoleLog.php
@@ -48,7 +48,10 @@ class ConsoleLog extends BaseLog {
  */
 	public function __construct($config = array()) {
 		parent::__construct($config);
-		if (DS === '\\' && !(bool)env('ANSICON')) {
+		if (
+			(DS === '\\' && !(bool)env('ANSICON')) ||
+			(function_exists('posix_isatty') && !posix_isatty($this->_output))
+		) {
 			$outputAs = ConsoleOutput::PLAIN;
 		} else {
 			$outputAs = ConsoleOutput::COLOR;


### PR DESCRIPTION
This prevents ANSI escape codes and style tags showing up in
cron-jobs, pipes or redirects.

I used `posix_isatty()` to detect if we're on a terminal or not.
