### PR TITLE
3.0 split utility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 	"replace": {
 		"cakephp/collection": "self.version",
 		"cakephp/event": "self.version",
-		"cakephp/validation": "self.version"
+		"cakephp/validation": "self.version",
+		"cakephp/utility": "self.version"
 	}
 }

--- a/src/Utility/README.md
+++ b/src/Utility/README.md
@@ -1,0 +1,88 @@
+# CakePHP Utility Classes
+
+This library provides a range of utility classes that are used throughout the CakePHP framework
+
+## What's in the toolbox?
+
+### Hash
+
+A ``Hash`` (as in PHP arrays) class, capable of extracting data using an intuitive DSL:
+
+```php
+$things = [
+	['name' => 'Mark', 'age' => 15],
+	['name' => 'Susan', 'age' => 30]
+	['name' => 'Lucy', 'age' => 25]
+];
+
+$bigPeople = Hash::extract('{n}[age>21].name', $things);
+
+// $bigPeople will contain ['Susan', 'Lucy']
+```
+
+Check the [official Hash class documentation](http://book.cakephp.org/3.0/en/core-utility-libraries/hash.html)
+
+### Inflector
+
+The Inflector class takes a string and can manipulate it to handle word variations
+such as pluralizations or camelizing.
+
+```php
+echo Inflector::pluralize('Apple'); // echoes Apples
+
+echo Inflector::singularize('People'); // echoes Person
+```
+
+Check the [official Inflector class documentation](http://book.cakephp.org/3.0/en/core-utility-libraries/inflector.html)
+
+### String
+
+The String class includes convenience methods for creating and manipulating strings.
+
+```php
+String::insert(
+    'My name is :name and I am :age years old.',
+    array('name' => 'Bob', 'age' => '65')
+);
+// Returns: "My name is Bob and I am 65 years old."
+
+$text = 'This is the song that never ends.';
+$result = String::wrap($text, 22);
+
+// Returns
+This is the song
+that never ends.
+```
+
+Check the [official String class documentation](http://book.cakephp.org/3.0/en/core-utility-libraries/string.html)
+
+### Security
+
+The security library handles basic security measures such as providing methods for hashing and encrypting data.
+
+```php
+$key = 'wt1U5MACWJFTXGenFoZoiLwQGrLgdbHA';
+$result = Security::encrypt($value, $key);
+
+Security::decrypt($result, $key);
+```
+
+Check the [official Security class documentation](http://book.cakephp.org/3.0/en/core-utility-libraries/security.html)
+
+### Xml
+
+The Xml class allows you to easily transform arrays into SimpleXMLElement or DOMDocument objects
+and back into arrays again
+
+```php
+$data = array(
+    'post' => array(
+        'id' => 1,
+        'title' => 'Best post',
+        'body' => ' ... '
+    )
+);
+$xml = Xml::build($data);
+```
+
+Check the [official Xml class documentation](http://book.cakephp.org/3.0/en/core-utility-libraries/xml.html)

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -15,7 +15,7 @@
 namespace Cake\Utility;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use InvalidArgumentException;
 
 /**
  * Security Library contains utility methods related to security
@@ -86,18 +86,18 @@ class Security {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
- * @throws \Cake\Core\Exception\Exception When there are errors.
+ * @throws \InvalidArgumentException When there are errors.
  * @return string Encrypted/Decrypted string
  */
 	public static function rijndael($text, $key, $operation) {
 		if (empty($key)) {
-			throw new Exception('You cannot use an empty key for Security::rijndael()');
+			throw new InvalidArgumentException('You cannot use an empty key for Security::rijndael()');
 		}
 		if (empty($operation) || !in_array($operation, array('encrypt', 'decrypt'))) {
-			throw new Exception('You must specify the operation for Security::rijndael(), either encrypt or decrypt');
+			throw new InvalidArgumentException('You must specify the operation for Security::rijndael(), either encrypt or decrypt');
 		}
 		if (strlen($key) < 32) {
-			throw new Exception('You must use a key larger than 32 bytes for Security::rijndael()');
+			throw new InvalidArgumentException('You must use a key larger than 32 bytes for Security::rijndael()');
 		}
 		$algorithm = MCRYPT_RIJNDAEL_256;
 		$mode = MCRYPT_MODE_CBC;
@@ -125,7 +125,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Encrypted data.
- * @throws \Cake\Core\Exception\Exception On invalid data or key.
+ * @throws \InvalidArgumentException On invalid data or key.
  */
 	public static function encrypt($plain, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'encrypt()');
@@ -153,11 +153,13 @@ class Security {
  * @param string $key Key to check.
  * @param string $method The method the key is being checked for.
  * @return void
- * @throws \Cake\Core\Exception\Exception When key length is not 256 bit/32 bytes
+ * @throws \InvalidArgumentException When key length is not 256 bit/32 bytes
  */
 	protected static function _checkKey($key, $method) {
 		if (strlen($key) < 32) {
-			throw new Exception(sprintf('Invalid key for %s, key must be at least 256 bits (32 bytes) long.', $method));
+			throw new InvalidArgumentException(
+				sprintf('Invalid key for %s, key must be at least 256 bits (32 bytes) long.', $method)
+			);
 		}
 	}
 
@@ -173,7 +175,7 @@ class Security {
 	public static function decrypt($cipher, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'decrypt()');
 		if (empty($cipher)) {
-			throw new Exception('The data to decrypt cannot be empty.');
+			throw new InvalidArgumentException('The data to decrypt cannot be empty.');
 		}
 		if ($hmacSalt === null) {
 			$hmacSalt = Configure::read('Security.salt');

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Utility;
 
-use Cake\Core\Configure;
 use InvalidArgumentException;
 
 /**
@@ -30,6 +29,13 @@ class Security {
  * @var string
  */
 	public static $hashType = 'sha1';
+
+/**
+ * The HMAC salt to use for encryption and decryption routines
+ *
+ * @var string
+ */
+	protected static $_salt;
 
 /**
  * Generate authorization hash.
@@ -60,7 +66,7 @@ class Security {
 
 		if ($salt) {
 			if (!is_string($salt)) {
-				$salt = Configure::read('Security.salt');
+				$salt = static::$_salt;
 			}
 			$string = $salt . $string;
 		}
@@ -131,7 +137,7 @@ class Security {
 		self::_checkKey($key, 'encrypt()');
 
 		if ($hmacSalt === null) {
-			$hmacSalt = Configure::read('Security.salt');
+			$hmacSalt = static::$_salt;
 		}
 
 		// Generate the encryption and hmac key.
@@ -178,7 +184,7 @@ class Security {
 			throw new InvalidArgumentException('The data to decrypt cannot be empty.');
 		}
 		if ($hmacSalt === null) {
-			$hmacSalt = Configure::read('Security.salt');
+			$hmacSalt = static::$_salt;
 		}
 
 		// Generate the encryption and hmac key.
@@ -202,6 +208,20 @@ class Security {
 		$cipher = substr($cipher, $ivSize);
 		$plain = mcrypt_decrypt($algorithm, $key, $cipher, $mode, $iv);
 		return rtrim($plain, "\0");
+	}
+
+/**
+ * Gets or sets the HMAC salt to be used for encryption/decryption
+ * routines.
+ *
+ * @param string $salt The salt to use for encryption routines
+ * @return string The currently configured salt
+ */
+	public static function salt($salt = null) {
+		if ($salt === null) {
+			return static::$_salt;
+		}
+		return static::$_salt = (string)$salt;
 	}
 
 }

--- a/src/Utility/String.php
+++ b/src/Utility/String.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Utility;
 
-use Cake\Core\Exception\Exception;
+use InvalidArgumentException;
 
 /**
  * String handling methods.
@@ -722,7 +722,7 @@ class String {
  * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
  * @param mixed $default Value to be returned when invalid size was used, for example 'Unknown type'
  * @return mixed Number of bytes as integer on success, `$default` on failure if not false
- * @throws \Cake\Core\Exception\Exception On invalid Unit type.
+ * @throws \InvalidArgumentException On invalid Unit type.
  * @link http://book.cakephp.org/3.0/en/core-libraries/helpers/text.html
  */
 	public static function parseFileSize($size, $default = false) {
@@ -750,7 +750,7 @@ class String {
 		if ($default !== false) {
 			return $default;
 		}
-		throw new Exception('No unit type.');
+		throw new InvalidArgumentException('No unit type.');
 	}
 
 

--- a/src/Utility/String.php
+++ b/src/Utility/String.php
@@ -753,5 +753,4 @@ class String {
 		throw new InvalidArgumentException('No unit type.');
 	}
 
-
 }

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Utility;
 
-use Cake\Core\Configure;
 use Cake\Utility\Exception\XmlException;
 use \DOMDocument;
 
@@ -197,7 +196,7 @@ class Xml {
 		$defaults = array(
 			'format' => 'tags',
 			'version' => '1.0',
-			'encoding' => Configure::read('App.encoding'),
+			'encoding' => mb_internal_encoding(),
 			'return' => 'simplexml',
 			'pretty' => false
 		);

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -1,0 +1,17 @@
+{
+	"name": "cakephp/utility",
+	"description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
+	"license": "MIT",
+	"authors": [
+		{
+		"name": "CakePHP Community",
+		"homepage": "http://cakephp.org"
+	}
+	],
+	"autoload": {
+		"psr-4": {
+			"Cake\\Utility\\": "."
+		}
+	},
+	"minimum-stability": "beta"
+}

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Utility;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 
@@ -244,6 +243,16 @@ class SecurityTest extends TestCase {
 		$txt = '';
 		$key = 'This is a key that is long enough to be ok.';
 		Security::decrypt($txt, $key);
+	}
+
+/**
+ * Tests that the salt can be set and retrieved
+ *
+ * @return void
+ */
+	public function testSalt() {
+		Security::salt('foobarbaz');
+		$this->assertEquals('foobarbaz', Security::salt());
 	}
 
 }

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -103,7 +103,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidOperation method
  *
- * @expectedException \Cake\Core\Exception\Exception
+ * @expectedException InvalidArgumentException
  * @return void
  */
 	public function testRijndaelInvalidOperation() {
@@ -115,7 +115,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidKey method
  *
- * @expectedException \Cake\Core\Exception\Exception
+ * @expectedException InvalidArgumentException
  * @return void
  */
 	public function testRijndaelInvalidKey() {
@@ -186,7 +186,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException \Cake\Core\Exception\Exception
+ * @expectedException InvalidArgumentException
  * @expectedExceptionMessage Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -223,7 +223,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException \Cake\Core\Exception\Exception
+ * @expectedException InvalidArgumentException
  * @expectedExceptionMessage Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -236,7 +236,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that empty data cause errors
  *
- * @expectedException \Cake\Core\Exception\Exception
+ * @expectedException InvalidArgumentException
  * @expectedExceptionMessage The data to decrypt cannot be empty.
  * @return void
  */

--- a/tests/TestCase/Utility/StringTest.php
+++ b/tests/TestCase/Utility/StringTest.php
@@ -1427,7 +1427,7 @@ podeís adquirirla.</span></p>
 /**
  * testFromReadableSize
  *
- * @expectedException \Cake\Core\Exception\Exception
+ * @expectedException InvalidArgumentException
  * @return void
  */
 	public function testparseFileSizeException() {


### PR DESCRIPTION
This set of changes make Utility completely independent of the rest of CakePHP. It introduces one change that needs to be reflected in the app template as `Configure` is no longer used inside this namespace.

Applications will need to add this to the bootstrap:

``` php
Security::salt(Configure::read('Security.salt'));
```
