### PR TITLE
Fix bake & other shells exiting incorrectly.

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -154,11 +154,14 @@ class ShellDispatcher {
 /**
  * Dispatches a CLI request
  *
+ * Converts a shell command result into an exit code. Null/True
+ * are treated as success. All other return values are an error.
+ *
  * @return int The cli command exit code. 0 is success.
  */
 	public function dispatch() {
-		$r = $this->_dispatch();
-		if ($r === null || $r === true) {
+		$result = $this->_dispatch();
+		if ($result === null || $result === true) {
 			return 0;
 		}
 		return 1;

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -157,7 +157,11 @@ class ShellDispatcher {
  * @return int The cli command exit code. 0 is success.
  */
 	public function dispatch() {
-		return $this->_dispatch() === true ? 0 : 1;
+		$r = $this->_dispatch();
+		if ($r === null || $r === true) {
+			return 0;
+		}
+		return 1;
 	}
 
 /**
@@ -320,16 +324,6 @@ class ShellDispatcher {
 	public function help() {
 		$this->args = array_merge(['command_list'], $this->args);
 		$this->dispatch();
-	}
-
-/**
- * Stop execution of the current script
- *
- * @param int|string $status see http://php.net/exit for values
- * @return void
- */
-	protected function _stop($status = 0) {
-		exit($status);
 	}
 
 }

--- a/src/Shell/BakeShell.php
+++ b/src/Shell/BakeShell.php
@@ -85,6 +85,7 @@ class BakeShell extends Shell {
 		}
 		$this->out('');
 		$this->out('By using <info>`cake bake [name]`</info> you can invoke a specific bake task.');
+		return false;
 	}
 
 /**

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -129,9 +129,10 @@ class ShellDispatcherTest extends TestCase {
 		$Shell = $this->getMock('Cake\Console\Shell');
 
 		$Shell->expects($this->once())->method('initialize');
-		$Shell->expects($this->once())->method('runCommand')
-			->with([])
+		$Shell->expects($this->at(0))->method('runCommand')
 			->will($this->returnValue(true));
+		$Shell->expects($this->at(1))->method('runCommand')
+			->will($this->returnValue(null));
 
 		$dispatcher->expects($this->any())
 			->method('findShell')
@@ -140,7 +141,12 @@ class ShellDispatcherTest extends TestCase {
 
 		$dispatcher->args = array('mock_with_main');
 		$result = $dispatcher->dispatch();
-		$this->assertEquals(0, $result);
+		$this->assertSame(0, $result);
+		$this->assertEquals(array(), $dispatcher->args);
+
+		$dispatcher->args = array('mock_with_main');
+		$result = $dispatcher->dispatch();
+		$this->assertSame(0, $result);
 		$this->assertEquals(array(), $dispatcher->args);
 	}
 

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -128,7 +128,7 @@ class ShellDispatcherTest extends TestCase {
 		$dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell']);
 		$Shell = $this->getMock('Cake\Console\Shell');
 
-		$Shell->expects($this->once())->method('initialize');
+		$Shell->expects($this->exactly(2))->method('initialize');
 		$Shell->expects($this->at(0))->method('runCommand')
 			->will($this->returnValue(true));
 		$Shell->expects($this->at(1))->method('runCommand')
@@ -198,7 +198,7 @@ class ShellDispatcherTest extends TestCase {
 
 		$dispatcher->args = array('example');
 		$result = $dispatcher->dispatch();
-		$this->assertEquals(1, $result);
+		$this->assertEquals(0, $result);
 	}
 
 /**
@@ -225,7 +225,7 @@ class ShellDispatcherTest extends TestCase {
 
 		$dispatcher->args = ['Example'];
 		$result = $dispatcher->dispatch();
-		$this->assertEquals(1, $result);
+		$this->assertEquals(0, $result);
 	}
 
 /**
@@ -252,7 +252,7 @@ class ShellDispatcherTest extends TestCase {
 
 		$dispatcher->args = array('sample');
 		$result = $dispatcher->dispatch();
-		$this->assertEquals(1, $result);
+		$this->assertEquals(0, $result);
 	}
 
 /**


### PR DESCRIPTION
If a shell command method returns `null`, we should treat the command as successful. Only when a shell returns `false` should we exit non-zero.

Refs #5063
