### PR TITLE
3.0 - Better magic property hint baking

### DIFF
--- a/src/Template/Bake/Controller/controller.ctp
+++ b/src/Template/Bake/Controller/controller.ctp
@@ -28,9 +28,12 @@ use <%= $namespace %>\Controller\AppController;
 /**
  * <%= $name %> Controller
  *
- * @property <%= $namespace %>\Model\Table\<%= $defaultModel %>Table $<%= $defaultModel %>
-<% foreach ($components as $component): %>
- * @property <%= $component %>Component $<%= $component %>
+ * @property \<%= $namespace %>\Model\Table\<%= $defaultModel %>Table $<%= $defaultModel %>
+<%
+foreach ($components as $component):
+	$classInfo = $this->Bake->classInfo($component, 'Controller/Component', 'Component');
+%>
+ * @property \<%= $classInfo['namespace'] %>\<%= $classInfo['class'] %> $<%= $classInfo['name'] %>
 <% endforeach; %>
  */
 class <%= $name %>Controller extends AppController {

--- a/src/Template/Bake/Controller/controller.ctp
+++ b/src/Template/Bake/Controller/controller.ctp
@@ -33,7 +33,7 @@ use <%= $namespace %>\Controller\AppController;
 foreach ($components as $component):
 	$classInfo = $this->Bake->classInfo($component, 'Controller/Component', 'Component');
 %>
- * @property \<%= $classInfo['namespace'] %>\<%= $classInfo['class'] %> $<%= $classInfo['name'] %>
+ * @property <%= $classInfo['fqn'] %> $<%= $classInfo['name'] %>
 <% endforeach; %>
  */
 class <%= $name %>Controller extends AppController {

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -1,6 +1,7 @@
 <?php
 namespace Cake\View\Helper;
 
+use Cake\Core\Configure;
 use Cake\Core\ConventionsTrait;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
@@ -90,6 +91,45 @@ class BakeHelper extends Helper {
 		};
 
 		return array_map($extractor, $table->associations()->type($assoc));
+	}
+
+/**
+ * Returns details about the given class.
+ *
+ * The returned array holds the following keys:
+ *
+ * - `namespace` (the full namespace without leading separator)
+ * - `class` (the class name)
+ * - `plugin` (either the name of the plugin, or `null`)
+ * - `name` (the name of the component without suffix)
+ * - `fullName` (the full name of the class, including possible vendor and plugin name)
+ *
+ * @param string $class Class name
+ * @param string $type Class type/sub-namespace
+ * @param string $suffix Class name suffix
+ * @return array Class info
+ */
+	public function classInfo($class, $type, $suffix) {
+		list($plugin, $name) = \pluginSplit($class);
+
+		$base = Configure::read('App.namespace');
+		if ($plugin !== null) {
+			$base = $plugin;
+		}
+		$base = str_replace('/', '\\', trim($base, '\\'));
+		$sub = '\\' . str_replace('/', '\\', trim($type, '\\'));
+
+		if (class_exists('\Cake' . $sub . '\\' . $name . $suffix)) {
+			$base = 'Cake';
+		}
+
+		return [
+			'namespace' => $base . $sub,
+			'plugin' => $plugin,
+			'class' => $name . $suffix,
+			'name' => $name,
+			'fullName' => $class
+		];
 	}
 
 }

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -98,6 +98,7 @@ class BakeHelper extends Helper {
  *
  * The returned array holds the following keys:
  *
+ * - `fqn` (the fully qualified name)
  * - `namespace` (the full namespace without leading separator)
  * - `class` (the class name)
  * - `plugin` (either the name of the plugin, or `null`)
@@ -118,12 +119,14 @@ class BakeHelper extends Helper {
 		}
 		$base = str_replace('/', '\\', trim($base, '\\'));
 		$sub = '\\' . str_replace('/', '\\', trim($type, '\\'));
+		$qn = $sub . '\\' . $name . $suffix;
 
-		if (class_exists('\Cake' . $sub . '\\' . $name . $suffix)) {
+		if (class_exists('\Cake' . $qn)) {
 			$base = 'Cake';
 		}
 
 		return [
+			'fqn' => '\\' . $base . $qn,
 			'namespace' => $base . $sub,
 			'plugin' => $plugin,
 			'class' => $name . $suffix,

--- a/tests/TestCase/Shell/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Shell/Task/ControllerTaskTest.php
@@ -142,6 +142,23 @@ class ControllerTaskTest extends TestCase {
 	}
 
 /**
+ * test bake with various component name variants
+ *
+ * @return void
+ */
+	public function testBakeComponents() {
+		$this->Task->expects($this->any())
+			->method('createFile')
+			->will($this->returnValue(true));
+
+		$this->Task->params['no-actions'] = true;
+		$this->Task->params['components'] = 'Csrf, Auth, Company/TestPluginThree.Something, TestPlugin.Other, Apple, NonExistent';
+
+		$result = $this->Task->bake('BakeArticles');
+		$this->assertSameAsFile(__FUNCTION__ . '.php', $result);
+	}
+
+/**
  * test the bake method
  *
  * @return void

--- a/tests/bake_compare/Controller/testBakeActions.php
+++ b/tests/bake_compare/Controller/testBakeActions.php
@@ -6,9 +6,9 @@ use App\Controller\AppController;
 /**
  * BakeArticles Controller
  *
- * @property App\Model\Table\BakeArticlesTable $BakeArticles
- * @property CsrfComponent $Csrf
- * @property AuthComponent $Auth
+ * @property \App\Model\Table\BakeArticlesTable $BakeArticles
+ * @property \Cake\Controller\Component\CsrfComponent $Csrf
+ * @property \Cake\Controller\Component\AuthComponent $Auth
  */
 class BakeArticlesController extends AppController {
 

--- a/tests/bake_compare/Controller/testBakeActionsContent.php
+++ b/tests/bake_compare/Controller/testBakeActionsContent.php
@@ -6,7 +6,7 @@ use App\Controller\AppController;
 /**
  * BakeArticles Controller
  *
- * @property App\Model\Table\BakeArticlesTable $BakeArticles
+ * @property \App\Model\Table\BakeArticlesTable $BakeArticles
  */
 class BakeArticlesController extends AppController {
 

--- a/tests/bake_compare/Controller/testBakeComponents.php
+++ b/tests/bake_compare/Controller/testBakeComponents.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Controller;
+
+use App\Controller\AppController;
+
+/**
+ * BakeArticles Controller
+ *
+ * @property \App\Model\Table\BakeArticlesTable $BakeArticles
+ * @property \Cake\Controller\Component\CsrfComponent $Csrf
+ * @property \Cake\Controller\Component\AuthComponent $Auth
+ * @property \Company\TestPluginThree\Controller\Component\SomethingComponent $Something
+ * @property \TestPlugin\Controller\Component\OtherComponent $Other
+ * @property \App\Controller\Component\AppleComponent $Apple
+ * @property \App\Controller\Component\NonExistentComponent $NonExistent
+ */
+class BakeArticlesController extends AppController {
+
+/**
+ * Components
+ *
+ * @var array
+ */
+	public $components = ['Csrf', 'Auth', 'Company/TestPluginThree.Something', 'TestPlugin.Other', 'Apple', 'NonExistent'];
+
+}

--- a/tests/bake_compare/Controller/testBakeNoActions.php
+++ b/tests/bake_compare/Controller/testBakeNoActions.php
@@ -6,9 +6,9 @@ use App\Controller\AppController;
 /**
  * BakeArticles Controller
  *
- * @property App\Model\Table\BakeArticlesTable $BakeArticles
- * @property CsrfComponent $Csrf
- * @property AuthComponent $Auth
+ * @property \App\Model\Table\BakeArticlesTable $BakeArticles
+ * @property \Cake\Controller\Component\CsrfComponent $Csrf
+ * @property \Cake\Controller\Component\AuthComponent $Auth
  */
 class BakeArticlesController extends AppController {
 

--- a/tests/bake_compare/Controller/testBakeWithPlugin.php
+++ b/tests/bake_compare/Controller/testBakeWithPlugin.php
@@ -6,7 +6,7 @@ use ControllerTest\Controller\AppController;
 /**
  * BakeArticles Controller
  *
- * @property ControllerTest\Model\Table\BakeArticlesTable $BakeArticles
+ * @property \ControllerTest\Model\Table\BakeArticlesTable $BakeArticles
  */
 class BakeArticlesController extends AppController {
 

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/Component/SomethingComponent.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/Component/SomethingComponent.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @since         1.2.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/Component/SomethingComponent.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/Component/SomethingComponent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class SomethingComponent
+ */
+namespace Company\TestPluginThree\Controller\Component;
+
+use Cake\Controller\Component;
+
+class SomethingComponent extends Component {
+}


### PR DESCRIPTION
For controllers the table property is missing a leading namespace separator, and components do not have any namespace at all, and using the plugin syntax creates hints like `Plugin.Component $Plugin.Component`.

This patch attempts to implement some kind of resolving, where default locations are assumed, that is either `\App\Controller\Component`, `\Cake\Controller\Component`, or `\Plugin\Controller\Component`.
