### PR TITLE
Fix issue with label=false.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1179,7 +1179,7 @@ class FormHelper extends Helper {
 			$label = $options['label'];
 		}
 
-		if ($label === false && isset($options['input'])) {
+		if ($label === false && $options['type'] === 'checkbox') {
 			return $options['input'];
 		}
 		if ($label === false) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5170,6 +5170,22 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test the label option being set to false.
+ *
+ * @return void
+ */
+	public function testInputLabelFalse() {
+		$this->Form->create($this->article);
+		$result = $this->Form->input('title', ['label' => false]);
+		$expected = [
+			'div' => ['class' => 'input text required'],
+			'input' => ['type' => 'text', 'required' => 'required', 'id' => 'title', 'name' => 'title'],
+			'/div'
+		];
+		$this->assertHtml($expected, $result);
+	}
+
+/**
  * testInputDateMaxYear method
  *
  * Let's say we want to only allow users born from 2006 to 2008 to register
@@ -6227,6 +6243,15 @@ class FormHelperTest extends TestCase {
 			'label' => ['for' => 'foo'],
 				'Foo',
 			'/label',
+			'/div'
+		];
+		$this->assertHtml($expected, $result);
+
+		$result = $this->Form->input('foo', ['type' => 'checkbox', 'label' => false]);
+		$expected = [
+			'div' => ['class' => 'input checkbox'],
+			['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
+			['input' => ['type' => 'checkbox', 'name' => 'foo', 'id' => 'foo', 'value' => '1']],
 			'/div'
 		];
 		$this->assertHtml($expected, $result);


### PR DESCRIPTION
Only return the input for checkbox type inputs as they are normally nested in the label.

Fixes #4991
