### PR TITLE
Reset global EventManager on IntegrationTestCase setup

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -14,6 +14,7 @@
 namespace Cake\TestSuite;
 
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\Routing\DispatcherFactory;
@@ -88,6 +89,16 @@ abstract class IntegrationTestCase extends TestCase {
  * @var \Cake\Network\Session
  */
 	protected $_requestSession;
+
+/**
+ * Reset the EventManager for before each test.
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		EventManager::instance(new EventManager());
+	}
 
 /**
  * Clear the state used for requests.

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
 use Cake\Network\Response;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
@@ -192,6 +193,29 @@ class IntegrationTestCaseTest extends IntegrationTestCase {
 		$this->_response->body('Some content');
 
 		$this->assertResponseContains('content');
+	}
+
+/**
+ * Test that works in tandem with testEventManagerReset2 to 
+ * test the EventManager reset.
+ *
+ * The return value is passed to testEventManagerReset2 as 
+ * an arguments.
+ *
+ * @return \Cake\Event\EventManager
+ */
+	public function testEventManagerReset1() {
+		return EventManager::instance();
+	}
+
+/**
+ * Test if the EventManager is reset between tests.
+ *
+ * @depends testEventManagerReset1
+ * @return void
+ */
+	public function testEventManagerReset2($prevEventManager) {
+		$this->assertNotSame($prevEventManager, EventManager::instance());
 	}
 
 }


### PR DESCRIPTION
Events are attached for each test, because the EventManager is not reset for each test. 

**Example** 
- I attach an eventListener in the bootstrap.php or Controller::beforeFilter by using EventManager::attach(). 
- Then I create an integration test with multiple tests. Each test sends a request using one of the convenience methods, like IntegrationTestCase::get() 

In the above example an eventListener is attached to the global EventManager on every executed test. This means that the callback is also executed multiple times. 

This is prevented by resetting the EventManager in IntegrationTestCase::setup().

Not sure if this is the best way to fix it. 
