### PR TITLE
Routing/Route/Route.php should typecast extensions to an array in constructor

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -106,7 +106,7 @@ class Route {
 			unset($this->defaults['[method]']);
 		}
 		if (isset($this->options['_ext'])) {
-			$this->_extensions = $this->options['_ext'];
+			$this->_extensions = (array)$this->options['_ext'];
 		}
 	}
 


### PR DESCRIPTION
Currently Routing/Route/Route.php typecasts extensions to an array when setting via the extensions() method, but not when they are set in the constructor.

Example:

``` js
$routes->connect('/document/:docId', [
        'controller' => 'Documents',
        'action' => 'view'
    ], [
        'pass' => ['docId'],
        '_ext' => 'json'
    ]);
```
