### PR TITLE
Fix PATCH not automatically decoding known request bodies.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -417,6 +417,7 @@ class RequestHandlerComponent extends Component {
 		$request = $this->request;
 		if (!$request->is('post') &&
 			!$request->is('put') &&
+			!$request->is('patch') &&
 			!$request->is('delete')
 		) {
 			return null;

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -616,6 +616,9 @@ class RequestHandlerComponentTest extends TestCase {
 		$result = $this->RequestHandler->requestedWith(array('rss', 'atom'));
 		$this->assertFalse($result);
 
+		$this->request->env('REQUEST_METHOD', 'PATCH');
+		$this->assertEquals('json', $this->RequestHandler->requestedWith());
+
 		$this->request->env('REQUEST_METHOD', 'DELETE');
 		$this->assertEquals('json', $this->RequestHandler->requestedWith());
 


### PR DESCRIPTION
Requests using PATCH should also have their bodies automatically converted into $this->request->data.

Refs #5215
