### PR TITLE
Remove unused constant.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,7 +34,6 @@ define('CAKE', CORE_PATH . 'src' . DS);
 define('CORE_TESTS', CORE_PATH . 'tests' . DS);
 define('CORE_TEST_CASES', CORE_TESTS . 'TestCase');
 define('TEST_APP', CORE_TESTS . 'test_app' . DS);
-define('LOG_ERROR', LOG_ERR);
 
 // Point app constants to the test app.
 define('APP', TEST_APP . 'TestApp' . DS);


### PR DESCRIPTION
This constant has no other uses in cakephp/cakephp or in cakephp/app. I'm pretty sure it is entirely unused at this point.
