### PR TITLE
Fix Memcached test, getMemcached() returns null when called before init

### DIFF
--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -360,6 +360,7 @@ class MemcachedEngineTest extends TestCase {
 			'password' => 'password'
 		);
 
+		$Memcached->setMemcached(new Memcached());
 		$this->skipIf(
 			method_exists($Memcached->getMemcached(), 'setSaslAuthData'),
 			'Memcached extension is installed with SASL support'


### PR DESCRIPTION
This lead to method_exists() always returning false.
