### PR TITLE
Don't force users to match existing config

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -116,6 +116,11 @@ abstract class ObjectRegistry {
 		}
 		$existingConfig = $existing->config();
 		unset($config['enabled'], $existingConfig['enabled']);
+
+		if (empty($config)) {
+			return;
+		}
+
 		if ($hasConfig && json_encode($config) !== json_encode($existingConfig)) {
 			$msg .= ' with the following config: ';
 			$msg .= var_export($existingConfig, true);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -227,28 +227,32 @@ class HelperRegistryTest extends TestCase {
 /**
  * Loading a helper with no config should "just work"
  *
+ * The addToAssertionCount call is to record that no exception was thrown
+
  * @return void
  */
 	public function testLoadMultipleTimesNoConfig() {
 		$this->Helpers->load('Html');
 		$this->Helpers->load('Html');
-		$this->assertTrue(true, 'Unable to load the same helper with no config');
+		$this->addToAssertionCount(1);
 	}
 
 /**
  * Loading a helper with bespoke config, where the subsequent load specifies no
  * config should "just work"
  *
+ * The addToAssertionCount call is to record that no exception was thrown
+ *
  * @return void
  */
 	public function testLoadMultipleTimesAlreadyConfigured() {
 		$this->Helpers->load('Html', ['same' => 'stuff']);
 		$this->Helpers->load('Html');
-		$this->assertTrue(true, 'Unable to load an already-configured helper with no config');
+		$this->addToAssertionCount(1);
 	}
 
 /**
- * Loading a helper with different config, should bark
+ * Loading a helper with different config, should throw an exception
  *
  * @expectedException RuntimeException
  * @return void

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -228,7 +228,7 @@ class HelperRegistryTest extends TestCase {
  * Loading a helper with no config should "just work"
  *
  * The addToAssertionCount call is to record that no exception was thrown
-
+ *
  * @return void
  */
 	public function testLoadMultipleTimesNoConfig() {

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -224,4 +224,38 @@ class HelperRegistryTest extends TestCase {
 		$this->assertCount(0, $this->Events->listeners('View.beforeRender'));
 	}
 
+/**
+ * Loading a helper with no config should "just work"
+ *
+ * @return void
+ */
+	public function testLoadMultipleTimesNoConfig() {
+		$this->Helpers->load('Html');
+		$this->Helpers->load('Html');
+		$this->assertTrue(true, 'Unable to load the same helper with no config');
+	}
+
+/**
+ * Loading a helper with bespoke config, where the subsequent load specifies no
+ * config should "just work"
+ *
+ * @return void
+ */
+	public function testLoadMultipleTimesAlreadyConfigured() {
+		$this->Helpers->load('Html', ['same' => 'stuff']);
+		$this->Helpers->load('Html');
+		$this->assertTrue(true, 'Unable to load an already-configured helper with no config');
+	}
+
+/**
+ * Loading a helper with different config, should bark
+ *
+ * @expectedException RuntimeException
+ * @return void
+ */
+	public function testLoadMultipleTimesDifferentConfigured() {
+		$this->Helpers->load('Html');
+		$this->Helpers->load('Html', ['same' => 'stuff']);
+	}
+
 }


### PR DESCRIPTION
If an object is in the registry already, and no bespoke config has been
specified - don't consider that an exceptional case.

The scenario which brought me here was having one helper like this:

```
<?php
namespace App\View\Helper;

use Cake\Core\Configure;
use Cake\View\View;
use Cake\View\Helper\UrlHelper as CakeUrlHelper;
use Cake\Routing\Router;

/**
 * Url helper
 */
class UrlHelper extends CakeUrlHelper {

    public function __construct(View $View, array $config = []) {
        $this->config('assetHost', Configure::read('static.host'));

        parent::__construct($View, $config);
    } 
```

And another like this:

```
<?php
namespace App\View\Helper;

use Cake\View\Helper;
use Cake\View\View;

/**
 * Breadcrumbs helper
 */
class BreadcrumbsHelper extends Helper {

    public $helpers = [ 
        'Url'
    ];  
```

And being confronted with:

> An Internal Error Has Occurred
> Error: The "Url" alias has already been loaded with the following config: array ( 'assetHost' => '//static.example.dev', ) which differs from array ( )
