### PR TITLE
3.0 - Open basedir compatibility

### DIFF
--- a/tests/TestCase/Shell/Task/ProjectTaskTest.php
+++ b/tests/TestCase/Shell/Task/ProjectTaskTest.php
@@ -24,9 +24,17 @@ use Cake\TestSuite\TestCase;
  * ProjectTask class enabling access to protected methods.
  */
 class TestProjectTask extends ProjectTask {
+
+/**
+ * Wrapper for `_isOpenBasedirProtected()`
+ *
+ * @param string $path The path to test.
+ * @return bool
+ */
 	public function isOpenBasedirProtected($path) {
 		return $this->_isOpenBasedirProtected($path);
 	}
+
 }
 
 /**


### PR DESCRIPTION
So here I am again, trying to sneak in some open basedir comatibility :shipit:

I know I know, [**we had this before**](https://github.com/cakephp/cakephp/pull/3687), and the overall tone was that `open_basedir` is as popular as chilli flavoured hemorrhoid suppositories, and of course suppressing errors was a bad idea. However, I still think `open_basedir` is a nice little helper to quick and easily apply certain restrictions to PHP, especially in Windows based development environments that don't offer as much flexibility as *nix systems.
