### PR TITLE
Making the scoping function in tree behavior more robust.

### DIFF
--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -631,7 +631,7 @@ class TreeBehavior extends Behavior {
 
 		$node = $this->_scope($this->_table->find())
 			->select([$parent, $left, $right])
-			->where([$primaryKey => $id])
+			->where([$this->_table->alias() . '.' . $primaryKey => $id])
 			->first();
 
 		if (!$node) {


### PR DESCRIPTION
Adding a table alias prefix to the column names makes it more
difficult to break when associations are forced in the find logic.

Closes https://github.com/cakephp/cakephp/issues/4961
