### PR TITLE
Fix duplicate errors when config data is not different.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -114,14 +114,24 @@ abstract class ObjectRegistry {
 		if (!$hasConfig) {
 			throw new RuntimeException($msg);
 		}
-		$existingConfig = $existing->config();
-		unset($config['enabled'], $existingConfig['enabled']);
-
 		if (empty($config)) {
 			return;
 		}
+		$existingConfig = $existing->config();
+		unset($config['enabled'], $existingConfig['enabled']);
 
-		if ($hasConfig && json_encode($config) !== json_encode($existingConfig)) {
+		$fail = false;
+		foreach ($config as $key => $value) {
+			if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
+				$fail = true;
+				break;
+			}
+			if (!array_key_exists($key, $existingConfig)) {
+				$fail = true;
+				break;
+			}
+		}
+		if ($fail) {
 			$msg .= ' with the following config: ';
 			$msg .= var_export($existingConfig, true);
 			$msg .= ' which differs from ' . var_export($config, true);

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -122,11 +122,11 @@ abstract class ObjectRegistry {
 
 		$fail = false;
 		foreach ($config as $key => $value) {
-			if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
+			if (!array_key_exists($key, $existingConfig)) {
 				$fail = true;
 				break;
 			}
-			if (!array_key_exists($key, $existingConfig)) {
+			if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
 				$fail = true;
 				break;
 			}

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -262,4 +262,15 @@ class HelperRegistryTest extends TestCase {
 		$this->Helpers->load('Html', ['same' => 'stuff']);
 	}
 
+/**
+ * Loading a helper with different config, should throw an exception
+ *
+ * @expectedException RuntimeException
+ * @return void
+ */
+	public function testLoadMultipleTimesDifferentConfigValues() {
+		$this->Helpers->load('Html', ['key' => 'value']);
+		$this->Helpers->load('Html', ['key' => 'new value']);
+	}
+
 }

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -252,9 +252,22 @@ class HelperRegistryTest extends TestCase {
 	}
 
 /**
+ * Loading a helper overriding defaults to default value
+ * should "just work"
+ *
+ * @return void
+ */
+	public function testLoadMultipleTimesDefaultConfigValuesWorks() {
+		$this->Helpers->load('Number', ['engine' => 'Cake\I18n\Number']);
+		$this->Helpers->load('Number');
+		$this->addToAssertionCount(1);
+	}
+
+/**
  * Loading a helper with different config, should throw an exception
  *
  * @expectedException RuntimeException
+ * @expectedExceptionMessage The "Html" alias has already been loaded with the following
  * @return void
  */
 	public function testLoadMultipleTimesDifferentConfigured() {
@@ -266,6 +279,7 @@ class HelperRegistryTest extends TestCase {
  * Loading a helper with different config, should throw an exception
  *
  * @expectedException RuntimeException
+ * @expectedExceptionMessage The "Html" alias has already been loaded with the following
  * @return void
  */
 	public function testLoadMultipleTimesDifferentConfigValues() {


### PR DESCRIPTION
Perform a more careful inspection of config data when checking duplicates. Simply check the json_encode() value has issues when default config is involved. array_diff\* have similar issues with nested data.

Since the empty config data will be the most common case the previous optimization is still valid and very useful.

Refs #5286
