### PR TITLE
Added a test for number->format

### DIFF
--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -88,6 +88,12 @@ class NumberTest extends TestCase {
 		$result = $this->Number->format($value, $options);
 		$expected = '1,23 €';
 		$this->assertEquals($expected, $result);
+
+		$value = 10000;
+		$options = array('locale' => 'fr_FR');
+		$result = $this->Number->format($value, $options);
+		$expected = '10 000';
+		$this->assertEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
If i added this test, it's because there is a problem with the local `fr_FR`. And i don't really know why it fail.
But it failed with CakePHP on my PC (Windows).
So i'm checking if it will fail with Travis (unix env) to see if the problem is related to Windows or Cake.

The problem :
![screenshot_11](https://cloud.githubusercontent.com/assets/8210023/4847344/f03548e0-6051-11e4-8c37-a45b63db4472.png)

Do not merge atm.
