### PR TITLE
Removing automatic XML building from http requests in the Xml class

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -15,9 +15,7 @@
 namespace Cake\Utility;
 
 use Cake\Core\Configure;
-use Cake\Network\Exception\SocketException;
 use Cake\Utility\Exception\XmlException;
-use Cake\Network\Http\Client;
 use \DOMDocument;
 
 /**
@@ -92,24 +90,20 @@ class Xml {
 
 		if (is_array($input) || is_object($input)) {
 			return static::fromArray($input, $options);
-		} elseif (strpos($input, '<') !== false) {
+		}
+
+		if (strpos($input, '<') !== false) {
 			return static::_loadXml($input, $options);
-		} elseif (file_exists($input)) {
+		}
+
+		if (file_exists($input)) {
 			return static::_loadXml(file_get_contents($input), $options);
-		} elseif (strpos($input, 'http://') === 0 || strpos($input, 'https://') === 0) {
-			try {
-				$socket = new Client(['redirect' => 10]);
-				$response = $socket->get($input);
-				if (!$response->isOk()) {
-					throw new XmlException('XML cannot be read.');
-				}
-				return static::_loadXml($response->body, $options);
-			} catch (SocketException $e) {
-				throw new XmlException('XML cannot be read.');
-			}
-		} elseif (!is_string($input)) {
+		}
+
+		if (!is_string($input)) {
 			throw new XmlException('Invalid input.');
 		}
+
 		throw new XmlException('XML cannot be read.');
 	}
 


### PR DESCRIPTION
This has a number of reasons:
- There were no tests for this piece of code
- We recommend using Xml::build for request input, this could be a security risk
- Creates an annoying dependency to the Network namespace
- Pre-configuring the HTTP client is impossible
- It is much cleaner and simple to just pass the response body into the function

We can document this in the migration guide and provide the code for using the HTTP client to download a resource and convert it to an XML object.
