### PR TITLE
3.0 Hash generated by DigestAuthhenticate::generateResponseHash() does not match $digest['response'] when using PUT

### DIFF
--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -112,7 +112,7 @@ class DigestAuthenticate extends BasicAuthenticate {
 		$password = $user[$field];
 		unset($user[$field]);
 
-		$hash = $this->generateResponseHash($digest, $password, $request->env('REQUEST_METHOD'));
+		$hash = $this->generateResponseHash($digest, $password, env('REQUEST_METHOD'));
 		if ($digest['response'] === $hash) {
 			return $user;
 		}


### PR DESCRIPTION
The hash generated by DigestAuthhenticate::generateResponseHash() does not match  $digest['response'] when submitting an existing form.

I can "fix" the issue by changing the following line

``` php
$hash = $this->generateResponseHash($digest, $password, $request->env('REQUEST_METHOD'));
```

in

``` php
$hash = $this->generateResponseHash($digest, $password, $_SERVER['REQUEST_METHOD']);
```

Adding some debug lines in DigestAuthenticate::getUser() results in following result:

``` php
debug($request->env('REQUEST_METHOD'));
debug($_SERVER['REQUEST_METHOD']);
die();
```

```
/src/Auth/DigestAuthenticate.php (line 115)
'PUT'
/src/Auth/DigestAuthenticate.php (line 116)
'POST'
```
