### PR TITLE
Use strftime in timeAgoInWords

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -270,7 +270,7 @@ class CakeTimeTest extends CakeTestCase {
 	public function testTimeAgoInWordsWithFormat() {
 		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
 		$this->assertEquals('on 2007-09-25', $result);
-		
+
 		$result = $this->Time->timeAgoInWords('2007-9-25', '%x');
 		$this->assertEquals('on '. strftime('%x', strtotime('2007-9-25')), $result);
 

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -263,20 +263,26 @@ class CakeTimeTest extends CakeTestCase {
 	}
 
 /**
- * Test the format option of timeAgoInWords()
+ * Test the format option of timeAgoInWords() with date() and strftime compatible strings
  *
  * @return void
  */
 	public function testTimeAgoInWordsWithFormat() {
 		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
 		$this->assertEquals('on 2007-09-25', $result);
-
-		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
-		$this->assertEquals('on 2007-09-25', $result);
+		
+		$result = $this->Time->timeAgoInWords('2007-9-25', '%x');
+		$this->assertEquals('on '. strftime('%x', strtotime('2007-9-25')), $result);
 
 		$result = $this->Time->timeAgoInWords(
 			strtotime('+2 weeks +2 days'),
 			'Y-m-d'
+		);
+		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
+		
+		$result = $this->Time->timeAgoInWords(
+			strtotime('+2 weeks +2 days'),
+			'%x'
 		);
 		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
 
@@ -285,6 +291,12 @@ class CakeTimeTest extends CakeTestCase {
 			array('end' => '1 month', 'format' => 'Y-m-d')
 		);
 		$this->assertEquals('on ' . date('Y-m-d', strtotime('+2 months +2 days')), $result);
+
+		$result = $this->Time->timeAgoInWords(
+			strtotime('+2 months +2 days'),
+			array('end' => '1 month', 'format' => '%x')
+		);
+		$this->assertEquals('on ' . strftime('%x', strtotime('+2 months +2 days')), $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -279,7 +279,7 @@ class CakeTimeTest extends CakeTestCase {
 			'Y-m-d'
 		);
 		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
-		
+
 		$result = $this->Time->timeAgoInWords(
 			strtotime('+2 weeks +2 days'),
 			'%x'

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -796,7 +796,11 @@ class CakeTime {
 		}
 
 		if ($diff > abs($now - self::fromString($end))) {
-			return sprintf($absoluteString, date($format, $inSeconds));
+			return sprintf($absoluteString,
+					(strpos($format, '%') === false) ?
+						date($format, $inSeconds) :
+						self::_strftime($format, $inSeconds)
+			);
 		}
 
 		// If more than a week, then take into account the length of months


### PR DESCRIPTION
Assuming that date() does not use any % in its format string and assuming strftime always has at least one % in its string, we could differentiate between both formats.
