### PR TITLE
Remove AS from table aliases.

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -175,7 +175,7 @@ class QueryCompiler {
 		$parts = $this->_stringifyExpressions($parts, $generator);
 		foreach ($parts as $k => $p) {
 			if (!is_numeric($k)) {
-				$p = $p . ' AS ' . $k;
+				$p = $p . ' ' . $k;
 			}
 			$normalized[] = $p;
 		}

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -182,7 +182,7 @@ class SqlserverTest extends \Cake\TestSuite\TestCase {
 			->from('articles')
 			->offset(10);
 		$expected = 'SELECT * FROM (SELECT id, title, (ROW_NUMBER() OVER (ORDER BY (SELECT NULL))) AS [_cake_page_rownum_] ' .
-			'FROM articles) AS _cake_paging_ ' .
+			'FROM articles) _cake_paging_ ' .
 			'WHERE _cake_paging_._cake_page_rownum_ > :c0';
 		$this->assertEquals($expected, $query->sql());
 
@@ -192,7 +192,7 @@ class SqlserverTest extends \Cake\TestSuite\TestCase {
 			->order(['id'])
 			->offset(10);
 		$expected = 'SELECT * FROM (SELECT id, title, (ROW_NUMBER() OVER (ORDER BY id)) AS [_cake_page_rownum_] ' .
-			'FROM articles) AS _cake_paging_ ' .
+			'FROM articles) _cake_paging_ ' .
 			'WHERE _cake_paging_._cake_page_rownum_ > :c0';
 		$this->assertEquals($expected, $query->sql());
 
@@ -204,7 +204,7 @@ class SqlserverTest extends \Cake\TestSuite\TestCase {
 			->limit(10)
 			->offset(50);
 		$expected = 'SELECT * FROM (SELECT id, title, (ROW_NUMBER() OVER (ORDER BY id)) AS [_cake_page_rownum_] ' .
-			'FROM articles WHERE title = :c0) AS _cake_paging_ ' .
+			'FROM articles WHERE title = :c0) _cake_paging_ ' .
 			'WHERE (_cake_paging_._cake_page_rownum_ > :c1 AND _cake_paging_._cake_page_rownum_ <= :c2)';
 		$this->assertEquals($expected, $query->sql());
 	}

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2560,11 +2560,11 @@ class QueryTest extends TestCase {
 
 		$query = new Query($this->connection);
 		$sql = $query->select('*')->from(['foo' => 'something'])->sql();
-		$this->assertQuotedQuery('FROM <something> AS <foo>$', $sql);
+		$this->assertQuotedQuery('FROM <something> <foo>$', $sql);
 
 		$query = new Query($this->connection);
 		$sql = $query->select('*')->from(['foo' => $query->newExpr('bar')])->sql();
-		$this->assertQuotedQuery('FROM \(bar\) AS <foo>$', $sql);
+		$this->assertQuotedQuery('FROM \(bar\) <foo>$', $sql);
 	}
 
 /**


### PR DESCRIPTION
Having AS causes issues with Oracle. While this is not a core driver, the AS keyword is not required by any supported driver.

Refs #4830
