### PR TITLE
Add typehint and missing full stops.

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -810,7 +810,7 @@ class PaginatorHelper extends Helper {
 		return $out;
 	}
 /**
- * Returns the meta-links for a paginated result set
+ * Returns the meta-links for a paginated result set.
  *
  * `echo $this->Paginator->meta();`
  *
@@ -819,7 +819,7 @@ class PaginatorHelper extends Helper {
  * `$this->Paginator->meta(['block' => true]);`
  *
  * Will append the output of the meta function to the named block - if true is passed the "meta"
- * block is used
+ * block is used.
  *
  * ### Options:
  *
@@ -827,9 +827,9 @@ class PaginatorHelper extends Helper {
  * - `block` The block name to append the output to, or false/absenst to return as a string
  *
  * @param array $options Array of options
- * @return string|null meta links
+ * @return string|null Meta links
  */
-	public function meta($options = []) {
+	public function meta(array $options = []) {
 		$model = isset($options['model']) ? $options['model'] : null;
 		$params = $this->params($model);
 		$links = [];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -814,7 +814,7 @@ class PaginatorHelper extends Helper {
  *
  * `echo $this->Paginator->meta();`
  *
- * Echos the links directly, will output nothing of there is neither a previous nor next page.
+ * Echos the links directly, will output nothing if there is neither a previous nor next page.
  *
  * `$this->Paginator->meta(['block' => true]);`
  *

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2023,7 +2023,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * Verify that no next and prev links are created for single page results
+ * Verifies that no next and prev links are created for single page results.
  *
  * @return void
  */
@@ -2043,7 +2043,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * Verify that page 1 only has a next link
+ * Verifies that page 1 only has a next link.
  *
  * @return void
  */
@@ -2063,7 +2063,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * Verify that the method will append to a block
+ * Verifies that the method will append to a block.
  *
  * @return void
  */
@@ -2084,7 +2084,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * Verify that the last page only has a prev link
+ * Verifies that the last page only has a prev link.
  *
  * @return void
  */
@@ -2105,7 +2105,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * Verify that a page in the middle has both links
+ * Verifies that a page in the middle has both links.
  *
  * @return void
  */
@@ -2124,4 +2124,5 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->meta();
 		$this->assertSame($expected, $result);
 	}
+
 }


### PR DESCRIPTION
Type hint correction to be consistent with other methods in that class.
