### PR TITLE
Make use of Security::salt() instead of Configure::read('Security.salt')...

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -130,7 +130,7 @@ class CookieComponent extends Component {
 		parent::__construct($collection, $config);
 
 		if (!$this->_config['key']) {
-			$this->config('key', Configure::read('Security.salt'));
+			$this->config('key', Security::salt());
 		}
 
 		$controller = $collection->getController();

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -345,7 +345,7 @@ class SecurityComponent extends Component {
 			$controller->request->here(),
 			serialize($fieldList),
 			$unlocked,
-			Configure::read('Security.salt')
+			Security::salt()
 		);
 		$check = Security::hash(implode('', $hashParts), 'sha1');
 		return ($token === $check);

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -17,6 +17,7 @@ namespace Cake\Error;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
+use Cake\Utility\Security;
 use Cake\Utility\String;
 use Exception;
 use InvalidArgumentException;
@@ -838,7 +839,7 @@ class Debugger {
  * @return void
  */
 	public static function checkSecurityKeys() {
-		if (Configure::read('Security.salt') === '__SALT__') {
+		if (Security::salt() === '__SALT__') {
 			trigger_error(sprintf('Please change the value of %s in %s to a salt value specific to your application.', '\'Security.salt\'', 'ROOT/config/app.php'), E_USER_NOTICE);
 		}
 	}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -497,7 +497,7 @@ class FormHelper extends Helper {
 			$this->_lastAction,
 			serialize($fields),
 			$unlocked,
-			Configure::read('Security.salt')
+			Security::salt()
 		);
 		$fields = Security::hash(implode('', $hashParts), 'sha1');
 

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -232,7 +232,7 @@ class FormAuthenticateTest extends TestCase {
 		$PluginModel = TableRegistry::get('TestPlugin.AuthUsers');
 		$user['id'] = 1;
 		$user['username'] = 'gwoo';
-		$user['password'] = password_hash(Configure::read('Security.salt') . 'cake', PASSWORD_BCRYPT);
+		$user['password'] = password_hash(Security::salt() . 'cake', PASSWORD_BCRYPT);
 		$PluginModel->save(new Entity($user));
 
 		$this->auth->config('userModel', 'TestPlugin.AuthUsers');

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Auth;
 use Cake\Auth\WeakPasswordHasher;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
 
 /**
  * Test case for WeakPasswordHasher
@@ -32,7 +33,7 @@ class WeakPasswordHasherTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		Configure::write('Security.salt', 'YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
+		Security::salt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
 	}
 
 /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -61,7 +61,7 @@ class AuthComponentTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		Configure::write('Security.salt', 'YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
+		Security::salt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
 		Configure::write('App.namespace', 'TestApp');
 
 		Router::scope('/', function($routes) {

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -146,7 +146,7 @@ class SecurityComponentTest extends TestCase {
 		$this->Controller->Security->config('blackHoleCallback', 'fail');
 		$this->Security = $this->Controller->Security;
 		$this->Security->session = $session;
-		Configure::write('Security.salt', 'foo!');
+		Security::salt('foo!');
 	}
 
 /**
@@ -659,7 +659,7 @@ class SecurityComponentTest extends TestCase {
 		$this->Controller->Security->startup($event);
 		$unlocked = 'Model.username';
 		$fields = array('Model.hidden', 'Model.password');
-		$fields = urlencode(Security::hash('/articles/index' . serialize($fields) . $unlocked . Configure::read('Security.salt')));
+		$fields = urlencode(Security::hash('/articles/index' . serialize($fields) . $unlocked . Security::salt()));
 
 		$this->Controller->request->data = array(
 			'Model' => array(
@@ -683,7 +683,7 @@ class SecurityComponentTest extends TestCase {
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->Security->startup($event);
 		$fields = array('Model.hidden', 'Model.password', 'Model.username');
-		$fields = urlencode(Security::hash(serialize($fields) . Configure::read('Security.salt')));
+		$fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
 
 		$this->Controller->request->data = array(
 			'Model' => array(
@@ -708,7 +708,7 @@ class SecurityComponentTest extends TestCase {
 		$this->Controller->Security->startup($event);
 		$unlocked = 'Model.username';
 		$fields = array('Model.hidden', 'Model.password');
-		$fields = urlencode(Security::hash(serialize($fields) . $unlocked . Configure::read('Security.salt')));
+		$fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
 
 		// Tamper the values.
 		$unlocked = 'Model.username|Model.password';
@@ -829,7 +829,7 @@ class SecurityComponentTest extends TestCase {
 		$this->Controller->Security->startup($event);
 		$unlocked = '';
 		$hashFields = array('TaxonomyData');
-		$fields = urlencode(Security::hash('/articles/index' . serialize($hashFields) . $unlocked . Configure::read('Security.salt')));
+		$fields = urlencode(Security::hash('/articles/index' . serialize($hashFields) . $unlocked . Security::salt()));
 
 		$this->Controller->request->data = array(
 			'TaxonomyData' => array(

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -20,6 +20,7 @@ use Cake\Routing\DispatcherFactory;
 use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
 
 /**
  */
@@ -40,7 +41,7 @@ class RequestActionTraitTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('App.namespace', 'TestApp');
-		Configure::write('Security.salt', 'not-the-default');
+		Security::salt('not-the-default');
 		DispatcherFactory::add('Routing');
 		DispatcherFactory::add('ControllerFactory');
 		$this->object = $this->getObjectForTrait('Cake\Routing\RequestActionTrait');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -174,7 +174,7 @@ class FormHelperTest extends TestCase {
 			]
 		];
 
-		Configure::write('Security.salt', 'foo!');
+		Security::salt('foo!');
 		Router::connect('/:controller', array('action' => 'index'));
 		Router::connect('/:controller/:action/*');
 	}
@@ -837,7 +837,7 @@ class FormHelperTest extends TestCase {
 		$this->Form->request->params['_Token'] = 'testKey';
 		$result = $this->Form->secure($fields);
 
-		$hash = Security::hash(serialize($fields) . Configure::read('Security.salt'));
+		$hash = Security::hash(serialize($fields) . Security::salt());
 		$hash .= ':' . 'Model.valid';
 		$hash = urlencode($hash);
 
@@ -5539,7 +5539,7 @@ class FormHelperTest extends TestCase {
 			'/posts/delete/1' .
 			serialize(array()) .
 			'' .
-			Configure::read('Security.salt')
+			Security::salt()
 		);
 		$hash .= '%3A';
 		$this->Form->request->params['_Token']['key'] = 'test';


### PR DESCRIPTION
After a recent update i got an error while reading data through the CookieComponent.
`Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.`

The error has been introduced by calling Configure::consume('Security.salt') in app/bootstrap.php here:
https://github.com/cakephp/app/blob/master/config/bootstrap.php#L135

By searching for 'Security.salt' in all cake's source folder I found that in other places there is the same problem.
