### PR TITLE
Unify templated tags.

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -72,7 +72,7 @@ class HtmlHelper extends Helper {
 			'parastart' => '<p{{attrs}}>',
 			'css' => '<link rel="{{rel}}" href="{{url}}"{{attrs}}/>',
 			'style' => '<style{{attrs}}>{{content}}</style>',
-			'charset' => '<meta http-equiv="Content-Type" content="text/html; charset={{charset}}" />',
+			'charset' => '<meta http-equiv="Content-Type" content="text/html; charset={{charset}}"/>',
 			'ul' => '<ul{{attrs}}>{{content}}</ul>',
 			'ol' => '<ol{{attrs}}>{{content}}</ol>',
 			'li' => '<li{{attrs}}>{{content}}</li>',

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1162,7 +1162,7 @@ class ViewTest extends TestCase {
 		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 		$result = $View->render('index');
 
-		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/>\s*<title>/", $result);
+		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\"\/>\s*<title>/", $result);
 		$this->assertRegExp("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
 		$this->assertRegExp("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
 
@@ -1180,7 +1180,7 @@ class ViewTest extends TestCase {
 		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 		$result = $View->render('index');
 
-		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/>\s*<title>/", $result);
+		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\"\/>\s*<title>/", $result);
 		$this->assertRegExp("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
 	}
 


### PR DESCRIPTION
We don't use a space at the end anymore for any other tag.
