### PR TITLE
Remove outdated information

### DIFF
--- a/src/Shell/TestShell.php
+++ b/src/Shell/TestShell.php
@@ -62,8 +62,8 @@ class TestShell extends Shell {
 		$this->err('');
 		$this->err('TestShell has been removed and replaced with <info>phpunit</info>.');
 		$this->err('');
-		$this->err('To run your application tests run <info>phpunit --stderr</info>');
-		$this->err('To run plugin tests, cd into the plugin directory and run <info>phpunit --stderr</info>');
+		$this->err('To run your application tests run <info>phpunit</info>');
+		$this->err('To run plugin tests, cd into the plugin directory and run <info>phpunit</info>');
 	}
 
 }


### PR DESCRIPTION
`--stderr` is outdated.

On Windows the output is this, by the way:

```
Test Shell has been removed.

TestShell has been removed and replaced with phpunit.

To run your application tests run phpunit
To run plugin tests, cd into the plugin directory and run phpunit
```

Kind of hard to see the "code" without the `<info>` parts working.

I wonder if it would be useful to add backticks around the commands:

``` php
$this->err('To run your application tests run `<info>phpunit</info>`');
```

etc
