### PR TITLE
Save table instance reference as behavior property.

### DIFF
--- a/src/Model/Behavior/CounterCacheBehavior.php
+++ b/src/Model/Behavior/CounterCacheBehavior.php
@@ -80,25 +80,6 @@ use Cake\ORM\Table;
 class CounterCacheBehavior extends Behavior {
 
 /**
- * Keeping a reference to the table in order to,
- * be able to retrieve associations and fetch records for counting.
- *
- * @var \Cake\ORM\Table
- */
-	protected $_table;
-
-/**
- * Constructor
- *
- * @param \Cake\ORM\Table $table The table this behavior is attached to.
- * @param array $config The config for this behavior.
- */
-	public function __construct(Table $table, array $config = []) {
-		parent::__construct($table, $config);
-		$this->_table = $table;
-	}
-
-/**
  * afterSave callback.
  *
  * Makes sure to update counter cache when a new record is created or updated.

--- a/src/Model/Behavior/TimestampBehavior.php
+++ b/src/Model/Behavior/TimestampBehavior.php
@@ -66,6 +66,7 @@ class TimestampBehavior extends Behavior {
  * overwrite the events to listen on
  *
  * @param array $config The config for this behavior.
+ * @return void
  */
 	public function initialize(array $config) {
 		if (isset($config['events'])) {

--- a/src/Model/Behavior/TimestampBehavior.php
+++ b/src/Model/Behavior/TimestampBehavior.php
@@ -60,17 +60,14 @@ class TimestampBehavior extends Behavior {
 	protected $_ts;
 
 /**
- * Constructor
+ * Initialize hook
  *
  * If events are specified - do *not* merge them with existing events,
  * overwrite the events to listen on
  *
- * @param \Cake\ORM\Table $table The table this behavior is attached to.
  * @param array $config The config for this behavior.
  */
-	public function __construct(Table $table, array $config = []) {
-		parent::__construct($table, $config);
-
+	public function initialize(array $config) {
 		if (isset($config['events'])) {
 			$this->config('events', $config['events'], false);
 		}

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -83,6 +83,7 @@ class TranslateBehavior extends Behavior {
  * Initialize hook
  *
  * @param array $config The config for this behavior.
+ * @return void
  */
 	public function initialize(array $config) {
 		$this->setupFieldAssociations(

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -39,6 +39,13 @@ use Cake\ORM\TableRegistry;
 class TranslateBehavior extends Behavior {
 
 /**
+ * Table instance
+ *
+ * @var \Cake\ORM\Table
+ */
+	protected $_table;
+
+/**
  * The locale name that will be used to override fields in the bound table
  * from the translations table
  *
@@ -70,9 +77,18 @@ class TranslateBehavior extends Behavior {
 	public function __construct(Table $table, array $config = []) {
 		$config += ['defaultLocale' => I18n::defaultLocale()];
 		parent::__construct($table, $config);
+	}
 
-		$config = $this->_config;
-		$this->setupFieldAssociations($config['fields'], $config['translationTable']);
+/**
+ * Initialize hook
+ *
+ * @param array $config The config for this behavior.
+ */
+	public function initialize(array $config) {
+		$this->setupFieldAssociations(
+			$this->_config['fields'],
+			$this->_config['translationTable']
+		);
 	}
 
 /**

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -39,13 +39,6 @@ use Cake\ORM\TableRegistry;
 class TranslateBehavior extends Behavior {
 
 /**
- * Table instance
- *
- * @var \Cake\ORM\Table
- */
-	protected $_table;
-
-/**
  * The locale name that will be used to override fields in the bound table
  * from the translations table
  *
@@ -78,7 +71,6 @@ class TranslateBehavior extends Behavior {
 		$config += ['defaultLocale' => I18n::defaultLocale()];
 		parent::__construct($table, $config);
 
-		$this->_table = $table;
 		$config = $this->_config;
 		$this->setupFieldAssociations($config['fields'], $config['translationTable']);
 	}

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -36,13 +36,6 @@ use Cake\ORM\Table;
 class TreeBehavior extends Behavior {
 
 /**
- * Table instance
- *
- * @var \Cake\ORM\Table
- */
-	protected $_table;
-
-/**
  * Cached copy of the first column in a table's primary key.
  *
  * @var string
@@ -74,17 +67,6 @@ class TreeBehavior extends Behavior {
 		'right' => 'rght',
 		'scope' => null
 	];
-
-/**
- * Constructor
- *
- * @param \Cake\ORM\Table $table The table this behavior is attached to.
- * @param array $config The config for this behavior.
- */
-	public function __construct(Table $table, array $config = []) {
-		parent::__construct($table, $config);
-		$this->_table = $table;
-	}
 
 /**
  * Before save listener.

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -104,6 +104,13 @@ class Behavior implements EventListenerInterface {
 	use InstanceConfigTrait;
 
 /**
+ * Table instance.
+ *
+ * @var \Cake\ORM\Table
+ */
+	protected $_table;
+
+/**
  * Reflection method cache for behaviors.
  *
  * Stores the reflected method + finder methods per class.
@@ -145,6 +152,7 @@ class Behavior implements EventListenerInterface {
 			$config
 		);
 		$this->config($config);
+		$this->_table = $table;
 	}
 
 /**

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -151,8 +151,21 @@ class Behavior implements EventListenerInterface {
 			$this->_defaultConfig,
 			$config
 		);
-		$this->config($config);
 		$this->_table = $table;
+		$this->config($config);
+		$this->initialize($config);
+	}
+
+/**
+ * Constructor hook method.
+ *
+ * Implement this method to avoid having to overwrite
+ * the constructor and call parent.
+ *
+ * @param array $config The configuration array this behavior is using.
+ * @return void
+ */
+	public function initialize(array $config) {
 	}
 
 /**


### PR DESCRIPTION
Many userland behaviors too would need a table reference so better
to save it in core Behavior's constructor itself and avoid overriding constructor.
