### PR TITLE
3.0 widget registry

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -74,7 +74,19 @@ class FormHelper extends Helper {
 			'date' => 'date', 'float' => 'number', 'integer' => 'number',
 			'decimal' => 'number', 'binary' => 'file', 'uuid' => 'string'
 		],
-		'widgets' => [],
+		'widgets' => [
+			'button' => ['Cake\View\Widget\ButtonWidget'],
+			'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
+			'file' => ['Cake\View\Widget\FileWidget'],
+			'label' => ['Cake\View\Widget\LabelWidget'],
+			'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
+			'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
+			'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
+			'select' => ['Cake\View\Widget\SelectBoxWidget'],
+			'textarea' => ['Cake\View\Widget\TextareaWidget'],
+			'datetime' => ['Cake\View\Widget\DateTimeWidget', 'select'],
+			'_default' => ['Cake\View\Widget\BasicWidget'],
+		],
 		'registry' => null,
 		'templates' => [
 			'button' => '<button{{attrs}}>{{text}}</button>',

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -18,15 +18,23 @@ use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
- * Input widget class for generating a textarea control.
+ * Basic input class.
  *
- * This class is intended as an internal implementation detail
- * of Cake\View\Helper\FormHelper and is not intended for direct use.
+ * This input class can be used to render basic simple
+ * input elements like hidden, text, email, tel and other
+ * types.
  */
-class Textarea implements WidgetInterface {
+class BasicWidget implements WidgetInterface {
 
 /**
- * Constructor
+ * StringTemplate instance.
+ *
+ * @var \Cake\View\StringTemplate
+ */
+	protected $_templates;
+
+/**
+ * Constructor.
  *
  * @param \Cake\View\StringTemplate $templates Templates list.
  */
@@ -35,32 +43,37 @@ class Textarea implements WidgetInterface {
 	}
 
 /**
- * Render a text area form widget.
+ * Render a text widget or other simple widget like email/tel/number.
  *
- * Data supports the following keys:
+ * This method accepts a number of keys:
  *
- * - `name` - Set the input name.
- * - `val` - A string of the option to mark as selected.
- * - `escape` - Set to false to disable HTML escaping.
+ * - `name` The name attribute.
+ * - `val` The value attribute.
+ * - `escape` Set to false to disable escaping on all attributes.
  *
- * All other keys will be converted into HTML attributes.
+ * Any other keys provided in $data will be converted into HTML attributes.
  *
- * @param array $data The data to build a textarea with.
+ * @param array $data The data to build an input with.
  * @param \Cake\View\Form\ContextInterface $context The current form context.
- * @return string HTML elements.
+ * @return string
  */
 	public function render(array $data, ContextInterface $context) {
 		$data += [
-			'val' => '',
 			'name' => '',
+			'val' => null,
+			'type' => 'text',
 			'escape' => true,
 		];
-		return $this->_templates->format('textarea', [
+		$data['value'] = $data['val'];
+		unset($data['val']);
+
+		return $this->_templates->format('input', [
 			'name' => $data['name'],
-			'value' => $data['escape'] ? h($data['val']) : $data['val'],
+			'type' => $data['type'],
 			'attrs' => $this->_templates->formatAttributes(
-				$data, ['name', 'val']
-			)
+				$data,
+				['name', 'type']
+			),
 		]);
 	}
 

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -24,7 +24,7 @@ use Cake\View\Widget\WidgetInterface;
  * If you need to make basic submit inputs with type=submit,
  * use the Basic input widget.
  */
-class Button implements WidgetInterface {
+class ButtonWidget implements WidgetInterface {
 
 /**
  * StringTemplate instance.

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -20,7 +20,7 @@ use Cake\View\Widget\WidgetInterface;
 /**
  * Input widget for creating checkbox widgets.
  */
-class Checkbox implements WidgetInterface {
+class CheckboxWidget implements WidgetInterface {
 
 /**
  * Template instance.

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -16,7 +16,7 @@ namespace Cake\View\Widget;
 
 use Cake\View\Form\ContextInterface;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\SelectBox;
+use Cake\View\Widget\SelectBoxWidget;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -25,7 +25,7 @@ use Cake\View\Widget\WidgetInterface;
  * This class is intended as an internal implementation detail
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class DateTime implements WidgetInterface {
+class DateTimeWidget implements WidgetInterface {
 
 /**
  * Select box widget.
@@ -60,9 +60,9 @@ class DateTime implements WidgetInterface {
  * Constructor
  *
  * @param \Cake\View\StringTemplate $templates Templates list.
- * @param \Cake\View\Widget\SelectBox $selectBox Selectbox widget instance.
+ * @param \Cake\View\Widget\SelectBoxWidget $selectBox Selectbox widget instance.
  */
-	public function __construct(StringTemplate $templates, SelectBox $selectBox) {
+	public function __construct(StringTemplate $templates, SelectBoxWidget $selectBox) {
 		$this->_select = $selectBox;
 		$this->_templates = $templates;
 	}

--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -18,23 +18,15 @@ use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
- * Basic input class.
+ * Input widget class for generating a file upload control.
  *
- * This input class can be used to render basic simple
- * input elements like hidden, text, email, tel and other
- * types.
+ * This class is intended as an internal implementation detail
+ * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class Basic implements WidgetInterface {
+class FileWidget implements WidgetInterface {
 
 /**
- * StringTemplate instance.
- *
- * @var \Cake\View\StringTemplate
- */
-	protected $_templates;
-
-/**
- * Constructor.
+ * Constructor
  *
  * @param \Cake\View\StringTemplate $templates Templates list.
  */
@@ -43,37 +35,33 @@ class Basic implements WidgetInterface {
 	}
 
 /**
- * Render a text widget or other simple widget like email/tel/number.
+ * Render a file upload form widget.
  *
- * This method accepts a number of keys:
+ * Data supports the following keys:
  *
- * - `name` The name attribute.
- * - `val` The value attribute.
- * - `escape` Set to false to disable escaping on all attributes.
+ * - `name` - Set the input name.
+ * - `escape` - Set to false to disable HTML escaping.
  *
- * Any other keys provided in $data will be converted into HTML attributes.
+ * All other keys will be converted into HTML attributes.
+ * Unlike other input objects the `val` property will be specifically
+ * ignored.
  *
- * @param array $data The data to build an input with.
+ * @param array $data The data to build a file input with.
  * @param \Cake\View\Form\ContextInterface $context The current form context.
- * @return string
+ * @return string HTML elements.
  */
 	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
-			'val' => null,
-			'type' => 'text',
 			'escape' => true,
 		];
-		$data['value'] = $data['val'];
 		unset($data['val']);
 
-		return $this->_templates->format('input', [
+		return $this->_templates->format('file', [
 			'name' => $data['name'],
-			'type' => $data['type'],
 			'attrs' => $this->_templates->formatAttributes(
-				$data,
-				['name', 'type']
-			),
+				$data, ['name', 'val']
+			)
 		]);
 	}
 
@@ -81,7 +69,11 @@ class Basic implements WidgetInterface {
  * {@inheritDoc}
  */
 	public function secureFields(array $data) {
-		return [$data['name']];
+		$fields = [];
+		foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $suffix) {
+			$fields[] = $data['name'] . '[' . $suffix . ']';
+		}
+		return $fields;
 	}
 
 }

--- a/src/View/Widget/LabelWidget.php
+++ b/src/View/Widget/LabelWidget.php
@@ -23,7 +23,7 @@ use Cake\View\Widget\WidgetInterface;
  * Generally this element is used by other widgets,
  * and FormHelper itself.
  */
-class Label implements WidgetInterface {
+class LabelWidget implements WidgetInterface {
 
 /**
  * Templates

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -22,7 +22,7 @@ use Cake\View\Widget\WidgetInterface;
  * Input widget class for generating multiple checkboxes.
  *
  */
-class MultiCheckbox implements WidgetInterface {
+class MultiCheckboxWidget implements WidgetInterface {
 
 	use IdGeneratorTrait;
 

--- a/src/View/Widget/NestingLabelWidget.php
+++ b/src/View/Widget/NestingLabelWidget.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Widget;
 
-use Cake\View\Widget\Label;
+use Cake\View\Widget\LabelWidget;
 
 /**
  * Form 'widget' for creating labels that contain their input.
@@ -22,7 +22,7 @@ use Cake\View\Widget\Label;
  * Generally this element is used by other widgets,
  * and FormHelper itself.
  */
-class NestingLabel extends Label {
+class NestingLabelWidget extends LabelWidget {
 
 /**
  * The template to use.

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -25,7 +25,7 @@ use Traversable;
  * This class is intended as an internal implementation detail
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class Radio implements WidgetInterface {
+class RadioWidget implements WidgetInterface {
 
 	use IdGeneratorTrait;
 

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -24,7 +24,7 @@ use Traversable;
  * This class is intended as an internal implementation detail
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class SelectBox implements WidgetInterface {
+class SelectBoxWidget implements WidgetInterface {
 
 /**
  * Template instance.

--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -18,12 +18,12 @@ use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
- * Input widget class for generating a file upload control.
+ * Input widget class for generating a textarea control.
  *
  * This class is intended as an internal implementation detail
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class File implements WidgetInterface {
+class TextareaWidget implements WidgetInterface {
 
 /**
  * Constructor
@@ -35,30 +35,29 @@ class File implements WidgetInterface {
 	}
 
 /**
- * Render a file upload form widget.
+ * Render a text area form widget.
  *
  * Data supports the following keys:
  *
  * - `name` - Set the input name.
+ * - `val` - A string of the option to mark as selected.
  * - `escape` - Set to false to disable HTML escaping.
  *
  * All other keys will be converted into HTML attributes.
- * Unlike other input objects the `val` property will be specifically
- * ignored.
  *
- * @param array $data The data to build a file input with.
+ * @param array $data The data to build a textarea with.
  * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string HTML elements.
  */
 	public function render(array $data, ContextInterface $context) {
 		$data += [
+			'val' => '',
 			'name' => '',
 			'escape' => true,
 		];
-		unset($data['val']);
-
-		return $this->_templates->format('file', [
+		return $this->_templates->format('textarea', [
 			'name' => $data['name'],
+			'value' => $data['escape'] ? h($data['val']) : $data['val'],
 			'attrs' => $this->_templates->formatAttributes(
 				$data, ['name', 'val']
 			)
@@ -69,11 +68,7 @@ class File implements WidgetInterface {
  * {@inheritDoc}
  */
 	public function secureFields(array $data) {
-		$fields = [];
-		foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $suffix) {
-			$fields[] = $data['name'] . '[' . $suffix . ']';
-		}
-		return $fields;
+		return [$data['name']];
 	}
 
 }

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -44,17 +44,17 @@ class WidgetRegistry {
  * @var array
  */
 	protected $_widgets = [
-		'button' => ['Cake\View\Widget\Button'],
-		'checkbox' => ['Cake\View\Widget\Checkbox'],
-		'file' => ['Cake\View\Widget\File'],
-		'label' => ['Cake\View\Widget\Label'],
-		'nestingLabel' => ['Cake\View\Widget\NestingLabel'],
-		'multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'nestingLabel'],
-		'radio' => ['Cake\View\Widget\Radio', 'nestingLabel'],
-		'select' => ['Cake\View\Widget\SelectBox'],
-		'textarea' => ['Cake\View\Widget\Textarea'],
-		'datetime' => ['Cake\View\Widget\DateTime', 'select'],
-		'_default' => ['Cake\View\Widget\Basic'],
+		'button' => ['Cake\View\Widget\ButtonWidget'],
+		'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
+		'file' => ['Cake\View\Widget\FileWidget'],
+		'label' => ['Cake\View\Widget\LabelWidget'],
+		'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
+		'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
+		'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
+		'select' => ['Cake\View\Widget\SelectBoxWidget'],
+		'textarea' => ['Cake\View\Widget\TextareaWidget'],
+		'datetime' => ['Cake\View\Widget\DateTimeWidget', 'select'],
+		'_default' => ['Cake\View\Widget\BasicWidget'],
 	];
 
 /**
@@ -179,7 +179,7 @@ class WidgetRegistry {
 		}
 
 		$class = array_shift($widget);
-		$className = App::className($class, 'View/Widget');
+		$className = App::className($class, 'View/Widget', 'Widget');
 		if ($className === false || !class_exists($className)) {
 			throw new \RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
 		}

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -160,16 +160,18 @@ class WidgetRegistry {
  * @param mixed $widget The widget to get
  * @return WidgetInterface
  * @throws \RuntimeException when class cannot be loaded or does not
- *   implement WidgetInterface.
+ *   implement WidgetInterface or not a View instance.
  */
 	protected function _resolveWidget($widget) {
 		$type = gettype($widget);
-		if ($type === 'object' && $widget instanceof WidgetInterface) {
+		if ($type === 'object' &&
+			($widget instanceof WidgetInterface || $widget instanceof View)
+		) {
 			return $widget;
 		}
 		if ($type === 'object') {
 			throw new \RuntimeException(
-				'Input objects must implement Cake\View\Widget\WidgetInterface.'
+				'Widget objects must implement Cake\View\Widget\WidgetInterface.'
 			);
 		}
 		if ($type === 'string') {

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -43,19 +43,7 @@ class WidgetRegistry {
  *
  * @var array
  */
-	protected $_widgets = [
-		'button' => ['Cake\View\Widget\ButtonWidget'],
-		'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
-		'file' => ['Cake\View\Widget\FileWidget'],
-		'label' => ['Cake\View\Widget\LabelWidget'],
-		'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
-		'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
-		'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
-		'select' => ['Cake\View\Widget\SelectBoxWidget'],
-		'textarea' => ['Cake\View\Widget\TextareaWidget'],
-		'datetime' => ['Cake\View\Widget\DateTimeWidget', 'select'],
-		'_default' => ['Cake\View\Widget\BasicWidget'],
-	];
+	protected $_widgets = [];
 
 /**
  * Templates to use.

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -80,7 +80,7 @@ class WidgetRegistry {
 				$this->add($widgets);
 			}
 		}
-		$this->add(['_view' => $view]);
+		$this->_widgets['_view'] = $view;
 	}
 
 /**
@@ -106,7 +106,7 @@ class WidgetRegistry {
  *
  * {{{
  * $registry->add([
- *   'label' => new MyLabel($templates),
+ *   'label' => new MyLabelWidget($templates),
  *   'checkbox' => ['Fancy.MyCheckbox', 'label']
  * ]);
  * }}}
@@ -117,8 +117,18 @@ class WidgetRegistry {
  *
  * @param array $widgets Array of widgets to use.
  * @return void
+ * @throws \RuntimeException When class does not implement WidgetInterface.
  */
 	public function add(array $widgets) {
+		foreach ($widgets as $object) {
+			if (gettype($object) === 'object' &&
+				!($object instanceof WidgetInterface)
+			) {
+				throw new \RuntimeException(
+					'Widget objects must implement Cake\View\Widget\WidgetInterface.'
+				);
+			}
+		}
 		$this->_widgets = $widgets + $this->_widgets;
 	}
 
@@ -160,20 +170,14 @@ class WidgetRegistry {
  * @param mixed $widget The widget to get
  * @return WidgetInterface
  * @throws \RuntimeException when class cannot be loaded or does not
- *   implement WidgetInterface or not a View instance.
+ *   implement WidgetInterface.
  */
 	protected function _resolveWidget($widget) {
 		$type = gettype($widget);
-		if ($type === 'object' &&
-			($widget instanceof WidgetInterface || $widget instanceof View)
-		) {
+		if ($type === 'object') {
 			return $widget;
 		}
-		if ($type === 'object') {
-			throw new \RuntimeException(
-				'Widget objects must implement Cake\View\Widget\WidgetInterface.'
-			);
-		}
+
 		if ($type === 'string') {
 			$widget = [$widget];
 		}

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -177,7 +177,7 @@ class WidgetRegistry {
 		}
 
 		$class = array_shift($widget);
-		$className = App::className($class, 'View/Input');
+		$className = App::className($class, 'View/Widget');
 		if ($className === false || !class_exists($className)) {
 			throw new \RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
 		}

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -16,12 +16,12 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\Basic;
+use Cake\View\Widget\BasicWidget;
 
 /**
  * Basic input test.
  */
-class BasicTest extends TestCase {
+class BasicWidgetTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
@@ -38,7 +38,7 @@ class BasicTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$text = new Basic($this->templates);
+		$text = new BasicWidget($this->templates);
 		$result = $text->render(['name' => 'my_input'], $this->context);
 		$expected = [
 			'input' => ['type' => 'text', 'name' => 'my_input']
@@ -52,7 +52,7 @@ class BasicTest extends TestCase {
  * @return void
  */
 	public function testRenderType() {
-		$text = new Basic($this->templates);
+		$text = new BasicWidget($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',
@@ -70,7 +70,7 @@ class BasicTest extends TestCase {
  * @return void
  */
 	public function testRenderWithValue() {
-		$text = new Basic($this->templates);
+		$text = new BasicWidget($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',
@@ -93,7 +93,7 @@ class BasicTest extends TestCase {
  * @return void
  */
 	public function testRenderAttributes() {
-		$text = new Basic($this->templates);
+		$text = new BasicWidget($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -16,12 +16,12 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\Button;
+use Cake\View\Widget\ButtonWidget;
 
 /**
  * Basic input test.
  */
-class ButtonTest extends TestCase {
+class ButtonWidgetTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
@@ -38,7 +38,7 @@ class ButtonTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$button = new Button($this->templates);
+		$button = new ButtonWidget($this->templates);
 		$result = $button->render(['name' => 'my_input'], $this->context);
 		$expected = [
 			'button' => ['type' => 'submit', 'name' => 'my_input'],
@@ -53,7 +53,7 @@ class ButtonTest extends TestCase {
  * @return void
  */
 	public function testRenderType() {
-		$button = new Button($this->templates);
+		$button = new ButtonWidget($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'button',
@@ -74,7 +74,7 @@ class ButtonTest extends TestCase {
  * @return void
  */
 	public function testRenderWithText() {
-		$button = new Button($this->templates);
+		$button = new ButtonWidget($this->templates);
 		$data = [
 			'text' => 'Some <value>'
 		];
@@ -102,7 +102,7 @@ class ButtonTest extends TestCase {
  * @return void
  */
 	public function testRenderAttributes() {
-		$button = new Button($this->templates);
+		$button = new ButtonWidget($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'text' => 'Go',

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -16,12 +16,12 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\Checkbox;
+use Cake\View\Widget\CheckboxWidget;
 
 /**
  * Checkbox test case
  */
-class CheckboxTest extends TestCase {
+class CheckboxWidgetTest extends TestCase {
 
 /**
  * setup method.
@@ -43,7 +43,7 @@ class CheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$checkbox = new Checkbox($this->templates);
+		$checkbox = new CheckboxWidget($this->templates);
 		$data = [
 			'name' => 'Comment[spam]',
 		];
@@ -78,7 +78,7 @@ class CheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderDisabled() {
-		$checkbox = new Checkbox($this->templates);
+		$checkbox = new CheckboxWidget($this->templates);
 		$data = [
 			'name' => 'Comment[spam]',
 			'disabled' => true,
@@ -101,7 +101,7 @@ class CheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderChecked() {
-		$checkbox = new Checkbox($this->templates);
+		$checkbox = new CheckboxWidget($this->templates);
 		$data = [
 			'name' => 'Comment[spam]',
 			'value' => 1,
@@ -167,7 +167,7 @@ class CheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderCheckedValue($checked) {
-		$checkbox = new Checkbox($this->templates);
+		$checkbox = new CheckboxWidget($this->templates);
 		$data = [
 			'name' => 'Comment[spam]',
 			'value' => 1,
@@ -207,7 +207,7 @@ class CheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderUnCheckedValue($checked) {
-		$checkbox = new Checkbox($this->templates);
+		$checkbox = new CheckboxWidget($this->templates);
 		$data = [
 			'name' => 'Comment[spam]',
 			'value' => 1,

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -16,13 +16,13 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\DateTime;
-use Cake\View\Widget\SelectBox;
+use Cake\View\Widget\DateTimeWidget;
+use Cake\View\Widget\SelectBoxWidget;
 
 /**
  * DateTime input test case
  */
-class DateTimeTest extends TestCase {
+class DateTimeWidgetTest extends TestCase {
 
 /**
  * @setUp
@@ -39,8 +39,8 @@ class DateTimeTest extends TestCase {
 		];
 		$this->templates = new StringTemplate($templates);
 		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
-		$this->selectBox = new SelectBox($this->templates);
-		$this->DateTime = new DateTime($this->templates, $this->selectBox);
+		$this->selectBox = new SelectBoxWidget($this->templates);
+		$this->DateTime = new DateTimeWidget($this->templates, $this->selectBox);
 	}
 
 /**

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -16,12 +16,12 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\File;
+use Cake\View\Widget\FileWidget;
 
 /**
  * File input test.
  */
-class FileTest extends TestCase {
+class FileWidgetTest extends TestCase {
 
 /**
  * setup
@@ -43,7 +43,7 @@ class FileTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$input = new File($this->templates);
+		$input = new FileWidget($this->templates);
 		$result = $input->render(['name' => 'image'], $this->context);
 		$expected = [
 			'input' => ['type' => 'file', 'name' => 'image'],
@@ -57,7 +57,7 @@ class FileTest extends TestCase {
  * @return void
  */
 	public function testRenderAttributes() {
-		$input = new File($this->templates);
+		$input = new FileWidget($this->templates);
 		$data = ['name' => 'image', 'required' => true, 'val' => 'nope'];
 		$result = $input->render($data, $this->context);
 		$expected = [

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -16,12 +16,12 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\Label;
+use Cake\View\Widget\LabelWidget;
 
 /**
  * Label test case.
  */
-class LabelTest extends TestCase {
+class LabelWidgetTest extends TestCase {
 
 /**
  * setup method.
@@ -43,7 +43,7 @@ class LabelTest extends TestCase {
  * @return void
  */
 	public function testRender() {
-		$label = new Label($this->templates);
+		$label = new LabelWidget($this->templates);
 		$data = [
 			'text' => 'My text',
 		];
@@ -62,7 +62,7 @@ class LabelTest extends TestCase {
  * @return void
  */
 	public function testRenderEscape() {
-		$label = new Label($this->templates);
+		$label = new LabelWidget($this->templates);
 		$data = [
 			'text' => 'My > text',
 			'for' => 'Some > value',
@@ -83,7 +83,7 @@ class LabelTest extends TestCase {
  * @return void
  */
 	public function testRenderAttributes() {
-		$label = new Label($this->templates);
+		$label = new LabelWidget($this->templates);
 		$data = [
 			'text' => 'My > text',
 			'for' => 'some-id',

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -16,13 +16,13 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\Label;
-use Cake\View\Widget\MultiCheckbox;
+use Cake\View\Widget\LabelWidget;
+use Cake\View\Widget\MultiCheckboxWidget;
 
 /**
  * MultiCheckbox test case.
  */
-class MultiCheckboxTest extends TestCase {
+class MultiCheckboxWidgetTest extends TestCase {
 
 /**
  * setup method.
@@ -46,8 +46,8 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$label = new Label($this->templates);
-		$input = new MultiCheckbox($this->templates, $label);
+		$label = new LabelWidget($this->templates);
+		$input = new MultiCheckboxWidget($this->templates, $label);
 		$data = [
 			'name' => 'Tags[id]',
 			'options' => [
@@ -89,8 +89,8 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderComplex() {
-		$label = new Label($this->templates);
-		$input = new MultiCheckbox($this->templates, $label);
+		$label = new LabelWidget($this->templates);
+		$input = new MultiCheckboxWidget($this->templates, $label);
 		$data = [
 			'name' => 'Tags[id]',
 			'options' => [
@@ -134,8 +134,8 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderEscaping() {
-		$label = new Label($this->templates);
-		$input = new MultiCheckbox($this->templates, $label);
+		$label = new LabelWidget($this->templates);
+		$input = new MultiCheckboxWidget($this->templates, $label);
 		$data = [
 			'name' => 'Tags[id]',
 			'options' => [
@@ -165,8 +165,8 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderSelected() {
-		$label = new Label($this->templates);
-		$input = new MultiCheckbox($this->templates, $label);
+		$label = new LabelWidget($this->templates);
+		$input = new MultiCheckboxWidget($this->templates, $label);
 		$data = [
 			'name' => 'Tags[id]',
 			'options' => [
@@ -219,8 +219,8 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderDisabled() {
-		$label = new Label($this->templates);
-		$input = new MultiCheckbox($this->templates, $label);
+		$label = new LabelWidget($this->templates);
+		$input = new MultiCheckboxWidget($this->templates, $label);
 		$data = [
 			'name' => 'Tags[id]',
 			'options' => [

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -17,13 +17,13 @@ namespace Cake\Test\TestCase\View\Widget;
 use Cake\Collection\Collection;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\NestingLabel;
-use Cake\View\Widget\Radio;
+use Cake\View\Widget\NestingLabelWidget;
+use Cake\View\Widget\RadioWidget;
 
 /**
  * Radio test case
  */
-class RadioTest extends TestCase {
+class RadioWidgetTest extends TestCase {
 
 /**
  * setup method.
@@ -51,8 +51,8 @@ class RadioTest extends TestCase {
 			'nestingLabel' => '<label{{attrs}}>{{text}}</label>',
 			'radioWrapper' => '{{input}}{{label}}'
 		]);
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Crayons[color]',
 			'label' => null,
@@ -110,8 +110,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Crayons[color]',
 			'label' => null,
@@ -154,8 +154,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderComplex() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Crayons[color]',
 			'options' => [
@@ -194,8 +194,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderIdSuffixGeneration() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Thing[value]',
 			'options' => ['a>b' => 'First', 'a<b' => 'Second']
@@ -230,8 +230,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderBooleanishValues() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Model[field]',
 			'options' => ['1' => 'Yes', '0' => 'No'],
@@ -305,8 +305,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderRequiredAndFormAttribute() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'published',
 			'options' => ['option A', 'option B'],
@@ -335,8 +335,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderEmptyOption() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Crayons[color]',
 			'options' => ['r' => 'Red'],
@@ -400,8 +400,8 @@ class RadioTest extends TestCase {
 			'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
 			'radioWrapper' => '{{label}}',
 		]);
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Crayons[color]',
 			'options' => ['r' => 'Red'],
@@ -427,8 +427,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderSelected() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Versions[ver]',
 			'val' => '1',
@@ -478,8 +478,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderDisabled() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Versions[ver]',
 			'options' => [
@@ -550,8 +550,8 @@ class RadioTest extends TestCase {
  * @return void
  */
 	public function testRenderLabelOptions() {
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Versions[ver]',
 			'options' => [
@@ -623,8 +623,8 @@ class RadioTest extends TestCase {
 		$this->templates->add([
 			'radioWrapper' => '<div class="radio">{{input}}{{label}}</div>'
 		]);
-		$label = new NestingLabel($this->templates);
-		$radio = new Radio($this->templates, $label);
+		$label = new NestingLabelWidget($this->templates);
+		$radio = new RadioWidget($this->templates, $label);
 		$data = [
 			'name' => 'Versions[ver]',
 			'options' => [

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -17,12 +17,12 @@ namespace Cake\Test\TestCase\View\Widget;
 use Cake\Collection\Collection;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\SelectBox;
+use Cake\View\Widget\SelectBoxWidget;
 
 /**
  * SelectBox test case
  */
-class SelectBoxTest extends TestCase {
+class SelectBoxWidgetTest extends TestCase {
 
 /**
  * setup method.
@@ -47,7 +47,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderNoOptions() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
@@ -67,7 +67,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
@@ -89,7 +89,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderSimpleIterator() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$options = new \ArrayObject(['a' => 'Albatross', 'b' => 'Budgie']);
 		$data = [
 			'name' => 'Birds[name]',
@@ -113,7 +113,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderSimpleIteratorWithEmpty() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$options = new Collection(['a' => 'Albatross', 'b' => 'Budgie']);
 		$data = [
 			'name' => 'Birds[name]',
@@ -137,7 +137,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderComplex() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
@@ -166,7 +166,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderSelected() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
@@ -208,7 +208,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderMultipleSelect() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
@@ -235,7 +235,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderMultipleSelected() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'multiple' => true,
 			'id' => 'BirdName',
@@ -270,7 +270,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderOptionGroups() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
 			'options' => [
@@ -316,7 +316,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderOptionGroupsEscape() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
 			'options' => [
@@ -361,7 +361,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderOptionGroupsWithAttributes() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
 			'options' => [
@@ -399,7 +399,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderOptionGroupsTraversable() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$mammals = new \ArrayObject(['beaver' => 'Beaver', 'elk' => 'Elk']);
 		$data = [
 			'name' => 'Birds[name]',
@@ -443,7 +443,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderOptionGroupsSelectedAndDisabled() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
 			'val' => ['1', '2', 'burp'],
@@ -484,7 +484,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderDisabled() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'disabled' => true,
 			'name' => 'Birds[name]',
@@ -503,7 +503,7 @@ class SelectBoxTest extends TestCase {
 		];
 		$this->assertHtml($expected, $result);
 
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'disabled' => [1],
 			'name' => 'numbers',
@@ -527,7 +527,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderDisabledMultiple() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'disabled' => ['a', 'c'],
 			'val' => 'a',
@@ -563,7 +563,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderEmptyOption() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
@@ -614,7 +614,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderEscapingOption() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
 			'options' => [
@@ -667,7 +667,7 @@ class SelectBoxTest extends TestCase {
  * @return void
  */
 	public function testRenderNullOptions() {
-		$select = new SelectBox($this->templates);
+		$select = new SelectBoxWidget($this->templates);
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -16,12 +16,12 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use Cake\View\Widget\Textarea;
+use Cake\View\Widget\TextareaWidget;
 
 /**
  * Textarea input test.
  */
-class TextareaTest extends TestCase {
+class TextareaWidgetTest extends TestCase {
 
 /**
  * setup
@@ -43,7 +43,7 @@ class TextareaTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$input = new Textarea($this->templates);
+		$input = new TextareaWidget($this->templates);
 		$result = $input->render(['name' => 'comment'], $this->context);
 		$expected = [
 			'textarea' => ['name' => 'comment'],
@@ -58,7 +58,7 @@ class TextareaTest extends TestCase {
  * @return void
  */
 	public function testRenderWithValue() {
-		$input = new Textarea($this->templates);
+		$input = new TextareaWidget($this->templates);
 		$data = ['name' => 'comment', 'data-foo' => '<val>', 'val' => 'some <html>'];
 		$result = $input->render($data, $this->context);
 		$expected = [

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -43,15 +43,15 @@ class WidgetRegistryTestCase extends TestCase {
  */
 	public function testAddInConstructor() {
 		$widgets = [
-			'text' => ['Cake\View\Widget\Basic'],
+			'text' => ['Cake\View\Widget\BasicWidget'],
 			'label' => ['Label'],
 		];
 		$inputs = new WidgetRegistry($this->templates, $this->view, $widgets);
 		$result = $inputs->get('text');
-		$this->assertInstanceOf('Cake\View\Widget\Basic', $result);
+		$this->assertInstanceOf('Cake\View\Widget\BasicWidget', $result);
 
 		$result = $inputs->get('label');
-		$this->assertInstanceOf('Cake\View\Widget\Label', $result);
+		$this->assertInstanceOf('Cake\View\Widget\LabelWidget', $result);
 	}
 
 /**
@@ -73,7 +73,7 @@ class WidgetRegistryTestCase extends TestCase {
  */
 	public function testLoadInConstructor() {
 		$inputs = new WidgetRegistry($this->templates, $this->view, 'test_widgets');
-		$this->assertInstanceOf('Cake\View\Widget\Label', $inputs->get('text'));
+		$this->assertInstanceOf('Cake\View\Widget\LabelWidget', $inputs->get('text'));
 	}
 
 /**
@@ -84,7 +84,7 @@ class WidgetRegistryTestCase extends TestCase {
 	public function testLoadPluginInConstuctor() {
 		Plugin::load('TestPlugin');
 		$inputs = new WidgetRegistry($this->templates, $this->view, 'TestPlugin.test_widgets');
-		$this->assertInstanceOf('Cake\View\Widget\Label', $inputs->get('text'));
+		$this->assertInstanceOf('Cake\View\Widget\LabelWidget', $inputs->get('text'));
 	}
 
 /**
@@ -95,7 +95,7 @@ class WidgetRegistryTestCase extends TestCase {
 	public function testAdd() {
 		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$result = $inputs->add([
-			'text' => ['Cake\View\Widget\Basic'],
+			'text' => ['Cake\View\Widget\BasicWidget'],
 		]);
 		$this->assertNull($result);
 		$result = $inputs->get('text');
@@ -103,7 +103,7 @@ class WidgetRegistryTestCase extends TestCase {
 
 		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$result = $inputs->add([
-			'hidden' => 'Cake\View\Widget\Basic',
+			'hidden' => 'Cake\View\Widget\BasicWidget',
 		]);
 		$this->assertNull($result);
 		$result = $inputs->get('hidden');
@@ -133,10 +133,10 @@ class WidgetRegistryTestCase extends TestCase {
 	public function testGet() {
 		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->add([
-			'text' => ['Cake\View\Widget\Basic'],
+			'text' => ['Cake\View\Widget\BasicWidget'],
 		]);
 		$result = $inputs->get('text');
-		$this->assertInstanceOf('Cake\View\Widget\Basic', $result);
+		$this->assertInstanceOf('Cake\View\Widget\BasicWidget', $result);
 		$this->assertSame($result, $inputs->get('text'));
 	}
 
@@ -148,10 +148,10 @@ class WidgetRegistryTestCase extends TestCase {
 	public function testGetFallback() {
 		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->add([
-			'_default' => ['Cake\View\Widget\Basic'],
+			'_default' => ['Cake\View\Widget\BasicWidget'],
 		]);
 		$result = $inputs->get('text');
-		$this->assertInstanceOf('Cake\View\Widget\Basic', $result);
+		$this->assertInstanceOf('Cake\View\Widget\BasicWidget', $result);
 
 		$result2 = $inputs->get('hidden');
 		$this->assertSame($result, $result2);
@@ -179,23 +179,23 @@ class WidgetRegistryTestCase extends TestCase {
 		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->clear();
 		$inputs->add([
-			'label' => ['Cake\View\Widget\Label'],
-			'multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'label']
+			'label' => ['Cake\View\Widget\LabelWidget'],
+			'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'label']
 		]);
 		$result = $inputs->get('multicheckbox');
-		$this->assertInstanceOf('Cake\View\Widget\MultiCheckbox', $result);
+		$this->assertInstanceOf('Cake\View\Widget\MultiCheckboxWidget', $result);
 	}
 
 /**
  * Test getting resolve dependency missing class
  *
  * @expectedException RuntimeException
- * @expectedExceptionMessage Unable to locate widget class "TestApp\View\Derp"
+ * @expectedExceptionMessage Unable to locate widget class "TestApp\View\DerpWidget"
  * @return void
  */
 	public function testGetResolveDependencyMissingClass() {
 		$inputs = new WidgetRegistry($this->templates, $this->view);
-		$inputs->add(['test' => ['TestApp\View\Derp']]);
+		$inputs->add(['test' => ['TestApp\View\DerpWidget']]);
 		$inputs->get('test');
 	}
 
@@ -209,7 +209,7 @@ class WidgetRegistryTestCase extends TestCase {
 	public function testGetResolveDependencyMissingDependency() {
 		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->clear();
-		$inputs->add(['multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'label']]);
+		$inputs->add(['multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'label']]);
 		$inputs->get('multicheckbox');
 	}
 

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -55,6 +55,18 @@ class WidgetRegistryTestCase extends TestCase {
 	}
 
 /**
+ * Test getting view instance from registry.
+ *
+ * @return void
+ */
+	public function testGetViewInstance() {
+		$inputs = new WidgetRegistry($this->templates, $this->view, []);
+
+		$result = $inputs->get('_view');
+		$this->assertInstanceOf('Cake\View\View', $result);
+	}
+
+/**
  * Test loading widgets files in the app.
  *
  * @return void

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -122,7 +122,6 @@ class WidgetRegistryTestCase extends TestCase {
 		$inputs->add([
 			'text' => new \StdClass()
 		]);
-		$inputs->get('text');
 	}
 
 /**

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -44,10 +44,14 @@ class WidgetRegistryTestCase extends TestCase {
 	public function testAddInConstructor() {
 		$widgets = [
 			'text' => ['Cake\View\Widget\Basic'],
+			'label' => ['Label'],
 		];
 		$inputs = new WidgetRegistry($this->templates, $this->view, $widgets);
 		$result = $inputs->get('text');
 		$this->assertInstanceOf('Cake\View\Widget\Basic', $result);
+
+		$result = $inputs->get('label');
+		$this->assertInstanceOf('Cake\View\Widget\Label', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -114,7 +114,7 @@ class WidgetRegistryTestCase extends TestCase {
  * Test adding an instance of an invalid type.
  *
  * @expectedException \RuntimeException
- * @expectedExceptionMessage Input objects must implement Cake\View\Widget\WidgetInterface
+ * @expectedExceptionMessage Widget objects must implement Cake\View\Widget\WidgetInterface
  * @return void
  */
 	public function testAddInvalidType() {

--- a/tests/test_app/Plugin/TestPlugin/config/test_widgets.php
+++ b/tests/test_app/Plugin/TestPlugin/config/test_widgets.php
@@ -3,5 +3,5 @@
  * Widgets list for testing.
  */
 $config = [
-	'text' => ['Cake\View\Widget\Label'],
+	'text' => ['Cake\View\Widget\LabelWidget'],
 ];

--- a/tests/test_app/config/test_widgets.php
+++ b/tests/test_app/config/test_widgets.php
@@ -3,5 +3,5 @@
  * Widgets list for testing.
  */
 $config = [
-	'text' => ['Cake\View\Widget\Label'],
+	'text' => ['Cake\View\Widget\LabelWidget'],
 ];


### PR DESCRIPTION
- Although I fixed the `instanceof` check in `_resolveWidget()` to allow retrieving View instance, those checks  add unnecessary overhead on each call to `get()`. I would suggest get rid to them or move the checks to `add()`.
- Why don't widget classes have suffix `Widget`?  They should imo.
