### PR TITLE
3.0 widgets merge

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -213,7 +213,7 @@ class FormHelper extends Helper {
 	}
 
 /**
- * Set the wiget registry the helper will use.
+ * Set the widget registry the helper will use.
  *
  * @param \Cake\View\Widget\WidgetRegistry $instance The registry instance to set.
  * @param array $widgets An array of widgets

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -112,7 +112,7 @@ class FormHelper extends Helper {
  *
  * @var array
  */
-	protected $_defaultWigets = [
+	protected $_defaultWidgets = [
 		'button' => ['Cake\View\Widget\ButtonWidget'],
 		'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
 		'file' => ['Cake\View\Widget\FileWidget'],
@@ -196,7 +196,7 @@ class FormHelper extends Helper {
  */
 	public function __construct(View $View, array $config = []) {
 		$registry = null;
-		$widgets = $this->_defaultWigets;
+		$widgets = $this->_defaultWidgets;
 		if (isset($config['registry'])) {
 			$registry = $config['registry'];
 			unset($config['registry']);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -74,20 +74,6 @@ class FormHelper extends Helper {
 			'date' => 'date', 'float' => 'number', 'integer' => 'number',
 			'decimal' => 'number', 'binary' => 'file', 'uuid' => 'string'
 		],
-		'widgets' => [
-			'button' => ['Cake\View\Widget\ButtonWidget'],
-			'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
-			'file' => ['Cake\View\Widget\FileWidget'],
-			'label' => ['Cake\View\Widget\LabelWidget'],
-			'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
-			'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
-			'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
-			'select' => ['Cake\View\Widget\SelectBoxWidget'],
-			'textarea' => ['Cake\View\Widget\TextareaWidget'],
-			'datetime' => ['Cake\View\Widget\DateTimeWidget', 'select'],
-			'_default' => ['Cake\View\Widget\BasicWidget'],
-		],
-		'registry' => null,
 		'templates' => [
 			'button' => '<button{{attrs}}>{{text}}</button>',
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
@@ -119,6 +105,25 @@ class FormHelper extends Helper {
 			'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
 			'submitContainer' => '<div class="submit">{{content}}</div>',
 		]
+	];
+
+/**
+ * Default widgets
+ *
+ * @var array
+ */
+	protected $_defaultWigets = [
+		'button' => ['Cake\View\Widget\ButtonWidget'],
+		'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
+		'file' => ['Cake\View\Widget\FileWidget'],
+		'label' => ['Cake\View\Widget\LabelWidget'],
+		'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
+		'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
+		'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
+		'select' => ['Cake\View\Widget\SelectBoxWidget'],
+		'textarea' => ['Cake\View\Widget\TextareaWidget'],
+		'datetime' => ['Cake\View\Widget\DateTimeWidget', 'select'],
+		'_default' => ['Cake\View\Widget\BasicWidget'],
 	];
 
 /**
@@ -190,17 +195,25 @@ class FormHelper extends Helper {
  * @param array $config Configuration settings for the helper.
  */
 	public function __construct(View $View, array $config = []) {
+		$registry = null;
+		$widgets = $this->_defaultWigets;
+		if (isset($config['registry'])) {
+			$registry = $config['registry'];
+			unset($config['registry']);
+		}
+		if (isset($config['widgets'])) {
+			$widgets = $config['widgets'] + $widgets;
+			unset($config['widgets']);
+		}
+
 		parent::__construct($View, $config);
-		$config = $this->_config;
 
-		$this->widgetRegistry($config['registry'], $config['widgets']);
-		$this->config(['widgets' => null, 'registry' => null]);
-
+		$this->widgetRegistry($registry, $widgets);
 		$this->_addDefaultContextProviders();
 	}
 
 /**
- * Set the input registry the helper will use.
+ * Set the wiget registry the helper will use.
  *
  * @param \Cake\View\Widget\WidgetRegistry $instance The registry instance to set.
  * @param array $widgets An array of widgets

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -204,6 +204,46 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that when specifying custom widgets the config array for that widget
+ * is overwritten instead of merged.
+ *
+ * @return void
+ */
+	public function testConstructWithWigets() {
+		$expected = [
+			'button' => ['Cake\View\Widget\ButtonWidget'],
+			'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
+			'file' => ['Cake\View\Widget\FileWidget'],
+			'label' => ['Cake\View\Widget\LabelWidget'],
+			'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
+			'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
+			'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
+			'select' => ['Cake\View\Widget\SelectBoxWidget'],
+			'textarea' => ['Cake\View\Widget\TextareaWidget'],
+			'datetime' => ['MyPlugin\View\Widget\DateTimeWidget', 'select'],
+			'_default' => ['Cake\View\Widget\BasicWidget']
+		];
+
+		$helper = $this->getMock(
+			'Cake\View\Helper\FormHelper',
+			['widgetRegistry'],
+			[],
+			'',
+			false
+		);
+		$helper->expects($this->once())
+			->method('widgetRegistry')
+			->with(null, $expected);
+
+		$config = [
+			'widgets' => [
+				'datetime' => ['MyPlugin\View\Widget\DateTimeWidget', 'select']
+			]
+		];
+		$helper->__construct($this->View, $config);
+	}
+
+/**
  * Test registering a new widget class and rendering it.
  *
  * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -209,7 +209,7 @@ class FormHelperTest extends TestCase {
  *
  * @return void
  */
-	public function testConstructWithWigets() {
+	public function testConstructWithWidgets() {
 		$expected = [
 			'button' => ['Cake\View\Widget\ButtonWidget'],
 			'checkbox' => ['Cake\View\Widget\CheckboxWidget'],


### PR DESCRIPTION
Relying on InstanceTrait::config() to merge the config caused problems as we
want the config array of each widget to be overwritten instead of being merged.

Also keeping the 'widgets' and 'registry' key in config served no purpose as
changing them at runtime wouldn't do anything since widget registry instance is
already created by constructor.

Fixes #5067
