### PR TITLE
Sqlserver fix

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -429,9 +429,21 @@ class SqlserverSchema extends BaseSchema {
  */
 	public function truncateTableSql(Table $table) {
 		$name = $this->_driver->quoteIdentifier($table->name());
-		return [
-			sprintf('TRUNCATE TABLE %s', $name)
+		$queries = [
+			sprintf('DELETE FROM TABLE %s', $name)
 		];
+		$pk = $table->primaryKey();
+		foreach ($pk as $column) {
+			$column = $table->column($column);
+			if (!empty($column['autoIncrement'])) {
+				$queries[] = sprintf(
+					'DBCC CHECKIDENT(%s, RESEED, 0)',
+					$this->_driver->quoteIdentifier($column)
+				);
+				break;
+			}
+		}
+		return $queries;
 	}
 
 }

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -430,17 +430,18 @@ class SqlserverSchema extends BaseSchema {
 	public function truncateTableSql(Table $table) {
 		$name = $this->_driver->quoteIdentifier($table->name());
 		$queries = [
-			sprintf('DELETE FROM TABLE %s', $name)
+			sprintf('DELETE FROM %s', $name)
 		];
+
+		// Restart identity sequences
 		$pk = $table->primaryKey();
-		foreach ($pk as $column) {
-			$column = $table->column($column);
-			if (!empty($column['autoIncrement'])) {
+		if (count($pk) === 1) {
+			$column = $table->column($pk[0]);
+			if (in_array($column['type'], ['integer', 'biginteger'])) {
 				$queries[] = sprintf(
 					'DBCC CHECKIDENT(%s, RESEED, 0)',
-					$this->_driver->quoteIdentifier($column)
+					$name
 				);
-				break;
 			}
 		}
 		return $queries;

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -230,8 +230,7 @@ class FixtureManager {
 				foreach ($fixtures as $fixture) {
 					if (!in_array($db->configName(), (array)$fixture->created)) {
 						$this->_setupTable($fixture, $db, $tables, $test->dropTables);
-					}
-					if (!$test->dropTables) {
+					} else {
 						$fixture->truncate($db);
 					}
 				}
@@ -325,7 +324,8 @@ class FixtureManager {
 			}
 
 			if (!in_array($db->configName(), (array)$fixture->created)) {
-				$this->_setupTable($fixture, $db, $dropTables);
+				$sources = $db->schemaCollection()->listTables();
+				$this->_setupTable($fixture, $db, $sources, $dropTables);
 			}
 			if (!$dropTables) {
 				$fixture->truncate($db);

--- a/tests/Fixture/ArticlesTagFixture.php
+++ b/tests/Fixture/ArticlesTagFixture.php
@@ -35,7 +35,9 @@ class ArticlesTagFixture extends TestFixture {
 			'tag_idx' => [
 				'type' => 'foreign',
 				'columns' => ['tag_id'],
-				'references' => ['tags', 'id']
+				'references' => ['tags', 'id'],
+				'update' => 'cascade',
+				'delete' => 'cascade',
 			]
 		]
 	);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -710,8 +710,9 @@ SQL;
 				'columns' => ['id']
 			]);
 		$result = $table->truncateSql($connection);
-		$this->assertCount(1, $result);
+		$this->assertCount(2, $result);
 		$this->assertEquals('TRUNCATE TABLE [schema_articles]', $result[0]);
+		$this->assertEquals('DBCC CHECKIDENT([schema_articles], RESEED, 0)', $result[1]);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -269,9 +269,8 @@ SQL;
 		$schema = new SchemaCollection($connection);
 		$result = $schema->listTables();
 		$this->assertInternalType('array', $result);
-		$this->assertCount(2, $result);
-		$this->assertEquals('schema_articles', $result[0]);
-		$this->assertEquals('schema_authors', $result[1]);
+		$this->assertContains('schema_articles', $result);
+		$this->assertContains('schema_authors', $result);
 	}
 
 /**
@@ -711,7 +710,7 @@ SQL;
 			]);
 		$result = $table->truncateSql($connection);
 		$this->assertCount(2, $result);
-		$this->assertEquals('TRUNCATE TABLE [schema_articles]', $result[0]);
+		$this->assertEquals('DELETE FROM [schema_articles]', $result[0]);
 		$this->assertEquals('DBCC CHECKIDENT([schema_articles], RESEED, 0)', $result[1]);
 	}
 


### PR DESCRIPTION
This should fix the AppVeyor builds and leave the postgres/sqlite/mysql builds also passing. Unlike other DB vendors, SQLserver cannot truncate a table that is referenced by foreign keys _ever_. Instead you have to use `DELETE FROM ...` and restart identity columns with `DBCC ...`. However, one can only call `CHECKINDENT` if the table actually has an identity column.
