### PR TITLE
Fix controller names not reflecting table names.

### DIFF
--- a/src/Shell/Task/ViewTask.php
+++ b/src/Shell/Task/ViewTask.php
@@ -448,10 +448,17 @@ class ViewTask extends BakeTask {
 				$target = $assoc->target();
 				$assocName = $assoc->name();
 				$alias = $target->alias();
+				$targetClass = get_class($target);
+				list($_, $className) = namespaceSplit($targetClass);
 
 				$modelClass = get_class($model);
-				if ($modelClass !== 'Cake\ORM\Table' && get_class($target) === $modelClass) {
+				if ($modelClass !== 'Cake\ORM\Table' && $targetClass === $modelClass) {
 					continue;
+				}
+
+				$className = preg_replace('/(.*)Table$/', '\1', $className);
+				if ($className === '') {
+					$className = $alias;
 				}
 
 				$associations[$type][$assocName] = [
@@ -460,7 +467,8 @@ class ViewTask extends BakeTask {
 					'primaryKey' => (array)$target->primaryKey(),
 					'displayField' => $target->displayField(),
 					'foreignKey' => $assoc->foreignKey(),
-					'controller' => $alias,
+					'alias' => $alias,
+					'controller' => $className,
 					'fields' => $target->schema()->columns(),
 				];
 			}

--- a/src/Template/Bake/default/views/form.ctp
+++ b/src/Template/Bake/default/views/form.ctp
@@ -31,8 +31,8 @@ $fields = collection($fields)
 		foreach ($associations as $type => $data) {
 			foreach ($data as $alias => $details) {
 				if ($details['controller'] != $this->name && !in_array($details['controller'], $done)) {
-					echo "\t\t<li><?= \$this->Html->link(__('List " . Inflector::humanize($details['controller']) . "'), ['controller' => '{$details['controller']}', 'action' => 'index']) ?> </li>\n";
-					echo "\t\t<li><?= \$this->Html->link(__('New " . Inflector::humanize(Inflector::singularize(Inflector::underscore($alias))) . "'), ['controller' => '{$details['controller']}', 'action' => 'add']) ?> </li>\n";
+					echo "\t\t<li><?= \$this->Html->link(__('List " . $this->_pluralHumanName($alias) . "'), ['controller' => '{$details['controller']}', 'action' => 'index']) ?> </li>\n";
+					echo "\t\t<li><?= \$this->Html->link(__('New " . $this->_singularHumanName($alias) . "'), ['controller' => '{$details['controller']}', 'action' => 'add']) ?> </li>\n";
 					$done[] = $details['controller'];
 				}
 			}

--- a/src/Template/Bake/default/views/index.ctp
+++ b/src/Template/Bake/default/views/index.ctp
@@ -29,8 +29,8 @@ $fields = collection($fields)
 	foreach ($associations as $type => $data) {
 		foreach ($data as $alias => $details) {
 			if ($details['controller'] != $this->name && !in_array($details['controller'], $done)) {
-				echo "\t\t<li><?= \$this->Html->link(__('List " . Inflector::humanize($details['controller']) . "'), ['controller' => '{$details['controller']}', 'action' => 'index']) ?> </li>\n";
-				echo "\t\t<li><?= \$this->Html->link(__('New " . Inflector::humanize(Inflector::singularize(Inflector::underscore($alias))) . "'), ['controller' => '{$details['controller']}', 'action' => 'add']) ?> </li>\n";
+				echo "\t\t<li><?= \$this->Html->link(__('List " . $this->_pluralHumanName($alias) . "'), ['controller' => '{$details['controller']}', 'action' => 'index']) ?> </li>\n";
+				echo "\t\t<li><?= \$this->Html->link(__('New " . $this->_singularHumanName($alias) . "'), ['controller' => '{$details['controller']}', 'action' => 'add']) ?> </li>\n";
 				$done[] = $details['controller'];
 			}
 		}

--- a/src/Template/Bake/default/views/view.ctp
+++ b/src/Template/Bake/default/views/view.ctp
@@ -65,7 +65,7 @@ $groupedFields += ['number' => [], 'string' => [], 'boolean' => [], 'date' => []
 	foreach ($associations as $type => $data) {
 		foreach ($data as $alias => $details) {
 			if ($details['controller'] != $this->name && !in_array($details['controller'], $done)) {
-				echo "\t\t<li><?= \$this->Html->link(__('List " . Inflector::humanize($details['controller']) . "'), ['controller' => '{$details['controller']}', 'action' => 'index']) ?> </li>\n";
+				echo "\t\t<li><?= \$this->Html->link(__('List " . $this->_pluralHumanName($alias) . "'), ['controller' => '{$details['controller']}', 'action' => 'index']) ?> </li>\n";
 				echo "\t\t<li><?= \$this->Html->link(__('New " . Inflector::humanize(Inflector::singularize(Inflector::underscore($alias))) . "'), ['controller' => '{$details['controller']}', 'action' => 'add']) ?> </li>\n";
 				$done[] = $details['controller'];
 			}

--- a/tests/TestCase/Shell/Task/ViewTaskTest.php
+++ b/tests/TestCase/Shell/Task/ViewTaskTest.php
@@ -313,6 +313,49 @@ class ViewTaskTest extends TestCase {
 	}
 
 /**
+ * Test getContent with associations
+ *
+ * @return void
+ */
+	public function testGetContentAssociations() {
+		$vars = array(
+			'modelClass' => 'ViewTaskComments',
+			'schema' => TableRegistry::get('ViewTaskComments')->schema(),
+			'primaryKey' => ['id'],
+			'displayField' => 'name',
+			'singularVar' => 'viewTaskComment',
+			'pluralVar' => 'viewTaskComments',
+			'singularHumanName' => 'View Task Comment',
+			'pluralHumanName' => 'View Task Comments',
+			'fields' => ['id', 'name', 'body'],
+			'associations' => [
+				'belongsTo' => [
+					'Authors' => [
+						'property' => 'author',
+						'variable' => 'author',
+						'primaryKey' => ['id'],
+						'displayField' => 'name',
+						'foreignKey' => 'author_id',
+						'alias' => 'Authors',
+						'controller' => 'ViewTaskAuthors',
+						'fields' => ['name'],
+					]
+				]
+			],
+			'keyFields' => [],
+		);
+		$result = $this->Task->getContent('view', $vars);
+
+		$this->assertContains('Delete View Task Comment', $result);
+		$this->assertContains('Edit View Task Comment', $result);
+		$this->assertContains('List Authors', $result);
+		$this->assertContains('New Author', $result);
+
+		$this->assertContains("'controller' => 'ViewTaskAuthors'", $result);
+	}
+
+
+/**
  * Test getContent with no pk
  *
  * @return void


### PR DESCRIPTION
Using an association's model name is generally going to be more accurate than using the alias. Often times models are aliased to have names that won't match their controller names.

Refs #5030
