### PR TITLE
Add Query::firstOrFail()

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -19,6 +19,7 @@ define('TIME_START', microtime(true));
 class_alias('Cake\Error\Debugger', 'Cake\Utility\Debugger');
 class_alias('Cake\Core\Configure\Engine\PhpConfig', 'Cake\Configure\Engine\PhpConfig');
 class_alias('Cake\Core\Configure\Engine\IniConfig', 'Cake\Configure\Engine\IniConfig');
+class_alias('Cake\Datasource\Exception\RecordNotFoundException', 'Cake\ORM\Exception\RecordNotFoundException');
 class_alias('Cake\ORM\Exception\RecordNotFoundException', 'Cake\ORM\Error\RecordNotFoundException');
 class_alias('Cake\Network\Exception\BadRequestException', 'Cake\Error\BadRequestException');
 class_alias('Cake\Network\Exception\ForbiddenException', 'Cake\Error\ForbiddenException');

--- a/src/Datasource/Exception/RecordNotFoundException.php
+++ b/src/Datasource/Exception/RecordNotFoundException.php
@@ -12,7 +12,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\ORM\Exception;
+namespace Cake\Datasource\Exception;
 
 use RuntimeException;
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -15,6 +15,7 @@
 namespace Cake\Datasource;
 
 use Cake\Collection\Iterator\MapReduce;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\QueryCacher;
 use Cake\Datasource\RepositoryInterface;
 
@@ -326,6 +327,23 @@ trait QueryTrait {
 			$this->limit(1);
 		}
 		return $this->all()->first();
+	}
+
+/**
+ * Get the first result from the executing query or raise an exception.
+ *
+ * @throws \Cake\Datasource\RecordNotFoundException When there is no first record.
+ * @return mixed The first result from the ResultSet.
+ */
+	public function firstOrFail() {
+		$entity = $this->first();
+		if ($entity) {
+			return $entity;
+		}
+		throw new RecordNotFoundException(sprintf(
+			'Record not found in table "%s"',
+			$this->repository()->table()
+		));
 	}
 
 /**

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -332,7 +332,7 @@ trait QueryTrait {
 /**
  * Get the first result from the executing query or raise an exception.
  *
- * @throws \Cake\Datasource\RecordNotFoundException When there is no first record.
+ * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
  * @return mixed The first result from the ResultSet.
  */
 	public function firstOrFail() {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -837,7 +837,7 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	}
 
 /**
- * Get the first result from the executing query or raist an exception.
+ * Get the first result from the executing query or raise an exception.
  *
  * @throws \Cake\ORM\RecordNotFoundException When there is no first record.
  * @return mixed The first result from the ResultSet.
@@ -847,13 +847,9 @@ class Query extends DatabaseQuery implements JsonSerializable {
 		if ($entity) {
 			return $entity;
 		}
-		$binder = new ValueBinder();
-		$conditions = $this->clause('where');
-
 		throw new RecordNotFoundException(sprintf(
-			'Record not found in table "%s" for conditions "%s"',
-			$this->repository()->table(),
-			$conditions->sql($binder)
+			'Record not found in table "%s"',
+			$this->repository()->table()
 		));
 	}
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -20,6 +20,7 @@ use Cake\Datasource\QueryTrait;
 use Cake\ORM\EagerLoader;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
+use Cake\ORM\Exception\RecordNotFoundException;
 use JsonSerializable;
 
 /**
@@ -833,6 +834,27 @@ class Query extends DatabaseQuery implements JsonSerializable {
 		}
 		$this->_autoFields = (bool)$value;
 		return $this;
+	}
+
+/**
+ * Get the first result from the executing query or raist an exception.
+ *
+ * @throws \Cake\ORM\RecordNotFoundException When there is no first record.
+ * @return mixed The first result from the ResultSet.
+ */
+	public function firstOrFail() {
+		$entity = $this->first();
+		if ($entity) {
+			return $entity;
+		}
+		$binder = new ValueBinder();
+		$conditions = $this->clause('where');
+
+		throw new RecordNotFoundException(sprintf(
+			'Record not found in table "%s" for conditions "%s"',
+			$this->repository()->table(),
+			$conditions->sql($binder)
+		));
 	}
 
 /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -20,7 +20,6 @@ use Cake\Datasource\QueryTrait;
 use Cake\ORM\EagerLoader;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
-use Cake\ORM\Exception\RecordNotFoundException;
 use JsonSerializable;
 
 /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -837,23 +837,6 @@ class Query extends DatabaseQuery implements JsonSerializable {
 	}
 
 /**
- * Get the first result from the executing query or raise an exception.
- *
- * @throws \Cake\ORM\RecordNotFoundException When there is no first record.
- * @return mixed The first result from the ResultSet.
- */
-	public function firstOrFail() {
-		$entity = $this->first();
-		if ($entity) {
-			return $entity;
-		}
-		throw new RecordNotFoundException(sprintf(
-			'Record not found in table "%s"',
-			$this->repository()->table()
-		));
-	}
-
-/**
  * Decorates the results iterator with MapReduce routines and formatters
  *
  * @param \Traversable $result Original results

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -30,7 +30,6 @@ use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Exception\MissingEntityException;
-use Cake\ORM\Exception\RecordNotFoundException;
 use Cake\ORM\Marshaller;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
@@ -941,17 +940,7 @@ class Table implements RepositoryInterface, EventListenerInterface {
 			}
 			$query->cache($cacheKey, $cacheConfig);
 		}
-
-		$entity = $query->first();
-
-		if ($entity) {
-			return $entity;
-		}
-		throw new RecordNotFoundException(sprintf(
-			'Record "%s" not found in table "%s"',
-			implode(',', (array)$primaryKey),
-			$this->table()
-		));
+		return $query->firstOrFail();
 	}
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -905,8 +905,6 @@ class Table implements RepositoryInterface, EventListenerInterface {
 /**
  * {@inheritDoc}
  *
- * @throws \Cake\ORM\Exception\RecordNotFoundException if no record can be found given
- * a primary key value.
  * @throws \InvalidArgumentException When $primaryKey has an incorrect number of elements.
  */
 	public function get($primaryKey, $options = []) {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3389,7 +3389,7 @@ class TableTest extends TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['addDefaultTypes', 'first', 'where', 'cache'],
+			['addDefaultTypes', 'firstOrFail', 'where', 'cache'],
 			[$this->connection, $table]
 		);
 
@@ -3404,7 +3404,7 @@ class TableTest extends TestCase {
 			->with([$table->alias() . '.bar' => 10])
 			->will($this->returnSelf());
 		$query->expects($this->never())->method('cache');
-		$query->expects($this->once())->method('first')
+		$query->expects($this->once())->method('firstOrFail')
 			->will($this->returnValue($entity));
 		$result = $table->get(10, $options);
 		$this->assertSame($entity, $result);
@@ -3449,7 +3449,7 @@ class TableTest extends TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['addDefaultTypes', 'first', 'where', 'cache'],
+			['addDefaultTypes', 'firstOrFail', 'where', 'cache'],
 			[$this->connection, $table]
 		);
 
@@ -3466,7 +3466,7 @@ class TableTest extends TestCase {
 		$query->expects($this->once())->method('cache')
 			->with($cacheKey, $cacheConfig)
 			->will($this->returnSelf());
-		$query->expects($this->once())->method('first')
+		$query->expects($this->once())->method('firstOrFail')
 			->will($this->returnValue($entity));
 		$result = $table->get(10, $options);
 		$this->assertSame($entity, $result);
@@ -3476,7 +3476,7 @@ class TableTest extends TestCase {
  * Tests that get() will throw an exception if the record was not found
  *
  * @expectedException \Cake\ORM\Exception\RecordNotFoundException
- * @expectedExceptionMessage Record "10" not found in table "articles"
+ * @expectedExceptionMessage Record not found in table "articles" for conditions "articles.id = :c0"
  * @return void
  */
 	public function testGetNotFoundException() {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3476,7 +3476,7 @@ class TableTest extends TestCase {
  * Tests that get() will throw an exception if the record was not found
  *
  * @expectedException \Cake\ORM\Exception\RecordNotFoundException
- * @expectedExceptionMessage Record not found in table "articles" for conditions "articles.id = :c0"
+ * @expectedExceptionMessage Record not found in table "articles"
  * @return void
  */
 	public function testGetNotFoundException() {


### PR DESCRIPTION
This method lets you use get() like behavior on any finder. This is intended to replace #5157.
