### PR TITLE
Always return an array from Table::primaryKey().

### DIFF
--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -419,8 +419,8 @@ class Table {
 /**
  * Get the column(s) used for the primary key.
  *
- * @return array|null Column name(s) for the primary key.
- *   Null will be returned if a table has no primary key.
+ * @return array Column name(s) for the primary key. An
+ *   empty list will be returned when the table has no primary key.
  */
 	public function primaryKey() {
 		foreach ($this->_constraints as $name => $data) {
@@ -428,7 +428,7 @@ class Table {
 				return $data['columns'];
 			}
 		}
-		return null;
+		return [];
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -318,6 +318,12 @@ class TableTest extends TestCase {
 				'columns' => ['id']
 			]);
 		$this->assertEquals(['id'], $table->primaryKey());
+
+		$table = new Table('articles');
+		$table->addColumn('id', 'integer')
+			->addColumn('title', 'string')
+			->addColumn('author_id', 'integer');
+		$this->assertEquals([], $table->primaryKey());
 	}
 
 /**


### PR DESCRIPTION
By having a consistent return type we can avoid errors downstream when tables don't have a primary key.

Refs #4862
