### PR TITLE
Relax PHP version requirement to 5.4.16.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"source": "https://github.com/cakephp/cakephp"
 	},
 	"require": {
-		"php": ">=5.4.19",
+		"php": ">=5.4.16",
 		"ext-intl": "*",
 		"ext-mcrypt": "*",
 		"ext-mbstring": "*",


### PR DESCRIPTION
This allows stock RHEL7 servers to run CakePHP. Hopefully 5.4.16 is high enough that we also avoid the performance issues in windows.

Refs #4607
