### PR TITLE
Fix plugin assets not being served by AssetFilter when using FastCGI.

### DIFF
--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -104,7 +104,6 @@ class AssetFilter extends DispatcherFilter {
  * @return void
  */
 	protected function _deliverAsset(Request $request, Response $response, $assetFile, $ext) {
-		ob_start();
 		$compressionEnabled = $response->compress();
 		if ($response->type($ext) === $ext) {
 			$contentType = 'application/octet-stream';
@@ -118,8 +117,7 @@ class AssetFilter extends DispatcherFilter {
 			$response->header('Content-Length', filesize($assetFile));
 		}
 		$response->cache(filemtime($assetFile));
-		$response->send();
-		ob_clean();
+		$response->sendHeaders();
 		readfile($assetFile);
 		if ($compressionEnabled) {
 			ob_end_flush();


### PR DESCRIPTION
Reponse::send() calls fastcgi_finish_request() which prevents
the output from readfile() being sent to client. Refs #4597
