### PR TITLE
Fix additional, pointless and sometimes harmful inflections.

### DIFF
--- a/src/Core/ConventionsTrait.php
+++ b/src/Core/ConventionsTrait.php
@@ -24,16 +24,6 @@ use Cake\Utility\Inflector;
 trait ConventionsTrait {
 
 /**
- * Creates the proper controller plural name for the specified controller class name
- *
- * @param string $name Controller class name
- * @return string Controller plural name
- */
-	protected function _controllerName($name) {
-		return Inflector::pluralize(Inflector::camelize($name));
-	}
-
-/**
  * Creates a fixture name
  *
  * @param string $name Model class name
@@ -41,16 +31,6 @@ trait ConventionsTrait {
  */
 	protected function _fixtureName($name) {
 		return Inflector::underscore($name);
-	}
-
-/**
- * Creates the proper model camelized name (plural) for the specified name
- *
- * @param string $name Name
- * @return string Camelized and plural model name
- */
-	protected function _modelName($name) {
-		return Inflector::pluralize(Inflector::camelize($name));
 	}
 
 /**
@@ -81,7 +61,7 @@ trait ConventionsTrait {
  */
 	protected function _modelNameFromKey($key) {
 		$key = str_replace('_id', '', $key);
-		return $this->_modelName($key);
+		return Inflector::pluralize(Inflector::classify($key));
 	}
 
 /**

--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -213,7 +213,7 @@ class BakeShell extends Shell {
 			$this->{$task}->connection = $this->connection;
 		}
 
-		$name = $this->_modelName($name);
+		$name = $this->_camelize($name);
 
 		$this->Model->bake($name);
 		$this->Controller->bake($name);

--- a/src/Shell/Task/ControllerTask.php
+++ b/src/Shell/Task/ControllerTask.php
@@ -51,12 +51,12 @@ class ControllerTask extends BakeTask {
 		if (empty($name)) {
 			$this->out('Possible controllers based on your current database:');
 			foreach ($this->listAll() as $table) {
-				$this->out('- ' . $this->_controllerName($table));
+				$this->out('- ' . $this->_camelize($table));
 			}
 			return true;
 		}
 
-		$controller = $this->_controllerName($name);
+		$controller = $this->_camelize($name);
 		$this->bake($controller);
 	}
 

--- a/src/Shell/Task/FixtureTask.php
+++ b/src/Shell/Task/FixtureTask.php
@@ -101,7 +101,7 @@ class FixtureTask extends BakeTask {
 		if (empty($name)) {
 			$this->out('Choose a fixture to bake from the following:');
 			foreach ($this->Model->listAll() as $table) {
-				$this->out('- ' . $this->_modelName($table));
+				$this->out('- ' . $this->_camelize($table));
 			}
 			return true;
 		}
@@ -110,7 +110,7 @@ class FixtureTask extends BakeTask {
 		if (isset($this->params['table'])) {
 			$table = $this->params['table'];
 		}
-		$model = $this->_modelName($name);
+		$model = $this->_camelize($name);
 		$this->bake($model, $table);
 	}
 

--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -81,12 +81,12 @@ class ModelTask extends BakeTask {
 		if (empty($name)) {
 			$this->out('Choose a model to bake from the following:');
 			foreach ($this->listAll() as $table) {
-				$this->out('- ' . $this->_modelName($table));
+				$this->out('- ' . $this->_camelize($table));
 			}
 			return true;
 		}
 
-		$this->bake($this->_modelName($name));
+		$this->bake($this->_camelize($name));
 	}
 
 /**
@@ -263,7 +263,7 @@ class ModelTask extends BakeTask {
 		$foreignKey = $this->_modelKey($tableName);
 
 		foreach ($this->listAll() as $otherTable) {
-			$otherModel = $this->getTableObject($this->_modelName($otherTable), $otherTable);
+			$otherModel = $this->getTableObject($this->_camelize($otherTable), $otherTable);
 			$otherSchema = $otherModel->schema();
 
 			// Exclude habtm join tables.
@@ -323,7 +323,7 @@ class ModelTask extends BakeTask {
 				$assocTable = substr($otherTable, 0, $otherOffset);
 			}
 			if ($assocTable && in_array($assocTable, $tables)) {
-				$habtmName = $this->_modelName($assocTable);
+				$habtmName = $this->_camelize($assocTable);
 				$assoc = [
 					'alias' => $habtmName,
 					'foreignKey' => $foreignKey,
@@ -549,7 +549,7 @@ class ModelTask extends BakeTask {
 		$counterCache = [];
 		foreach ($belongsTo['belongsTo'] as $otherTable) {
 			$otherAlias = $otherTable['alias'];
-			$otherModel = $this->getTableObject($this->_modelName($otherAlias), Inflector::underscore($otherAlias));
+			$otherModel = $this->getTableObject($this->_camelize($otherAlias), Inflector::underscore($otherAlias));
 
 			try {
 				$otherSchema = $otherModel->schema();
@@ -665,7 +665,7 @@ class ModelTask extends BakeTask {
 		$this->_modelNames = [];
 		$this->_tables = $this->_getAllTables();
 		foreach ($this->_tables as $table) {
-			$this->_modelNames[] = $this->_modelName($table);
+			$this->_modelNames[] = $this->_camelize($table);
 		}
 		return $this->_tables;
 	}
@@ -709,7 +709,7 @@ class ModelTask extends BakeTask {
 		if (isset($this->params['table'])) {
 			return $this->params['table'];
 		}
-		return Inflector::tableize($name);
+		return Inflector::underscore($name);
 	}
 
 /**

--- a/src/Shell/Task/ViewTask.php
+++ b/src/Shell/Task/ViewTask.php
@@ -108,7 +108,7 @@ class ViewTask extends BakeTask {
 			$this->out('Possible tables to bake views for based on your current database:');
 			$this->Model->connection = $this->connection;
 			foreach ($this->Model->listAll() as $table) {
-				$this->out('- ' . $this->_controllerName($table));
+				$this->out('- ' . $this->_camelize($table));
 			}
 			return true;
 		}
@@ -149,7 +149,7 @@ class ViewTask extends BakeTask {
  * @return void
  */
 	public function model($table) {
-		$tableName = $this->_controllerName($table);
+		$tableName = $this->_camelize($table);
 		$plugin = null;
 		if (!empty($this->params['plugin'])) {
 			$plugin = $this->params['plugin'] . '.';
@@ -165,7 +165,7 @@ class ViewTask extends BakeTask {
  * @return void
  */
 	public function controller($table, $controller = null) {
-		$tableName = $this->_controllerName($table);
+		$tableName = $this->_camelize($table);
 		if (empty($controller)) {
 			$controller = $tableName;
 		}

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -91,7 +91,7 @@ class BakeShellTest extends TestCase {
 
 		$this->Shell->connection = '';
 		$this->Shell->params = [];
-		$this->Shell->all('Comment');
+		$this->Shell->all('Comments');
 	}
 
 /**

--- a/tests/TestCase/Shell/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Shell/Task/ControllerTaskTest.php
@@ -325,7 +325,7 @@ class ControllerTaskTest extends TestCase {
  */
 	public static function nameVariations() {
 		return array(
-			array('BakeArticles'), array('BakeArticle'), array('bake_article'), array('bake_articles')
+			array('BakeArticles'), array('bake_articles')
 		);
 	}
 

--- a/tests/TestCase/Shell/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Shell/Task/FixtureTaskTest.php
@@ -150,7 +150,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains("public \$table = 'comments';"));
 
-		$this->Task->main('article');
+		$this->Task->main('articles');
 	}
 
 /**
@@ -168,7 +168,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('class ArticlesFixture'));
 
-		$this->Task->main('TestPlugin.Article');
+		$this->Task->main('TestPlugin.Articles');
 	}
 
 /**
@@ -280,7 +280,7 @@ class FixtureTaskTest extends TestCase {
 				$this->stringContains('public $records'),
 				$this->logicalNot($this->stringContains('public $import'))
 			));
-		$result = $this->Task->main('Article');
+		$result = $this->Task->main('Articles');
 	}
 
 /**

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -124,9 +124,6 @@ class ModelTaskTest extends TestCase {
  * @return void
  */
 	public function testGetTable() {
-		$result = $this->Task->getTable('BakeArticle');
-		$this->assertEquals('bake_articles', $result);
-
 		$result = $this->Task->getTable('BakeArticles');
 		$this->assertEquals('bake_articles', $result);
 
@@ -1008,7 +1005,7 @@ class ModelTaskTest extends TestCase {
  */
 	public static function nameVariations() {
 		return array(
-			array('BakeArticles'), array('BakeArticle'), array('bake_article'), array('bake_articles')
+			array('BakeArticles'), array('bake_articles')
 		);
 	}
 

--- a/tests/TestCase/Shell/Task/ViewTaskTest.php
+++ b/tests/TestCase/Shell/Task/ViewTaskTest.php
@@ -226,7 +226,7 @@ class ViewTaskTest extends TestCase {
 		$this->assertEquals('Articles', $this->Task->modelName);
 
 		$this->Task->model('NotThere');
-		$this->assertEquals('NotTheres', $this->Task->modelName);
+		$this->assertEquals('NotThere', $this->Task->modelName);
 	}
 
 /**
@@ -629,7 +629,7 @@ class ViewTaskTest extends TestCase {
  * @return void
  */
 	public static function nameVariations() {
-		return [['ViewTaskComments'], ['ViewTaskComment'], ['view_task_comment']];
+		return [['ViewTaskComments'], ['view_task_comments']];
 	}
 
 /**


### PR DESCRIPTION
Since CakePHP 3.0's conventions are that most things are plural, we don't need to be pluralizing things as people will be thinking in terms of plural forms. Removing this code from bake makes it much easier to accomodate names like menus without incorrectly inflecting them.

Fixes #4647
