### PR TITLE
3.0 fix translate

### DIFF
--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -173,6 +173,7 @@ class TranslateBehavior extends Behavior {
 		$options['associated'] = $newOptions + $options['associated'];
 
 		$this->_bundleTranslatedFields($entity);
+		$bundled = $entity->get('_i18n') ?: [];
 
 		if ($locale === $this->config('defaultLocale')) {
 			return;
@@ -204,7 +205,7 @@ class TranslateBehavior extends Behavior {
 			]);
 		}
 
-		$entity->set('_i18n', array_values($modified + $new));
+		$entity->set('_i18n', array_merge($bundled, array_values($modified + $new)));
 		$entity->set('_locale', $locale, ['setter' => false]);
 		$entity->dirty('_locale', false);
 

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -224,20 +224,12 @@ trait SelectableAssociationTrait {
 			$filterQuery->offset(null);
 		}
 
-		$joins = $filterQuery->join();
-		foreach ($joins as $i => $join) {
-			if (strtolower($join['type']) !== 'inner') {
-				unset($joins[$i]);
-			}
-		}
-
 		$keys = (array)$query->repository()->primaryKey();
 
 		if ($this->type() === $this::MANY_TO_ONE) {
 			$keys = (array)$this->foreignKey();
 		}
 
-		$filterQuery->join($joins, [], true);
 		$fields = $query->aliasFields($keys);
 		return $filterQuery->select($fields, true);
 	}

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -18,9 +18,18 @@ use Cake\Collection\Collection;
 use Cake\Event\Event;
 use Cake\I18n\I18n;
 use Cake\Model\Behavior\TranslateBehavior;
+use Cake\Model\Behavior\Translate\TranslateTrait;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+
+/**
+ * Stub entity class
+ */
+class Article extends Entity {
+
+	use TranslateTrait;
+}
 
 /**
  * Translate behavior test case
@@ -756,6 +765,33 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertCount(3, $all);
 		$article = $all->first();
 		$this->assertNotEmpty($article->get('_translations'));
+	}
+
+/**
+ * Tests that multiple translations saved when having a default locale
+ * are correclty saved
+ *
+ * @return void
+ */
+	public function testSavingWithNonDefaultLocale() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->entityClass(__NAMESPACE__ . '\Article');
+		I18n::locale('fra');
+		$translations = [
+			'fra' => ['title' => 'Un article'],
+			'spa' => ['title' => 'Un artículo']
+		];
+
+		$article = $table->get(1);
+		foreach ($translations as $lang => $data) {
+			$article->translation($lang)->set($data, ['guard' => false]);
+		}
+
+		$table->save($article);
+		$article = $table->find('translations')->where(['Articles.id' => 1])->first();
+		$this->assertEquals('Un article', $article->translation('fra')->title);
+		$this->assertEquals('Un artículo', $article->translation('spa')->title);
 	}
 
 }


### PR DESCRIPTION
Fixes #4726 and remove the magic left join removal for the subquery strategy.

The joins were being removed previously as a way to generate smaller queries under the assumption that they would not affect the final result, but @AD7six  figured out that would not always be the case.
