### PR TITLE
Fix getMockForModel() using the incorrect datasource.

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -26,6 +26,7 @@ App::uses('Model', 'Model');
  * Secondary Post stub class.
  */
 class SecondaryPost extends Model {
+
 /**
  * @var string
  */
@@ -35,6 +36,7 @@ class SecondaryPost extends Model {
  * @var string
  */
 	public $useDbConfig = 'secondary';
+
 }
 
 /**
@@ -437,9 +439,9 @@ class CakeTestCaseTest extends CakeTestCase {
 			)
 		), App::RESET);
 		CakePlugin::load('TestPlugin');
-		ConnectionManager::create('test_secondary', [
+		ConnectionManager::create('test_secondary', array(
 			'datasource' => 'Database/TestLocalDriver'
-		]);
+		));
 		$post = $this->getMockForModel('SecondaryPost', array('save'));
 		$this->assertEquals('test_secondary', $post->useDbConfig);
 		ConnectionManager::drop('test_secondary');

--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -17,9 +17,25 @@
  * @since         CakePHP v 1.2.0.4487
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
+App::uses('CakePlugin', 'Core');
 App::uses('Controller', 'Controller');
 App::uses('CakeHtmlReporter', 'TestSuite/Reporter');
+App::uses('Model', 'Model');
+
+/**
+ * Secondary Post stub class.
+ */
+class SecondaryPost extends Model {
+/**
+ * @var string
+ */
+	public $useTable = 'posts';
+
+/**
+ * @var string
+ */
+	public $useDbConfig = 'secondary';
+}
 
 /**
  * CakeTestCaseTest
@@ -391,9 +407,9 @@ class CakeTestCaseTest extends CakeTestCase {
  */
 	public function testGetMockForModel() {
 		App::build(array(
-				'Model' => array(
-					CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS
-				)
+			'Model' => array(
+				CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS
+			)
 		), App::RESET);
 		$Post = $this->getMockForModel('Post');
 
@@ -409,15 +425,36 @@ class CakeTestCaseTest extends CakeTestCase {
 	}
 
 /**
+ * Test getMockForModel on secondary datasources.
+ *
+ * @return void
+ */
+	public function testGetMockForModelSecondaryDatasource() {
+		App::build(array(
+			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS),
+			'Model/Datasource/Database' => array(
+				CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS . 'Datasource' . DS . 'Database' . DS
+			)
+		), App::RESET);
+		CakePlugin::load('TestPlugin');
+		ConnectionManager::create('test_secondary', [
+			'datasource' => 'Database/TestLocalDriver'
+		]);
+		$post = $this->getMockForModel('SecondaryPost', array('save'));
+		$this->assertEquals('test_secondary', $post->useDbConfig);
+		ConnectionManager::drop('test_secondary');
+	}
+
+/**
  * test getMockForModel() with plugin models
  *
  * @return void
  */
 	public function testGetMockForModelWithPlugin() {
 		App::build(array(
-				'Plugin' => array(
-					CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS
-				)
+			'Plugin' => array(
+				CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS
+			)
 		), App::RESET);
 		CakePlugin::load('TestPlugin');
 		$this->getMockForModel('TestPlugin.TestPluginAppModel');
@@ -425,6 +462,7 @@ class CakeTestCaseTest extends CakeTestCase {
 
 		$result = ClassRegistry::init('TestPlugin.TestPluginComment');
 		$this->assertInstanceOf('TestPluginComment', $result);
+		$this->assertEquals('test', $result->useDbConfig);
 
 		$TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComment', array('save'));
 
@@ -445,7 +483,7 @@ class CakeTestCaseTest extends CakeTestCase {
  * @return void
  */
 	public function testGetMockForModelModel() {
-		$Mock = $this->getMockForModel('Model', array('save'), array('name' => 'Comment'));
+		$Mock = $this->getMockForModel('Model', array('save', 'setDataSource'), array('name' => 'Comment'));
 
 		$result = ClassRegistry::init('Comment');
 		$this->assertInstanceOf('Model', $result);

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -722,13 +722,23 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 
 		list($plugin, $name) = pluginSplit($model, true);
 		App::uses($name, $plugin . 'Model');
+
 		$config = array_merge((array)$config, array('name' => $name));
+		unset($config['ds']);
 
 		if (!class_exists($name)) {
 			throw new MissingModelException(array($model));
 		}
-
 		$mock = $this->getMock($name, $methods, array($config));
+
+		$availableDs = array_keys(ConnectionManager::enumConnectionObjects());
+		if ($mock->useDbConfig === 'default') {
+			$mock->setDataSource('test');
+		}
+		if ($mock->useDbConfig !== 'test' && in_array('test_' . $mock->useDbConfig, $availableDs)) {
+			$mock->setDataSource('test_' . $mock->useDbConfig);
+		}
+
 		ClassRegistry::removeObject($name);
 		ClassRegistry::addObject($name, $mock);
 		return $mock;


### PR DESCRIPTION
Because getMockForModel() does not go through the test datasource injection in ClassRegistry::init() we need to duplicate the basics of that logic here. Thankfully, we already have a mock so we can do that datasource switching without reflection. Of course this means there will be limitations to how/when this will work, but I feel those scenarios can probably be solved by not using mocks, or by mocking out the problematic methods. This set of changes makes getMockForModel() work with secondary datasources, as one would expect it to do, but I'm not sure it ever did.

Refs #4694
