### PR TITLE
Revert "add test to prove requesthandler works correct with Angular wonk...

### DIFF
--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -198,20 +198,6 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	}
 
 /**
- * Test that RequestHandler sets $this->ext when Angular sends its wonky-ish headers.
- *
- * @return void
- */
-	public function testInitializeContentTypeWithAngularAccept() {
-		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/plain, * / *';
-		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('json');
-
-		$this->RequestHandler->initialize($this->Controller);
-		$this->assertEquals('json', $this->RequestHandler->ext);
-	}
-
-/**
  * Test that RequestHandler sets $this->ext when jQuery sends its wonky-ish headers
  * and the application is configured to handle multiple extensions
  *


### PR DESCRIPTION
...y accept headers"

This reverts commit 8507ef83f175bbf3f6532dc68b6051f0d41acd82.

Incorrect header was used for this test, Cake cannot safely determine correct header.
To get CakePHP to respond with json, you can modify the angular common headers.
