### PR TITLE
3.0 - Fixing issue where TranslateBehavior always expects a record

### DIFF
--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -331,9 +331,11 @@ class TranslateBehavior extends Behavior {
 				unset($row[$name]);
 			}
 
-			$row['_locale'] = $locale;
-			if ($hydrated) {
-				$row->clean();
+			if (!is_null($row)) {
+				$row['_locale'] = $locale;
+				if ($hydrated) {
+					$row->clean();
+				}
 			}
 
 			return $row;

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -311,6 +311,9 @@ class TranslateBehavior extends Behavior {
  */
 	protected function _rowMapper($results, $locale) {
 		return $results->map(function ($row) use ($locale) {
+			if ($row === null) {
+				return $row;	
+			}
 			$hydrated = !is_array($row);
 
 			foreach ($this->_config['fields'] as $field) {
@@ -331,11 +334,9 @@ class TranslateBehavior extends Behavior {
 				unset($row[$name]);
 			}
 
-			if ($row !== null) {
-				$row['_locale'] = $locale;
-				if ($hydrated) {
-					$row->clean();
-				}
+			$row['_locale'] = $locale;
+			if ($hydrated) {
+				$row->clean();
 			}
 
 			return $row;

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -331,7 +331,7 @@ class TranslateBehavior extends Behavior {
 				unset($row[$name]);
 			}
 
-			if (!is_null($row)) {
+			if ($row !== null) {
 				$row['_locale'] = $locale;
 				if ($hydrated) {
 					$row->clean();


### PR DESCRIPTION
If a main table associates to a table that uses TranslateBehavior, and the record in that associated table doesn't come back from the DB, the behavior should check for that before trying to post-process on the record.
