### PR TITLE
3.0 countercache

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -230,7 +230,10 @@ trait EntityTrait {
 
 			$this->dirty($p, true);
 
-			if (!isset($this->_original[$p]) && isset($this->_properties[$p]) && $this->_properties[$p] !== $value) {
+			if (!isset($this->_original[$p]) &&
+				isset($this->_properties[$p]) &&
+			 	$this->_properties[$p] !== $value
+			 ) {
 				$this->_original[$p] = $this->_properties[$p];
 			}
 
@@ -509,7 +512,9 @@ trait EntityTrait {
 	public function extractOriginal(array $properties) {
 		$result = [];
 		foreach ($properties as $property) {
-			if (($this->getOriginal($property) !== null) && ($this->getOriginal($property) !== $this->get($property))) {
+			if ($this->getOriginal($property) !== null &&
+				$this->getOriginal($property) !== $this->get($property)
+			) {
 				$result[$property] = $this->getOriginal($property);
 			}
 		}

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -232,8 +232,8 @@ trait EntityTrait {
 
 			if (!isset($this->_original[$p]) &&
 				isset($this->_properties[$p]) &&
-			 	$this->_properties[$p] !== $value
-			 ) {
+				$this->_properties[$p] !== $value
+			) {
 				$this->_original[$p] = $this->_properties[$p];
 			}
 
@@ -512,10 +512,9 @@ trait EntityTrait {
 	public function extractOriginal(array $properties) {
 		$result = [];
 		foreach ($properties as $property) {
-			if ($this->getOriginal($property) !== null &&
-				$this->getOriginal($property) !== $this->get($property)
-			) {
-				$result[$property] = $this->getOriginal($property);
+			$original = $this->getOriginal($property);
+			if ($original !== null && $original !== $this->get($property)) {
+				$result[$property] = $original;
 			}
 		}
 		return $result;

--- a/src/Model/Behavior/CounterCacheBehavior.php
+++ b/src/Model/Behavior/CounterCacheBehavior.php
@@ -153,6 +153,11 @@ class CounterCacheBehavior extends Behavior {
 		$countConditions = $entity->extract($foreignKeys);
 		$updateConditions = array_combine($primaryKeys, $countConditions);
 
+		$countOriginalConditions = $entity->extractOriginal($foreignKeys);
+		if ($countOriginalConditions !== []) {
+			$updateOriginalConditions = array_combine($primaryKeys, $countOriginalConditions);
+		}
+
 		foreach ($settings as $field => $config) {
 			if (is_int($field)) {
 				$field = $config;
@@ -166,6 +171,11 @@ class CounterCacheBehavior extends Behavior {
 			}
 
 			$assoc->target()->updateAll([$field => $count], $updateConditions);
+
+			if (isset($updateOriginalConditions)) {
+				$count = $this->_getCount($config, $countOriginalConditions);
+				$assoc->target()->updateAll([$field => $count], $updateOriginalConditions);
+			}
 		}
 	}
 

--- a/tests/Fixture/CounterCacheCategoriesFixture.php
+++ b/tests/Fixture/CounterCacheCategoriesFixture.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @since         1.2.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\Fixture;
@@ -17,23 +17,20 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * Counter Cache Test Fixtures
+ * Short description for class.
  *
  */
-class CounterCachePostsFixture extends TestFixture {
+class CounterCacheCategoriesFixture extends TestFixture {
 
 	public $fields = array(
 		'id' => ['type' => 'integer'],
-		'title' => ['type' => 'string', 'length' => 255],
-		'user_id' => ['type' => 'integer', 'null' => true],
-		'category_id' => ['type' => 'integer', 'null' => true],
-		'published' => ['type' => 'boolean', 'null' => false, 'default' => false],
+		'name' => ['type' => 'string', 'length' => 255, 'null' => false],
+		'post_count' => ['type' => 'integer', 'null' => true],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 	);
 
 	public $records = array(
-		array('title' => 'Rock and Roll', 'user_id' => 1, 'category_id' => 1, 'published' => 0),
-		array('title' => 'Music', 'user_id' => 1, 'category_id' => 2, 'published' => 1),
-		array('title' => 'Food', 'user_id' => 2, 'category_id' => 2, 'published' => 1),
+		array('name' => 'Sport', 'post_count' => 1),
+		array('name' => 'Music', 'post_count' => 2),
 	);
 }

--- a/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
@@ -46,7 +46,8 @@ class CounterCacheBehaviorTest extends TestCase {
  */
 	public $fixtures = [
 		'core.counter_cache_users',
-		'core.counter_cache_posts'
+		'core.counter_cache_posts',
+		'core.counter_cache_categories',
 	];
 
 /**
@@ -60,6 +61,11 @@ class CounterCacheBehaviorTest extends TestCase {
 
 		$this->user = TableRegistry::get('Users', [
 			'table' => 'counter_cache_users',
+			'connection' => $this->connection
+		]);
+
+		$this->category = TableRegistry::get('Categories', [
+			'table' => 'counter_cache_categories',
 			'connection' => $this->connection
 		]);
 
@@ -162,26 +168,38 @@ class CounterCacheBehaviorTest extends TestCase {
  */
 	public function testUpdate() {
 		$this->post->belongsTo('Users');
+		$this->post->belongsTo('Categories');
 
 		$this->post->addBehavior('CounterCache', [
 			'Users' => [
 				'post_count'
-			]
+			],
+			'Categories' => [
+				'post_count'
+			],
 		]);
 
 		$user1 = $this->_getUser(1);
 		$user2 = $this->_getUser(2);
+		$category1 = $this->_getCategory(1);
+		$category2 = $this->_getCategory(2);
 		$post = $this->post->find('all')->first();
 		$this->assertEquals(2, $user1->get('post_count'));
 		$this->assertEquals(1, $user2->get('post_count'));
+		$this->assertEquals(1, $category1->get('post_count'));
+		$this->assertEquals(2, $category2->get('post_count'));
 
-		$entity = $this->post->patchEntity($post, ['user_id' => 2]);
+		$entity = $this->post->patchEntity($post, ['user_id' => 2, 'category_id' => 2]);
 		$this->post->save($entity);
 
 		$user1 = $this->_getUser(1);
 		$user2 = $this->_getUser(2);
+		$category1 = $this->_getCategory(1);
+		$category2 = $this->_getCategory(2);
 		$this->assertEquals(1, $user1->get('post_count'));
 		$this->assertEquals(2, $user2->get('post_count'));
+		$this->assertEquals(0, $category1->get('post_count'));
+		$this->assertEquals(3, $category2->get('post_count'));
 	}
 
 /**
@@ -309,11 +327,21 @@ class CounterCacheBehaviorTest extends TestCase {
 	}
 
 /**
- * Returns entity for user 1
+ * Returns entity for user
  *
  * @return Entity
  */
 	protected function _getUser($id = 1) {
 		return $this->user->find('all')->where(['id' => $id])->first();
 	}
+
+/**
+ * Returns entity for category
+ *
+ * @return Entity
+ */
+	protected function _getCategory($id = 1) {
+		return $this->category->find('all')->where(['id' => $id])->first();
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
@@ -156,6 +156,35 @@ class CounterCacheBehaviorTest extends TestCase {
 	}
 
 /**
+ * Testing update simple counter caching when updating a record association
+ *
+ * @return void
+ */
+	public function testUpdate() {
+		$this->post->belongsTo('Users');
+
+		$this->post->addBehavior('CounterCache', [
+			'Users' => [
+				'post_count'
+			]
+		]);
+
+		$user1 = $this->_getUser(1);
+		$user2 = $this->_getUser(2);
+		$post = $this->post->find('all')->first();
+		$this->assertEquals(2, $user1->get('post_count'));
+		$this->assertEquals(1, $user2->get('post_count'));
+
+		$entity = $this->post->patchEntity($post, ['user_id' => 2]);
+		$this->post->save($entity);
+
+		$user1 = $this->_getUser(1);
+		$user2 = $this->_getUser(2);
+		$this->assertEquals(1, $user1->get('post_count'));
+		$this->assertEquals(2, $user2->get('post_count'));
+	}
+
+/**
  * Testing counter cache with custom find
  *
  * @return void
@@ -284,7 +313,7 @@ class CounterCacheBehaviorTest extends TestCase {
  *
  * @return Entity
  */
-	protected function _getUser() {
-		return $this->user->find('all')->where(['id' => 1])->first();
+	protected function _getUser($id = 1) {
+		return $this->user->find('all')->where(['id' => $id])->first();
 	}
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -30,14 +30,20 @@ class EntityTest extends TestCase {
  */
 	public function testSetOneParamNoSetters() {
 		$entity = new Entity;
+		$this->assertNull($entity->getOriginal('foo'));
 		$entity->set('foo', 'bar');
 		$this->assertEquals('bar', $entity->foo);
+		$this->assertEquals('bar', $entity->getOriginal('foo'));
 
 		$entity->set('foo', 'baz');
 		$this->assertEquals('baz', $entity->foo);
+		$this->assertEquals('bar', $entity->getOriginal('foo'));
 
 		$entity->set('id', 1);
 		$this->assertSame(1, $entity->id);
+		$this->assertEquals(1, $entity->getOriginal('id'));
+		$this->assertEquals('bar', $entity->getOriginal('foo'));
+
 	}
 
 /**
@@ -57,6 +63,8 @@ class EntityTest extends TestCase {
 		$this->assertEquals('baz', $entity->foo);
 		$this->assertSame(2, $entity->id);
 		$this->assertSame(3, $entity->thing);
+		$this->assertEquals('bar', $entity->getOriginal('foo'));
+		$this->assertEquals(1, $entity->getOriginal('id'));
 	}
 
 /**
@@ -570,11 +578,12 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testIsNew() {
-		$entity = new Entity([
+		$data = [
 			'id' => 1,
 			'title' => 'Foo',
 			'author_id' => 3
-		]);
+		];
+		$entity = new Entity($data);
 		$this->assertTrue($entity->isNew());
 
 		$entity->isNew(true);
@@ -1062,6 +1071,7 @@ class EntityTest extends TestCase {
 			'accessible' => ['*' => true, 'name' => true],
 			'properties' => ['foo' => 'bar'],
 			'dirty' => ['foo' => true],
+			'original' => [],
 			'virtual' => ['baz'],
 			'errors' => ['foo' => ['An error']],
 			'repository' => 'foos'

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -43,7 +43,6 @@ class EntityTest extends TestCase {
 		$this->assertSame(1, $entity->id);
 		$this->assertEquals(1, $entity->getOriginal('id'));
 		$this->assertEquals('bar', $entity->getOriginal('foo'));
-
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3005,9 +3005,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals(4, $tags[2]->id);
 		$this->assertEquals(1, $tags[2]->_joinData->article_id);
 		$this->assertEquals(4, $tags[2]->_joinData->tag_id);
-
-		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
-		$this->assertEquals($tags, $article->tags);
 	}
 
 /**


### PR DESCRIPTION
ref #4797 

This fixes the counter cache not being updated when the belongsTo association field is modified.
It introduces a `_oldProperties` to Entities and allow to freeze all properties value when saving.

Unfortunatly as @markstory stated in the issue it doubles the amount of memory each modified entity uses.
