### PR TITLE
Prioritize extracting validation messages when validation-domain is set

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -180,11 +180,12 @@ class ExtractTask extends AppShell {
 			$this->_exclude = array_merge($this->_exclude, App::path('plugins'));
 		}
 
-		if (!empty($this->params['ignore-model-validation']) || (!$this->_isExtractingApp() && empty($plugin))) {
-			$this->_extractValidation = false;
-		}
 		if (!empty($this->params['validation-domain'])) {
 			$this->_validationDomain = $this->params['validation-domain'];
+		} else {
+			if (!$this->_isExtractingApp() && empty($plugin)) {
+				$this->_extractValidation = false;
+			}
 		}
 
 		if ($this->_extractCore) {


### PR DESCRIPTION
When creating a new Croogo release, in the app dir, I typicallyrun the following:

```
Console/cake i18n extract \
    --paths `pwd`/Vendor/croogo/croogo/ \
    --output /home/rachman/work/core/croogo-locale/ \
    --merge no \
    --validation-domain croogo \
    --extract-core no \
    --overwrite \
    --exclude Vendor/croogo/croogo/View,Vendor/croogo/croogo/Plugin,vendor 
```

It's suppose to extract the i18n messages to a separate git working directory for the locale repository. However, it is not extracting model validation messages.

This PR prioritize extracting validation messages to address the aforementioned use case.
