### PR TITLE
3.0 Used ConventionsTrait in Association

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\ORM;
 
+use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\Event;
@@ -29,6 +30,8 @@ use Cake\Utility\Inflector;
  *
  */
 abstract class Association {
+
+	use ConventionsTrait;
 
 /**
  * Strategy name to use joins for fetching associated records

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -41,8 +41,7 @@ class BelongsTo extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->target()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_modelKey($this->target()->alias());
 			}
 			return $this->_foreignKey;
 		}

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -123,8 +123,7 @@ class BelongsToMany extends Association {
 	public function targetForeignKey($key = null) {
 		if ($key === null) {
 			if ($this->_targetForeignKey === null) {
-				$key = Inflector::singularize($this->target()->alias());
-				$this->_targetForeignKey = Inflector::underscore($key) . '_id';
+				$this->_targetForeignKey = $this->_modelKey($this->target()->alias());
 			}
 			return $this->_targetForeignKey;
 		}

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -15,7 +15,6 @@
 namespace Cake\ORM\Association;
 
 use Cake\ORM\Association\SelectableAssociationTrait;
-use Cake\Utility\Inflector;
 
 /**
  * Represents a type of association that that needs to be recovered by performing
@@ -55,8 +54,7 @@ trait ExternalAssociationTrait {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->source()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_modelKey($this->source()->alias());
 			}
 			return $this->_foreignKey;
 		}

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -42,8 +42,7 @@ class HasOne extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->source()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_modelKey($this->source()->alias());
 			}
 			return $this->_foreignKey;
 		}


### PR DESCRIPTION
Some rework of #4578 (see comments)

Used ConventionsTrait::_modelKey() for more DRY foreign keys creation.
