### PR TITLE
Fix deep associations being hydrated incorrectly.

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -454,7 +454,6 @@ class EagerLoader {
 			);
 			$statement = new CallbackStatement($statement, $driver, $f);
 		}
-
 		return $statement;
 	}
 
@@ -510,6 +509,10 @@ class EagerLoader {
 		$keys = [];
 		while ($result = $statement->fetch('assoc')) {
 			foreach ($collectKeys as $parts) {
+				// Missed joins will have null in the results.
+				if ($parts[2] && !isset($result[$parts[1][0]])) {
+					continue;
+				}
 				if ($parts[2]) {
 					$keys[$parts[0]][] = $result[$parts[1][0]];
 					continue;

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -390,6 +390,7 @@ class ResultSet implements ResultSetInterface {
 			$alias = $assoc['nestKey'];
 			$instance = $assoc['instance'];
 
+			// Doing this before we're sure the root assoc has data is the problem.
 			if (!isset($results[$alias])) {
 				$results = $instance->defaultRowValue($results, $assoc['canBeJoined']);
 				continue;
@@ -404,7 +405,7 @@ class ResultSet implements ResultSetInterface {
 
 				$hasData = false;
 				foreach ($results[$alias] as $v) {
-					if ($v !== null) {
+					if ($v !== null && $v !== []) {
 						$hasData = true;
 						break;
 					}

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -473,4 +473,33 @@ class QueryRegressionTest extends TestCase {
 		$this->assertEquals(2, $count);
 	}
 
+/**
+ * Test that deep containments don't generate empty entities for
+ * intermediary relations.
+ *
+ * @return void
+ */
+	public function testContainNoEmptyAssociatedObjects() {
+		$comments = TableRegistry::get('Comments');
+		$comments->belongsTo('Users');
+		$users = TableRegistry::get('Users');
+		$users->hasMany('Articles', [
+			'foreignKey' => 'author_id'
+		]);
+
+		$comments->updateAll(['user_id' => 99], ['id' => 1]);
+
+		$result = $comments->find()
+			->contain(['Users'])
+			->where(['Comments.id' => 1])
+			->first();
+		$this->assertNull($result->user, 'No record should be null.');
+
+		$result = $comments->find()
+			->contain(['Users', 'Users.Articles'])
+			->where(['Comments.id' => 1])
+			->first();
+		$this->assertNull($result->user, 'No record should be null.');
+	}
+
 }


### PR DESCRIPTION
Fix deep associations that involve non-joinable relations from being incorrectly hydrated.

Fixes #4804 
