### PR TITLE
Avoid notice thrown in debug().

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -52,7 +52,11 @@ if (!function_exists('debug')) {
 		$lineInfo = '';
 		if ($showFrom) {
 			$trace = Debugger::trace(array('start' => 1, 'depth' => 2, 'format' => 'array'));
-			$file = str_replace(array(CAKE_CORE_INCLUDE_PATH, ROOT), '', $trace[0]['file']);
+			$search = array(ROOT);
+			if (defined('CAKE_CORE_INCLUDE_PATH')) {
+				array_unshift($search, CAKE_CORE_INCLUDE_PATH);
+			}
+			$file = str_replace($search, '', $trace[0]['file']);
 			$line = $trace[0]['line'];
 		}
 		$html = <<<HTML


### PR DESCRIPTION
In a test case, I got

```
Use of undefined constant CAKE_CORE_INCLUDE_PATH - assumed 'CAKE_CORE_INCLUDE_PATH

...\vendor\cakephp\cakephp\src\basics.php:55
```

when using `debug($foo);`.

In other places where this constant is being used there is a check for it:

```
if (!defined('CAKE_CORE_INCLUDE_PATH') || !defined('APP')) {
    return $path;
}
```

So the same thing should be used here.
