### PR TITLE
3.0 - Make distribution archives smaller.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,17 @@
 *.gif binary
 *.ico binary
 *.mo binary
+
+# Remove files for archives generated using `git archive`
+appveyor.yml export-ignore
+CONTRIBUTING.md export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+Makefile export-ignore
+phpunit.xml.dist export-ignore
+.travis.yml export-ignore
+tests/test_app export-ignore
+tests/TestCase export-ignore
+tests/bake_compare export-ignore
+tests/bootstrap.php export-ignore


### PR DESCRIPTION
Tests and other config files are ignored in archives generated using
`git archive`. Fixtures are kept back as they are often used in app / plugin
tests.

This change brings down the file size of zip balls generated by GH from ~1.9MB to ~1.1MB
