### PR TITLE
Improving performance when quering information_schema

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -213,9 +213,9 @@ class MysqlSchema extends BaseSchema {
 		$sql = 'SELECT * FROM information_schema.key_column_usage AS kcu
 			INNER JOIN information_schema.referential_constraints AS rc
 			ON (kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME)
-			WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ?';
+			WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ? and rc.TABLE_NAME = ?';
 
-		return [$sql, [$config['database'], $tableName]];
+		return [$sql, [$config['database'], $tableName, $tableName]];
 	}
 
 /**


### PR DESCRIPTION
When running on a database server with a large information_schema database, this query is abnormally long, optimised per http://dev.mysql.com/doc/refman/5.6/en/information-schema-optimization.html
