### PR TITLE
Make CakeResponse::file() accept ranges even when download option is fal...

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1382,18 +1382,17 @@ class CakeResponse {
 				$name = $options['name'];
 			}
 			$this->download($name);
-			$this->header('Accept-Ranges', 'bytes');
 			$this->header('Content-Transfer-Encoding', 'binary');
+		}
 
-			$httpRange = env('HTTP_RANGE');
-			if (isset($httpRange)) {
-				$this->_fileRange($file, $httpRange);
-			} else {
-				$this->header('Content-Length', $fileSize);
-			}
+		$this->header('Accept-Ranges', 'bytes');
+		$httpRange = env('HTTP_RANGE');
+		if (isset($httpRange)) {
+			$this->_fileRange($file, $httpRange);
 		} else {
 			$this->header('Content-Length', $fileSize);
 		}
+
 		$this->_clearBuffer();
 		$this->_file = $file;
 	}

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -1219,7 +1219,7 @@ class CakeResponseTest extends CakeTestCase {
 		$result = $response->send();
 		$output = ob_get_clean();
 		$this->assertEquals("/* this is the test asset css file */\n", $output);
-		$this->assertTrue($result !== false);
+		$this->assertNotSame($result, false);
 	}
 
 /**
@@ -1276,7 +1276,7 @@ class CakeResponseTest extends CakeTestCase {
 		$result = $response->send();
 		$output = ob_get_clean();
 		$this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
-		$this->assertTrue($result !== false);
+		$this->assertNotSame($result, false);
 		if ($currentUserAgent !== null) {
 			$_SERVER['HTTP_USER_AGENT'] = $currentUserAgent;
 		}
@@ -1340,7 +1340,7 @@ class CakeResponseTest extends CakeTestCase {
 		$result = $response->send();
 		$output = ob_get_clean();
 		$this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
-		$this->assertTrue($result !== false);
+		$this->assertNotSame($result, false);
 		if ($currentUserAgent !== null) {
 			$_SERVER['HTTP_USER_AGENT'] = $currentUserAgent;
 		}
@@ -1406,7 +1406,7 @@ class CakeResponseTest extends CakeTestCase {
 		$result = $response->send();
 		$output = ob_get_clean();
 		$this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
-		$this->assertTrue($result !== false);
+		$this->assertNotSame($result, false);
 		if ($currentUserAgent !== null) {
 			$_SERVER['HTTP_USER_AGENT'] = $currentUserAgent;
 		}
@@ -1676,7 +1676,7 @@ class CakeResponseTest extends CakeTestCase {
 		$output = ob_get_clean();
 		$this->assertEquals(206, $response->statusCode());
 		$this->assertEquals("is the test asset ", $output);
-		$this->assertTrue($result !== false);
+		$this->assertNotSame($result, false);
 	}
 
 /**
@@ -1814,7 +1814,7 @@ class CakeResponseTest extends CakeTestCase {
 		$output = ob_get_clean();
 		$this->assertEquals(206, $response->statusCode());
 		$this->assertEquals("is the test asset ", $output);
-		$this->assertTrue($result !== false);
+		$this->assertNotSame($result, false);
 	}
 
 /**


### PR DESCRIPTION
fix #2172 
