### PR TITLE
Fix errors baking tree models.

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -646,6 +646,14 @@ class ModelTask extends BakeTask {
 		$filename = $path . 'Table' . DS . $name . 'Table.php';
 		$this->out("\n" . sprintf('Baking table class for %s...', $name), 1, Shell::QUIET);
 		$this->createFile($filename, $out);
+
+		// Work around composer caching that classes/files do not exist.
+		// Check for the file as it might not exist in tests.
+		if (file_exists($filename)) {
+			require_once($filename);
+		}
+		TableRegistry::clear();
+
 		$emptyFile = $path . 'Table' . DS . 'empty';
 		$this->_deleteEmptyFile($emptyFile);
 		return $out;

--- a/src/Shell/Task/ViewTask.php
+++ b/src/Shell/Task/ViewTask.php
@@ -357,6 +357,11 @@ class ViewTask extends BakeTask {
 			$vars = $this->_loadController();
 		}
 
+		if (empty($vars['primaryKey'])) {
+			$this->error('Cannot generate views for models with no primary key');
+			return false;
+		}
+
 		$this->Template->set('action', $action);
 		$this->Template->set('plugin', $this->plugin);
 		$this->Template->set($vars);

--- a/tests/TestCase/Shell/Task/ViewTaskTest.php
+++ b/tests/TestCase/Shell/Task/ViewTaskTest.php
@@ -102,7 +102,7 @@ class ViewTaskTest extends TestCase {
 		parent::setUp();
 
 		Configure::write('App.namespace', 'TestApp');
-		$this->_setupTask(['in', 'err', 'createFile', '_stop']);
+		$this->_setupTask(['in', 'err', 'error', 'createFile', '_stop']);
 
 		TableRegistry::get('ViewTaskComments', [
 			'className' => __NAMESPACE__ . '\ViewTaskCommentsTable',
@@ -310,6 +310,33 @@ class ViewTaskTest extends TestCase {
 		$this->assertContains('$testViewModel->id', $result);
 		$this->assertContains('$testViewModel->name', $result);
 		$this->assertContains('$testViewModel->body', $result);
+	}
+
+/**
+ * Test getContent with no pk
+ *
+ * @return void
+ */
+	public function testGetContentWithNoPrimaryKey() {
+		$vars = array(
+			'modelClass' => 'TestViewModel',
+			'schema' => TableRegistry::get('ViewTaskComments')->schema(),
+			'primaryKey' => [],
+			'displayField' => 'name',
+			'singularVar' => 'testViewModel',
+			'pluralVar' => 'testViewModels',
+			'singularHumanName' => 'Test View Model',
+			'pluralHumanName' => 'Test View Models',
+			'fields' => ['id', 'name', 'body'],
+			'associations' => [],
+			'keyFields' => [],
+		);
+		$this->Task->expects($this->once())
+			->method('error')
+			->with($this->stringContains('Cannot generate views for models'));
+
+		$result = $this->Task->getContent('view', $vars);
+		$this->assertFalse($result);
 	}
 
 /**


### PR DESCRIPTION
When generating code for tree models, bake incorrectly assumed that the parent/child associations had separate tables. Reloading the registry by itself should work, however, composer caches that files do not exist and requires us to manually include the newly generated class.

I also fixed another error where generating views for tables with no primary key would issue notices and generate incorrect code. Since bake can't really do much with tables that don't have primary keys I think it is best for now to error out.

Refs #4914
