### PR TITLE
Fix / being handled incorrect by referer()

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -604,7 +604,7 @@ class Controller implements EventListenerInterface {
 		}
 
 		$referer = $this->request->referer($local);
-		if ($referer === '/' && $default) {
+		if ($referer === '/' && $default && $default !== $referer) {
 			return Router::url($default, !$local);
 		}
 		return $referer;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -575,6 +575,30 @@ class ControllerTest extends TestCase {
 	}
 
 /**
+ * Test that the referer is not absolute if it is '/'.
+ *
+ * This avoids the base path being applied twice on string urls.
+ *
+ * @return void
+ */
+	public function testRefererSlash() {
+		$request = $this->getMock('Cake\Network\Request', ['referer']);
+		$request->base = '/base';
+		Router::pushRequest($request);
+
+		$request->expects($this->any())->method('referer')
+			->will($this->returnValue('/'));
+
+		$controller = new Controller($request);
+		$result = $controller->referer('/', true);
+		$this->assertEquals('/', $result);
+
+		$controller = new Controller($request);
+		$result = $controller->referer('/some/path', true);
+		$this->assertEquals('/base/some/path', $result);
+	}
+
+/**
  * testSetAction method
  *
  * @return void

--- a/tests/test_app/TestApp/Controller/PagesController.php
+++ b/tests/test_app/TestApp/Controller/PagesController.php
@@ -40,13 +40,6 @@ class PagesController extends AppController {
 	public $helpers = array('Html', 'Session');
 
 /**
- * This controller does not use a model
- *
- * @var array
- */
-	public $uses = array();
-
-/**
  * Displays a view
  *
  * @param mixed What page to display


### PR DESCRIPTION
When the referer is `/` Controller::referer() should not be appending the base path as it results in the base path being added twice causing incorrect results in AuthComponent.

Refs #4812
