### PR TITLE
An array should be passed to allowMethod to allow multiple methods

### DIFF
--- a/src/Template/Bake/default/actions/controller_actions.ctp
+++ b/src/Template/Bake/default/actions/controller_actions.ctp
@@ -132,7 +132,7 @@ $allAssociations = array_merge(
  */
 	public function delete($id = null) {
 		$<?= $singularName ?> = $this-><?= $currentModelName ?>->get($id);
-		$this->request->allowMethod('post', 'delete');
+		$this->request->allowMethod(['post', 'delete']);
 		if ($this-><?= $currentModelName; ?>->delete($<?= $singularName ?>)) {
 			$this->Flash->success('The <?= strtolower($singularHumanName) ?> has been deleted.');
 		} else {


### PR DESCRIPTION
A baked controller has a delete method containing

``` php
$this->request->allowMethod('post', 'delete');
```

this should be 

``` php
$this->request->allowMethod(['post', 'delete']);
```
