### PR TITLE
2.6 Fix html helper regression

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -900,6 +900,22 @@ class HtmlHelperTest extends CakeTestCase {
 	}
 
 /**
+ * Resource names must be treated differently for css() and script()
+ *
+ * @return void
+ */
+	public function testBufferedCssAndScriptWithIdenticalResourceName() {
+		$this->View->expects($this->at(0))
+			->method('append')
+			->with('css', $this->stringContains('test.min.css'));
+		$this->View->expects($this->at(1))
+			->method('append')
+			->with('script', $this->stringContains('test.min.js'));
+		$this->Html->css('test.min', array('inline' => false));
+		$this->Html->script('test.min', array('inline' => false));
+	}
+
+/**
  * test timestamp enforcement for script tags.
  *
  * @return void

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -449,11 +449,11 @@ class HtmlHelper extends AppHelper {
 			return;
 		}
 
-		if ($options['once'] && isset($this->_includedAssets[$path])) {
+		if ($options['once'] && isset($this->_includedAssets[__METHOD__][$path])) {
 			return '';
 		}
 		unset($options['once']);
-		$this->_includedAssets[$path] = true;
+		$this->_includedAssets[__METHOD__][$path] = true;
 
 		if (strpos($path, '//') !== false) {
 			$url = $path;
@@ -552,10 +552,10 @@ class HtmlHelper extends AppHelper {
 			}
 			return null;
 		}
-		if ($options['once'] && isset($this->_includedAssets[$url])) {
+		if ($options['once'] && isset($this->_includedAssets[__METHOD__][$url])) {
 			return null;
 		}
-		$this->_includedAssets[$url] = true;
+		$this->_includedAssets[__METHOD__][$url] = true;
 
 		if (strpos($url, '//') === false) {
 			$url = $this->assetUrl($url, $options + array('pathPrefix' => Configure::read('App.jsBaseUrl'), 'ext' => '.js'));


### PR DESCRIPTION
The following view code:

``` php
$this->Html->css('test.min', array('inline' => false));
$this->Html->script('test.min', array('inline' => false));
```

will not output the `test.min.js` `<script>` tag.

Fix suggested by @AD7six 
