### PR TITLE
3.0 ORM: Automagic foreignKey resolution draft

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -740,7 +740,7 @@ abstract class Association {
 /**
  * Helper method used to generate a default foreign key for the source or target table.
  *
- * @param \Cake\ORM\Table Table instance
+ * @param \Cake\ORM\Table $table Table instance
  * @return array|string
  */
 	protected function _getForeignKey(Table $table) {
@@ -753,7 +753,7 @@ abstract class Association {
 		$base = Inflector::underscore($alias);
 
 		$foreignKey = [];
-		foreach ((array) $primaryKey as $key) {
+		foreach ((array)$primaryKey as $key) {
 			$foreignKey[] = $base . '_' . $key;
 		}
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -738,6 +738,29 @@ abstract class Association {
 	}
 
 /**
+ * Helper method used to generate a default foreign key for the source or target table.
+ *
+ * @param \Cake\ORM\Table Table instance
+ * @return array|string
+ */
+	protected function _getForeignKey(Table $table) {
+		$primaryKey = $table->primaryKey();
+		$alias = Inflector::singularize($table->alias());
+		$base = Inflector::underscore($alias);
+
+		$foreignKey = [];
+		foreach ((array) $primaryKey as $key) {
+			$foreignKey[] = $base . '_' . $key;
+		}
+
+		if (count($foreignKey) === 1) {
+			return $foreignKey[0];
+		} else {
+			return $foreignKey;
+		}
+	}
+
+/**
  * Proxies property retrieval to the target table. This is handy for getting this
  * association's associations
  *

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -760,7 +760,7 @@ abstract class Association {
 		if (count($foreignKey) === 1) {
 			$foreignKey = $foreignKey[0];
 		}
-		
+
 		return $foreignKey;
 	}
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -744,7 +744,11 @@ abstract class Association {
  * @return array|string
  */
 	protected function _getForeignKey(Table $table) {
-		$primaryKey = $table->primaryKey();
+		if ($table->connection()) {
+			$primaryKey = $table->primaryKey();
+		} else {
+			$primaryKey = 'id';
+		}
 		$alias = Inflector::singularize($table->alias());
 		$base = Inflector::underscore($alias);
 
@@ -754,10 +758,10 @@ abstract class Association {
 		}
 
 		if (count($foreignKey) === 1) {
-			return $foreignKey[0];
-		} else {
-			return $foreignKey;
+			$foreignKey = $foreignKey[0];
 		}
+		
+		return $foreignKey;
 	}
 
 /**

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -41,8 +41,7 @@ class BelongsTo extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->target()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_getForeignKey($this->target());
 			}
 			return $this->_foreignKey;
 		}

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -123,8 +123,7 @@ class BelongsToMany extends Association {
 	public function targetForeignKey($key = null) {
 		if ($key === null) {
 			if ($this->_targetForeignKey === null) {
-				$key = Inflector::singularize($this->target()->alias());
-				$this->_targetForeignKey = Inflector::underscore($key) . '_id';
+				$this->_targetForeignKey = $this->_getForeignKey($this->target());
 			}
 			return $this->_targetForeignKey;
 		}

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -15,7 +15,6 @@
 namespace Cake\ORM\Association;
 
 use Cake\ORM\Association\SelectableAssociationTrait;
-use Cake\Utility\Inflector;
 
 /**
  * Represents a type of association that that needs to be recovered by performing
@@ -55,8 +54,7 @@ trait ExternalAssociationTrait {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->source()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_getForeignKey($this->source());
 			}
 			return $this->_foreignKey;
 		}

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -42,8 +42,7 @@ class HasOne extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->source()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_getForeignKey($this->source());
 			}
 			return $this->_foreignKey;
 		}

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -180,26 +180,6 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Tests that using hasOne with a table having a multi column primary
- * key will work if the foreign key is passed
- *
- * @expectedException \RuntimeException
- * @expectedExceptionMessage Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"
- * @return void
- */
-	public function testAttachToMultiPrimaryKeyMistmatch() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
-		$config = [
-			'sourceTable' => $this->user,
-			'targetTable' => $this->profile,
-			'conditions' => ['Profiles.is_active' => true],
-		];
-		$this->user->primaryKey(['id', 'site_id']);
-		$association = new HasOne('Profiles', $config);
-		$association->attachTo($query, ['includeFields' => false]);
-	}
-
-/**
  * Test that saveAssociated() ignores non entity values.
  *
  * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -498,10 +498,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'sort' => ['foo' => 'asc']
 		];
 		$table = new Table(['table' => 'authors', 'connection' => $this->connection]);
-		$belongsToMany = $table->belongsToMany('tag', $options);
+		$belongsToMany = $table->belongsToMany('tags', $options);
 		$this->assertInstanceOf('\Cake\ORM\Association\BelongsToMany', $belongsToMany);
-		$this->assertSame($belongsToMany, $table->association('tag'));
-		$this->assertEquals('tag', $belongsToMany->name());
+		$this->assertSame($belongsToMany, $table->association('tags'));
+		$this->assertEquals('tags', $belongsToMany->name());
 		$this->assertEquals('thing_id', $belongsToMany->foreignKey());
 		$this->assertEquals(['b' => 'c'], $belongsToMany->conditions());
 		$this->assertEquals(['foo' => 'asc'], $belongsToMany->sort());
@@ -1857,7 +1857,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testDeleteBelongsToMany() {
 		$table = TableRegistry::get('articles');
-		$table->belongsToMany('tag', [
+		$table->belongsToMany('tags', [
 			'foreignKey' => 'article_id',
 			'joinTable' => 'articles_tags'
 		]);


### PR DESCRIPTION
Following #4577

Here is a draft of automagic `foreignKey` resolution.
This is just a feature proposition ;). Maybe it will prove useful in the future.

I've also included a fix for some table tests where belongsToMany associations pointed to non-existing `tag` tables. This caused table description to fail while getting `primaryKey` from schema.
