### PR TITLE
3.0 - Do not magically overwrite `multiple` option if it's truly

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1176,7 +1176,9 @@ class FormHelper extends Helper {
 
 		if ($allowOverride && substr($fieldName, -5) === '._ids') {
 			$options['type'] = 'select';
-			$options['multiple'] = true;
+			if (empty($options['multiple'])) {
+				$options['multiple'] = true;
+			}
 		}
 
 		if ($options['type'] === 'select' && array_key_exists('step', $options)) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2821,6 +2821,43 @@ class FormHelperTest extends TestCase {
 			'/div'
 		);
 		$this->assertHtml($expected, $result);
+
+		// make sure that for HABTM the multiple option is not being overwritten in case it's truly
+		$options = array(
+			1 => 'blue',
+			2 => 'red'
+		);
+		$result = $this->Form->input('tags._ids', ['options' => $options, 'multiple' => 'checkbox']);
+		$expected = array(
+			'div' => array('class' => 'input select'),
+			'label' => array('for' => 'tags-ids'),
+			'Tags',
+			'/label',
+			'input' => array('type' => 'hidden', 'name' => 'tags[_ids]', 'value' => ''),
+
+			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'tags-ids-1')),
+			array('input' => array(
+				'id' => 'tags-ids-1', 'type' => 'checkbox',
+				'value' => '1', 'name' => 'tags[_ids][]'
+			)),
+			'blue',
+			'/label',
+			'/div',
+
+			array('div' => array('class' => 'checkbox')),
+			array('label' => array('for' => 'tags-ids-2')),
+			array('input' => array(
+				'id' => 'tags-ids-2', 'type' => 'checkbox',
+				'value' => '2', 'name' => 'tags[_ids][]'
+			)),
+			'red',
+			'/label',
+			'/div',
+
+			'/div'
+		);
+		$this->assertHtml($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
This ensures that it is possible to create multi-checkbox selects for
HABTM associations.
