### PR TITLE
Update IntegrationTestCase::_buildRequest

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -320,7 +320,7 @@ class IntegrationTestCase extends TestCase {
 			'cookies' => $this->_cookie,
 			'session' => $session,
 		];
-		$env[];
+		$env = [];
 		if (isset($this->_request['headers'])) {
 			foreach ($this->_request['headers'] as $k => $v) {
 				$env['HTTP_' . str_replace('-', '_', strtoupper($k))] = $v;

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -320,14 +320,15 @@ class IntegrationTestCase extends TestCase {
 			'cookies' => $this->_cookie,
 			'session' => $session,
 		];
+		$env[];
 		if (isset($this->_request['headers'])) {
-			$env = [];
 			foreach ($this->_request['headers'] as $k => $v) {
 				$env['HTTP_' . str_replace('-', '_', strtoupper($k))] = $v;
 			}
-			$props['environment'] = $env;
 			unset($this->_request['headers']);
 		}
+		$env['REQUEST_METHOD'] = $method;
+		$props['environment'] = $env;
 		$props += $this->_request;
 		return new Request($props);
 	}


### PR DESCRIPTION
Hi,

I'm not sure it's the better way to do this but the parameter **$method** is currently not use in this function.
I was trying to test my controller : #4606

I used **$this->put('/actions/changeStatus/1.json', ['status_id' => 2])**.
But the request of the controller didn't have an environment variable **REQUEST_METHOD**.
Or more precisely, it equalled to null.

```
$this->request->env('REQUEST_METHOD') // null
```

So these lines, that i changed, resolve this problem.

Jason.
