### PR TITLE
Removing unrelated parameter in comment

### DIFF
--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -40,7 +40,6 @@ class PagesController extends AppController {
 /**
  * Displays a view
  *
- * @param mixed What page to display
  * @return void
  * @throws NotFoundException When the view file could not be found
  *	or MissingViewException in debug mode.


### PR DESCRIPTION
That parameter doesn't exists in display() function (in fact is not a parameter) and is breaking the [CakePHP code standards](https://github.com/cakephp/cakephp-codesniffer)
