### PR TITLE
Correct method casing.

### DIFF
--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -191,7 +191,7 @@ class Time extends Carbon implements JsonSerializable {
 /**
  * Returns a UNIX timestamp.
  *
- * @return string Unix timestamp
+ * @return string UNIX timestamp
  */
 	public function toUnixString() {
 		return $this->format('U');

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -189,7 +189,7 @@ class TimeHelper extends Helper {
  */
 	public function toAtom($dateString, $timezone = null) {
 		$timezone = $timezone ?: date_default_timezone_get();
-		return (new Time($dateString))->timezone($timezone)->toATOMString();
+		return (new Time($dateString))->timezone($timezone)->toAtomString();
 	}
 
 /**
@@ -200,9 +200,9 @@ class TimeHelper extends Helper {
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
-	public function toRSS($dateString, $timezone = null) {
+	public function toRss($dateString, $timezone = null) {
 		$timezone = $timezone ?: date_default_timezone_get();
-		return (new Time($dateString))->timezone($timezone)->toRSSString();
+		return (new Time($dateString))->timezone($timezone)->toRssString();
 	}
 
 /**


### PR DESCRIPTION
Our method standards suggests using camelBacked for classes like Json and Xml.
Thus, these methods should also be called and documented this way.
What do you think?

Especially, since `toRSSString` looks really weird...

For the record: It would be even better if Carbon changed its method naming.
