### PR TITLE
Add Table::findOrNew()

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -939,21 +939,22 @@ class Table implements RepositoryInterface, EventListener {
  *
  * Using the attributes defined in $search a find() will be done to locate
  * an existing record. If that record exists it will be returned. If it does
- * not exist, a new entity will be created. In both cases, the $additional properties
- * will be patched into the entity.
+ * not exist, a new entity will be created with the $search properties, and
+ * the $defaults. When a new entity is created, it will be saved.
  *
  * @param array $search The criteria to find existing records by.
- * @param array $additional The array of additional attributes to patch into
- *   the new or existing entity.
+ * @param array $defaults The array of defaults to patch into
+ *   the new entity if it is created.
  * @return \Cake\Datasource\EntityInterface An entity.
  */
-	public function findOrNew($search, $additional = []) {
+	public function findOrCreate($search, $defaults = []) {
 		$query = $this->find()->where($search);
 		$row = $query->first();
 		if ($row) {
-			return $this->patchEntity($row, $additional);
+			return $row;
 		}
-		return $this->newEntity($search + $additional);
+		$entity = $this->newEntity($search + $defaults);
+		return $this->save($entity);
 	}
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -935,6 +935,28 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
+ * Finds an existing record or creates a new record.
+ *
+ * Using the attributes defined in $search a find() will be done to locate
+ * an existing record. If that record exists it will be returned. If it does
+ * not exist, a new entity will be created. In both cases, the $additional properties
+ * will be patched into the entity.
+ *
+ * @param array $search The criteria to find existing records by.
+ * @param array $additional The array of additional attributes to patch into
+ *   the new or existing entity.
+ * @return Cake\Datasource\EntityInterface An entity.
+ */
+	public function findOrNew($search, $additional = []) {
+		$query = $this->find()->where($search);
+		$row = $query->first();
+		if ($row) {
+			return $this->patchEntity($row, $additional);
+		}
+		return $this->newEntity($search + $additional);
+	}
+
+/**
  * {@inheritDoc}
  */
 	public function query() {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -935,7 +935,7 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
- * Finds an existing record or creates a new record.
+ * Finds an existing record or creates a new one.
  *
  * Using the attributes defined in $search a find() will be done to locate
  * an existing record. If that record exists it will be returned. If it does
@@ -945,7 +945,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param array $search The criteria to find existing records by.
  * @param array $additional The array of additional attributes to patch into
  *   the new or existing entity.
- * @return Cake\Datasource\EntityInterface An entity.
+ * @return \Cake\Datasource\EntityInterface An entity.
  */
 	public function findOrNew($search, $additional = []) {
 		$query = $this->find()->where($search);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -943,17 +943,21 @@ class Table implements RepositoryInterface, EventListener {
  * the $defaults. When a new entity is created, it will be saved.
  *
  * @param array $search The criteria to find existing records by.
- * @param array $defaults The array of defaults to patch into
- *   the new entity if it is created.
+ * @param callable $callback A callback that will be invoked for newly
+ *   created entities. This callback will be called *before* the entity
+ *   is persisted.
  * @return \Cake\Datasource\EntityInterface An entity.
  */
-	public function findOrCreate($search, $defaults = []) {
+	public function findOrCreate($search, callable $callback = null) {
 		$query = $this->find()->where($search);
 		$row = $query->first();
 		if ($row) {
 			return $row;
 		}
-		$entity = $this->newEntity($search + $defaults);
+		$entity = $this->newEntity($search);
+		if ($callback) {
+			$callback($entity);
+		}
 		return $this->save($entity);
 	}
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -954,7 +954,8 @@ class Table implements RepositoryInterface, EventListener {
 		if ($row) {
 			return $row;
 		}
-		$entity = $this->newEntity($search);
+		$entity = $this->newEntity();
+		$entity->set($search, ['guard' => false]);
 		if ($callback) {
 			$callback($entity);
 		}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -958,7 +958,7 @@ class Table implements RepositoryInterface, EventListener {
 		if ($callback) {
 			$callback($entity);
 		}
-		return $this->save($entity);
+		return $this->save($entity) ?: $entity;
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3530,4 +3530,37 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Test the findOrNew method.
+ *
+ * @return void
+ */
+	public function testFindOrNew() {
+		$articles = TableRegistry::get('Articles');
+		$article = $articles->findOrNew(['title' => 'Not there'], ['body' => 'New body']);
+
+		$this->assertTrue($article->isNew());
+		$this->assertNull($article->id);
+		$this->assertEquals('Not there', $article->title);
+		$this->assertEquals('New body', $article->body);
+
+		$article = $articles->findOrNew(['title' => 'First Article'], ['body' => 'New body']);
+
+		$this->assertFalse($article->isNew());
+		$this->assertNotNull($article->id);
+		$this->assertEquals('First Article', $article->title);
+		$this->assertEquals('New body', $article->body);
+
+		$article = $articles->findOrNew(
+			['author_id' => 2, 'title' => 'First Article'],
+			['published' => 'N', 'body' => 'New body']
+		);
+		$this->assertTrue($article->isNew());
+		$this->assertNull($article->id);
+		$this->assertEquals('First Article', $article->title);
+		$this->assertEquals('New body', $article->body);
+		$this->assertEquals('N', $article->published);
+		$this->assertEquals(2, $article->author_id);
+	}
+
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3537,19 +3537,23 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testFindOrCreate() {
 		$articles = TableRegistry::get('Articles');
+
 		$article = $articles->findOrCreate(['title' => 'Not there'], function ($article) {
 			$article->body = 'New body';
 		});
-
 		$this->assertFalse($article->isNew());
 		$this->assertNotNull($article->id);
 		$this->assertEquals('Not there', $article->title);
 		$this->assertEquals('New body', $article->body);
 
+		$article = $articles->findOrCreate(['title' => 'Not there']);
+		$this->assertFalse($article->isNew());
+		$this->assertNotNull($article->id);
+		$this->assertEquals('Not there', $article->title);
+
 		$article = $articles->findOrCreate(['title' => 'First Article'], function ($article) {
 			$this->fail('Should not be called for existing entities.');
 		});
-
 		$this->assertFalse($article->isNew());
 		$this->assertNotNull($article->id);
 		$this->assertEquals('First Article', $article->title);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3537,26 +3537,26 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testFindOrNew() {
 		$articles = TableRegistry::get('Articles');
-		$article = $articles->findOrNew(['title' => 'Not there'], ['body' => 'New body']);
+		$article = $articles->findOrCreate(['title' => 'Not there'], ['body' => 'New body']);
 
-		$this->assertTrue($article->isNew());
-		$this->assertNull($article->id);
+		$this->assertFalse($article->isNew());
+		$this->assertNotNull($article->id);
 		$this->assertEquals('Not there', $article->title);
 		$this->assertEquals('New body', $article->body);
 
-		$article = $articles->findOrNew(['title' => 'First Article'], ['body' => 'New body']);
+		$article = $articles->findOrCreate(['title' => 'First Article'], ['body' => 'New body']);
 
 		$this->assertFalse($article->isNew());
 		$this->assertNotNull($article->id);
 		$this->assertEquals('First Article', $article->title);
-		$this->assertEquals('New body', $article->body);
+		$this->assertNotEquals('New body', $article->body);
 
-		$article = $articles->findOrNew(
+		$article = $articles->findOrCreate(
 			['author_id' => 2, 'title' => 'First Article'],
 			['published' => 'N', 'body' => 'New body']
 		);
-		$this->assertTrue($article->isNew());
-		$this->assertNull($article->id);
+		$this->assertFalse($article->isNew());
+		$this->assertNotNull($article->id);
 		$this->assertEquals('First Article', $article->title);
 		$this->assertEquals('New body', $article->body);
 		$this->assertEquals('N', $article->published);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3531,29 +3531,34 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test the findOrNew method.
+ * Test the findOrCreate method.
  *
  * @return void
  */
-	public function testFindOrNew() {
+	public function testFindOrCreate() {
 		$articles = TableRegistry::get('Articles');
-		$article = $articles->findOrCreate(['title' => 'Not there'], ['body' => 'New body']);
+		$article = $articles->findOrCreate(['title' => 'Not there'], function ($article) {
+			$article->body = 'New body';
+		});
 
 		$this->assertFalse($article->isNew());
 		$this->assertNotNull($article->id);
 		$this->assertEquals('Not there', $article->title);
 		$this->assertEquals('New body', $article->body);
 
-		$article = $articles->findOrCreate(['title' => 'First Article'], ['body' => 'New body']);
+		$article = $articles->findOrCreate(['title' => 'First Article'], function ($article) {
+			$this->fail('Should not be called for existing entities.');
+		});
 
 		$this->assertFalse($article->isNew());
 		$this->assertNotNull($article->id);
 		$this->assertEquals('First Article', $article->title);
-		$this->assertNotEquals('New body', $article->body);
 
 		$article = $articles->findOrCreate(
 			['author_id' => 2, 'title' => 'First Article'],
-			['published' => 'N', 'body' => 'New body']
+			function ($article) {
+				$article->set(['published' => 'N', 'body' => 'New body']);
+			}
 		);
 		$this->assertFalse($article->isNew());
 		$this->assertNotNull($article->id);


### PR DESCRIPTION
This method lets you easily find an existing entity or generate a new entity with the chosen properties. In addition to finding entities, it lets you patch/set additional attributes on the found/created entity.

I decided to call the method `findOrNew()` as I wanted it to have consistency with `newEntity()` and I was concerned that `findOrCreate()` might imply that the entity would be saved.

Refs #4631
