### PR TITLE
3.0: Rename validatePresence to requirePresence.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1020,7 +1020,7 @@ class Table implements RepositoryInterface, EventListenerInterface {
  *	return $validator
  *	->add('email', 'valid-email', ['rule' => 'email'])
  *	->add('password', 'valid', ['rule' => 'notEmpty'])
- *	->validatePresence('username');
+ *	->requirePresence('username');
  * }
  * }}}
  *

--- a/src/Template/Bake/default/classes/table.ctp
+++ b/src/Template/Bake/default/classes/table.ctp
@@ -115,7 +115,7 @@ foreach ($validation as $field => $rules):
 				);
 			else:
 				$validationMethods[] = sprintf(
-					"->validatePresence('%s', 'create')",
+					"->requirePresence('%s', 'create')",
 					$field
 				);
 				$validationMethods[] = sprintf(

--- a/src/Validation/README.md
+++ b/src/Validation/README.md
@@ -13,14 +13,14 @@ use Cake\Validation\Validator;
 
 $validator = new Validator();
 $validator
-    ->validatePresence('email')
+    ->requirePresence('email')
     ->add('email', 'validFormat', [
         'rule' => 'email',
         'message' => 'E-mail must be valid'
     ])
-    ->validatePresence('name')
+    ->requirePresence('name')
     ->notEmpty('name', 'We need your name.')
-    ->validatePresence('comment')
+    ->requirePresence('comment')
     ->notEmpty('comment', 'You need to give a comment.');
 
 $errors = $validator->errors($_POST);

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -319,8 +319,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  *
  * @param string $field the name of the field
  * @param bool|string $mode Valid values are true, false, 'create', 'update'
- * @param string $message The validation message to show if the field presence
- * is required.
+ * @param string $message The message to show if the field presence validation fails.
  * @return Validator this instance
  */
 	public function requirePresence($field, $mode = true, $message = null) {
@@ -338,8 +337,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  *
  * @param string $field the name of the field
  * @param bool|string $mode Valid values are true, false, 'create', 'update'
- * @param string $message The validation message to show if the field presence
- * is required.
+ * @param string $message The message to show if the field presence validation fails.
  * @return Validator this instance
  * @deprecated 3.0.0 Will be removed in 3.0.0.
  */

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -323,12 +323,28 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  * is required.
  * @return Validator this instance
  */
-	public function validatePresence($field, $mode = true, $message = null) {
+	public function requirePresence($field, $mode = true, $message = null) {
 		$this->field($field)->isPresenceRequired($mode);
 		if ($message) {
 			$this->_presenceMessages[$field] = $message;
 		}
 		return $this;
+	}
+
+/**
+ * Sets whether a field is required to be present in data array.
+ *
+ * Alias for requirePresence().
+ *
+ * @param string $field the name of the field
+ * @param bool|string $mode Valid values are true, false, 'create', 'update'
+ * @param string $message The validation message to show if the field presence
+ * is required.
+ * @return Validator this instance
+ * @deprecated 3.0.0 Will be removed in 3.0.0.
+ */
+	public function validatePresence($field, $mode = true, $message = null) {
+		return $this->requirePresence($field, $mode, $message);
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2066,7 +2066,7 @@ class TableTest extends TestCase {
 			'username' => 'superuser'
 		]);
 		$table = TableRegistry::get('users');
-		$table->validator()->validatePresence('password');
+		$table->validator()->requirePresence('password');
 		$this->assertFalse($table->save($entity));
 		$this->assertNotEmpty($entity->errors('password'));
 		$this->assertSame($entity, $table->validator()->provider('entity'));
@@ -2083,7 +2083,7 @@ class TableTest extends TestCase {
 			'username' => 'superuser'
 		]);
 		$table = TableRegistry::get('users');
-		$table->validator()->validatePresence('password');
+		$table->validator()->requirePresence('password');
 		$this->assertFalse($table->save($entity));
 		$this->assertNotEmpty($entity->errors('password'));
 	}
@@ -2098,7 +2098,7 @@ class TableTest extends TestCase {
 			'username' => 'superuser'
 		]);
 		$table = TableRegistry::get('users');
-		$validator = (new Validator)->validatePresence('password');
+		$validator = (new Validator)->requirePresence('password');
 		$table->validator('custom', $validator);
 		$this->assertFalse($table->save($entity, ['validate' => 'custom']));
 		$this->assertNotEmpty($entity->errors('password'));
@@ -2117,7 +2117,7 @@ class TableTest extends TestCase {
 			'password' => 'hey'
 		]);
 		$table = TableRegistry::get('users');
-		$table->validator()->validatePresence('password');
+		$table->validator()->requirePresence('password');
 		$this->assertSame($entity, $table->save($entity));
 		$this->assertEmpty($entity->errors('password'));
 	}
@@ -2136,7 +2136,7 @@ class TableTest extends TestCase {
 			$this->assertSame($entity, $en);
 			$this->assertTrue($opt['crazy']);
 			$this->assertSame($ev->subject()->validator('default'), $val);
-			$val->validatePresence('password');
+			$val->requirePresence('password');
 		}, 'Model.beforeValidate');
 		$this->assertFalse($table->save($entity, ['crazy' => true]));
 		$this->assertNotEmpty($entity->errors('password'));
@@ -2171,7 +2171,7 @@ class TableTest extends TestCase {
 			'password' => 'hey'
 		]);
 		$table = TableRegistry::get('users');
-		$table->validator()->validatePresence('password');
+		$table->validator()->requirePresence('password');
 		$table->eventManager()->attach(function ($ev, $en, $opt, $val) use ($entity) {
 			$this->assertSame($entity, $en);
 			$this->assertTrue($opt['crazy']);
@@ -2207,10 +2207,10 @@ class TableTest extends TestCase {
 		$table = TableRegistry::get('articles');
 		$table->belongsTo('authors');
 		$table->hasMany('ArticlesTags');
-		$validator = (new Validator)->validatePresence('body');
+		$validator = (new Validator)->requirePresence('body');
 		$table->validator('custom', $validator);
 
-		$validator2 = (new Validator)->validatePresence('thing');
+		$validator2 = (new Validator)->requirePresence('thing');
 		$table->authors->validator('default', $validator2);
 		$this->assertFalse($table->save($entity, ['validate' => 'custom']), 'default was not used');
 		$this->assertNotEmpty($entity->author->errors('thing'));
@@ -2242,13 +2242,13 @@ class TableTest extends TestCase {
 		$table->belongsTo('Authors');
 		$table->hasMany('Comments');
 
-		$validator = (new Validator)->validatePresence('body');
+		$validator = (new Validator)->requirePresence('body');
 		$table->validator('default', $validator);
 
-		$authorValidate = (new Validator)->validatePresence('bio');
+		$authorValidate = (new Validator)->requirePresence('bio');
 		$table->Authors->validator('default', $authorValidate);
 
-		$commentValidate = (new Validator)->validatePresence('author');
+		$commentValidate = (new Validator)->requirePresence('author');
 		$table->Comments->validator('default', $commentValidate);
 
 		$result = $table->save($entity);

--- a/tests/TestCase/Shell/Task/ModelTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModelTaskTest.php
@@ -794,7 +794,7 @@ class ModelTaskTest extends TestCase {
 			$result);
 		$this->assertContains("->allowEmpty('id', 'create')", $result);
 		$this->assertContains("->allowEmpty('email')", $result);
-		$this->assertContains("->validatePresence('name', 'create')", $result);
+		$this->assertContains("->requirePresence('name', 'create')", $result);
 	}
 
 /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -94,22 +94,22 @@ class ValidatorTest extends TestCase {
 	}
 
 /**
- * Tests the validatePresence method
+ * Tests the requirePresence method
  *
  * @return void
  */
-	public function testValidatePresence() {
+	public function testRequirePresence() {
 		$validator = new Validator;
-		$this->assertSame($validator, $validator->validatePresence('title'));
+		$this->assertSame($validator, $validator->requirePresence('title'));
 		$this->assertTrue($validator->field('title')->isPresenceRequired());
 
-		$validator->validatePresence('title', false);
+		$validator->requirePresence('title', false);
 		$this->assertFalse($validator->field('title')->isPresenceRequired());
 
-		$validator->validatePresence('title', 'create');
+		$validator->requirePresence('title', 'create');
 		$this->assertEquals('create', $validator->field('title')->isPresenceRequired());
 
-		$validator->validatePresence('title', 'update');
+		$validator->requirePresence('title', 'update');
 		$this->assertEquals('update', $validator->field('title')->isPresenceRequired());
 	}
 
@@ -120,19 +120,19 @@ class ValidatorTest extends TestCase {
  */
 	public function testIsPresenceRequired() {
 		$validator = new Validator;
-		$this->assertSame($validator, $validator->validatePresence('title'));
+		$this->assertSame($validator, $validator->requirePresence('title'));
 		$this->assertTrue($validator->isPresenceRequired('title', true));
 		$this->assertTrue($validator->isPresenceRequired('title', false));
 
-		$validator->validatePresence('title', false);
+		$validator->requirePresence('title', false);
 		$this->assertFalse($validator->isPresenceRequired('title', true));
 		$this->assertFalse($validator->isPresenceRequired('title', false));
 
-		$validator->validatePresence('title', 'create');
+		$validator->requirePresence('title', 'create');
 		$this->assertTrue($validator->isPresenceRequired('title', true));
 		$this->assertFalse($validator->isPresenceRequired('title', false));
 
-		$validator->validatePresence('title', 'update');
+		$validator->requirePresence('title', 'update');
 		$this->assertTrue($validator->isPresenceRequired('title', false));
 		$this->assertFalse($validator->isPresenceRequired('title', true));
 	}
@@ -144,14 +144,14 @@ class ValidatorTest extends TestCase {
  */
 	public function testErrorsWithPresenceRequired() {
 		$validator = new Validator;
-		$validator->validatePresence('title');
+		$validator->requirePresence('title');
 		$errors = $validator->errors(['foo' => 'something']);
 		$expected = ['title' => ['This field is required']];
 		$this->assertEquals($expected, $errors);
 
 		$this->assertEmpty($validator->errors(['title' => 'bar']));
 
-		$validator->validatePresence('title', false);
+		$validator->requirePresence('title', false);
 		$this->assertEmpty($validator->errors(['foo' => 'bar']));
 	}
 
@@ -162,7 +162,7 @@ class ValidatorTest extends TestCase {
  */
 	public function testCustomErrorsWithPresenceRequired() {
 		$validator = new Validator;
-		$validator->validatePresence('title', true, 'Custom message');
+		$validator->requirePresence('title', true, 'Custom message');
 		$errors = $validator->errors(['foo' => 'something']);
 		$expected = ['title' => ['Custom message']];
 		$this->assertEquals($expected, $errors);


### PR DESCRIPTION
The name of this method should be what it does, requiring the presence.
Everything is _validation_ here (even other rules), but the requiring (or not) is the specific task of this method.

It fits better to the other methods like `Validator::isPresenceRequired()`, as well.
It is also closer to the former way of saying `require => true/false`.

The former method name stays as alias for BC reasons during upgrades until 3.0 stable.
