### PR TITLE
Fix issue in PoFileParser where only slashes from translations of type array are stripped.

### DIFF
--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -134,8 +134,10 @@ class PoFileParser {
 		$translation = $item['translated'];
 
 		if (is_array($translation)) {
-			$translation = stripcslashes($translation[0]);
+			$translation = $translation[0];
 		}
+
+		$translation = stripcslashes($translation);
 
 		if ($context) {
 			$messages[$singular]['_context'][$context] = $translation;

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -73,4 +73,17 @@ class PoFileParserTest extends TestCase {
 		$this->assertCount(12, $messages);
 		$this->assertTextEquals("v\nsecond line", $messages["valid\nsecond line"]);
 	}
+
+/**
+ * Test parsing a file with quoted strings
+ *
+ * @return void
+ */
+	public function testQuotedString() {
+		$parser = new PoFileParser;
+		$file = APP . 'Locale' . DS . 'en' . DS . 'default.po';
+		$messages = $parser->parse($file);
+
+		$this->assertTextEquals('this is a "quoted string" (translated)', $messages['this is a "quoted string"']);
+	}
 }


### PR DESCRIPTION
I was experiencing an issue using a .po file only setup (no .mo files) where translated escaped data was not stripped of slashes.

This PR should fix the issue.

Original msgid: 
`msgid "Not a member yet? Please register <a href=\"{0}\">here</a>."``

Translated Before fix:
`Noch kein Mitglied? <a href=\"{0}\" target=\"_blank\">Hier</a> kannst du``

Translated after fix:
`Noch kein Mitglied? <a href="{0}" target="_blank">Hier</a> kannst du`

as present in PO file:

```
#: Template/Workshops/subscribe.ctp:18
msgid "Not a member yet? Please register <a href=\"{0}\">here</a>."
msgstr ""
"Noch kein Mitglied? <a href=\"{0}\" target=\"_blank\">Hier</a> kannst du "
"dich anmelden."
```
