### PR TITLE
Fix risky tests

### DIFF
--- a/tests/TestCase/Routing/Filter/AssetFilterTest.php
+++ b/tests/TestCase/Routing/Filter/AssetFilterTest.php
@@ -224,6 +224,7 @@ class AssetFilterTest extends TestCase {
 		$request = new Request($url);
 		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
 
+		ob_start();
 		$filter->beforeDispatch($event);
 		$result = ob_get_contents();
 		ob_end_clean();

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -37,6 +37,7 @@ class TestCaseTest extends TestCase {
 	public function testAssertHtmlBasic() {
 		$test = new AssertHtmlTestCase('testAssertHtmlQuotes');
 		$result = $test->run();
+		ob_start();
 		$this->assertEquals(0, $result->errorCount());
 		$this->assertTrue($result->wasSuccessful());
 		$this->assertEquals(0, $result->failureCount());
@@ -128,6 +129,7 @@ class TestCaseTest extends TestCase {
 	public function testNumericValuesInExpectationForAssertHtml() {
 		$test = new AssertHtmlTestCase('testNumericValuesInExpectationForAssertHtml');
 		$result = $test->run();
+		ob_start();
 		$this->assertEquals(0, $result->errorCount());
 		$this->assertTrue($result->wasSuccessful());
 		$this->assertEquals(0, $result->failureCount());
@@ -141,12 +143,14 @@ class TestCaseTest extends TestCase {
 	public function testBadAssertHtml() {
 		$test = new AssertHtmlTestCase('testBadAssertHtml');
 		$result = $test->run();
+		ob_start();
 		$this->assertEquals(0, $result->errorCount());
 		$this->assertFalse($result->wasSuccessful());
 		$this->assertEquals(1, $result->failureCount());
 
 		$test = new AssertHtmlTestCase('testBadAssertHtml2');
 		$result = $test->run();
+		ob_start();
 		$this->assertEquals(0, $result->errorCount());
 		$this->assertFalse($result->wasSuccessful());
 		$this->assertEquals(1, $result->failureCount());
@@ -165,6 +169,8 @@ class TestCaseTest extends TestCase {
 		$test->fixtureManager = $manager;
 		$manager->expects($this->once())->method('loadSingle');
 		$result = $test->run();
+		ob_start();
+
 		$this->assertEquals(0, $result->errorCount());
 	}
 
@@ -176,10 +182,12 @@ class TestCaseTest extends TestCase {
 	public function testSkipIf() {
 		$test = new FixturizedTestCase('testSkipIfTrue');
 		$result = $test->run();
+		ob_start();
 		$this->assertEquals(1, $result->skippedCount());
 
 		$test = new FixturizedTestCase('testSkipIfFalse');
 		$result = $test->run();
+		ob_start();
 		$this->assertEquals(0, $result->skippedCount());
 	}
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1475,23 +1475,33 @@ class ViewTest extends TestCase {
 /**
  * Test that starting the same block twice throws an exception
  *
- * @expectedException \Cake\Core\Exception\Exception
  * @return void
  */
 	public function testStartBlocksTwice() {
-		$this->View->start('first');
-		$this->View->start('first');
+		try {
+			$this->View->start('first');
+			$this->View->start('first');
+			$this->fail('No exception');
+		} catch (\Cake\Core\Exception\Exception $e) {
+			ob_end_clean();
+			$this->assertTrue(true);
+		}
 	}
 
 /**
  * Test that an exception gets thrown when you leave a block open at the end
  * of a view.
  *
- * @expectedException \LogicException
  * @return void
  */
 	public function testExceptionOnOpenBlock() {
-		$this->View->render('open_block');
+		try {
+			$this->View->render('open_block');
+			$this->fail('No exception');
+		} catch (\LogicException $e) {
+			ob_end_clean();
+			$this->assertContains('The "no_close" block was left open', $e->getMessage());
+		}
 	}
 
 /**
@@ -1514,23 +1524,32 @@ TEXT;
 /**
  * Make sure that extending the current view with itself causes an exception
  *
- * @expectedException LogicException
  * @return void
  */
 	public function testExtendSelf() {
-		$this->View->layout = false;
-		$this->View->render('extend_self');
+		try {
+			$this->View->layout = false;
+			$this->View->render('extend_self');
+			$this->fail('No exception');
+		} catch (\LogicException $e) {
+			ob_end_clean();
+			$this->assertContains('cannot have views extend themselves', $e->getMessage());
+		}
 	}
 
 /**
  * Make sure that extending in a loop causes an exception
  *
- * @expectedException LogicException
  * @return void
  */
 	public function testExtendLoop() {
-		$this->View->layout = false;
-		$this->View->render('extend_loop');
+		try {
+			$this->View->layout = false;
+			$this->View->render('extend_loop');
+		} catch (\LogicException $e) {
+			ob_end_clean();
+			$this->assertContains('cannot have views extend in a loop', $e->getMessage());
+		}
 	}
 
 /**
@@ -1554,12 +1573,18 @@ TEXT;
 /**
  * Extending an element which doesn't exist should throw a missing view exception
  *
- * @expectedException LogicException
  * @return void
  */
 	public function testExtendMissingElement() {
-		$this->View->layout = false;
-		$this->View->render('extend_missing_element');
+		try {
+			$this->View->layout = false;
+			$this->View->render('extend_missing_element');
+			$this->fail('No exception');
+		} catch (\LogicException $e) {
+			ob_end_clean();
+			ob_end_clean();
+			$this->assertContains('element', $e->getMessage());
+		}
 	}
 
 /**

--- a/tests/test_app/Plugin/Company/TestPluginThree/webroot/css/company.css
+++ b/tests/test_app/Plugin/Company/TestPluginThree/webroot/css/company.css
@@ -1,0 +1,1 @@
+/* company.css */


### PR DESCRIPTION
Fix the various tests that were failing as 'risky' in the past. Most are related to PHPUnit being very picky about output buffering levels these days.
