### PR TITLE
3.0 between expression

### DIFF
--- a/src/Database/Dialect/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Dialect/TupleComparisonTranslatorTrait.php
@@ -53,7 +53,7 @@ trait TupleComparisonTranslatorTrait {
 		}
 
 		$value = $expression->getValue();
-		$op = $expression->type();
+		$op = $expression->getOperator();
 		$true = new QueryExpression('1');
 
 		if ($value instanceof Query) {
@@ -63,7 +63,7 @@ trait TupleComparisonTranslatorTrait {
 			}
 			$value->select($true, true);
 			$expression->field($true);
-			$expression->type('=');
+			$expression->setOperator('=');
 			return;
 		}
 
@@ -86,7 +86,7 @@ trait TupleComparisonTranslatorTrait {
 
 		$expression->field($true);
 		$expression->value($surrogate);
-		$expression->type('=');
+		$expression->setOperator('=');
 	}
 
 }

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\FieldTrait;
 use Cake\Database\ValueBinder;
 
 /**
@@ -24,12 +25,7 @@ use Cake\Database\ValueBinder;
  */
 class BetweenExpression implements ExpressionInterface {
 
-/**
- * The first value in the expression
- *
- * @var mixed
- */
-	protected $_field;
+	use FieldTrait;
 
 /**
  * The first value in the expression

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\FieldTrait;
 use Cake\Database\ValueBinder;
 
@@ -23,7 +24,7 @@ use Cake\Database\ValueBinder;
  *
  * @internal
  */
-class BetweenExpression implements ExpressionInterface {
+class BetweenExpression implements ExpressionInterface, FieldInterface {
 
 	use FieldTrait;
 

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -99,7 +99,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface {
 	public function traverse(callable $callable) {
 		foreach ([$this->_field, $this->_from, $this->_to] as $part) {
 			if ($part instanceof ExpressionInterface) {
-				$callable($this->_value);
+				$callable($part);
 			}
 		}
 	}

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
+
+/**
+ * An expression object that represents a SQL BETWEEN snippet
+ *
+ * @internal
+ */
+class BetweenExpression implements ExpressionInterface {
+
+/**
+ * The first value in the expression
+ *
+ * @var mixed
+ */
+	protected $_field;
+
+/**
+ * The first value in the expression
+ *
+ * @var mixed
+ */
+	protected $_from;
+
+/**
+ * The second value in the expression
+ *
+ * @var mixed
+ */
+	protected $_to;
+
+/**
+ * Constructor
+ *
+ * @param mixed $value the value to use as the operand for the expression
+ * @param int $mode either UnaryExpression::PREFIX or UnaryExpression::POSTFIX
+ */
+	public function __construct($field, $from, $to, $type = null) {
+		$this->_field = $field;
+		$this->_from = $from;
+		$this->_to = $to;
+		$this->$type = $type;
+	}
+
+/**
+ * Converts the expression to its string representation
+ *
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
+ * @return string
+ */
+	public function sql(ValueBinder $generator) {
+		$parts = [
+			'from' => $this->_from,
+			'to' => $this->_to
+		];
+
+		$field = $this->_field;
+		if ($field instanceof ExpressionInterface) {
+			$field = $field->sql($generator);
+		}
+
+		foreach ($parts as $name => $part) {
+			if ($field instanceof ExpressionInterface) {
+				$parts[$name] = $part->sql($generator);
+				continue;
+			}
+			$parts[$name] = $this->_bindValue($part, $generator, $this->_type);
+		}
+
+		return sprintf('%s BETWEEN %s AND %s', $field, $parts['from'], $parts['to']);
+	}
+
+/**
+ * {@inheritDoc}
+ *
+ */
+	public function traverse(callable $callable) {
+		foreach ([$this->_field, $this->_from, $this->_to] as $part) {
+			if ($part instanceof ExpressionInterface) {
+				$callable($this->_value);
+			}
+		}
+	}
+
+/**
+ * Registers a value in the placeholder generator and returns the generated placeholder
+ *
+ * @param mixed $value The value to bind
+ * @param \Cake\Database\ValueBinder $generator The value binder to use
+ * @param string $type The type of $value
+ * @return string generated placeholder
+ */
+	protected function _bindValue($value, $generator, $type) {
+		$placeholder = $generator->placeholder('c');
+		$generator->bind($placeholder, $value, $type);
+		return $placeholder;
+	}
+}

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -46,6 +46,13 @@ class BetweenExpression implements ExpressionInterface {
 	protected $_to;
 
 /**
+ * The data type for the from and to arguments
+ *
+ * @var mixed
+ */
+	protected $_type;
+
+/**
  * Constructor
  *
  * @param mixed $value the value to use as the operand for the expression
@@ -55,7 +62,7 @@ class BetweenExpression implements ExpressionInterface {
 		$this->_field = $field;
 		$this->_from = $from;
 		$this->_to = $to;
-		$this->$type = $type;
+		$this->_type = $type;
 	}
 
 /**

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -55,8 +55,10 @@ class BetweenExpression implements ExpressionInterface {
 /**
  * Constructor
  *
- * @param mixed $value the value to use as the operand for the expression
- * @param int $mode either UnaryExpression::PREFIX or UnaryExpression::POSTFIX
+ * @param mixed $field The field name to compare for values in between the rage
+ * @param mixed $from The initial value of the range
+ * @param mixed $to The ending value in the comparison range
+ * @param string $type The data type name to bind the values with
  */
 	public function __construct($field, $from, $to, $type = null) {
 		$this->_field = $field;

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -55,10 +55,10 @@ class BetweenExpression implements ExpressionInterface {
 /**
  * Constructor
  *
- * @param mixed $field The field name to compare for values in between the rage
- * @param mixed $from The initial value of the range
- * @param mixed $to The ending value in the comparison range
- * @param string $type The data type name to bind the values with
+ * @param mixed $field The field name to compare for values in between the range.
+ * @param mixed $from The initial value of the range.
+ * @param mixed $to The ending value in the comparison range.
+ * @param string $type The data type name to bind the values with.
  */
 	public function __construct($field, $from, $to, $type = null) {
 		$this->_field = $field;

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\FieldTrait;
 use Cake\Database\ValueBinder;
 
@@ -25,7 +26,7 @@ use Cake\Database\ValueBinder;
  *
  * @internal
  */
-class Comparison implements ExpressionInterface {
+class Comparison implements ExpressionInterface, FieldInterface {
 
 	use FieldTrait;
 

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\FieldTrait;
 use Cake\Database\ValueBinder;
 
 /**
@@ -26,12 +27,7 @@ use Cake\Database\ValueBinder;
  */
 class Comparison implements ExpressionInterface {
 
-/**
- * The field name or expression to be used in the left hand side of the operator
- *
- * @var string
- */
-	protected $_field;
+	use FieldTrait;
 
 /**
  * The value to be used in the right hand side of the operation
@@ -73,16 +69,6 @@ class Comparison implements ExpressionInterface {
 	}
 
 /**
- * Sets the field name
- *
- * @param string $field The field to compare with.
- * @return void
- */
-	public function field($field) {
-		$this->_field = $field;
-	}
-
-/**
  * Sets the value
  *
  * @param mixed $value The value to compare
@@ -90,15 +76,6 @@ class Comparison implements ExpressionInterface {
  */
 	public function value($value) {
 		$this->_value = $value;
-	}
-
-/**
- * Returns the field name
- *
- * @return string|\Cake\Database\ExpressionInterface
- */
-	public function getField() {
-		return $this->_field;
 	}
 
 /**

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -24,7 +24,7 @@ use Cake\Database\ValueBinder;
  *
  * @internal
  */
-class Comparison extends QueryExpression {
+class Comparison implements ExpressionInterface {
 
 /**
  * The field name or expression to be used in the left hand side of the operator
@@ -48,17 +48,24 @@ class Comparison extends QueryExpression {
 	protected $_type;
 
 /**
+ * The operator used for comparing field and value
+ *
+ * @var string
+ */
+	protected $_operator;
+
+/**
  * Constructor
  *
  * @param string $field the field name to compare to a value
  * @param mixed $value The value to be used in comparison
  * @param string $type the type name used to cast the value
- * @param string $conjunction the operator used for comparing field and value
+ * @param string $operator the operator used for comparing field and value
  */
-	public function __construct($field, $value, $type, $conjunction) {
+	public function __construct($field, $value, $type, $operator) {
 		$this->field($field);
 		$this->value($value);
-		$this->type($conjunction);
+		$this->_operator = $operator;
 
 		if (is_string($type)) {
 			$this->_type = $type;
@@ -104,6 +111,25 @@ class Comparison extends QueryExpression {
 	}
 
 /**
+ * Returns the operator used for comparison
+ *
+ * @return string
+ */
+	public function getOperator() {
+		return $this->_operator;
+	}
+
+/**
+ * Sets the operator to use for the comparison
+ *
+ * @param string $operator The operator to be used for the comparison.
+ * @return void
+ */
+	public function setOperator($operator) {
+		$this->_operator = $operator;
+	}
+
+/**
  * Convert the expression into a SQL fragment.
  *
  * @param \Cake\Database\ValueBinder $generator Placeholder generator object
@@ -123,7 +149,7 @@ class Comparison extends QueryExpression {
 			list($template, $value) = $this->_stringExpression($generator);
 		}
 
-		return sprintf($template, $field, $this->_conjunction, $value);
+		return sprintf($template, $field, $this->_operator, $value);
 	}
 
 /**
@@ -204,15 +230,6 @@ class Comparison extends QueryExpression {
 		}
 
 		return implode(',', $parts);
-	}
-
-/**
- * Returns the number of expression this class represents
- *
- * @return int
- */
-	public function count() {
-		return 1;
 	}
 
 }

--- a/src/Database/Expression/FieldInterface.php
+++ b/src/Database/Expression/FieldInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+/**
+ * Describes a getter and a setter for the a field property. Useful for expressions
+ * that contain the an identifier to compare against.
+ *
+ * @internal
+ */
+interface FieldInterface {
+
+/**
+ * Sets the field name
+ *
+ * @param string $field The field to compare with.
+ * @return void
+ */
+	public function field($field);
+
+/**
+ * Returns the field name
+ *
+ * @return string|\Cake\Database\ExpressionInterface
+ */
+	public function getField();
+
+}

--- a/src/Database/Expression/FieldInterface.php
+++ b/src/Database/Expression/FieldInterface.php
@@ -16,7 +16,7 @@ namespace Cake\Database\Expression;
 
 /**
  * Describes a getter and a setter for the a field property. Useful for expressions
- * that contain the an identifier to compare against.
+ * that contain an identifier to compare against.
  *
  * @internal
  */

--- a/src/Database/Expression/FieldTrait.php
+++ b/src/Database/Expression/FieldTrait.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
+
+/**
+ * Contains the field property with a getter and a setter for it
+ *
+ * @internal
+ */
+trait FieldTrait {
+
+/**
+ * The field name or expression to be used in the left hand side of the operator
+ *
+ * @var string
+ */
+	protected $_field;
+
+/**
+ * Sets the field name
+ *
+ * @param string $field The field to compare with.
+ * @return void
+ */
+	public function field($field) {
+		$this->_field = $field;
+	}
+
+/**
+ * Returns the field name
+ *
+ * @return string|\Cake\Database\ExpressionInterface
+ */
+	public function getField() {
+		return $this->_field;
+	}
+
+}

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -298,6 +298,10 @@ class QueryExpression implements ExpressionInterface, Countable {
 		return $this->add(new Comparison($field, $values, $type, 'NOT IN'));
 	}
 
+	public function between($field, $from, $to, $type = null) {
+		return $this->add(new BetweenExpression($field, $from, $to, $type));
+	}
+
 // @codingStandardsIgnoreStart
 /**
  * Returns a new QueryExpression object containing all the conditions passed

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -298,6 +298,16 @@ class QueryExpression implements ExpressionInterface, Countable {
 		return $this->add(new Comparison($field, $values, $type, 'NOT IN'));
 	}
 
+/**
+ * Adds a new condition to the expression object in the form
+ * "field BETWEEN from AND to".
+ *
+ * @param mixed $field The field name to compare for values in between the range.
+ * @param mixed $from The initial value of the range.
+ * @param mixed $to The ending value in the comparison range.
+ *@param string $type the type name for $value as configured using the Type map.
+ * @return QueryExpression
+ */
 	public function between($field, $from, $to, $type = null) {
 		return $this->add(new BetweenExpression($field, $from, $to, $type));
 	}

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -76,7 +76,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  *
  * @param string $conjunction value to be used for joining conditions. If null it
  * will not set any value, but return the currently stored one
- * @return string|QueryExpression
+ * @return string|$this
  */
 	public function type($conjunction = null) {
 		if ($conjunction === null) {
@@ -105,7 +105,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param array $types associative array of fields pointing to the type of the
  * values that are being passed. Used for correctly binding values to statements.
  * @see \Cake\Database\Query::where() for examples on conditions
- * @return QueryExpression
+ * @return $this
  */
 	public function add($conditions, $types = []) {
 		if (is_string($conditions)) {
@@ -130,7 +130,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $type the type name for $value as configured using the Type map.
  * If it is suffixed with "[]" and the value is an array then multiple placeholders
  * will be created, one per each value in the array.
- * @return QueryExpression
+ * @return $this
  */
 	public function eq($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, '='));
@@ -144,7 +144,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $type the type name for $value as configured using the Type map.
  * If it is suffixed with "[]" and the value is an array then multiple placeholders
  * will be created, one per each value in the array.
- * @return QueryExpression
+ * @return $this
  */
 	public function notEq($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, '!='));
@@ -156,7 +156,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function gt($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, '>'));
@@ -168,7 +168,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function lt($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, '<'));
@@ -180,7 +180,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function gte($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, '>='));
@@ -192,7 +192,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function lte($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, '<='));
@@ -203,7 +203,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  *
  * @param string|\Cake\Database\ExpressionInterface $field database field to be
  * tested for null
- * @return QueryExpression
+ * @return $this
  */
 	public function isNull($field) {
 		if (!($field instanceof ExpressionInterface)) {
@@ -217,7 +217,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  *
  * @param string|\Cake\Database\ExpressionInterface $field database field to be
  * tested for not null
- * @return QueryExpression
+ * @return $this
  */
 	public function isNotNull($field) {
 		if (!($field instanceof ExpressionInterface)) {
@@ -232,7 +232,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function like($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, 'LIKE'));
@@ -244,7 +244,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function notLike($field, $value, $type = null) {
 		return $this->add(new Comparison($field, $value, $type, 'NOT LIKE'));
@@ -257,7 +257,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param array $values the value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function in($field, $values, $type = null) {
 		$type = $type ?: 'string';
@@ -275,8 +275,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * passed in $conditions. If there are more $values than $conditions, the last $value is used as the `ELSE` value
  * @param array $types associative array of types to be associated with the values
  * passed in $values
- *
- * @return QueryExpression
+ * @return $this
  */
 	public function addCase($conditions, $values = [], $types = []) {
 		return $this->add(new CaseExpression($conditions, $values, $types));
@@ -289,7 +288,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field database field to be compared against value
  * @param array $values the value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function notIn($field, $values, $type = null) {
 		$type = $type ?: 'string';
@@ -306,7 +305,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param mixed $from The initial value of the range.
  * @param mixed $to The ending value in the comparison range.
  * @param string $type the type name for $value as configured using the Type map.
- * @return QueryExpression
+ * @return $this
  */
 	public function between($field, $from, $to, $type = null) {
 		return $this->add(new BetweenExpression($field, $from, $to, $type));
@@ -355,7 +354,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string|array|QueryExpression $conditions to be added and negated
  * @param array $types associative array of fields pointing to the type of the
  * values that are being passed. Used for correctly binding values to statements.
- * @return QueryExpression
+ * @return $this
  */
 	public function not($conditions, $types = []) {
 		return $this->add(['NOT' => $conditions], $types);
@@ -426,7 +425,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * modified part is stored.
  *
  * @param callable $callable The callable to apply to each part.
- * @return QueryExpression
+ * @return $this
  */
 	public function iterateParts(callable $callable) {
 		$parts = [];
@@ -505,7 +504,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $field The value from with the actual field and operator will
  * be extracted.
  * @param mixed $value The value to be bound to a placeholder for the field
- * @return string|QueryExpression
+ * @return string|\Cake\Database\ExpressionInterface
  */
 	protected function _parseCondition($field, $value) {
 		$operator = '=';
@@ -517,7 +516,6 @@ class QueryExpression implements ExpressionInterface, Countable {
 		}
 
 		$type = $this->typeMap()->type($expression);
-		$multi = false;
 		$operator = strtolower(trim($operator));
 
 		$typeMultiple = strpos($type, '[]') !== false;

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -305,7 +305,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param mixed $field The field name to compare for values in between the range.
  * @param mixed $from The initial value of the range.
  * @param mixed $to The ending value in the comparison range.
- *@param string $type the type name for $value as configured using the Type map.
+ * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
 	public function between($field, $from, $to, $type = null) {

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -62,7 +62,7 @@ class TupleComparison extends Comparison {
 		$values = $this->_stringifyValues($generator);
 
 		$field = implode(', ', $fields);
-		return sprintf($template, $field, $this->_conjunction, $values);
+		return sprintf($template, $field, $this->_operator, $values);
 	}
 
 /**
@@ -179,7 +179,7 @@ class TupleComparison extends Comparison {
  * @return bool
  */
 	public function isMulti() {
-		return in_array(strtolower($this->_conjunction), ['in', 'not in']);
+		return in_array(strtolower($this->_operator), ['in', 'not in']);
 	}
 
 }

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -15,7 +15,7 @@
 namespace Cake\Database;
 
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Expression\Comparison;
+use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
 
@@ -71,7 +71,7 @@ class IdentifierQuoter {
  * @return void
  */
 	public function quoteExpression($expression) {
-		if ($expression instanceof Comparison) {
+		if ($expression instanceof FieldInterface) {
 			$this->_quoteComparison($expression);
 			return;
 		}
@@ -174,12 +174,12 @@ class IdentifierQuoter {
 	}
 
 /**
- * Quotes identifiers in comparison expression objects
+ * Quotes identifiers in expression objects implementing the field interface
  *
- * @param \Cake\Database\Expression\Comparison $expression The comparison expression to quote.
+ * @param \Cake\Database\Expression\FieldInterface $expression The expression to quote.
  * @return void
  */
-	protected function _quoteComparison(Comparison $expression) {
+	protected function _quoteComparison(FieldInterface $expression) {
 		$field = $expression->getField();
 		if (is_string($field)) {
 			$expression->field($this->_driver->quoteIdentifier($field));
@@ -191,11 +191,6 @@ class IdentifierQuoter {
 			$expression->field($quoted);
 		} elseif ($field instanceof ExpressionInterface) {
 			$this->quoteExpression($field);
-		}
-
-		$value = $expression->getValue();
-		if ($value instanceof ExpressionInterface) {
-			$this->quoteExpression($value);
 		}
 	}
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1133,7 +1133,7 @@ class QueryTest extends TestCase {
 		$result = $query
 			->select(['id'])
 			->from('comments')
-			->where(function($exp) {
+			->where(function ($exp) {
 				return $exp->between('id', 5, 6, 'integer');
 			})
 			->execute();
@@ -1157,7 +1157,7 @@ class QueryTest extends TestCase {
 		$result = $query
 			->select(['id'])
 			->from('comments')
-			->where(function($exp) {
+			->where(function ($exp) {
 				$from = new \DateTime('2007-03-18 10:51:00');
 				$to = new \DateTime('2007-03-18 10:54:00');
 				return $exp->between('created', $from, $to, 'datetime');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1123,6 +1123,56 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to use a between expression
+ * in a where condition
+ *
+ * @return void
+ */
+	public function testWhereWithBetween() {
+		$query = new Query($this->connection);
+		$result = $query
+			->select(['id'])
+			->from('comments')
+			->where(function($exp) {
+				return $exp->between('id', 5, 6, 'integer');
+			})
+			->execute();
+
+		$this->assertCount(2, $result);
+		$first = $result->fetch('assoc');
+		$this->assertEquals(5, $first['id']);
+
+		$second = $result->fetch('assoc');
+		$this->assertEquals(6, $second['id']);
+	}
+
+/**
+ * Tests that it is possible to use a between expression
+ * in a where condition with a complex data type
+ *
+ * @return void
+ */
+	public function testWhereWithBetweenComplex() {
+		$query = new Query($this->connection);
+		$result = $query
+			->select(['id'])
+			->from('comments')
+			->where(function($exp) {
+				$from = new \DateTime('2007-03-18 10:51:00');
+				$to = new \DateTime('2007-03-18 10:54:00');
+				return $exp->between('created', $from, $to, 'datetime');
+			})
+			->execute();
+
+		$this->assertCount(2, $result);
+		$first = $result->fetch('assoc');
+		$this->assertEquals(4, $first['id']);
+
+		$second = $result->fetch('assoc');
+		$this->assertEquals(5, $second['id']);
+	}
+
+/**
  * Tests nesting query expressions both using arrays and closures
  *
  * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1173,6 +1173,31 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to use an expresison object
+ * as the field for a between expression
+ *
+ * @return void
+ */
+	public function testWhereWithBetweenWithExpressionField() {
+		$query = new Query($this->connection);
+		$result = $query
+			->select(['id'])
+			->from('comments')
+			->where(function ($exp, $q) {
+				$field = $q->newExpr('COALESCE(id, 1)');
+				return $exp->between($field, 5, 6, 'integer');
+			})
+			->execute();
+
+		$this->assertCount(2, $result);
+		$first = $result->fetch('assoc');
+		$this->assertEquals(5, $first['id']);
+
+		$second = $result->fetch('assoc');
+		$this->assertEquals(6, $second['id']);
+	}
+
+/**
  * Tests nesting query expressions both using arrays and closures
  *
  * @return void


### PR DESCRIPTION
Implements a new `between()` method in the `QueryExpression` object and cleans up the `Comparison` object as some of its code was rather confusing.
