### PR TITLE
Fix forms with 24hr datetime inputs being blackholed.

### DIFF
--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -527,12 +527,22 @@ class DateTimeWidget implements WidgetInterface {
 	}
 
 /**
- * {@inheritDoc}
+ * Returns a list of fields that need to be secured for this widget.
+ *
+ * When the hour picker is in 24hr mode (null or format=24) the meridian
+ * picker will be omitted.
+ *
+ * @param array $data The data to render.
+ * @return array Array of fields to secure.
  */
 	public function secureFields(array $data) {
 		$fields = [];
+		$hourFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
 		foreach ($this->_selects as $type) {
-			if ($data[$type] !== false) {
+			if ($type === 'meridian' && ($hourFormat === null || $hourFormat === 24)) {
+				continue;
+			}
+			if (!isset($data[$type]) || $data[$type] !== false) {
 				$fields[] = $data['name'] . '[' . $type . ']';
 			}
 		}

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4567,7 +4567,6 @@ class FormHelperTest extends TestCase {
 			'Contact.date.day',
 			'Contact.date.hour',
 			'Contact.date.minute',
-			'Contact.date.meridian',
 		];
 		$this->assertEquals($expected, $this->Form->fields);
 

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -966,4 +966,46 @@ class DateTimeWidgetTest extends TestCase {
 		$this->assertHtml($expected, $result);
 	}
 
+/**
+ * Test that secureFields omits removed selects
+ *
+ * @return void
+ */
+	public function testSecureFields() {
+		$data = [
+			'name' => 'date',
+		];
+		$result = $this->DateTime->secureFields($data);
+		$expected = [
+			'date[year]', 'date[month]', 'date[day]',
+			'date[hour]', 'date[minute]', 'date[second]',
+		];
+		$this->assertEquals($expected, $result, 'No meridian on 24hr input');
+
+		$data = [
+			'name' => 'date',
+			'hour' => ['format' => 24]
+		];
+		$result = $this->DateTime->secureFields($data);
+		$this->assertEquals($expected, $result, 'No meridian on 24hr input');
+
+		$data = [
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => [
+				'format' => 12,
+				'data-foo' => 'test'
+			],
+			'minute' => false,
+			'second' => false,
+		];
+		$result = $this->DateTime->secureFields($data);
+		$expected = [
+			'date[hour]', 'date[meridian]'
+		];
+		$this->assertEquals($expected, $result);
+	}
+
 }


### PR DESCRIPTION
Omit the meridian picker from the secured fields if the form has a 24 hour format hour picker.

Refs #5105
