### PR TITLE
Harden interface for Config engine classes.

### DIFF
--- a/src/Core/Configure/ConfigEngineInterface.php
+++ b/src/Core/Configure/ConfigEngineInterface.php
@@ -36,6 +36,6 @@ interface ConfigEngineInterface {
  * @param array $data The data to dump.
  * @return bool True on success or false on failure.
  */
-	public function dump($key, $data);
+	public function dump($key, array $data);
 
 }

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -72,12 +72,12 @@ class IniConfig implements ConfigEngineInterface {
  * Build and construct a new ini file parser. The parser can be used to read
  * ini files that are on the filesystem.
  *
- * @param string $path Path to load ini config files from. Defaults to CONFIG.
- * @param string $section Only get one section, leave null to parse and fetch
+ * @param string|null $path Path to load ini config files from. Defaults to CONFIG.
+ * @param string|null $section Only get one section, leave null to parse and fetch
  *     all sections in the ini file.
  */
 	public function __construct($path = null, $section = null) {
-		if (!$path) {
+		if ($path === null) {
 			$path = CONFIG;
 		}
 		$this->_path = $path;
@@ -154,7 +154,7 @@ class IniConfig implements ConfigEngineInterface {
  * @param array $data The data to convert to ini file.
  * @return int Bytes saved.
  */
-	public function dump($key, $data) {
+	public function dump($key, array $data) {
 		$result = array();
 		foreach ($data as $k => $value) {
 			$isSection = false;

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -37,10 +37,10 @@ class PhpConfig implements ConfigEngineInterface {
 /**
  * Constructor for PHP Config file reading.
  *
- * @param string $path The path to read config files from. Defaults to CONFIG.
+ * @param string|null $path The path to read config files from. Defaults to CONFIG.
  */
 	public function __construct($path = null) {
-		if (!$path) {
+		if ($path === null) {
 			$path = CONFIG;
 		}
 		$this->_path = $path;
@@ -84,7 +84,7 @@ class PhpConfig implements ConfigEngineInterface {
  * @param array $data Data to dump.
  * @return int Bytes saved.
  */
-	public function dump($key, $data) {
+	public function dump($key, array $data) {
 		$contents = '<?php' . "\n" . '$config = ' . var_export($data, true) . ';';
 
 		$filename = $this->_getFilePath($key);


### PR DESCRIPTION
Stricter handling of types makes it less subjective to coding errors.
Also corrected doc blocks.

Follow up on how most null cases are handled in the 3.x framework so far.
