### PR TITLE
3.0 Hash get/extract performance improvements

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -57,12 +57,21 @@ class Hash {
 			$parts = $path;
 		}
 
-		foreach ($parts as $key) {
-			if (is_array($data) && isset($data[$key])) {
-				$data = $data[$key];
-			} else {
-				return $default;
-			}
+		switch (count($parts)) {
+			case 1:
+				return isset($data[$parts[0]]) ? $data[$parts[0]] : $default;
+			case 2:
+				return isset($data[$parts[0]][$parts[1]]) ? $data[$parts[0]][$parts[1]] : $default;
+			case 3:
+				return isset($data[$parts[0]][$parts[1]][$parts[2]]) ? $data[$parts[0]][$parts[1]][$parts[2]] : $default;
+			default:
+				foreach ($parts as $key) {
+					if (is_array($data) && isset($data[$key])) {
+						$data = $data[$key];
+					} else {
+						return $default;
+					}
+				}
 		}
 
 		return $data;

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -65,7 +65,7 @@ class Hash {
 
 		foreach ($parts as $key) {
 			if (is_array($data) && isset($data[$key])) {
-				$data =& $data[$key];
+				$data = $data[$key];
 			} else {
 				return $default;
 			}

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -44,13 +44,7 @@ class Hash {
 			return $default;
 		}
 
-		$isString = is_string($path);
-
-		if ($isString && strpos($path, '.') === false) {
-			return isset($data[$path]) ? $data[$path] : $default;
-		}
-
-		if ($isString || is_numeric($path)) {
+		if (is_string($path) || is_numeric($path)) {
 			$parts = explode('.', $path);
 		} else {
 			if (!is_array($path)) {

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -114,6 +114,9 @@ class Hash {
 		}
 
 		if (strpos($path, '[') === false) {
+			if (function_exists('array_column') && preg_match('|^\{n\}\.(\w+)$|', $path, $matches)) {
+				return array_column($data, $matches[1]);
+			}
 			$tokens = explode('.', $path);
 		} else {
 			$tokens = String::tokenize($path, '.', '[', ']');


### PR DESCRIPTION
I made couple performance improvements on the methods `get` and `extract`:
- Using `array_column()` function on `Hash::extract()` when available (PHP 5.5+). It increases the performance in about **84%** when using PHP 5.5+ and the path has the format `{n}.field`. The downside is it decreases the performance in about 4.5% when the format doesn't match on PHP 5.5+ and about 2% on PHP 5.4 in any case.
- Since PHP 5.3 the variables are no longer duplicated in memory, so I removed the reference assignment on `Hash::get()`. It improves the performance in about 2%.
- Since `Hash::get()` is not recursive, I removed the check that verifies if the path is a single field. Incredibly it increased the performance in about 15%.
- Since we use `Hash::get()` for many things internally, such as configurations, I added a quick check for up 3 levels. If the the path has up to 3 levels the code will check by `isset` instead of loop thru the array and find it. It increased the performance in about 30% for up 3 levels. I didn't check how much it decreased by lazy reasons (:stuck_out_tongue_winking_eye:), but it shouldn't be much and the improvement for the reference variable should compensate it.

In general, the `Hash::get()` method is about 43% faster if contains up to 3 levels. Just as reference, the default installation of CakePHP 3.0 calls `Hash::get()` 40 times.

PS: I tried to use `array_column()` combine on `Hash::combine()` as well, but the method has custom formats, which could make the method complicated to read. I don't know how often people use it with the format `{n}.field1`, `{n}.field2` to compensate the readability downside.
