### PR TITLE
3.0 - Update BakeShell output

### DIFF
--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -76,10 +76,9 @@ class BakeShell extends Shell {
 			$this->out('Add your database connection information to config/app.php.');
 			return false;
 		}
-		$this->out('The following commands can be used to generate skeleton code for your application.');
-		$this->out('');
-		$this->out('<info>Available bake commands:</info>');
-		$this->out('');
+		$this->out('The following commands can be used to generate skeleton code for your application.', 2);
+		$this->out('<info>Available bake commands:</info>', 2);
+		$this->out('- all');
 		foreach ($this->tasks as $task) {
 			list($p, $name) = pluginSplit($task);
 			$this->out('- ' . Inflector::underscore($name));
@@ -237,7 +236,7 @@ class BakeShell extends Shell {
 			' If run with no command line arguments, Bake guides the user through the class creation process.' .
 			' You can customize the generation process by telling Bake where different parts of your application are using command line arguments.'
 		)->addSubcommand('all', [
-			'help' => 'Bake a complete MVC skeleton. Optional: <name> of a model.',
+			'help' => 'Bake a complete MVC skeleton.',
 		])->addOption('connection', [
 			'help' => 'Database connection to use in conjunction with `bake all`.',
 			'short' => 'c',

--- a/tests/TestCase/Shell/BakeShellTest.php
+++ b/tests/TestCase/Shell/BakeShellTest.php
@@ -104,7 +104,7 @@ class BakeShellTest extends TestCase {
 			->method('out')
 			->with($this->stringContains('The following commands'));
 
-		$this->Shell->expects($this->exactly(19))
+		$this->Shell->expects($this->exactly(18))
 			->method('out');
 
 		$this->Shell->loadTasks();


### PR DESCRIPTION
- Make use of newline param
- Add "all" subcommand to output with no args or --help flag
- Remove "optional" text, because it's a lie.
