### PR TITLE
3.0 translate type

### DIFF
--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -259,6 +259,9 @@ class TranslateBehavior extends Behavior {
  * @return \Cake\ORM\Query
  */
 	public function findTranslations(Query $query, array $options) {
+		if (isset($options['filterEmpty']) && $options['filterEmpty'] !== $this->_config['filterEmpty']) {
+			$this->setupFieldAssociations($this->_config['fields'], $this->_config['translationTable'], $options['filterEmpty']);
+		}
 		$locales = isset($options['locales']) ? $options['locales'] : [];
 		$table = $this->_config['translationTable'];
 		return $query

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -53,6 +53,12 @@ class TranslateBehavior extends Behavior {
 	protected $_locale;
 
 /**
+ * If true, resets the i18n associations in _rowMapper
+ * @var bool
+ */
+	protected $_resetAssociations = false;
+
+/**
  * Default config
  *
  * These are merged with user-provided configuration when the behavior is used.
@@ -260,6 +266,7 @@ class TranslateBehavior extends Behavior {
  */
 	public function findTranslations(Query $query, array $options) {
 		if (isset($options['filterEmpty']) && $options['filterEmpty'] !== $this->_config['filterEmpty']) {
+			$this->_resetAssociations = true;
 			$this->setupFieldAssociations($this->_config['fields'], $this->_config['translationTable'], $options['filterEmpty']);
 		}
 		$locales = isset($options['locales']) ? $options['locales'] : [];
@@ -283,6 +290,10 @@ class TranslateBehavior extends Behavior {
  * @return \Cake\Collection\Collection
  */
 	protected function _rowMapper($results, $locale) {
+		if ($this->_resetAssociations) {
+			$this->_resetAssociations = false;
+			$this->setupFieldAssociations($this->_config['fields'], $this->_config['translationTable'], $this->_config['filterEmpty']);
+		}
 		return $results->map(function($row) use ($locale) {
 			$options = ['setter' => false, 'guard' => false];
 

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -64,7 +64,7 @@ class TranslateBehavior extends Behavior {
 		'implementedMethods' => ['locale' => 'locale'],
 		'fields' => [],
 		'translationTable' => 'i18n',
-		'type' => 'LEFT'
+		'filterEmpty' => false
 	];
 
 /**
@@ -77,7 +77,7 @@ class TranslateBehavior extends Behavior {
 		parent::__construct($table, $config);
 		$this->_table = $table;
 		$config = $this->_config;
-		$this->setupFieldAssociations($config['fields'], $config['translationTable'], $config['type']);
+		$this->setupFieldAssociations($config['fields'], $config['translationTable'], $config['filterEmpty']);
 	}
 
 /**
@@ -91,7 +91,7 @@ class TranslateBehavior extends Behavior {
  * @param string $table the table name to use for storing each field translation
  * @return void
  */
-	public function setupFieldAssociations($fields, $table, $type) {
+	public function setupFieldAssociations($fields, $table, $filterEmpty) {
 		$alias = $this->_table->alias();
 		foreach ($fields as $field) {
 			$name = $this->_table->alias() . '_' . $field . '_translation';
@@ -101,7 +101,7 @@ class TranslateBehavior extends Behavior {
 			$this->_table->hasOne($name, [
 				'targetTable' => $target,
 				'foreignKey' => 'foreign_key',
-				'joinType' => $type,
+				'joinType' => $filterEmpty ? 'INNER' : 'LEFT',
 				'conditions' => [
 					$name . '.model' => $alias,
 					$name . '.field' => $field,

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -63,7 +63,8 @@ class TranslateBehavior extends Behavior {
 		'implementedFinders' => ['translations' => 'findTranslations'],
 		'implementedMethods' => ['locale' => 'locale'],
 		'fields' => [],
-		'translationTable' => 'i18n'
+		'translationTable' => 'i18n',
+		'type' => 'LEFT'
 	];
 
 /**
@@ -76,7 +77,7 @@ class TranslateBehavior extends Behavior {
 		parent::__construct($table, $config);
 		$this->_table = $table;
 		$config = $this->_config;
-		$this->setupFieldAssociations($config['fields'], $config['translationTable']);
+		$this->setupFieldAssociations($config['fields'], $config['translationTable'], $config['type']);
 	}
 
 /**
@@ -90,7 +91,7 @@ class TranslateBehavior extends Behavior {
  * @param string $table the table name to use for storing each field translation
  * @return void
  */
-	public function setupFieldAssociations($fields, $table) {
+	public function setupFieldAssociations($fields, $table, $type) {
 		$alias = $this->_table->alias();
 		foreach ($fields as $field) {
 			$name = $this->_table->alias() . '_' . $field . '_translation';
@@ -100,7 +101,7 @@ class TranslateBehavior extends Behavior {
 			$this->_table->hasOne($name, [
 				'targetTable' => $target,
 				'foreignKey' => 'foreign_key',
-				'joinType' => 'LEFT',
+				'joinType' => $type,
 				'conditions' => [
 					$name . '.model' => $alias,
 					$name . '.field' => $field,


### PR DESCRIPTION
This PR gives devs the ability to use an INNER join in the TranslateBehavior.
Example `Table` usage:

```
$this->addBehavior('Translate', ['filterEmpty' => true, 'fields' => ['title'']]);
```

Refs #4652
