### PR TITLE
Remove unneeded use statements.

### DIFF
--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -15,7 +15,6 @@
 namespace Cake\Database\Dialect;
 
 use Cake\Database\Expression\FunctionExpression;
-use Cake\Database\Query;
 use Cake\Database\SqlDialectTrait;
 
 /**

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Database\Driver;
 
-use Cake\Database\Query;
 use Cake\Database\Statement\PDOStatement;
 use PDO;
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -15,7 +15,6 @@
 namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\SqliteDialectTrait;
-use Cake\Database\Query;
 use Cake\Database\Statement\PDOStatement;
 use Cake\Database\Statement\SqliteStatement;
 use PDO;

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -15,7 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Error;
 use PDO;
 
 /**

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -15,7 +15,6 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Error;
 use PDO;
 
 /**

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -17,7 +17,6 @@ namespace Cake\Datasource;
 use Cake\Collection\Iterator\MapReduce;
 use Cake\Datasource\QueryCacher;
 use Cake\Datasource\RepositoryInterface;
-use Cake\Datasource\ResultSetDecorator;
 
 /**
  * Contains the characteristics for an object that is attached to a repository and

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\I18n;
 
-use Aura\Intl\Exception as LoadException;
 use Aura\Intl\FormatterLocator;
 use Aura\Intl\PackageLocator;
 use Aura\Intl\TranslatorFactory;

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -23,7 +23,6 @@ use Cake\Log\Log;
 use Cake\Network\Http\FormData\Part;
 use Cake\Utility\Hash;
 use Cake\Utility\String;
-use Cake\View\View;
 use InvalidArgumentException;
 use LogicException;
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -17,7 +17,6 @@ namespace Cake\ORM;
 use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\ResultSetDecorator;
-use Cake\Event\Event;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
@@ -717,7 +716,7 @@ abstract class Association {
 /**
  * Helper method to infer the requested finder and its options.
  *
- * Returns the inferred options from the finder $type. 
+ * Returns the inferred options from the finder $type.
  *
  * ### Examples:
  *

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -18,7 +18,6 @@ use Cake\Core\Configure;
 use Cake\Network\Request;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
-use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
 
 /**

--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -17,7 +17,6 @@ namespace Cake\TestSuite;
 use Cake\Controller\Error\MissingComponentException;
 use Cake\Controller\Error\MissingControllerException;
 use Cake\Core\App;
-use Cake\Error;
 use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Session;

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -19,7 +19,6 @@ use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Core\Exception\Exception;
 use Cake\TestSuite\Fixture\TestFixture;
-use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
 
 /**

--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -14,8 +14,6 @@
  */
 namespace Cake\View\Helper;
 
-use Cake\View\StringTemplate;
-
 /**
  * Adds string template functionality to any class by providing methods to
  * load and parse string templates.


### PR DESCRIPTION
Now my sniffer is all green.

But the /tests folder still contains 254 possible unnecessary use statements ;)
If someone is bored:

```
.\bin\cake CodeSniffer.cleanup unused_use /path/to/cake3/tests/
```
