### PR TITLE
SecurityComponent::requireSecure() should accept no argument

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -147,7 +147,7 @@ class SecurityComponent extends Component {
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#SecurityComponent::requireSecure
  */
-	public function requireSecure($actions) {
+	public function requireSecure($actions = null) {
 		$this->_requireMethod('Secure', (array)$actions);
 	}
 

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -236,8 +236,8 @@ class SecurityComponentTest extends TestCase {
 	public function testRequireSecureFail() {
 		$_SERVER['HTTPS'] = 'off';
 		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->request['action'] = 'posted';
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->Security->requireSecure(array('posted'));
 		$this->Controller->Security->startup($event);
 		$this->assertTrue($this->Controller->failed);
@@ -249,11 +249,41 @@ class SecurityComponentTest extends TestCase {
  * @return void
  */
 	public function testRequireSecureSucceed() {
+		$_SERVER['HTTPS'] = 'on';
 		$_SERVER['REQUEST_METHOD'] = 'Secure';
 		$this->Controller->request['action'] = 'posted';
-		$_SERVER['HTTPS'] = 'on';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->Security->requireSecure('posted');
+		$this->Controller->Security->startup($event);
+		$this->assertFalse($this->Controller->failed);
+	}
+
+/**
+ * testRequireSecureEmptyFail method
+ *
+ * @return void
+ */
+	public function testRequireSecureEmptyFail() {
+		$_SERVER['HTTPS'] = 'off';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$this->Controller->request['action'] = 'posted';
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->Controller->Security->requireSecure();
+		$this->Controller->Security->startup($event);
+		$this->assertTrue($this->Controller->failed);
+	}
+
+/**
+ * testRequireSecureEmptySucceed method
+ *
+ * @return void
+ */
+	public function testRequireSecureEmptySucceed() {
+		$_SERVER['HTTPS'] = 'on';
+		$_SERVER['REQUEST_METHOD'] = 'Secure';
+		$this->Controller->request['action'] = 'posted';
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->Controller->Security->requireSecure();
 		$this->Controller->Security->startup($event);
 		$this->assertFalse($this->Controller->failed);
 	}


### PR DESCRIPTION
According to documentation requireSecure() "Can be called with no arguments to force all actions to require a SSL-secured". Fixed to do that and also added the tests for this occasion.
