### PR TITLE
Raise an exception on invalid belongs to many data.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -277,6 +277,7 @@ class BelongsToMany extends Association {
  * @param \Cake\ORM\Query $fetchQuery The query to get results from
  * @param array $options The options passed to the eager loader
  * @return array
+ * @throws \RuntimeException when the association property is not part of the results set.
  */
 	protected function _buildResultMap($fetchQuery, $options) {
 		$resultMap = [];
@@ -285,6 +286,12 @@ class BelongsToMany extends Association {
 		$hydrated = $fetchQuery->hydrate();
 
 		foreach ($fetchQuery->all() as $result) {
+			if (!isset($result[$property])) {
+				throw new \RuntimeException(sprintf(
+					'"%s" is missing from the belongsToMany results. Results cannot be created.',
+					$property
+				));
+			}
 			$result[$this->_junctionProperty] = $result[$property];
 			unset($result[$property]);
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -80,6 +80,20 @@ class QueryRegressionTest extends TestCase {
 	}
 
 /**
+ * Tests that eagerloading belongsToMany with find list fails with a helpful message.
+ *
+ * @expectedException \RuntimeException
+ * @return void
+ */
+	public function testEagerLoadingBelongsToManyList() {
+		$table = TableRegistry::get('Articles');
+		$table->belongsToMany('Tags', [
+			'finder' => 'list'
+		]);
+		$table->find()->contain('Tags')->toArray();
+	}
+
+/**
  * Tests that duplicate aliases in contain() can be used, even when they would
  * naturally be attached to the query instead of eagerly loaded. What should
  * happen here is that One of the duplicates will be changed to be loaded using


### PR DESCRIPTION
If an association uses an incorrect find type (like list), the results cannot be joined together so we should raise an exception.

Refs #5282
