### PR TITLE
Cleaning up and simplifying code after adding the new finder feature

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -155,16 +155,10 @@ class PaginatorComponent extends Component {
 
 		$options += ['page' => 1];
 		$options['page'] = intval($options['page']) < 1 ? 1 : (int)$options['page'];
-
-		if (!isset($options['finder']) && isset($options['findType'])) {
-			trigger_error('You should use finder instead of findType', E_USER_DEPRECATED);
-			$options['finder'] = $options['findType'];
-		}
-		$type = !empty($options['finder']) ? $options['finder'] : 'all';
-		unset($options['finder'], $options['maxLimit']);
+		list($finder, $options) = $this->_extractFinder($options);
 
 		if (empty($query)) {
-			$query = $object->find($type, $options);
+			$query = $object->find($finder, $options);
 		}
 
 		$query->applyOptions($options);
@@ -190,7 +184,7 @@ class PaginatorComponent extends Component {
 		}
 
 		$paging = array(
-			'finder' => $type,
+			'finder' => $finder,
 			'page' => $page,
 			'current' => $numResults,
 			'count' => $count,
@@ -218,6 +212,30 @@ class PaginatorComponent extends Component {
 		}
 
 		return $results;
+	}
+
+/**
+ * Extracts the finder name and options out of the provided pagination options
+ *
+ * @param array $options the pagination options
+ * @return array An array containing in the first position the finder name and
+ * in the second the options to be passed to it
+ */
+	protected function _extractFinder($options) {
+		if (!isset($options['finder']) && isset($options['findType'])) {
+			trigger_error('You should use finder instead of findType', E_USER_DEPRECATED);
+			$options['finder'] = $options['findType'];
+		}
+
+		$type = !empty($options['finder']) ? $options['finder'] : 'all';
+		unset($options['finder'], $options['maxLimit']);
+
+		if (is_array($type)) {
+			$options = $options + (array)current($type);
+			$type = key($type);
+		}
+
+		return [$type, $options];
 	}
 
 /**

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -85,8 +85,10 @@ trait SelectableAssociationTrait {
 			$filter = $this->_buildSubquery($options['query']);
 		}
 
+		$finder = isset($options['finder']) ? $options['finder'] : $this->finder();
+		list($finder, $opts) = $this->_extractFinder($finder);
 		$fetchQuery = $this
-			->find(isset($options['finder']) ? $options['finder'] : 'all')
+			->find($finder, $opts)
 			->where($options['conditions'])
 			->eagerLoaded(true)
 			->hydrate($options['query']->hydrate());

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1454,9 +1454,6 @@ class Table implements RepositoryInterface, EventListener {
  * @throws \BadMethodCallException
  */
 	public function callFinder($type, Query $query, array $options = []) {
-		if (is_array($type)) {
-			list($type, $options) = $this->_inferFinderTypeAndOptions($type, $options);
-		}
 		$query->applyOptions($options);
 		$options = $query->getOptions();
 		$finder = 'find' . $type;
@@ -1948,43 +1945,6 @@ class Table implements RepositoryInterface, EventListener {
 			'behaviors' => $this->_behaviors->loaded(),
 			'defaultConnection' => $this->defaultConnectionName(),
 			'connectionName' => $conn ? $conn->configName() : null
-		];
-	}
-
-/**
- * Helper method to infer the requested finder and its options.
- *
- * Returns the inferred options from the finder $type. 
- *
- * ### Examples:
- *
- * The following will call the finder 'translations' with the value of the finder as its options:
- * $query->contain(['Comments' => ['finder' => ['translations']]]);
- * $query->contain(['Comments' => ['finder' => ['translations' => []]]]);
- * $query->contain(['Comments' => ['finder' => ['translations' => ['locales' => ['en_US']]]]]);
- * $query->contain(['Comments' => ['finder' => ['translations' => 'customOption']]]);
- *
- * @param array $type Finder type as an array.
- * @return array
- */
-	protected function _inferFinderTypeAndOptions(array $type) {
-		$options = [];
-		if (count($type)) {
-			$v = array_values($type)[0];
-			$k = array_keys($type)[0];
-			if (is_array($v)) {
-				$type = $k;
-				$options = $v;
-			} elseif (is_string($v) && !$k) {
-				$type = $v;
-			} elseif (is_string($v)) {
-				$type = $k;
-				$options = [$v];
-			}
-		}
-		return [
-			$type,
-			$options
 		];
 	}
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -155,7 +155,12 @@ class PaginatorComponentTest extends TestCase {
 		];
 		$table = TableRegistry::get('PaginatorPosts');
 
-		$expected = $table->find('author', ['conditions' => ['PaginatorPosts.author_id' => $settings['PaginatorPosts']['finder']['author']['author_id']]])
+		$expected = $table
+			->find('author', [
+				'conditions' => [
+					'PaginatorPosts.author_id' => 1
+				]
+			])
 			->count();
 		$result = $this->Paginator->paginate($table, $settings)->count();
 


### PR DESCRIPTION
Removing an extra syntax option out of the custom finder per association feature and trying to keep the Table code a bit more lean.
