### PR TITLE
Make View::addHelper() set the loaded helper as View's property.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -674,8 +674,7 @@ class View {
 		$registry = $this->helpers();
 		$helpers = $registry->normalizeArray($this->helpers);
 		foreach ($helpers as $properties) {
-			list(, $class) = pluginSplit($properties['class']);
-			$this->{$class} = $registry->load($properties['class'], $properties['config']);
+			$this->addHelper($properties['class'], $properties['config']);
 		}
 	}
 
@@ -764,7 +763,8 @@ class View {
  * @see HelperRegistry::load()
  */
 	public function addHelper($helperName, array $config = []) {
-		return $this->helpers()->load($helperName, $config);
+		list(, $class) = pluginSplit($helperName);
+		return $this->{$class} = $this->helpers()->load($helperName, $config);
 	}
 
 /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -906,14 +906,18 @@ class ViewTest extends TestCase {
 	}
 
 /**
- * Test __get allowing access to helpers.
+ * Test loading helper using addHelper().
  *
  * @return void
  */
-	public function testMagicGetAndAddHelper() {
+	public function testAddHelper() {
 		$View = new View();
-		$View->addHelper('Html');
+
+		$View->addHelper('Html', ['foo' => 'bar']);
 		$this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
+
+		$config = $View->Html->config();
+		$this->assertEquals('bar', $config['foo']);
 	}
 
 /**
@@ -924,11 +928,17 @@ class ViewTest extends TestCase {
 	public function testLoadHelpers() {
 		$View = new View();
 
-		$View->helpers = array('Html', 'Form');
+		$View->helpers = ['Html' => ['foo' => 'bar'], 'Form' => ['foo' => 'baz']];
 		$View->loadHelpers();
 
 		$this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html, 'Object type is wrong.');
 		$this->assertInstanceOf('Cake\View\Helper\FormHelper', $View->Form, 'Object type is wrong.');
+
+		$config = $View->Html->config();
+		$this->assertEquals('bar', $config['foo']);
+
+		$config = $View->Form->config();
+		$this->assertEquals('baz', $config['foo']);
 	}
 
 /**


### PR DESCRIPTION
This makes it's behavior consistent with `Controller::addComponent()` and `Controller::loadModel()`.

Also updated test cases to properly test various helper loading methods.
