### PR TITLE
3.0 : Fix Hash not returning correct value with special paths

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -316,7 +316,7 @@ class Hash {
 		$count = count($path);
 		$last = $count - 1;
 		foreach ($path as $i => $key) {
-			if (is_numeric($key) && intval($key) > 0 || $key === '0') {
+			if ((is_numeric($key) && intval($key) > 0 || $key === '0') && strpos($key, '0') !== 0) {
 				$key = intval($key);
 			}
 			if ($op === 'insert') {

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1370,6 +1370,13 @@ class HashTest extends TestCase {
 			'pages' => array('name' => array()),
 		);
 		$this->assertEquals($expected, $result);
+
+		$a = array(
+			'foo' => array('bar' => 'baz')
+		);
+		$result = Hash::insert($a, 'some.0123.path', array('foo' => array('bar' => 'baz')));
+		$expected = array('foo' => array('bar' => 'baz'));
+		$this->assertEquals($expected, Hash::get($result, 'some.0123.path'));
 	}
 
 /**


### PR DESCRIPTION
Refs to #4574, only for the 3.0 branch. Stumbled upon the same problem.
Same fix as in #4575 was applied.

I don't know if there will be some kind of big magical merge of this kind of stuff before releasing 3.0, so if it's useless, feel free to close this.
