### PR TITLE
Update FormHelper.php

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2695,7 +2695,7 @@ class FormHelperTest extends CakeTestCase {
 			array('label' => array('for' => "ContactMultiple")),
 			'Multiple',
 			'/label',
-			array('input' => array('type' => 'hidden', 'name' => "data[Contact][multiple]", 'value' => '', 'id' => "ContactMultiple")),
+			array('input' => array('type' => 'hidden', 'name' => "data[Contact][multiple]", 'value' => '', 'id' => "ContactMultiple", 'disabled' => 'disabled')),
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array('type' => 'checkbox', 'name' => "data[Contact][multiple][]", 'value' => 1, 'disabled' => 'disabled', 'id' => "ContactMultiple1")),
 			array('label' => array('for' => "ContactMultiple1")),
@@ -5004,7 +5004,7 @@ class FormHelperTest extends CakeTestCase {
 			'Multiple',
 			'/label',
 			'input' => array(
-				'type' => 'hidden', 'name' => 'data[Contact][multiple]', 'value' => '', 'id' => 'ContactMultiple_'
+				'type' => 'hidden', 'name' => 'data[Contact][multiple]', 'value' => '', 'id' => 'ContactMultiple_', 'disabled' => 'disabled'
 			),
 			'select' => array(
 				'name' => 'data[Contact][multiple][]', 'disabled' => 'disabled', 'multiple' => 'multiple', 'id' => 'ContactMultiple'

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2069,7 +2069,8 @@ class FormHelper extends AppHelper {
 					'id' => $attributes['id'] . ($style ? '' : '_'),
 					'secure' => false,
 					'form' => isset($attributes['form']) ? $attributes['form'] : null,
-					'name' => $attributes['name']
+					'name' => $attributes['name'],
+					'disabled' => $attributes['disabled']
 				);
 				$select[] = $this->hidden(null, $hiddenAttributes);
 			}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2070,7 +2070,7 @@ class FormHelper extends AppHelper {
 					'secure' => false,
 					'form' => isset($attributes['form']) ? $attributes['form'] : null,
 					'name' => $attributes['name'],
-					'disabled' => $attributes['disabled']
+					'disabled' => $attributes['disabled'] === true || $attributes['disabled'] === 'disabled'
 				);
 				$select[] = $this->hidden(null, $hiddenAttributes);
 			}


### PR DESCRIPTION
disabled multiple checkbox input should not generate an enabled hidden input,
as it leads to saving empty data upon submission -> carrying the disabled attribute to the hidden input prevents this
