### PR TITLE
Add query->cleanCopy().

### DIFF
--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -160,11 +160,8 @@ trait SelectableAssociationTrait {
  */
 	protected function _buildSubquery($query) {
 		$filterQuery = clone $query;
-		$filterQuery->autoFields(false);
-		$filterQuery->limit(null);
-		$filterQuery->offset(null);
-		$filterQuery->order([], true);
-		$filterQuery->contain([], true);
+		$filterQuery->clear();
+
 		$joins = $filterQuery->join();
 		foreach ($joins as $i => $join) {
 			if (strtolower($join['type']) !== 'inner') {

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -159,8 +159,7 @@ trait SelectableAssociationTrait {
  * @return \Cake\ORM\Query
  */
 	protected function _buildSubquery($query) {
-		$filterQuery = clone $query;
-		$filterQuery->clear();
+		$filterQuery = $query->cleanCopy();
 
 		$joins = $filterQuery->join();
 		foreach ($joins as $i => $join) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -468,9 +468,9 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	}
 
 /**
- * Clear many the clauses that will make cloned queries behave incorrectly.
+ * Creates a copy of this current query and resets some state.
  *
- * The following clauses/features will be cleared:
+ * The following state will be cleared:
  *
  * - autoFields
  * - limit
@@ -479,15 +479,21 @@ class Query extends DatabaseQuery implements JsonSerializable {
  * - result formatters
  * - order
  * - containments
+ *
+ * This method creates query clones that are useful when working with subqueries.
+ *
+ * @return \Cake\ORM\Query
  */
-	public function clear() {
-		$this->autoFields(false);
-		$this->limit(null);
-		$this->order([], true);
-		$this->offset(null);
-		$this->mapReduce(null, null, true);
-		$this->formatResults(null, true);
-		$this->contain([], true);
+	public function cleanCopy() {
+		$query = clone $this;
+		$query->autoFields(false);
+		$query->limit(null);
+		$query->order([], true);
+		$query->offset(null);
+		$query->mapReduce(null, null, true);
+		$query->formatResults(null, true);
+		$query->contain([], true);
+		return $query;
 	}
 
 /**
@@ -496,9 +502,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
  * @return int
  */
 	public function count() {
-		$query = clone $this;
-		$query->clear();
-
+		$query = $this->cleanCopy();
 		$counter = $this->_counter;
 
 		if ($counter) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -468,18 +468,37 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	}
 
 /**
+ * Clear many the clauses that will make cloned queries behave incorrectly.
+ *
+ * The following clauses/features will be cleared:
+ *
+ * - autoFields
+ * - limit
+ * - offset
+ * - map/reduce functions
+ * - result formatters
+ * - order
+ * - containments
+ */
+	public function clear() {
+		$this->autoFields(false);
+		$this->limit(null);
+		$this->order([], true);
+		$this->offset(null);
+		$this->mapReduce(null, null, true);
+		$this->formatResults(null, true);
+		$this->contain([], true);
+	}
+
+/**
  * Returns the COUNT(*) for the query.
  *
  * @return int
  */
 	public function count() {
 		$query = clone $this;
-		$query->autoFields(false);
-		$query->limit(null);
-		$query->order([], true);
-		$query->offset(null);
-		$query->mapReduce(null, null, true);
-		$query->formatResults(null, true);
+		$query->clear();
+
 		$counter = $this->_counter;
 
 		if ($counter) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2089,4 +2089,26 @@ class QueryTest extends TestCase {
 		$this->assertEquals(3, $result);
 	}
 
+/**
+ * test that cleanCopy makes a cleaned up clone.
+ *
+ * @return void
+ */
+	public function testCleanCopy() {
+		$table = TableRegistry::get('Articles');
+		$table->hasMany('Comments');
+
+		$query = $table->find();
+		$query->offset(10)
+			->limit(1)
+			->order(['Articles.id' => 'DESC'])
+			->contain(['Comments']);
+		$copy = $query->cleanCopy();
+
+		$this->assertNotSame($copy, $query);
+		$this->assertNull($copy->clause('offset'));
+		$this->assertNull($copy->clause('limit'));
+		$this->assertNull($copy->clause('order'));
+	}
+
 }


### PR DESCRIPTION
I found a few duplicated blocks of code related to clearing query state when subqueries are created. Having a function will help prevent code getting out of sync in the future.
