### PR TITLE
Implementing ability to use a custom join type in contain

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -432,6 +432,7 @@ abstract class Association {
  * - propertyPath: A dot separated string representing the path of association
  *   properties to be followed from the passed query main entity to this
  *   association
+ * - joinType: The SQL join type to use in the query.
  *
  * @param Query $query the query to be altered to include the target table data
  * @param array $options Any extra options or overrides to be taken in account
@@ -441,12 +442,13 @@ abstract class Association {
  */
 	public function attachTo(Query $query, array $options = []) {
 		$target = $this->target();
+		$joinType = empty($options['joinType']) ? $this->joinType() : $options['joinType'];
 		$options += [
 			'includeFields' => true,
 			'foreignKey' => $this->foreignKey(),
 			'conditions' => [],
 			'fields' => [],
-			'type' => empty($options['matching']) ? $this->joinType() : 'INNER',
+			'type' => empty($options['matching']) ? $joinType : 'INNER',
 			'table' => $target->table(),
 			'finder' => $this->finder()
 		];

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -58,7 +58,8 @@ class EagerLoader {
 		'sort' => 1,
 		'matching' => 1,
 		'queryBuilder' => 1,
-		'finder' => 1
+		'finder' => 1,
+		'joinType' => 1
 	];
 
 /**
@@ -93,6 +94,7 @@ class EagerLoader {
  * - queryBuilder: Equivalent to passing a callable instead of an options array
  * - matching: Whether to inform the association class that it should filter the
  *  main query by the results fetched by that class.
+ * - joinType: For joinable associations, the SQL join type to use.
  *
  * @param array|string $associations list of table aliases to be queried.
  * When this method is called multiple times it will merge previous list with

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2152,4 +2152,26 @@ class QueryTest extends TestCase {
 		$this->assertEquals($authorId, $resultWithAuthor->first()['author']['id']);
 	}
 
+/**
+ * Tests that it is possible to pass a custom join type for an association when
+ * using contain
+ *
+ * @return void
+ */
+	public function testContainWithCustomJoinType() {
+		$table = TableRegistry::get('Articles');
+		$table->belongsTo('Authors');
+
+		$articles = $table->find()
+			->contain([
+				'Authors' => [
+					'joinType' => 'inner',
+					'conditions' => ['Authors.id' => 3]
+				]
+			])
+			->toArray();
+		$this->assertCount(1, $articles);
+		$this->assertEquals(3, $articles[0]->author->id);
+	}
+
 }


### PR DESCRIPTION
This helps overriding association settings without setting state
in the association classes.

Will be used for implementing a feature request in TranslateBehavior
