### PR TITLE
2.6 Add Support for MySQL Table Comments

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -397,8 +397,10 @@ class CakeSchema extends Object {
 	}
 
 /**
- * Generate the code for a table. Takes a table name and $fields array
- * Returns a completed variable declaration to be used in schema classes.
+ * Generate the schema code for a table.
+ *
+ * Takes a table name and $fields array and returns a completed,
+ * escaped variable declaration to be used in schema classes.
  *
  * @param string $table Table name you want returned.
  * @param array $fields Array of field information to generate the table with.
@@ -426,10 +428,7 @@ class CakeSchema extends Object {
 					$col .= implode(",\n\t\t\t", $props) . "\n\t\t";
 				} elseif ($field === 'tableParameters') {
 					$col = "\t\t'tableParameters' => array(";
-					$props = array();
-					foreach ((array)$value as $key => $param) {
-						$props[] = "'{$key}' => '$param'";
-					}
+					$props = $this->_values($value);
 					$col .= implode(', ', $props);
 				}
 				$col .= ")";

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -102,7 +102,8 @@ class Mysql extends DboSource {
 	public $tableParameters = array(
 		'charset' => array('value' => 'DEFAULT CHARSET', 'quote' => false, 'join' => '=', 'column' => 'charset'),
 		'collate' => array('value' => 'COLLATE', 'quote' => false, 'join' => '=', 'column' => 'Collation'),
-		'engine' => array('value' => 'ENGINE', 'quote' => false, 'join' => '=', 'column' => 'Engine')
+		'engine' => array('value' => 'ENGINE', 'quote' => false, 'join' => '=', 'column' => 'Engine'),
+		'comment' => array('value' => 'COMMENT', 'quote' => true, 'join' => '=', 'column' => 'Comment'),
 	);
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -704,7 +704,8 @@ class MysqlTest extends CakeTestCase {
 				'tableParameters' => array(
 					'charset' => 'utf8',
 					'collate' => 'utf8_general_ci',
-					'engine' => 'InnoDB'
+					'engine' => 'InnoDB',
+					'comment' => 'Newly table added comment.',
 				)
 			)
 		));
@@ -712,6 +713,7 @@ class MysqlTest extends CakeTestCase {
 		$this->assertContains('DEFAULT CHARSET=utf8', $result);
 		$this->assertContains('ENGINE=InnoDB', $result);
 		$this->assertContains('COLLATE=utf8_general_ci', $result);
+		$this->assertContains('COMMENT=\'Newly table added comment.\'', $result);
 
 		$this->Dbo->rawQuery($result);
 		$result = $this->Dbo->listDetailedSources($this->Dbo->fullTableName('altertest', false, false));
@@ -775,13 +777,15 @@ class MysqlTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$table = $this->Dbo->fullTableName($tableName);
-		$this->Dbo->rawQuery('CREATE TABLE ' . $table . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id)) ENGINE=MyISAM DEFAULT CHARSET=cp1250 COLLATE=cp1250_general_ci;');
+		$this->Dbo->rawQuery('CREATE TABLE ' . $table . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id)) ENGINE=MyISAM DEFAULT CHARSET=cp1250 COLLATE=cp1250_general_ci COMMENT=\'Table\'\'s comment\';');
 		$result = $this->Dbo->readTableParameters($this->Dbo->fullTableName($tableName, false, false));
 		$this->Dbo->rawQuery('DROP TABLE ' . $table);
 		$expected = array(
 			'charset' => 'cp1250',
 			'collate' => 'cp1250_general_ci',
-			'engine' => 'MyISAM');
+			'engine' => 'MyISAM',
+			'comment' => 'Table\'s comment',
+		);
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
Adds suppport for reading and writing table comments.

Example:

``` php
public $backups = array(
        'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false, 'key' => 'primary'),
        // Some fields
        'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
        'created_by' => array('type' => 'integer', 'null' => true, 'default' => null, 'unsigned' => false),
        'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
        'modified_by' => array('type' => 'integer', 'null' => true, 'default' => null, 'unsigned' => false),
        'indexes' => array(
            'PRIMARY' => array('column' => 'id', 'unique' => 1)
        ),
        // Table comment gets added at the end of tableParameters
        'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci', 'engine' => 'InnoDB', 'comment' => 'foo bar baz1')
    );
```

Creating the table:

``` sql
CREATE TABLE `cakephp_test`.`backups` (
        `id` int(11) NOT NULL AUTO_INCREMENT,
       /* some fields */
        `created` datetime DEFAULT NULL,
        `created_by` int(11) DEFAULT NULL,
        `modified` datetime DEFAULT NULL,
        `modified_by` int(11) DEFAULT NULL,     PRIMARY KEY  (`id`))    DEFAULT CHARSET=utf8,
        COLLATE=utf8_general_ci,
        ENGINE=InnoDB,
        COMMENT='foo bar baz1';
```

Altering the table:

``` sql
ALTER TABLE `cakephp_test`.`backups`
        COMMENT='foo bar baz';
```

Altering the table when comment becomes empty string:

``` sql
ALTER TABLE `cakephp_test`.`backups`
        COMMENT='';
```
