### PR TITLE
Entityclass for mock

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -567,6 +567,16 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$options += TableRegistry::config($alias);
 
 		$mock = $this->getMock($options['className'], $methods, [$options]);
+
+		if (empty($options['entityClass']) && $mock->entityClass() === '\Cake\ORM\Entity') {
+			$parts = explode('\\', $options['className']);
+			$entityAlias = Inflector::singularize(substr(array_pop($parts), 0, -5));
+			$entityClass = implode('\\', array_slice($parts, 0, -1)) . '\Entity\\' . $entityAlias;
+			if (class_exists($entityClass)) {
+				$mock->entityClass($entityClass);
+			}
+		}
+
 		TableRegistry::set($baseClass, $mock);
 		return $mock;
 	}

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -339,10 +339,14 @@ class TestCaseTest extends TestCase {
 			->method('save')
 			->will($this->returnValue('mocked'));
 		$this->assertEquals('mocked', $Posts->save($entity));
+		$this->assertEquals('\Cake\ORM\Entity', $Posts->entityClass());
 
 		$Posts = $this->getMockForModel('Posts', ['doSomething']);
 		$this->assertInstanceOf('Cake\Database\Connection', $Posts->connection());
 		$this->assertEquals('test', $Posts->connection()->configName());
+
+		$Tags = $this->getMockForModel('Tags', ['doSomething']);
+		$this->assertEquals('TestApp\Model\Entity\Tag', $Tags->entityClass());
 	}
 
 /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -377,6 +377,7 @@ class TestCaseTest extends TestCase {
 		$TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments', array('save'));
 
 		$this->assertInstanceOf('\TestPlugin\Model\Table\TestPluginCommentsTable', $TestPluginComment);
+		$this->assertEquals('\Cake\ORM\Entity', $TestPluginComment->entityClass());
 		$TestPluginComment->expects($this->at(0))
 			->method('save')
 			->will($this->returnValue(true));
@@ -387,6 +388,10 @@ class TestCaseTest extends TestCase {
 		$entity = new \Cake\ORM\Entity(array());
 		$this->assertTrue($TestPluginComment->save($entity));
 		$this->assertFalse($TestPluginComment->save($entity));
+
+		$TestPluginAuthors = $this->getMockForModel('TestPlugin.Authors', array('doSomething'));
+		$this->assertInstanceOf('\TestPlugin\Model\Table\AuthorsTable', $TestPluginAuthors);
+		$this->assertEquals('TestPlugin\Model\Entity\Author', $TestPluginAuthors->entityClass());
 	}
 
 /**

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Entity/Author.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Entity/Author.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TestPlugin\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * Tests entity class used for asserting correct entity is loaded
+ *
+ */
+class Author extends Entity {
+
+}


### PR DESCRIPTION
TestCase::getMockForModel always returned an object with \Cake\ORM\Entity as entityClass. 

This should be the case if the entity class file does not exists. But if it exists it should be used, unless a different entity class is defined in the TableObject. 

I have added some code that sets the right entity. This code is only executed if the default entity (\Cake\ORM\Entity) is used and no 'entityClass' is provided in the $options array. 
