### PR TITLE
Fix mergeMany() and composite keys.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -320,11 +320,11 @@ class Marshaller {
 
 /**
  * Merges each of the elements from `$data` into each of the entities in `$entities
- * and recursively does the same for each one of the association names passed in
+ * and recursively does the same for each of the association names passed in
  * `$options`. When merging associations, if an entity is not present in the parent
- * entity for such association, a new one will be created.
+ * entity for a given association, a new one will be created.
  *
- * Records in `$data` are matched against the entities by using the primary key
+ * Records in `$data` are matched against the entities using the primary key
  * column. Entries in `$entities` that cannot be matched to any record in
  * `$data` will be discarded. Records in `$data` that could not be matched will
  * be marshalled as a new entity.
@@ -335,12 +335,12 @@ class Marshaller {
  *
  * ### Options:
  *
- * * associated: Associations listed here will be marshalled as well.
- * * fieldList: A whitelist of fields to be assigned to the entity. If not present,
+ * - associated: Associations listed here will be marshalled as well.
+ * - fieldList: A whitelist of fields to be assigned to the entity. If not present,
  *   the accessible fields list in the entity will be used.
  *
  * @param array|\Traversable $entities the entities that will get the
- * data merged in
+ *   data merged in
  * @param array $data list of arrays to be merged into the entities
  * @param array $options List of options.
  * @return array

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1038,6 +1038,36 @@ class MarshallerTest extends TestCase {
 	}
 
 /**
+ * Test that mergeMany() handles composite key associations properly.
+ *
+ * The articles_tags table has a composite primary key, and should be
+ * handled correctly.
+ *
+ * @return void
+ */
+	public function testMergeManyCompositeKey() {
+		$articlesTags = TableRegistry::get('ArticlesTags');
+
+		$entities = [
+			new OpenEntity(['article_id' => 1, 'tag_id' => 2]),
+			new OpenEntity(['article_id' => 1, 'tag_id' => 1]),
+		];
+		$entities[0]->clean();
+		$entities[1]->clean();
+
+		$data = [
+			['article_id' => 1, 'tag_id' => 1],
+			['article_id' => 1, 'tag_id' => 2]
+		];
+		$marshall = new Marshaller($articlesTags);
+		$result = $marshall->mergeMany($entities, $data);
+
+		$this->assertCount(2, $result, 'Should have two records');
+		$this->assertSame($entities[0], $result[0], 'Should retain object');
+		$this->assertSame($entities[1], $result[1], 'Should retain object');
+	}
+
+/**
  * Tests merge with data types that need to be marshalled
  *
  * @return void

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1033,6 +1033,8 @@ class MarshallerTest extends TestCase {
 		$this->assertNotSame($entities[0], $result[0]);
 		$this->assertSame($entities[1], $result[0]);
 		$this->assertEquals('Changed 2', $result[0]->comment);
+
+		$this->assertEquals('Comment 1', $result[1]->comment);
 	}
 
 /**


### PR DESCRIPTION
mergeMany() needs to be composite key aware as tables/associations can easily have composite keys. I've used `;` as a separator as I've not seen many composite keys with them, and even when they do an out of  place `;` will still enforce uniqueness.

Refs #4817
