### PR TITLE
3.0 - Only clearing value bindings if the query was executed.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1591,7 +1591,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 		$this->_dirty = true;
 		$this->_transformedQuery = null;
 
-		if ($this->_valueBinder) {
+		if ($this->_iterator && $this->_valueBinder) {
 			$this->valueBinder()->reset();
 		}
 	}

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2153,6 +2153,23 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to bind arguments to a query and it will return the right
+ * results
+ *
+ * @return void
+ */
+	public function testCustomBindings() {
+		$table = TableRegistry::get('Articles');
+		$query = $table->find()->where(['id >' => 1]);
+		$query->where(function ($exp) {
+			return $exp->add('author_id = :author');
+		});
+		$query->bind(':author', 1, 'integer');
+		$this->assertEquals(1, $query->count());
+		$this->assertEquals(3, $query->first()->id);
+	}
+
+/**
  * Tests that it is possible to pass a custom join type for an association when
  * using contain
  *


### PR DESCRIPTION
Closes #4926
