### PR TITLE
Show stack trace for fatal errors if xdebug is loaded.

### DIFF
--- a/lib/Cake/View/Errors/fatal_error.ctp
+++ b/lib/Cake/View/Errors/fatal_error.ctp
@@ -32,3 +32,8 @@
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'fatal_error.ctp'); ?>
 </p>
+<?php
+if (extension_loaded('xdebug')) {
+	xdebug_print_function_stack();
+}
+?>


### PR DESCRIPTION
Backport of https://github.com/cakephp/cakephp/pull/5045 for 2.x
