### PR TITLE
Fix paginator options when disabled.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -1006,6 +1006,17 @@ class PaginatorHelperTest extends CakeTestCase {
 			)
 		);
 
+		$result = $this->Paginator->prev('<i class="fa fa-angle-left"></i>', array('escape' => false), null, array('class' => 'prev disabled'));
+		$expected = array(
+			'span' => array('class' => 'prev disabled'),
+			'a' => array('href' => '/', 'rel' => 'prev'),
+			'i' => array('class' => 'fa fa-angle-left'),
+			'/i',
+			'/a',
+			'/span'
+		);
+		$this->assertTags($result, $expected);
+
 		$result = $this->Paginator->prev('<< Previous', null, '<strong>Disabled</strong>');
 		$expected = array(
 			'span' => array('class' => 'prev'),

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -1017,6 +1017,16 @@ class PaginatorHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
+		$result = $this->Paginator->prev('<i class="fa fa-angle-left"></i>', array('escape' => false), null, array('escape' => true));
+		$expected = array(
+			'span' => array('class' => 'prev'),
+			'a' => array('href' => '/', 'rel' => 'prev'),
+			'&lt;i class=&quot;fa fa-angle-left&quot;&gt;&lt;/i&gt;',
+			'/a',
+			'/span'
+		);
+		$this->assertTags($result, $expected);
+
 		$result = $this->Paginator->prev('<< Previous', null, '<strong>Disabled</strong>');
 		$expected = array(
 			'span' => array('class' => 'prev'),

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -1009,10 +1009,8 @@ class PaginatorHelperTest extends CakeTestCase {
 		$result = $this->Paginator->prev('<i class="fa fa-angle-left"></i>', array('escape' => false), null, array('class' => 'prev disabled'));
 		$expected = array(
 			'span' => array('class' => 'prev disabled'),
-			'a' => array('href' => '/', 'rel' => 'prev'),
 			'i' => array('class' => 'fa fa-angle-left'),
 			'/i',
-			'/a',
 			'/span'
 		);
 		$this->assertTags($result, $expected);
@@ -1020,9 +1018,7 @@ class PaginatorHelperTest extends CakeTestCase {
 		$result = $this->Paginator->prev('<i class="fa fa-angle-left"></i>', array('escape' => false), null, array('escape' => true));
 		$expected = array(
 			'span' => array('class' => 'prev'),
-			'a' => array('href' => '/', 'rel' => 'prev'),
 			'&lt;i class=&quot;fa fa-angle-left&quot;&gt;&lt;/i&gt;',
-			'/a',
 			'/span'
 		);
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -499,8 +499,7 @@ class PaginatorHelper extends AppHelper {
 			if (!empty($disabledTitle) && $disabledTitle !== true) {
 				$title = $disabledTitle;
 			}
-
-			$options = (array)$disabledOptions + array_intersect_key($options, array_keys($_defaults)) + $_defaults;
+			$options = (array)$disabledOptions + array_intersect_key($options, $_defaults) + $_defaults;
 		} elseif (!$this->{$check}($options['model'])) {
 			return '';
 		}

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -499,7 +499,8 @@ class PaginatorHelper extends AppHelper {
 			if (!empty($disabledTitle) && $disabledTitle !== true) {
 				$title = $disabledTitle;
 			}
-			$options = (array)$disabledOptions + $options + $_defaults;
+
+			$options = (array)$disabledOptions + array_intersect_key($options, array_keys($_defaults)) + $_defaults;
 		} elseif (!$this->{$check}($options['model'])) {
 			return '';
 		}

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -499,9 +499,9 @@ class PaginatorHelper extends AppHelper {
 			if (!empty($disabledTitle) && $disabledTitle !== true) {
 				$title = $disabledTitle;
 			}
-			$options = (array)$disabledOptions + $_defaults;
+			$options = (array)$disabledOptions + $options + $_defaults;
 		} elseif (!$this->{$check}($options['model'])) {
-			return null;
+			return '';
 		}
 
 		foreach (array_keys($_defaults) as $key) {


### PR DESCRIPTION
Fix a paginator bug (or at least unexpected behavior) when using disabled options and the prev/next links being disabled.

Currently

```
$this->Paginator->prev('<i class="fa fa-angle-left"></i>', array('escape' => false)); 
// or
$this->Paginator->prev('<i class="fa fa-angle-left"></i>', array('escape' => false), null, array('class' => 'prev disabled'));
```

would display just fine (non-escaped) for enabled links. Once it is disabled, it will escape suddenly.
I think the general opinion would be that $disabledOptions can extend/overwrite the normal $options, not having to repeat all options again there.

This resolves it.

Thanks for Patrick for pointing it out to me earlier.

Also fixing return type to "empty string" where null was returned.
