### PR TITLE
Fix routing extensions leaking out of their scopes.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -127,9 +127,10 @@ class RouteBuilder {
 	}
 
 /**
- * Get or set the extensions in this route collection.
+ * Get or set the extensions in this route builder's scope.
  *
- * Setting extensions does not modify existing routes.
+ * Future routes connected in through this builder will have the connected
+ * extensions applied. However, setting extensions does not modify existing routes.
  *
  * @param null|string|array $extensions Either the extensions to use or null.
  * @return array|void

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -148,6 +148,13 @@ class Router {
 	protected static $_urlFilters = [];
 
 /**
+ * Default extensions defined with Router::extensions()
+ *
+ * @var array
+ */
+	protected static $_defaultExtensions = [];
+
+/**
  * Get or set default route class.
  *
  * @param string|null $routeClass Class name.
@@ -724,7 +731,9 @@ class Router {
 	}
 
 /**
- * Get/Set valid extensions. Instructs the router to parse out file extensions
+ * Get or set valid extensions for all routes connected later.
+ *
+ * Instructs the router to parse out file extensions
  * from the URL. For example, http://example.com/posts.rss would yield a file
  * extension of "rss". The file extension itself is made available in the
  * controller as `$this->request->params['_ext']`, and is used by the RequestHandler
@@ -747,10 +756,13 @@ class Router {
 			if (!static::$initialized) {
 				static::_loadRoutes();
 			}
-			return $collection->extensions();
+			return array_unique(array_merge(static::$_defaultExtensions, $collection->extensions()));
 		}
-
-		return $collection->extensions($extensions, $merge);
+		$extensions = (array)$extensions;
+		if ($merge) {
+			$extensions = array_unique(array_merge(static::$_defaultExtensions, $extensions));
+		}
+		return static::$_defaultExtensions = $extensions;
 	}
 
 /**
@@ -845,7 +857,7 @@ class Router {
 	public static function scope($path, $params = [], $callback = null) {
 		$builder = new RouteBuilder(static::$_collection, '/', [], [
 			'routeClass' => static::defaultRouteClass(),
-			'extensions' => static::$_collection->extensions()
+			'extensions' => static::$_defaultExtensions
 		]);
 		$builder->scope($path, $params, $callback);
 	}


### PR DESCRIPTION
Each route builder should not leak extensions into other scopes. When defining extensions in one route builder, they should not automatically be available in other scopes. What we want to avoid is a plugin like DebugKit adding `.json` extensions to all the application routes.

Refs #5089
