### PR TITLE
Disable autoFields for association subqueries

### DIFF
--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -160,6 +160,7 @@ trait SelectableAssociationTrait {
  */
 	protected function _buildSubquery($query) {
 		$filterQuery = clone $query;
+		$filterQuery->autoFields(false);
 		$filterQuery->limit(null);
 		$filterQuery->order([], true);
 		$filterQuery->contain([], true);


### PR DESCRIPTION
Causes problems because it loads all fields for subqueries
