### PR TITLE
Make fixtures using foreign keys easy to use.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -470,6 +470,24 @@ class Connection {
 	}
 
 /**
+ * Run driver specific SQL to disable foreign key checks.
+ *
+ * @return void
+ */
+	public function disableForeignKeys() {
+		$this->execute($this->_driver->disableForeignKeySql());
+	}
+
+/**
+ * Run driver specific SQL to enable foreign key checks.
+ *
+ * @return void
+ */
+	public function enableForeignKeys() {
+		$this->execute($this->_driver->enableForeignKeySql());
+	}
+
+/**
  * Executes a callable function inside a transaction, if any exception occurs
  * while executing the passed callable, the transaction will be rolled back
  * If the result of the callable function is ``false``, the transaction will

--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -62,4 +62,16 @@ trait MysqlDialectTrait {
 		return $this->_schemaDialect;
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function disableForeignKeySQL() {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function enableForeignKeySQL() {
+	}
+
 }

--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -66,12 +66,14 @@ trait MysqlDialectTrait {
  * {@inheritDoc}
  */
 	public function disableForeignKeySQL() {
+		return 'SET foreign_key_checks = 0';
 	}
 
 /**
  * {@inheritDoc}
  */
 	public function enableForeignKeySQL() {
+		return 'SET foreign_key_checks = 1';
 	}
 
 }

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -136,4 +136,16 @@ trait PostgresDialectTrait {
 		}
 		return $this->_schemaDialect;
 	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function disableForeignKeySQL() {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function enableForeignKeySQL() {
+	}
 }

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -141,11 +141,13 @@ trait PostgresDialectTrait {
  * {@inheritDoc}
  */
 	public function disableForeignKeySQL() {
+		return 'SET CONSTRAINTS ALL DEFERRED';
 	}
 
 /**
  * {@inheritDoc}
  */
 	public function enableForeignKeySQL() {
+		return 'SET CONSTRAINTS ALL IMMEDIATE';
 	}
 }

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -159,4 +159,16 @@ trait SqliteDialectTrait {
 		return $this->_schemaDialect;
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function disableForeignKeySQL() {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function enableForeignKeySQL() {
+	}
+
 }

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -163,12 +163,14 @@ trait SqliteDialectTrait {
  * {@inheritDoc}
  */
 	public function disableForeignKeySQL() {
+		return 'PRAGMA foreign_keys = OFF';
 	}
 
 /**
  * {@inheritDoc}
  */
 	public function enableForeignKeySQL() {
+		return 'PRAGMA foreign_keys = ON';
 	}
 
 }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -233,4 +233,16 @@ trait SqlserverDialectTrait {
 		return new SqlserverCompiler();
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function disableForeignKeySQL() {
+	}
+
+/**
+ * {@inheritDoc}
+ */
+	public function enableForeignKeySQL() {
+	}
+
 }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -237,12 +237,14 @@ trait SqlserverDialectTrait {
  * {@inheritDoc}
  */
 	public function disableForeignKeySQL() {
+		return 'EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"';
 	}
 
 /**
  * {@inheritDoc}
  */
 	public function enableForeignKeySQL() {
+		return 'EXEC sp_msforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"';
 	}
 
 }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -145,6 +145,20 @@ abstract class Driver {
 	public abstract function rollbackSavePointSQL($name);
 
 /**
+ * Get the SQL for disabling foreign keys
+ *
+ * @return string
+ */
+	public abstract function disableForeignKeySQL();
+
+/**
+ * Get the SQL for enabling foreign keys
+ *
+ * @return string
+ */
+	public abstract function enableForeignKeySQL();
+
+/**
  * Returns whether this driver supports save points for nested transactions
  *
  * @return bool true if save points are supported, false otherwise

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -121,6 +121,30 @@ abstract class Driver {
 	public abstract function rollbackTransaction();
 
 /**
+ * Get the SQL for releasing a save point.
+ *
+ * @param string $name The table name
+ * @return string
+ */
+	public abstract function releaseSavePointSQL($name);
+
+/**
+ * Get the SQL for creating a save point.
+ *
+ * @param string $name The table name
+ * @return string
+ */
+	public abstract function savePointSQL($name);
+
+/**
+ * Get the SQL for rollingback a save point.
+ *
+ * @param string $name The table name
+ * @return string
+ */
+	public abstract function rollbackSavePointSQL($name);
+
+/**
  * Returns whether this driver supports save points for nested transactions
  *
  * @return bool true if save points are supported, false otherwise
@@ -128,6 +152,7 @@ abstract class Driver {
 	public function supportsSavePoints() {
 		return true;
 	}
+
 
 /**
  * Returns a value in a safe representation to be used in a query string

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -475,4 +475,18 @@ class PostgresSchema extends BaseSchema {
 		];
 	}
 
+/**
+ * Generate the SQL to drop a table.
+ *
+ * @param \Cake\Database\Schema\Table $table Table instance
+ * @return array SQL statements to drop a table.
+ */
+	public function dropTableSql(Table $table) {
+		$sql = sprintf(
+			'DROP TABLE %s CASCADE',
+			$this->_driver->quoteIdentifier($table->name())
+		);
+		return [$sql];
+	}
+
 }

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -428,7 +428,7 @@ class PostgresSchema extends BaseSchema {
 		);
 		if ($data['type'] === Table::CONSTRAINT_FOREIGN) {
 			return $prefix . sprintf(
-				' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s DEFERABLE INITIALLY IMMEDIATE',
+				' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s DEFERRABLE INITIALLY IMMEDIATE',
 				implode(', ', $columns),
 				$this->_driver->quoteIdentifier($data['references'][0]),
 				$this->_driver->quoteIdentifier($data['references'][1]),
@@ -471,7 +471,7 @@ class PostgresSchema extends BaseSchema {
 	public function truncateTableSql(Table $table) {
 		$name = $this->_driver->quoteIdentifier($table->name());
 		return [
-			sprintf('TRUNCATE %s RESTART IDENTITY', $name)
+			sprintf('TRUNCATE %s RESTART IDENTITY CASCADE', $name)
 		];
 	}
 

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -428,7 +428,7 @@ class PostgresSchema extends BaseSchema {
 		);
 		if ($data['type'] === Table::CONSTRAINT_FOREIGN) {
 			return $prefix . sprintf(
-				' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s',
+				' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s DEFERABLE INITIALLY IMMEDIATE',
 				implode(', ', $columns),
 				$this->_driver->quoteIdentifier($data['references'][0]),
 				$this->_driver->quoteIdentifier($data['references'][1]),

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -235,6 +235,7 @@ class FixtureManager {
 				$db = ConnectionManager::get($fixture->connection, false);
 				$db->transactional(function($db) use ($fixtures, $test) {
 					$tables = $db->schemaCollection()->listTables();
+					$db->disableForeignKeys();
 					foreach ($fixtures as $fixture) {
 						if (!in_array($db->configName(), (array)$fixture->created)) {
 							$this->_setupTable($fixture, $db, $tables, $test->dropTables);
@@ -244,6 +245,7 @@ class FixtureManager {
 						}
 						$fixture->insert($db);
 					}
+					$db->enableForeignKeys();
 				});
 			}
 		} catch (\PDOException $e) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -254,7 +254,7 @@ class FixtureManager {
  * @param array $fixtures The array of fixtures a list of connections is needed from.
  * @return array An array of connection names.
  */
-	protected function _fixtureConnections ($fixtures) {
+	protected function _fixtureConnections($fixtures) {
 		$dbs = [];
 		foreach ($fixtures as $f) {
 			if (!empty($this->_loaded[$f])) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -332,7 +332,6 @@ class FixtureManager {
 						$fixture->drop($db);
 					}
 				}
-				$db->enableForeignKeys();
 			});
 		}
 	}

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -184,24 +184,15 @@ class FixtureManager {
  *
  * @param \Cake\TestSuite\Fixture\TestFixture $fixture the fixture object to create
  * @param Connection $db the datasource instance to use
+ * @param array $sources The existing tables in the datasource.
  * @param bool $drop whether drop the fixture if it is already created or not
  * @return void
  */
-	protected function _setupTable(TestFixture $fixture, Connection $db = null, $drop = true) {
-		if (!$db) {
-			if (!empty($fixture->connection)) {
-				$db = ConnectionManager::get($fixture->connection, false);
-			}
-			if (!$db) {
-				$db = ConnectionManager::get('test', false);
-			}
-		}
+	protected function _setupTable(TestFixture $fixture, Connection $db, array $sources, $drop = true) {
 		if (!empty($fixture->created) && in_array($db->configName(), $fixture->created)) {
 			return;
 		}
 
-		$schemaCollection = $db->schemaCollection();
-		$sources = (array)$schemaCollection->listTables();
 		$table = $fixture->table;
 		$exists = in_array($table, $sources);
 
@@ -243,9 +234,10 @@ class FixtureManager {
 			foreach ($dbs as $db => $fixtures) {
 				$db = ConnectionManager::get($fixture->connection, false);
 				$db->transactional(function($db) use ($fixtures, $test) {
+					$tables = $db->schemaCollection()->listTables();
 					foreach ($fixtures as $fixture) {
 						if (!in_array($db->configName(), (array)$fixture->created)) {
-							$this->_setupTable($fixture, $db, $test->dropTables);
+							$this->_setupTable($fixture, $db, $tables, $test->dropTables);
 						}
 						if (!$test->dropTables) {
 							$fixture->truncate($db);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -277,11 +277,13 @@ class FixtureManager {
 		foreach ($dbs as $connection => $fixtures) {
 			$db = ConnectionManager::get($connection, false);
 			$db->transactional(function($db) use ($fixtures, $connection) {
+				$db->disableForeignKeys();
 				foreach ($fixtures as $f) {
 					if (!empty($fixture->created) && in_array($connection, $fixture->created)) {
 						$fixture->truncate($db);
 					}
 				}
+				$db->enableForeignKeys();
 			});
 		}
 	}

--- a/tests/Fixture/ArticlesTagFixture.php
+++ b/tests/Fixture/ArticlesTagFixture.php
@@ -31,7 +31,12 @@ class ArticlesTagFixture extends TestFixture {
 		'article_id' => ['type' => 'integer', 'null' => false],
 		'tag_id' => ['type' => 'integer', 'null' => false],
 		'_constraints' => [
-			'UNIQUE_TAG2' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]
+			'unique_tag' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']],
+			'tag_idx' => [
+				'type' => 'foreign',
+				'columns' => ['tag_id'],
+				'references' => ['tags', 'id']
+			]
 		]
 	);
 

--- a/tests/Fixture/TagFixture.php
+++ b/tests/Fixture/TagFixture.php
@@ -28,7 +28,7 @@ class TagFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'integer'],
+		'id' => ['type' => 'integer', 'null' => false],
 		'name' => ['type' => 'string', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 	);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -680,31 +680,31 @@ SQL;
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id']],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT DEFERRABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'cascade'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
+				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'restrict'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT DEFERRABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'setNull'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
+				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT DEFERRABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
+				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE INITIALLY IMMEDIATE'
 			],
 		];
 	}

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -878,7 +878,7 @@ SQL;
 		$table = new Table('schema_articles');
 		$result = $table->dropSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals('DROP TABLE "schema_articles"', $result[0]);
+		$this->assertEquals('DROP TABLE "schema_articles" CASCADE', $result[0]);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -900,7 +900,7 @@ SQL;
 			]);
 		$result = $table->truncateSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals('TRUNCATE "schema_articles" RESTART IDENTITY', $result[0]);
+		$this->assertEquals('TRUNCATE "schema_articles" RESTART IDENTITY CASCADE', $result[0]);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -680,31 +680,31 @@ SQL;
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id']],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT'
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'cascade'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT'
+				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'restrict'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT'
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'setNull'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT'
+				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT'
+				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERABLE INITIALLY IMMEDIATE'
 			],
 		];
 	}

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1719,7 +1719,9 @@ class QueryTest extends TestCase {
 				});
 		};
 		$query = $table->find()
-			->contain(['Articles' => $builder, 'Articles.Authors' => $builder]);
+			->contain(['Articles' => $builder, 'Articles.Authors' => $builder])
+			->order(['Articles.id' => 'ASC']);
+
 		$query->formatResults(function($results) {
 			return $results->map(function($row) {
 				return sprintf(
@@ -1799,9 +1801,11 @@ class QueryTest extends TestCase {
 		$table->belongsTo('Articles');
 		$table->association('Articles')->target()->belongsTo('Authors');
 
-		$query = $table->find()->contain(['Articles' => function($q) {
-			return $q->contain('Authors');
-		}]);
+		$query = $table->find()
+			->order(['Articles.id' => 'ASC'])
+			->contain(['Articles' => function($q) {
+				return $q->contain('Authors');
+			}]);
 		$results = $query->extract('article.author.name')->toArray();
 		$expected = ['mariano', 'mariano', 'larry', 'larry'];
 		$this->assertEquals($expected, $results);

--- a/tests/TestCase/Shell/OrmCacheShellTest.php
+++ b/tests/TestCase/Shell/OrmCacheShellTest.php
@@ -29,7 +29,7 @@ class OrmCacheShellTest extends TestCase {
  *
  * @var array
  */
-	public $fixtures = ['core.article', 'core.tag'];
+	public $fixtures = ['core.article', 'core.articles_tag', 'core.tag'];
 
 /**
  * setup method

--- a/tests/TestCase/Shell/OrmCacheShellTest.php
+++ b/tests/TestCase/Shell/OrmCacheShellTest.php
@@ -29,7 +29,7 @@ class OrmCacheShellTest extends TestCase {
  *
  * @var array
  */
-	public $fixtures = ['core.article', 'core.articles_tag', 'core.tag'];
+	public $fixtures = ['core.article', 'core.tag'];
 
 /**
  * setup method

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -37,7 +37,8 @@ class ModelTaskTest extends TestCase {
 	public $fixtures = array(
 		'core.bake_article', 'core.bake_comment', 'core.bake_articles_bake_tag',
 		'core.bake_tag', 'core.user', 'core.category_thread', 'core.number_tree',
-		'core.counter_cache_user', 'core.counter_cache_post', 'core.articles_tag'
+		'core.counter_cache_user', 'core.counter_cache_post',
+		'core.tag', 'core.articles_tag'
 	);
 
 /**

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -1109,9 +1109,9 @@ class ModelTaskTest extends TestCase {
 		$this->Task->connection = 'test';
 		$this->Task->skipTables = ['articles_tags', 'bake_tags', 'counter_cache_posts'];
 
-		$this->Task->Fixture->expects($this->exactly(7))
+		$this->Task->Fixture->expects($this->exactly(8))
 			->method('bake');
-		$this->Task->Test->expects($this->exactly(7))
+		$this->Task->Test->expects($this->exactly(8))
 			->method('bake');
 
 		$filename = $this->_normalizePath(APP . 'Model/Entity/BakeArticle.php');

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -44,8 +44,8 @@ class TestTaskTest extends TestCase {
 		'core.article',
 		'core.author',
 		'core.comment',
-		'core.articles_tag',
 		'core.tag',
+		'core.articles_tag',
 	];
 
 /**


### PR DESCRIPTION
Foreign keys are currently very painful to use in the test suite. You have to manage the order of your fixtures very carefully, and sometimes even that is not enough.

This set of changes adds a way to disable/enable keys from the connection. No specific tests were added as the basic behavior of the fixture manager did not change. Instead, I added foreign keys to a fixture to help ensure this continues working.
