### PR TITLE
3.0 counter cache error with lambda counters

### DIFF
--- a/src/Model/Behavior/CounterCacheBehavior.php
+++ b/src/Model/Behavior/CounterCacheBehavior.php
@@ -165,7 +165,7 @@ class CounterCacheBehavior extends Behavior {
 			}
 
 			if (!is_string($config) && is_callable($config)) {
-				$count = $config($event, $entity, $this->_table);
+				$count = $config($event, $entity, $this->_table, false);
 			} else {
 				$count = $this->_getCount($config, $countConditions);
 			}
@@ -173,7 +173,11 @@ class CounterCacheBehavior extends Behavior {
 			$assoc->target()->updateAll([$field => $count], $updateConditions);
 
 			if (isset($updateOriginalConditions)) {
-				$count = $this->_getCount($config, $countOriginalConditions);
+				if (!is_string($config) && is_callable($config)) {
+					$count = $config($event, $entity, $this->_table, true);
+				} else {
+					$count = $this->_getCount($config, $countOriginalConditions);
+				}
 				$assoc->target()->updateAll([$field => $count], $updateOriginalConditions);
 			}
 		}

--- a/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
@@ -270,11 +270,15 @@ class CounterCacheBehaviorTest extends TestCase {
 
 		$this->post->addBehavior('CounterCache', [
 			'Users' => [
-				'posts_published' => function (Event $orgEvent, Entity $orgEntity, Table $orgTable) use ($entity, $table) {
+				'posts_published' => function (Event $orgEvent, Entity $orgEntity, Table $orgTable, $original) use ($entity, $table) {
 					$this->assertSame($orgTable, $table);
 					$this->assertSame($orgEntity, $entity);
 
-					return 2;
+					if (!$original) {
+						return 2;
+					} else {
+						return 1;
+					}
 				}
 			]
 		]);

--- a/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CounterCacheBehaviorTest.php
@@ -258,6 +258,40 @@ class CounterCacheBehaviorTest extends TestCase {
 	}
 
 /**
+ * Testing counter cache with lambda returning number and changing of related ID
+ *
+ * @return void
+ */
+	public function testLambdaNumberUpdate() {
+		$this->post->belongsTo('Users');
+
+		$table = $this->post;
+		$entity = $this->_getEntity();
+
+		$this->post->addBehavior('CounterCache', [
+			'Users' => [
+				'posts_published' => function (Event $orgEvent, Entity $orgEntity, Table $orgTable) use ($entity, $table) {
+					$this->assertSame($orgTable, $table);
+					$this->assertSame($orgEntity, $entity);
+
+					return 2;
+				}
+			]
+		]);
+
+		$this->post->save($entity);
+		$between = $this->_getUser();
+		$entity->user_id = 2;
+		$this->post->save($entity);
+		$afterUser1 = $this->_getUser(1);
+		$afterUser2 = $this->_getUser(2);
+
+		$this->assertEquals(2, $between->get('posts_published'));
+		$this->assertEquals(1, $afterUser1->get('posts_published'));
+		$this->assertEquals(2, $afterUser2->get('posts_published'));
+	}
+
+/**
  * Testing counter cache with lambda returning subqueryn
  *
  * @return void


### PR DESCRIPTION
When using counterCache with a lambda counter, it would error if the entity foreign_key is updated as it was calling _getCount() with the lambda (and _getCount expects an array)

I added in a $original argument to the counterCache callable to determine what part of the count is being called.
