### PR TITLE
2.6 - Update - Components / AuthComponent.php

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -163,7 +163,7 @@ class AuthComponent extends Component {
  *
  * @var string
  */
-	public static $sessionKey = 'Auth.User';
+	public $sessionKey = 'Auth.User';
 
 /**
  * The current user, used for stateless authentication when


### PR DESCRIPTION
Removed the static definition intending to keep $this->Auth->sessionKey directly settable in Controllers as other Auth variables.
