### PR TITLE
Do not pluralize twice.

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -119,7 +119,7 @@ class TestFixture {
 			if (isset($matches[1])) {
 				$table = $matches[1];
 			}
-			$this->table = Inflector::tableize(Inflector::pluralize($table));
+			$this->table = Inflector::tableize($table);
 		}
 
 		if (empty($this->import) && !empty($this->fields)) {


### PR DESCRIPTION
Even though it doesn't seem to fix the inflection bug of https://github.com/cakephp/cakephp/issues/4685 there is no need to pluralize twice - as tableize() already does that internally:

```
$result = static::pluralize(static::underscore($className));
```

PS: I checked, and this is not an issue in 2.x - seems to be introduced in 3.0 only.
