### PR TITLE
Mark localized validation as deprecated for 3.0

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -640,6 +640,7 @@ class Validation {
  * @param string|null $regex Regular expression to use
  * @param string $country Country code (defaults to 'all')
  * @return bool Success
+ * @deprecated 3.0.0 Will be removed in 3.0.0. Please use the Localized plugin instead.
  */
 	public static function phone($check, $regex = null, $country = 'all') {
 		if (is_array($check)) {
@@ -682,6 +683,7 @@ class Validation {
  * @param string|null $regex Regular expression to use
  * @param string $country Country to use for formatting
  * @return bool Success
+ * @deprecated 3.0.0 Will be removed in 3.0.0. Please use the Localized plugin instead.
  */
 	public static function postal($check, $regex = null, $country = 'us') {
 		if (is_array($check)) {


### PR DESCRIPTION
First step to https://github.com/cakephp/cakephp/issues/5236
Communicate it now.

I didnt remove it yet as the Localized plugin is not yet ready for 3.0 and until stable we ease migration of existing applications by keeping it for now.
