### PR TITLE
Add Model.initialize event and rework how Component::initialize() works

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -28,8 +28,6 @@ use Cake\Log\LogTrait;
  * Components can provide several callbacks that are fired at various stages of the request
  * cycle. The available callbacks are:
  *
- * - `initialize(Event $event)`
- *   Called before the controller's beforeFilter method.
  * - `startup(Event $event)`
  *   Called after the controller's beforeFilter method, and before the
  *   controller action is called.
@@ -99,6 +97,18 @@ class Component implements EventListener {
 		if (!empty($this->components)) {
 			$this->_componentMap = $registry->normalizeArray($this->components);
 		}
+		$this->initialize($config);
+	}
+
+/**
+ * Constructor hook method.
+ *
+ * Implement this method to avoid having to overwrite
+ * the constructor and call parent.
+ *
+ * @return void
+ */
+	public function initialize(array $config) {
 	}
 
 /**
@@ -131,7 +141,7 @@ class Component implements EventListener {
  */
 	public function implementedEvents() {
 		$eventMap = [
-			'Controller.initialize' => 'initialize',
+			// 'Controller.initialize' => 'initialize',
 			'Controller.startup' => 'startup',
 			'Controller.beforeRender' => 'beforeRender',
 			'Controller.beforeRedirect' => 'beforeRedirect',

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -141,7 +141,7 @@ class Component implements EventListener {
  */
 	public function implementedEvents() {
 		$eventMap = [
-			// 'Controller.initialize' => 'initialize',
+			'Controller.initialize' => 'beforeFilter',
 			'Controller.startup' => 'startup',
 			'Controller.beforeRender' => 'beforeRender',
 			'Controller.beforeRedirect' => 'beforeRedirect',

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -23,11 +23,19 @@ use Cake\Log\LogTrait;
  * controller logic that can be composed into a controller. Components also
  * provide request life-cycle callbacks for injecting logic at specific points.
  *
+ * ## Initialize hook
+ *
+ * Like Controller and Table, this class has an initialize() hook that you can use
+ * to add custom 'constructor' logic. It is important to remember that each request
+ * (and sub-request) will only make one instance of any given component.
+ *
  * ## Life cycle callbacks
  *
  * Components can provide several callbacks that are fired at various stages of the request
  * cycle. The available callbacks are:
  *
+ * - `beforeFilter(Event $event)`
+ *   Called before the controller's beforeFilter method by default.
  * - `startup(Event $event)`
  *   Called after the controller's beforeFilter method, and before the
  *   controller action is called.
@@ -106,6 +114,7 @@ class Component implements EventListener {
  * Implement this method to avoid having to overwrite
  * the constructor and call parent.
  *
+ * @param array $config The configuration array this component is using.
  * @return void
  */
 	public function initialize(array $config) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -261,12 +261,16 @@ class Controller implements EventListener {
 			$this->viewPath = $viewPath;
 		}
 
-		if ($request instanceof Request) {
-			$this->setRequest($request);
+		if (!($request instanceof Request)) {
+			$request = new Request();
 		}
-		if ($response instanceof Response) {
-			$this->response = $response;
+		$this->setRequest($request);
+
+		if (!($response instanceof Response)) {
+			$response = new Response();
 		}
+		$this->response = $response;
+
 		if ($eventManager) {
 			$this->eventManager($eventManager);
 		}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -230,6 +230,7 @@ class Table implements RepositoryInterface, EventListener {
 
 		$this->initialize($config);
 		$this->_eventManager->attach($this);
+		$this->dispatchEvent('Model.initialize');
 	}
 
 /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -148,10 +148,10 @@ class TestComponent extends Component {
 /**
  * initialize method
  *
- * @param Event $event
+ * @param array $config
  * @return void
  */
-	public function initialize(Event $event) {
+	public function initialize(array $config) {
 	}
 
 /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -56,10 +56,10 @@ class BlueberryComponent extends Component {
 /**
  * initialize method
  *
- * @param Event $event
+ * @param array $config
  * @return void
  */
-	public function initialize(Event $event) {
+	public function initialize(array $config) {
 		$this->testName = 'BlueberryComponent';
 	}
 

--- a/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
@@ -33,12 +33,11 @@ class OrangeComponent extends Component {
 /**
  * initialize method
  *
- * @param Event $event
- * @param Controller $controller
+ * @param array $config
  * @return void
  */
-	public function initialize(Event $event) {
-		$this->Controller = $event->subject();
+	public function initialize(array $config) {
+		$this->Controller = $this->_registry->getController();
 		$this->Banana->testField = 'OrangeField';
 	}
 


### PR DESCRIPTION
This is a possibly controversial change that solves #4796 and an annoying difference around components vs. everything else.
#### New Shiny
- New `Model.initialize` event that is fired after the initialize() method, just like in controllers.
- Component::initialize() works like the other initialize methods. This also solves a long standing issue around sub components not getting their initialize method invoked.
- Component::beforeFilter() added.
- Controllers _always_ have a request/response now.
### Breaking changes
- Component::intialize() is no longer an event listener.
