### PR TITLE
AuthComponent::login() returning deprecated method

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -604,7 +604,7 @@ class AuthComponent extends Component {
 			$this->Session->renew();
 			$this->Session->write(self::$sessionKey, $user);
 		}
-		return $this->user();
+		return (bool)$this->user();
 	}
 
 /**

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -604,7 +604,7 @@ class AuthComponent extends Component {
 			$this->Session->renew();
 			$this->Session->write(self::$sessionKey, $user);
 		}
-		return $this->loggedIn();
+		return $this->user();
 	}
 
 /**


### PR DESCRIPTION
Changed $this->loggedIn() to $this->user(), as per the PHPDOC for loggedIn() at line 817
