### PR TITLE
3.0 reliable beforefind

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -256,12 +256,9 @@ class Connection {
  * @return \Cake\Database\StatementInterface executed statement
  */
 	public function run(Query $query) {
-		$binder = $query->valueBinder();
-		$binder->resetCount();
-		list($query, $sql) = $this->driver()->compileQuery($query, $binder);
-
+		$sql = $query->sql();
 		$statement = $this->prepare($sql);
-		$binder->attachTo($statement);
+		$query->valueBinder()->attachTo($statement);
 		$statement->execute();
 
 		return $statement;

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -146,7 +146,7 @@ class TranslateBehavior extends Behavior {
 		if ($locale === $this->config('defaultLocale')) {
 			return;
 		}
-	
+
 		$conditions = function ($field, $locale, $query, $select) {
 			return function ($q) use ($field, $locale, $query, $select) {
 				$q->where([$q->repository()->alias() . '.locale' => $locale]);

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -146,18 +146,35 @@ class TranslateBehavior extends Behavior {
 		if ($locale === $this->config('defaultLocale')) {
 			return;
 		}
+	
+		$conditions = function ($field, $locale, $query, $select) {
+			return function ($q) use ($field, $locale, $query, $select) {
+				$q->where([$q->repository()->alias() . '.locale' => $locale]);
+				$alias = $this->_table->alias();
 
-		$conditions = function ($q) use ($locale) {
-			return $q
-				->select(['id', 'content'])
-				->where([$q->repository()->alias() . '.locale' => $locale]);
+				if ($query->autoFields() ||
+					in_array($field, $select, true) ||
+					in_array("$alias.$field", $select, true)
+				) {
+					$q->select(['id', 'content']);
+				}
+
+				return $q;
+			};
 		};
 
 		$contain = [];
 		$fields = $this->_config['fields'];
 		$alias = $this->_table->alias();
+		$select = $query->clause('select');
+
 		foreach ($fields as $field) {
-			$contain[$alias . '_' . $field . '_translation'] = $conditions;
+			$contain[$alias . '_' . $field . '_translation'] = $conditions(
+				$field,
+				$locale,
+				$query,
+				$select
+			);
 		}
 
 		$query->contain($contain);

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -607,15 +607,15 @@ class Query extends DatabaseQuery implements JsonSerializable {
  * {@inheritDoc}
  */
 	public function sql(ValueBinder $binder = null) {
-		$this->_transformQuery();
-
 		if (!$this->_beforeFindFired && $this->_type === 'select') {
 			$table = $this->repository();
 			$table->dispatchEvent('Model.beforeFind', [$this, $this->_options, !$this->eagerLoaded()]);
 			$this->_beforeFindFired = true;
 		}
 
-		return parent::sql($binder);
+		$this->_transformQuery();
+		$sql = parent::sql($binder);
+		return $sql;
 	}
 
 /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -107,7 +107,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	protected $_eagerLoader;
 
 /**
- * True if the beforeFind even has already been triggered for this query
+ * True if the beforeFind event has already been triggered for this query
  *
  * @var bool
  */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -609,7 +609,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	public function sql(ValueBinder $binder = null) {
 		$this->_transformQuery();
 
-		if (!$this->_beforeFindFired) {
+		if (!$this->_beforeFindFired && $this->_type === 'select') {
 			$table = $this->repository();
 			$table->dispatchEvent('Model.beforeFind', [$this, $this->_options, !$this->eagerLoaded()]);
 			$this->_beforeFindFired = true;

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -107,6 +107,13 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	protected $_eagerLoader;
 
 /**
+ * True if the beforeFind even has already been triggered for this query
+ *
+ * @var bool
+ */
+	protected $_beforeFindFired = false;
+
+/**
  * Constructor
  *
  * @param \Cake\Database\Connection $connection The connection object
@@ -601,15 +608,14 @@ class Query extends DatabaseQuery implements JsonSerializable {
  */
 	public function sql(ValueBinder $binder = null) {
 		$this->_transformQuery();
-		return parent::sql($binder);
-	}
 
-/**
- * {@inheritDoc}
- */
-	public function execute() {
-		$this->_transformQuery();
-		return parent::execute();
+		if (!$this->_beforeFindFired) {
+			$table = $this->repository();
+			$table->dispatchEvent('Model.beforeFind', [$this, $this->_options, !$this->eagerLoaded()]);
+			$this->_beforeFindFired = true;
+		}
+
+		return parent::sql($binder);
 	}
 
 /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -524,6 +524,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 		if (!$complex) {
 			$statement = $query
 				->select($count, true)
+				->autoFields(false)
 				->execute();
 		} else {
 			$statement = $this->connection()->newQuery()

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -794,4 +794,23 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('Un artículo', $article->translation('spa')->title);
 	}
 
+/**
+ * Tests that translation queries are added to union queries as well.
+ *
+ * @return void
+ */
+	public function testTranslationWithUnionQuery() {
+		$table = TableRegistry::get('Comments');
+		$table->addBehavior('Translate', ['fields' => ['comment']]);
+		$table->locale('spa');
+		$query = $table->find()->where(['Comments.id' => 6]);
+		$query2 = $table->find()->where(['Comments.id' => 5]);
+		$query->union($query2);
+		$results = $query->toArray();
+		$this->assertCount(2, $results);
+
+		$this->assertEquals('First Comment for Second Article', $results[0]->comment);
+		$this->assertEquals('Second Comment for Second Article', $results[1]->comment);
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -148,7 +148,12 @@ class TranslateBehaviorTest extends TestCase {
 
 		$results = $table->find()
 			->select(['id', 'title', 'body'])
-			->contain(['Comments' => ['fields' => ['article_id', 'comment']]])
+			->contain([
+				'Comments' => [
+					'fields' => ['article_id', 'comment'],
+					'sort' => ['Comments.id' => 'ASC']
+				]
+			])
 			->hydrate(false)
 			->toArray();
 
@@ -806,7 +811,7 @@ class TranslateBehaviorTest extends TestCase {
 		$query = $table->find()->where(['Comments.id' => 6]);
 		$query2 = $table->find()->where(['Comments.id' => 5]);
 		$query->union($query2);
-		$results = $query->toArray();
+		$results = $query->sortBy('id')->toArray();
 		$this->assertCount(2, $results);
 
 		$this->assertEquals('First Comment for Second Article', $results[0]->comment);


### PR DESCRIPTION
The Model.beforeFind event is now triggered in Query::sql(), this has a couple advantages:
- Calling `$query->sql()` for debugging will now contain the full actual query to be executed
- Queries used as sub-expressions (like in unions) will contain modifications made by behaviors or other callbacks.

Refs https://github.com/cakephp/cakephp/issues/5115
