### PR TITLE
Fix issues where doubly prefixed would fail

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -256,7 +256,11 @@ class Controller implements EventListenerInterface {
 		if (!$this->viewPath) {
 			$viewPath = $this->name;
 			if (isset($request->params['prefix'])) {
-				$viewPath = Inflector::camelize($request->params['prefix']) . DS . $viewPath;
+				$prefixes = array_map(
+					'Cake\Utility\Inflector::camelize',
+					explode('/', $request->params['prefix'])
+				);
+				$viewPath = implode('/', $prefixes) . DS . $viewPath;
 			}
 			$this->viewPath = $viewPath;
 		}

--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -65,7 +65,11 @@ class ControllerFactoryFilter extends DispatcherFilter {
 			$controller = $request->params['controller'];
 		}
 		if (!empty($request->params['prefix'])) {
-			$namespace .= '/' . Inflector::camelize($request->params['prefix']);
+			$prefixes = array_map(
+				'Cake\Utility\Inflector::camelize',
+				explode('/', $request->params['prefix'])
+			);
+			$namespace .= '/' . implode('/', $prefixes);
 		}
 		$className = false;
 		if ($pluginPath . $controller) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -906,9 +906,13 @@ class View {
 
 		$layoutPaths = ['Layout' . DS . $subDir];
 		if (!empty($this->request->params['prefix'])) {
+			$prefixPath = array_map(
+				'Cake\Utility\Inflector::camelize',
+				explode('/', $this->request->params['prefix'])
+			);
 			array_unshift(
 				$layoutPaths,
-				Inflector::camelize($this->request->params['prefix']) . DS . $layoutPaths[0]
+				implode('/', $prefixPath) . DS . $layoutPaths[0]
 			);
 		}
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -812,6 +812,13 @@ class ControllerTest extends TestCase {
 		$Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
 		$this->assertEquals('Admin' . DS . 'Posts', $Controller->viewPath);
 
+		$request->addParams(array(
+			'prefix' => 'admin/super'
+		));
+		$response = $this->getMock('Cake\Network\Response');
+		$Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
+		$this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewPath);
+
 		$request = new Request('pages/home');
 		$Controller = new \TestApp\Controller\PagesController($request, $response);
 		$this->assertEquals('Pages', $Controller->viewPath);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -804,7 +804,6 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testUrlGenerationWithPrefix() {
-		Configure::write('Routing.prefixes', array('admin'));
 		Router::reload();
 
 		Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
@@ -993,6 +992,26 @@ class RouterTest extends TestCase {
 		});
 		$result = Router::url(['prefix' => 'admin', 'plugin' => 'MyPlugin', 'controller' => 'Forms', 'action' => 'edit', 2]);
 		$expected = '/admin/my_plugin/forms/edit/2';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Test URL generation with multiple prefixes.
+ *
+ * @return void
+ */
+	public function testUrlGenerationMultiplePrefixes() {
+		Router::prefix('admin', function ($routes) {
+			$routes->prefix('backoffice', function ($routes) {
+				$routes->fallbacks();
+			});
+		});
+		$result = Router::url([
+			'prefix' => 'admin/backoffice',
+			'controller' => 'Dashboards',
+			'action' => 'home'
+		]);
+		$expected = '/admin/backoffice/dashboards/home';
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -635,9 +635,20 @@ class ViewTest extends TestCase {
 		$View = new TestView();
 
 		// Prefix specific layout
-		$View->request->params['prefix'] = 'FooPrefix';
+		$View->request->params['prefix'] = 'foo_prefix';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
 			'FooPrefix' . DS . 'Layout' . DS . 'default.ctp';
+		$result = $View->getLayoutFileName();
+		$this->assertPathEquals($expected, $result);
+
+		$View->request->params['prefix'] = 'FooPrefix';
+		$result = $View->getLayoutFileName();
+		$this->assertPathEquals($expected, $result);
+
+		// Nested prefix layout
+		$View->request->params['prefix'] = 'foo_prefix/bar_prefix';
+		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
+			'FooPrefix' . DS . 'BarPrefix' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
 		$this->assertPathEquals($expected, $result);
 


### PR DESCRIPTION
On case-sensitive file systems doubly prefixed paths would fail as the generated path would be `Browse\assets` instead of `Browse\Assets`.

Refs #5166
