### PR TITLE
3.0 - Fix a typo "Indentifier" -> "Identifier"

### DIFF
--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -82,7 +82,7 @@ class IdentifierQuoter {
 		}
 
 		if ($expression instanceof IdentifierExpression) {
-			$this->_quoteIndetifierExpression($expression);
+			$this->_quoteIdentifierExpression($expression);
 			return;
 		}
 	}
@@ -220,7 +220,7 @@ class IdentifierQuoter {
  * @param \Cake\Database\Expression\IdentifierExpression $expression The identifiers to quote.
  * @return void
  */
-	protected function _quoteIndetifierExpression(IdentifierExpression $expression) {
+	protected function _quoteIdentifierExpression(IdentifierExpression $expression) {
 		$expression->setIdentifier(
 			$this->_driver->quoteIdentifier($expression->getIdentifier())
 		);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2889,7 +2889,7 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Assertion for comparing a regex pattern against a query having its indentifiers
+ * Assertion for comparing a regex pattern against a query having its identifiers
  * quoted. It accepts queries quoted with the characters `<` and `>`. If the third
  * parameter is set to true, it will alter the pattern to both accept quoted and
  * unquoted queries


### PR DESCRIPTION
Fix a typo in a method name and in comments

"Identifier" was spelled "Indentifier"
