### PR TITLE
Improvements to Hash::expand and Hash::merge. (3.0)

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -674,11 +674,11 @@ class Hash {
 			while (!empty($stack)) {
 				foreach ($stack as $curKey => &$curMerge) {
 					foreach ($curMerge[0] as $key => &$val) {
-						if (!empty($curMerge[1][$key]) && (array)$curMerge[1][$key]===$curMerge[1][$key] && (array)$val===$val) {
+						if (!empty($curMerge[1][$key]) && (array)$curMerge[1][$key] === $curMerge[1][$key] && (array)$val === $val) {
 							$stack[] = array(&$val, &$curMerge[1][$key]);
-						} elseif ((int)$key===$key && isset($curMerge[1][$key])) {
+						} elseif ((int)$key === $key && isset($curMerge[1][$key])) {
 							$curMerge[1][] = $val;
-						}  else {
+						} else {
 							$curMerge[1][$key] = $val;
 						}
 					}
@@ -716,11 +716,11 @@ class Hash {
 		while (!empty($stack)) {
 			foreach ($stack as $curKey => &$curMerge) {
 				foreach ($curMerge[0] as $key => &$val) {
-					if (!empty($curMerge[1][$key]) && (array)$curMerge[1][$key]===$curMerge[1][$key] && (array)$val===$val) {
+					if (!empty($curMerge[1][$key]) && (array)$curMerge[1][$key] === $curMerge[1][$key] && (array)$val === $val) {
 						$stack[] = array(&$val, &$curMerge[1][$key]);
-					} elseif ((int)$key===$key && isset($curMerge[1][$key])) {
+					} elseif ((int)$key === $key && isset($curMerge[1][$key])) {
 						$curMerge[1][] = $val;
-					}  else {
+					} else {
 						$curMerge[1][$key] = $val;
 					}
 				}


### PR DESCRIPTION
Because of the recursion in these functions, processing very large
arrays would take a very long time. I rewrote the functions to
eliminate any unnecessary recursion and function calls. Large arrays
are now processed much faster.
