### PR TITLE
Ticket #5041: have Auth::login() send Auth.afterIdentify event

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -14,13 +14,14 @@
 
 App::uses('Security', 'Utility');
 App::uses('Hash', 'Utility');
+App::uses('CakeEventListener', 'Event');
 
 /**
  * Base Authentication class with common methods and properties.
  *
  * @package       Cake.Controller.Component.Auth
  */
-abstract class BaseAuthenticate {
+abstract class BaseAuthenticate implements CakeEventListener {
 
 /**
  * Settings for this object.
@@ -64,6 +65,15 @@ abstract class BaseAuthenticate {
  * @var AbstractPasswordHasher
  */
 	protected $_passwordHasher;
+
+/**
+ * Implemented events
+ *
+ * @return array of events => callbacks.
+ */
+	public function implementedEvents() {
+		return array();
+	}
 
 /**
  * Constructor

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -26,6 +26,7 @@ App::uses('Hash', 'Utility');
 App::uses('CakeSession', 'Model/Datasource');
 App::uses('BaseAuthorize', 'Controller/Component/Auth');
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
+App::uses('CakeEvent', 'Event');
 
 /**
  * Authentication control component class
@@ -608,7 +609,6 @@ class AuthComponent extends Component {
 		if ($user) {
 			$this->Session->renew();
 			$this->Session->write(self::$sessionKey, $user);
-			App::uses('CakeEvent', 'Event');
 			$event = new CakeEvent('Auth.afterIdentify', $this, array('user' => $user));
 			$this->_Collection->getController()->getEventManager()->dispatch($event);
 		}

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -799,7 +799,9 @@ class AuthComponent extends Component {
 				throw new CakeException(__d('cake_dev', 'Authentication objects must implement an %s method.', 'authenticate()'));
 			}
 			$settings = array_merge($global, (array)$settings);
-			$this->_authenticateObjects[] = new $className($this->_Collection, $settings);
+			$auth = new $className($this->_Collection, $settings);
+			$this->_Collection->getController()->getEventManager()->attach($auth);
+			$this->_authenticateObjects[] = $auth;
 		}
 		return $this->_authenticateObjects;
 	}

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -608,6 +608,9 @@ class AuthComponent extends Component {
 		if ($user) {
 			$this->Session->renew();
 			$this->Session->write(self::$sessionKey, $user);
+			App::uses('CakeEvent', 'Event');
+			$event = new CakeEvent('Auth.afterIdentify', $this, array('user' => $user));
+			$this->_Collection->getController()->getEventManager()->dispatch($event);
 		}
 		return (bool)$this->user();
 	}

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -20,6 +20,7 @@ App::uses('Controller', 'Controller');
 App::uses('AuthComponent', 'Controller/Component');
 App::uses('AclComponent', 'Controller/Component');
 App::uses('FormAuthenticate', 'Controller/Component/Auth');
+App::uses('CakeEvent', 'Event');
 
 /**
  * TestAuthComponent class
@@ -271,7 +272,7 @@ class AjaxAuthController extends Controller {
  *
  * @package Cake.Test.Case.Event
  */
-class CakeEventTestListener {
+class AuthEventTestListener {
 
 	public $callStack = array();
 
@@ -426,9 +427,8 @@ class AuthComponentTest extends CakeTestCase {
 			->method('renew');
 
 		$manager = $this->Controller->getEventManager();
-		$listener = $this->getMock('CakeEventTestListener');
+		$listener = $this->getMock('AuthEventTestListener');
 		$manager->attach(array($listener, 'listenerFunction'), 'Auth.afterIdentify');
-		App::uses('CakeEvent', 'Event');
 		$event = new CakeEvent('Auth.afterIdentify', $this->Auth, array('user' => $user));
 		$listener->expects($this->once())->method('listenerFunction')->with($event);
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -69,50 +69,6 @@ class TestBaseAuthenticate extends BaseAuthenticate {
 }
 
 /**
- * TestFormAuthenticate class
- *
- * @package       Cake.Test.Case.Controller.Component
- */
-class TestBaseAuthenticate extends BaseAuthenticate {
-
-/**
- * Implemented events
- *
- * @return array of events => callbacks.
- */
-	public function implementedEvents() {
-		return array(
-			'Auth.afterIdentify' => 'afterIdentify'
-		);
-	}
-
-	public $afterIdentifyCallable = null;
-
-/**
- * Test function to be used in event dispatching
- *
- * @return void
- */
-	public function afterIdentify($event) {
-		call_user_func($this->afterIdentifyCallable, $event);
-	}
-
-/**
- * Authenticate a user based on the request information.
- *
- * @param CakeRequest $request Request to get authentication information from.
- * @param CakeResponse $response A response object that can have headers added.
- * @return array|bool Either false on failure, or an array of user data on success.
- */
-	public function authenticate(CakeRequest $request, CakeResponse $response) {
-		return array(
-			'id' => 1,
-			'username' => 'mark'
-		);
-	}
-}
-
-/**
  * TestAuthComponent class
  *
  * @package       Cake.Test.Case.Controller.Component

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -56,7 +56,7 @@ class TestBaseAuthenticate extends BaseAuthenticate {
  *
  * @param CakeRequest $request Request to get authentication information from.
  * @param CakeResponse $response A response object that can have headers added.
- * @return mixed Either false on failure, or an array of user data on success.
+ * @return array|bool Either false on failure, or an array of user data on success.
  */
 	public function authenticate(CakeRequest $request, CakeResponse $response) {
 		return array(
@@ -84,7 +84,7 @@ class TestAuthComponent extends AuthComponent {
  * Helper method to add/set an authenticate object instance
  *
  * @param int $index The index at which to add/set the object
- * @param Object $object The object to add/set
+ * @param object $object The object to add/set
  * @return void
  */
 	public function setAuthenticateObject($index, $object) {
@@ -95,10 +95,10 @@ class TestAuthComponent extends AuthComponent {
  * Helper method to get an authenticate object instance
  *
  * @param int $index The index at which to get the object
- * @return Object $object
+ * @return object $object
  */
 	public function getAuthenticateObject($index) {
-    $this->constructAuthenticate();
+		$this->constructAuthenticate();
 		return isset($this->_authenticateObjects[$index]) ? $this->_authenticateObjects[$index] : null;
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -20,7 +20,6 @@ App::uses('Controller', 'Controller');
 App::uses('AuthComponent', 'Controller/Component');
 App::uses('AclComponent', 'Controller/Component');
 App::uses('FormAuthenticate', 'Controller/Component/Auth');
-App::uses('CakeEvent', 'Event');
 
 /**
  * TestAuthComponent class
@@ -429,6 +428,7 @@ class AuthComponentTest extends CakeTestCase {
 		$manager = $this->Controller->getEventManager();
 		$listener = $this->getMock('AuthEventTestListener');
 		$manager->attach(array($listener, 'listenerFunction'), 'Auth.afterIdentify');
+		App::uses('CakeEvent', 'Event');
 		$event = new CakeEvent('Auth.afterIdentify', $this->Auth, array('user' => $user));
 		$listener->expects($this->once())->method('listenerFunction')->with($event);
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -21,6 +21,7 @@ App::uses('AuthComponent', 'Controller/Component');
 App::uses('AclComponent', 'Controller/Component');
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
 App::uses('FormAuthenticate', 'Controller/Component/Auth');
+App::uses('CakeEvent', 'Event');
 
 /**
  * TestFormAuthenticate class
@@ -64,6 +65,7 @@ class TestBaseAuthenticate extends BaseAuthenticate {
 			'username' => 'mark'
 		);
 	}
+
 }
 
 /**
@@ -506,7 +508,6 @@ class AuthComponentTest extends CakeTestCase {
 		$auth = $this->Auth->getAuthenticateObject(0);
 		$listener = $this->getMock('AuthEventTestListener');
 		$auth->afterIdentifyCallable = array($listener, 'listenerFunction');
-		App::uses('CakeEvent', 'Event');
 		$event = new CakeEvent('Auth.afterIdentify', $this->Auth, array('user' => $user));
 		$listener->expects($this->once())->method('listenerFunction')->with($event);
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -267,6 +267,27 @@ class AjaxAuthController extends Controller {
 }
 
 /**
+ * Mock class used to test event dispatching
+ *
+ * @package Cake.Test.Case.Event
+ */
+class CakeEventTestListener {
+
+	public $callStack = array();
+
+/**
+ * Test function to be used in event dispatching
+ *
+ * @return void
+ */
+	public function listenerFunction() {
+		$this->callStack[] = __FUNCTION__;
+	}
+
+}
+
+
+/**
  * AuthComponentTest class
  *
  * @package       Cake.Test.Case.Controller.Component
@@ -403,6 +424,13 @@ class AuthComponentTest extends CakeTestCase {
 
 		$this->Auth->Session->expects($this->once())
 			->method('renew');
+
+		$manager = $this->Controller->getEventManager();
+		$listener = $this->getMock('CakeEventTestListener');
+		$manager->attach(array($listener, 'listenerFunction'), 'Auth.afterIdentify');
+		App::uses('CakeEvent', 'Event');
+		$event = new CakeEvent('Auth.afterIdentify', $this->Auth, array('user' => $user));
+		$listener->expects($this->once())->method('listenerFunction')->with($event);
 
 		$result = $this->Auth->login();
 		$this->assertTrue($result);


### PR DESCRIPTION
Per ticket #5041. I augmented `testLogin()` to avoid duplicating the auth code, since there were already 3 assertions done there.
