### PR TITLE
Make CakeSession::read() return null for all failure cases.

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -378,7 +378,7 @@ class CakeSession {
  */
 	public static function read($name = null) {
 		if (empty($name) && $name !== null) {
-			return false;
+			return null;
 		}
 		if (!self::_hasSession() || !self::start()) {
 			return null;

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -280,7 +280,7 @@ class CakeSessionTest extends CakeTestCase {
  * @return void
  */
 	public function testReadyEmpty() {
-		$this->assertFalse(TestCakeSession::read(''));
+		$this->assertNull(TestCakeSession::read(''));
 	}
 
 /**


### PR DESCRIPTION
Refs #4849
