### PR TITLE
Implementing __set_state for CakeRoute

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -546,4 +546,22 @@ class CakeRoute {
 		return $out;
 	}
 
+	/**
+	 * Set state magic method to support var_export
+	 *
+	 * This method helps for applications that want to implement
+	 * router caching.
+	 *
+	 * @param array $fields
+	 * @return CakeRoute
+	 */
+	public static function __set_state($fields) {
+		$class = function_exists('get_called_class') ? get_called_class() : __CLASS__;
+		$obj = new $class('');
+		foreach ($fields as $field => $value) {
+			$obj->$field = $value;
+		}
+		return $obj;
+	}
+
 }

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -546,15 +546,15 @@ class CakeRoute {
 		return $out;
 	}
 
-	/**
-	 * Set state magic method to support var_export
-	 *
-	 * This method helps for applications that want to implement
-	 * router caching.
-	 *
-	 * @param array $fields
-	 * @return CakeRoute
-	 */
+/**
+ * Set state magic method to support var_export
+ *
+ * This method helps for applications that want to implement
+ * router caching.
+ *
+ * @param array $fields Key/Value of object attributes
+ * @return CakeRoute A new instance of the route
+ */
 	public static function __set_state($fields) {
 		$class = function_exists('get_called_class') ? get_called_class() : __CLASS__;
 		$obj = new $class('');

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -984,7 +984,9 @@ class CakeRouteTest extends CakeTestCase {
  */
 	public function testSetState() {
 		$route = new CakeRoute('/', array('controller' => 'pages', 'action' => 'display', 'home'));
+		// @codingStandardsIgnoreStart
 		$retrievedRoute = eval('return ' . var_export($route, true) . ';');
+		// @codingStandardsIgnoreEnd
 		$this->assertEquals($route, $retrievedRoute);
 	}
 

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -977,4 +977,15 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Test for var_export on CakeRoute
+ *
+ * @return void
+ */
+	public function testSetState() {
+		$route = new CakeRoute('/', array('controller' => 'pages', 'action' => 'display', 'home'));
+		$retrievedRoute = eval('return ' . var_export($route, true) . ';');
+		$this->assertEquals($route, $retrievedRoute);
+	}
+
 }

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -978,16 +978,33 @@ class CakeRouteTest extends CakeTestCase {
 	}
 
 /**
- * Test for var_export on CakeRoute
+ * Test for __set_state magic method on CakeRoute
  *
  * @return void
  */
 	public function testSetState() {
-		$route = new CakeRoute('/', array('controller' => 'pages', 'action' => 'display', 'home'));
-		// @codingStandardsIgnoreStart
-		$retrievedRoute = eval('return ' . var_export($route, true) . ';');
-		// @codingStandardsIgnoreEnd
-		$this->assertEquals($route, $retrievedRoute);
+		$route = CakeRoute::__set_state(array(
+			'keys' => array(),
+			'options' => array(),
+			'defaults' => array(
+				'controller' => 'pages',
+				'action' => 'display',
+				'home',
+			),
+			'template' => '/',
+			'_greedy' => false,
+			'_compiledRoute' => null,
+			'_headerMap' => array (
+				'type' => 'content_type',
+				'method' => 'request_method',
+				'server' => 'server_name',
+			),
+		));
+		$this->assertInstanceOf('CakeRoute', $route);
+		$this->assertSame('/', $route->match(array('controller' => 'pages', 'action' => 'display', 'home')));
+		$this->assertFalse($route->match(array('controller' => 'pages', 'action' => 'display', 'about')));
+		$expected = array('controller' => 'pages', 'action' => 'display', 'pass' => array('home'), 'named' => array());
+		$this->assertEquals($expected, $route->parse('/'));
 	}
 
 }


### PR DESCRIPTION
It helps the applications to cache the routes using var_export when possible.
