### PR TITLE
3.0- PaginatorHelper url generation

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -417,7 +417,7 @@ class PaginatorHelper extends Helper {
 		];
 
 		if (!empty($this->_config['options']['url'])) {
-			$url = array_merge($this->_config['options']['url'], $url);
+			$url = array_merge($url, $this->_config['options']['url']);
 		}
 		$url = array_merge(array_filter($url), $options);
 


### PR DESCRIPTION
it appears that when there is a query string in the url of the pagination helper like this : 
![capture](https://cloud.githubusercontent.com/assets/4977112/4646659/463c9808-5475-11e4-9589-67966663c3ce.PNG)

The parameters are lost when moving to page 2
![capture2](https://cloud.githubusercontent.com/assets/4977112/4646665/5b6fe068-5475-11e4-9c57-e91786d11111.PNG)

This PR corrects this problem as shown bellow
![capture3](https://cloud.githubusercontent.com/assets/4977112/4646681/7faa4130-5475-11e4-8c16-4df4cb8e0e78.PNG)
