### PR TITLE
Flush TableRegistry when generating controllers/models.

### DIFF
--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -67,6 +67,7 @@ class ControllerTask extends BakeTask {
  */
 	public function all() {
 		foreach ($this->listAll() as $table) {
+			TableRegistry::clear();
 			$this->main($table);
 		}
 	}

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -129,6 +129,7 @@ class ModelTask extends BakeTask {
 			if (in_array($table, $this->skipTables)) {
 				continue;
 			}
+			TableRegistry::clear();
 			$this->main($table);
 		}
 	}


### PR DESCRIPTION
Because tests will attach any and all associations, we need to flush the registry in all() commands. This flushes out belongsToMany associations that have also generated hasMany associations to their parent tables.

Refs #4143
