### PR TITLE
Fix dispatch filters that have regular string as a key

### DIFF
--- a/lib/Cake/Routing/Dispatcher.php
+++ b/lib/Cake/Routing/Dispatcher.php
@@ -97,7 +97,7 @@ class Dispatcher implements CakeEventListener {
 
 		foreach ($filters as $index => $filter) {
 			$settings = array();
-			if (is_array($filter) && !is_int($index)) {
+			if (is_array($filter) && !is_int($index) && class_exists($index)) {
 				$settings = $filter;
 				$filter = $index;
 			}

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -1328,6 +1328,16 @@ class DispatcherTest extends CakeTestCase {
 		$dispatcher->dispatch($request, $response);
 		$this->assertEquals('Dispatcher.afterDispatch', $request->params['eventName']);
 
+		$dispatcher = new TestDispatcher();
+		Configure::write('Dispatcher.filters', array(
+			'filterTest' => array('callable' => array($dispatcher, 'filterTest'), 'on' => 'before')
+		));
+
+		$request = new CakeRequest('/');
+		$response = $this->getMock('CakeResponse', array('send'));
+		$dispatcher->dispatch($request, $response);
+		$this->assertEquals('Dispatcher.beforeDispatch', $request->params['eventName']);
+
 		// Test that it is possible to skip the route connection process
 		$dispatcher = new TestDispatcher();
 		Configure::write('Dispatcher.filters', array(


### PR DESCRIPTION
_attachFilters function in Displatcher class always assume that any filter with string as a key is always a valid class name.

Check class_exists before add key and value to settings and callable class

From #4613
