### PR TITLE
Mime Type on HTML Emails

### DIFF
--- a/cake/libs/controller/components/email.php
+++ b/cake/libs/controller/components/email.php
@@ -621,7 +621,6 @@ class EmailComponent extends Object{
 		} elseif ($this->sendAs === 'text') {
 			$headers['Content-Type'] = 'text/plain; charset=' . $this->charset;
 		} elseif ($this->sendAs === 'html') {
-			$headers['MIME-Version'] = '1.0';
 			$headers['Content-Type'] = 'text/html; charset=' . $this->charset;
 		} elseif ($this->sendAs === 'both') {
 			$headers['Content-Type'] = 'multipart/alternative; boundary="alt-' . $this->__boundary . '"';

--- a/cake/libs/controller/components/email.php
+++ b/cake/libs/controller/components/email.php
@@ -617,7 +617,6 @@ class EmailComponent extends Object{
 		}
 
 		if (!empty($this->attachments)) {
-			$headers['MIME-Version'] = '1.0';
 			$headers['Content-Type'] = 'multipart/mixed; boundary="' . $this->__boundary . '"';
 		} elseif ($this->sendAs === 'text') {
 			$headers['Content-Type'] = 'text/plain; charset=' . $this->charset;
@@ -627,7 +626,8 @@ class EmailComponent extends Object{
 		} elseif ($this->sendAs === 'both') {
 			$headers['Content-Type'] = 'multipart/alternative; boundary="alt-' . $this->__boundary . '"';
 		}
-
+		
+		$headers['MIME-Version'] = '1.0';
 		$headers['Content-Transfer-Encoding'] = '7bit';
 
         $this->header($headers);

--- a/cake/libs/controller/components/email.php
+++ b/cake/libs/controller/components/email.php
@@ -622,6 +622,7 @@ class EmailComponent extends Object{
 		} elseif ($this->sendAs === 'text') {
 			$headers['Content-Type'] = 'text/plain; charset=' . $this->charset;
 		} elseif ($this->sendAs === 'html') {
+			$headers['MIME-Version'] = '1.0';
 			$headers['Content-Type'] = 'text/html; charset=' . $this->charset;
 		} elseif ($this->sendAs === 'both') {
 			$headers['Content-Type'] = 'multipart/alternative; boundary="alt-' . $this->__boundary . '"';


### PR DESCRIPTION
Some email readers can not interpret HTML emails without the MIME-Version set on the email header.
