### PR TITLE
Fix ObjectRegistry duplicate detection when comparing nested arrays

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -114,10 +114,11 @@ abstract class ObjectRegistry {
 		if (!$hasConfig) {
 			throw new RuntimeException($msg);
 		}
-		unset($config['enabled']);
-		if ($hasConfig && array_diff_assoc($config, $existing->config()) != []) {
+		$existingConfig = $existing->config();
+		unset($config['enabled'], $existingConfig['enabled']);
+		if ($hasConfig && json_encode($config) !== json_encode($existingConfig)) {
 			$msg .= ' with the following config: ';
-			$msg .= var_export($this->{$name}->config(), true);
+			$msg .= var_export($existingConfig, true);
 			$msg .= ' which differs from ' . var_export($config, true);
 			throw new RuntimeException($msg);
 		}

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -106,6 +106,25 @@ class ComponentTest extends TestCase {
 	}
 
 /**
+ * Test a duplicate component being loaded more than once with same and differing configurations.
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage The "Banana" alias has already been loaded with the following config:
+ * @return void
+ */
+	public function testDuplicateComponentInitialize() {
+		$Collection = new ComponentRegistry();
+		$Collection->load('Banana', ['property' => ['closure' => function () {
+		}]]);
+		$Collection->load('Banana', ['property' => ['closure' => function () {
+		}]]);
+
+		$this->assertInstanceOf('TestApp\Controller\Component\BananaComponent', $Collection->Banana, 'class is wrong');
+
+		$Collection->load('Banana', ['property' => ['differs']]);
+	}
+
+/**
  * Test mutually referencing components.
  *
  * @return void


### PR DESCRIPTION
- Resolves non-descript "Array to string conversion" error message on PHP 5.4+
- See https://bugs.php.net/bug.php?id=60198 and https://bugs.php.net/bug.php?id=62115
- Opted for `json_encode` vs. adding extra code or dependency on Hash (`serialize` doesn't handle closures)
- Stricter equality check involves unsetting 'enabled' key from both sides (otherwise tests fail elsewhere)
