### PR TITLE
Request now understands HTTPS if variable is 'on' instead of 1

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -126,7 +126,7 @@ class Request implements \ArrayAccess {
 		'delete' => array('env' => 'REQUEST_METHOD', 'value' => 'DELETE'),
 		'head' => array('env' => 'REQUEST_METHOD', 'value' => 'HEAD'),
 		'options' => array('env' => 'REQUEST_METHOD', 'value' => 'OPTIONS'),
-		'ssl' => array('env' => 'HTTPS', 'value' => 1),
+		'ssl' => array('env' => 'HTTPS', 'options' => [1, 'on']),
 		'ajax' => array('env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'),
 		'flash' => array('env' => 'HTTP_USER_AGENT', 'pattern' => '/^(Shockwave|Adobe) Flash/'),
 		'requested' => array('param' => 'requested', 'value' => 1)


### PR DESCRIPTION
With HTTPS in Ubuntu/Apache superglobal `$_SERVER('HTTPS')` holds `'on'` instead of `1` and `Request::is('ssl')` was failing to understand that.

Inexplicably how, included tests against `'on'` and `'I am not empty'` values passed and still pass after this change but they don't work in reality.
