### PR TITLE
Test if "Address"/"Addresses" inflects correct in general

### DIFF
--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -170,6 +170,7 @@ class InflectorTest extends TestCase {
 		$this->assertEquals(Inflector::singularize('body_curves'), 'body_curve');
 		$this->assertEquals(Inflector::singularize('metadata'), 'metadata');
 		$this->assertEquals(Inflector::singularize('files_metadata'), 'files_metadata');
+		$this->assertEquals(Inflector::singularize('addresses'), 'address');
 		$this->assertEquals(Inflector::singularize(''), '');
 	}
 
@@ -237,6 +238,7 @@ class InflectorTest extends TestCase {
 		$this->assertEquals(Inflector::pluralize('metadata'), 'metadata');
 		$this->assertEquals(Inflector::pluralize('files_metadata'), 'files_metadata');
 		$this->assertEquals(Inflector::pluralize('stadia'), 'stadia');
+		$this->assertEquals(Inflector::pluralize('Address'), 'Addresses');
 		$this->assertEquals(Inflector::pluralize(''), '');
 	}
 


### PR DESCRIPTION
There seem to be regressions for some not so uncommon inflections somehow.
Those pluralizations worked just fine in 2.x

```
Address => Addresses
```

see [here](http://sandbox.dereuromark.de/sandbox/inflector?string=Address)

Might have happened in one of the optimization commits along the road - https://github.com/cakephp/cakephp/commits/3.0/src/Utility/Inflector.php

Any takers?

Refs https://github.com/cakephp/cakephp/issues/4685

PS: This currently fails as expected.
