### PR TITLE
Fix timeAgo Timezones problem

### DIFF
--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -278,8 +278,7 @@ class Time extends Carbon implements JsonSerializable {
 		}
 
 		if ($diff > abs($now - (new static($end))->format('U'))) {
-			$absoluteTime = new static($inSeconds);
-			return sprintf($absoluteString, $absoluteTime->i18nFormat($format));
+			return sprintf($absoluteString, $this->i18nFormat($format));
 		}
 
 		// If more than a week, then take into account the length of months


### PR DESCRIPTION
There was problem when setting    `date_default_timezone_set()` in `bootstrap.php`, because previous solution was recreating the time object from seconds which were in UTC. It is simplier to just use `$this` instead.
