### PR TITLE
Make unsetting the email pattern work as expected.

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -553,7 +553,9 @@ class CakeEmail {
 /**
  * EmailPattern setter/getter
  *
- * @param string $regex for email address validation
+ * @param string|bool|null $regex The pattern to use for email address validation,
+ *   null to unset the pattern and make use of filter_var() instead, false or
+ *   nothing to return the current value
  * @return string|$this
  */
 	public function emailPattern($regex = false) {
@@ -602,10 +604,11 @@ class CakeEmail {
  * @throws SocketException If email address does not validate
  */
 	protected function _validateEmail($email) {
-		if ($this->_emailPattern === null && filter_var($email, FILTER_VALIDATE_EMAIL)) {
-			return;
-		}
-		if (preg_match($this->_emailPattern, $email)) {
+		if ($this->_emailPattern === null) {
+			if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+				return;
+			}
+		} elseif (preg_match($this->_emailPattern, $email)) {
 			return;
 		}
 		throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $email));

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -387,6 +387,25 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 /**
+ * Tests that it is possible to unset the email pattern and make use of filter_var() instead.
+ *
+ * @return void
+ *
+ * @expectedException SocketException
+ * @expectedExceptionMessage Invalid email: "fail.@example.com"
+ */
+	public function testUnsetEmailPattern() {
+		$email = new CakeEmail();
+		$this->assertSame(CakeEmail::EMAIL_PATTERN, $email->emailPattern());
+
+		$email->emailPattern(null);
+		$this->assertNull($email->emailPattern());
+
+		$email->to('pass@example.com');
+		$email->to('fail.@example.com');
+	}
+
+/**
  * testFormatAddress method
  *
  * @return void


### PR DESCRIPTION
When set to `null`, only `filter_var()` should be used. This is a
partial backport of #5111
