### PR TITLE
Enable sslmode for PostgreSQL connections

### DIFF
--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -50,6 +50,10 @@
  * For MySQL, Postgres specifies the character encoding to use when connecting to the
  * database. Uses database default not specified.
  *
+ * sslmode =>
+ * For Postgres specifies whether to 'disable', 'allow', 'prefer', or 'require' SSL for the 
+ * connection. The default value is 'allow'.
+ *
  * unix_socket =>
  * For MySQL to connect via socket specify the `unix_socket` parameter instead of `host` and `port`
  *

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -46,6 +46,7 @@ class Postgres extends DboSource {
 		'schema' => 'public',
 		'port' => 5432,
 		'encoding' => '',
+		'sslmode' => 'allow',
 		'flags' => array()
 	);
 
@@ -118,7 +119,7 @@ class Postgres extends DboSource {
 
 		try {
 			$this->_connection = new PDO(
-				"pgsql:host={$config['host']};port={$config['port']};dbname={$config['database']}",
+				"pgsql:host={$config['host']};port={$config['port']};dbname={$config['database']};sslmode={$config['sslmode']}",
 				$config['login'],
 				$config['password'],
 				$flags


### PR DESCRIPTION
By default, PHP 5.5 and PostgreSQL PDO will not allow SSL connections. This adds the default of "allow", but also the user may override the setting to "require" or any of the other potential values. 

See: http://php.net/manual/en/function.pg-connect.php
