### PR TITLE
Don't log fixture-related db activity

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -259,11 +259,18 @@ class FixtureManager {
 		$dbs = $this->_fixtureConnections($fixtures);
 		foreach ($dbs as $connection => $fixtures) {
 			$db = ConnectionManager::get($connection, false);
+			$logQueries = $db->logQueries();
+			if ($logQueries) {
+				$db->logQueries(false);
+			}
 			$db->transactional(function ($db) use ($fixtures, $operation) {
 				$db->disableForeignKeys();
 				$operation($db, $fixtures);
 				$db->enableForeignKeys();
 			});
+			if ($logQueries) {
+				$db->logQueries(true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Otherwise, if the query log is enabled for seeing what a test case is
doing it's hidden in create table/insert fixture log entries.

This would also match the behavior in earlier versions.
