### PR TITLE
3.0 restore appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 build: false
-shallow_clone: true
+shallow_clone: false
 platform: 'x86'
 clone_folder: c:\projects\cakephp
 branches:

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -181,12 +181,12 @@ class Debugger {
  * as well as export the variable using exportVar. By default the log is written to the debug log.
  *
  * @param mixed $var Variable or content to log
- * @param int $level type of log to use. Defaults to LOG_DEBUG
+ * @param int|string $level type of log to use. Defaults to 'debug'
  * @param int $depth The depth to output to. Defaults to 3.
  * @return void
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#Debugger::log
  */
-	public static function log($var, $level = LOG_DEBUG, $depth = 3) {
+	public static function log($var, $level = 'debug', $depth = 3) {
 		$source = static::trace(array('start' => 1)) . "\n";
 		Log::write($level, "\n" . $source . static::exportVar($var, $depth));
 	}

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1273,7 +1273,7 @@ class Email {
 			return;
 		}
 		$config = [
-			'level' => LOG_DEBUG,
+			'level' => 'debug',
 			'scope' => 'email'
 		];
 		if ($this->_profile['log'] !== true) {

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -492,7 +492,7 @@ TEXT;
 		$val = array(
 			'test' => array('key' => 'val')
 		);
-		Debugger::log($val, LOG_DEBUG, 0);
+		Debugger::log($val, 'debug', 0);
 	}
 
 /**

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -250,12 +250,12 @@ class LogTest extends TestCase {
 		));
 
 		$testMessage = 'selective logging';
-		Log::write(LOG_WARNING, $testMessage);
+		Log::write('warning', $testMessage);
 
 		$this->assertFileExists(LOGS . 'eggs.log');
 		$this->assertFileNotExists(LOGS . 'spam.log');
 
-		Log::write(LOG_DEBUG, $testMessage);
+		Log::write('debug', $testMessage);
 		$this->assertFileExists(LOGS . 'spam.log');
 
 		$contents = file_get_contents(LOGS . 'spam.log');


### PR DESCRIPTION
Appveyor built was broken after #5120 .
This PR restore a working behavior by disabling `shallow_clone`. (thank's @lorenzo )

Also fixes some failing tests after #5141 for windows.
