### PR TITLE
3.0 plugin shell aliases

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -213,7 +213,7 @@ class ShellDispatcher {
 					Log::write(
 						'debug',
 						"command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",
-						['console']
+						['shell-dispatcher']
 					);
 				}
 				$aliases += [$shell => $plugin];
@@ -224,7 +224,8 @@ class ShellDispatcher {
 			if (isset($fixed[$shell])) {
 				Log::write(
 					'debug',
-					"command '$shell' in plugin '$plugin' was not aliased, conflicts with another shell"
+					"command '$shell' in plugin '$plugin' was not aliased, conflicts with another shell",
+					['shell-dispatcher']
 				);
 				continue;
 			}

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -19,8 +19,8 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\Core\Plugin;
-use Cake\Utility\Inflector;
 use Cake\Shell\Task\CommandTask;
+use Cake\Utility\Inflector;
 
 /**
  * Shell dispatcher handles dispatching cli commands.

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -169,7 +169,7 @@ class ShellDispatcherTest extends TestCase {
 	}
 
 /**
- * Verify you can dispatch a plugin's main shell with the plugin name alone
+ * Verify you can dispatch a plugin's main shell with the shell name alone
  *
  * @return void
  */
@@ -182,15 +182,15 @@ class ShellDispatcherTest extends TestCase {
 
 		$dispatcher->expects($this->at(1))
 			->method('_shellExists')
-			->with('TestPlugin.TestPlugin')
+			->with('TestPlugin.Example')
 			->will($this->returnValue('TestPlugin\Console\Command\TestPluginShell'));
 
 		$dispatcher->expects($this->at(2))
 			->method('_createShell')
-			->with('TestPlugin\Console\Command\TestPluginShell', 'TestPlugin.TestPlugin')
+			->with('TestPlugin\Console\Command\TestPluginShell', 'TestPlugin.Example')
 			->will($this->returnValue($Shell));
 
-		$dispatcher->args = array('test_plugin');
+		$dispatcher->args = array('example');
 		$result = $dispatcher->dispatch();
 		$this->assertEquals(1, $result);
 	}
@@ -209,15 +209,42 @@ class ShellDispatcherTest extends TestCase {
 
 		$dispatcher->expects($this->at(1))
 			->method('_shellExists')
-			->with('TestPlugin.TestPlugin')
+			->with('TestPlugin.Example')
 			->will($this->returnValue('TestPlugin\Console\Command\TestPluginShell'));
 
 		$dispatcher->expects($this->at(2))
 			->method('_createShell')
-			->with('TestPlugin\Console\Command\TestPluginShell', 'TestPlugin.TestPlugin')
+			->with('TestPlugin\Console\Command\TestPluginShell', 'TestPlugin.Example')
 			->will($this->returnValue($Shell));
 
-		$dispatcher->args = ['TestPlugin'];
+		$dispatcher->args = ['Example'];
+		$result = $dispatcher->dispatch();
+		$this->assertEquals(1, $result);
+	}
+
+/**
+ * Verify that in case of conflict, app shells take precedence in alias list
+ *
+ * @return void
+ */
+	public function testDispatchShortPluginAliasConflict() {
+		$dispatcher = $this->getMock(
+			'Cake\Console\ShellDispatcher',
+			['_shellExists', '_createShell']
+		);
+		$Shell = $this->getMock('Cake\Console\Shell');
+
+		$dispatcher->expects($this->at(1))
+			->method('_shellExists')
+			->with('Sample')
+			->will($this->returnValue('App\Shell\SampleShell'));
+
+		$dispatcher->expects($this->at(2))
+			->method('_createShell')
+			->with('App\Shell\SampleShell', 'Sample')
+			->will($this->returnValue($Shell));
+
+		$dispatcher->args = array('sample');
 		$result = $dispatcher->dispatch();
 		$this->assertEquals(1, $result);
 	}

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -112,7 +112,8 @@ class CompletionShellTest extends TestCase {
 		$this->Shell->runCommand(['commands']);
 		$output = $this->out->output;
 
-		$expected = "TestPlugin.example TestPluginTwo.example TestPluginTwo.welcome bake i18n orm_cache server test sample\n";
+		$expected = "TestPlugin.example TestPlugin.sample " .
+			"TestPluginTwo.example TestPluginTwo.welcome bake i18n orm_cache server test sample\n";
 		$this->assertTextEquals($expected, $output);
 	}
 

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class SampleShell
+ *
+ */
+namespace TestPlugin\Shell;
+
+use Cake\Console\Shell;
+
+class SampleShell extends Shell {
+
+/**
+ * main method
+ *
+ * @return void
+ */
+	public function main() {
+		$this->out('This is the main method called from SampleShell');
+	}
+}
+


### PR DESCRIPTION
This aliases plugin shells so that no plugin prefix is needed when invoking them:

Before:

``` shell
bin/cake DebugKit.whitespace
```

Now:

``` shell
bin/cake whitespace
```

In case of conflict with shells in app, the aliasing does not occur and you will need to invoke the shell using plugin notation. Plugin aliases are processed in the order plugins where loaded, in case of conflicts with other plugins, the first plugin in the list will prevail.
