### PR TITLE
Remove singularization on schema class names

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -292,10 +292,10 @@ class SchemaShell extends AppShell {
 		$Schema = $this->Schema->load($options);
 
 		if (!$Schema) {
-			$this->err(__d('cake_console', 'The chosen schema could not be loaded. Attempted to load:'));
-			$this->err(__d('cake_console', 'File: %s', $this->Schema->path . DS . $this->Schema->file));
-			$this->err(__d('cake_console', 'Name: %s', $this->Schema->name));
-			return $this->_stop();
+			$this->err(__d('cake_console', '<error>Error</error>: The chosen schema could not be loaded. Attempted to load:'));
+			$this->err(__d('cake_console', '- file: %s', $this->Schema->path . DS . $this->Schema->file));
+			$this->err(__d('cake_console', '- name: %s', $this->Schema->name));
+			return $this->_stop(2);
 		}
 		$table = null;
 		if (isset($this->args[1])) {

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -89,7 +89,7 @@ class SchemaShell extends AppShell {
 				$name = $plugin;
 			}
 		}
-		$name = Inflector::classify($name);
+		$name = Inflector::camelize($name);
 		$this->Schema = new CakeSchema(compact('name', 'path', 'file', 'connection', 'plugin'));
 	}
 

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -617,19 +617,19 @@ class SchemaShellTest extends CakeTestCase {
 		$this->Shell->params = array(
 			'plugin' => 'TestPlugin',
 			'connection' => 'test',
-			'name' => 'custom_name',
+			'name' => 'custom_names',
 			'force' => false,
 			'overwrite' => true,
 		);
 		$this->Shell->startup();
-		if (file_exists($this->Shell->Schema->path . DS . 'custom_name.php')) {
-			unlink($this->Shell->Schema->path . DS . 'custom_name.php');
+		if (file_exists($this->Shell->Schema->path . DS . 'custom_names.php')) {
+			unlink($this->Shell->Schema->path . DS . 'custom_names.php');
 		}
 		$this->Shell->generate();
 
-		$contents = file_get_contents($this->Shell->Schema->path . DS . 'custom_name.php');
-		$this->assertRegExp('/class CustomNameSchema/', $contents);
-		unlink($this->Shell->Schema->path . DS . 'custom_name.php');
+		$contents = file_get_contents($this->Shell->Schema->path . DS . 'custom_names.php');
+		$this->assertRegExp('/class CustomNamesSchema/', $contents);
+		unlink($this->Shell->Schema->path . DS . 'custom_names.php');
 		CakePlugin::unload();
 	}
 


### PR DESCRIPTION
Using camelize() does the transformation we want without also singularizing the name. This makes user input more transparent and fixes issues around plugin schemas with plural names.

I also fixed the error output so it was a bit easier to read and had a non-zero exit code.

Refs #4993
