### PR TITLE
Add error highlighting to error message.

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -199,7 +199,9 @@ class ExtractTask extends Shell {
 					$this->_output = $response . DS;
 					break;
 				} else {
-					$this->err('The directory path you supplied was not found. Please try again.');
+					$this->err('');
+					$this->err('<error>The directory path you supplied was ' .
+						'not found. Please try again.</error>');
 				}
 				$this->out();
 			}


### PR DESCRIPTION
The issue as reported in #4956 was that the path was not created. An error was being displayed but it wasn't obvious as it looked like normal text. I think colouring the error and spacing it better will work better.

Refs #4956
