### PR TITLE
Fix Validation namespace requirement

### DIFF
--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -13,5 +13,8 @@
 			"Cake\\Validation\\": "."
 		}
 	},
-	"minimum-stability": "beta"
+	"require": {
+		"cakephp/utility": "dev-master"
+	},
+	"minimum-stability": "dev"
 }


### PR DESCRIPTION
The Validation class uses a single method from the string class. This means that there should be a requirement in composer.json
