### PR TITLE
Add back tests/bootstrap.php to git archive.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,4 +41,3 @@ phpunit.xml.dist export-ignore
 tests/test_app export-ignore
 tests/TestCase export-ignore
 tests/bake_compare export-ignore
-tests/bootstrap.php export-ignore


### PR DESCRIPTION
This file can be included in plugin's tests/bootstrap.php and avoid
having to write lot of boilerplate code to run standalone plugin tests.
