### PR TITLE
Change default replacement for Inflector::slug().

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -679,7 +679,7 @@ class Inflector {
 	}
 
 /**
- * Returns a string with all spaces converted to underscores (by default), accented
+ * Returns a string with all spaces converted to dashes (by default), accented
  * characters converted to non-accented characters, and non word characters removed.
  *
  * @param string $string the string you want to slug
@@ -687,7 +687,7 @@ class Inflector {
  * @return string
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/inflector.html#Inflector::slug
  */
-	public static function slug($string, $replacement = '_') {
+	public static function slug($string, $replacement = '-') {
 		$quotedReplacement = preg_quote($replacement, '/');
 
 		$map = array(

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1133,7 +1133,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testCallBehaviorMethod() {
 		$table = TableRegistry::get('article');
 		$table->addBehavior('Sluggable');
-		$this->assertEquals('some_value', $table->slugify('some value'));
+		$this->assertEquals('some-value', $table->slugify('some value'));
 	}
 
 /**
@@ -1144,7 +1144,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testCallBehaviorAliasedMethod() {
 		$table = TableRegistry::get('article');
 		$table->addBehavior('Sluggable', ['implementedMethods' => ['wednesday' => 'slugify']]);
-		$this->assertEquals('some_value', $table->wednesday('some value'));
+		$this->assertEquals('some-value', $table->wednesday('some value'));
 	}
 
 /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -249,18 +249,18 @@ class InflectorTest extends TestCase {
  */
 	public function testInflectorSlug() {
 		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more');
-		$expected = 'Foo_Bar_Not_just_for_breakfast_any_more';
-		$this->assertEquals($expected, $result);
-
-		$result = Inflector::slug('this/is/a/path');
-		$expected = 'this_is_a_path';
-		$this->assertEquals($expected, $result);
-
-		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more', "-");
 		$expected = 'Foo-Bar-Not-just-for-breakfast-any-more';
 		$this->assertEquals($expected, $result);
 
-		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more', "+");
+		$result = Inflector::slug('this/is/a/path');
+		$expected = 'this-is-a-path';
+		$this->assertEquals($expected, $result);
+
+		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '_');
+		$expected = 'Foo_Bar_Not_just_for_breakfast_any_more';
+		$this->assertEquals($expected, $result);
+
+		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '+');
 		$expected = 'Foo+Bar+Not+just+for+breakfast+any+more';
 		$this->assertEquals($expected, $result);
 
@@ -293,7 +293,7 @@ class InflectorTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('controller/action/りんご/1');
-		$expected = 'controller_action_りんご_1';
+		$expected = 'controller-action-りんご-1';
 		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('の話が出たので大丈夫かなあと');
@@ -301,11 +301,11 @@ class InflectorTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('posts/view/한국어/page:1/sort:asc');
-		$expected = 'posts_view_한국어_page_1_sort_asc';
+		$expected = 'posts-view-한국어-page-1-sort-asc';
 		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug("non\xc2\xa0breaking\xc2\xa0space");
-		$this->assertEquals('non_breaking_space', $result);
+		$this->assertEquals('non-breaking-space', $result);
 	}
 
 /**
@@ -330,7 +330,7 @@ class InflectorTest extends TestCase {
 	public function testInflectorSlugWithMap() {
 		Inflector::rules('transliteration', array('r' => '1'));
 		$result = Inflector::slug('replace every r');
-		$expected = '1eplace_eve1y_1';
+		$expected = '1eplace-eve1y-1';
 		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('replace every r', '_');
@@ -490,13 +490,13 @@ class InflectorTest extends TestCase {
  * @return void
  */
 	public function testCustomTransliterationRule() {
-		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing_ae_o_a');
+		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing-ae-o-a');
 
 		Inflector::rules('transliteration', array('å' => 'aa', 'ø' => 'oe'));
-		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing_ae_oe_aa');
+		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing-ae-oe-aa');
 
 		Inflector::rules('transliteration', array('æ' => 'ae', 'å' => 'aa'), true);
-		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing_ae_ø_aa');
+		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing-ae-ø-aa');
 	}
 
 /**


### PR DESCRIPTION
Use dash instead of underscore.

> We recommend that you use hyphens (-) instead of underscores (_) in your URLs.

[Source](https://support.google.com/webmasters/answer/76329?hl=en).

Majority of the sites use dash for slugs.
