### PR TITLE
Update EntityContext.php

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -445,7 +445,7 @@ class EntityContext implements ContextInterface {
 		$parts = explode('.', $field);
 		$table = $this->_getTable($parts);
 		$column = (array)$table->schema()->column(array_pop($parts));
-		$whitelist = ['length' => null, 'precision' => null];
+		$whitelist = ['length' => null, 'precision' => null, 'unsigned' => false];
 		return array_intersect_key($column, $whitelist);
 	}
 


### PR DESCRIPTION
if you have this information in FormHelper than you can could add ['min' => 0] when 'unsigned' attributes is !empty() and input type is 'number' - I would like to do that but at the moment I think I can't.
Or is there any chance to overwrite the EntityContext class? Which I think could be useful too.

of course I could overwrite the _addDefaultContextProviders() method in FormHelper but this doesn't look like the perfect solution
