### PR TITLE
Fix radio & multicheckbox

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1006,6 +1006,10 @@ class FormHelper extends Helper {
 				$opts = $options['options'];
 				unset($options['options']);
 				return $this->radio($fieldName, $opts, $options);
+			case 'multicheckbox':
+				$opts = $options['options'];
+				unset($options['options']);
+				return $this->multicheckbox($fieldName, $opts, $options);
 			case 'url':
 				$options = $this->_initInputField($fieldName, $options);
 				return $this->widget($options['type'], $options);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1233,7 +1233,8 @@ class FormHelper extends Helper {
 		$options += ['id' => null, 'input' => null, 'nestedInput' => false];
 
 		$labelAttributes['for'] = $options['id'];
-		if (in_array($options['type'], ['radio', 'multicheckbox'], true)) {
+		$groupTypes = ['radio', 'multicheckbox', 'date', 'time', 'datetime'];
+		if (in_array($options['type'], $groupTypes, true)) {
 			$labelAttributes['for'] = false;
 		}
 		if ($options['nestedInput']) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -925,7 +925,7 @@ class FormHelper extends Helper {
 		$label = $options['label'];
 		unset($options['label']);
 		$nestedInput = false;
-		if (in_array($options['type'], ['radio', 'checkbox'], true)) {
+		if ($options['type'] === 'checkbox') {
 			$nestedInput = true;
 		}
 		$nestedInput = isset($options['nestedInput']) ? $options['nestedInput'] : $nestedInput;
@@ -1174,7 +1174,7 @@ class FormHelper extends Helper {
  * @return bool|string false or Generated label element
  */
 	protected function _getLabel($fieldName, $options) {
-		if (in_array($options['type'], ['radio', 'hidden'])) {
+		if (in_array($options['type'], ['hidden'])) {
 			return false;
 		}
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1174,7 +1174,7 @@ class FormHelper extends Helper {
  * @return bool|string false or Generated label element
  */
 	protected function _getLabel($fieldName, $options) {
-		if (in_array($options['type'], ['hidden'])) {
+		if ($options['type'] === 'hidden') {
 			return false;
 		}
 
@@ -1233,6 +1233,9 @@ class FormHelper extends Helper {
 		$options += ['id' => null, 'input' => null, 'nestedInput' => false];
 
 		$labelAttributes['for'] = $options['id'];
+		if (in_array($options['type'], ['radio', 'multicheckbox'], true)) {
+			$labelAttributes['for'] = false;
+		}
 		if ($options['nestedInput']) {
 			$labelAttributes['input'] = $options['input'];
 		}

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -187,6 +187,13 @@ class Radio implements WidgetInterface {
 			$escape
 		);
 
+		if (
+			$label === false &&
+			strpos($this->_templates->get('radioWrapper'), '{{input}}') === false
+		) {
+			$label = $input;
+		}
+
 		return $this->_templates->format('radioWrapper', [
 			'input' => $input,
 			'label' => $label,

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2416,7 +2416,7 @@ class FormHelperTest extends TestCase {
 		));
 		$expected = array(
 			'div' => array('class' => 'input datetime'),
-			'label' => array('for' => 'prueba'),
+			'<label',
 			'Prueba',
 			'/label',
 			'This is it!',
@@ -2458,7 +2458,7 @@ class FormHelperTest extends TestCase {
 		));
 		$expected = array(
 			'div' => array('class' => 'input datetime'),
-			'label' => array('for' => 'prefix-prueba'),
+			'<label',
 			'Prueba',
 			'/label',
 			'This is it!',
@@ -4788,15 +4788,14 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeLabelIdMatchesFirstInput() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->input('Model.date', array('type' => 'date'));
-		$this->assertContains('label for="ModelDateMonth"', $result);
+		$this->assertContains('<label>Date</label>', $result);
 
 		$result = $this->Form->input('Model.date', array('type' => 'date', 'dateFormat' => 'DMY'));
-		$this->assertContains('label for="ModelDateDay"', $result);
+		$this->assertContains('<label>Date</label>', $result);
 
 		$result = $this->Form->input('Model.date', array('type' => 'date', 'dateFormat' => 'YMD'));
-		$this->assertContains('label for="ModelDateYear"', $result);
+		$this->assertContains('<label>Date</label>', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3395,7 +3395,7 @@ class FormHelperTest extends TestCase {
 		]);
 		$expected = [
 			['div' => ['class' => 'input radio']],
-				['label' => ['for' => 'test']],
+				'<label',
 				'Test',
 				'/label',
 				['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
@@ -4227,7 +4227,7 @@ class FormHelperTest extends TestCase {
 		]);
 		$expected = [
 			['div' => ['class' => 'input multicheckbox']],
-			['label' => ['for' => 'category']],
+			'<label',
 			'Category',
 			'/label',
 			'input' => ['type' => 'hidden', 'name' => 'category', 'value' => ''],
@@ -6405,7 +6405,7 @@ class FormHelperTest extends TestCase {
 			['label' => ['for' => 'confirm-n']],
 			'No',
 			'/label',
-			['label' => ['for' => 'confirm']],
+			'<label',
 			'Confirm',
 			'/label',
 			'/div',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3384,6 +3384,70 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that input works with radio types
+ *
+ * @return void
+ */
+	public function testInputRadio() {
+		$result = $this->Form->input('test', [
+			'type' => 'radio',
+			'options' => ['A', 'B'],
+		]);
+		$expected = [
+			['div' => ['class' => 'input radio']],
+				['label' => ['for' => 'test']],
+				'Test',
+				'/label',
+				['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+				['label' => ['for' => 'test-0']],
+					['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+					'A',
+				'/label',
+				['label' => ['for' => 'test-1']],
+					['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+					'B',
+				'/label',
+			'/div',
+		];
+		$this->assertHtml($expected, $result);
+
+		$result = $this->Form->input('test', [
+			'type' => 'radio',
+			'options' => ['A', 'B'],
+			'label' => false
+		]);
+		$expected = [
+			['div' => ['class' => 'input radio']],
+				['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '']],
+				['label' => ['for' => 'test-0']],
+					['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+					'A',
+				'/label',
+				['label' => ['for' => 'test-1']],
+					['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+					'B',
+				'/label',
+			'/div',
+		];
+		$this->assertHtml($expected, $result);
+	}
+
+/**
+ * Test that radio() works with label = false
+ *
+ * @return void
+ */
+	public function testRadioNoLabel() {
+		$result = $this->Form->radio('Model.field', ['A', 'B'], ['label' => false]);
+		$expected = [
+			'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => ''],
+			['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0']],
+			['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1']],
+		];
+		$this->assertHtml($expected, $result);
+	}
+
+/**
  * test generating radio input inside label ala twitter bootstrap
  *
  * @return void
@@ -6340,6 +6404,9 @@ class FormHelperTest extends TestCase {
 			['input' => ['type' => 'radio', 'name' => 'confirm', 'id' => 'confirm-n', 'value' => 'N']],
 			['label' => ['for' => 'confirm-n']],
 			'No',
+			'/label',
+			['label' => ['for' => 'confirm']],
+			'Confirm',
 			'/label',
 			'/div',
 		];

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4152,6 +4152,39 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that input() works with multicheckbox.
+ *
+ * @return void
+ */
+	public function testInputMultiCheckbox() {
+		$result = $this->Form->input('category', [
+			'type' => 'multicheckbox',
+			'options' => ['1', '2'],
+		]);
+		$expected = [
+			['div' => ['class' => 'input multicheckbox']],
+			['label' => ['for' => 'category']],
+			'Category',
+			'/label',
+			'input' => ['type' => 'hidden', 'name' => 'category', 'value' => ''],
+			['div' => ['class' => 'checkbox']],
+				['label' => ['for' => 'category-0']],
+					['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '0', 'id' => 'category-0']],
+					'1',
+				'/label',
+			'/div',
+			['div' => ['class' => 'checkbox']],
+				['label' => ['for' => 'category-1']],
+					['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '1', 'id' => 'category-1']],
+					'2',
+				'/label',
+			'/div',
+			'/div',
+		];
+		$this->assertHtml($expected, $result);
+	}
+
+/**
  * testCheckbox method
  *
  * Test generation of checkboxes


### PR DESCRIPTION
While looking into #5003 I found a few issues with FormHelper that I've fixed:
- `input(type=multicheckbox)` did not work. It emitted notice errors and was generally broken.
- `input(type=radio)` was lacking an input group label. This made it inconsistent with multicheckbox, and datetime inputs.
- `input(type=radio, label=false)` did not work. This option did nothing.
- The for attribute on group labels for multicheckbox, radio, and datetime inputs were wrong. I've opted to remove the incorrect attribute.
