### PR TITLE
Make bake generate IntegrationTestCases.

### DIFF
--- a/src/Template/Bake/default/classes/test.ctp
+++ b/src/Template/Bake/default/classes/test.ctp
@@ -25,7 +25,7 @@ namespace <?= $baseNamespace; ?>\Test\TestCase\<?= $subNamespace ?>;
 use <?= $dependency; ?>;
 <?php endforeach; ?>
 <?php if ($isController): ?>
-use Cake\TestSuite\ControllerTestCase;
+use Cake\TestSuite\IntegrationTestCase;
 <?php else: ?>
 use Cake\TestSuite\TestCase;
 <?php endif; ?>
@@ -34,7 +34,7 @@ use Cake\TestSuite\TestCase;
  * <?= $fullClassName ?> Test Case
  */
 <?php if ($isController): ?>
-class <?= $className ?>Test extends ControllerTestCase {
+class <?= $className ?>Test extends IntegrationTestCase {
 <?php else: ?>
 class <?= $className ?>Test extends TestCase {
 <?php endif; ?>

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -385,7 +385,7 @@ class TestTaskTest extends TestCase {
 		$result = $this->Task->bake('Controller', 'PostsController');
 
 		$this->assertContains("use TestApp\Controller\PostsController", $result);
-		$this->assertContains('class PostsControllerTest extends ControllerTestCase', $result);
+		$this->assertContains('class PostsControllerTest extends IntegrationTestCase', $result);
 
 		$this->assertNotContains('function setUp()', $result);
 		$this->assertNotContains("\$this->Posts = new PostsController()", $result);
@@ -413,7 +413,7 @@ class TestTaskTest extends TestCase {
 		$result = $this->Task->bake('controller', 'Admin\Posts');
 
 		$this->assertContains("use TestApp\Controller\Admin\PostsController", $result);
-		$this->assertContains('class PostsControllerTest extends ControllerTestCase', $result);
+		$this->assertContains('class PostsControllerTest extends IntegrationTestCase', $result);
 
 		$this->assertNotContains('function setUp()', $result);
 		$this->assertNotContains("\$this->Posts = new PostsController()", $result);


### PR DESCRIPTION
ControllerTestCase is deprecated and will be going away. Bake should generate tests using this new test class.

Refs #4592
