### PR TITLE
Correct return types.

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -171,7 +171,7 @@ class CookieComponent extends Component {
  * @param null|string|array $option Either the option name to set, or an array of options to set,
  *   or null to read config options for a given key.
  * @param string|null $value Either the value to set, or empty when $option is an array.
- * @return void
+ * @return array|null
  */
 	public function configKey($keyname, $option = null, $value = null) {
 		if ($option === null) {
@@ -183,6 +183,7 @@ class CookieComponent extends Component {
 			$option = [$option => $value];
 		}
 		$this->_keyConfig[$keyname] = $option;
+		return null;
 	}
 
 /**

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -625,7 +625,7 @@ class RequestHandlerComponent extends Component {
  * Maps a content type alias back to its mime-type(s)
  *
  * @param string|array $alias String alias to convert back into a content type. Or an array of aliases to map.
- * @return string Null on an undefined alias. String value of the mapped alias type. If an
+ * @return string|null Null on an undefined alias. String value of the mapped alias type. If an
  *   alias maps to more than one content type, the first one will be returned.
  */
 	public function mapAlias($alias) {

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -236,7 +236,7 @@ class SecurityComponent extends Component {
 			if (in_array($this->request->params['action'], $requireAuth) || $requireAuth == array('*')) {
 				if (!isset($controller->request->data['_Token'])) {
 					if (!$this->blackHole($controller, 'auth')) {
-						return null;
+						return false;
 					}
 				}
 
@@ -250,12 +250,12 @@ class SecurityComponent extends Component {
 						!in_array($this->request->params['action'], $tData['allowedActions'])
 					) {
 						if (!$this->blackHole($controller, 'auth')) {
-							return null;
+							return false;
 						}
 					}
 				} else {
 					if (!$this->blackHole($controller, 'auth')) {
-						return null;
+						return false;
 					}
 				}
 			}

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -167,7 +167,7 @@ if (!function_exists('env')) {
  * environment information.
  *
  * @param string $key Environment variable name.
- * @return string Environment variable setting.
+ * @return string|null Environment variable setting.
  * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#env
  */
 	function env($key) {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -134,7 +134,7 @@ class Connection {
  */
 	public function configName() {
 		if (empty($this->_config['name'])) {
-			return null;
+			return '';
 		}
 		return $this->_config['name'];
 	}

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -151,7 +151,7 @@ class PostgresSchema extends BaseSchema {
  * We need to remove those.
  *
  * @param string $default The default value.
- * @return string
+ * @return string|null
  */
 	protected function _defaultValue($default) {
 		if (is_numeric($default) || $default === null) {

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -44,7 +44,7 @@ class BinaryType extends \Cake\Database\Type {
  *
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
- * @return resource
+ * @return resource|null
  * @throws \Cake\Core\Exception\Exception
  */
 	public function toPHP($value, Driver $driver) {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -596,7 +596,7 @@ class Folder {
 			$path = $this->pwd();
 		}
 		if (!$path) {
-			return null;
+			return false;
 		}
 		$path = Folder::slashTerm($path);
 		if (is_dir($path)) {

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -723,7 +723,7 @@ class Response {
  * e.g `type(array('jpg' => 'text/plain'));`
  *
  * @param string $contentType Content type key.
- * @return mixed current content type or false if supplied an invalid content type
+ * @return mixed Current content type or false if supplied an invalid content type
  */
 	public function type($contentType = null) {
 		if ($contentType === null) {
@@ -751,7 +751,7 @@ class Response {
  * e.g `getMimeType('pdf'); // returns 'application/pdf'`
  *
  * @param string $alias the content type alias to map
- * @return mixed string mapped mime type or false if $alias is not mapped
+ * @return mixed String mapped mime type or false if $alias is not mapped
  */
 	public function getMimeType($alias) {
 		if (isset($this->_mimeTypes[$alias])) {
@@ -837,7 +837,7 @@ class Response {
  *   if set to false, the response will be set to private
  *   if no value is provided, it will return whether the response is sharable or not
  * @param int $time time in seconds after which the response should no longer be considered fresh
- * @return bool
+ * @return bool|null
  */
 	public function sharable($public = null, $time = null) {
 		if ($public === null) {
@@ -872,7 +872,7 @@ class Response {
  * If called with no parameters, this function will return the current max-age value if any
  *
  * @param int $seconds if null, the method will return the current s-maxage value
- * @return int
+ * @return int|null
  */
 	public function sharedMaxAge($seconds = null) {
 		if ($seconds !== null) {
@@ -892,7 +892,7 @@ class Response {
  * If called with no parameters, this function will return the current max-age value if any
  *
  * @param int $seconds if null, the method will return the current max-age value
- * @return int
+ * @return int|null
  */
 	public function maxAge($seconds = null) {
 		if ($seconds !== null) {
@@ -955,7 +955,7 @@ class Response {
  * `$response->expires()` Will return the current expiration header value
  *
  * @param string|\DateTime $time Valid time string or \DateTime instance.
- * @return string
+ * @return string|null
  */
 	public function expires($time = null) {
 		if ($time !== null) {
@@ -979,7 +979,7 @@ class Response {
  * `$response->modified()` Will return the current Last-Modified header value
  *
  * @param string|\DateTime $time Valid time string or \DateTime instance.
- * @return string
+ * @return string|null
  */
 	public function modified($time = null) {
 		if ($time !== null) {
@@ -1024,7 +1024,7 @@ class Response {
  *
  * @param string|array $cacheVariances a single Vary string or an array
  *   containing the list for variances.
- * @return array
+ * @return array|null
  */
 	public function vary($cacheVariances = null) {
 		if ($cacheVariances !== null) {
@@ -1056,7 +1056,7 @@ class Response {
  * @param string $hash the unique hash that identifies this response
  * @param bool $weak whether the response is semantically the same as
  *   other with the same hash or not
- * @return string
+ * @return string|null
  */
 	public function etag($hash = null, $weak = false) {
 		if ($hash !== null) {

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -352,7 +352,7 @@ class Session {
 		}
 
 		if (!isset($_SESSION)) {
-			return null;
+			return false;
 		}
 
 		return Hash::get($_SESSION, $name) !== null;

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -188,7 +188,7 @@ class Socket {
  */
 	public function context() {
 		if (!$this->connection) {
-			return;
+			return null;
 		}
 		return stream_context_get_options($this->connection);
 	}
@@ -232,7 +232,7 @@ class Socket {
 /**
  * Get the last error as a string.
  *
- * @return string Last error
+ * @return string|null Last error
  */
 	public function lastError() {
 		if (!empty($this->lastError)) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -255,7 +255,7 @@ class ResultSet implements ResultSetInterface {
  * end of the results simulating the behavior when the result set is backed
  * by a statement.
  *
- * @return array|object
+ * @return array|object|null
  */
 	public function first() {
 		if (isset($this->_results[0])) {

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -48,7 +48,7 @@ class AssetFilter extends DispatcherFilter {
 
 		$url = urldecode($request->url);
 		if (strpos($url, '..') !== false || strpos($url, '.') === false) {
-			return;
+			return null;
 		}
 
 		$assetFile = $this->_getAssetFile($url);

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -149,7 +149,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  *
  * @param string $name  The name under which the provider should be set.
  * @param null|object|string $object Provider object or class name.
- * @return Validator|object|string
+ * @return Validator|object|string|null
  */
 	public function provider($name, $object = null) {
 		if ($object === null) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -175,7 +175,7 @@ class PaginatorHelper extends Helper {
  *
  * @param string $model Optional model name. Uses the default if none is specified.
  * @param array $options Options for pagination links. See #options for list of keys.
- * @return string The name of the key by which the recordset is being sorted, or
+ * @return string|null The name of the key by which the recordset is being sorted, or
  *  null if the results are not currently sorted.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sortKey
  */
@@ -491,7 +491,7 @@ class PaginatorHelper extends Helper {
 /**
  * Gets the default model of the paged sets
  *
- * @return string Model name or null if the pagination isn't initialized.
+ * @return string|null Model name or null if the pagination isn't initialized.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::defaultModel
  */
 	public function defaultModel() {


### PR DESCRIPTION
Correct return types both in doc blocks and code if possible.

For methods like etag() I would rather like to simplify the return type from `@return string|null` to just "string" for example, though. Especially where there cannot be any empty valid strings or '0' strings involved.
