### PR TITLE
SASL with Memcached is only supported with binary protocol

### DIFF
--- a/lib/Cake/Cache/Engine/MemcachedEngine.php
+++ b/lib/Cake/Cache/Engine/MemcachedEngine.php
@@ -130,6 +130,7 @@ class MemcachedEngine extends CacheEngine {
 					__d('cake_dev', 'Memcached extension is not build with SASL support')
 				);
 			}
+			$this->_Memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
 			$this->_Memcached->setSaslAuthData($this->settings['login'], $this->settings['password']);
 		}
 


### PR DESCRIPTION
I saw warning messages when I used MamchedEngine for Session Handler(use MemCachier).
Memcached::setSaslAuthData() required binary protocol.

```
Warning (2): Memcached::setSaslAuthData(): SASL is only supported with binary protocol [CORE/Cake/Cache/Engine/MemcachedEngine.php, line 130]

Memcached::setSaslAuthData() - [internal], line ??
MemcachedEngine::init() - CORE/Cake/Cache/Engine/MemcachedEngine.php, line 130
Cache::_buildEngine() - CORE/Cake/Cache/Cache.php, line 180
Cache::config() - CORE/Cake/Cache/Cache.php, line 151
Configure::{closure}() - ROOT/Config/bootstrap/environments/heroku.php, line 43
Environment::setup() - ROOT/Plugin/Environments/Lib/Environment.php, line 101
Environment::start() - ROOT/Plugin/Environments/Lib/Environment.php, line 45
include - ROOT/Config/bootstrap/environments.php, line 8
include - ROOT/Config/bootstrap.php, line 19
Configure::bootstrap() - CORE/Cake/Core/Configure.php, line 92
include - CORE/Cake/bootstrap.php, line 175
[main] - ROOT/webroot/index.php, line 85
```

This PR is added binary protocol option in MemcachedEngine.
