### PR TITLE
3.0 table get finder

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -929,7 +929,7 @@ class Table implements RepositoryInterface, EventListenerInterface {
 		$cacheConfig = isset($options['cache']) ? $options['cache'] : false;
 		$cacheKey = isset($options['key']) ? $options['key'] : false;
 		$finder = isset($options['finder']) ? $options['finder'] : 'all';
-		unset($options['key'], $options['cache']);
+		unset($options['cache'], $options['key'], $options['finder']);
 
 		$query = $this->find($finder, $options)->where($conditions);
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -928,9 +928,10 @@ class Table implements RepositoryInterface, EventListenerInterface {
 
 		$cacheConfig = isset($options['cache']) ? $options['cache'] : false;
 		$cacheKey = isset($options['key']) ? $options['key'] : false;
+		$finder = isset($options['finder']) ? $options['finder'] : 'all';
 		unset($options['key'], $options['cache']);
 
-		$query = $this->find('all', $options)->where($conditions);
+		$query = $this->find($finder, $options)->where($conditions);
 
 		if ($cacheConfig) {
 			if (!$cacheKey) {


### PR DESCRIPTION
This would allow custom finders in calls to Table::get. I like the simplicity of `get` but I can't use it a lot right now since I need to it know if a record _should_ be returned, not just if it exists or not.

```
$post = $this->Posts->get($id, ['finder' => 'published']);
```
