### PR TITLE
3.0 - Move checkbox hidden field outside of the label

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -958,6 +958,10 @@ class FormHelper extends Helper {
 		}
 		$nestedInput = isset($options['nestedInput']) ? $options['nestedInput'] : $nestedInput;
 
+		if ($nestedInput == true && $options['type'] === 'checkbox' && !array_key_exists('hiddenField', $options) && $label !== false) {
+			$options['hiddenField'] = '_split';
+		}
+
 		$input = $this->_getInput($fieldName, $options);
 		if ($options['type'] === 'hidden') {
 			if ($newTemplates) {
@@ -1287,11 +1291,11 @@ class FormHelper extends Helper {
  *
  * @param string $fieldName Name of a field, like this "Modelname.fieldname"
  * @param array $options Array of HTML attributes.
- * @return string An HTML text input element.
+ * @return string|array An HTML text input element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  */
 	public function checkbox($fieldName, array $options = []) {
-		$options += array('hiddenField' => true, 'value' => 1);
+		$options += ['hiddenField' => true, 'value' => 1];
 
 		// Work around value=>val translations.
 		$value = $options['value'];
@@ -1313,7 +1317,7 @@ class FormHelper extends Helper {
 			$output = $this->hidden($fieldName, $hiddenOptions);
 		}
 
-		if ($options['hiddenField'] == '_split') {
+		if ($options['hiddenField'] === '_split') {
 			unset($options['hiddenField'], $options['type']);
 			return ['hidden' => $output, 'input' => $this->widget('checkbox', $options)];
 		}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -94,7 +94,7 @@ class FormHelper extends Helper {
 			'inputContainer' => '<div class="input {{type}}{{required}}">{{content}}</div>',
 			'inputContainerError' => '<div class="input {{type}}{{required}} error">{{content}}{{error}}</div>',
 			'label' => '<label{{attrs}}>{{text}}</label>',
-			'nestingLabel' => '<label{{attrs}}>{{input}}{{text}}</label>',
+			'nestingLabel' => '{{hidden}}<label{{attrs}}>{{input}}{{text}}</label>',
 			'legend' => '<legend>{{text}}</legend>',
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
@@ -769,6 +769,9 @@ class FormHelper extends Helper {
 			'text' => $text,
 		];
 		if (isset($options['input'])) {
+			if (is_array($options['input'])) {
+				$attrs = $options['input'] + $attrs;
+			}
 			return $this->widget('nestingLabel', $attrs);
 		}
 		return $this->widget('label', $attrs);
@@ -1298,16 +1301,21 @@ class FormHelper extends Helper {
 
 		$output = '';
 		if ($options['hiddenField']) {
-			$hiddenOptions = array(
+			$hiddenOptions = [
 				'name' => $options['name'],
-				'value' => ($options['hiddenField'] !== true ? $options['hiddenField'] : '0'),
+				'value' => ($options['hiddenField'] !== true && $options['hiddenField'] !== '_split' ? $options['hiddenField'] : '0'),
 				'form' => isset($options['form']) ? $options['form'] : null,
 				'secure' => false
-			);
+			];
 			if (isset($options['disabled']) && $options['disabled']) {
 				$hiddenOptions['disabled'] = 'disabled';
 			}
 			$output = $this->hidden($fieldName, $hiddenOptions);
+		}
+
+		if ($options['hiddenField'] == '_split') {
+			unset($options['hiddenField'], $options['type']);
+			return ['hidden' => $output, 'input' => $this->widget('checkbox', $options)];
 		}
 		unset($options['hiddenField'], $options['type']);
 		return $output . $this->widget('checkbox', $options);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -958,7 +958,7 @@ class FormHelper extends Helper {
 		}
 		$nestedInput = isset($options['nestedInput']) ? $options['nestedInput'] : $nestedInput;
 
-		if ($nestedInput == true && $options['type'] === 'checkbox' && !array_key_exists('hiddenField', $options) && $label !== false) {
+		if ($nestedInput === true && $options['type'] === 'checkbox' && !array_key_exists('hiddenField', $options) && $label !== false) {
 			$options['hiddenField'] = '_split';
 		}
 

--- a/src/View/Widget/LabelWidget.php
+++ b/src/View/Widget/LabelWidget.php
@@ -72,13 +72,15 @@ class LabelWidget implements WidgetInterface {
 		$data += [
 			'text' => '',
 			'input' => '',
+			'hidden' => '',
 			'escape' => true,
 		];
 
 		return $this->_templates->format($this->_labelTemplate, [
 			'text' => $data['escape'] ? h($data['text']) : $data['text'],
 			'input' => $data['input'],
-			'attrs' => $this->_templates->formatAttributes($data, ['text', 'input']),
+			'hidden' => $data['hidden'],
+			'attrs' => $this->_templates->formatAttributes($data, ['text', 'input', 'hidden']),
 		]);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1476,12 +1476,12 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->input('something', array('type' => 'checkbox'));
 		$expected = array(
 			'div' => array('class' => 'input checkbox'),
-			'label' => array('for' => 'something'),
 			array('input' => array(
 				'type' => 'hidden',
 				'name' => 'something',
 				'value' => '0'
 			)),
+			'label' => array('for' => 'something'),
 			array('input' => array(
 				'type' => 'checkbox',
 				'name' => 'something',
@@ -2386,8 +2386,8 @@ class FormHelperTest extends TestCase {
 		));
 		$expected = array(
 			'div' => array('class' => 'input checkbox'),
-			'label' => array('for' => 'user-disabled'),
 			'input' => array('type' => 'hidden', 'name' => 'User[disabled]', 'value' => '0'),
+			'label' => array('for' => 'user-disabled'),
 			array('input' => array(
 				'type' => 'checkbox',
 				'name' => 'User[disabled]',
@@ -2815,12 +2815,12 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->input('Model.user', array('type' => 'checkbox'));
 		$expected = array(
 			'div' => array('class' => 'input checkbox'),
-			'label' => array('for' => 'model-user'),
 			array('input' => array(
 				'type' => 'hidden',
 				'name' => 'Model[user]',
 				'value' => 0,
 			)),
+			'label' => array('for' => 'model-user'),
 			array('input' => array(
 				'name' => 'Model[user]',
 				'type' => 'checkbox',
@@ -6405,7 +6405,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testInputsNotNested() {
 		$this->Form->templates([
-			'nestingLabel' => '{{input}}<label{{attrs}}>{{text}}</label>',
+			'nestingLabel' => '{{hidden}}{{input}}<label{{attrs}}>{{text}}</label>',
 			'formGroup' => '{{input}}{{label}}',
 		]);
 		$result = $this->Form->input('foo', ['type' => 'checkbox']);
@@ -6496,8 +6496,8 @@ class FormHelperTest extends TestCase {
 		]);
 		$expected = [
 			'div' => ['class' => 'check'],
-			'label' => ['for' => 'accept'],
 			['input' => ['type' => 'hidden', 'name' => 'accept', 'value' => 0]],
+			'label' => ['for' => 'accept'],
 			['input' => ['id' => 'accept', 'type' => 'checkbox', 'name' => 'accept', 'value' => 1]],
 			'Accept',
 			'/label',


### PR DESCRIPTION
Currently checkboxes are being rendered as

``` html
<div class="checkbox">
    <label for="checkbox-field">
        <input type="hidden" name="checkbox_field" value="0">
        <input type="checkbox" name="checkbox_field" value="1" id="checkbox-field">
        A checkbox
    </label>
</div>
```

which is not valid HTML as a label may only contain a single descendant input element.

This PR adds a special `_split` hiddenField option for checkboxes which will return an array from `checkbox` instead of a string. The array has two keys, 'hidden' and 'input'. `input()` will split up the input array and the label widget will treat the 'hidden' as a new template field. The 'nestingLabel' template has been updated with the `{{hidden}}` field.

The final result is the following:

``` html
<div class="checkbox">
    <input type="hidden" name="checkbox_field" value="0">
    <label for="checkbox-field">
        <input type="checkbox" name="checkbox_field" value="1" id="checkbox-field">
        A checkbox
    </label>
</div>
```
