### PR TITLE
Use (int) instead of intval() for performance reasons and to unify it.

### DIFF
--- a/lib/Cake/Cache/Engine/ApcEngine.php
+++ b/lib/Cake/Cache/Engine/ApcEngine.php
@@ -75,7 +75,7 @@ class ApcEngine extends CacheEngine {
  */
 	public function read($key) {
 		$time = time();
-		$cachetime = intval(apc_fetch($key . '_expires'));
+		$cachetime = (int)apc_fetch($key . '_expires');
 		if ($cachetime !== 0 && ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime)) {
 			return false;
 		}

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -165,7 +165,7 @@ class FileEngine extends CacheEngine {
 
 		$this->_File->rewind();
 		$time = time();
-		$cachetime = intval($this->_File->current());
+		$cachetime = (int)$this->_File->current();
 
 		if ($cachetime !== false && ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime)) {
 			if ($this->settings['lock']) {

--- a/lib/Cake/Cache/Engine/WincacheEngine.php
+++ b/lib/Cake/Cache/Engine/WincacheEngine.php
@@ -80,7 +80,7 @@ class WincacheEngine extends CacheEngine {
  */
 	public function read($key) {
 		$time = time();
-		$cachetime = intval(wincache_ucache_get($key . '_expires'));
+		$cachetime = (int)wincache_ucache_get($key . '_expires');
 		if ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime) {
 			return false;
 		}

--- a/lib/Cake/Cache/Engine/XcacheEngine.php
+++ b/lib/Cake/Cache/Engine/XcacheEngine.php
@@ -80,7 +80,7 @@ class XcacheEngine extends CacheEngine {
 	public function read($key) {
 		if (xcache_isset($key)) {
 			$time = time();
-			$cachetime = intval(xcache_get($key . '_expires'));
+			$cachetime = (int)xcache_get($key . '_expires');
 			if ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime) {
 				return false;
 			}

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -579,8 +579,8 @@ class AclShell extends AppShell {
  * @return array aro, aco, action
  */
 	protected function _getParams() {
-		$aro = is_numeric($this->args[0]) ? intval($this->args[0]) : $this->args[0];
-		$aco = is_numeric($this->args[1]) ? intval($this->args[1]) : $this->args[1];
+		$aro = is_numeric($this->args[0]) ? (int)$this->args[0] : $this->args[0];
+		$aco = is_numeric($this->args[1]) ? (int)$this->args[1] : $this->args[1];
 		$aroName = $aro;
 		$acoName = $aco;
 

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -452,14 +452,14 @@ class ControllerTask extends BakeTask {
 				return $this->_stop();
 			}
 
-			if (!$enteredController || intval($enteredController) > count($controllers)) {
+			if (!$enteredController || (int)$enteredController > count($controllers)) {
 				$this->err(__d('cake_console', "The Controller name you supplied was empty,\nor the number you selected was not an option. Please try again."));
 				$enteredController = '';
 			}
 		}
 
-		if (intval($enteredController) > 0 && intval($enteredController) <= count($controllers)) {
-			$controllerName = $controllers[intval($enteredController) - 1];
+		if ((int)$enteredController > 0 && (int)$enteredController <= count($controllers)) {
+			$controllerName = $controllers[(int)$enteredController - 1];
 		} else {
 			$controllerName = Inflector::camelize($enteredController);
 		}

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -417,7 +417,7 @@ class ExtractTask extends AppShell {
 				if ($mapCount === count($strings)) {
 					extract(array_combine($map, $strings));
 					$category = isset($category) ? $category : 6;
-					$category = intval($category);
+					$category = (int)$category;
 					$categoryName = $categories[$category];
 					$domain = isset($domain) ? $domain : 'default';
 					$details = array(

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -176,7 +176,7 @@ class ModelTask extends BakeTask {
 				$prompt = __d('cake_console', 'Make a selection from the choices above');
 			}
 			$choice = $this->in($prompt, null, $default);
-			if (intval($choice) > 0 && intval($choice) <= $max) {
+			if ((int)$choice > 0 && (int)$choice <= $max) {
 				$valid = true;
 			}
 		}
@@ -765,7 +765,7 @@ class ModelTask extends BakeTask {
 			if (!empty($showKeys)) {
 				$this->out(__d('cake_console', 'A helpful List of possible keys'));
 				$foreignKey = $this->inOptions($showKeys, __d('cake_console', 'What is the foreignKey?'));
-				$foreignKey = $showKeys[intval($foreignKey)];
+				$foreignKey = $showKeys[(int)$foreignKey];
 			}
 			if (!isset($foreignKey)) {
 				$foreignKey = $this->in(__d('cake_console', 'What is the foreignKey? Specify your own.'), null, $suggestedForeignKey);
@@ -985,14 +985,14 @@ class ModelTask extends BakeTask {
 				return $this->_stop();
 			}
 
-			if (!$enteredModel || intval($enteredModel) > count($this->_modelNames)) {
+			if (!$enteredModel || (int)$enteredModel > count($this->_modelNames)) {
 				$this->err(__d('cake_console', "The model name you supplied was empty,\n" .
 					"or the number you selected was not an option. Please try again."));
 				$enteredModel = '';
 			}
 		}
-		if (intval($enteredModel) > 0 && intval($enteredModel) <= count($this->_modelNames)) {
-			return $this->_modelNames[intval($enteredModel) - 1];
+		if ((int)$enteredModel > 0 && (int)$enteredModel <= count($this->_modelNames)) {
+			return $this->_modelNames[(int)$enteredModel - 1];
 		}
 
 		return $enteredModel;

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -728,7 +728,7 @@ class ModelTask extends BakeTask {
 		while (strtolower($wannaDoMoreAssoc) === 'y') {
 			$assocs = array('belongsTo', 'hasOne', 'hasMany', 'hasAndBelongsToMany');
 			$this->out(__d('cake_console', 'What is the association type?'));
-			$assocType = intval($this->inOptions($assocs, __d('cake_console', 'Enter a number')));
+			$assocType = (int)$this->inOptions($assocs, __d('cake_console', 'Enter a number'));
 
 			$this->out(__d('cake_console', "For the following options be very careful to match your setup exactly.\n" .
 				"Any spelling mistakes will cause errors."));

--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -203,7 +203,7 @@ class PluginTask extends AppShell {
 			}
 			$prompt = __d('cake_console', 'Choose a plugin path from the paths above.');
 			$choice = $this->in($prompt, null, 1);
-			if (intval($choice) > 0 && intval($choice) <= $max) {
+			if ((int)$choice > 0 && (int)$choice <= $max) {
 				$valid = true;
 			}
 		}

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -414,7 +414,7 @@ class CookieComponent extends Component {
 		$now = new DateTime();
 
 		if (is_int($expires) || is_numeric($expires)) {
-			return $this->_expires = $now->format('U') + intval($expires);
+			return $this->_expires = $now->format('U') + (int)$expires;
 		}
 		$now->modify($expires);
 		return $this->_expires = $now->format('U');

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -179,7 +179,7 @@ class PaginatorComponent extends Component {
 			$extra['type'] = $type;
 		}
 
-		if (intval($page) < 1) {
+		if ((int)$page < 1) {
 			$page = 1;
 		}
 		$page = $options['page'] = (int)$page;

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -211,7 +211,7 @@ class PaginatorComponent extends Component {
 			}
 			$count = $object->find('count', array_merge($parameters, $extra));
 		}
-		$pageCount = intval(ceil($count / $limit));
+		$pageCount = (int)ceil($count / $limit);
 		$requestedPage = $page;
 		$page = max(min($page, $pageCount), 1);
 

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -493,7 +493,7 @@ class Mysql extends DboSource {
 					if ($idx->Index_type === 'FULLTEXT') {
 						$index[$idx->Key_name]['type'] = strtolower($idx->Index_type);
 					} else {
-						$index[$idx->Key_name]['unique'] = intval($idx->Non_unique == 0);
+						$index[$idx->Key_name]['unique'] = (int)($idx->Non_unique == 0);
 					}
 				} else {
 					if (!empty($index[$idx->Key_name]['column']) && !is_array($index[$idx->Key_name]['column'])) {

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -219,10 +219,10 @@ class Postgres extends DboSource {
 					} elseif ($c->type === 'uuid') {
 						$length = 36;
 					} else {
-						$length = intval($c->oct_length);
+						$length = (int)$c->oct_length;
 					}
 				} elseif (!empty($c->char_length)) {
-					$length = intval($c->char_length);
+					$length = (int)$c->char_length;
 				} else {
 					$length = $this->length($c->type);
 				}

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -726,7 +726,7 @@ class Postgres extends DboSource {
 			return 36;
 		}
 		if ($limit) {
-			return intval($limit);
+			return (int)$limit;
 		}
 		return null;
 	}

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -509,7 +509,7 @@ class Sqlite extends DboSource {
 							$key['name'] = 'PRIMARY';
 						}
 						$index[$key['name']]['column'] = $keyCol[0]['name'];
-						$index[$key['name']]['unique'] = intval($key['unique'] == 1);
+						$index[$key['name']]['unique'] = (int)$key['unique'] === 1;
 					} else {
 						if (!is_array($index[$key['name']]['column'])) {
 							$col[] = $index[$key['name']]['column'];

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -537,9 +537,9 @@ class Sqlserver extends DboSource {
 				if (version_compare($this->getVersion(), '11', '<') && preg_match('/FETCH\sFIRST\s+([0-9]+)/i', $limit, $offset)) {
 					preg_match('/OFFSET\s*(\d+)\s*.*?(\d+)\s*ROWS/', $limit, $limitOffset);
 
-					$limit = 'TOP ' . intval($limitOffset[2]);
-					$page = intval($limitOffset[1] / $limitOffset[2]);
-					$offset = intval($limitOffset[2] * $page);
+					$limit = 'TOP ' . (int)$limitOffset[2];
+					$page = (int)($limitOffset[1] / $limitOffset[2]);
+					$offset = (int)($limitOffset[2] * $page);
 
 					$rowCounter = self::ROW_COUNTER;
 					$sql = "SELECT {$limit} * FROM (

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3048,7 +3048,7 @@ class DboSource extends DataSource {
 				list($col, $limit) = explode('(', $col);
 			}
 			if ($limit !== null) {
-				return intval($limit);
+				return (int)$limit;
 			}
 			return null;
 		}
@@ -3089,7 +3089,7 @@ class DboSource extends DataSource {
 				}
 			}
 		}
-		return intval($length);
+		return (int)$length;
 	}
 
 /**
@@ -3456,10 +3456,10 @@ class DboSource extends DataSource {
 			if (is_bool($value)) {
 				return 'boolean';
 			}
-			if (is_float($value) && floatval($value) === $value) {
+			if (is_float($value) && (float)$value === $value) {
 				return 'float';
 			}
-			if (is_int($value) && intval($value) === $value) {
+			if (is_int($value) && (int)$value === $value) {
 				return 'integer';
 			}
 			if (is_string($value) && strlen($value) > 255) {

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2094,7 +2094,7 @@ class Model extends Object implements CakeEventListener {
 
 				if (isset($keys['old'][$foreignKey]) && $keys['old'][$foreignKey] != $keys[$foreignKey]) {
 					$conditions[$fkQuoted] = $keys['old'][$foreignKey];
-					$count = intval($this->find('count', compact('conditions', 'recursive')));
+					$count = (int)$this->find('count', compact('conditions', 'recursive'));
 
 					$Model->updateAll(
 						array($field => $count),
@@ -2108,7 +2108,7 @@ class Model extends Object implements CakeEventListener {
 					$conditions = array_merge($conditions, (array)$conditions);
 				}
 
-				$count = intval($this->find('count', compact('conditions', 'recursive')));
+				$count = (int)$this->find('count', compact('conditions', 'recursive'));
 
 				$Model->updateAll(
 					array($field => $count),
@@ -2979,7 +2979,7 @@ class Model extends Object implements CakeEventListener {
 			$query = $this->{'_find' . ucfirst($type)}('before', $query);
 		}
 
-		if (!is_numeric($query['page']) || intval($query['page']) < 1) {
+		if (!is_numeric($query['page']) || (int)$query['page'] < 1) {
 			$query['page'] = 1;
 		}
 
@@ -3092,7 +3092,7 @@ class Model extends Object implements CakeEventListener {
 					return count($results);
 				}
 
-				return intval($results[0][$key]['count']);
+				return (int)$results[0][$key]['count'];
 			}
 		}
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -2528,7 +2528,7 @@ class ModelWriteTest extends BaseModelTest {
 				'user' => 'some user',
 				'password' => 'some password'
 		)));
-		$this->assertTrue(is_int($TestModel->id) || (intval($TestModel->id) === 5));
+		$this->assertTrue(is_int($TestModel->id) || ((int)$TestModel->id === 5));
 		$id = $TestModel->id;
 
 		$TestModel->save(array(

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -187,7 +187,7 @@ class DebuggerTest extends CakeTestCase {
 			'error' => array(),
 			'code' => array(), '8', '/code',
 			'file' => array(), 'preg:/[^<]+/', '/file',
-			'line' => array(), '' . (intval(__LINE__) - 7), '/line',
+			'line' => array(), '' . ((int)__LINE__ - 7), '/line',
 			'preg:/Undefined variable:\s+foo/',
 			'/error'
 		);
@@ -246,7 +246,7 @@ class DebuggerTest extends CakeTestCase {
 			'<error',
 			'<code', '8', '/code',
 			'<file', 'preg:/[^<]+/', '/file',
-			'<line', '' . (intval(__LINE__) - 7), '/line',
+			'<line', '' . ((int)__LINE__ - 7), '/line',
 			'preg:/Undefined variable:\s+foo/',
 			'/error'
 		);

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -321,7 +321,7 @@ class CakeTime {
 		}
 
 		if (is_int($dateString) || is_numeric($dateString)) {
-			$date = intval($dateString);
+			$date = (int)$dateString;
 		} elseif (
 			$dateString instanceof DateTime &&
 			$dateString->getTimezone()->getName() != date_default_timezone_get()

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -994,12 +994,12 @@ class CakeTime {
 			$time = self::fromString($dateString);
 		}
 		return gmmktime(
-			intval(date('G', $time)),
-			intval(date('i', $time)),
-			intval(date('s', $time)),
-			intval(date('n', $time)),
-			intval(date('j', $time)),
-			intval(date('Y', $time))
+			(int)date('G', $time),
+			(int)date('i', $time),
+			(int)date('s', $time),
+			(int)date('n', $time),
+			(int)date('j', $time),
+			(int)date('Y', $time)
 		);
 	}
 

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -290,8 +290,8 @@ class Hash {
 		$count = count($path);
 		$last = $count - 1;
 		foreach ($path as $i => $key) {
-			if (is_numeric($key) && intval($key) > 0 || $key === '0') {
-				$key = intval($key);
+			if (is_numeric($key) && (int)$key > 0 || $key === '0') {
+				$key = (int)$key;
 			}
 			if ($op === 'insert') {
 				if ($i === $last) {

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -560,7 +560,7 @@ class Set {
 		}
 
 		foreach ($path as $i => $key) {
-			if (is_numeric($key) && intval($key) > 0 || $key === '0') {
+			if (is_numeric($key) && (int)$key > 0 || $key === '0') {
 				if (isset($data[$key])) {
 					$data = $data[$key];
 				} else {
@@ -657,8 +657,8 @@ class Set {
 		}
 
 		foreach ($path as $i => $key) {
-			if (is_numeric($key) && intval($key) > 0 || $key === '0') {
-				$key = intval($key);
+			if (is_numeric($key) && (int)$key > 0 || $key === '0') {
+				$key = (int)$key;
 			}
 			if ($i === count($path) - 1) {
 				return (is_array($data) && array_key_exists($key, $data));

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2893,7 +2893,7 @@ class FormHelper extends AppHelper {
 				}
 				break;
 			case 'year':
-				$current = intval(date('Y'));
+				$current = (int)date('Y');
 
 				$min = !isset($options['min']) ? $current - 20 : (int)$options['min'];
 				$max = !isset($options['max']) ? $current + 20 : (int)$options['max'];

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -292,7 +292,7 @@ class JsHelper extends AppHelper {
  */
 	public function link($title, $url = null, $options = array()) {
 		if (!isset($options['id'])) {
-			$options['id'] = 'link-' . intval(mt_rand());
+			$options['id'] = 'link-' . (int)mt_rand();
 		}
 		list($options, $htmlOptions) = $this->_getHtmlOptions($options);
 		$out = $this->Html->link($title, $url, $htmlOptions);
@@ -368,7 +368,7 @@ class JsHelper extends AppHelper {
  */
 	public function submit($caption = null, $options = array()) {
 		if (!isset($options['id'])) {
-			$options['id'] = 'submit-' . intval(mt_rand());
+			$options['id'] = 'submit-' . (int)mt_rand();
 		}
 		$formOptions = array('div');
 		list($options, $htmlOptions) = $this->_getHtmlOptions($options, $formOptions);

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -740,7 +740,7 @@ class PaginatorHelper extends AppHelper {
 		$out = '';
 
 		if ($modulus && $params['pageCount'] > $modulus) {
-			$half = intval($modulus / 2);
+			$half = (int)($modulus / 2);
 			$end = $params['page'] + $half;
 
 			if ($end > $params['pageCount']) {


### PR DESCRIPTION
Micro-optimization (no its not nano^^) of int/float casting.
(int) is about 3 times faster than the method call. Same for (float).

And we already mainly use (int), (float) casts etc where applicable.

I used my auto-correct [Cast sniff](https://github.com/dereuromark/cakephp-codesniffer/blob/master/Vendor/PHP/CodeSniffer/Standards/MyCakePHP/Sniffs/PHP/CastSniff.php)

```
cake CodeSniffer.CodeSniffer run --sniffs MyCakePHP.PHP.Cast {corefolder} -v -f
```

That means, we could make this a CakePHP code-sniffer rule to keep the improvement in the future.

It should be noted that I skipped on non-trivial replacements (more than a single argument) for now due to  probably errors then (`intval($x + $y)` would need to keep the parentheses). It would be easy to keep the additional (superfluous) parentheses, if no-one minds though. That would probably eliminate the change of errors.

// Inspired by [this](https://github.com/briannesbitt/Carbon/pull/169) and [this](http://hakre.wordpress.com/2010/05/13/php-casting-vs-intval/).
