### PR TITLE
Fix SQLite result sets failing with nested queries or unions

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -306,7 +306,7 @@ class Sqlite extends DboSource {
 			foreach (String::tokenize($selectpart, ',', '(', ')') as $part) {
 				$fromPos = stripos($part, ' FROM ');
 				if ($fromPos !== false) {
-					$selects[] = trim(substr($part, 0, $fromPos)); 
+					$selects[] = trim(substr($part, 0, $fromPos));
 					break;
 				}
 				$selects[] = $part;

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -302,9 +302,15 @@ class Sqlite extends DboSource {
 		$querystring = $results->queryString;
 		if (stripos($querystring, 'SELECT') === 0 && stripos($querystring, 'FROM') > 0) {
 			$selectpart = substr($querystring, 7);
-			$selects = String::tokenize($selectpart, ',', '(', ')');
-			$last = count($selects) - 1;
-			$selects[$last] = trim(substr($selects[$last], 0, stripos($selects[$last], 'FROM')));
+			$selects = array();
+			foreach (String::tokenize($selectpart, ',', '(', ')') as $part) {
+				$fromPos = stripos($part, ' FROM ');
+				if ($fromPos !== false) {
+					$selects[] = trim(substr($part, 0, $fromPos)); 
+					break;
+				}
+				$selects[] = $part;
+			}
 		} elseif (strpos($querystring, 'PRAGMA table_info') === 0) {
 			$selects = array('cid', 'name', 'type', 'notnull', 'dflt_value', 'pk');
 		} elseif (strpos($querystring, 'PRAGMA index_list') === 0) {

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -300,12 +300,11 @@ class Sqlite extends DboSource {
 		// PDO::getColumnMeta is experimental and does not work with sqlite3,
 		// so try to figure it out based on the querystring
 		$querystring = $results->queryString;
-		if (stripos($querystring, 'SELECT') === 0) {
-			$last = strripos($querystring, 'FROM');
-			if ($last !== false) {
-				$selectpart = substr($querystring, 7, $last - 8);
-				$selects = String::tokenize($selectpart, ',', '(', ')');
-			}
+		if (stripos($querystring, 'SELECT') === 0 && stripos($querystring, 'FROM') > 0) {
+			$selectpart = substr($querystring, 7);
+			$selects = String::tokenize($selectpart, ',', '(', ')');
+			$last = count($selects) - 1;
+			$selects[$last] = trim(substr($selects[$last], 0, stripos($selects[$last], 'FROM')));
 		} elseif (strpos($querystring, 'PRAGMA table_info') === 0) {
 			$selects = array('cid', 'name', 'type', 'notnull', 'dflt_value', 'pk');
 		} elseif (strpos($querystring, 'PRAGMA index_list') === 0) {

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -518,4 +518,28 @@ class SqliteTest extends CakeTestCase {
 		$this->assertNotContains($scientificNotation, $result);
 	}
 
+/**
+ * Test that fields are parsed out in a reasonable fashion.
+ *
+ * @return void
+ */
+	public function testFetchRowColumnParsing() {
+		$this->loadFixtures('User');
+		$sql = 'SELECT "User"."id", "User"."user", "User"."password", "User"."created", (1 + 1) AS "two" ' .
+			'FROM "users" AS "User" WHERE ' .
+			'"User"."id" IN (SELECT MAX("id") FROM "users")';
+		$result = $this->Dbo->fetchRow($sql);
+
+		$this->assertArrayHasKey('User', $result);
+		$this->assertArrayHasKey('0', $result);
+		$this->assertCount(2, $result, 'Too many top level keys');
+		$this->assertCount(4, $result['User'], 'Too many keys');
+		$this->assertCount(1, $result['0'], 'Too many keys');
+		$this->assertArrayHasKey('id', $result['User']);
+		$this->assertArrayHasKey('user', $result['User']);
+		$this->assertArrayHasKey('password', $result['User']);
+		$this->assertArrayHasKey('created', $result['User']);
+		$this->assertArrayHasKey('two', $result['0']);
+	}
+
 }

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -527,19 +527,37 @@ class SqliteTest extends CakeTestCase {
 		$this->loadFixtures('User');
 		$sql = 'SELECT "User"."id", "User"."user", "User"."password", "User"."created", (1 + 1) AS "two" ' .
 			'FROM "users" AS "User" WHERE ' .
-			'"User"."id" IN (SELECT MAX("id") FROM "users")';
+			'"User"."id" IN (SELECT MAX("id") FROM "users") ' .
+			'OR "User.id" IN (5, 6, 7, 8)';
 		$result = $this->Dbo->fetchRow($sql);
 
-		$this->assertArrayHasKey('User', $result);
-		$this->assertArrayHasKey('0', $result);
-		$this->assertCount(2, $result, 'Too many top level keys');
-		$this->assertCount(4, $result['User'], 'Too many keys');
-		$this->assertCount(1, $result['0'], 'Too many keys');
-		$this->assertArrayHasKey('id', $result['User']);
-		$this->assertArrayHasKey('user', $result['User']);
-		$this->assertArrayHasKey('password', $result['User']);
-		$this->assertArrayHasKey('created', $result['User']);
-		$this->assertArrayHasKey('two', $result['0']);
+		$expected = array(
+			'User' => array(
+				'id' => 4,
+				'user' => 'garrett',
+				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+				'created' => '2007-03-17 01:22:23'
+			),
+			0 => array(
+				'two' => 2
+			)
+		);
+		$this->assertEquals($expected, $result);
+
+		$sql = 'SELECT "User"."id", "User"."user" ' .
+			'FROM "users" AS "User" WHERE "User"."id" = 4 ' .
+			'UNION ' .
+			'SELECT "User"."id", "User"."user" ' .
+			'FROM "users" AS "User" WHERE "User"."id" = 3';
+		$result = $this->Dbo->fetchRow($sql);
+
+		$expected = array(
+			'User' => array(
+				'id' => 3,
+				'user' => 'larry',
+			),
+		);
+		$this->assertEquals($expected, $result);
 	}
 
 }


### PR DESCRIPTION
I think this fixes the issues described in #3972. By 'parsing' the entire query string and iterating it we can find the first `FROM` clause more deterministically.
