### PR TITLE
Consolidate doc block headers

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -30,7 +30,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * and passes both the value and key for them on each step.
  * Returns the same collection for chaining.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $collection = (new Collection($items))->each(function ($value, $key) {
@@ -104,7 +104,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * in the current iteration and  the key of the element as arguments, in that
  * order.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $overTwentyOne = (new Collection([24, 45, 60, 15]))->every(function ($value, $key) {
@@ -126,7 +126,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * in the current iteration and the key of the element as arguments, in that
  * order.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $hasYoungPeople = (new Collection([24, 45, 15]))->every(function ($value, $key) {
@@ -220,7 +220,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * Returns the top element in this collection after being sorted by a property.
  * Check the sortBy method for information on the callback and $type parameters
  *
- * ###Examples:
+ * ### Examples:
  *
  * {{{
  * // For a collection of employees
@@ -246,7 +246,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * Returns the bottom element in this collection after being sorted by a property.
  * Check the sortBy method for information on the callback and $type parameters
  *
- * ###Examples:
+ * ### Examples:
  *
  * {{{
  * // For a collection of employees
@@ -279,7 +279,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * element. Please note that the callback function could be called more than once
  * per element.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = $collection->sortBy(function ($user) {
@@ -315,7 +315,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * a dot separated path of properties that should be followed to get the last
  * one in the path.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = [
@@ -358,7 +358,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * a dot separated path of properties that should be followed to get the last
  * one in the path.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = [
@@ -397,7 +397,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * a dot separated path of properties that should be followed to get the last
  * one in the path.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = [
@@ -430,7 +430,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * Returns the total sum of all the values extracted with $matcher
  * or of this collection.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = [
@@ -483,7 +483,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * Looks through each value in the list, returning a Collection of all the
  * values that contain all of the key-value pairs listed in $conditions.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = [

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -53,7 +53,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * in the current iteration, the key of the element and this collection as
  * arguments, in that order.
  *
- * ##Example:
+ * ## Example:
  *
  * Filtering odd numbers in an array, at the end only the value 2 will
  * be present in the resulting collection:
@@ -79,7 +79,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * in the current iteration, the key of the element and this collection as
  * arguments, in that order.
  *
- * ##Example:
+ * ## Example:
  *
  * Filtering even numbers in an array, at the end only values 1 and 3 will
  * be present in the resulting collection:
@@ -157,7 +157,7 @@ interface CollectionInterface extends Iterator, JsonSerializable {
  * in the current iteration, the key of the element and this collection as
  * arguments, in that order.
  *
- * ##Example:
+ * ## Example:
  *
  * Getting a collection of booleans where true indicates if a person is female:
  *

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -21,7 +21,7 @@ use SplHeap;
  * An iterator that will return the passed items in order. The order is given by
  * the value returned in a callback function that maps each of the elements.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $items = [$user1, $user2, $user3];

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -61,7 +61,7 @@ class TreeIterator extends RecursiveIteratorIterator {
  * the current element as first parameter, the current iteration key as second
  * parameter, and the iterator instance as third argument.
  *
- * ##Example
+ * ## Example
  *
  * {{{
  *	$printer = (new Collection($treeStructure))->listNested()->printer('name');

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -275,7 +275,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * or set of fields, you may pass an array of fields to filter on. Beware that
  * this option might not be fully supported in all database systems.
  *
- * ##Examples:
+ * ## Examples:
  *
  * {{{
  * // Filters products with the same name and city
@@ -355,7 +355,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * This method can be used for select, update and delete statements.
  *
- * ##Examples:
+ * ## Examples:
  *
  * {{{
  *	$query->from(['p' => 'posts']); // Produces FROM posts p
@@ -755,7 +755,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * that each array entry will be joined to the other using the AND operator, unless
  * you nest the conditions in the array using other operator.
  *
- * ##Examples:
+ * ## Examples:
  *
  * {{{
  * $query->where(['title' => 'Hello World')->andWhere(['author_id' => 1]);
@@ -816,7 +816,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * that each array entry will be joined to the other using the OR operator, unless
  * you nest the conditions in the array using other operator.
  *
- * ##Examples:
+ * ## Examples:
  *
  * {{{
  * $query->where(['title' => 'Hello World')->orWhere(['title' => 'Foo']);
@@ -874,7 +874,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * By default this function will append any passed argument to the list of fields
  * to be selected, unless the second argument is set to true.
  *
- * ##Examples:
+ * ## Examples:
  *
  * {{{
  * $query->order(['title' => 'DESC', 'author_id' => 'ASC']);
@@ -929,7 +929,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * By default this function will append any passed argument to the list of fields
  * to be grouped, unless the second argument is set to true.
  *
- * ##Examples:
+ * ## Examples:
  *
  * {{{
  * // Produces GROUP BY id, title

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -339,7 +339,7 @@ trait QueryTrait {
  * Returns an array with the custom options that were applied to this query
  * and that were not already processed by another method in this class.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  *	$query->applyOptions(['doABarrelRoll' => true, 'fields' => ['id', 'name']);

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -41,7 +41,7 @@ interface RepositoryInterface {
  * Returns a single record after finding it by its primary key, if no record is
  * found this method throws an exception.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $id = 10;

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -571,7 +571,7 @@ class BelongsToMany extends Association {
  * By default this method will also unset each of the entity objects stored inside
  * the source entity.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $article->tags = [$tag1, $tag2, $tag3, $tag4];
@@ -653,7 +653,7 @@ class BelongsToMany extends Association {
  * Additional options for new links to be saved can be passed in the third argument,
  * check `Table::save()` for information on the accepted options.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $article->tags = [$tag1, $tag2, $tag3, $tag4];


### PR DESCRIPTION
Also, some examples use

```
### Example:
```

some

```
## Example:
```

Should we also consolidate the heading levels? It seems the majority starts at 3 (###).
