### PR TITLE
Always skip Mysql tests when not using Mysql for test connection.

### DIFF
--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -28,11 +28,12 @@ use \PDO;
 class MysqlTest extends TestCase {
 
 /**
- * Helper method for skipping tests that need a real connection.
+ * setup
  *
  * @return void
  */
-	protected function _needsConnection() {
+	public function setup() {
+		parent::setUp();
 		$config = Configure::read('Datasource.test');
 		$this->skipIf(strpos($config['datasource'], 'Mysql') === false, 'Not using Mysql for test config');
 	}


### PR DESCRIPTION
Removing unused method which was added in 34489502b082aa1199b160f57b197a50350c526f
Always skipping now, as the test fatals when having only pdo_sqlite.
