### PR TITLE
Fix asset delivery for vendor namespaced plugins.

### DIFF
--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -80,9 +80,12 @@ class AssetFilter extends DispatcherFilter {
 		$parts = explode('/', $url);
 		$pluginPart = [];
 		for ($i = 0; $i < 2; $i++) {
+			if (!isset($parts[$i])) {
+				break;
+			}
 			$pluginPart[] = Inflector::camelize($parts[$i]);
 			$plugin = implode('/', $pluginPart);
-			if ($plugin && Plugin::loaded($plugin)) {
+			if (Plugin::loaded($plugin)) {
 				$parts = array_slice($parts, $i + 1);
 				$fileFragment = implode(DS, $parts);
 				$pluginWebroot = Plugin::path($plugin) . 'webroot' . DS;

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -78,12 +78,16 @@ class AssetFilter extends DispatcherFilter {
  */
 	protected function _getAssetFile($url) {
 		$parts = explode('/', $url);
-		$plugin = Inflector::camelize($parts[0]);
-		if ($plugin && Plugin::loaded($plugin)) {
-			unset($parts[0]);
-			$fileFragment = implode(DS, $parts);
-			$pluginWebroot = Plugin::path($plugin) . 'webroot' . DS;
-			return $pluginWebroot . $fileFragment;
+		$pluginPart = [];
+		for ($i = 0; $i < 2; $i++) {
+			$pluginPart[] = Inflector::camelize($parts[$i]);
+			$plugin = implode('/', $pluginPart);
+			if ($plugin && Plugin::loaded($plugin)) {
+				$parts = array_slice($parts, $i + 1);
+				$fileFragment = implode(DS, $parts);
+				$pluginWebroot = Plugin::path($plugin) . 'webroot' . DS;
+				return $pluginWebroot . $fileFragment;
+			}
 		}
 	}
 

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -85,7 +85,7 @@ class AssetFilter extends DispatcherFilter {
 			}
 			$pluginPart[] = Inflector::camelize($parts[$i]);
 			$plugin = implode('/', $pluginPart);
-			if (Plugin::loaded($plugin)) {
+			if ($plugin && Plugin::loaded($plugin)) {
 				$parts = array_slice($parts, $i + 1);
 				$fileFragment = implode(DS, $parts);
 				$pluginWebroot = Plugin::path($plugin) . 'webroot' . DS;

--- a/tests/TestCase/Routing/Filter/AssetFilterTest.php
+++ b/tests/TestCase/Routing/Filter/AssetFilterTest.php
@@ -203,6 +203,10 @@ class AssetFilterTest extends TestCase {
 				'test_plugin/css/theme_one.htc',
 				'Plugin/TestPlugin/webroot/css/theme_one.htc'
 			),
+			array(
+				'company/test_plugin_three/css/company.css',
+				'Plugin/Company/TestPluginThree/webroot/css/company.css'
+			),
 		);
 	}
 
@@ -210,11 +214,10 @@ class AssetFilterTest extends TestCase {
  * Test assets
  *
  * @dataProvider assetProvider
- * @outputBuffering enabled
  * @return void
  */
 	public function testAsset($url, $file) {
-		Plugin::load(array('TestPlugin', 'PluginJs'));
+		Plugin::load(array('Company/TestPluginThree', 'TestPlugin', 'PluginJs'));
 
 		$filter = new AssetFilter();
 		$response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
@@ -222,7 +225,8 @@ class AssetFilterTest extends TestCase {
 		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
 
 		$filter->beforeDispatch($event);
-		$result = ob_get_clean();
+		$result = ob_get_contents();
+		ob_end_clean();
 
 		$path = TEST_APP . str_replace('/', DS, $file);
 		$file = file_get_contents($path);


### PR DESCRIPTION
Search up to two directories for plugin names as people will often use vendor namespaced plugins and AssetFilter should handle that scenario.

I've also fixed up the Risky test output in PHPUnit as this will incorrectly mask any failures in the future.

Fixes #4616
