### PR TITLE
3.0 buffered iterator

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -892,7 +892,7 @@ trait CollectionTrait {
 
 /**
  * Returns a new collection where the operations performed by this collection.
- * Not matter how many times the new collection is iterated, those operations will
+ * No matter how many times the new collection is iterated, those operations will
  * only be performed once.
  *
  * This can also be used to make any non-rewindable iterator rewindable.

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -17,6 +17,7 @@ namespace Cake\Collection;
 use AppendIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
+use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;
 use Cake\Collection\Iterator\InsertIterator;
@@ -879,14 +880,10 @@ trait CollectionTrait {
  * You can think of this method as a way to create save points for complex
  * calculations in a collection.
  *
- * @param bool $preserveKeys whether to use the keys returned by this
- * collection as the array keys. Keep in mind that it is valid for iterators
- * to return the same key for different elements, setting this value to false
- * can help getting all items if keys are not important in the result.
  * @return \Cake\Collection\Collection
  */
-	public function compile($preserveKeys = true) {
-		return new Collection($this->toArray($preserveKeys));
+	public function compile() {
+		return new BufferedIterator($this);
 	}
 
 /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -17,7 +17,6 @@ namespace Cake\Collection;
 use AppendIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
-use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;
 use Cake\Collection\Iterator\InsertIterator;
@@ -880,10 +879,14 @@ trait CollectionTrait {
  * You can think of this method as a way to create save points for complex
  * calculations in a collection.
  *
+ * @param bool $preserveKeys whether to use the keys returned by this
+ * collection as the array keys. Keep in mind that it is valid for iterators
+ * to return the same key for different elements, setting this value to false
+ * can help getting all items if keys are not important in the result.
  * @return \Cake\Collection\Collection
  */
-	public function compile() {
-		return new BufferedIterator($this);
+	public function compile($preserveKeys = true) {
+		return new Collection($this->toArray($preserveKeys));
 	}
 
 /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -17,6 +17,7 @@ namespace Cake\Collection;
 use AppendIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
+use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;
 use Cake\Collection\Iterator\InsertIterator;
@@ -887,6 +888,19 @@ trait CollectionTrait {
  */
 	public function compile($preserveKeys = true) {
 		return new Collection($this->toArray($preserveKeys));
+	}
+
+/**
+ * Returns a new collection where the operations performed by this collection.
+ * Not matter how many times the new collection is iterated, those operations will
+ * only be performed once.
+ *
+ * This can also be used to make any non-rewindable iterator rewindable.
+ *
+ * @return \Cake\Collection\Iterator\BufferedIterator
+ */
+	public function buffered() {
+		return new BufferedIterator($this);
 	}
 
 /**

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -80,7 +80,7 @@ class BufferedIterator extends Collection {
 /**
  * Returns the current key in the iterator
  *
- * @return array|object
+ * @return mixed
  */
 	public function key() {
 		return $this->_key;
@@ -89,7 +89,7 @@ class BufferedIterator extends Collection {
 /**
  * Returns the current record in the iterator
  *
- * @return array|object
+ * @return mixed
  */
 	public function current() {
 		return $this->_current;

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -60,6 +60,13 @@ class BufferedIterator extends Collection {
 	protected $_started = false;
 
 /**
+ * Whether or not the internal iterator's has reached its end
+ *
+ * @var boolean
+ */
+	protected $_finished = false;
+
+/**
  * Maintains an in-memory cache of the results yielded by the internal
  * iterator.
  *
@@ -127,6 +134,7 @@ class BufferedIterator extends Collection {
 			]);
 		}
 
+		$this->_finished = !$valid;
 		return $valid;
 	}
 
@@ -137,7 +145,10 @@ class BufferedIterator extends Collection {
  */
 	public function next() {
 		$this->_index++;
-		parent::next();
+
+		if (!$this->_finished) {
+			parent::next();
+		}
 	}
 
 }

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -128,7 +128,7 @@ class BufferedIterator extends Collection {
 		if ($valid) {
 			$this->_current = parent::current();
 			$this->_key = parent::key();
-			$this->_buffer->add($this->_index, [
+			$this->_buffer->push([
 				'key' => $this->_key,
 				'value' => $this->_current
 			]);

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -40,17 +40,23 @@ class BufferedIterator extends Collection {
 /**
  * Last record fetched from the inner iterator
  *
- * @var array
+ * @var mixed
  */
 	protected $_current;
 
 /**
  * Last key obtained from the inner iterator
  *
- * @var array
+ * @var mixed
  */
 	protected $_key;
 
+/**
+ * Whether or not the internal iterator's rewind method was already
+ * called
+ *
+ * @var boolean
+ */
 	protected $_started = false;
 
 /**
@@ -64,14 +70,17 @@ class BufferedIterator extends Collection {
 		parent::__construct($items);
 	}
 
+/**
+ * Returns the current key in the iterator
+ *
+ * @return array|object
+ */
 	public function key() {
 		return $this->_key;
 	}
 
 /**
- * Returns the current record in the result iterator
- *
- * Part of Iterator interface.
+ * Returns the current record in the iterator
  *
  * @return array|object
  */
@@ -81,7 +90,6 @@ class BufferedIterator extends Collection {
 
 /**
  * Rewinds the collection
- *
  *
  * @return void
  */
@@ -96,8 +104,9 @@ class BufferedIterator extends Collection {
 	}
 
 /**
+ * Returns whether or not the iterator has more elements
  *
- * @return mixed
+ * @return boolean
  */
 	public function valid() {
 		if ($this->_buffer->offsetExists($this->_index)) {
@@ -113,7 +122,7 @@ class BufferedIterator extends Collection {
 			$this->_current = parent::current();
 			$this->_key = parent::key();
 			$this->_buffer->add($this->_index, [
-				'key' => $this->_index,
+				'key' => $this->_key,
 				'value' => $this->_current
 			]);
 		}
@@ -121,6 +130,11 @@ class BufferedIterator extends Collection {
 		return $valid;
 	}
 
+/**
+ * Advances the iterator pointer to the next element
+ *
+ * @return void
+ */
 	public function next() {
 		$this->_index++;
 		parent::next();

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Collection\Iterator;
+
+use Cake\Collection\Collection;
+use SplDoublyLinkedList;
+
+/**
+ * Creates an iterator from another iterator that will keep in memory the results
+ * from the inner iterator so they don't have to be calculated again.
+ */
+class BufferedIterator extends Collection {
+
+/**
+ * The in-memory cache containing results from previous iterators
+ *
+ * @var callable
+ */
+	protected $_buffer;
+
+/**
+ * Points to the next record number that should be fetched
+ *
+ * @var int
+ */
+	protected $_index = 0;
+
+/**
+ * Last record fetched from the inner iterator
+ *
+ * @var array
+ */
+	protected $_current;
+
+/**
+ * Last key obtained from the inner iterator
+ *
+ * @var array
+ */
+	protected $_key;
+
+	protected $_started = false;
+
+/**
+ * Maintains an in-memory cache of the results yielded by the internal
+ * iterator.
+ *
+ * @param array|\Traversable $items The items to be filtered.
+ */
+	public function __construct($items) {
+		$this->_buffer = new SplDoublyLinkedList;
+		parent::__construct($items);
+	}
+
+	public function key() {
+		return $this->_key;
+	}
+
+/**
+ * Returns the current record in the result iterator
+ *
+ * Part of Iterator interface.
+ *
+ * @return array|object
+ */
+	public function current() {
+		return $this->_current;
+	}
+
+/**
+ * Rewinds the collection
+ *
+ *
+ * @return void
+ */
+	public function rewind() {
+		if ($this->_index === 0 && !$this->_started) {
+			$this->_started = true;
+			parent::rewind();
+			return;
+		}
+
+		$this->_index = 0;
+	}
+
+/**
+ *
+ * @return mixed
+ */
+	public function valid() {
+		if ($this->_buffer->offsetExists($this->_index)) {
+			$current = $this->_buffer->offsetGet($this->_index);
+			$this->_current = $current['value'];
+			$this->_key = $current['key'];
+			return true;
+		}
+
+		$valid = parent::valid();
+
+		if ($valid) {
+			$this->_current = parent::current();
+			$this->_key = parent::key();
+			$this->_buffer->add($this->_index, [
+				'key' => $this->_index,
+				'value' => $this->_current
+			]);
+		}
+
+		return $valid;
+	}
+
+	public function next() {
+		$this->_index++;
+		parent::next();
+	}
+
+}

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -18,8 +18,8 @@ use Cake\Collection\Collection;
 use SplDoublyLinkedList;
 
 /**
- * Creates an iterator from another iterator that will keep in memory the results
- * from the inner iterator so they don't have to be calculated again.
+ * Creates an iterator from another iterator that will keep the results of the inner
+ * iterator in memory, so that results don't have to be re-calculated.
  */
 class BufferedIterator extends Collection {
 
@@ -60,7 +60,7 @@ class BufferedIterator extends Collection {
 	protected $_started = false;
 
 /**
- * Whether or not the internal iterator's has reached its end
+ * Whether or not the internal iterator has reached its end.
  *
  * @var boolean
  */

--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -18,9 +18,6 @@ use Cake\Collection\Collection;
 use Countable;
 use JsonSerializable;
 use Serializable;
-use IteratorIterator;
-use Cake\ORM\ResultSet;
-use Cake\Collection\Iterator\BufferedIterator;
 
 /**
  * Generic ResultSet decorator. This will make any traversable object appear to

--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -18,6 +18,9 @@ use Cake\Collection\Collection;
 use Countable;
 use JsonSerializable;
 use Serializable;
+use IteratorIterator;
+use Cake\ORM\ResultSet;
+use Cake\Collection\Iterator\BufferedIterator;
 
 /**
  * Generic ResultSet decorator. This will make any traversable object appear to

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -14,9 +14,11 @@
  */
 namespace Cake\Test\TestCase\Collection;
 
+use ArrayIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\TestSuite\TestCase;
+use NoRewindIterator;
 
 /**
  * CollectionTest
@@ -643,6 +645,19 @@ class CollectionTest extends TestCase {
 		$compiled = $collection->map($callable)->compile();
 		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $compiled->toArray());
 		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $compiled->toArray());
+	}
+
+/**
+ * Tests converting a non rewindable iterator into a rewindable one using
+ * the buffered method.
+ *
+ * @return void
+ */
+	public function testBuffered() {
+		$items = new NoRewindIterator(new ArrayIterator(['a' => 4, 'b' => 5, 'c' => 6]));
+		$buffered = (new Collection($items))->buffered();
+		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $buffered->toArray());
+		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $buffered->toArray());
 	}
 
 /**


### PR DESCRIPTION
Adds a new iterator meant to cache results from the iterator it wraps. This improves the `Collection::compile()` method by not fetching all elements immediately and will help me fix a nasty bug in the ORM ResultSet later on.
