### PR TITLE
Mime Type on HTML Emails Fix

### DIFF
--- a/cake/libs/controller/components/email.php
+++ b/cake/libs/controller/components/email.php
@@ -617,7 +617,6 @@ class EmailComponent extends Object{
 		}
 
 		if (!empty($this->attachments)) {
-			$headers['MIME-Version'] = '1.0';
 			$headers['Content-Type'] = 'multipart/mixed; boundary="' . $this->__boundary . '"';
 		} elseif ($this->sendAs === 'text') {
 			$headers['Content-Type'] = 'text/plain; charset=' . $this->charset;
@@ -626,7 +625,8 @@ class EmailComponent extends Object{
 		} elseif ($this->sendAs === 'both') {
 			$headers['Content-Type'] = 'multipart/alternative; boundary="alt-' . $this->__boundary . '"';
 		}
-
+		
+		$headers['MIME-Version'] = '1.0';
 		$headers['Content-Transfer-Encoding'] = '7bit';
 
         $this->header($headers);


### PR DESCRIPTION
Some email readers can not interpret HTML emails without the MIME-Version set on the email header.
From https://github.com/cakephp/cakephp/pull/4839
