### PR TITLE
Allow associations inline with contain specify their own finder methods

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -445,7 +445,8 @@ abstract class Association {
 			'conditions' => [],
 			'fields' => [],
 			'type' => empty($options['matching']) ? $this->joinType() : 'INNER',
-			'table' => $target->table()
+			'table' => $target->table(),
+			'finder' => null
 		];
 
 		if (!empty($options['foreignKey'])) {
@@ -455,7 +456,7 @@ abstract class Association {
 			}
 		}
 
-		$dummy = $this->find()->eagerLoaded(true);
+		$dummy = $this->find($options['finder'])->eagerLoaded(true);
 		if (!empty($options['queryBuilder'])) {
 			$dummy = $options['queryBuilder']($dummy);
 			if (!($dummy instanceof Query)) {

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -86,7 +86,7 @@ trait SelectableAssociationTrait {
 		}
 
 		$fetchQuery = $this
-			->find('all')
+			->find(isset($options['finder']) ? $options['finder'] : 'all')
 			->where($options['conditions'])
 			->eagerLoaded(true)
 			->hydrate($options['query']->hydrate());

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -57,7 +57,8 @@ class EagerLoader {
 		'fields' => 1,
 		'sort' => 1,
 		'matching' => 1,
-		'queryBuilder' => 1
+		'queryBuilder' => 1,
+		'finder' => 1
 	];
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1440,6 +1440,9 @@ class Table implements RepositoryInterface, EventListener {
  * @throws \BadMethodCallException
  */
 	public function callFinder($type, Query $query, array $options = []) {
+		if (is_array($type)) {
+			list($type, $options) = $this->_inferFinderTypeAndOptions($type, $options);
+		}
 		$query->applyOptions($options);
 		$options = $query->getOptions();
 		$finder = 'find' . ucfirst($type);
@@ -1931,6 +1934,34 @@ class Table implements RepositoryInterface, EventListener {
 			'behaviors' => $this->_behaviors->loaded(),
 			'defaultConnection' => $this->defaultConnectionName(),
 			'connectionName' => $conn ? $conn->configName() : null
+		];
+	}
+
+/**
+ * Helper method to infer the requested finder and its options.
+ *
+ * Returns the inferred options from the finder $type.
+ *
+ * @return array
+ */
+	protected function _inferFinderTypeAndOptions(array $type) {
+		$options = [];
+		if (count($type)) {
+			$v = array_values($type)[0];
+			$k = array_keys($type)[0];
+			if (is_array($v)) {
+				$type = $k;
+				$options = $v;
+			} elseif (is_string($v) && !$k) {
+				$type = $v;
+			} elseif (is_string($v)) {
+				$type = $k;
+				$options = [$v];
+			}
+		}
+		return [
+			$type,
+			$options
 		];
 	}
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1940,8 +1940,18 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * Helper method to infer the requested finder and its options.
  *
- * Returns the inferred options from the finder $type.
+ * Returns the inferred options from the finder $type. 
  *
+ * ### Examples:
+ *
+ * The following will call the finder 'translations' with the value of the finder as its options:
+ * $query->contain(['Comments' => ['finder' => 'translations']]);
+ * $query->contain(['Comments' => ['finder' => ['translations']]]);
+ * $query->contain(['Comments' => ['finder' => ['translations' => []]]]);
+ * $query->contain(['Comments' => ['finder' => ['translations' => ['locales' => ['en_US']]]]]);
+ * $query->contain(['Comments' => ['finder' => ['translations' => 'customOption']]]);
+ *
+ * @param array $type Finder type as an array.
  * @return array
  */
 	protected function _inferFinderTypeAndOptions(array $type) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1945,7 +1945,6 @@ class Table implements RepositoryInterface, EventListener {
  * ### Examples:
  *
  * The following will call the finder 'translations' with the value of the finder as its options:
- * $query->contain(['Comments' => ['finder' => 'translations']]);
  * $query->contain(['Comments' => ['finder' => ['translations']]]);
  * $query->contain(['Comments' => ['finder' => ['translations' => []]]]);
  * $query->contain(['Comments' => ['finder' => ['translations' => ['locales' => ['en_US']]]]]);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -150,13 +150,12 @@ class PaginatorComponentTest extends TestCase {
 		$this->loadFixtures('Post');
 		$settings = [
 			'PaginatorPosts' => [
-				'finder' => 'author',
-				'author_id' => 1
+				'finder' => ['author' => ['author_id' => 1]]
 			]
 		];
 		$table = TableRegistry::get('PaginatorPosts');
 
-		$expected = $table->find('author', ['conditions' => ['PaginatorPosts.author_id' => $settings['PaginatorPosts']['author_id']]])
+		$expected = $table->find('author', ['conditions' => ['PaginatorPosts.author_id' => $settings['PaginatorPosts']['finder']['author']['author_id']]])
 			->count();
 		$result = $this->Paginator->paginate($table, $settings)->count();
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2111,4 +2111,37 @@ class QueryTest extends TestCase {
 		$this->assertNull($copy->clause('order'));
 	}
 
+/**
+ * Test that finder options sent through via contain are sent to custom finder.
+ *
+ * @return void
+ */
+	public function testContainFinderCanSpecifyOptions() {
+		$table = TableRegistry::get('Articles');
+		$table->belongsTo(
+			'Authors',
+			['className' => 'TestApp\Model\Table\AuthorsTable']
+		);
+		$authorId = 1;
+
+		$resultWithoutAuthor = $table->find('all')
+			->where(['Articles.author_id' => $authorId])
+			->contain([
+				'Authors' => [
+					'finder' => ['byAuthor' => ['author_id' => 2]]
+				]
+			]);
+
+		$resultWithAuthor = $table->find('all')
+			->where(['Articles.author_id' => $authorId])
+			->contain([
+				'Authors' => [
+					'finder' => ['byAuthor' => ['author_id' => $authorId]]
+				]
+			]);
+
+		$this->assertEmpty($resultWithoutAuthor->first()['author']);
+		$this->assertEquals($authorId, $resultWithAuthor->first()['author']['id']);
+	}
+
 }

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -12,6 +12,7 @@
 namespace TestApp\Model\Table;
 
 use Cake\ORM\Table;
+use Cake\ORM\Query;
 
 /**
  * Author table class
@@ -21,6 +22,13 @@ class AuthorsTable extends Table {
 
 	public function initialize(array $config) {
 		$this->hasMany('articles');
+	}
+
+	public function findByAuthor(Query $query, array $options = []) {
+		if (isset($options['author_id'])) {
+			$query->where(['Articles.id' => $options['author_id']]);
+		}
+		return $query;
 	}
 
 }


### PR DESCRIPTION
Sorry, pull #4413 was out of whack with the 3.0 base. This PR is up-to-date and a single squash of the changes needed for this.
Travis is complaining about allocating memory which is (should be) unrelated.

Refs issue #4408.

Thanks!
