### PR TITLE
Fix fatal errors on _joinData

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -821,7 +821,7 @@ abstract class Association {
  * Each implementing class should handle the cascaded delete as
  * required.
  *
- * @param \Cake\ORM\EntityInterface $entity The entity that started the cascaded delete.
+ * @param \Cake\Datasource\EntityInterface $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return bool Success
  */
@@ -841,9 +841,9 @@ abstract class Association {
  * Extract the target's association data our from the passed entity and proxies
  * the saving operation to the target table.
  *
- * @param \Cake\ORM\EntityInterface $entity the data to be saved
+ * @param \Cake\Datasource\EntityInterface $entity the data to be saved
  * @param array|\ArrayObject $options The options for saving associated data.
- * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
+ * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  */

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -16,8 +16,8 @@ namespace Cake\ORM;
 
 use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetDecorator;
-use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -821,11 +821,11 @@ abstract class Association {
  * Each implementing class should handle the cascaded delete as
  * required.
  *
- * @param \Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param \Cake\ORM\EntityInterface $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return bool Success
  */
-	public abstract function cascadeDelete(Entity $entity, array $options = []);
+	public abstract function cascadeDelete(EntityInterface $entity, array $options = []);
 
 /**
  * Returns whether or not the passed table is the owning side for this
@@ -841,12 +841,12 @@ abstract class Association {
  * Extract the target's association data our from the passed entity and proxies
  * the saving operation to the target table.
  *
- * @param \Cake\ORM\Entity $entity the data to be saved
+ * @param \Cake\ORM\EntityInterface $entity the data to be saved
  * @param array|\ArrayObject $options The options for saving associated data.
- * @return bool|Entity false if $entity could not be saved, otherwise it returns
+ * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  */
-	public abstract function saveAssociated(Entity $entity, array $options = []);
+	public abstract function saveAssociated(EntityInterface $entity, array $options = []);
 
 }

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -15,9 +15,9 @@
 namespace Cake\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\SelectableAssociationTrait;
-use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 
@@ -53,11 +53,11 @@ class BelongsTo extends Association {
  *
  * BelongsTo associations are never cleared in a cascading delete scenario.
  *
- * @param \Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param \Cake\ORM\EntityInterface $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return bool Success.
  */
-	public function cascadeDelete(Entity $entity, array $options = []) {
+	public function cascadeDelete(EntityInterface $entity, array $options = []) {
 		return true;
 	}
 
@@ -107,16 +107,16 @@ class BelongsTo extends Association {
  * saved on the target table for this association by passing supplied
  * `$options`
  *
- * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param \Cake\ORM\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
- * @return bool|Entity false if $entity could not be saved, otherwise it returns
+ * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  */
-	public function saveAssociated(Entity $entity, array $options = []) {
+	public function saveAssociated(EntityInterface $entity, array $options = []) {
 		$targetEntity = $entity->get($this->property());
-		if (empty($targetEntity) || !($targetEntity instanceof Entity)) {
+		if (empty($targetEntity) || !($targetEntity instanceof EntityInterface)) {
 			return $entity;
 		}
 

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -53,7 +53,7 @@ class BelongsTo extends Association {
  *
  * BelongsTo associations are never cleared in a cascading delete scenario.
  *
- * @param \Cake\ORM\EntityInterface $entity The entity that started the cascaded delete.
+ * @param \Cake\Datasource\EntityInterface $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return bool Success.
  */
@@ -107,10 +107,10 @@ class BelongsTo extends Association {
  * saved on the target table for this association by passing supplied
  * `$options`
  *
- * @param \Cake\ORM\EntityInterface $entity an entity from the source table
+ * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
- * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
+ * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\ORM\Association;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
-use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -304,11 +304,11 @@ class BelongsToMany extends Association {
 /**
  * Clear out the data in the junction table for a given entity.
  *
- * @param \Cake\ORM\Entity $entity The entity that started the cascading delete.
+ * @param \Cake\ORM\EntityInterface $entity The entity that started the cascading delete.
  * @param array $options The options for the original delete.
  * @return bool Success.
  */
-	public function cascadeDelete(Entity $entity, array $options = []) {
+	public function cascadeDelete(EntityInterface $entity, array $options = []) {
 		$foreignKey = (array)$this->foreignKey();
 		$primaryKey = (array)$this->source()->primaryKey();
 		$conditions = [];
@@ -375,17 +375,17 @@ class BelongsToMany extends Association {
  * of the entities intended to be saved by this method, they will be updated,
  * not deleted.
  *
- * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param \Cake\ORM\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
  * @throws \InvalidArgumentException if the property representing the association
  * in the parent entity cannot be traversed
- * @return bool|Entity false if $entity could not be saved, otherwise it returns
+ * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  * @see BelongsToMany::replaceLinks()
  */
-	public function saveAssociated(Entity $entity, array $options = []) {
+	public function saveAssociated(EntityInterface $entity, array $options = []) {
 		$targetEntity = $entity->get($this->property());
 		$strategy = $this->saveStrategy();
 
@@ -412,17 +412,17 @@ class BelongsToMany extends Association {
  * Persists each of the entities into the target table and creates links between
  * the parent entity and each one of the saved target entities.
  *
- * @param \Cake\ORM\Entity $parentEntity the source entity containing the target
+ * @param \Cake\ORM\EntityInterface $parentEntity the source entity containing the target
  * entities to be saved.
  * @param array|\Traversable $entities list of entities to persist in target table and to
  * link to the parent entity
  * @param array $options list of options accepted by Table::save()
  * @throws \InvalidArgumentException if the property representing the association
  * in the parent entity cannot be traversed
- * @return \Cake\ORM\Entity|bool The parent entity after all links have been
+ * @return \Cake\ORM\EntityInterface|bool The parent entity after all links have been
  * created if no errors happened, false otherwise
  */
-	protected function _saveTarget(Entity $parentEntity, $entities, $options) {
+	protected function _saveTarget(EntityInterface $parentEntity, $entities, $options) {
 		$joinAssociations = false;
 		if (!empty($options['associated'][$this->_junctionProperty]['associated'])) {
 			$joinAssociations = $options['associated'][$this->_junctionProperty]['associated'];
@@ -440,7 +440,7 @@ class BelongsToMany extends Association {
 		$persisted = [];
 
 		foreach ($entities as $k => $entity) {
-			if (!($entity instanceof Entity)) {
+			if (!($entity instanceof EntityInterface)) {
 				break;
 			}
 
@@ -474,14 +474,14 @@ class BelongsToMany extends Association {
 /**
  * Creates links between the source entity and each of the passed target entities
  *
- * @param \Cake\ORM\Entity $sourceEntity the entity from source table in this
+ * @param \Cake\ORM\EntityInterface $sourceEntity the entity from source table in this
  * association
  * @param array $targetEntities list of entities to link to link to the source entity using the
  * junction table
  * @param array $options list of options accepted by Table::save()
  * @return bool success
  */
-	protected function _saveLinks(Entity $sourceEntity, $targetEntities, $options) {
+	protected function _saveLinks(EntityInterface $sourceEntity, $targetEntities, $options) {
 		$target = $this->target();
 		$junction = $this->junction();
 		$source = $this->source();
@@ -496,7 +496,7 @@ class BelongsToMany extends Association {
 
 		foreach ($targetEntities as $e) {
 			$joint = $e->get($jointProperty);
-			if (!$joint || !($joint instanceof Entity)) {
+			if (!$joint || !($joint instanceof EntityInterface)) {
 				$joint = new $entityClass([], ['markNew' => true, 'source' => $junctionAlias]);
 			}
 
@@ -538,7 +538,7 @@ class BelongsToMany extends Association {
  *
  * `$article->get('tags')` will contain all tags in `$newTags` after liking
  *
- * @param \Cake\ORM\Entity $sourceEntity the row belonging to the `source` side
+ * @param \Cake\ORM\EntityInterface $sourceEntity the row belonging to the `source` side
  * of this association
  * @param array $targetEntities list of entities belonging to the `target` side
  * of this association
@@ -547,7 +547,7 @@ class BelongsToMany extends Association {
  * detected to not be already persisted
  * @return bool true on success, false otherwise
  */
-	public function link(Entity $sourceEntity, array $targetEntities, array $options = []) {
+	public function link(EntityInterface $sourceEntity, array $targetEntities, array $options = []) {
 		$this->_checkPersistenceStatus($sourceEntity, $targetEntities);
 		$property = $this->property();
 		$links = $sourceEntity->get($property) ?: [];
@@ -579,7 +579,7 @@ class BelongsToMany extends Association {
  *
  * `$article->get('tags')` will contain only `[$tag4]` after deleting in the database
  *
- * @param \Cake\ORM\Entity $sourceEntity an entity persisted in the source table for
+ * @param \Cake\ORM\EntityInterface $sourceEntity an entity persisted in the source table for
  * this association
  * @param array $targetEntities list of entities persisted in the target table for
  * this association
@@ -589,7 +589,7 @@ class BelongsToMany extends Association {
  * any of them is lacking a primary key value
  * @return void
  */
-	public function unlink(Entity $sourceEntity, array $targetEntities, $cleanProperty = true) {
+	public function unlink(EntityInterface $sourceEntity, array $targetEntities, $cleanProperty = true) {
 		$this->_checkPersistenceStatus($sourceEntity, $targetEntities);
 		$property = $this->property();
 
@@ -662,7 +662,7 @@ class BelongsToMany extends Association {
  *
  * `$article->get('tags')` will contain only `[$tag1, $tag3]` at the end
  *
- * @param \Cake\ORM\Entity $sourceEntity an entity persisted in the source table for
+ * @param \Cake\ORM\EntityInterface $sourceEntity an entity persisted in the source table for
  * this association
  * @param array $targetEntities list of entities from the target table to be linked
  * @param array $options list of options to be passed to `save` persisting or
@@ -671,7 +671,7 @@ class BelongsToMany extends Association {
  * any of them is lacking a primary key value
  * @return bool success
  */
-	public function replaceLinks(Entity $sourceEntity, array $targetEntities, array $options = []) {
+	public function replaceLinks(EntityInterface $sourceEntity, array $targetEntities, array $options = []) {
 		$primaryKey = (array)$this->source()->primaryKey();
 		$primaryValue = $sourceEntity->extract($primaryKey);
 
@@ -805,7 +805,7 @@ class BelongsToMany extends Association {
  * Returns the list of joint entities that exist between the source entity
  * and each of the passed target entities
  *
- * @param \Cake\ORM\Entity $sourceEntity The row belonging to the source side
+ * @param \Cake\ORM\EntityInterface $sourceEntity The row belonging to the source side
  *   of this association.
  * @param array $targetEntities The rows belonging to the target side of this
  *   association.
@@ -826,7 +826,7 @@ class BelongsToMany extends Association {
 		foreach ($targetEntities as $entity) {
 			$joint = $entity->get($jointProperty);
 
-			if (!$joint || !($joint instanceof Entity)) {
+			if (!$joint || !($joint instanceof EntityInterface)) {
 				$missing[] = $entity->extract($primary);
 				continue;
 			}

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -496,10 +496,8 @@ class BelongsToMany extends Association {
 
 		foreach ($targetEntities as $e) {
 			$joint = $e->get($jointProperty);
-			if (!$joint) {
-				$joint = new $entityClass;
-				$joint->isNew(true);
-				$joint->source($junctionAlias);
+			if (!$joint || !($joint instanceof Entity)) {
+				$joint = new $entityClass([], ['markNew' => true, 'source' => $junctionAlias]);
 			}
 
 			$joint->set(array_combine(
@@ -828,7 +826,7 @@ class BelongsToMany extends Association {
 		foreach ($targetEntities as $entity) {
 			$joint = $entity->get($jointProperty);
 
-			if (!$joint) {
+			if (!$joint || !($joint instanceof Entity)) {
 				$missing[] = $entity->extract($primary);
 				continue;
 			}

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -304,7 +304,7 @@ class BelongsToMany extends Association {
 /**
  * Clear out the data in the junction table for a given entity.
  *
- * @param \Cake\ORM\EntityInterface $entity The entity that started the cascading delete.
+ * @param \Cake\Datasource\EntityInterface $entity The entity that started the cascading delete.
  * @param array $options The options for the original delete.
  * @return bool Success.
  */
@@ -375,12 +375,12 @@ class BelongsToMany extends Association {
  * of the entities intended to be saved by this method, they will be updated,
  * not deleted.
  *
- * @param \Cake\ORM\EntityInterface $entity an entity from the source table
+ * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
  * @throws \InvalidArgumentException if the property representing the association
  * in the parent entity cannot be traversed
- * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
+ * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  * @see BelongsToMany::replaceLinks()
@@ -412,14 +412,14 @@ class BelongsToMany extends Association {
  * Persists each of the entities into the target table and creates links between
  * the parent entity and each one of the saved target entities.
  *
- * @param \Cake\ORM\EntityInterface $parentEntity the source entity containing the target
+ * @param \Cake\Datasource\EntityInterface $parentEntity the source entity containing the target
  * entities to be saved.
  * @param array|\Traversable $entities list of entities to persist in target table and to
  * link to the parent entity
  * @param array $options list of options accepted by Table::save()
  * @throws \InvalidArgumentException if the property representing the association
  * in the parent entity cannot be traversed
- * @return \Cake\ORM\EntityInterface|bool The parent entity after all links have been
+ * @return \Cake\Datasource\EntityInterface|bool The parent entity after all links have been
  * created if no errors happened, false otherwise
  */
 	protected function _saveTarget(EntityInterface $parentEntity, $entities, $options) {
@@ -474,7 +474,7 @@ class BelongsToMany extends Association {
 /**
  * Creates links between the source entity and each of the passed target entities
  *
- * @param \Cake\ORM\EntityInterface $sourceEntity the entity from source table in this
+ * @param \Cake\Datasource\EntityInterface $sourceEntity the entity from source table in this
  * association
  * @param array $targetEntities list of entities to link to link to the source entity using the
  * junction table
@@ -538,7 +538,7 @@ class BelongsToMany extends Association {
  *
  * `$article->get('tags')` will contain all tags in `$newTags` after liking
  *
- * @param \Cake\ORM\EntityInterface $sourceEntity the row belonging to the `source` side
+ * @param \Cake\Datasource\EntityInterface $sourceEntity the row belonging to the `source` side
  * of this association
  * @param array $targetEntities list of entities belonging to the `target` side
  * of this association
@@ -579,7 +579,7 @@ class BelongsToMany extends Association {
  *
  * `$article->get('tags')` will contain only `[$tag4]` after deleting in the database
  *
- * @param \Cake\ORM\EntityInterface $sourceEntity an entity persisted in the source table for
+ * @param \Cake\Datasource\EntityInterface $sourceEntity an entity persisted in the source table for
  * this association
  * @param array $targetEntities list of entities persisted in the target table for
  * this association
@@ -662,7 +662,7 @@ class BelongsToMany extends Association {
  *
  * `$article->get('tags')` will contain only `[$tag1, $tag3]` at the end
  *
- * @param \Cake\ORM\EntityInterface $sourceEntity an entity persisted in the source table for
+ * @param \Cake\Datasource\EntityInterface $sourceEntity an entity persisted in the source table for
  * this association
  * @param array $targetEntities list of entities from the target table to be linked
  * @param array $options list of options to be passed to `save` persisting or
@@ -805,7 +805,7 @@ class BelongsToMany extends Association {
  * Returns the list of joint entities that exist between the source entity
  * and each of the passed target entities
  *
- * @param \Cake\ORM\EntityInterface $sourceEntity The row belonging to the source side
+ * @param \Cake\Datasource\EntityInterface $sourceEntity The row belonging to the source side
  *   of this association.
  * @param array $targetEntities The rows belonging to the target side of this
  *   association.

--- a/src/ORM/Association/DependentDeleteTrait.php
+++ b/src/ORM/Association/DependentDeleteTrait.php
@@ -28,7 +28,7 @@ trait DependentDeleteTrait {
  *
  * This method does nothing if the association is not dependent.
  *
- * @param \Cake\ORM\EntityInterface $entity The entity that started the cascaded delete.
+ * @param \Cake\Datasource\EntityInterface $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return bool Success.
  */

--- a/src/ORM/Association/DependentDeleteTrait.php
+++ b/src/ORM/Association/DependentDeleteTrait.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\ORM\Association;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 
 /**
  * Implements cascading deletes for dependent associations.
@@ -28,11 +28,11 @@ trait DependentDeleteTrait {
  *
  * This method does nothing if the association is not dependent.
  *
- * @param \Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param \Cake\ORM\EntityInterface $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return bool Success.
  */
-	public function cascadeDelete(Entity $entity, array $options = []) {
+	public function cascadeDelete(EntityInterface $entity, array $options = []) {
 		if (!$this->dependent()) {
 			return true;
 		}

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -18,7 +18,7 @@ namespace Cake\ORM\Association;
 use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Association\ExternalAssociationTrait;
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 
 /**
@@ -64,15 +64,15 @@ class HasMany extends Association {
  * saved on the target table for this association by passing supplied
  * `$options`
  *
- * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param \Cake\ORM\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
- * @return bool|Entity false if $entity could not be saved, otherwise it returns
+ * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  * @throws \InvalidArgumentException when the association data cannot be traversed.
  */
-	public function saveAssociated(Entity $entity, array $options = []) {
+	public function saveAssociated(EntityInterface $entity, array $options = []) {
 		$targetEntities = $entity->get($this->property());
 		if (empty($targetEntities)) {
 			return $entity;
@@ -92,7 +92,7 @@ class HasMany extends Association {
 		$original = $targetEntities;
 
 		foreach ($targetEntities as $k => $targetEntity) {
-			if (!($targetEntity instanceof Entity)) {
+			if (!($targetEntity instanceof EntityInterface)) {
 				break;
 			}
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -15,10 +15,10 @@
  */
 namespace Cake\ORM\Association;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Association\ExternalAssociationTrait;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 
 /**
@@ -64,10 +64,10 @@ class HasMany extends Association {
  * saved on the target table for this association by passing supplied
  * `$options`
  *
- * @param \Cake\ORM\EntityInterface $entity an entity from the source table
+ * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
- * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
+ * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  * @throws \InvalidArgumentException when the association data cannot be traversed.

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\ORM\Association;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Association\SelectableAssociationTrait;
-use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 
@@ -95,16 +95,16 @@ class HasOne extends Association {
  * saved on the target table for this association by passing supplied
  * `$options`
  *
- * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param \Cake\ORM\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
- * @return bool|Entity false if $entity could not be saved, otherwise it returns
+ * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  */
-	public function saveAssociated(Entity $entity, array $options = []) {
+	public function saveAssociated(EntityInterface $entity, array $options = []) {
 		$targetEntity = $entity->get($this->property());
-		if (empty($targetEntity) || !($targetEntity instanceof Entity)) {
+		if (empty($targetEntity) || !($targetEntity instanceof EntityInterface)) {
 			return $entity;
 		}
 

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -95,10 +95,10 @@ class HasOne extends Association {
  * saved on the target table for this association by passing supplied
  * `$options`
  *
- * @param \Cake\ORM\EntityInterface $entity an entity from the source table
+ * @param \Cake\Datasource\EntityInterface $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in
  * the target table
- * @return bool|EntityInterface false if $entity could not be saved, otherwise it returns
+ * @return bool|\Cake\Datasource\EntityInterface false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
  */

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -314,9 +314,8 @@ class TimeHelper extends Helper {
 	}
 
 /**
- * Returns a formatted date string, given either a UNIX timestamp or a valid strtotime() date string.
- *
- * This method takes into account the default date format for the current language if an LC_TIME file is used.
+ * Returns a formatted date string, given either a Datetime instance,
+ * UNIX timestamp or a valid strtotime() date string.
  *
  * @param int|string|\DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $format Intl compatible format string.

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2801,6 +2801,25 @@ class TableTest extends TestCase {
 	}
 
 /**
+ * Test that belongsToMany can be saved with _joinData data.
+ *
+ * @return void
+ */
+	public function testSaveBelongsToManyJoinData() {
+		$articles = TableRegistry::get('Articles');
+		$article = $articles->get(1, ['contain' => ['Tags']]);
+		$data = [
+			'tags' => [
+				['id' => 1, '_joinData' => ['highlighted' => 1]],
+				['id' => 3]
+			]
+		];
+		$article = $articles->patchEntity($article, $data);
+		$result = $articles->save($article);
+		$this->assertSame($result, $article);
+	}
+
+/**
  * Tests saving belongsToMany records can delete all links.
  *
  * @group save


### PR DESCRIPTION
Fix fatal errors caused by un marshalled _joinData properties. The BelongsToMany association was assuming that this property would always contain an entity, which it doesn't.

I have also updated the associations to typehint against the interface instead of the concrete type.

Refs #5130
