### PR TITLE
Update PaginatorComponent.php

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -159,9 +159,10 @@ class PaginatorComponent extends Component {
 
 		if (empty($query)) {
 			$query = $object->find($finder, $options);
+		} else {
+			$query->applyOptions($options);
 		}
 
-		$query->applyOptions($options);
 		$results = $query->all();
 		$numResults = count($results);
 		$count = $numResults ? $query->count() : 0;


### PR DESCRIPTION
controller:

```
$this->paginate['conditions'] = ['field_name' => 5];
$this->paginate();
```

results to:

```
WHERE (field_name = 5 AND field_name = 5)
```

the reason is pretty simple:
both $object->find and $query->applyOptions($options) add where(['field_name' => 5])

I am not quite sure if this change breaks anything but at least it solves this issue.

As a workaround I did the following:

```
$conditions = $this->paginate['conditions'];
unset($this->paginate['conditions']);
$paginationData = $this->paginate($this->{$this->modelClass}->find()->where($conditions));
```

this works because not the model object but a Query object is passed therefore $object->find is not executed.
