### PR TITLE
3.0 - Adding PSR-3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 		"ext-mbstring": "*",
 		"nesbot/Carbon": "1.8.*",
 		"ircmaxell/password-compat": "1.0.*",
-		"aura/intl": "1.1.*"
+		"aura/intl": "1.1.*",
+		"psr/log": "1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*"

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -15,6 +15,7 @@
 namespace Cake\Log\Engine;
 
 use Cake\Core\InstanceConfigTrait;
+use JsonSerializable;
 use Psr\Log\AbstractLogger;
 
 /**
@@ -72,6 +73,33 @@ abstract class BaseLog extends AbstractLogger {
  */
 	public function scopes() {
 		return $this->_config['scopes'];
+	}
+
+/**
+ * Converts to string the provided data so it can be logged. The context
+ * can optionally be used by log engines to interpolate variables
+ * or add additional info to the logged message.
+ *
+ * @param mixed $data The data to be converted to string and logged.
+ * @param array $context Additional logging information for the message.
+ * @return string
+ */
+	protected function _format($data, array $context = []) {
+		if (is_string($data)) {
+			return $data;
+		}
+
+		$object = is_object($data);
+
+		if ($object && method_exists('__toString', $data)) {
+			return (string)$data;
+		}
+
+		if ($object && $object instanceof JsonSerializable) {
+			return json_encode($data);
+		}
+
+		return print_r($data, true);
 	}
 
 }

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -91,11 +91,11 @@ abstract class BaseLog extends AbstractLogger {
 
 		$object = is_object($data);
 
-		if ($object && method_exists('__toString', $data)) {
+		if ($object && method_exists($data, '__toString')) {
 			return (string)$data;
 		}
 
-		if ($object && $object instanceof JsonSerializable) {
+		if ($object && $data instanceof JsonSerializable) {
 			return json_encode($data);
 		}
 

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -15,13 +15,13 @@
 namespace Cake\Log\Engine;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\Log\LogInterface;
+use Psr\Log\AbstractLogger;
 
 /**
  * Base log engine class.
  *
  */
-abstract class BaseLog implements LogInterface {
+abstract class BaseLog extends AbstractLogger {
 
 	use InstanceConfigTrait;
 

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -86,6 +86,7 @@ class ConsoleLog extends BaseLog {
  * @return bool success of write.
  */
 	public function log($level, $message, array $context = []) {
+		$message = $this->_format($message, $context);
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
 		return $this->_output->write(sprintf('<%s>%s</%s>', $level, $output, $level), false);
 	}

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -82,11 +82,10 @@ class ConsoleLog extends BaseLog {
  *
  * @param string $level The severity level of log you are making.
  * @param string $message The message you want to log.
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param array $context Additional information about the logged message
  * @return bool success of write.
  */
-	public function write($level, $message, $scope = []) {
+	public function log($level, $message, array $context = []) {
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
 		return $this->_output->write(sprintf('<%s>%s</%s>', $level, $output, $level), false);
 	}

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -16,6 +16,7 @@ namespace Cake\Log\Engine;
 
 use Cake\Core\Configure;
 use Cake\Log\Engine\BaseLog;
+use Cake\Utility\String;
 
 /**
  * File Storage stream for Logging. Writes logs to different files
@@ -100,7 +101,7 @@ class FileLog extends BaseLog {
 			if (is_numeric($this->_config['size'])) {
 				$this->_size = (int)$this->_config['size'];
 			} else {
-				$this->_size = CakeNumber::fromReadableSize($this->_config['size']);
+				$this->_size = String::parseFileSize($this->_config['size']);
 			}
 		}
 	}
@@ -111,11 +112,10 @@ class FileLog extends BaseLog {
  * @param string $level The severity level of the message being written.
  *    See Cake\Log\Log::$_levels for list of possible levels.
  * @param string $message The message you want to log.
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param array $context Additional information about the logged message
  * @return bool success of write.
  */
-	public function write($level, $message, $scope = []) {
+	public function log($level, $message, array $context = []) {
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
 		$filename = $this->_getFilename($level);
 		if (!empty($this->_size)) {
@@ -131,6 +131,7 @@ class FileLog extends BaseLog {
 		$exists = file_exists($pathname);
 		$result = file_put_contents($pathname, $output, FILE_APPEND);
 		static $selfError = false;
+
 		if (!$selfError && !$exists && !chmod($pathname, (int)$mask)) {
 			$selfError = true;
 			trigger_error(vsprintf(
@@ -138,6 +139,7 @@ class FileLog extends BaseLog {
 				array($mask, $pathname)), E_USER_WARNING);
 			$selfError = false;
 		}
+
 		return $result;
 	}
 

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -116,6 +116,7 @@ class FileLog extends BaseLog {
  * @return bool success of write.
  */
 	public function log($level, $message, array $context = []) {
+		$message = $this->_format($message, $context);
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
 		$filename = $this->_getFilename($level);
 		if (!empty($this->_size)) {

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -89,11 +89,10 @@ class SyslogLog extends BaseLog {
  *
  * @param string $level The severity level of log you are making.
  * @param string $message The message you want to log.
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param array $context Additional information about the logged message
  * @return bool success of write.
  */
-	public function write($level, $message, $scope = []) {
+	public function log($level, $message, array $context = []) {
 		if (!$this->_open) {
 			$config = $this->_config;
 			$this->_open($config['prefix'], $config['flag'], $config['facility']);

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -104,7 +104,7 @@ class SyslogLog extends BaseLog {
 			$priority = $this->_levelMap[$level];
 		}
 
-		$messages = explode("\n", $message);
+		$messages = explode("\n", $this->_format($message, $context));
 		foreach ($messages as $message) {
 			$message = sprintf($this->_config['format'], $level, $message);
 			$this->_write($priority, $message);

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -312,7 +312,7 @@ class Log {
  *
  * @param int|string $level The severity level of the message being written.
  *    The value must be an integer or string matching a known level.
- * @param string $message Message content to log
+ * @param mixed $message Message content to log
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -36,7 +36,7 @@ use InvalidArgumentException;
  * classname to use loggers in the `App\Log\Engine` & `Cake\Log\Engine` namespaces.
  * You can also use plugin short hand to use logging classes provided by plugins.
  *
- * Log adapters are required to implement `Cake\Log\LogInterface`, and there is a
+ * Log adapters are required to implement `Psr\Log\LoggerInterface`, and there is a
  * built-in base class (`Cake\Log\Engine\BaseLog`) that can be used for custom loggers.
  *
  * Outside of the `className` key, all other configuration values will be passed to the
@@ -308,7 +308,7 @@ class Log {
  *
  * If no configured logger can handle a log message (because of level or scope restrictions)
  * then the logged message will be ignored and silently dropped. You can check if this has happened
- * by inspecting the return of write().  If false the message was not handled.
+ * by inspecting the return of write(). If false the message was not handled.
  *
  * @param int|string $level The severity level of the message being written.
  *    The value must be an integer or string matching a known level.
@@ -329,26 +329,26 @@ class Log {
 		}
 
 		$logged = false;
+		$scope = (array)$scope;
+
 		foreach (static::$_registry->loaded() as $streamName) {
 			$logger = static::$_registry->{$streamName};
 			$levels = $scopes = null;
+
 			if ($logger instanceof BaseLog) {
 				$levels = $logger->levels();
 				$scopes = $logger->scopes();
 			}
-			$correctLevel = (
-				empty($levels) ||
-				in_array($level, $levels)
-			);
-			$inScope = (
-				empty($scopes) ||
-				count(array_intersect((array)$scope, $scopes)) > 0
-			);
+
+			$correctLevel = empty($levels) || in_array($level, $levels);
+			$inScope = empty($scopes) || array_intersect($scope, $scopes);
+
 			if ($correctLevel && $inScope) {
-				$logger->write($level, $message, $scope);
+				$logger->log($level, $message, $scope);
 				$logged = true;
 			}
 		}
+
 		return $logged;
 	}
 

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -313,7 +313,7 @@ class Log {
  * @param int|string $level The severity level of the message being written.
  *    The value must be an integer or string matching a known level.
  * @param mixed $message Message content to log
- * @param string|array $context Additioanl data to be used for logging the message.
+ * @param string|array $context Additional data to be used for logging the message.
  *  The special `scope` key can be passed to be used for further filtering of the
  *  log engines to be used. If a string or a numerically index array is passed, it
  *  will be treated as the `scope` key.
@@ -363,8 +363,11 @@ class Log {
  * Convenience method to log emergency messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function emergency($message, $scope = array()) {
@@ -375,8 +378,11 @@ class Log {
  * Convenience method to log alert messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function alert($message, $scope = array()) {
@@ -387,8 +393,11 @@ class Log {
  * Convenience method to log critical messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function critical($message, $scope = array()) {
@@ -399,8 +408,11 @@ class Log {
  * Convenience method to log error messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function error($message, $scope = array()) {
@@ -411,8 +423,11 @@ class Log {
  * Convenience method to log warning messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function warning($message, $scope = array()) {
@@ -423,8 +438,11 @@ class Log {
  * Convenience method to log notice messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function notice($message, $scope = array()) {
@@ -435,8 +453,11 @@ class Log {
  * Convenience method to log debug messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function debug($message, $scope = array()) {
@@ -447,8 +468,11 @@ class Log {
  * Convenience method to log info messages
  *
  * @param string $message log message
- * @param string|array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
+ * @param string|array $context Additional data to be used for logging the message.
+ *  The special `scope` key can be passed to be used for further filtering of the
+ *  log engines to be used. If a string or a numerically index array is passed, it
+ *  will be treated as the `scope` key.
+ *  See Cake\Log\Log::config() for more information on logging scopes.
  * @return bool Success
  */
 	public static function info($message, $scope = array()) {

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -16,8 +16,8 @@ namespace Cake\Log;
 
 use Cake\Core\App;
 use Cake\Core\ObjectRegistry;
-use Cake\Log\LogInterface;
-use \RuntimeException;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Registry of loaded log engines
@@ -74,12 +74,12 @@ class LogEngineRegistry extends ObjectRegistry {
 			$instance = new $class($settings);
 		}
 
-		if ($instance instanceof LogInterface) {
+		if ($instance instanceof LoggerInterface) {
 			return $instance;
 		}
 
 		throw new RuntimeException(
-			'Loggers must implement Cake\Log\LogInterface.'
+			'Loggers must implement Psr\Log\LoggerInterface.'
 		);
 	}
 

--- a/src/Log/LogInterface.php
+++ b/src/Log/LogInterface.php
@@ -21,18 +21,9 @@ use Psr\Log\LoggerInterface;
 /**
  * LogInterface is the interface that should be implemented
  * by all classes that are going to be used as Log streams.
+ *
+ * @deprecated
  */
 interface LogInterface extends LoggerInterface {
 
-/**
- * Write method to handle writes being made to the Logger
- *
- * @param string $level The severity level of the message being written.
- *    See Cake\Log\Log::$_levels for list of possible levels.
- * @param string $message Message content to log
- * @param array $scope The scope(s) a log message is being created in.
- *    See Cake\Log\Log::config() for more information on logging scopes.
- * @return void
- */
-	public function write($level, $message, $scope = []);
 }

--- a/src/Log/LogInterface.php
+++ b/src/Log/LogInterface.php
@@ -16,11 +16,13 @@
  */
 namespace Cake\Log;
 
+use Psr\Log\LoggerInterface;
+
 /**
- * LogStreamInterface is the interface that should be implemented
+ * LogInterface is the interface that should be implemented
  * by all classes that are going to be used as Log streams.
  */
-interface LogInterface {
+interface LogInterface extends LoggerInterface {
 
 /**
  * Write method to handle writes being made to the Logger
@@ -28,7 +30,7 @@ interface LogInterface {
  * @param string $level The severity level of the message being written.
  *    See Cake\Log\Log::$_levels for list of possible levels.
  * @param string $message Message content to log
- * @param string|array $scope The scope(s) a log message is being created in.
+ * @param array $scope The scope(s) a log message is being created in.
  *    See Cake\Log\Log::config() for more information on logging scopes.
  * @return void
  */

--- a/src/Log/LogTrait.php
+++ b/src/Log/LogTrait.php
@@ -13,6 +13,8 @@
  */
 namespace Cake\Log;
 
+use Psr\Log\LogLevel;
+
 /**
  * A trait providing an object short-cut method
  * to logging.
@@ -23,16 +25,13 @@ trait LogTrait {
  * Convenience method to write a message to Log. See Log::write()
  * for more information on writing to logs.
  *
- * @param string $msg Log message.
+ * @param mixed $msg Log message.
  * @param int|string $level Error level.
- * @param string|array $scope The name of the log scope.
+ * @param string|array $context Additional log data relevant to this message.
  * @return bool Success of log write.
  */
-	public function log($msg, $level = LOG_ERR, $scope = []) {
-		if (!is_string($msg)) {
-			$msg = print_r($msg, true);
-		}
-		return Log::write($level, $msg, $scope);
+	public function log($msg, $level = LogLevel::ERROR, $context = []) {
+		return Log::write($level, $msg, $context);
 	}
 
 }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -90,13 +90,13 @@ class QueryLoggerTest extends \Cake\TestSuite\TestCase {
 		$query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
 		$query->params = ['string', '3', null];
 
-		$engine = $this->getMock('\Cake\Log\Engine\BaseLog', ['write'], ['scopes' => ['queriesLog']]);
+		$engine = $this->getMock('\Cake\Log\Engine\BaseLog', ['log'], ['scopes' => ['queriesLog']]);
 		Log::engine('queryLoggerTest', $engine);
 
-		$engine2 = $this->getMock('\Cake\Log\Engine\BaseLog', ['write'], ['scopes' => ['foo']]);
+		$engine2 = $this->getMock('\Cake\Log\Engine\BaseLog', ['log'], ['scopes' => ['foo']]);
 		Log::engine('queryLoggerTest2', $engine2);
 
-		$engine2->expects($this->never())->method('write');
+		$engine2->expects($this->never())->method('log');
 		$logger->log($query);
 	}
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -447,18 +447,18 @@ TEXT;
  * @return void
  */
 	public function testLog() {
-		$mock = $this->getMock('Cake\Log\Engine\BaseLog', ['write']);
+		$mock = $this->getMock('Cake\Log\Engine\BaseLog', ['log']);
 		Log::config('test', ['engine' => $mock]);
 
 		$mock->expects($this->at(0))
-			->method('write')
+			->method('log')
 			->with('debug', $this->logicalAnd(
 				$this->stringContains('DebuggerTest::testLog'),
 				$this->stringContains('cool')
 			));
 
 		$mock->expects($this->at(1))
-			->method('write')
+			->method('log')
 			->with('debug', $this->logicalAnd(
 				$this->stringContains('DebuggerTest::testLog'),
 				$this->stringContains('[main]'),
@@ -478,11 +478,11 @@ TEXT;
  * @return void
  */
 	public function testLogDepth() {
-		$mock = $this->getMock('Cake\Log\Engine\BaseLog', ['write']);
+		$mock = $this->getMock('Cake\Log\Engine\BaseLog', ['log']);
 		Log::config('test', ['engine' => $mock]);
 
 		$mock->expects($this->at(0))
-			->method('write')
+			->method('log')
 			->with('debug', $this->logicalAnd(
 				$this->stringContains('DebuggerTest::testLog'),
 				$this->stringContains('test'),

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -82,7 +82,7 @@ class ErrorHandlerTest extends TestCase {
 		Router::setRequestInfo($request);
 		Configure::write('debug', true);
 
-		$this->_logger = $this->getMock('Cake\Log\LogInterface');
+		$this->_logger = $this->getMock('Psr\Log\LoggerInterface');
 
 		Log::reset();
 		Log::config('error_test', [
@@ -183,7 +183,7 @@ class ErrorHandlerTest extends TestCase {
 		$this->_restoreError = true;
 
 		$this->_logger->expects($this->once())
-			->method('write')
+			->method('log')
 			->with(
 				$this->matchesRegularExpression('(notice|debug)'),
 				'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ + 3) . ']' . "\n\n"
@@ -204,7 +204,7 @@ class ErrorHandlerTest extends TestCase {
 		$this->_restoreError = true;
 
 		$this->_logger->expects($this->once())
-			->method('write')
+			->method('log')
 			->with(
 				$this->matchesRegularExpression('(notice|debug)'),
 				$this->logicalAnd(
@@ -243,7 +243,7 @@ class ErrorHandlerTest extends TestCase {
 		$error = new NotFoundException('Kaboom!');
 
 		$this->_logger->expects($this->once())
-			->method('write')
+			->method('log')
 			->with('error', $this->logicalAnd(
 				$this->stringContains('[Cake\Network\Exception\NotFoundException] Kaboom!'),
 				$this->stringContains('ErrorHandlerTest->testHandleExceptionLog')
@@ -263,7 +263,7 @@ class ErrorHandlerTest extends TestCase {
 		$forbidden = new ForbiddenException('Fooled you!');
 
 		$this->_logger->expects($this->once())
-			->method('write')
+			->method('log')
 			->with(
 				'error',
 				$this->stringContains('[Cake\Network\Exception\ForbiddenException] Fooled you!')
@@ -332,14 +332,14 @@ class ErrorHandlerTest extends TestCase {
  */
 	public function testHandleFatalErrorLog() {
 		$this->_logger->expects($this->at(0))
-			->method('write')
+			->method('log')
 			->with('error', $this->logicalAnd(
 				$this->stringContains(__FILE__ . ', line ' . (__LINE__ + 9)),
 				$this->stringContains('Fatal Error (1)'),
 				$this->stringContains('Something wrong')
 			));
 		$this->_logger->expects($this->at(1))
-			->method('write')
+			->method('log')
 			->with('error', $this->stringContains('[Cake\Error\FatalErrorException] Something wrong'));
 
 		$errorHandler = new TestErrorHandler(['log' => true]);

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -27,7 +27,7 @@ class ConsoleLogTest extends TestCase {
 /**
  * Test writing to ConsoleOutput
  */
-	public function testConsoleOutputWrites() {
+	public function testConsoleOutputlogs() {
 		$output = $this->getMock('Cake\Console\ConsoleOutput');
 
 		$output->expects($this->at(0))
@@ -41,7 +41,7 @@ class ConsoleLogTest extends TestCase {
 		$log = new ConsoleLog([
 			'stream' => $output
 		]);
-		$log->write('error', 'oh noes');
+		$log->log('error', 'oh noes');
 	}
 
 /**
@@ -49,12 +49,12 @@ class ConsoleLogTest extends TestCase {
  *
  * @return void
  */
-	public function testWriteToFileStream() {
+	public function testlogToFileStream() {
 		$filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
 		$log = new ConsoleLog([
 			'stream' => $filename
 		]);
-		$log->write('error', 'oh noes');
+		$log->log('error', 'oh noes');
 		$fh = fopen($filename, 'r');
 		$line = fgets($fh);
 		$this->assertContains('Error: oh noes', $line);

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -34,19 +34,19 @@ class FileLogTest extends TestCase {
 		$this->_deleteLogs(LOGS);
 
 		$log = new FileLog();
-		$log->write('warning', 'Test warning');
+		$log->log('warning', 'Test warning');
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 
 		$result = file_get_contents(LOGS . 'error.log');
 		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning/', $result);
 
-		$log->write('debug', 'Test warning');
+		$log->log('debug', 'Test warning');
 		$this->assertTrue(file_exists(LOGS . 'debug.log'));
 
 		$result = file_get_contents(LOGS . 'debug.log');
 		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Debug: Test warning/', $result);
 
-		$log->write('random', 'Test warning');
+		$log->log('random', 'Test warning');
 		$this->assertTrue(file_exists(LOGS . 'random.log'));
 
 		$result = file_get_contents(LOGS . 'random.log');
@@ -54,7 +54,7 @@ class FileLogTest extends TestCase {
 	}
 
 /**
- * test using the path setting to write logs in other places.
+ * test using the path setting to log logs in other places.
  *
  * @return void
  */
@@ -63,7 +63,7 @@ class FileLogTest extends TestCase {
 		$this->_deleteLogs($path);
 
 		$log = new FileLog(compact('path'));
-		$log->write('warning', 'Test warning');
+		$log->log('warning', 'Test warning');
 		$this->assertTrue(file_exists($path . 'error.log'));
 	}
 
@@ -82,7 +82,7 @@ class FileLogTest extends TestCase {
 			'size' => 35,
 			'rotate' => 2
 		));
-		$log->write('warning', 'Test warning one');
+		$log->log('warning', 'Test warning one');
 		$this->assertTrue(file_exists($path . 'error.log'));
 
 		$result = file_get_contents($path . 'error.log');
@@ -90,7 +90,7 @@ class FileLogTest extends TestCase {
 		$this->assertEquals(0, count(glob($path . 'error.log.*')));
 
 		clearstatcache();
-		$log->write('warning', 'Test warning second');
+		$log->log('warning', 'Test warning second');
 
 		$files = glob($path . 'error.log.*');
 		$this->assertEquals(1, count($files));
@@ -101,7 +101,7 @@ class FileLogTest extends TestCase {
 
 		sleep(1);
 		clearstatcache();
-		$log->write('warning', 'Test warning third');
+		$log->log('warning', 'Test warning third');
 
 		$result = file_get_contents($path . 'error.log');
 		$this->assertRegExp('/Warning: Test warning third/', $result);
@@ -119,7 +119,7 @@ class FileLogTest extends TestCase {
 
 		sleep(1);
 		clearstatcache();
-		$log->write('warning', 'Test warning fourth');
+		$log->log('warning', 'Test warning fourth');
 
 		// rotate count reached so file count should not increase
 		$files = glob($path . 'error.log.*');
@@ -141,7 +141,7 @@ class FileLogTest extends TestCase {
 			'rotate' => 0
 		));
 		file_put_contents($path . 'debug.log.0000000000', "The oldest log file with over 35 bytes.\n");
-		$log->write('debug', 'Test debug');
+		$log->log('debug', 'Test debug');
 		$this->assertTrue(file_exists($path . 'debug.log'));
 
 		$result = file_get_contents($path . 'debug.log');
@@ -159,21 +159,21 @@ class FileLogTest extends TestCase {
 		$this->_deleteLogs($path);
 
 		$log = new FileLog(array('path' => $path, 'mask' => 0666));
-		$log->write('warning', 'Test warning one');
+		$log->log('warning', 'Test warning one');
 		$result = substr(sprintf('%o', fileperms($path . 'error.log')), -4);
 		$expected = '0666';
 		$this->assertEquals($expected, $result);
 		unlink($path . 'error.log');
 
 		$log = new FileLog(array('path' => $path, 'mask' => 0644));
-		$log->write('warning', 'Test warning two');
+		$log->log('warning', 'Test warning two');
 		$result = substr(sprintf('%o', fileperms($path . 'error.log')), -4);
 		$expected = '0644';
 		$this->assertEquals($expected, $result);
 		unlink($path . 'error.log');
 
 		$log = new FileLog(array('path' => $path, 'mask' => 0640));
-		$log->write('warning', 'Test warning three');
+		$log->log('warning', 'Test warning three');
 		$result = substr(sprintf('%o', fileperms($path . 'error.log')), -4);
 		$expected = '0640';
 		$this->assertEquals($expected, $result);

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -18,6 +18,39 @@ namespace Cake\Test\TestCase\Log\Engine;
 
 use Cake\Log\Engine\FileLog;
 use Cake\TestSuite\TestCase;
+use JsonSerializable;
+
+/**
+ * Class used for testing when an object is passed to a logger
+ *
+ */
+class StringObject {
+
+/**
+ * String representation of the object
+ *
+ * @return string
+ */
+	public function __toString() {
+		return 'Hey!';
+	}
+}
+
+/**
+ * Class used for testing when an serializable is passed to a logger
+ *
+ */
+class JsonObject implements JsonSerializable {
+
+/**
+ * String representation of the object
+ *
+ * @return string
+ */
+	public function jsonSerialize() {
+		return ['hello' => 'world'];
+	}
+}
 
 /**
  * FileLogTest class
@@ -51,6 +84,23 @@ class FileLogTest extends TestCase {
 
 		$result = file_get_contents(LOGS . 'random.log');
 		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Random: Test warning/', $result);
+
+		$object = new StringObject;
+		$log->log('debug', $object);
+		$this->assertTrue(file_exists(LOGS . 'debug.log'));
+		$result = file_get_contents(LOGS . 'debug.log');
+		$this->assertContains('Debug: Hey!', $result);
+
+		$object = new JsonObject;
+		$log->log('debug', $object);
+		$this->assertTrue(file_exists(LOGS . 'debug.log'));
+		$result = file_get_contents(LOGS . 'debug.log');
+		$this->assertContains('Debug: ' . json_encode(['hello' => 'world']), $result);
+
+		$log->log('debug', [1, 2]);
+		$this->assertTrue(file_exists(LOGS . 'debug.log'));
+		$result = file_get_contents(LOGS . 'debug.log');
+		$this->assertContains('Debug: ' . print_r([1, 2], true), $result);
 	}
 
 /**

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -29,7 +29,7 @@ class SyslogLogTest extends TestCase {
 	public function testOpenLog() {
 		$log = $this->getMock('Cake\Log\Engine\SyslogLog', array('_open', '_write'));
 		$log->expects($this->once())->method('_open')->with('', LOG_ODELAY, LOG_USER);
-		$log->write('debug', 'message');
+		$log->log('debug', 'message');
 
 		$log = $this->getMock('Cake\Log\Engine\SyslogLog', array('_open', '_write'));
 		$log->config(array(
@@ -40,7 +40,7 @@ class SyslogLogTest extends TestCase {
 		));
 		$log->expects($this->once())->method('_open')
 			->with('thing', LOG_NDELAY, LOG_MAIL);
-		$log->write('debug', 'message');
+		$log->log('debug', 'message');
 	}
 
 /**
@@ -52,7 +52,7 @@ class SyslogLogTest extends TestCase {
 	public function testWriteOneLine($type, $expected) {
 		$log = $this->getMock('Cake\Log\Engine\SyslogLog', array('_open', '_write'));
 		$log->expects($this->once())->method('_write')->with($expected, $type . ': Foo');
-		$log->write($type, 'Foo');
+		$log->log($type, 'Foo');
 	}
 
 /**
@@ -65,7 +65,7 @@ class SyslogLogTest extends TestCase {
 		$log->expects($this->at(1))->method('_write')->with(LOG_DEBUG, 'debug: Foo');
 		$log->expects($this->at(2))->method('_write')->with(LOG_DEBUG, 'debug: Bar');
 		$log->expects($this->exactly(2))->method('_write');
-		$log->write('debug', "Foo\nBar");
+		$log->log('debug', "Foo\nBar");
 	}
 
 /**

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -440,10 +440,10 @@ class LogTest extends TestCase {
 		$this->assertNull($engine->passedScope);
 
 		Log::write('debug', 'test message', 'foo');
-		$this->assertEquals(['foo'], $engine->passedScope);
+		$this->assertEquals(['scope' => ['foo']], $engine->passedScope);
 
 		Log::write('debug', 'test message', ['foo', 'bar']);
-		$this->assertEquals(['foo', 'bar'], $engine->passedScope);
+		$this->assertEquals(['scope' => ['foo', 'bar']], $engine->passedScope);
 
 		$result = Log::write('debug', 'test message');
 		$this->assertFalse($result);

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -440,7 +440,7 @@ class LogTest extends TestCase {
 		$this->assertNull($engine->passedScope);
 
 		Log::write('debug', 'test message', 'foo');
-		$this->assertEquals('foo', $engine->passedScope);
+		$this->assertEquals(['foo'], $engine->passedScope);
 
 		Log::write('debug', 'test message', ['foo', 'bar']);
 		$this->assertEquals(['foo', 'bar'], $engine->passedScope);

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -35,14 +35,14 @@ class LogTraitTest extends TestCase {
  * @return void
  */
 	public function testLog() {
-		$mock = $this->getMock('Cake\Log\LogInterface');
+		$mock = $this->getMock('Psr\Log\LoggerInterface');
 		$mock->expects($this->at(0))
 			->method('log')
 			->with('error', 'Testing');
 
 		$mock->expects($this->at(1))
 			->method('log')
-			->with('debug', print_r(array(1, 2), true));
+			->with('debug',array(1, 2));
 
 		Log::config('trait_test', ['engine' => $mock]);
 		$subject = $this->getObjectForTrait('Cake\Log\LogTrait');

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -37,11 +37,11 @@ class LogTraitTest extends TestCase {
 	public function testLog() {
 		$mock = $this->getMock('Cake\Log\LogInterface');
 		$mock->expects($this->at(0))
-			->method('write')
+			->method('log')
 			->with('error', 'Testing');
 
 		$mock->expects($this->at(1))
-			->method('write')
+			->method('log')
 			->with('debug', print_r(array(1, 2), true));
 
 		Log::config('trait_test', ['engine' => $mock]);

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -1277,12 +1277,12 @@ class EmailTest extends TestCase {
  * @return void
  */
 	public function testSendWithLog() {
-		$log = $this->getMock('Cake\Log\Engine\BaseLog', ['write'], [['scopes' => 'email']]);
+		$log = $this->getMock('Cake\Log\Engine\BaseLog', ['log'], [['scopes' => 'email']]);
 
 		$message = 'Logging This';
 
 		$log->expects($this->once())
-			->method('write')
+			->method('log')
 			->with(
 				'debug',
 				$this->logicalAnd(
@@ -1310,9 +1310,9 @@ class EmailTest extends TestCase {
 	public function testSendWithLogAndScope() {
 		$message = 'Logging This';
 
-		$log = $this->getMock('Cake\Log\Engine\BaseLog', ['write'], ['scopes' => ['email']]);
+		$log = $this->getMock('Cake\Log\Engine\BaseLog', ['log'], ['scopes' => ['email']]);
 		$log->expects($this->once())
-			->method('write')
+			->method('log')
 			->with(
 				'debug',
 				$this->logicalAnd(

--- a/tests/test_app/Plugin/TestPlugin/src/Log/Engine/TestPluginLog.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Log/Engine/TestPluginLog.php
@@ -15,14 +15,15 @@
 namespace TestPlugin\Log\Engine;
 
 use Cake\Log\LogInterface;
+use Psr\Log\AbstractLogger;
 
 /**
  * Test Suite Test Plugin Logging stream class.
  *
  */
-class TestPluginLog implements LogInterface {
+class TestPluginLog extends AbstractLogger {
 
-	public function write($level, $message, $scope = []) {
+	public function log($level, $message, array $context = []) {
 	}
 
 }

--- a/tests/test_app/TestApp/Log/Engine/TestAppLog.php
+++ b/tests/test_app/TestApp/Log/Engine/TestAppLog.php
@@ -26,8 +26,8 @@ class TestAppLog extends BaseLog {
 
 	public $passedScope = null;
 
-	public function write($level, $message, $scope = []) {
-		$this->passedScope = $scope;
+	public function log($level, $message, array $context = []) {
+		$this->passedScope = $context;
 	}
 
 }


### PR DESCRIPTION
Enforces the PSR-3 logging interface to our logging engines. This has the advantage of making them immediately usable inside other projects (such as elastica) and make using monolog a one liner.

This introduces a breaking change, as the Logging engines will have to implement more methods. BaseLog, helps with this task as only one of the methods remains abstract. In general, people will only need to rename `write` and use `log` instead.

The static class remains as a proxy for the logger engines as was left unchanged. Additionally, the forced use of `print_r` in `LogTrait` was removed, it is now the job of log engines to format the message as dictated by PSR-3.

For people wanting to use monolog, it becomes as easy as adding this to their `app.php`

``` php
'Log' => [
        'default' => function() {
            return new \Monolog\Logger('app');
        },
    ],
```

Closes https://github.com/cakephp/cakephp/issues/2033
