### PR TITLE
Fix empty collections being treated as EntityContext.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -16,6 +16,7 @@ namespace Cake\View\Helper;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
+use Cake\Collection\Collection;
 use Cake\ORM\Entity;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -216,11 +217,16 @@ class FormHelper extends Helper {
 		});
 
 		$this->addContextProvider('orm', function ($request, $data) {
-			if (
-				$data['entity'] instanceof Entity ||
-				$data['entity'] instanceof Traversable ||
-				(is_array($data['entity']) && !isset($data['entity']['schema']))
-			) {
+			if (is_array($data['entity']) || $data['entity'] instanceof Traversable) {
+				$pass = (new Collection($data['entity']))->first() !== null;
+				if ($pass) {
+					return new EntityContext($request, $data);
+				}
+			}
+			if ($data['entity'] instanceof Entity) {
+				return new EntityContext($request, $data);
+			}
+			if (is_array($data['entity']) && empty($data['entity']['schema'])) {
 				return new EntityContext($request, $data);
 			}
 		});

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -272,6 +272,9 @@ class FormHelperTest extends TestCase {
 	public function contextSelectionProvider() {
 		$entity = new Article();
 		$collection = $this->getMock('Cake\Collection\Collection', ['extract'], [[$entity]]);
+		$emptyCollection = new Collection([]);
+		$emptyArray = [];
+		$arrayObject = new \ArrayObject([]);
 		$data = [
 			'schema' => [
 				'title' => ['type' => 'string']
@@ -281,7 +284,9 @@ class FormHelperTest extends TestCase {
 		return [
 			'entity' => [$entity, 'Cake\View\Form\EntityContext'],
 			'collection' => [$collection, 'Cake\View\Form\EntityContext'],
+			'empty_collection' => [$emptyCollection, 'Cake\View\Form\NullContext'],
 			'array' => [$data, 'Cake\View\Form\ArrayContext'],
+			'array_object' => [$arrayObject, 'Cake\View\Form\NullContext'],
 			'none' => [null, 'Cake\View\Form\NullContext'],
 			'false' => [false, 'Cake\View\Form\NullContext'],
 		];


### PR DESCRIPTION
An empty collection should not fall into the EntityContext as it will cause errors downstream. Instead of just sniffing against Travserable, using a temporary Collection to access the first element will give a better test of what is in an object/array.

Fixes #4698
