### PR TITLE
Fix insert queries failing with expression objects.

### DIFF
--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -116,15 +116,21 @@ trait SqliteDialectTrait {
 
 		$newQuery = $query->connection()->newQuery();
 		$cols = $v->columns();
+		$placeholder = 0;
 		$replaceQuery = false;
+
 		foreach ($v->values() as $k => $val) {
 			$fillLength = count($cols) - count($val);
 			if ($fillLength > 0) {
 				$val = array_merge($val, array_fill(0, $fillLength, null));
 			}
-			$val = array_map(function ($val) {
-				return $val instanceof ExpressionInterface ? $val : '?';
-			}, $val);
+
+			foreach ($val as $col => $attr) {
+				if (!($attr instanceof ExpressionInterface)) {
+					$val[$col] = sprintf(':c%d', $placeholder);
+					$placeholder++;
+				}
+			}
 
 			$select = array_combine($cols, $val);
 			if ($k === 0) {

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -149,6 +149,9 @@ class ValuesExpression implements ExpressionInterface {
 		foreach ($this->_values as $row) {
 			$row = array_merge($defaults, $row);
 			foreach ($row as $column => $value) {
+				if ($value instanceof ExpressionInterface) {
+					$value = $value->sql($generator);
+				}
 				$type = $this->typeMap()->type($column);
 				$generator->bind($i++, $value, $type);
 			}

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -146,25 +146,28 @@ class ValuesExpression implements ExpressionInterface {
 
 		$i = 0;
 		$defaults = array_fill_keys($this->_columns, null);
+		$placeholders = [];
+
 		foreach ($this->_values as $row) {
 			$row = array_merge($defaults, $row);
+			$rowPlaceholders = [];
 			foreach ($row as $column => $value) {
 				if ($value instanceof ExpressionInterface) {
-					$value = $value->sql($generator);
+					$rowPlaceholders[] = '(' . $value->sql($generator) . ')';
+					continue;
 				}
 				$type = $this->typeMap()->type($column);
-				$generator->bind($i++, $value, $type);
+				$placeholder = $generator->placeholder($i);
+				$rowPlaceholders[] = $placeholder;
+				$generator->bind($placeholder, $value, $type);
 			}
+			$placeholders[] = implode(', ', $rowPlaceholders);
 		}
 
 		if ($this->query()) {
 			return ' ' . $this->query()->sql($generator);
 		}
 
-		$placeholders = [];
-		$numColumns = count($this->_columns);
-		$rowPlaceholders = implode(', ', array_fill(0, $numColumns, '?'));
-		$placeholders = array_fill(0, count($this->_values), $rowPlaceholders);
 		return sprintf(' VALUES (%s)', implode('), (', $placeholders));
 	}
 
@@ -185,6 +188,14 @@ class ValuesExpression implements ExpressionInterface {
 		foreach ($this->_values as $v) {
 			if ($v instanceof ExpressionInterface) {
 				$v->traverse($visitor);
+			}
+			if (!is_array($v)) {
+				continue;
+			}
+			foreach ($v as $column => $field) {
+				if ($field instanceof ExpressionInterface) {
+					$field->traverse($visitor);
+				}
 			}
 		}
 	}

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -63,14 +63,11 @@ class ValueBinder {
  * @return string to be used as a placeholder in a query expression
  */
 	public function placeholder($token) {
-		$param = $token;
 		$number = $this->_bindingsCount++;
-
-		if ($param[0] !== ':' || $param !== '?') {
-			$param = sprintf(':c%s', $number);
+		if ($token[0] !== ':' || $token !== '?') {
+			$token = sprintf(':c%s', $number);
 		}
-
-		return $param;
+		return $token;
 	}
 
 /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2295,6 +2295,27 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Test that insert can use expression objects as values.
+ *
+ * @return void
+ */
+	public function testInsertExpressionValues() {
+		$query = new Query($this->connection);
+		$query->insert(['title'])
+			->into('articles')
+			->values(['title' => $query->newExpr("SELECT 'jose'")]);
+
+		$result = $query->sql();
+		$this->assertQuotedQuery(
+			"INSERT INTO <articles> \(<title>\) VALUES (?)",
+			$result,
+			true
+		);
+		$result = $query->execute();
+		$this->assertCount(1, $result);
+	}
+
+/**
  * Tests that functions are correctly transformed and their parameters are bound
  *
  * @group FunctionExpression

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2130,7 +2130,7 @@ class QueryTest extends TestCase {
 		$result = $query->sql();
 		$this->assertQuotedQuery(
 			'INSERT INTO <articles> \(<title>, <body>\) ' .
-			'VALUES \(\?, \?\)',
+			'VALUES \(:c0, :c1\)',
 			$result,
 			true
 		);
@@ -2166,7 +2166,7 @@ class QueryTest extends TestCase {
 		$result = $query->sql();
 		$this->assertQuotedQuery(
 			'INSERT INTO <articles> \(<title>, <body>\) ' .
-			'VALUES \(\?, \?\)',
+			'VALUES \(:c0, :c1\)',
 			$result,
 			true
 		);
@@ -2305,12 +2305,18 @@ class QueryTest extends TestCase {
 			->into('articles')
 			->values(['title' => $query->newExpr("SELECT 'jose'")]);
 
-		$result = $query->sql();
-		$this->assertQuotedQuery(
-			"INSERT INTO <articles> \(<title>\) VALUES (?)",
-			$result,
-			true
-		);
+		$result = $query->execute();
+		$this->assertCount(1, $result);
+
+		$subquery = new Query($this->connection);
+		$subquery->select(['name'])
+			->from('authors')
+			->where(['id' => 1]);
+
+		$query = new Query($this->connection);
+		$query->insert(['title'])
+			->into('articles')
+			->values(['title' => $subquery]);
 		$result = $query->execute();
 		$this->assertCount(1, $result);
 	}

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -293,6 +293,19 @@ class QueryRegressionTest extends TestCase {
 	}
 
 /**
+ * Test that save() works with entities containing expressions
+ * as properties.
+ *
+ * @return void
+ */
+	public function testSaveWithExpressionProperty() {
+		$articles = TableRegistry::get('Articles');
+		$article = $articles->newEntity();
+		$article->title = new \Cake\Database\Expression\QueryExpression("SELECT 'jose'");
+		$this->assertSame($article, $articles->save($article));
+	}
+
+/**
  * Tests that whe saving deep associations for a belongsToMany property,
  * data is not removed becuase of excesive associations filtering.
  *


### PR DESCRIPTION
Insert queries should support expression objects as values. This allows geo features from MySQL to be used, and enables other platform specific SQL functions.

Refs #4671
