### PR TITLE
correct variable mismatch

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -190,7 +190,7 @@ class ShellDispatcher {
  * This permits a plugin which implements a shell of the same name to be accessed
  * Using the shell name alone
  *
- * @return void
+ * @return array the resultant list of aliases
  */
 	public function addShortPluginAliases() {
 		$plugins = Plugin::loaded();
@@ -208,14 +208,6 @@ class ShellDispatcher {
 			}
 
 			foreach ($list[$plugin] as $shell) {
-				if (isset($aliases[$shell])) {
-					$other = $aliased[$shell];
-					Log::write(
-						'debug',
-						"command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",
-						['shell-dispatcher']
-					);
-				}
 				$aliases += [$shell => $plugin];
 			}
 		}
@@ -229,8 +221,22 @@ class ShellDispatcher {
 				);
 				continue;
 			}
+
+			$other = static::alias($shell);
+			if ($other) {
+				$other = $aliases[$shell];
+				Log::write(
+					'debug',
+					"command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",
+					['shell-dispatcher']
+				);
+				continue;
+			}
+
 			static::alias($shell, "$plugin.$shell");
 		}
+
+		return static::$_aliases;
 	}
 
 /**

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -90,6 +90,26 @@ class ShellDispatcherTest extends TestCase {
 	}
 
 /**
+ * testAddShortPluginAlias
+ *
+ * @return void
+ */
+	public function testAddShortPluginAlias() {
+		$expected = [
+			'Example' => 'TestPlugin.example'
+		];
+		$result = $this->dispatcher->addShortPluginAliases();
+		$this->assertSame($expected, $result, 'Should return the list of aliased plugin shells');
+
+		ShellDispatcher::alias('Example', 'SomeOther.PluginsShell');
+		$expected = [
+			'Example' => 'SomeOther.PluginsShell'
+		];
+		$result = $this->dispatcher->addShortPluginAliases();
+		$this->assertSame($expected, $result, 'Should not overwrite existing aliases');
+	}
+
+/**
  * Test getting shells with aliases.
  *
  * @return void


### PR DESCRIPTION
The variable `$aliased` was referenced in error.

Slight reorganisation whilst fixing that to also prevent the short plugin alias logic from overwriting existing aliases.
