### PR TITLE
Actually showing exception for warning users about username

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -17,6 +17,7 @@ namespace Cake\Database;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
 use Cake\Database\ValueBinder;
+use InvalidArgumentException;
 
 /**
  * Represents a database diver containing all specificities for
@@ -52,8 +53,14 @@ abstract class Driver {
  * Constructor
  *
  * @param array $config The configuration for the driver.
+ * @throws InvalidArgumentException
  */
 	public function __construct($config = []) {
+		if (empty($config['username']) && !empty($config['login'])) {
+			throw new InvalidArgumentException(
+				'Please pass "username" instead of "login" for connecting to the database'
+			);
+		}
 		$config += $this->_baseConfig;
 		$this->_config = $config;
 		if (!empty($config['quoteIdentifiers'])) {

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -15,7 +15,6 @@
 namespace Cake\Database\Driver;
 
 use Cake\Database\Statement\PDOStatement;
-use InvalidArgumentException;
 use PDO;
 
 /**
@@ -36,14 +35,8 @@ trait PDODriverTrait {
  * @param string $dsn A Driver-specific PDO-DSN
  * @param array $config configuration to be used for creating connection
  * @return bool true on success
- * @throws InvalidArgumentException
  */
 	protected function _connect($dsn, array $config) {
-		if (empty($config['username']) && !empty($config['login'])) {
-			throw new InvalidArgumentException(
-				'Please pass "username" instead of "login" for connecting to the database'
-			);
-		}
 		$connection = new PDO(
 			$dsn,
 			$config['username'],


### PR DESCRIPTION
Due to configuration merging, users were not getting the help exception for prompting them to change login to username in their configuration.
