### PR TITLE
3.0 - Query caching for \Cake\ORM\Table::get

### DIFF
--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -29,10 +29,24 @@ use Traversable;
 class QueryCacher {
 
 /**
- * Constructor.
+ * Constructor requires cache key and cache engine (config) to be used
+ * either as two separate arguments or in an array:
  *
- * @param string|\Closure $key The key or function to generate a key.
- * @param string|CacheEngine $config The cache config name or cache engine instance.
+ * {{{
+ * new QueryCacher('my_cached_query', 'cache_config_name');
+ * }}}
+ *
+ * or:
+ *
+ * {{{
+ * new QueryCacher([
+ *  'key' => 'my_cached_query',
+ *  'config' => 'cache_config_name'
+ * ]);
+ * }}}
+ *
+ * @param string|\Closure|array $key The key or function to generate a key.
+ * @param string|CacheEngine|null $config The cache config name or cache engine instance.
  * @throws RuntimeException
  */
 	public function __construct($key, $config = null) {

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -36,10 +36,10 @@ class QueryCacher {
  * @throws RuntimeException
  */
 	public function __construct($key, $config = null) {
-        if (is_array($key)) {
-            $config = $key['config'];
-            $key = $key['key'];
-        }
+		if (is_array($key)) {
+			$config = $key['config'];
+			$key = $key['key'];
+		}
 
 		if (!is_string($key) && !is_callable($key)) {
 			throw new RuntimeException('Cache keys must be strings or callables.');

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -35,7 +35,12 @@ class QueryCacher {
  * @param string|CacheEngine $config The cache config name or cache engine instance.
  * @throws RuntimeException
  */
-	public function __construct($key, $config) {
+	public function __construct($key, $config = null) {
+        if (is_array($key)) {
+            $config = $key['config'];
+            $key = $key['key'];
+        }
+
 		if (!is_string($key) && !is_callable($key)) {
 			throw new RuntimeException('Cache keys must be strings or callables.');
 		}

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -454,7 +454,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 			'having' => 'having',
 			'contain' => 'contain',
 			'page' => 'page',
-            'cache' => 'cache'
+			'cache' => 'cache'
 		];
 
 		ksort($options);

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -454,6 +454,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 			'having' => 'having',
 			'contain' => 'contain',
 			'page' => 'page',
+            'cache' => 'cache'
 		];
 
 		ksort($options);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -925,16 +925,16 @@ class Table implements RepositoryInterface, EventListener {
 		}
 		$conditions = array_combine($key, $primaryKey);
 
-        if (isset($options['cache'])) {
-            if (!is_array($options['cache'])) {
-                $options['cache'] = [
-                    'config' => $options['cache']
-                ];
-            }
-            if (!isset($options['cache']['key'])) {
-                $options['cache']['key'] = $this->table() . '_' . json_encode($primaryKey);
-            }
-        }
+		if (isset($options['cache'])) {
+			if (!is_array($options['cache'])) {
+				$options['cache'] = [
+					'config' => $options['cache']
+				];
+			}
+			if (!isset($options['cache']['key'])) {
+				$options['cache']['key'] = $this->table() . '_' . json_encode($primaryKey);
+			}
+		}
 
 		$entity = $this->find('all', $options)->where($conditions)->first();
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -924,6 +924,18 @@ class Table implements RepositoryInterface, EventListener {
 			));
 		}
 		$conditions = array_combine($key, $primaryKey);
+
+        if (isset($options['cache'])) {
+            if (!is_array($options['cache'])) {
+                $options['cache'] = [
+                    'config' => $options['cache']
+                ];
+            }
+            if (!isset($options['cache']['key'])) {
+                $options['cache']['key'] = $this->table() . '_' . json_encode($primaryKey);
+            }
+        }
+
 		$entity = $this->find('all', $options)->where($conditions)->first();
 
 		if ($entity) {

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -125,6 +125,19 @@ class QueryCacherTest extends TestCase {
 	}
 
 /**
+ * Test fetching with a cache hit.
+ *
+ * @return void
+ */
+    public function testFetchCacheHitConstructedWithArray() {
+        $this->_mockRead('my_key', 'A winner');
+        $cacher = new QueryCacher(['key' => 'my_key', 'config' => $this->engine]);
+        $query = $this->getMock('stdClass');
+        $result = $cacher->fetch($query);
+        $this->assertEquals('A winner', $result);
+    }
+
+/**
  * Helper for building mocks.
  */
 	protected function _mockRead($key, $value = false) {

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -129,13 +129,13 @@ class QueryCacherTest extends TestCase {
  *
  * @return void
  */
-    public function testFetchCacheHitConstructedWithArray() {
-        $this->_mockRead('my_key', 'A winner');
-        $cacher = new QueryCacher(['key' => 'my_key', 'config' => $this->engine]);
-        $query = $this->getMock('stdClass');
-        $result = $cacher->fetch($query);
-        $this->assertEquals('A winner', $result);
-    }
+	public function testFetchCacheHitConstructedWithArray() {
+		$this->_mockRead('my_key', 'A winner');
+		$cacher = new QueryCacher(['key' => 'my_key', 'config' => $this->engine]);
+		$query = $this->getMock('stdClass');
+		$result = $cacher->fetch($query);
+		$this->assertEquals('A winner', $result);
+	}
 
 /**
  * Helper for building mocks.

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3304,27 +3304,27 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->find();
 	}
 
-    public function dataProviderGet()
-    {
-        return [
-            [
-                ['fields' => ['id']],
-                ['fields' => ['id']]
-            ],
-            [
-                ['fields' => ['id'], 'cache' => 'some_cache'],
-                ['fields' => ['id'], 'cache' => ['key' => 'name_[10]', 'config' => 'some_cache']]
-            ],
-            [
-                ['fields' => ['id'], 'cache' => ['config' => 'some_cache']],
-                ['fields' => ['id'], 'cache' => ['key' => 'name_[10]', 'config' => 'some_cache']]
-            ],
-            [
-                ['fields' => ['id'], 'cache' => ['key' => 'some_key', 'config' => 'some_cache']],
-                ['fields' => ['id'], 'cache' => ['key' => 'some_key', 'config' => 'some_cache']]
-            ]
-        ];
-    }
+	public function dataProviderGet()
+	{
+		return [
+			[
+				['fields' => ['id']],
+				['fields' => ['id']]
+			],
+			[
+				['fields' => ['id'], 'cache' => 'some_cache'],
+				['fields' => ['id'], 'cache' => ['key' => 'name_[10]', 'config' => 'some_cache']]
+			],
+			[
+				['fields' => ['id'], 'cache' => ['config' => 'some_cache']],
+				['fields' => ['id'], 'cache' => ['key' => 'name_[10]', 'config' => 'some_cache']]
+			],
+			[
+				['fields' => ['id'], 'cache' => ['key' => 'some_key', 'config' => 'some_cache']],
+				['fields' => ['id'], 'cache' => ['key' => 'some_key', 'config' => 'some_cache']]
+			]
+		];
+	}
 
 /**
  * Test that get() will use the primary key for searching and return the first
@@ -3346,7 +3346,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 				]
 			]]
 		);
-        $table->table('name');
+		$table->table('name');
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3304,13 +3304,36 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->find();
 	}
 
+    public function dataProviderGet()
+    {
+        return [
+            [
+                ['fields' => ['id']],
+                ['fields' => ['id']]
+            ],
+            [
+                ['fields' => ['id'], 'cache' => 'some_cache'],
+                ['fields' => ['id'], 'cache' => ['key' => 'name_[10]', 'config' => 'some_cache']]
+            ],
+            [
+                ['fields' => ['id'], 'cache' => ['config' => 'some_cache']],
+                ['fields' => ['id'], 'cache' => ['key' => 'name_[10]', 'config' => 'some_cache']]
+            ],
+            [
+                ['fields' => ['id'], 'cache' => ['key' => 'some_key', 'config' => 'some_cache']],
+                ['fields' => ['id'], 'cache' => ['key' => 'some_key', 'config' => 'some_cache']]
+            ]
+        ];
+    }
+
 /**
  * Test that get() will use the primary key for searching and return the first
  * entity found
  *
+ * @dataProvider dataProviderGet
  * @return void
  */
-	public function testGet() {
+	public function testGet($options, $expectedFinderOptions) {
 		$table = $this->getMock(
 			'\Cake\ORM\Table',
 			['callFinder', 'query'],
@@ -3323,6 +3346,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 				]
 			]]
 		);
+        $table->table('name');
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
@@ -3334,7 +3358,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->expects($this->once())->method('query')
 			->will($this->returnValue($query));
 		$table->expects($this->once())->method('callFinder')
-			->with('all', $query, ['fields' => ['id']])
+			->with('all', $query, $expectedFinderOptions)
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('where')
@@ -3342,7 +3366,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnSelf());
 		$query->expects($this->once())->method('first')
 			->will($this->returnValue($entity));
-		$result = $table->get(10, ['fields' => ['id']]);
+
+		$result = $table->get(10, $options);
 		$this->assertSame($entity, $result);
 	}
 


### PR DESCRIPTION
I recently wanted to use query cache with wonderful `\Cake\ORM\Table::get` and found out, that it wasn't possible. Do you think something like this might be useful?

At first I was only considering this: https://github.com/sukihub/cakephp/compare/cakephp:3.0...sukihub:3.0-cacheable-get-v1 but having cache option available in find might be a little bit more useful.

I did not add test for `Query` class (`QueryTest::testApplyOptions`) since (1) the change there was trivial and (2) there is no easy way to check what's in `_cache` in `QueryTrait` other than actually "firing" the query with "real" cache. Should however work just fine. 

What do you think?
