### PR TITLE
Update test generation to always include at least one method

### DIFF
--- a/src/Shell/Task/TestTask.php
+++ b/src/Shell/Task/TestTask.php
@@ -26,6 +26,7 @@ use Cake\ORM\Association;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use ReflectionClass;
 
 /**
  * Task class for creating and updating test files.
@@ -304,14 +305,16 @@ class TestTask extends BakeTask {
  * @return array Array of method names.
  */
 	public function getTestableMethods($className) {
-		$classMethods = get_class_methods($className);
-		$parentMethods = get_class_methods(get_parent_class($className));
-		$thisMethods = array_diff($classMethods, $parentMethods);
+		$class = new ReflectionClass($className);
 		$out = [];
-		foreach ($thisMethods as $method) {
-			if (substr($method, 0, 1) !== '_' && $method != strtolower($className)) {
-				$out[] = $method;
+		foreach ($class->getMethods() as $method) {
+			if ($method->getDeclaringClass()->getName() != $className) {
+				continue;
 			}
+			if (!$method->isPublic()) {
+				continue;
+			}
+			$out[] = $method->getName();
 		}
 		return $out;
 	}

--- a/src/Template/Bake/default/classes/test.ctp
+++ b/src/Template/Bake/default/classes/test.ctp
@@ -77,13 +77,24 @@ class <?= $className ?>Test extends TestCase {
 <?php endif; ?>
 <?php foreach ($methods as $method): ?>
 /**
- * test<?= Inflector::camelize($method) ?> method
+ * Test <?= $method ?> method
  *
  * @return void
  */
 	public function test<?= Inflector::camelize($method) ?>() {
-		$this->markTestIncomplete('test<?= Inflector::camelize($method) ?> not implemented.');
+		$this->markTestIncomplete('Not implemented yet.');
 	}
 
 <?php endforeach; ?>
+<?php if (empty($methods)): ?>
+/**
+ * Test initial setup
+ *
+ * @return void
+ */
+	public function testInitialization() {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
+<?php endif; ?>
 }

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -444,7 +444,7 @@ class TestTaskTest extends TestCase {
 		$this->assertContains("\$this->Apple = new AppleComponent(\$registry)", $result);
 
 		$this->assertContains('function testStartup()', $result);
-		$this->assertContains('$this->markTestIncomplete(\'testStartup not implemented.\')', $result);
+		$this->assertContains('$this->markTestIncomplete(\'Not implemented yet.\')', $result);
 
 		$this->assertContains('function tearDown()', $result);
 		$this->assertContains('unset($this->Apple)', $result);

--- a/tests/TestCase/Shell/Task/TestTaskTest.php
+++ b/tests/TestCase/Shell/Task/TestTaskTest.php
@@ -206,7 +206,7 @@ class TestTaskTest extends TestCase {
  */
 	public function testMethodIntrospection() {
 		$result = $this->Task->getTestableMethods('TestApp\Model\Table\ArticlesTable');
-		$expected = ['findpublished', 'dosomething', 'dosomethingelse'];
+		$expected = ['initialize', 'findpublished', 'dosomething', 'dosomethingelse'];
 		$this->assertEquals($expected, array_map('strtolower', $result));
 	}
 


### PR DESCRIPTION
Generated tests should always include at least one method to avoid PHPUnit errors. I've also update the method reflection to include methods defined in the parent, but overridden in child classes as those methods will also need tests.

Refs #4892
