### PR TITLE
Fix incorrect entity being used for missing indexes.

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -267,7 +267,7 @@ class EntityContext implements ContextInterface {
 			$next = $this->_getProp($entity, $prop);
 
 			if ($next === null && $prop !== '_ids') {
-				return false;
+				return new Entity();
 			}
 
 			$isLast = ($i === $last && isset($next));

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -649,6 +649,42 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test isRequired on associated entities.
+ *
+ * @return void
+ */
+	public function testIsRequiredAssociatedHasManyMissingObject() {
+		$this->_setupTables();
+
+		$comments = TableRegistry::get('Comments');
+		$validator = $comments->validator();
+		$validator->allowEmpty('comment', function ($context) {
+			return $context['providers']['entity']->isNew();
+		});
+
+		$row = new Article([
+			'title' => 'My title',
+			'comments' => [
+				new Entity(['comment' => 'First comment'], ['markNew' => false]),
+			]
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+			'validator' => 'default',
+		]);
+
+		$this->assertTrue(
+			$context->isRequired('comments.0.comment'),
+			'comment is required as object is not new'
+		);
+		$this->assertFalse(
+			$context->isRequired('comments.1.comment'),
+			'comment is not required as missing object is "new"'
+		);
+	}
+
+/**
  * Test isRequired on associated entities with custom validators.
  *
  * @return void
@@ -862,6 +898,37 @@ class EntityContextTest extends TestCase {
 
 		$expected = ['Required'];
 		$this->assertEquals($expected, $context->error('user.username'));
+	}
+
+/**
+ * Test error on associated entities.
+ *
+ * @return void
+ */
+	public function testErrorAssociatedHasMany() {
+		$this->_setupTables();
+
+		$comments = TableRegistry::get('Comments');
+		$row = new Article([
+			'title' => 'My title',
+			'comments' => [
+				new Entity(['comment' => '']),
+				new Entity(['comment' => 'Second comment']),
+			]
+		]);
+		$row->comments[0]->errors('comment', ['Is required']);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+			'validator' => 'default',
+		]);
+
+		$this->assertEquals([], $context->error('title'));
+		$this->assertEquals([], $context->error('comments.0.user_id'));
+		$this->assertEquals([], $context->error('comments.0'));
+		$this->assertEquals(['Is required'], $context->error('comments.0.comment'));
+		$this->assertEquals([], $context->error('comments.1'));
+		$this->assertEquals([], $context->error('comments.1.comment'));
 	}
 
 /**


### PR DESCRIPTION
When reading non-existing entities after existing ones have been read, we should not re-use the previous context by accident. Instead a new blank entity should be used. This properly simulates the state of the missing entity, as it will be missing errors, and all attributes.

I also tried to add a test for #4792 but wasn't able to reproduce the error, so I'm waiting on some additional information.

Refs #4769
