### PR TITLE
PHPUnit can be included as a phar file.

### DIFF
--- a/lib/Cake/TestSuite/CakeTestRunner.php
+++ b/lib/Cake/TestSuite/CakeTestRunner.php
@@ -15,7 +15,9 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-require_once 'PHPUnit/TextUI/TestRunner.php';
+if (!defined('__PHPUNIT_PHAR__')) {
+	require_once 'PHPUnit/TextUI/TestRunner.php';
+}
 
 App::uses('CakeFixtureManager', 'TestSuite/Fixture');
 

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -16,7 +16,9 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-require_once 'PHPUnit/TextUI/Command.php';
+if (!defined('__PHPUNIT_PHAR__')) {
+	require_once 'PHPUnit/TextUI/Command.php';
+}
 
 App::uses('CakeTestRunner', 'TestSuite');
 App::uses('CakeTestLoader', 'TestSuite');

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -151,6 +151,12 @@ class CakeTestSuiteDispatcher {
 			} elseif (is_dir($vendor . DS . 'PHPUnit')) {
 				ini_set('include_path', $vendor . PATH_SEPARATOR . ini_get('include_path'));
 				break;
+			} elseif (is_file($vendor . DS . 'phpunit.phar')) {
+				$backup = $GLOBALS['_SERVER']['SCRIPT_NAME'];
+				$GLOBALS['_SERVER']['SCRIPT_NAME'] = '-';
+				$included = include_once $vendor . DS . 'phpunit.phar';
+				$GLOBALS['_SERVER']['SCRIPT_NAME'] = $backup;
+				return $included;
 			}
 		}
 		include 'PHPUnit' . DS . 'Autoload.php';

--- a/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
@@ -15,7 +15,9 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-require_once 'PHPUnit/TextUI/ResultPrinter.php';
+ if (!defined('__PHPUNIT_PHAR__')) {
+	require_once 'PHPUnit/TextUI/ResultPrinter.php';
+}
 
 /**
  * CakeBaseReporter contains common reporting features used in the CakePHP Test suite

--- a/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
@@ -15,7 +15,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
- if (!defined('__PHPUNIT_PHAR__')) {
+if (!defined('__PHPUNIT_PHAR__')) {
 	require_once 'PHPUnit/TextUI/ResultPrinter.php';
 }
 


### PR DESCRIPTION
No need to install phpunit in order to run unit tests.  Simply place
phpunit.phar in any of the vendor folders.
