### PR TITLE
Fix Hash::remove() removing data even if the path is not matched

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -1488,6 +1488,18 @@ class HashTest extends CakeTestCase {
 			)
 		);
 		$this->assertEquals($expected, $result);
+
+		$array = array(
+			0 => 'foo',
+			1 => array(
+				0 => 'baz'
+			)
+		);
+		$expected = $array;
+		$result = Hash::remove($array, '{n}.part');
+		$this->assertEquals($expected, $result);
+		$result = Hash::remove($array, '{n}.{n}.part');
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -355,7 +355,7 @@ class Hash {
 				if (empty($data[$k])) {
 					unset($data[$k]);
 				}
-			} elseif ($match) {
+			} elseif ($match && empty($nextPath)) {
 				unset($data[$k]);
 			}
 		}


### PR DESCRIPTION
I found an odd behavior with `Hash::remove()`.
Consider this sample of code :

``` php
$array = array(
    0 => 'foo',
    1 => array(
        0 => 'baz'
    )
);

$results = Hash::remove($array, '{n}.path');
debug($results);
```

I would expect `$results` to be exactly equal to `$array` as the path `'{n}.path'` does not exist in `$array`.
However, this outputs this array :

``` php
array(
    1 => array(
        0 => 'baz'
    )
);
```

`Hash::remove()` strips out the first value even if the path is not fully matched.
This PR provides a fix that prevents `Hash::remove()` from removing values in this scenario.
I know a `Hash::check($array, '{n}.path')` does the trick and should prevent this kind of thing from happening but I think this is an unexpected behavior (well at least, it is to me).
