### PR TITLE
an unnecessary E_NOTICE caused by CakeResponse::download()

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1507,7 +1507,9 @@ class CakeResponse {
 	protected function _flushBuffer() {
 		//@codingStandardsIgnoreStart
 		@flush();
-		@ob_flush();
+		if (ob_get_level()) {
+			@ob_flush();
+		}
 		//@codingStandardsIgnoreEnd
 	}
 


### PR DESCRIPTION
Fix an unnecessary E_NOTICE when CakeResponse::download() is called without CakeResponse::compress().

ob_start() is called only if CakeResponse::compress() is called.
But, ob_flush() is always called in CakeResponse::_flushBuffer() if CakeResponse::download() is called.
It causes an unnecessary E_NOTICE and the following message is passed to ErrorHandler::handleError():

```
Notice:ob_flush() [<a href='http://php.net/ref.outcontrol'>ref.outcontrol</a>]: failed to flush buffer. No buffer to flush
```

This resolves it.
