### PR TITLE
3.0 exception's namespace strictly

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -116,7 +116,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testWriteNonExistingConfig() {
@@ -126,7 +126,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testIncrementNonExistingConfig() {
@@ -136,7 +136,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testDecrementNonExistingConfig() {
@@ -182,7 +182,7 @@ class CacheTest extends TestCase {
 /**
  * testConfigInvalidEngine method
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testConfigInvalidEngine() {
@@ -194,7 +194,7 @@ class CacheTest extends TestCase {
 /**
  * test that trying to configure classes that don't extend CacheEngine fail.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testConfigInvalidObject() {
@@ -208,7 +208,7 @@ class CacheTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a cache adapter.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {
@@ -286,7 +286,7 @@ class CacheTest extends TestCase {
 
 /**
  * testGroupConfigsThrowsException method
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  */
 	public function testGroupConfigsThrowsException() {
 		Cache::groupConfigs('bogus');
@@ -353,7 +353,7 @@ class CacheTest extends TestCase {
 /**
  * testWriteEmptyValues method
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage An empty value is not valid as a cache key
  * @return void
  */
@@ -417,7 +417,7 @@ class CacheTest extends TestCase {
 /**
  * Test that failed writes cause errors to be triggered.
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException \PHPUnit_Framework_Error
  * @return void
  */
 	public function testWriteTriggerError() {

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -51,7 +51,7 @@ class ShellDispatcherTest extends TestCase {
 /**
  * Test error on missing shell
  *
- * @expectedException Cake\Console\Exception\MissingShellException
+ * @expectedException \Cake\Console\Exception\MissingShellException
  * @return void
  */
 	public function testFindShellMissing() {
@@ -61,7 +61,7 @@ class ShellDispatcherTest extends TestCase {
 /**
  * Test error on missing plugin shell
  *
- * @expectedException Cake\Console\Exception\MissingShellException
+ * @expectedException \Cake\Console\Exception\MissingShellException
  * @return void
  */
 	public function testFindShellMissingPlugin() {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -736,7 +736,7 @@ class PaginatorComponentTest extends TestCase {
 /**
  * test paginate() and custom find with deprecated option.
  *
- * @expectedException PHPUnit_Framework_Error_Deprecated
+ * @expectedException \PHPUnit_Framework_Error_Deprecated
  * @return void
  */
 	public function testPaginateCustomFindOldOption() {

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -232,7 +232,7 @@ class ConfigureTest extends TestCase {
 /**
  * testLoad method
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @return void
  */
 	public function testLoadExceptionOnNonExistantFile() {
@@ -436,7 +436,7 @@ class ConfigureTest extends TestCase {
 /**
  * test engine() throwing exceptions on missing interface.
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException \PHPUnit_Framework_Error
  * @return void
  */
 	public function testEngineExceptionOnIncorrectClass() {

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -165,7 +165,7 @@ class StaticConfigTraitTest extends TestCase {
 /**
  * Tests that failing to pass a string to parseDsn will throw an exception
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testParseBadType() {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2180,7 +2180,7 @@ class QueryTest extends TestCase {
 /**
  * Inserting nothing should not generate an error.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage At least 1 column is required to perform an insert.
  * @return void
  */

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -53,7 +53,7 @@ class DateTypeTest extends TestCase {
 /**
  * Tests that passing invalid data will throw an exception
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testToPHPError() {

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -53,7 +53,7 @@ class TimeTypeTest extends TestCase {
 /**
  * Tests that passing invalid data will throw an exception
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testToPHPError() {

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -89,7 +89,7 @@ class TypeTest extends TestCase {
 /**
  * Tests trying to build an unknown type throws exception
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testBuildUnknownType() {

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -83,7 +83,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test for errors on duplicate config.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot reconfigure existing key "test_variant"
  * @return void
  */

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -220,7 +220,7 @@ class DebuggerTest extends TestCase {
 /**
  * Test that choosing a non-existent format causes an exception
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testOutputAsException() {

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -90,8 +90,8 @@ class IcuFormatterTest extends TestCase {
 
 /**
  * Tests that passing a message in the wrong format will throw an exception
- * 
- * @expectedException Aura\Intl\Exception\CannotInstantiateFormatter
+ *
+ * @expectedException \Aura\Intl\Exception\CannotInstantiateFormatter
  * @return void
  */
 	public function testBadMessageFormat() {

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -69,7 +69,7 @@ class LogTest extends TestCase {
 /**
  * test all the errors from failed logger imports
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @return void
  */
 	public function testImportingLoggerFailure() {

--- a/tests/TestCase/Model/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TimestampBehaviorTest.php
@@ -184,7 +184,7 @@ class TimestampBehaviorTest extends TestCase {
 /**
  * testInvalidEventConfig
  *
- * @expectedException UnexpectedValueException
+ * @expectedException \UnexpectedValueException
  * @expectedExceptionMessage When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid
  * @return void
  */

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -670,7 +670,7 @@ class TreeBehaviorTest extends TestCase {
 /**
  * Tests that trying to create a cycle throws an exception
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage Cannot use node "5" as parent for entity "2"
  * @return void
  */

--- a/tests/TestCase/Model/ModelAwareTraitTest.php
+++ b/tests/TestCase/Model/ModelAwareTraitTest.php
@@ -91,7 +91,7 @@ class ModelAwareTraitTest extends TestCase {
  * test MissingModelException being thrown
  *
  * @return void
- * @expectedException Cake\Model\Exception\MissingModelException
+ * @expectedException \Cake\Model\Exception\MissingModelException
  * @expectedExceptionMessage Model class "Magic" of type "Test" could not be found.
  */
 	public function testMissingModelException() {

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -251,7 +251,7 @@ class EmailTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidEmails
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testInvalidEmail($value) {
@@ -262,7 +262,7 @@ class EmailTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidEmails
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testInvalidEmailAdd($value) {
@@ -456,7 +456,7 @@ class EmailTest extends TestCase {
  * testMessageIdInvalid method
  *
  * @return void
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  */
 	public function testMessageIdInvalid() {
 		$this->CakeEmail->messageId('my-email@localhost');
@@ -731,7 +731,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using unknown transports fails.
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage Transport config "Invalid" is missing.
  */
 	public function testTransportInvalid() {
@@ -741,7 +741,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using classes with no send method fails.
  *
- * @expectedException LogicException
+ * @expectedException \LogicException
  */
 	public function testTransportInstanceInvalid() {
 		$this->CakeEmail->transport(new \StdClass());
@@ -750,7 +750,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using unknown transports fails.
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage The value passed for the "$name" argument must be either a string, or an object, integer given.
  */
 	public function testTransportTypeInvalid() {
@@ -800,7 +800,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised when duplicate transports are configured.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  */
 	public function testConfigTransportErrorOnDuplicate() {
 		Email::dropTransport('debug');
@@ -856,7 +856,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised on duplicate config set.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testConfigErrorOnDuplicate() {
@@ -887,7 +887,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using an invalid profile fails.
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage Unknown email configuration "derp".
  */
 	public function testProfileInvalid() {
@@ -995,7 +995,7 @@ class EmailTest extends TestCase {
 /**
  * testSendWithoutFrom method
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testSendWithoutFrom() {
@@ -1009,7 +1009,7 @@ class EmailTest extends TestCase {
 /**
  * testSendWithoutTo method
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testSendWithoutTo() {
@@ -1023,7 +1023,7 @@ class EmailTest extends TestCase {
 /**
  * test send without a transport method
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot send email, transport was not defined.
  * @return void
  */

--- a/tests/TestCase/Network/Email/SmtpTransportTest.php
+++ b/tests/TestCase/Network/Email/SmtpTransportTest.php
@@ -131,7 +131,7 @@ class SmtpTransportTest extends TestCase {
 /**
  * testConnectEhloTlsOnNonTlsServer method
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @expectedExceptionMessage SMTP server did not accept the connection or trying to connect to non TLS SMTP server using TLS.
  * @return void
  */
@@ -152,7 +152,7 @@ class SmtpTransportTest extends TestCase {
 /**
  * testConnectEhloNoTlsOnRequiredTlsServer method
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @expectedExceptionMessage SMTP authentication method not allowed, check if SMTP server requires TLS.
  * @return void
  */
@@ -191,7 +191,7 @@ class SmtpTransportTest extends TestCase {
 /**
  * testConnectFail method
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @expectedExceptionMessage SMTP server did not accept the connection.
  * @return void
  */

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -691,7 +691,7 @@ class RequestTest extends TestCase {
 /**
  * Test __call exceptions
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @return void
  */
 	public function testMagicCallExceptionOnUnknownMethod() {

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -112,7 +112,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the statusCode method
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testStatusCode() {
@@ -397,7 +397,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the httpCodes method
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testHttpCodes() {
@@ -1157,7 +1157,7 @@ class ResponseTest extends TestCase {
 /**
  * testFileNotFound
  *
- * @expectedException Cake\Network\Exception\NotFoundException
+ * @expectedException \Cake\Network\Exception\NotFoundException
  * @return void
  */
 	public function testFileNotFound() {
@@ -1168,7 +1168,7 @@ class ResponseTest extends TestCase {
 /**
  * test file with ..
  *
- * @expectedException Cake\Network\Exception\NotFoundException
+ * @expectedException \Cake\Network\Exception\NotFoundException
  * @return void
  */
 	public function testFileWithPathTraversal() {

--- a/tests/TestCase/Network/Session/CacheSessionTest.php
+++ b/tests/TestCase/Network/Session/CacheSessionTest.php
@@ -97,7 +97,7 @@ class CacheSessionTest extends TestCase {
 /**
  * Tests that a cache config is required
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage The cache configuration name to use is required
  * @return void
  */

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -431,7 +431,7 @@ class SessionTest extends TestCase {
 /**
  * Tests instantiating a missing engine
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage The class "Derp" does not exist and cannot be used as a session engine
  * @return void
  */

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -116,7 +116,7 @@ class SocketTest extends TestCase {
  * testInvalidConnection method
  *
  * @dataProvider invalidConnections
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @return void
  */
 	public function testInvalidConnection($data) {
@@ -248,7 +248,7 @@ class SocketTest extends TestCase {
 /**
  * testEncrypt
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @return void
  */
 	public function testEnableCryptoSocketExceptionNoSsl() {
@@ -264,7 +264,7 @@ class SocketTest extends TestCase {
 /**
  * testEnableCryptoSocketExceptionNoTls
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @return void
  */
 	public function testEnableCryptoSocketExceptionNoTls() {
@@ -326,7 +326,7 @@ class SocketTest extends TestCase {
 /**
  * testEnableCryptoExceptionEnableTwice
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @return void
  */
 	public function testEnableCryptoExceptionEnableTwice() {
@@ -340,7 +340,7 @@ class SocketTest extends TestCase {
 /**
  * testEnableCryptoExceptionDisableTwice
  *
- * @expectedException Cake\Network\Exception\SocketException
+ * @expectedException \Cake\Network\Exception\SocketException
  * @return void
  */
 	public function testEnableCryptoExceptionDisableTwice() {

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -119,7 +119,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate method error
  *
- * @expectedException LogicException
+ * @expectedException \LogicException
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"
  * @return void
  */
@@ -149,7 +149,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate finder error
  *
- * @expectedException LogicException
+ * @expectedException \LogicException
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"
  * @return void
  */
@@ -243,7 +243,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot call "nope"
  */
 	public function testCallError() {
@@ -280,7 +280,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot call finder "nope"
  */
 	public function testCallFinderError() {
@@ -291,7 +291,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unloaded behavior methods.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot call "slugify" it does not belong to any attached behavior.
  */
 	public function testUnloadBehaviorThenCall() {
@@ -304,7 +304,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unloaded behavior finders.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot call finder "noslug" it does not belong to any attached behavior.
  */
 	public function testUnloadBehaviorThenCallFinder() {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1487,7 +1487,7 @@ class QueryTest extends TestCase {
 /**
  * cache() should fail on non select queries.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @return void
  */
 	public function testCacheErrorOnNonSelect() {
@@ -1968,7 +1968,7 @@ class QueryTest extends TestCase {
  * Tests that it is not allowed to use matching on an association
  * that is already added to containments.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage Cannot use "matching" on "Authors" as there is another association with the same alias
  * @return void
  */

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -84,7 +84,7 @@ class TableRegistryTest extends TestCase {
 /**
  * Test calling config() on existing instances throws an error.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage You cannot configure "Users", it has already been constructed.
  * @return void
  */
@@ -141,7 +141,7 @@ class TableRegistryTest extends TestCase {
 /**
  * Test get with config throws an exception if the alias exists already.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage You cannot configure "Users", it already exists in the registry.
  * @return void
  */

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2277,7 +2277,7 @@ class TableTest extends TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 0 required 1
  * @return void
  */
@@ -2290,7 +2290,7 @@ class TableTest extends TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 1 required 2
  * @return void
  */
@@ -2303,7 +2303,7 @@ class TableTest extends TestCase {
 /**
  * Test magic findByXX errors when there is a mix of or & and.
  *
- * @expectedException BadMethodCallException
+ * @expectedException \BadMethodCallException
  * @expectedExceptionMessage Cannot mix "and" & "or" in a magic finder. Use find() instead.
  * @return void
  */

--- a/tests/TestCase/Routing/DispatcherFactoryTest.php
+++ b/tests/TestCase/Routing/DispatcherFactoryTest.php
@@ -56,7 +56,7 @@ class DispatcherFactoryTest extends TestCase {
 /**
  * Test add filter missing
  *
- * @expectedException Cake\Routing\Exception\MissingDispatcherFilterException
+ * @expectedException \Cake\Routing\Exception\MissingDispatcherFilterException
  * @return void
  */
 	public function testAddFilterMissing() {

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -63,7 +63,7 @@ class DispatcherFilterTest extends TestCase {
 /**
  * Test constructor error invalid when
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage "when" conditions must be a callable.
  * @return void
  */

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -35,7 +35,7 @@ class RouteCollectionTest extends TestCase {
 /**
  * Test parse() throws an error on unknown routes.
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @expectedExceptionMessage A route matching "/" could not be found
  */
 	public function testParseMissingRoute() {
@@ -126,7 +126,7 @@ class RouteCollectionTest extends TestCase {
 /**
  * Test match() throws an error on unknown routes.
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @expectedExceptionMessage A route matching "array (
  */
 	public function testMatchError() {
@@ -191,7 +191,7 @@ class RouteCollectionTest extends TestCase {
 /**
  * Test matching routes with names and failing
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @return void
  */
 	public function testMatchNamedError() {

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1524,7 +1524,7 @@ class RouterTest extends TestCase {
 /**
  * Test exceptions when parsing fails.
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  */
 	public function testParseError() {
 		Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
@@ -2012,7 +2012,7 @@ class RouterTest extends TestCase {
 /**
  * test that patterns work for :action
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @return void
  */
 	public function testParsingWithPatternOnAction() {
@@ -2037,7 +2037,7 @@ class RouterTest extends TestCase {
 /**
  * Test url() works with patterns on :action
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @return void
  */
 	public function testUrlPatternOnAction() {
@@ -2213,7 +2213,7 @@ class RouterTest extends TestCase {
 /**
  * testRegexRouteMatching error
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @return void
  */
 	public function testRegexRouteMatchingError() {
@@ -2224,7 +2224,7 @@ class RouterTest extends TestCase {
 /**
  * testRegexRouteMatching method
  *
- * @expectedException Cake\Routing\Exception\MissingRouteException
+ * @expectedException \Cake\Routing\Exception\MissingRouteException
  * @return void
  */
 	public function testRegexRouteMatchUrl() {
@@ -2295,7 +2295,7 @@ class RouterTest extends TestCase {
 /**
  * test that route classes must extend \Cake\Routing\Route\Route
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testCustomRouteException() {

--- a/tests/TestCase/Shell/OrmCacheShellTest.php
+++ b/tests/TestCase/Shell/OrmCacheShellTest.php
@@ -143,7 +143,7 @@ class OrmCacheShellTest extends TestCase {
 /**
  * Test build() with a non-existing connection name.
  *
- * @expectedException Cake\Datasource\Exception\MissingDatasourceConfigException
+ * @expectedException \Cake\Datasource\Exception\MissingDatasourceConfigException
  * @return void
  */
 	public function testBuildInvalidConnection() {
@@ -154,7 +154,7 @@ class OrmCacheShellTest extends TestCase {
 /**
  * Test clear() with an invalid connection name.
  *
- * @expectedException Cake\Datasource\Exception\MissingDatasourceConfigException
+ * @expectedException \Cake\Datasource\Exception\MissingDatasourceConfigException
  * @return void
  */
 	public function testClearInvalidConnection() {

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -232,7 +232,7 @@ class TestFixtureTest extends TestCase {
 /**
  * test create method, trigger error
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException \PHPUnit_Framework_Error
  * @return void
  */
 	public function testCreateError() {

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1606,7 +1606,7 @@ class HashTest extends TestCase {
 /**
  * test combine() giving errors on key/value length mismatches.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @return void
  */
 	public function testCombineErrorMissingValue() {
@@ -1620,7 +1620,7 @@ class HashTest extends TestCase {
 /**
  * test combine() giving errors on key/value length mismatches.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @return void
  */
 	public function testCombineErrorMissingKey() {

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -102,7 +102,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidOperation method
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testRijndaelInvalidOperation() {
@@ -114,7 +114,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidKey method
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testRijndaelInvalidKey() {
@@ -185,7 +185,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -222,7 +222,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -235,7 +235,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that empty data cause errors
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage The data to decrypt cannot be empty.
  * @return void
  */

--- a/tests/TestCase/Utility/StringTest.php
+++ b/tests/TestCase/Utility/StringTest.php
@@ -1427,7 +1427,7 @@ podeís adquirirla.</span></p>
 /**
  * testparseFileSizeException
  *
- * @expectedException InvalidArgumentException
+ * @expectedException \InvalidArgumentException
  * @return void
  */
 	public function testparseFileSizeException() {

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -168,7 +168,7 @@ class XmlTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidDataProvider
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @return void
  */
 	public function testBuildInvalidData($value) {
@@ -536,7 +536,7 @@ XML;
  * testFromArrayFail method
  *
  * @dataProvider invalidArrayDataProvider
- * @expectedException Exception
+ * @expectedException \Exception
  * @return void
  */
 	public function testFromArrayFail($value) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -329,7 +329,7 @@ class FormHelperTest extends TestCase {
 /**
  * Test adding an invalid context class.
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage Context objects must implement Cake\View\Form\ContextInterface
  * @return void
  */

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -772,7 +772,7 @@ class ViewTest extends TestCase {
 /**
  * Test elementInexistent method
  *
- * @expectedException Cake\View\Exception\MissingElementException
+ * @expectedException \Cake\View\Exception\MissingElementException
  * @return void
  */
 	public function testElementInexistent() {
@@ -782,7 +782,7 @@ class ViewTest extends TestCase {
 /**
  * Test elementInexistent3 method
  *
- * @expectedException Cake\View\Exception\MissingElementException
+ * @expectedException \Cake\View\Exception\MissingElementException
  * @return void
  */
 	public function testElementInexistent3() {
@@ -1367,7 +1367,7 @@ class ViewTest extends TestCase {
  * This should produce a "Object of class TestObjectWithoutToString could not be converted to string" error
  * which gets thrown as a PHPUnit_Framework_Error Exception by PHPUnit.
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException \PHPUnit_Framework_Error
  * @return void
  */
 	public function testBlockSetObjectWithoutToString() {
@@ -1420,7 +1420,7 @@ class ViewTest extends TestCase {
  * This should produce a "Object of class TestObjectWithoutToString could not be converted to string" error
  * which gets thrown as a PHPUnit_Framework_Error Exception by PHPUnit.
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException \PHPUnit_Framework_Error
  * @return void
  */
 	public function testBlockAppendObjectWithoutToString() {
@@ -1450,7 +1450,7 @@ class ViewTest extends TestCase {
  * This should produce a "Object of class TestObjectWithoutToString could not be converted to string" error
  * which gets thrown as a PHPUnit_Framework_Error Exception by PHPUnit.
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException \PHPUnit_Framework_Error
  * @return void
  */
 	public function testBlockPrependObjectWithoutToString() {

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -139,7 +139,7 @@ class ViewVarsTraitTest extends TestCase {
 /**
  * test getView() throws exception if view class cannot be found
  *
- * @expectedException Cake\View\Exception\MissingViewException
+ * @expectedException \Cake\View\Exception\MissingViewException
  * @expectedExceptionMessage View class "Foo" is missing.
  * @return void
  */
@@ -150,7 +150,7 @@ class ViewVarsTraitTest extends TestCase {
 /**
  * test createView() throws exception if view class cannot be found
  *
- * @expectedException Cake\View\Exception\MissingViewException
+ * @expectedException \Cake\View\Exception\MissingViewException
  * @expectedExceptionMessage View class "Foo" is missing.
  * @return void
  */

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -159,7 +159,7 @@ class WidgetRegistryTestCase extends TestCase {
 /**
  * Test getting errors
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage Unknown widget "foo"
  * @return void
  */
@@ -188,7 +188,7 @@ class WidgetRegistryTestCase extends TestCase {
 /**
  * Test getting resolve dependency missing class
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage Unable to locate widget class "TestApp\View\DerpWidget"
  * @return void
  */
@@ -201,7 +201,7 @@ class WidgetRegistryTestCase extends TestCase {
 /**
  * Test getting resolve dependency missing dependency
  *
- * @expectedException RuntimeException
+ * @expectedException \RuntimeException
  * @expectedExceptionMessage Unknown widget "label"
  * @return void
  */


### PR DESCRIPTION
In test case, exception's namespace strictly on `@expectedException`.
