### PR TITLE
3.0 DB config debug 

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -649,13 +649,13 @@ class Connection {
 		$config = $replace + $this->_config;
 
 		return [
-			'_config' => $config,
-			'_driver' => $this->_driver,
-			'_transactionLevel' => $this->_transactionLevel,
-			'_transactionStarted' => $this->_transactionStarted,
-			'_useSavePoints' => $this->_useSavePoints,
-			'_logQueries' => $this->_logQueries,
-			'_logger' => $this->_logger
+			'config' => $config,
+			'driver' => $this->_driver,
+			'transactionLevel' => $this->_transactionLevel,
+			'transactionStarted' => $this->_transactionStarted,
+			'useSavePoints' => $this->_useSavePoints,
+			'logQueries' => $this->_logQueries,
+			'logger' => $this->_logger
 		];
 	}
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -629,4 +629,34 @@ class Connection {
 		return $log;
 	}
 
+/**
+ * Returns an array that can be used to describe the internal state of this
+ * object.
+ *
+ * @return array
+ */
+	public function __debugInfo() {
+		$secrets = [
+			'password' => '*****',
+			'login' => '*****',
+			'host' => '*****',
+			'database' => '*****',
+			'port' => '*****',
+			'prefix' => '*****',
+			'schema' => '*****'
+		];
+		$replace = array_intersect_key($secrets, $this->_config);
+		$config = $replace + $this->_config;
+
+		return [
+			'_config' => $config,
+			'_driver' => $this->_driver,
+			'_transactionLevel' => $this->_transactionLevel,
+			'_transactionStarted' => $this->_transactionStarted,
+			'_useSavePoints' => $this->_useSavePoints,
+			'_logQueries' => $this->_logQueries,
+			'_logger' => $this->_logger
+		];
+	}
+
 }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -316,4 +316,32 @@ abstract class Driver {
 		$this->_connection = null;
 	}
 
+/**
+ * Returns an array that can be used to describe the internal state of this
+ * object.
+ *
+ * @return array
+ */
+    public function __debugInfo() {
+		$secrets = [
+			'password' => '*****',
+			'login' => '*****',
+			'host' => '*****',
+			'database' => '*****',
+			'port' => '*****',
+			'prefix' => '*****',
+			'schema' => '*****'
+		];
+		$replace = array_intersect_key($secrets, $this->_config);
+                
+        return [
+            '_baseConfig' => $replace + $this->_baseConfig,
+            '_config' => $replace + $this->_config,
+            '_autoQuoting' => $this->_autoQuoting,
+            '_startQuote' => $this->_startQuote,
+            '_endQuote' => $this->_endQuote,
+            '_schemaDialect' => get_class($this->_schemaDialect)
+        ];
+    }
+
 }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -323,24 +323,8 @@ abstract class Driver {
  * @return array
  */
 	public function __debugInfo() {
-		$secrets = [
-			'password' => '*****',
-			'login' => '*****',
-			'host' => '*****',
-			'database' => '*****',
-			'port' => '*****',
-			'prefix' => '*****',
-			'schema' => '*****'
-		];
-		$replace = array_intersect_key($secrets, $this->_config);
-
 		return [
-			'_baseConfig' => $replace + $this->_baseConfig,
-			'_config' => $replace + $this->_config,
-			'_autoQuoting' => $this->_autoQuoting,
-			'_startQuote' => $this->_startQuote,
-			'_endQuote' => $this->_endQuote,
-			'_schemaDialect' => get_class($this->_schemaDialect)
+			'connected' => $this->isConnected()
 		];
 	}
 

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -322,7 +322,7 @@ abstract class Driver {
  *
  * @return array
  */
-    public function __debugInfo() {
+	public function __debugInfo() {
 		$secrets = [
 			'password' => '*****',
 			'login' => '*****',
@@ -333,15 +333,15 @@ abstract class Driver {
 			'schema' => '*****'
 		];
 		$replace = array_intersect_key($secrets, $this->_config);
-                
-        return [
-            '_baseConfig' => $replace + $this->_baseConfig,
-            '_config' => $replace + $this->_config,
-            '_autoQuoting' => $this->_autoQuoting,
-            '_startQuote' => $this->_startQuote,
-            '_endQuote' => $this->_endQuote,
-            '_schemaDialect' => get_class($this->_schemaDialect)
-        ];
-    }
+
+		return [
+			'_baseConfig' => $replace + $this->_baseConfig,
+			'_config' => $replace + $this->_config,
+			'_autoQuoting' => $this->_autoQuoting,
+			'_startQuote' => $this->_startQuote,
+			'_endQuote' => $this->_endQuote,
+			'_schemaDialect' => get_class($this->_schemaDialect)
+		];
+	}
 
 }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -523,18 +523,6 @@ class Debugger {
  * @return string Exported array.
  */
 	protected static function _array(array $var, $depth, $indent) {
-		$secrets = array(
-			'password' => '*****',
-			'login' => '*****',
-			'host' => '*****',
-			'database' => '*****',
-			'port' => '*****',
-			'prefix' => '*****',
-			'schema' => '*****'
-		);
-		$replace = array_intersect_key($secrets, $var);
-		$var = $replace + $var;
-
 		$out = "[";
 		$break = $end = null;
 		if (!empty($var)) {

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -572,41 +572,6 @@ TEXT;
 	}
 
 /**
- * testNoDbCredentials
- *
- * If a connection error occurs, the config variable is passed through exportVar
- * *** our database login credentials such that they are never visible
- *
- * @return void
- */
-	public function testNoDbCredentials() {
-		$config = array(
-			'datasource' => 'mysql',
-			'persistent' => false,
-			'host' => 'void.cakephp.org',
-			'login' => 'cakephp-user',
-			'password' => 'cakephp-password',
-			'database' => 'cakephp-database',
-			'prefix' => ''
-		);
-
-		$output = Debugger::exportVar($config);
-
-		$expectedArray = array(
-			'datasource' => 'mysql',
-			'persistent' => false,
-			'host' => '*****',
-			'login' => '*****',
-			'password' => '*****',
-			'database' => '*****',
-			'prefix' => ''
-		);
-		$expected = Debugger::exportVar($expectedArray);
-
-		$this->assertEquals($expected, $output);
-	}
-
-/**
  * Test that exportVar() doesn't loop through recursive structures.
  *
  * @return void


### PR DESCRIPTION
I've moved masking of DB credentials from Debugger to Driver and Connection via __debugInfo()
Hiding reserved keys from all arrays made debugging a bit annoying while working with password hashing, HTTP etc.

I've also fixed nesting of _schemaDialect debug by displaying only a class name of the dialect.
