### PR TITLE
Correct commands and make them more visible.

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -23,8 +23,7 @@ use Cake\Utility\Inflector;
 /**
  * Shell dispatcher handles dispatching cli commands.
  *
- * Consult https://github.com/cakephp/app/tree/master/App/Console/cake.php
- * for how this class is used in practice.
+ * Consult /bin/cake.php for how this class is used in practice.
  */
 class ShellDispatcher {
 

--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -85,7 +85,7 @@ class BakeShell extends Shell {
 			$this->out('- ' . Inflector::underscore($name));
 		}
 		$this->out('');
-		$this->out('By using <info>Console/cake bake [name]</info> you can invoke a specific bake task.');
+		$this->out('By using <info>`cake bake [name]`</info> you can invoke a specific bake task.');
 	}
 
 /**
@@ -205,7 +205,7 @@ class BakeShell extends Shell {
 			foreach ($this->Model->listAll() as $table) {
 				$this->out('- ' . $table);
 			}
-			$this->out('Run <info>cake bake all [name]</info> to generate skeleton files.');
+			$this->out('Run <info>`cake bake all [name]`</info> to generate skeleton files.');
 			return false;
 		}
 

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -51,7 +51,7 @@ class CommandListShell extends Shell {
 	public function main() {
 		if (empty($this->params['xml'])) {
 			$this->out("<info>Current Paths:</info>", 2);
-			$this->out("* app: " . APP_DIR);
+			$this->out("* app:  " . APP_DIR);
 			$this->out("* root: " . rtrim(ROOT, DS));
 			$this->out("* core: " . rtrim(CORE_PATH, DS));
 			$this->out("");
@@ -84,9 +84,9 @@ class CommandListShell extends Shell {
 			$this->out();
 		}
 
-		$this->out("To run an app or core command, type <info>cake shell_name [args]</info>");
-		$this->out("To run a plugin command, type <info>cake Plugin.shell_name [args]</info>");
-		$this->out("To get help on a specific command, type <info>cake shell_name --help</info>", 2);
+		$this->out("To run an app or core command, type <info>`cake shell_name [args]`</info>");
+		$this->out("To run a plugin command, type <info>`cake Plugin.shell_name [args]`</info>");
+		$this->out("To get help on a specific command, type <info>`cake shell_name --help`</info>", 2);
 	}
 
 /**

--- a/src/Shell/ServerShell.php
+++ b/src/Shell/ServerShell.php
@@ -132,7 +132,7 @@ class ServerShell extends Shell {
 
 		$port = ':' . $this->_port;
 		$this->out(sprintf('built-in server is running in http://%s%s/', $this->_host, $port));
-		$this->out(sprintf('You can exit with <info>CTRL-C</info>'));
+		$this->out(sprintf('You can exit with <info>`CTRL-C`</info>'));
 		system($command);
 	}
 

--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -59,7 +59,7 @@ class PluginTask extends BakeTask {
 	public function main($name = null) {
 		if (empty($name)) {
 			$this->err('<error>You must provide a plugin name in CamelCase format.</error>');
-			$this->err('To make an "Example" plugin, run <info>Console/cake bake plugin Example</info>.');
+			$this->err('To make an "Example" plugin, run <info>`cake bake plugin Example`</info>.');
 			return false;
 		}
 		$plugin = $this->_camelize($name);

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -116,7 +116,7 @@ class TestTask extends BakeTask {
 			$this->out(++$i . '. ' . $option);
 		}
 		$this->out('');
-		$this->out('Re-run your command as Console/cake bake <type> <classname>');
+		$this->out('Re-run your command as `cake bake <type> <classname>`');
 	}
 
 /**
@@ -142,7 +142,7 @@ class TestTask extends BakeTask {
 			$this->out(++$i . '. ' . $option);
 		}
 		$this->out('');
-		$this->out('Re-run your command as Console/cake bake ' . $type . ' <classname>');
+		$this->out('Re-run your command as `cake bake ' . $type . ' <classname>`');
 	}
 
 /**

--- a/src/Shell/TestShell.php
+++ b/src/Shell/TestShell.php
@@ -58,12 +58,12 @@ class TestShell extends Shell {
  * @return void
  */
 	public function outputWarning() {
-		$this->err('<error>Test Shell has been removed.</error>');
+		$this->err('<error>TestShell has been removed.</error>');
 		$this->err('');
-		$this->err('TestShell has been removed and replaced with <info>phpunit</info>.');
+		$this->err('TestShell has been replaced with <info>`phpunit`</info>.');
 		$this->err('');
-		$this->err('To run your application tests run <info>phpunit</info>');
-		$this->err('To run plugin tests, cd into the plugin directory and run <info>phpunit</info>');
+		$this->err('To run your application tests run <info>`phpunit`</info>');
+		$this->err('To run plugin tests, cd into the plugin directory and run <info>`phpunit`</info>');
 	}
 
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/4482

I used `cake bake [name]` as `bin/cake ...` would only be correct for some OS, while on others (WIN) it must be `.\bin\cake ...` for example.
So using the generic form here makes most sense. This also unifies it across the framework code since it has already been used this way in other places.
