### PR TITLE
Fixes SQLServer throwing a 'string not uuid' type error if a query is done with a empty value to a uuid field.

### DIFF
--- a/src/Database/Type/UuidType.php
+++ b/src/Database/Type/UuidType.php
@@ -45,7 +45,7 @@ class UuidType extends \Cake\Database\Type {
  * @return mixed
  */
 	public function toDatabase($value, Driver $driver) {
-		if ($value === null) {
+		if ($value === null || $value === '') {
 			return null;
 		}
 		return strval($value);

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -114,4 +114,23 @@ class TableUuidTest extends TestCase {
 		$this->assertCount(0, $query->execute(), 'No rows left');
 	}
 
+/**
+ * Tests that sql server does not error when an empty uuid is bound
+ *
+ * @return void
+ */
+	public function testEmptyUuid() {
+		$this->skipIf(
+			!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Empty UUIDs only affect SQLServer uniqueidentifier field types'
+		);
+		$id = '';
+		$table = TableRegistry::get('uuiditems');
+		$entity = $table->find('all')
+			->where(['id' => $id])
+			->first();
+
+		$this->assertNull($entity);
+	}
+
 }


### PR DESCRIPTION
Example:

I have a table with a `uniqueidentifier` primary key:

``` php
$table->find()->where(['id' => null]);
```

Will work correctly, however

``` php
$table->find()->where(['id' => '']);
```

Will throw a PDOException with `Conversion failed when converting from a character string`.

This causes problems with, for example, association form fields with a 'empty' default value.

I've added an extra check in the UuidType class to map empty strings to `null` values.
