### PR TITLE
Unifying variable names representing a table name in the Schema system

### DIFF
--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -111,38 +111,38 @@ abstract class BaseSchema {
 /**
  * Generate the SQL to describe a table.
  *
- * @param string $name The table name to get information on.
+ * @param string $tableName The table name to get information on.
  * @param array $config The connection configuration.
  * @return array An array of (sql, params) to execute.
  */
-	abstract public function describeColumnSql($name, $config);
+	abstract public function describeColumnSql($tableName, $config);
 
 /**
  * Generate the SQL to describe the indexes in a table.
  *
- * @param string $table The table name to get information on.
+ * @param string $tableName The table name to get information on.
  * @param array $config The connection configuration.
  * @return array An array of (sql, params) to execute.
  */
-	abstract public function describeIndexSql($table, $config);
+	abstract public function describeIndexSql($tableName, $config);
 
 /**
  * Generate the SQL to describe the foreign keys in a table.
  *
- * @param string $table The table name to get information on.
+ * @param string $tableName The table name to get information on.
  * @param array $config The connection configuration.
  * @return array An array of (sql, params) to execute.
  */
-	abstract public function describeForeignKeySql($table, $config);
+	abstract public function describeForeignKeySql($tableName, $config);
 
 /**
  * Generate the SQL to describe table options
  *
- * @param string $name Table name.
+ * @param string $tableName Table name.
  * @param array $config The connection configuration.
  * @return array SQL statements to get options for a table.
  */
-	public function describeOptionsSql($name, $config) {
+	public function describeOptionsSql($tableName, $config) {
 		return ['', ''];
 	}
 

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -32,22 +32,22 @@ class MysqlSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeColumnSql($name, $config) {
-		return ['SHOW FULL COLUMNS FROM ' . $this->_driver->quoteIdentifier($name), []];
+	public function describeColumnSql($tableName, $config) {
+		return ['SHOW FULL COLUMNS FROM ' . $this->_driver->quoteIdentifier($tableName), []];
 	}
 
 /**
  * {@inheritDoc}
  */
-	public function describeIndexSql($name, $config) {
-		return ['SHOW INDEXES FROM ' . $this->_driver->quoteIdentifier($name), []];
+	public function describeIndexSql($tableName, $config) {
+		return ['SHOW INDEXES FROM ' . $this->_driver->quoteIdentifier($tableName), []];
 	}
 
 /**
  * {@inheritDoc}
  */
-	public function describeOptionsSql($name, $config) {
-		return ['SHOW TABLE STATUS WHERE Name = ?', [$name]];
+	public function describeOptionsSql($tableName, $config) {
+		return ['SHOW TABLE STATUS WHERE Name = ?', [$tableName]];
 	}
 
 /**
@@ -209,13 +209,13 @@ class MysqlSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeForeignKeySql($table, $config) {
+	public function describeForeignKeySql($tableName, $config) {
 		$sql = 'SELECT * FROM information_schema.key_column_usage AS kcu
 			INNER JOIN information_schema.referential_constraints AS rc
 			ON (kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME)
 			WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ?';
 
-		return [$sql, [$config['database'], $table]];
+		return [$sql, [$config['database'], $tableName]];
 	}
 
 /**

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -34,7 +34,7 @@ class PostgresSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeColumnSql($name, $config) {
+	public function describeColumnSql($tableName, $config) {
 		$sql =
 		'SELECT DISTINCT table_schema AS schema, column_name AS name, data_type AS type,
 			is_nullable AS null, column_default AS default,
@@ -50,7 +50,7 @@ class PostgresSchema extends BaseSchema {
 		ORDER BY ordinal_position';
 
 		$schema = empty($config['schema']) ? 'public' : $config['schema'];
-		return [$sql, [$name, $schema, $config['database']]];
+		return [$sql, [$tableName, $schema, $config['database']]];
 	}
 
 /**
@@ -173,7 +173,7 @@ class PostgresSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeIndexSql($table, $config) {
+	public function describeIndexSql($tableName, $config) {
 		$sql = 'SELECT
 			c2.relname,
 			i.indisprimary,
@@ -198,7 +198,7 @@ class PostgresSchema extends BaseSchema {
 		if (!empty($config['schema'])) {
 			$schema = $config['schema'];
 		}
-		return [$sql, [$table, $schema]];
+		return [$sql, [$tableName, $schema]];
 	}
 
 /**
@@ -257,7 +257,7 @@ class PostgresSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeForeignKeySql($table, $config) {
+	public function describeForeignKeySql($tableName, $config) {
 		$sql = "SELECT
 			r.conname AS name,
 			r.confupdtype AS update_type,
@@ -275,7 +275,7 @@ class PostgresSchema extends BaseSchema {
 			AND r.contype = 'f'";
 
 		$schema = empty($config['schema']) ? 'public' : $config['schema'];
-		return [$sql, [$table, $schema]];
+		return [$sql, [$tableName, $schema]];
 	}
 
 /**

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -100,10 +100,10 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeColumnSql($name, $config) {
+	public function describeColumnSql($tableName, $config) {
 		$sql = sprintf(
 			'PRAGMA table_info(%s)',
-			$this->_driver->quoteIdentifier($name)
+			$this->_driver->quoteIdentifier($tableName)
 		);
 		return [$sql, []];
 	}
@@ -135,10 +135,10 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeIndexSql($table, $config) {
+	public function describeIndexSql($tableName, $config) {
 		$sql = sprintf(
 			'PRAGMA index_list(%s)',
-			$this->_driver->quoteIdentifier($table)
+			$this->_driver->quoteIdentifier($tableName)
 		);
 		return [$sql, []];
 	}
@@ -180,8 +180,8 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeForeignKeySql($table, $config) {
-		$sql = sprintf('PRAGMA foreign_key_list(%s)', $this->_driver->quoteIdentifier($table));
+	public function describeForeignKeySql($tableName, $config) {
+		$sql = sprintf('PRAGMA foreign_key_list(%s)', $this->_driver->quoteIdentifier($tableName));
 		return [$sql, []];
 	}
 

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -40,7 +40,7 @@ class SqlserverSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeColumnSql($name, $config) {
+	public function describeColumnSql($tableName, $config) {
 		$sql =
 		"SELECT DISTINCT TABLE_SCHEMA AS [schema], COLUMN_NAME AS [name], DATA_TYPE AS [type],
 			IS_NULLABLE AS [null], COLUMN_DEFAULT AS [default],
@@ -53,7 +53,7 @@ class SqlserverSchema extends BaseSchema {
 		ORDER BY ordinal_position";
 
 		$schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
-		return [$sql, [$name, $schema]];
+		return [$sql, [$tableName, $schema]];
 	}
 
 /**
@@ -160,7 +160,7 @@ class SqlserverSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeIndexSql($table, $config) {
+	public function describeIndexSql($tableName, $config) {
 		$sql = "
 			SELECT
 				I.[name] AS [index_name],
@@ -178,7 +178,7 @@ class SqlserverSchema extends BaseSchema {
 		";
 
 		$schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
-		return [$sql, [$table, $schema]];
+		return [$sql, [$tableName, $schema]];
 	}
 
 /**
@@ -221,7 +221,7 @@ class SqlserverSchema extends BaseSchema {
 /**
  * {@inheritDoc}
  */
-	public function describeForeignKeySql($table, $config) {
+	public function describeForeignKeySql($tableName, $config) {
 		$sql = "
 			SELECT FK.[name] AS [foreign_key_name], FK.[delete_referential_action_desc] AS [delete_type],
 				FK.[update_referential_action_desc] AS [update_type], C.name AS [column], RT.name AS [reference_table],
@@ -237,7 +237,7 @@ class SqlserverSchema extends BaseSchema {
 		";
 
 		$schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
-		return [$sql, [$table, $schema]];
+		return [$sql, [$tableName, $schema]];
 	}
 
 /**


### PR DESCRIPTION
While working on #4505, I noticed that in the Schema system, variables representing a table name did not always have the same name, which confused me at first.
Sometimes it was `$table`, sometimes it was `$name`. This PR aims to unify the name used accross the Schema system.

I went for `$tableName` as `$table` is already used in some methods but needs to be a \Schema\Table instance.
