### PR TITLE
to correctly return SET() type

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -784,6 +784,9 @@ class Mysql extends DboSource {
 		if (strpos($col, 'enum') !== false) {
 			return "enum($vals)";
 		}
+		if (strpos($col, 'set') !== false) {
+			return "set($vals)";
+		}
 		return 'text';
 	}
 


### PR DESCRIPTION
SET() data type is retuned as TEXT
