### PR TITLE
Make boolean fields not required by default.

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -331,8 +331,10 @@ class EntityContext implements ContextInterface {
 		if (!$validator->hasField($field)) {
 			return false;
 		}
-		$allowed = $validator->isEmptyAllowed($field, $isNew);
-		return $allowed === false;
+		if ($this->type($field) !== 'boolean') {
+			return $validator->isEmptyAllowed($field, $isNew) === false;
+		}
+		return false;
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -593,6 +593,32 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test validator for boolean fields.
+ *
+ * @return void
+ */
+	public function testIsRequiredBooleanField() {
+		$this->_setupTables();
+
+		$context = new EntityContext($this->request, [
+			'entity' => new Entity(),
+			'table' => 'Articles',
+		]);
+		$articles = TableRegistry::get('Articles');
+		$articles->schema()->addColumn('comments_on', [
+			'type' => 'boolean'
+		]);
+
+		$validator = $articles->validator();
+		$validator->add('comments_on', 'is_bool', [
+			'rule' => 'boolean'
+		]);
+		$articles->validator('default', $validator);
+
+		$this->assertFalse($context->isRequired('title'));
+	}
+
+/**
  * Test validator as a string.
  *
  * @return void


### PR DESCRIPTION
Having boolean fields (checkboxes) marked as required by default makes working with optional checkboxes really hard. Instead we won't automatically mark checkboxes as required.

Refs #5168
