### PR TITLE
Issue 5190 pt1

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -401,12 +401,12 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  * }}}
  *
  * It is possible to conditionally disallow emptiness on a field by passing a callback
- * as a second argument. The callback will receive the validation context array as
+ * as the third argument. The callback will receive the validation context array as
  * argument:
  *
  * {{{
- * $validator->notEmpty('email', function ($context) {
- *	return $context['newRecord'] && $context['data']['role'] !== 'admin';
+ * $validator->notEmpty('email', 'Email is required', function ($context) {
+ *   return $context['newRecord'] && $context['data']['role'] !== 'admin';
  * });
  * }}}
  *

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -268,7 +268,8 @@ class EntityContext implements ContextInterface {
 			$isLast = ($i === $last);
 
 			if (!$isLast && $next === null && $prop !== '_ids') {
-				return new Entity();
+				$table = $this->_getTable($path);
+				return $table->newEntity();
 			}
 
 			$isTraversable = (

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -29,6 +29,15 @@ use Cake\View\Form\EntityContext;
  * Test stub.
  */
 class Article extends Entity {
+
+/**
+ * Testing stub method.
+ *
+ * @return bool
+ */
+	public function isRequired() {
+		return true;
+	}
 }
 
 /**
@@ -648,6 +657,37 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test isRequired on associated entities with custom validators.
+ *
+ * Ensures that missing associations use the correct entity class
+ * so provider methods work correctly.
+ *
+ * @return void
+ */
+	public function testIsRequiredAssociatedCustomValidator() {
+		$this->_setupTables();
+		$users = TableRegistry::get('Users');
+		$articles = TableRegistry::get('Articles');
+
+		$validator = $articles->validator();
+		$validator->notEmpty('title', 'nope', function ($context) {
+			return $context['providers']['entity']->isRequired();
+		});
+		$articles->validator('default', $validator);
+
+		$row = new Entity([
+			'username' => 'mark'
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Users',
+			'validator' => 'default',
+		]);
+
+		$this->assertTrue($context->isRequired('articles.0.title'));
+	}
+
+/**
  * Test isRequired on associated entities.
  *
  * @return void
@@ -943,6 +983,7 @@ class EntityContextTest extends TestCase {
 		$articles = TableRegistry::get('Articles');
 		$articles->belongsTo('Users');
 		$articles->hasMany('Comments');
+		$articles->entityClass(__NAMESPACE__ . '\Article');
 
 		$comments = TableRegistry::get('Comments');
 		$users = TableRegistry::get('Users');

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -38,6 +38,7 @@ class Article extends Entity {
 	public function isRequired() {
 		return true;
 	}
+
 }
 
 /**


### PR DESCRIPTION
Fix an annoying issue where notEmpty() callbacks would cause fatal errors as the entity would be the incorrect type.

Refs #5190
