### PR TITLE
Cleanup use statements

### DIFF
--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -15,11 +15,8 @@
 namespace Cake\Auth;
 
 use Cake\Controller\ComponentRegistry;
-use Cake\Controller\Controller;
-use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Network\Request;
-use Cake\Utility\Inflector;
 
 /**
  * Abstract base authorization adapter for AuthComponent.

--- a/src/Collection/Iterator/TreePrinter.php
+++ b/src/Collection/Iterator/TreePrinter.php
@@ -15,7 +15,6 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\CollectionTrait;
-use Cake\Collection\Iterator\TreePrinter;
 use RecursiveIteratorIterator;
 
 /**

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -19,7 +19,6 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
-use Cake\Error\Debugger;
 use Cake\Event\Event;
 use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Request;

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -16,7 +16,6 @@ namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
-use Cake\Core\Configure;
 use Cake\I18n\Time;
 use Cake\Network\Request;
 use Cake\Network\Response;

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -16,7 +16,6 @@ namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Request;

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -15,7 +15,6 @@
 namespace Cake\Core;
 
 use Cake\Core\Plugin;
-use Cake\Utility\Inflector;
 
 /**
  * App is responsible for resource location, and path management.

--- a/src/ORM/EntityValidator.php
+++ b/src/ORM/EntityValidator.php
@@ -14,8 +14,6 @@
  */
 namespace Cake\ORM;
 
-use Cake\Event\Event;
-
 /**
  * Contains logic for validating entities and their associations
  *

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -20,7 +20,6 @@ use Cake\Database\Schema\Table as Schema;
 use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\RepositoryInterface;
-use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -15,7 +15,6 @@
 namespace Cake\Routing;
 
 use Cake\Controller\Controller;
-use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManagerTrait;
 use Cake\Network\Request;

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -16,7 +16,6 @@ namespace Cake\Routing;
 
 use BadMethodCallException;
 use Cake\Core\App;
-use Cake\Routing\Router;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -14,12 +14,8 @@
  */
 namespace Cake\Routing;
 
-use Cake\Core\App;
-use Cake\Error;
 use Cake\Routing\Exception\MissingRouteException;
-use Cake\Routing\Router;
 use Cake\Routing\Route\Route;
-use Cake\Utility\Inflector;
 
 /**
  * Contains a collection of routes.

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -14,12 +14,8 @@
  */
 namespace Cake\View;
 
-use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Core\Plugin;
 use Cake\Event\EventListener;
-use Cake\Routing\Router;
-use Cake\Utility\Inflector;
 
 /**
  * Abstract base class for all other Helpers in CakePHP.

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -16,9 +16,7 @@ namespace Cake\View;
 
 use Cake\Cache\Cache;
 use Cake\Core\App;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
 use Cake\Log\LogTrait;


### PR DESCRIPTION
We definitely need a sniff for this.
Maybe one can wrap my detection lib here in some sort of "Use" sniff.

I also found 30+ more issues with https://github.com/dereuromark/cakephp-codesniffer/tree/3.0#cleanup and

```
.\bin\cake CodeSniffer.cleanup unused_use /path/to/cake3/src/
```

The tests folder I didnt even look into yet.
