### PR TITLE
Better method signatures for Routing.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -63,7 +63,7 @@ class RequestHandlerComponent extends Component {
  * Contains the file extension parsed out by the Router
  *
  * @var string
- * @see Router::parseExtensions()
+ * @see Router::extensions()
  */
 	public $ext = null;
 
@@ -149,7 +149,7 @@ class RequestHandlerComponent extends Component {
  *
  * @param Event $event The initialize event that was fired.
  * @return void
- * @see Router::parseExtensions()
+ * @see Router::extensions()
  */
 	public function initialize(Event $event) {
 		if (isset($this->request->params['_ext'])) {
@@ -207,7 +207,7 @@ class RequestHandlerComponent extends Component {
  * The startup method of the RequestHandler enables several automatic behaviors
  * related to the detection of certain properties of the HTTP request, including:
  *
- * - If Router::parseExtensions() is enabled, the layout and template type are
+ * - If Router::extensions() is enabled, the layout and template type are
  *   switched based on the parsed extension or Accept-Type header. For example, if `controller/action.xml`
  *   is requested, the view path becomes `app/View/Controller/xml/action.ctp`. Also if
  *   `controller/action` is requested with `Accept-Type: application/xml` in the headers

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -219,7 +219,7 @@ class RouteBuilder {
  * - 'actions' - Override the method names used for connecting actions.
  *
  * @param string $name A controller name to connect resource routes for.
- * @param array|callable $options Options to use when generating REST routes
+ * @param array|callable $options Options to use when generating REST routes, or a callback.
  * @param callable $callback An optional callback to be executed in a nested scope. Nested
  *   scopes inherit the existing path and 'id' parameter.
  * @return array Array of mapped resources
@@ -514,8 +514,8 @@ class RouteBuilder {
  * to the supplied parameters.
  *
  * @param string $path The path to create a scope for.
- * @param array|callable $params Either the parameters to add to routes, or a callback
- * @param callable $callback The callback to invoke that builds the plugin routes
+ * @param array|callable $params Either the parameters to add to routes, or a callback.
+ * @param callable $callback The callback to invoke that builds the plugin routes.
  *   Only required when $params is defined.
  * @return void
  * @throws \InvalidArgumentException when there is no callable parameter.

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -219,7 +219,7 @@ class RouteBuilder {
  * - 'actions' - Override the method names used for connecting actions.
  *
  * @param string $name A controller name to connect resource routes for.
- * @param array $options Options to use when generating REST routes
+ * @param array|callable $options Options to use when generating REST routes
  * @param callable $callback An optional callback to be executed in a nested scope. Nested
  *   scopes inherit the existing path and 'id' parameter.
  * @return array Array of mapped resources
@@ -440,7 +440,7 @@ class RouteBuilder {
  *   shifted into the passed arguments. As well as supplying patterns for routing parameters.
  * @return array Array of routes
  */
-	public function redirect($route, $url, $options = []) {
+	public function redirect($route, $url, array $options = []) {
 		$options['routeClass'] = 'Cake\Routing\Route\RedirectRoute';
 		if (is_string($url)) {
 			$url = array('redirect' => $url);

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -285,11 +285,11 @@ class RouteCollection {
 		if ($extensions === null) {
 			return $this->_extensions;
 		}
-		if (!$merge) {
-			$this->_extensions = (array)$extensions;
-			return;
+		$extensions = (array)$extensions;
+		if ($merge) {
+			$extensions = array_merge($this->_extensions, $extensions);
 		}
-		$this->_extensions = array_unique(array_merge($this->_extensions, (array)$extensions));
+		$this->_extensions = array_unique($extensions);
 	}
 
 }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -99,7 +99,7 @@ class RouteCollection {
 
 		$extensions = $route->extensions();
 		if ($extensions) {
-			$this->addExtensions($extensions);
+			$this->extensions($extensions);
 		}
 	}
 
@@ -275,26 +275,21 @@ class RouteCollection {
 	}
 
 /**
- * Add one or more extensions.
- *
- * @param array $extensions The extensions to add.
- * @return void
- */
-	public function addExtensions(array $extensions) {
-		$this->_extensions = array_unique(array_merge($this->_extensions, $extensions));
-	}
-
-/**
  * Get/set the extensions that the route collection could handle.
  *
  * @param null|string|array $extensions Either the list of extensions to set, or null to get.
+ * @param bool $merge If extensions should be merged on top of the existing ones.
  * @return array The valid extensions.
  */
-	public function extensions($extensions = null) {
+	public function extensions($extensions = null, $merge = true) {
 		if ($extensions === null) {
 			return $this->_extensions;
 		}
-		$this->_extensions = (array)$extensions;
+		if (!$merge) {
+			$this->_extensions = (array)$extensions;
+			return;
+		}
+		$this->_extensions = array_unique(array_merge($this->_extensions, (array)$extensions));
 	}
 
 }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -74,7 +74,7 @@ class RouteCollection {
  *   `_name` option, which enables named routes.
  * @return void
  */
-	public function add(Route $route, $options = []) {
+	public function add(Route $route, array $options = []) {
 		$this->_routes[] = $route;
 
 		// Explicit names
@@ -292,7 +292,7 @@ class RouteCollection {
  */
 	public function extensions($extensions = null) {
 		if ($extensions === null) {
-			return array_unique($this->_extensions);
+			return $this->_extensions;
 		}
 		$this->_extensions = (array)$extensions;
 	}

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -729,14 +729,7 @@ class Router {
  */
 	public static function parseExtensions($extensions = null, $merge = true) {
 		$collection = static::$_collection;
-		if ($extensions === null) {
-			return $collection->extensions();
-		}
-		$extensions = (array)$extensions;
-		if ($merge) {
-			$extensions = array_merge($collection->extensions(), $extensions);
-		}
-		return $collection->extensions($extensions, false);
+		return $collection->extensions($extensions, $merge);
 	}
 
 /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -735,7 +735,7 @@ class Router {
 		if ($merge) {
 			$extensions = array_merge($collection->extensions(), $extensions);
 		}
-		return $collection->extensions($extensions);
+		return $collection->extensions($extensions, false);
 	}
 
 /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -709,7 +709,7 @@ class Router {
 	}
 
 /**
- * Set/add valid extensions. Instructs the router to parse out file extensions
+ * Get/set/add valid extensions. Instructs the router to parse out file extensions
  * from the URL. For example, http://example.com/posts.rss would yield a file
  * extension of "rss". The file extension itself is made available in the
  * controller as `$this->params['_ext']`, and is used by the RequestHandler
@@ -725,25 +725,13 @@ class Router {
  *   If null it will return the currently set extensions.
  * @param bool $merge Default true will merge extensions. Set to false to override
  *   current extensions.
- * @return array
- */
-	public static function parseExtensions($extensions = null, $merge = true) {
-		$collection = static::$_collection;
-		return $collection->extensions($extensions, $merge);
-	}
-
-/**
- * Get the list of extensions that can be parsed by Router.
- *
- * To add / update extensions use `Router::parseExtensions()`
- *
  * @return array Array of extensions Router is configured to parse.
  */
-	public static function extensions() {
+	public static function extensions($extensions = null, $merge = true) {
 		if (!static::$initialized) {
 			static::_loadRoutes();
 		}
-		return static::$_collection->extensions();
+		return static::$_collection->extensions($extensions, $merge);
 	}
 
 /**
@@ -823,7 +811,7 @@ class Router {
  * specific kinds of scopes.
  *
  * Routing scopes will inherit the globally set extensions configured with
- * Router::parseExtensions(). You can also set valid extensions using
+ * Router::extensions(). You can also set valid extensions using
  * `$routes->extensions()` in your closure.
  *
  * @param string $path The path prefix for the scope. This path will be prepended

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -768,7 +768,7 @@ class Router {
  * @param array $options The array of options.
  * @return \Cake\Network\Request The modified request
  */
-	public static function parseNamedParams(Request $request, $options = []) {
+	public static function parseNamedParams(Request $request, array $options = []) {
 		$options += array('separator' => ':');
 		if (empty($request->params['pass'])) {
 			$request->params['named'] = [];
@@ -841,7 +841,7 @@ class Router {
  * @return null|\Cake\Routing\RouteBuilder The route builder
  *   was created/used.
  */
-	public static function scope($path, $params = [], $callback = null) {
+	public static function scope($path, array $params = [], $callback = null) {
 		$builder = new RouteBuilder(static::$_collection, '/', [], [
 			'routeClass' => static::defaultRouteClass(),
 			'extensions' => static::$_collection->extensions()

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -721,9 +721,10 @@ class Router {
  * An array of valid extension can be passed to this method. If called without
  * any parameters it will return current list of set extensions.
  *
- * @param array|string $extensions List of extensions to be added as valid extension
+ * @param array|string|null $extensions List of extensions to be added as valid extension.
+ *   If null it will return the currently set extensions.
  * @param bool $merge Default true will merge extensions. Set to false to override
- *   current extensions
+ *   current extensions.
  * @return array
  */
 	public static function parseExtensions($extensions = null, $merge = true) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -728,9 +728,6 @@ class Router {
  * @return array Array of extensions Router is configured to parse.
  */
 	public static function extensions($extensions = null, $merge = true) {
-		if (!static::$initialized) {
-			static::_loadRoutes();
-		}
 		return static::$_collection->extensions($extensions, $merge);
 	}
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -834,14 +834,14 @@ class Router {
  *
  * @param string $path The path prefix for the scope. This path will be prepended
  *   to all routes connected in the scoped collection.
- * @param array $params An array of routing defaults to add to each connected route.
+ * @param array|callable $params An array of routing defaults to add to each connected route.
  *   If you have no parameters, this argument can be a callable.
  * @param callable $callback The callback to invoke with the scoped collection.
  * @throws \InvalidArgumentException When an invalid callable is provided.
  * @return null|\Cake\Routing\RouteBuilder The route builder
  *   was created/used.
  */
-	public static function scope($path, array $params = [], $callback = null) {
+	public static function scope($path, $params = [], $callback = null) {
 		$builder = new RouteBuilder(static::$_collection, '/', [], [
 			'routeClass' => static::defaultRouteClass(),
 			'extensions' => static::$_collection->extensions()

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -213,7 +213,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->assertEquals('xml', $this->RequestHandler->ext);
 
 		$this->RequestHandler->ext = null;
-		Router::parseExtensions(array('json', 'xml'), false);
+		Router::parseExtensions(['json', 'xml'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -125,7 +125,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testInitializeContentTypeSettingExt() {
 		$event = new Event('Controller.initialize', $this->Controller);
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
-		Router::parseExtensions('json', false);
+		Router::extensions('json', false);
 
 		$this->assertNull($this->RequestHandler->ext);
 
@@ -143,7 +143,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('json', false);
+		Router::extensions('json', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -158,7 +158,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/plain, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('csv', false);
+		Router::extensions('csv', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -174,7 +174,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions(['rss', 'json'], false);
+		Router::extensions(['rss', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -189,7 +189,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/html, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('json', false);
+		Router::extensions('json', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -207,13 +207,13 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, application/xml, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions(['xml', 'json'], false);
+		Router::extensions(['xml', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('xml', $this->RequestHandler->ext);
 
 		$this->RequestHandler->ext = null;
-		Router::parseExtensions(['json', 'xml'], false);
+		Router::extensions(['json', 'xml'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -228,7 +228,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions(['xml', 'json'], false);
+		Router::extensions(['xml', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -243,7 +243,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions(['html', 'xml'], false);
+		Router::extensions(['html', 'xml'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -256,7 +256,7 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInititalizeFirefoxHeaderNotXml() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;image/png,image/jpeg,image/*;q=0.9,*/*;q=0.8';
-		Router::parseExtensions(['xml', 'json'], false);
+		Router::extensions(['xml', 'json'], false);
 
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -272,7 +272,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		$extensions = Router::extensions();
-		Router::parseExtensions('xml', false);
+		Router::extensions('xml', false);
 
 		$this->Controller->request = $this->getMock('Cake\Network\Request', ['accepts']);
 		$this->Controller->request->expects($this->any())
@@ -282,7 +282,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
 
-		call_user_func_array(array('Cake\Routing\Router', 'parseExtensions'), [$extensions, false]);
+		call_user_func_array(array('Cake\Routing\Router', 'extensions'), [$extensions, false]);
 	}
 
 /**
@@ -359,7 +359,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testJsonViewLoaded() {
-		Router::parseExtensions(['json', 'xml', 'ajax'], false);
+		Router::extensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'json';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -376,7 +376,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testXmlViewLoaded() {
-		Router::parseExtensions(['json', 'xml', 'ajax'], false);
+		Router::extensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'xml';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -393,7 +393,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testAjaxViewLoaded() {
-		Router::parseExtensions(['json', 'xml', 'ajax'], false);
+		Router::extensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'ajax';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -409,7 +409,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testNoViewClassExtension() {
-		Router::parseExtensions(['json', 'xml', 'ajax', 'csv'], false);
+		Router::extensions(['json', 'xml', 'ajax', 'csv'], false);
 		$this->Controller->request->params['_ext'] = 'csv';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -301,13 +301,13 @@ class RouteCollectionTest extends TestCase {
 	public function testExtensions() {
 		$this->assertEquals([], $this->collection->extensions());
 
-		$this->collection->extensions('json');
+		$this->collection->extensions('json', false);
 		$this->assertEquals(['json'], $this->collection->extensions());
 
-		$this->collection->extensions(['rss', 'xml']);
+		$this->collection->extensions(['rss', 'xml'], false);
 		$this->assertEquals(['rss', 'xml'], $this->collection->extensions());
 
-		$this->collection->addExtensions(['json']);
+		$this->collection->extensions(['json']);
 		$this->assertEquals(['rss', 'xml', 'json'], $this->collection->extensions());
 	}
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -277,7 +277,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testMapResourcesWithExtension() {
-		Router::parseExtensions(['json', 'xml'], false);
+		Router::extensions(['json', 'xml'], false);
 
 		Router::mapResources('Posts', ['_ext' => 'json']);
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -811,7 +811,7 @@ class RouterTest extends TestCase {
 		Router::connect('/reset/*', array('admin' => true, 'controller' => 'users', 'action' => 'reset'));
 		Router::connect('/tests', array('controller' => 'tests', 'action' => 'index'));
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::parseExtensions('rss', false);
+		Router::extensions('rss', false);
 
 		$request = new Request();
 		$request->addParams(array(
@@ -1525,13 +1525,13 @@ class RouterTest extends TestCase {
 	}
 
 /**
- * testParseExtensions method
+ * testExtensions method
  *
  * @return void
  */
-	public function testParseExtensions() {
+	public function testExtensions() {
 		Router::extensions();
-		Router::parseExtensions('rss', false);
+		Router::extensions('rss', false);
 		$this->assertContains('rss', Router::extensions());
 	}
 
@@ -1541,7 +1541,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testSetExtensions() {
-		Router::parseExtensions('rss', false);
+		Router::extensions('rss', false);
 		$this->assertContains('rss', Router::extensions());
 
 		$this->_connectDefaultRoutes();
@@ -1552,7 +1552,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts.xml');
 		$this->assertFalse(isset($result['_ext']));
 
-		Router::parseExtensions(array('xml'));
+		Router::extensions(array('xml'));
 	}
 
 /**
@@ -1581,7 +1581,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testExtensionParsing() {
-		Router::parseExtensions('rss', false);
+		Router::extensions('rss', false);
 		$this->_connectDefaultRoutes();
 
 		$result = Router::parse('/posts.rss');
@@ -1609,7 +1609,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::parseExtensions(['rss', 'xml'], false);
+		Router::extensions(['rss', 'xml'], false);
 		$this->_connectDefaultRoutes();
 
 		$result = Router::parse('/posts.xml');
@@ -1651,7 +1651,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::parseExtensions('rss', false);
+		Router::extensions('rss', false);
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', '_ext' => 'rss'));
 		$result = Router::parse('/controller/action');
 		$expected = array(
@@ -1980,7 +1980,7 @@ class RouterTest extends TestCase {
 	public function testParsingWithTrailingPeriodAndParseExtensions() {
 		Router::reload();
 		Router::connect('/:controller/:action/*');
-		Router::parseExtensions('json', false);
+		Router::extensions('json', false);
 
 		$result = Router::parse('/posts/view/something.');
 		$this->assertEquals('something.', $result['pass'][0], 'Period was chopped off %s');
@@ -2369,7 +2369,7 @@ class RouterTest extends TestCase {
  */
 	public function testReverseWithExtension() {
 		Router::connect('/:controller/:action/*');
-		Router::parseExtensions('json', false);
+		Router::extensions('json', false);
 
 		$request = new Request('/posts/view/1.json');
 		$request->addParams(array(

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2695,7 +2695,7 @@ class RouterTest extends TestCase {
 	}
 
 /**
- * Connect some fallback routes for testing router behavior.
+ * Connect some fallback routes for testing Router behavior.
  *
  * @return void
  */

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -14,7 +14,7 @@
  */
 use Cake\Routing\Router;
 
-Router::parseExtensions('json');
+Router::extensions('json');
 Router::scope('/', function($routes) {
 	$routes->connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
 	$routes->connect('/some_alias', array('controller' => 'tests_apps', 'action' => 'some_method'));


### PR DESCRIPTION
Also, addExtensions() already array_unique()s it. No need to do that twice then.

Refs https://github.com/cakephp/cakephp/pull/3802
