### PR TITLE
Fix IN replacement in virtual fields for MYSQL.

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1410,11 +1410,10 @@ class DboSource extends DataSource {
 	protected function _fetchHasMany(Model $Model, $query, $ids) {
 		$ids = array_unique($ids);
 
-		$query = str_replace('{$__cakeID__$}', implode(', ', $ids), $query);
 		if (count($ids) > 1) {
-			$query = str_replace('= (', 'IN (', $query);
+			$query = str_replace('= ({$__cakeID__$}', 'IN ({$__cakeID__$}', $query);
 		}
-
+		$query = str_replace('{$__cakeID__$}', implode(', ', $ids), $query);
 		return $this->fetchAll($query, $Model->cacheQueries);
 	}
 

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3428,6 +3428,31 @@ SQL;
 	}
 
 /**
+ * test find() generating usable virtual fields to use in query
+ *
+ * @return void
+ */
+	public function testVirtualFieldsWithSubquery() {
+		$this->loadFixtures('Article', 'Comment', 'User', 'Tag', 'ArticlesTag');
+		$this->Dbo->virtualFieldSeparator = '__';
+		$Article = ClassRegistry::init('Article');
+		$commentsTable = $this->Dbo->fullTableName('comments', false, false);
+		$Article->Comment->virtualFields = array(
+			'extra' => 'SELECT id FROM ' . $commentsTable . ' WHERE id = (SELECT 1)',
+		);
+		$conditions = array('Article.id' => array(1, 2));
+		$contain = array('Comment.extra');
+		$result = $Article->find('all', compact('conditions', 'contain'));
+
+		$expected = 'SELECT `Comment`.`id`, `Comment`.`article_id`, `Comment`.`user_id`, `Comment`.`comment`, `Comment`.`published`, `Comment`.`created`,' .
+			' `Comment`.`updated`, (SELECT id FROM comments WHERE id = (SELECT 1)) AS  `Comment__extra`' .
+			' FROM `cake_test`.`comments` AS `Comment`   WHERE `Comment`.`article_id` IN (1, 2)';
+		$test = ConnectionManager::getDatasource('test');
+		$log = $test->getLog();
+		$this->assertTextEquals($expected, $log['log'][116]['query']);
+	}
+
+/**
  * test conditions to generate query conditions for virtual fields
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3449,7 +3449,7 @@ SQL;
 
 		$expected = 'SELECT `Comment`.`id`, `Comment`.`article_id`, `Comment`.`user_id`, `Comment`.`comment`, `Comment`.`published`, `Comment`.`created`,' .
 			' `Comment`.`updated`, (SELECT id FROM comments WHERE id = (SELECT 1)) AS  `Comment__extra`' .
-			' FROM `cake_test`.`comments` AS `Comment`   WHERE `Comment`.`article_id` IN (1, 2)';
+			' FROM `cakephp_test`.`comments` AS `Comment`   WHERE `Comment`.`article_id` IN (1, 2)';
 
 		$log = $test->getLog();
 		$this->assertTextEquals($expected, $log['log'][count($log['log']) - 2]['query']);

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3428,7 +3428,7 @@ SQL;
 	}
 
 /**
- * test find() generating usable virtual fields to use in query
+ * test find() generating usable virtual fields to use in query without modifying custom subqueries.
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3442,14 +3442,17 @@ SQL;
 		);
 		$conditions = array('Article.id' => array(1, 2));
 		$contain = array('Comment.extra');
+
+		$test = ConnectionManager::getDatasource('test');
+		$test->getLog();
 		$result = $Article->find('all', compact('conditions', 'contain'));
 
 		$expected = 'SELECT `Comment`.`id`, `Comment`.`article_id`, `Comment`.`user_id`, `Comment`.`comment`, `Comment`.`published`, `Comment`.`created`,' .
 			' `Comment`.`updated`, (SELECT id FROM comments WHERE id = (SELECT 1)) AS  `Comment__extra`' .
 			' FROM `cake_test`.`comments` AS `Comment`   WHERE `Comment`.`article_id` IN (1, 2)';
-		$test = ConnectionManager::getDatasource('test');
+
 		$log = $test->getLog();
-		$this->assertTextEquals($expected, $log['log'][116]['query']);
+		$this->assertTextEquals($expected, $log['log'][count($log['log']) - 2]['query']);
 	}
 
 /**


### PR DESCRIPTION
Adding a basic test case for 
https://github.com/cakephp/cakephp/pull/1449

Without the change, the 

```
(SELECT id FROM comments WHERE id = (SELECT 1)) AS  `Comment__extra`'
```

would be (wrongly) modified to

```
(SELECT id FROM comments WHERE id IN (SELECT 1)) AS  `Comment__extra`'
```
