### PR TITLE
Fix missing validation errors on associated ID property.

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -265,12 +265,12 @@ class EntityContext implements ContextInterface {
 		for ($i = 0; $i < $len; $i++) {
 			$prop = $path[$i];
 			$next = $this->_getProp($entity, $prop);
+			$isLast = ($i === $last);
 
-			if ($next === null && $prop !== '_ids') {
+			if (!$isLast && $next === null && $prop !== '_ids') {
 				return new Entity();
 			}
 
-			$isLast = ($i === $last && isset($next));
 			$isTraversable = (
 				is_array($next) ||
 				$next instanceof Traversable ||

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -505,7 +505,6 @@ class EntityContextTest extends TestCase {
 
 		$result = $context->val('id');
 		$this->assertEquals($row->id, $result);
-
 		$this->assertNull($context->val('profile.id'));
 	}
 
@@ -917,6 +916,8 @@ class EntityContextTest extends TestCase {
 			]
 		]);
 		$row->comments[0]->errors('comment', ['Is required']);
+		$row->comments[0]->errors('article_id', ['Is required']);
+
 		$context = new EntityContext($this->request, [
 			'entity' => $row,
 			'table' => 'Articles',
@@ -927,8 +928,10 @@ class EntityContextTest extends TestCase {
 		$this->assertEquals([], $context->error('comments.0.user_id'));
 		$this->assertEquals([], $context->error('comments.0'));
 		$this->assertEquals(['Is required'], $context->error('comments.0.comment'));
+		$this->assertEquals(['Is required'], $context->error('comments.0.article_id'));
 		$this->assertEquals([], $context->error('comments.1'));
 		$this->assertEquals([], $context->error('comments.1.comment'));
+		$this->assertEquals([], $context->error('comments.1.article_id'));
 	}
 
 /**


### PR DESCRIPTION
When reading errors off an association and the last property is null/undefined the entity containing the missing property should be used.

Fixes #4792
