### PR TITLE
Fix file_map being regenerated on every request.

### DIFF
--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -148,6 +148,8 @@ App::uses('Cache', 'Cache');
 App::uses('Object', 'Core');
 App::uses('Multibyte', 'I18n');
 
+App::$bootstrapping = true;
+
 /**
  * Full URL prefix
  */
@@ -169,8 +171,6 @@ if (!defined('FULL_BASE_URL')) {
 Configure::write('App.imageBaseUrl', IMAGES_URL);
 Configure::write('App.cssBaseUrl', CSS_URL);
 Configure::write('App.jsBaseUrl', JS_URL);
-
-App::$bootstrapping = true;
 
 Configure::bootstrap(isset($boot) ? $boot : true);
 


### PR DESCRIPTION
A mistake a few months ago caused the file_map to always be regenerated as Configure::write() would cause both Configure and Hash to be loaded, invalidating the file map. By entering bootstrap mode earlier we can avoid that.

Refs #5229
