### PR TITLE
Cleanup of isUnique

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3315,9 +3315,10 @@ class Model extends Object implements CakeEventListener {
 		}
 		if (!is_array($fields)) {
 			$fields = func_get_args();
-			if (is_bool($fields[count($fields) - 1])) {
-				$or = $fields[count($fields) - 1];
-				unset($fields[count($fields) - 1]);
+			$fieldCount = count($fields) - 1;
+			if (is_bool($fields[$fieldCount])) {
+				$or = $fields[$fieldCount];
+				unset($fields[$fieldCount]);
 			}
 		}
 


### PR DESCRIPTION
isUnique takes the count of the args multiple times.  Store the count in a variable to cut down on overhead.
