### PR TITLE
Repaired loop if referrer is equal to current

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -419,8 +419,8 @@ class CakeRequest implements ArrayAccess {
  */
 	public function referer($local = false) {
 		$ref = env('HTTP_REFERER');
-		$here = Configure::read('App.fullBaseUrl').$this->here;
-		$base = Configure::read('App.fullBaseUrl').$this->webroot;
+		$here = Configure::read('App.fullBaseUrl') . $this->here;
+		$base = Configure::read('App.fullBaseUrl') . $this->webroot;
 
 		if (!empty($ref) && !empty($base) && $here !== $ref) {
 			if ($local && strpos($ref, $base) === 0) {

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -419,8 +419,8 @@ class CakeRequest implements ArrayAccess {
  */
 	public function referer($local = false) {
 		$ref = env('HTTP_REFERER');
-		$here = Configure::read('App.fullBaseUrl'). $this->here;
-		$base = Configure::read('App.fullBaseUrl') .$this->webroot;
+		$here = Configure::read('App.fullBaseUrl').$this->here;
+		$base = Configure::read('App.fullBaseUrl').$this->webroot;
 
 		if (!empty($ref) && !empty($base) && $here !== $ref) {
 			if ($local && strpos($ref, $base) === 0) {
@@ -432,7 +432,7 @@ class CakeRequest implements ArrayAccess {
 				return $ref;
 			}
 		}
-	    return '/';
+		return '/';
 	}
 
 /**

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -419,7 +419,7 @@ class CakeRequest implements ArrayAccess {
  */
 	public function referer($local = false) {
 		$ref = env('HTTP_REFERER');
-		$here = Configure::read('App.fullBaseUrl'). $this->here ;
+		$here = Configure::read('App.fullBaseUrl'). $this->here;
 		$base = Configure::read('App.fullBaseUrl') .$this->webroot;
 
 		if (!empty($ref) && !empty($base) && $here !== $ref) {

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -418,22 +418,22 @@ class CakeRequest implements ArrayAccess {
  * @return string The referring address for this request.
  */
 	public function referer($local = false) {
-		$ref = env('HTTP_REFERER');
-
-		$base = Configure::read('App.fullBaseUrl') . $this->webroot;
-		if (!empty($ref) && !empty($base)) {
-			if ($local && strpos($ref, $base) === 0) {
-				$ref = substr($ref, strlen($base));
-				if ($ref[0] !== '/') {
-					$ref = '/' . $ref;
-				}
-				return $ref;
-			} elseif (!$local) {
-				return $ref;
-			}
-		}
-		return '/';
-	}
+	        $ref = env('HTTP_REFERER');
+	        $here = Configure::read('App.fullBaseUrl'). $this->here ;
+	        $base = Configure::read('App.fullBaseUrl') .$this->webroot;
+	
+	        if (!empty($ref) && !empty($base) && $here !== $ref) {
+	            if ($local && strpos($ref, $base) === 0) {
+	                if ($ref[0] !== '/') {
+	                    $ref = '/' . $ref;
+	                }
+	                return $ref;
+	            } elseif (!$local) {
+	                return $ref;
+	            }
+	        }
+	        return '/';
+    	}
 
 /**
  * Missing method handler, handles wrapping older style isAjax() type methods

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -418,22 +418,22 @@ class CakeRequest implements ArrayAccess {
  * @return string The referring address for this request.
  */
 	public function referer($local = false) {
-	        $ref = env('HTTP_REFERER');
-	        $here = Configure::read('App.fullBaseUrl'). $this->here ;
-	        $base = Configure::read('App.fullBaseUrl') .$this->webroot;
-	
-	        if (!empty($ref) && !empty($base) && $here !== $ref) {
-	            if ($local && strpos($ref, $base) === 0) {
-	                if ($ref[0] !== '/') {
-	                    $ref = '/' . $ref;
-	                }
-	                return $ref;
-	            } elseif (!$local) {
-	                return $ref;
-	            }
-	        }
-	        return '/';
-    	}
+		$ref = env('HTTP_REFERER');
+		$here = Configure::read('App.fullBaseUrl'). $this->here ;
+		$base = Configure::read('App.fullBaseUrl') .$this->webroot;
+
+		if (!empty($ref) && !empty($base) && $here !== $ref) {
+			if ($local && strpos($ref, $base) === 0) {
+				if ($ref[0] !== '/') {
+					$ref = '/' . $ref;
+				}
+				return $ref;
+			} elseif (!$local) {
+				return $ref;
+			}
+		}
+	    return '/';
+	}
 
 /**
  * Missing method handler, handles wrapping older style isAjax() type methods


### PR DESCRIPTION
If in any case when applying below code to redirect on successful login 

``` php
 $this->redirect($this->referer($this->Auth->loginRedirect));
```

if first attemp fails, the referrer is equal to login page, thus, ends up in a redirect loop at login page.
