### PR TITLE
Configure::read('App.wwwRoot')

### DIFF
--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -155,7 +155,7 @@ class UrlHelper extends Helper {
 				$file = str_replace('/', '\\', $file);
 			}
 
-			if (file_exists(Configure::read('App.www_root') . $theme . $file)) {
+			if (file_exists(Configure::read('App.wwwRoot') . $theme . $file)) {
 				$webPath = $this->request->webroot . $theme . $asset[0];
 			} else {
 				$themePath = Plugin::path($this->theme);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -480,8 +480,8 @@ class HtmlHelperTest extends TestCase {
  * @return void
  */
 	public function testThemeAssetsInMainWebrootPath() {
-		$webRoot = Configure::read('App.www_root');
-		Configure::write('App.www_root', TEST_APP . 'webroot/');
+		$webRoot = Configure::read('App.wwwRoot');
+		Configure::write('App.wwwRoot', TEST_APP . 'webroot/');
 
 		$this->Html->Url->theme = 'TestTheme';
 		$result = $this->Html->css('webroot_test');

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -261,8 +261,8 @@ class UrlHelperTest extends TestCase {
 		$expected = '/test_theme/img/test.jpg';
 		$this->assertEquals($expected, $result);
 
-		$webRoot = Configure::read('App.www_root');
-		Configure::write('App.www_root', TEST_APP . 'TestApp/webroot/');
+		$webRoot = Configure::read('App.wwwRoot');
+		Configure::write('App.wwwRoot', TEST_APP . 'TestApp/webroot/');
 
 		$result = $this->Helper->webroot('/img/cake.power.gif');
 		$expected = '/test_theme/img/cake.power.gif';
@@ -280,7 +280,7 @@ class UrlHelperTest extends TestCase {
 		$expected = '/img/cake.icon.gif?some=param';
 		$this->assertEquals($expected, $result);
 
-		Configure::write('App.www_root', $webRoot);
+		Configure::write('App.wwwRoot', $webRoot);
 	}
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -72,7 +72,7 @@ Configure::write('App', [
 	'baseUrl' => false,
 	'dir' => APP_DIR,
 	'webroot' => 'webroot',
-	'www_root' => WWW_ROOT,
+	'wwwRoot' => WWW_ROOT,
 	'fullBaseUrl' => 'http://localhost',
 	'imageBaseUrl' => 'img/',
 	'jsBaseUrl' => 'js/',


### PR DESCRIPTION
Instead of `App.www_root` this should be consistent with other keys like `App.imageBaseUrl` and `App.fullBaseUrl` and all other config keys - so camelBacked as `App.wwwRoot`.

There are also a few constant usages left in 3.0. E.g.:

```
$webrootPath = WWW_ROOT . str_replace('/', DS, $filepath);
```

Should those also use the Configure option instead?
