### PR TITLE
Deprecated tableize()

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -636,6 +636,7 @@ class Inflector {
  *
  * @param string $className Name of class to get database table name for
  * @return string Name of the database table for given class
+ * @deprecated 3.0.0 Use Inflector::underscore() instead.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/inflector.html#Inflector::tableize
  */
 	public static function tableize($className) {


### PR DESCRIPTION
I vote for deprecating this method in 3.0 beta and remove it in 3.0 stable.
Since the main usage in 2.x was from Singular ModelName to plural table_name, this was fine.
But now in 3.x the table classes are in plural and therefore this method does not really make much sense anymore and would/should simply be a wrapper for underscore().

We should rather use underscore() directly to go from table class (plural) to table name (also plural).
