### PR TITLE
Add limit parameter to page()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1016,9 +1016,14 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Pages should start at 1.
  *
  * @param int $num The page number you want.
+ * @param int $limit The number of rows you want in the page. If null
+ *  the current limit clause will be used.
  * @return $this
  */
-	public function page($num) {
+	public function page($num, $limit = null) {
+		if ($limit !== null) {
+			$this->limit($limit);
+		}
 		$limit = $this->clause('limit');
 		if ($limit === null) {
 			$limit = 25;

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1621,9 +1621,15 @@ class QueryTest extends TestCase {
 		$result = $query->select('id')->from('comments')
 			->limit(1)
 			->page(2)
+			->order(['id' => 'asc'])
 			->execute();
 		$this->assertCount(1, $result);
 		$this->assertEquals(['id' => 2], $result->fetch('assoc'));
+
+		$query = new Query($this->connection);
+		$query->select('id')->from('comments')->page(3, 10);
+		$this->assertEquals(10, $query->clause('limit'));
+		$this->assertEquals(20, $query->clause('offset'));
 
 		$query = new Query($this->connection);
 		$query->select('id')->from('comments')->page(1);


### PR DESCRIPTION
Being able to set the limit and offset with the page() method makes it a bit easier to use as the operation is less order dependent.

Refs #4641
