### PR TITLE
unconditionally replace <? and ?>

### DIFF
--- a/src/View/BakeView.php
+++ b/src/View/BakeView.php
@@ -44,9 +44,8 @@ class BakeView extends View {
  */
 	protected $_defaultConfig = [
 		'phpTagReplacements' => [
-			'<?=' => "<CakePHPBakePhpOpenTag=",
-			'<?php' => "<CakePHPBakePhpOpenTag",
-			' ?>' => " CakePHPBakePhpCloseTag>"
+			'<?' => "<CakePHPBakeOpenTag",
+			'?>' => "CakePHPBakeCloseTag>"
 		],
 		'replacements' => [
 			'/\n[ \t]+<%- /' => "\n<% ",


### PR DESCRIPTION
This prevents bake from being sensitive to short-open tags ini setting.

Fixes #5242 
