### PR TITLE
hardcode a relative path to core installed via composer

### DIFF
--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -340,6 +340,11 @@ class ProjectTask extends AppShell {
 		$root = strpos(CAKE_CORE_INCLUDE_PATH, '/') === 0 ? " DS . '" : "'";
 		$corePath = $root . str_replace(DS, "' . DS . '", trim(CAKE_CORE_INCLUDE_PATH, DS)) . "'";
 
+		$composer = ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
+		if (file_exists($composer)) {
+			$corePath = " ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib'";
+		}
+
 		$result = str_replace('__CAKE_PATH__', $corePath, $contents, $count);
 		if ($hardCode) {
 			$result = str_replace('//define(\'CAKE_CORE', 'define(\'CAKE_CORE', $result);


### PR DESCRIPTION
detect a cake core installed via composer while baking a project
and set the CAKE_CORE_INCLUDE_PATH as [book suggests](http://book.cakephp.org/2.0/en/installation/advanced-installation.html#installing-cakephp-with-composer)
