### PR TITLE
3.0 - Query caching for \Cake\ORM\Table::get (updated)

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -925,16 +925,16 @@ class Table implements RepositoryInterface, EventListener {
 		}
 		$conditions = array_combine($key, $primaryKey);
 
-        if (isset($options['cache'])) {
-            $cache = $options['cache'];
-            unset($options['cache']);
-        }
+		if (isset($options['cache'])) {
+			$cache = $options['cache'];
+			unset($options['cache']);
+		}
 
-        $query = $this->find('all', $options);
+		$query = $this->find('all', $options);
 
-        if (isset($cache)) {
-            $query->cache($this->table() . '_' . json_encode($primaryKey), $cache);
-        }
+		if (isset($cache)) {
+			$query->cache($this->table() . '_' . json_encode($primaryKey), $cache);
+		}
 
 		$entity = $query->where($conditions)->first();
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -924,7 +924,19 @@ class Table implements RepositoryInterface, EventListener {
 			));
 		}
 		$conditions = array_combine($key, $primaryKey);
-		$entity = $this->find('all', $options)->where($conditions)->first();
+
+        if (isset($options['cache'])) {
+            $cache = $options['cache'];
+            unset($options['cache']);
+        }
+
+        $query = $this->find('all', $options);
+
+        if (isset($cache)) {
+            $query->cache($this->table() . '_' . json_encode($primaryKey), $cache);
+        }
+
+		$entity = $query->where($conditions)->first();
 
 		if ($entity) {
 			return $entity;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3326,7 +3326,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['addDefaultTypes', 'first', 'where'],
+			['addDefaultTypes', 'first', 'where', 'cache'],
 			[$this->connection, $table]
 		);
 
@@ -3340,6 +3340,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$query->expects($this->once())->method('where')
 			->with([$table->alias() . '.bar' => 10])
 			->will($this->returnSelf());
+		$query->expects($this->never())->method('cache');
 		$query->expects($this->once())->method('first')
 			->will($this->returnValue($entity));
 		$result = $table->get(10, ['fields' => ['id']]);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3351,44 +3351,44 @@ class TableTest extends \Cake\TestSuite\TestCase {
  *
  * @return void
  */
-    public function testGetWithCache() {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['callFinder', 'query'],
-            [[
-                'connection' => $this->connection,
-                'schema' => [
-                    'id' => ['type' => 'integer'],
-                    'bar' => ['type' => 'integer'],
-                    '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]]
-                ]
-            ]]
-        );
+	public function testGetWithCache() {
+		$table = $this->getMock(
+			'\Cake\ORM\Table',
+			['callFinder', 'query'],
+			[[
+				'connection' => $this->connection,
+				'schema' => [
+					'id' => ['type' => 'integer'],
+					'bar' => ['type' => 'integer'],
+					'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]]
+				]
+			]]
+		);
 
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['addDefaultTypes', 'first', 'where', 'cache'],
-            [$this->connection, $table]
-        );
+		$query = $this->getMock(
+			'\Cake\ORM\Query',
+			['addDefaultTypes', 'first', 'where', 'cache'],
+			[$this->connection, $table]
+		);
 
-        $entity = new \Cake\ORM\Entity;
-        $table->expects($this->once())->method('query')
-            ->will($this->returnValue($query));
-        $table->expects($this->once())->method('callFinder')
-            ->with('all', $query, ['fields' => ['id']])
-            ->will($this->returnValue($query));
+		$entity = new \Cake\ORM\Entity;
+		$table->expects($this->once())->method('query')
+			->will($this->returnValue($query));
+		$table->expects($this->once())->method('callFinder')
+			->with('all', $query, ['fields' => ['id']])
+			->will($this->returnValue($query));
 
-        $query->expects($this->once())->method('where')
-            ->with([$table->alias() . '.bar' => 10])
-            ->will($this->returnSelf());
-        $query->expects($this->once())->method('cache')
-            ->with($table->table() . '_[10]', 'any_cache')
-            ->will($this->returnSelf());
-        $query->expects($this->once())->method('first')
-            ->will($this->returnValue($entity));
-        $result = $table->get(10, ['fields' => ['id'], 'cache' => 'any_cache']);
-        $this->assertSame($entity, $result);
-    }
+		$query->expects($this->once())->method('where')
+			->with([$table->alias() . '.bar' => 10])
+			->will($this->returnSelf());
+		$query->expects($this->once())->method('cache')
+			->with($table->table() . '_[10]', 'any_cache')
+			->will($this->returnSelf());
+		$query->expects($this->once())->method('first')
+			->will($this->returnValue($entity));
+		$result = $table->get(10, ['fields' => ['id'], 'cache' => 'any_cache']);
+		$this->assertSame($entity, $result);
+	}
 
 /**
  * Tests that get() will throw an exception if the record was not found


### PR DESCRIPTION
Support for query cache in `\Cake\ORM\Table::get`, based on discussion in https://github.com/cakephp/cakephp/pull/4815

The duplication in `TableTest` bothers me a little bit (`testGet` and `testGetWithCache`), but I did not refactor it, since I did not find how you usually deal with it (there are only `test*` methods in the class).
