### PR TITLE
Implement less aggressive casting in ORM.

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -94,14 +94,19 @@ class DateTimeType extends \Cake\Database\Type {
 
 		$class = static::$dateTimeClass;
 		try {
+			$compare = $date = false;
 			if ($value === '' || $value === null || $value === false || $value === true) {
 				return null;
 			} elseif (is_numeric($value)) {
 				$date = new $class('@' . $value);
 			} elseif (is_string($value)) {
 				$date = new $class($value);
+				$compare = true;
 			}
-			if (isset($date)) {
+			if ($compare && $date && $date->format($this->_format) !== $value) {
+				return $value;
+			}
+			if ($date) {
 				return $date;
 			}
 		} catch (\Exception $e) {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -74,7 +74,10 @@ class FloatType extends \Cake\Database\Type {
 		if ($value === null || $value === '') {
 			return null;
 		}
-		return floatval($value);
+		if (is_numeric($value)) {
+			return (float)$value;
+		}
+		return $value;
 	}
 
 }

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -74,7 +74,13 @@ class IntegerType extends \Cake\Database\Type {
 		if ($value === null || $value === '') {
 			return null;
 		}
-		return (int)$value;
+		if (is_int($value)) {
+			return $value;
+		}
+		if (ctype_digit($value)) {
+			return (int)$value;
+		}
+		return $value;
 	}
 
 }

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -100,11 +100,12 @@ class DateTimeTypeTest extends TestCase {
 			['', null],
 			['derpy', 'derpy'],
 			['2013-nope!', '2013-nope!'],
+			['13-06-26', '13-06-26'],
 
 			// valid string types
 			['1392387900', new Time('@1392387900')],
 			[1392387900, new Time('@1392387900')],
-			['2014-02-14', new Time('2014-02-14')],
+			['2014-02-14 00:00:00', new Time('2014-02-14 00:00:00')],
 			['2014-02-14 13:14:15', new Time('2014-02-14 13:14:15')],
 
 			// valid array types

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -96,12 +96,13 @@ class DateTypeTest extends TestCase {
 			['', null],
 			['derpy', 'derpy'],
 			['2013-nope!', '2013-nope!'],
+			['14-02-14', '14-02-14'],
+			['2014-02-14 13:14:15', '2014-02-14 13:14:15'],
 
 			// valid string types
 			['1392387900', $date],
 			[1392387900, $date],
 			['2014-02-14', new Time('2014-02-14')],
-			['2014-02-14 13:14:15', new Time('2014-02-14 00:00:00')],
 
 			// valid array types
 			[

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -76,13 +76,16 @@ class FloatTypeTest extends TestCase {
  */
 	public function testMarshal() {
 		$result = $this->type->marshal('some data', $this->driver);
-		$this->assertSame(0.0, $result);
+		$this->assertSame('some data', $result);
 
 		$result = $this->type->marshal('', $this->driver);
 		$this->assertNull($result);
 
 		$result = $this->type->marshal('2.51', $this->driver);
 		$this->assertSame(2.51, $result);
+
+		$result = $this->type->marshal('3.5 bears', $this->driver);
+		$this->assertSame('3.5 bears', $result);
 	}
 
 /**

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -76,13 +76,25 @@ class IntegerTypeTest extends TestCase {
  */
 	public function testMarshal() {
 		$result = $this->type->marshal('some data', $this->driver);
-		$this->assertSame(0, $result);
+		$this->assertSame('some data', $result);
 
 		$result = $this->type->marshal('', $this->driver);
 		$this->assertNull($result);
 
 		$result = $this->type->marshal('0', $this->driver);
 		$this->assertSame(0, $result);
+
+		$result = $this->type->marshal('105', $this->driver);
+		$this->assertSame(105, $result);
+
+		$result = $this->type->marshal(105, $this->driver);
+		$this->assertSame(105, $result);
+
+		$result = $this->type->marshal('1.25', $this->driver);
+		$this->assertSame('1.25', $result);
+
+		$result = $this->type->marshal('2 monkeys', $this->driver);
+		$this->assertSame('2 monkeys', $result);
 	}
 
 /**

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -95,12 +95,13 @@ class TimeTypeTest extends TestCase {
 			['', null],
 			['derpy', 'derpy'],
 			['16-nope!', '16-nope!'],
+			['14:15', '14:15'],
+			['2014-02-14 13:14:15', '2014-02-14 13:14:15'],
 
 			// valid string types
 			['1392387900', $date],
 			[1392387900, $date],
 			['13:10:10', new Time('13:10:10')],
-			['2014-02-14 13:14:15', new Time('2014-02-14 13:14:15')],
 
 			// valid array types
 			[

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -185,6 +185,27 @@ class MarshallerTest extends TestCase {
 	}
 
 /**
+ * Ensure that marshalling casts reasonably.
+ *
+ * @return void
+ */
+	public function testOneOnlyCastMatchingData() {
+		$data = [
+			'title' => 'My title',
+			'body' => 'My content',
+			'author_id' => 'derp',
+			'created' => 'fale'
+		];
+		$this->articles->entityClass(__NAMESPACE__ . '\OpenEntity');
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, []);
+
+		$this->assertSame($data['title'], $result->title);
+		$this->assertSame($data['author_id'], $result->author_id, 'No cast on bad data.');
+		$this->assertSame($data['created'], $result->created, 'No cast on bad data.');
+	}
+
+/**
  * Test one() follows mass-assignment rules.
  *
  * @return void


### PR DESCRIPTION
This set of changes makes the type casting that occurs during marshaling to be far less aggressive. My aim is to solve the problems described in #4790, #4922 and others. By only casting data that is approximately the right type entities will have the opportunity to have invalid data which can then fail validation.

The most dramatic changes are in the date/time/datetime types as they now only cast string data that exactly matches the formats they use. Conversion from array forms is unaffected.
