### PR TITLE
consider TINYTEXT as TEXT

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -106,7 +106,7 @@ class MysqlSchema extends BaseSchema {
 		if ($col === 'char') {
 			return ['type' => 'string', 'fixed' => true, 'length' => $length];
 		}
-		if (strpos($col, 'char') !== false || $col === 'tinytext') {
+		if (strpos($col, 'char') !== false) {
 			return ['type' => 'string', 'length' => $length];
 		}
 		if (strpos($col, 'text') !== false) {

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -97,7 +97,7 @@ class MysqlSchemaTest extends TestCase {
 			],
 			[
 				'TINYTEXT',
-				['type' => 'string', 'length' => null]
+				['type' => 'text', 'length' => null]
 			],
 			[
 				'BLOB',


### PR DESCRIPTION
change the mysql column type for `tinytext`so `Formhelper::input()` will generate textarea instead of standard input.
ref #4772
