### PR TITLE
3.0 extract schema cache

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -21,6 +21,8 @@ use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\Query;
+use Cake\Database\Schema\CachedCollection;
+use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\ValueBinder;
 
 /**
@@ -80,6 +82,13 @@ class Connection {
  * @var QueryLogger
  */
 	protected $_logger = null;
+
+/**
+ * The schema collection object
+ *
+ * @var \Cake\Database\Schema\Collection
+ */
+	protected $_schemaCollection;
 
 /**
  * Constructor.
@@ -280,12 +289,25 @@ class Connection {
 	}
 
 /**
- * Get a Schema\Collection object for this connection.
+ * Gets or sets a Schema\Collection object for this connection.
  *
+ * @param \Cake\Database\Schema\Collection $collection The schema collection object
  * @return \Cake\Database\Schema\Collection
  */
-	public function schemaCollection() {
-		return new \Cake\Database\Schema\Collection($this);
+	public function schemaCollection(SchemaCollection $collection = null) {
+		if ($collection !== null) {
+			return $this->_schemaCollection = $collection;
+		}
+
+		if ($this->_schemaCollection !== null) {
+			return $this->_schemaCollection;
+		}
+
+		if (!empty($this->_config['cacheMetadata'])) {
+			return $this->_schemaCollection = new CachedCollection($this, $this->_config['cacheMetadata']);
+		}
+
+		return $this->_schemaCollection = new SchemaCollection($this);
 	}
 
 /**
@@ -584,6 +606,7 @@ class Connection {
  * @return void
  */
 	public function cacheMetadata($cache) {
+		$this->_schemaCollection = null;
 		$this->_config['cacheMetadata'] = $cache;
 	}
 

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -36,7 +36,7 @@ class CachedCollection extends Collection {
  * Constructor.
  *
  * @param \Cake\Database\Connection $connection The connection instance.
- * @param string|boolean The cache key or boolean false to disable caching.
+ * @param string|bool $cacheKey The cache key or boolean false to disable caching.
  */
 	public function __construct(Connection $connection, $cacheKey = true) {
 		parent::__construct($connection);

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Schema;
+
+use Cake\Cache\Cache;
+use Cake\Database\Connection;
+use Cake\Database\Schema\Collection;
+
+/**
+ * Extends the schema collection class to provide caching
+ *
+ */
+class CachedCollection extends Collection {
+
+/**
+ * The name of the cache config key to use for caching table metadata,
+ * of false if disabled.
+ *
+ * @var string|bool
+ */
+	protected $_cache = false;
+
+/**
+ * Constructor.
+ *
+ * @param \Cake\Database\Connection $connection The connection instance.
+ * @param string|boolean The cache key or boolean false to disable caching.
+ */
+	public function __construct(Connection $connection, $cacheKey = true) {
+		parent::__construct($connection);
+		$this->cacheMetadata($cacheKey);
+	}
+
+/**
+ * {@inheritDoc}
+ *
+ */
+	public function describe($name, array $options = []) {
+		$options += ['forceRefresh' => false];
+		$cacheConfig = $this->cacheMetadata();
+		$cacheKey = $this->cacheKey($name);
+
+		if (!empty($cacheConfig) && !$options['forceRefresh']) {
+			$cached = Cache::read($cacheKey, $cacheConfig);
+			if ($cached !== false) {
+				return $cached;
+			}
+		}
+
+		$table = parent::describe($name, $options);
+
+		if (!empty($cacheConfig)) {
+			Cache::write($cacheKey, $table, $cacheConfig);
+		}
+
+		return $table;
+	}
+
+/**
+ * Get the cache key for a given name.
+ *
+ * @param string $name The name to get a cache key for.
+ * @return string The cache key.
+ */
+	public function cacheKey($name) {
+		return $this->_connection->configName() . '_' . $name;
+	}
+
+/**
+ * Sets the cache config name to use for caching table metadata, or
+ * disabels it if false is passed.
+ * If called with no arguments it returns the current configuration name.
+ *
+ * @param bool $enable whether or not to enable caching
+ * @return string|bool
+ */
+	public function cacheMetadata($enable = null) {
+		if ($enable === null) {
+			return $this->_cache;
+		}
+		if ($enable === true) {
+			$enable = '_cake_model_';
+		}
+		return $this->_cache = $enable;
+	}
+
+}

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -812,4 +812,25 @@ class ConnectionTest extends TestCase {
 		});
 	}
 
+/**
+ * Tests it is possible to set a schema collection object
+ *
+ * @return void
+ */
+	public function testSchemaCollection() {
+		$driver = $this->getMockFormDriver();
+		$connection = $this->getMock(
+			'\Cake\Database\Connection',
+			['connect'],
+			[['driver' => $driver]]
+		);
+
+		$schema = $connection->schemaCollection();
+		$this->assertInstanceOf('Cake\Database\Schema\Collection', $schema);
+
+		$schema = $this->getMock('Cake\Database\Schema\Collection', [], [$connection]);
+		$connection->schemaCollection($schema);
+		$this->assertSame($schema, $connection->schemaCollection());
+	}
+
 }

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -77,7 +77,9 @@ class CollectionTest extends TestCase {
 		$table = $this->connection->schemaCollection()->describe('users');
 
 		Cache::delete('test_users', '_cake_model_');
-		$schema->cacheMetadata(true);
+		$this->connection->cacheMetadata(true);
+		$schema = $this->connection->schemaCollection();
+
 		$result = $schema->describe('users');
 		$this->assertEquals($table, $result);
 


### PR DESCRIPTION
Moves the caching logic in Schema\Collection to another object. This makes injecting custom schema objects easier, for example when using the database layer without the rest of CakePHP. This was the last blocker I found for extracting the Database namespace into its own repo.
