### PR TITLE
Gracefully handle invalid chunks in HttpSocket

### DIFF
--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -15,7 +15,6 @@
  * @since         CakePHP(tm) v 1.2.0.4206
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 App::uses('HttpResponse', 'Network/Http');
 
 /**
@@ -453,12 +452,13 @@ class HttpResponseTest extends CakeTestCase {
 /**
  * testDecodeChunkedBodyError method
  *
- * @expectedException SocketException
  * @return void
  */
 	public function testDecodeChunkedBodyError() {
 		$encoded = "19\r\nThis is a chunked message\r\nE\r\n\nThat is cool\n\r\n";
-		$this->HttpResponse->decodeChunkedBody($encoded);
+		$result = $this->HttpResponse->decodeChunkedBody($encoded);
+		$expected = "This is a chunked message\nThat is cool\n";
+		$this->assertEquals($expected, $result['body']);
 	}
 
 /**


### PR DESCRIPTION
When invalid chunks are detected we should assume the server is incorrect and handle the remaining content as a single large chunk.

Refs #5140
