### PR TITLE
Fix Incorrect ID in SQLserver

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,7 +42,7 @@
 		<env name="db_dsn" value="mysql://localhost/cake_test"/>
 		-->
 		<!-- SQL Server
-		<env name="db_dsn" value="sqlsrv://localhost/cake_test"/>
+		<env name="db_dsn" value="sqlserver://localhost/cake_test"/>
 		-->
 	</php>
 </phpunit>

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -47,6 +47,24 @@ class SqlserverCompiler extends QueryCompiler {
 	];
 
 /**
+ * Generates the INSERT part of a SQL query
+ *
+ * To better handle concurrency and low transaction isolation levels,
+ * we also include an OUTPUT clause so we can ensure we get the inserted
+ * row's data back.
+ *
+ * @param array $parts The parts to build
+ * @param \Cake\Database\Query $query The query that is being compiled
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @return string
+ */
+	protected function _buildInsertPart($parts, $query, $generator) {
+		$table = $parts[0];
+		$columns = $this->_stringifyExpressions($parts[1], $generator);
+		return sprintf('INSERT INTO %s (%s) OUTPUT INSERTED.*', $table, implode(', ', $columns));
+	}
+
+/**
  * Generates the LIMIT part of a SQL query
  *
  * @param int $limit the limit clause

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -276,7 +276,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
 		if ($column && $this->columnCount()) {
 			$row = $this->fetch('assoc');
 		}
-		if ($column && $row) {
+		if (isset($row[$column])) {
 			return $row[$column];
 		}
 		return $this->_driver->lastInsertId($table, $column);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1323,7 +1323,7 @@ class Table implements RepositoryInterface, EventListenerInterface {
 			->values($data)
 			->execute();
 
-		if ($statement->rowCount() > 0) {
+		if ($statement->rowCount() !== 0) {
 			$success = $entity;
 			$entity->set($filteredKeys, ['guard' => false]);
 			foreach ($primary as $key => $v) {

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -210,4 +210,32 @@ class SqlserverTest extends TestCase {
 		$this->assertEquals($expected, $query->sql());
 	}
 
+/**
+ * Test that insert queries have results available to them.
+ *
+ * @return void
+ */
+	public function testInsertUsesOutput() {
+		$driver = $this->getMock(
+			'Cake\Database\Driver\Sqlserver',
+			['_connect', 'connection'],
+			[[]]
+		);
+		$connection = $this->getMock(
+			'\Cake\Database\Connection',
+			['connect', 'driver'],
+			[['log' => false]]
+		);
+		$connection
+			->expects($this->any())
+			->method('driver')
+			->will($this->returnValue($driver));
+		$query = new \Cake\Database\Query($connection);
+		$query->insert(['title'])
+			->into('articles')
+			->values(['title' => 'A new article']);
+		$expected = 'INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)';
+		$this->assertEquals($expected, $query->sql());
+	}
+
 }


### PR DESCRIPTION
Fixes #5104. I've included @Laykou's proposed changes along with a small tweak to `Table::_insert()` to accommodate SQLserver returning -1 rows when OUTPUT is being used.
