### PR TITLE
Fix controller mock

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -567,7 +567,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$options += TableRegistry::config($alias);
 
 		$mock = $this->getMock($options['className'], $methods, [$options]);
-		TableRegistry::set($alias, $mock);
+		TableRegistry::set($baseClass, $mock);
 		return $mock;
 	}
 

--- a/tests/TestCase/TestSuite/ControllerTestCaseTest.php
+++ b/tests/TestCase/TestSuite/ControllerTestCaseTest.php
@@ -108,6 +108,7 @@ class ControllerTestCaseTest extends TestCase {
 		));
 
 		$this->assertInstanceOf('TestApp\Model\Table\PostsTable', $Posts->Posts);
+		$this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $Posts->Posts);
 		$this->assertNull($Posts->Posts->deleteAll(array()));
 		$this->assertNull($Posts->Posts->find('all'));
 		$this->assertNull($Posts->RequestHandler->isXml());
@@ -180,9 +181,11 @@ class ControllerTestCaseTest extends TestCase {
 		));
 		$this->assertEquals('Tests', $Tests->name);
 		$this->assertInstanceOf('TestPlugin\Controller\Component\PluginsComponent', $Tests->Plugins);
+		$this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $Tests->Plugins);
 
 		$result = TableRegistry::get('TestPlugin.TestPluginComments');
 		$this->assertInstanceOf('TestPlugin\Model\Table\TestPluginCommentsTable', $result);
+		$this->assertInstanceOf('PHPUnit_Framework_MockObject_MockObject', $result);
 	}
 
 /**


### PR DESCRIPTION
Cake\TestSuite\TestCase::getMockForModel() was using the wrong alias for a model in a plugin.

getMockForModel('PluginName.ModelName') stored the mock in TableRegistry::$_instances with 'PluginName.ModelName' as key. 

The correct key is 'ModelName'
