### PR TITLE
3.0 - Change default request data to empty array instead of null in IntegrationTestCase

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -240,7 +240,7 @@ abstract class IntegrationTestCase extends TestCase {
  * @param array|null $data The request data.
  * @return void
  */
-	protected function _sendRequest($url, $method, $data = null) {
+	protected function _sendRequest($url, $method, $data = []) {
 		$request = $this->_buildRequest($url, $method, $data);
 		$response = new Response();
 		$dispatcher = DispatcherFactory::create();


### PR DESCRIPTION
Having the default set to null causes Hash::get() errors in Request::data().
