### PR TITLE
Fixed overwriting of files when Folder::SKIP is set

### DIFF
--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -673,7 +673,7 @@ class Folder {
 				$to = Folder::addPathElement($toDir, $item);
 				if (($options['scheme'] != Folder::SKIP || !is_dir($to)) && !in_array($item, $exceptions)) {
 					$from = Folder::addPathElement($fromDir, $item);
-					if (is_file($from)) {
+					if (is_file($from) && (!is_file($to) || $options['scheme'] != Folder::SKIP)) {
 						if (copy($from, $to)) {
 							chmod($to, intval($mode, 8));
 							touch($to, filemtime($from));


### PR DESCRIPTION
fix for #4520 
