### PR TITLE
Add default prefix to RedisEngine

### DIFF
--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -59,7 +59,7 @@ class RedisEngine extends CacheEngine {
 		}
 		parent::init(array_merge(array(
 			'engine' => 'Redis',
-			'prefix' => null,
+			'prefix' => Inflector::slug(APP_DIR) . '_',
 			'server' => '127.0.0.1',
 			'database' => 0,
 			'port' => 6379,

--- a/lib/Cake/Test/Case/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/RedisEngineTest.php
@@ -77,6 +77,7 @@ class RedisEngineTest extends CakeTestCase {
 			'persistent' => true,
 			'password' => false,
 			'database' => 0,
+			'unix_socket' => false,
 		);
 		$this->assertEquals($expecting, $settings);
 	}


### PR DESCRIPTION
This makes redis work like the other cache engines. Also by having a default prefix the clear() method will not wipe all the data in the current redis database.

I also fixed a failing test.

Refs #4876
