### PR TITLE
TranslateBehavior now uses original atomic option value, if set

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -437,6 +437,10 @@ class TranslateBehavior extends ModelBehavior {
 			$tempData = $this->_prepareTranslations($Model, $tempData);
 		}
 		$locale = $this->_getLocale($Model);
+		$atomic = array();
+		if (isset($options['atomic'])) {
+			$atomic = array('atomic' => $options['atomic']);
+		}
 
 		foreach ($tempData as $field => $value) {
 			unset($conditions['content']);
@@ -466,10 +470,11 @@ class TranslateBehavior extends ModelBehavior {
 					$RuntimeModel->save(array(
 						$RuntimeModel->alias => array_merge(
 							$conditions, array('id' => $translations[$_locale])
-						)
+						),
+						$atomic
 					));
 				} else {
-					$RuntimeModel->save(array($RuntimeModel->alias => $conditions));
+					$RuntimeModel->save(array($RuntimeModel->alias => $conditions), $atomic);
 				}
 			}
 		}

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -720,6 +720,54 @@ class TranslateBehaviorTest extends CakeTestCase {
 	}
 
 /**
+ * testSaveAssociatedAtomic method
+ *
+ * @return void
+ */
+	public function testSaveAssociatedAtomic() {
+		$this->loadFixtures('Translate', 'TranslatedItem');
+
+		$TestModel = new TranslatedItem();
+		$data = array(
+			'slug' => 'fourth_translated',
+			'title' => array(
+				'eng' => 'Title #4'
+			),
+			'content' => array(
+				'eng' => 'Content #4'
+			),
+			'translated_article_id' => 1,
+		);
+		$Mock = $this->getMockForModel('TranslateTestModel', array('save'));
+		$TestModel->Behaviors->Translate->runtime[$TestModel->alias]['model'] = $Mock;
+
+		$with = array(
+			'TranslateTestModel' => array (
+				'model' => 'TranslatedItem',
+				'foreign_key' => '4',
+				'field' => 'content',
+				'locale' => 'eng',
+				'content' => 'Content #4',
+			)
+		);
+		$Mock->expects($this->at(0))->method('save')->with($with, array('atomic' => false));
+
+		$with = array(
+			'TranslateTestModel' => array (
+				'model' => 'TranslatedItem',
+				'foreign_key' => '4',
+				'field' => 'title',
+				'locale' => 'eng',
+				'content' => 'Title #4',
+			)
+		);
+		$Mock->expects($this->at(1))->method('save')->with($with, array('atomic' => false));
+
+		$TestModel->create();
+		$TestModel->saveAssociated($data, array('atomic' => false));
+	}
+
+/**
  * Test that saving only some of the translated fields allows the record to be found again.
  *
  * @return void


### PR DESCRIPTION
Fixes #4852

Will add tests later.
