### PR TITLE
Fixing error on _confirm

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -162,8 +162,7 @@ class Helper implements EventListenerInterface {
  * @return string onclick JS code
  */
 	protected function _confirm($message, $okCode, $cancelCode = '', $options = array()) {
-		$message = json_encode($message);
-		$confirm = "if (confirm({$message})) { {$okCode} } {$cancelCode}";
+		$confirm = "if (confirm('{$message}')) { {$okCode} } {$cancelCode}";
 		if (isset($options['escape']) && $options['escape'] === false) {
 			$confirm = h($confirm);
 		}


### PR DESCRIPTION
double quotes from json_encode results in an js error (onclick="if (confirm("Are you sure you want to delete # 2?"))......")
