### PR TITLE
3.0 update error message

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -143,7 +143,7 @@ class ExceptionRenderer {
 		}
 		$this->controller->response->statusCode($code);
 		$this->controller->set(array(
-			'message' => h($message),
+			'message' => $message,
 			'url' => h($url),
 			'error' => $exception,
 			'code' => $code,

--- a/src/View/Exception/MissingCellException.php
+++ b/src/View/Exception/MissingCellException.php
@@ -22,6 +22,6 @@ use Cake\Core\Exception\Exception;
  */
 class MissingCellException extends Exception {
 
-	protected $_messageTemplate = 'Cell class "%s" is missing.';
+	protected $_messageTemplate = 'Cell class %s is missing.';
 
 }

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -423,13 +423,14 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testError500Message() {
-		$exception = new InternalErrorException('An Internal Error Has Occurred');
+		$exception = new InternalErrorException('An Internal Error Has Occurred.');
 		$ExceptionRenderer = new ExceptionRenderer($exception);
 		$ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', array('statusCode', '_sendHeader'));
 		$ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(500);
 
 		$result = $ExceptionRenderer->render();
 		$this->assertContains('<h2>An Internal Error Has Occurred</h2>', $result->body());
+		$this->assertContains('An Internal Error Has Occurred.</p>', $result->body());
 	}
 
 /**

--- a/tests/test_app/TestApp/Template/Error/error500.ctp
+++ b/tests/test_app/TestApp/Template/Error/error500.ctp
@@ -14,13 +14,14 @@
  */
 use Cake\Core\Configure;
 ?>
-<h2><?= h($message) ?></h2>
+<h2><?= __d('cake', 'An Internal Error Has Occurred.') ?></h2>
 <p class="error">
-	<strong><?= __d('cake', 'Error'); ?>: </strong>
-	<?= __d('cake', 'An Internal Error Has Occurred.'); ?>
+	<strong><?= __d('cake', 'Error') ?>: </strong>
+	<?= h($message, false) ?>
 </p>
 <?php
 if (Configure::read('debug')):
+	echo $this->element('auto_table_warning');
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/tests/test_app/TestApp/Template/Error/error500.ctp
+++ b/tests/test_app/TestApp/Template/Error/error500.ctp
@@ -14,10 +14,10 @@
  */
 use Cake\Core\Configure;
 ?>
-<h2><?= __d('cake', 'An Internal Error Has Occurred.') ?></h2>
+<h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
 <p class="error">
 	<strong><?= __d('cake', 'Error') ?>: </strong>
-	<?= h($message, false) ?>
+	<?= h($message) ?>
 </p>
 <?php
 if (Configure::read('debug')):


### PR DESCRIPTION
This changes the following error message : 
![capture3](https://cloud.githubusercontent.com/assets/4977112/4177918/08d48dac-3668-11e4-90f3-4c3fca786fa1.PNG)

to this
![capture4](https://cloud.githubusercontent.com/assets/4977112/4177919/0fa13c2a-3668-11e4-8f9e-4ba8d862d600.PNG)

By the way, IMO it would make much more sense to display this error like this : 
![capture6](https://cloud.githubusercontent.com/assets/4977112/4177920/14ad1a68-3668-11e4-967e-2e8e81c52844.PNG)

as it would follow others error like 
![capture2](https://cloud.githubusercontent.com/assets/4977112/4177922/1c65450a-3668-11e4-8395-2b26555fb105.PNG)

Let me know if you agree with the last proposal and I'll update the PR.
