### PR TITLE
3.0 merge

### DIFF
--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -82,8 +82,8 @@ class BasicAuthenticate extends BaseAuthenticate {
 /**
  * Handles an unauthenticated access attempt by sending appropriate login headers
  *
- * @param Request $request A request object.
- * @param Response $response A response object.
+ * @param \Cake\Network\Request $request A request object.
+ * @param \Cake\Network\Response $response A response object.
  * @return void
  * @throws \Cake\Network\Exception\UnauthorizedException
  */

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -73,26 +73,26 @@ class FlashComponent extends Component {
  * @return void
  */
 	public function set($message, array $options = []) {
-		$opts = array_merge($this->config(), $options);
+		$options += $this->config();
 
 		if ($message instanceof \Exception) {
-			$opts['params'] += ['code' => $message->getCode()];
+			$options['params'] += ['code' => $message->getCode()];
 			$message = $message->getMessage();
 		}
 
-		list($plugin, $element) = pluginSplit($opts['element']);
+		list($plugin, $element) = pluginSplit($options['element']);
 
 		if ($plugin) {
-			$opts['element'] = $plugin . '.Flash/' . $element;
+			$options['element'] = $plugin . '.Flash/' . $element;
 		} else {
-			$opts['element'] = 'Flash/' . $element;
+			$options['element'] = 'Flash/' . $element;
 		}
 
-		$this->_session->write('Flash.' . $opts['key'], [
+		$this->_session->write('Flash.' . $options['key'], [
 			'message' => $message,
-			'key' => $opts['key'],
-			'element' => $opts['element'],
-			'params' => $opts['params']
+			'key' => $options['key'],
+			'element' => $options['element'],
+			'params' => $options['params']
 		]);
 	}
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -300,11 +300,11 @@ class Debugger {
 		);
 
 		for ($i = $options['start']; $i < $count && $i < $options['depth']; $i++) {
-			$trace = array_merge(array('file' => '[internal]', 'line' => '??'), $backtrace[$i]);
+			$trace = $backtrace[$i] + array('file' => '[internal]', 'line' => '??');
 			$signature = $reference = '[main]';
 
 			if (isset($backtrace[$i + 1])) {
-				$next = array_merge($_trace, $backtrace[$i + 1]);
+				$next = $backtrace[$i + 1] + $_trace;
 				$signature = $reference = $next['function'];
 
 				if (!empty($next['class'])) {
@@ -689,7 +689,7 @@ class Debugger {
 				);
 				unset($strings['links']);
 			}
-			$self->_templates[$format] = array_merge($self->_templates[$format], $strings);
+			$self->_templates[$format] = $strings + $self->_templates[$format];
 		} else {
 			$self->_templates[$format] = $strings;
 		}
@@ -779,7 +779,7 @@ class Debugger {
 
 		$data['trace'] = $trace;
 		$data['id'] = 'cakeErr' . uniqid();
-		$tpl = array_merge($this->_templates['base'], $this->_templates[$this->_outputFormat]);
+		$tpl = $this->_templates[$this->_outputFormat] + $this->_templates['base'];
 
 		if (isset($tpl['links'])) {
 			foreach ($tpl['links'] as $key => $val) {

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -425,7 +425,7 @@ class Client {
  * Uses the authentication type to choose the correct strategy
  * and use its methods to add headers.
  *
- * @param Request $request The request to modify.
+ * @param \Cake\Network\Http\Request $request The request to modify.
  * @param array $options Array of options containing the 'auth' key.
  * @return void
  */
@@ -441,7 +441,7 @@ class Client {
  * Uses the authentication type to choose the correct strategy
  * and use its methods to add headers.
  *
- * @param Request $request The request to modify.
+ * @param \Cake\Network\Http\Request $request The request to modify.
  * @param array $options Array of options containing the 'proxy' key.
  * @return void
  */

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -343,10 +343,7 @@ class PaginatorHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sort
  */
 	public function sort($key, $title = null, array $options = []) {
-		$options = array_merge(
-			['url' => array(), 'model' => null, 'escape' => true],
-			$options
-		);
+		$options += ['url' => array(), 'model' => null, 'escape' => true];
 		$url = $options['url'];
 		unset($options['url']);
 
@@ -519,6 +516,7 @@ class PaginatorHelper extends Helper {
  *    custom content you would like.
  *
  * @param string|array $options Options for the counter string. See #options for list of keys.
+ *   If string it will be used as format.
  * @return string Counter string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::counter
  */
@@ -527,12 +525,10 @@ class PaginatorHelper extends Helper {
 			$options = array('format' => $options);
 		}
 
-		$options = array_merge(
-			[
-				'model' => $this->defaultModel(),
-				'format' => 'pages',
-			],
-		$options);
+		$options += [
+			'model' => $this->defaultModel(),
+			'format' => 'pages',
+		];
 
 		$paging = $this->params($options['model']);
 		if (!$paging['pageCount']) {
@@ -737,10 +733,7 @@ class PaginatorHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::first
  */
 	public function first($first = '<< first', array $options = []) {
-		$options = array_merge(
-			['model' => $this->defaultModel(), 'escape' => true],
-			$options
-		);
+		$options += ['model' => $this->defaultModel(), 'escape' => true];
 
 		$params = $this->params($options['model']);
 
@@ -789,11 +782,7 @@ class PaginatorHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::last
  */
 	public function last($last = 'last >>', array $options = array()) {
-		$options = array_merge(
-			['model' => $this->defaultModel(), 'escape' => true],
-			$options
-		);
-
+		$options += ['model' => $this->defaultModel(), 'escape' => true];
 		$params = $this->params($options['model']);
 
 		if ($params['pageCount'] <= 1) {

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -220,7 +220,7 @@ class TextHelper extends Helper {
  */
 	public function autoLink($text, array $options = array()) {
 		$text = $this->autoLinkUrls($text, $options);
-		return $this->autoLinkEmails($text, array_merge($options, array('escape' => false)));
+		return $this->autoLinkEmails($text, array('escape' => false) + $options);
 	}
 
 /**


### PR DESCRIPTION
Clean up merges.
String key based arrays should be merged with + operator (3-5x faster and usually more correct with falsy values - unifies this across the core code).

Also refs doc block corrections from https://github.com/cakephp/cakephp/pull/3802
