### PR TITLE
3.0 - Remove empty files for test and plugin bakes

### DIFF
--- a/src/Shell/Task/PluginTask.php
+++ b/src/Shell/Task/PluginTask.php
@@ -138,6 +138,8 @@ class PluginTask extends BakeTask {
 			$out .= "class AppController extends BaseController {\n\n";
 			$out .= "}\n";
 			$this->createFile($this->path . $plugin . DS . $classBase . DS . 'Controller' . DS . $controllerFileName, $out);
+			$emptyFile = $this->path  . 'empty';
+			$this->_deleteEmptyFile($emptyFile);
 
 			$hasAutoloader = $this->_modifyAutoloader($plugin, $this->path);
 			$this->_generateRoutes($plugin, $this->path);

--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -209,6 +209,8 @@ class TestTask extends BakeTask {
 		$out = $this->Template->generate('classes', 'test');
 
 		$filename = $this->testCaseFileName($type, $fullClassName);
+		$emptyFile = $this->getPath() . $this->getSubspacePath($type) . DS . 'empty';
+		$this->_deleteEmptyFile($emptyFile);
 		if ($this->createFile($filename, $out)) {
 			return $out;
 		}
@@ -270,6 +272,22 @@ class TestTask extends BakeTask {
 			$class .= $suffix;
 		}
 		return $namespace . '\\' . $subSpace . '\\' . $class;
+	}
+
+/**
+ * Gets the subspace path for a test.
+ *
+ * @param string $type The Type of object you are generating tests for eg. controller.
+ * @return string Path of the subspace.
+ */
+	public function getSubspacePath($type) {
+		$namespace = Configure::read('App.namespace');
+		if ($this->plugin) {
+			$namespace = $this->plugin;
+		}
+		$suffix = $this->classSuffixes[strtolower($type)];
+		$subspace = $this->mapType($type);
+		return str_replace('\\', DS, $subspace);
 	}
 
 /**


### PR DESCRIPTION
Follow up to https://github.com/cakephp/cakephp/pull/4523. This removes empty files after Test (Behavior, Component, Helper) and Plugin bakes.
