### PR TITLE
Validation upload file

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -951,6 +951,48 @@ class Validation {
 	}
 
 /**
+ * Validate an uploaded file.
+ *
+ * Helps join `uploadError`, `fileSize` and `mimeType` into
+ * one higher level validation method.
+ *
+ * ### Options
+ *
+ * - `types` - A list of valid mime types. If empty all types
+ *   will be accepted. The `type` will not be looked at, instead
+ *   the file type will be checked with ext/finfo.
+ * - `minSize` - The minimum file size. Defaults to not checking.
+ * - `maxSize` - The maximum file size. Defaults to not checking.
+ *
+ * @param array $file The uploaded file data from PHP.
+ * @param array $options An array of options for the validation.
+ * @return bool
+ */
+	public static function uploadedFile($file, $options = []) {
+		$options += ['minSize' => null, 'maxSize' => null, 'types' => null];
+		if (!is_array($file)) {
+			return false;
+		}
+		$keys = ['name', 'tmp_name', 'error', 'type', 'size'];
+		if (array_keys($file) != $keys) {
+			return false;
+		}
+		if (!static::uploadError($file)) {
+			return false;
+		}
+		if (isset($options['minSize']) && !static::fileSize($file, '>=', $options['minSize'])) {
+			return false;
+		}
+		if (isset($options['maxSize']) && !static::fileSize($file, '<=', $options['maxSize'])) {
+			return false;
+		}
+		if (isset($options['types']) && !static::mimeType($file, $options['types'])) {
+			return false;
+		}
+		return true;
+	}
+
+/**
  * Lazily populate the IP address patterns used for validations
  *
  * @return void

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -967,6 +967,7 @@ class Validation {
  * - `minSize` - The minimum file size. Defaults to not checking.
  * - `maxSize` - The maximum file size. Defaults to not checking.
  * - `optional` - Whether or not this file is optional. Defaults to false.
+ *   If true a missing file will pass the validator regardless of other constraints.
  *
  * @param array $file The uploaded file data from PHP.
  * @param array $options An array of options for the validation.
@@ -988,6 +989,9 @@ class Validation {
 		}
 		if (!static::uploadError($file, $options['optional'])) {
 			return false;
+		}
+		if ($options['optional'] && (int)$file['error'] === UPLOAD_ERR_NO_FILE) {
+			return true;
 		}
 		if (isset($options['minSize']) && !static::fileSize($file, '>=', $options['minSize'])) {
 			return false;

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2421,4 +2421,30 @@ class ValidationTest extends TestCase {
 		$this->assertFalse(Validation::uploadedFile($file, $options), 'Too big');
 	}
 
+/**
+ * Test uploaded file validation.
+ *
+ * @return void
+ */
+	public function testUploadedFileNoFile() {
+		$file = [
+			'name' => '',
+			'tmp_name' => TEST_APP . 'webroot/img/cake.power.gif',
+			'error' => UPLOAD_ERR_NO_FILE,
+			'type' => '',
+			'size' => 0
+		];
+		$options = [
+			'optional' => true,
+			'minSize' => 500,
+			'types' => ['image/gif', 'image/png']
+		];
+		$this->assertTrue(Validation::uploadedFile($file, $options), 'No file should be ok.');
+
+		$options = [
+			'optional' => false
+		];
+		$this->assertFalse(Validation::uploadedFile($file, $options), 'File is required.');
+	}
+
 }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2342,4 +2342,77 @@ class ValidationTest extends TestCase {
 		$this->assertFalse(Validation::fileSize(array('tmp_name' => $image), '>', '1KB'));
 	}
 
+/**
+ * Test uploaded file validation.
+ *
+ * @return void
+ */
+	public function testUploadedFileErrorCode() {
+		$this->assertFalse(Validation::uploadedFile('derp'));
+		$invalid = [
+			'name' => 'testing'
+		];
+		$this->assertFalse(Validation::uploadedFile($invalid));
+
+		$file = [
+			'name' => 'cake.power.gif',
+			'tmp_name' => TEST_APP . 'webroot/img/cake.power.gif',
+			'error' => UPLOAD_ERR_OK,
+			'type' => 'image/gif',
+			'size' => 201
+		];
+		$this->assertTrue(Validation::uploadedFile($file));
+
+		$file['error'] = UPLOAD_ERR_NO_FILE;
+		$this->assertFalse(Validation::uploadedFile($file), 'Error upload should fail.');
+	}
+
+/**
+ * Test uploaded file validation.
+ *
+ * @return void
+ */
+	public function testUploadedFileMimeType() {
+		$file = [
+			'name' => 'cake.power.gif',
+			'tmp_name' => TEST_APP . 'webroot/img/cake.power.gif',
+			'error' => UPLOAD_ERR_OK,
+			'type' => 'text/plain',
+			'size' => 201
+		];
+		$options = [
+			'types' => ['text/plain']
+		];
+		$this->assertFalse(Validation::uploadedFile($file, $options), 'Incorrect mimetype.');
+
+		$options = [
+			'types' => ['image/gif', 'image/png']
+		];
+		$this->assertTrue(Validation::uploadedFile($file, $options));
+	}
+
+/**
+ * Test uploaded file validation.
+ *
+ * @return void
+ */
+	public function testUploadedFileSize() {
+		$file = [
+			'name' => 'cake.power.gif',
+			'tmp_name' => TEST_APP . 'webroot/img/cake.power.gif',
+			'error' => UPLOAD_ERR_OK,
+			'type' => 'text/plain',
+			'size' => 201
+		];
+		$options = [
+			'minSize' => 500
+		];
+		$this->assertFalse(Validation::uploadedFile($file, $options), 'Too small');
+
+		$options = [
+			'maxSize' => 100
+		];
+		$this->assertFalse(Validation::uploadedFile($file, $options), 'Too big');
+	}
+
 }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2322,6 +2322,12 @@ class ValidationTest extends TestCase {
 		$this->assertFalse(Validation::uploadError(2));
 		$this->assertFalse(Validation::uploadError(array('error' => 2)));
 		$this->assertFalse(Validation::uploadError(array('error' => '2')));
+
+		$this->assertFalse(Validation::uploadError(UPLOAD_ERR_NO_FILE));
+		$this->assertFalse(Validation::uploadError(UPLOAD_ERR_FORM_SIZE, true));
+		$this->assertFalse(Validation::uploadError(UPLOAD_ERR_INI_SIZE, true));
+		$this->assertFalse(Validation::uploadError(UPLOAD_ERR_NO_TMP_DIR, true));
+		$this->assertTrue(Validation::uploadError(UPLOAD_ERR_NO_FILE, true));
 	}
 
 /**


### PR DESCRIPTION
Add `Validation::uploadedFile()` as a simple wrapper around the various file upload validation methods. It also makes it easier to deal with optional files which was something that came up in #4456.
