### PR TITLE
3.0 add cakephp-codesniffer to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 		"psr/log": "1.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "*"
+		"phpunit/phpunit": "*",
+		"cakephp/cakephp-codesniffer": "dev-master"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*",
-		"cakephp/cakephp-codesniffer": "dev-master"
+		"cakephp/cakephp-codesniffer": "*"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
This is a good way to easily check for cs with PHP standard without the overhead of using pear.

it allows to use `vendor/bin/phpcs --standard=CakePHP` as stated [here](https://github.com/cakephp/cakephp-codesniffer).

Also easier in my opinion to keep up to date with latest changes.
