### PR TITLE
Don't hardcode paths when baking a plugin

### DIFF
--- a/src/Template/Bake/tests/bootstrap.ctp
+++ b/src/Template/Bake/tests/bootstrap.ctp
@@ -2,10 +2,6 @@
 /**
  * Tests bootstrap file
  *
- * Allow a plugin to run its own tests whether CakePHP is installed directly
- * as a vendor for the plugin, or if the plugin has itself been installed as
- * a dependency for an application
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -22,6 +18,10 @@
 <?php
 /**
  * Test suite bootstrap for <%= $plugin %>.
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
  */
 $findRoot = function($root) {
 	do {

--- a/src/Template/Bake/tests/bootstrap.ctp
+++ b/src/Template/Bake/tests/bootstrap.ctp
@@ -23,7 +23,7 @@
 /**
  * Test suite bootstrap for <%= $plugin %>.
  */
-function find_root($root) {
+$findRoot = function($root) {
 	do {
 		$lastRoot = $root;
 		$root = dirname($root);
@@ -33,9 +33,9 @@ function find_root($root) {
 	} while($root !== $lastRoot);
 
 	throw new Exception("Cannot find the root of the application, unable to run tests");
-}
-
-$root = find_root(__FILE__);
+};
+$root = $findRoot(__FILE__);
+unset($findRoot);
 
 chdir($root);
 require $root . '/config/bootstrap.php';

--- a/src/Template/Bake/tests/bootstrap.ctp
+++ b/src/Template/Bake/tests/bootstrap.ctp
@@ -1,7 +1,41 @@
+<%
+/**
+ * Tests bootstrap file
+ *
+ * Allow a plugin to run its own tests whether CakePHP is installed directly
+ * as a vendor for the plugin, or if the plugin has itself been installed as
+ * a dependency for an application
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+%>
 <?php
 /**
  * Test suite bootstrap for <%= $plugin %>.
  */
-// Customize this to be a relative path for embedded plugins.
-// For standalone plugins, this should point at a CakePHP installation.
-require '<%= $root %>/config/bootstrap.php';
+function find_root($root) {
+	do {
+		$lastRoot = $root;
+		$root = dirname($root);
+		if (is_dir($root . '/vendor/cakephp/cakephp')) {
+			return $root;
+		}
+	} while($root !== $lastRoot);
+
+	throw new Exception("Cannot find the root of the application, unable to run tests");
+}
+
+$root = find_root(__FILE__);
+
+chdir($root);
+require $root . '/config/bootstrap.php';


### PR DESCRIPTION
Right now baking a plugin produces a bootstrap file like so:

```
<?php
/**
 * Test suite bootstrap for Example.
 */
// Customize this to be a relative path for embedded plugins.
// For standalone plugins, this should point at a CakePHP installation.
require '/var/www/cakephp.dev/config/bootstrap.php';
```

Having hardcoded paths makes things break/inflexible for distributed plugins.
## Examples

This always worked, and still does (because it doesn't use the plugin's test bootstrap file):

```
cd my/app
phpunit plugin/Example/tests
```

This currently only works on the machine that baked the plugin (or more accurately on any machine with the same dir structure as the machine that baked the plugin), and still does:

```
cd my/app/plugin/Example
phpunit
```

This one currently doesn't work, but will with this PR:

```
git clone <some-plugin>
cd some-plugin
composer install
phpunit
```

The last example is possibly most interesting for travis use.

Though in addition to that I'm in the habit of downloading, composer install-ing, and phpunit-ing anything I'm considering using to see if it works - and it's disheartening that by default 3.0 plugins fail this smoke test.
