### PR TITLE
3.0 Avoid multiple RunTimeException

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -311,9 +311,7 @@ class Session {
 		}
 
 		if (ini_get('session.use_cookies') && headers_sent($file, $line)) {
-			throw new \RuntimeException(
-				sprintf('Cannot start session, headers already sent in "%s" at line %d', $file, $line)
-			);
+			return;
 		}
 
 		if (!session_start()) {

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -293,8 +293,7 @@ class Session {
  * Starts the Session.
  *
  * @return bool True if session was started
- * @throws \RuntimeException if the session was already started or headers were already
- * sent
+ * @throws \RuntimeException if the session was already started
  */
 	public function start() {
 		if ($this->_started) {


### PR DESCRIPTION
In addition to refactor header sending #4597, as tested with @lorenzo , we need also to stop the Exception from being thrown by session.
here was the previous result when trying to do `debug(`ss') from a controller :

![capture d ecran 2014-09-13 15 44 02](https://cloud.githubusercontent.com/assets/4977112/4260864/3cae4214-3b52-11e4-9a1f-efabbb6cb000.png)
