### PR TITLE
Truncate tables when they already exist.

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -203,6 +203,7 @@ class FixtureManager {
 			$fixture->create($db);
 		} else {
 			$fixture->created[] = $db->configName();
+			$fixture->truncate($db);
 		}
 	}
 


### PR DESCRIPTION
This solves an annoying workflow interruption when the following happens:
1. Create a test case and make mistake that creates a fatal error.
2. Fix the error and re-run the test.

If your fixtures use uuid keys, you'll get an annoying duplicate primary key error that should really not happen.
