### PR TITLE
Don't treat underscore prefixed method names as private.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -384,16 +384,13 @@ class Controller implements EventListener {
 	}
 
 /**
- * Check if the request's action is marked as private, with an underscore,
- * or if the request is attempting to directly accessing a prefixed action.
+ * Check if the request's action is a public method.
  *
  * @param \ReflectionMethod $method The method to be invoked.
- * @param \Cake\Network\Request $request The request to check.
  * @return bool
  */
-	protected function _isPrivateAction(\ReflectionMethod $method, Request $request) {
+	protected function _isPrivateAction(\ReflectionMethod $method) {
 		return (
-			$method->name[0] === '_' ||
 			!$method->isPublic() ||
 			!in_array($method->name, $this->methods)
 		);

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\ORM;
 
-use Cake\Core\InstanceConfigTrait;
 use Cake\Core\Exception\Exception;
+use Cake\Core\InstanceConfigTrait;
 use Cake\Event\EventListener;
 
 /**
@@ -331,12 +331,9 @@ class Behavior implements EventListener {
 
 		foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
 			$methodName = $method->getName();
-			if (in_array($methodName, $baseMethods)) {
-				continue;
-			}
-
-			$methodName = $method->getName();
-			if (strpos($methodName, '_') === 0 || isset($eventMethods[$methodName])) {
+			if (in_array($methodName, $baseMethods) ||
+				isset($eventMethods[$methodName])
+			) {
 				continue;
 			}
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -778,22 +778,6 @@ class ControllerTest extends TestCase {
 	}
 
 /**
- * test invoking hidden methods.
- *
- * @expectedException \Cake\Controller\Exception\PrivateActionException
- * @expectedExceptionMessage Private Action TestController::_hidden() is not directly accessible.
- * @return void
- */
-	public function testInvokeActionHidden() {
-		$url = new Request('test/_hidden/');
-		$url->addParams(array('controller' => 'test_controller', 'action' => '_hidden'));
-		$response = $this->getMock('Cake\Network\Response');
-
-		$Controller = new TestController($url, $response);
-		$Controller->invokeAction();
-	}
-
-/**
  * test invoking controller methods.
  *
  * @expectedException \Cake\Controller\Exception\PrivateActionException


### PR DESCRIPTION
Refs #4499
