### PR TITLE
Fixing memcached tests

### DIFF
--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -351,7 +351,7 @@ class MemcachedEngineTest extends TestCase {
  * @return void
  */
 	public function testSaslAuthException() {
-		$Memcached = new TestMemcachedEngine();
+		$MemcachedEngine = new TestMemcachedEngine();
 		$config = array(
 			'engine' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
@@ -360,16 +360,16 @@ class MemcachedEngineTest extends TestCase {
 			'password' => 'password'
 		);
 
-		$Memcached->setMemcached(new Memcached());
+		$Memcached = new Memcached();
 		$this->skipIf(
-			method_exists($Memcached->getMemcached(), 'setSaslAuthData'),
+			method_exists($Memcached, 'setSaslAuthData'),
 			'Memcached extension is installed with SASL support'
 		);
 
 		$this->setExpectedException(
 			'InvalidArgumentException', 'Memcached extension is not build with SASL support'
 		);
-		$Memcached->init($config);
+		$MemcachedEngine->init($config);
 	}
 
 /**


### PR DESCRIPTION
My previous attempt fixed it locally, but broke the travis builds. Now passing both locally(skipping this test) and on travis. The AppVeyor build did overwrite the travis fail, sorry for that.
