### PR TITLE
Update TextHelper::autoParagraph() remove closing new line.

### DIFF
--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -251,6 +251,7 @@ class TextHelper extends AppHelper {
 				$text .= '<p>' . nl2br(trim($txt, "\n")) . "</p>\n";
 			}
 			$text = preg_replace('|<p>\s*</p>|', '', $text);
+			$text = trim($text);
 		}
 		return $text;
 	}


### PR DESCRIPTION
The additional trim() removes the last newline for better output control (e.g. the one past the last /p close tag).

RFC: Remove any /n from this methods (as it is better to not have white spaces in generated code that may or may not require special css treatment in some circumstances)
