### PR TITLE
3.0 dynamic strategy

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -59,7 +59,8 @@ class EagerLoader {
 		'matching' => 1,
 		'queryBuilder' => 1,
 		'finder' => 1,
-		'joinType' => 1
+		'joinType' => 1,
+		'strategy' => 1
 	];
 
 /**
@@ -382,7 +383,11 @@ class EagerLoader {
  * but is not possible to change the strategy due to conflicting settings
  */
 	protected function _correctStrategy(&$config, $alias) {
-		if (!$config['canBeJoined']) {
+		$currentStrategy = isset($config['config']['strategy']) ?
+			$config['config']['strategy'] :
+			'join';
+
+		if (!$config['canBeJoined'] || $currentStrategy !== 'join') {
 			return $config;
 		}
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2197,6 +2197,9 @@ class QueryTest extends TestCase {
 			->toArray();
 		$this->assertCount(3, $articles);
 		$this->assertEquals(3, $articles[1]->author->id);
+
+		$this->assertNull($articles[0]->author);
+		$this->assertNull($articles[2]->author);
 	}
 
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2174,4 +2174,29 @@ class QueryTest extends TestCase {
 		$this->assertEquals(3, $articles[0]->author->id);
 	}
 
+/**
+ * Tests that it is possible to override the contain strategy using the
+ * containments array. In this case, no inner join will be made and for that
+ * reason, the parent association will not be filtered as the strategy changed
+ * from join to select.
+ *
+ * @return void
+ */
+	public function testContainWithStrategyOverride() {
+		$table = TableRegistry::get('Articles');
+		$table->belongsTo('Authors', [
+			'joinType' => 'INNER'
+		]);
+		$articles = $table->find()
+			->contain([
+				'Authors' => [
+					'strategy' => 'select',
+					'conditions' => ['Authors.id' => 3]
+				]
+			])
+			->toArray();
+		$this->assertCount(3, $articles);
+		$this->assertEquals(3, $articles[1]->author->id);
+	}
+
 }


### PR DESCRIPTION
Adds the ability to override the eager loading strategy for some associations using th containment's array. 

Closes https://github.com/cakephp/cakephp/issues/4895
