### PR TITLE
Fixes suggesting the wrong class name

### DIFF
--- a/src/Template/Error/missing_controller.ctp
+++ b/src/Template/Error/missing_controller.ctp
@@ -52,7 +52,7 @@ namespace <?= h($namespace); ?>\Controller<?= h($prefixNs); ?>;
 
 use <?= h($namespace); ?>\Controller\AppController;
 
-class <?= h($class) . 'Controller extends ' . h($plugin); ?>AppController {
+class <?= h($class) . 'Controller extends'; ?> AppController {
 
 }
 </pre>


### PR DESCRIPTION
Bake generates controller classes that extend `AppController` and I believe this is the correct behavior, while this view suggested the developer extend `{PluginName}AppController`
