### PR TITLE
Add a hasFinder method to table object

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1482,6 +1482,19 @@ class Table implements RepositoryInterface, EventListenerInterface {
 	}
 
 /**
+ * Returns true if the finder exists for the table
+ *
+ * @param string $type name of finder to check
+ *
+ * @return bool
+ */
+	public function hasFinder($type) {
+		$finder = 'find' . $type;
+
+		return method_exists($this, $finder) || ($this->_behaviors && $this->_behaviors->hasFinder($type));
+	}
+
+/**
  * Calls a finder method directly and applies it to the passed query,
  * if no query is passed a new one will be created and returned
  *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3732,6 +3732,11 @@ class TableTest extends TestCase {
 		EventManager::instance()->detach($cb, 'Model.initialize');
 	}
 
+/**
+ * Tests the hasFinder method
+ *
+ * @return void
+ */
 	public function testHasFinder() {
 		$table = TableRegistry::get('articles');
 		$table->addBehavior('Sluggable');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3732,4 +3732,12 @@ class TableTest extends TestCase {
 		EventManager::instance()->detach($cb, 'Model.initialize');
 	}
 
+	public function testHasFinder() {
+		$table = TableRegistry::get('articles');
+		$table->addBehavior('Sluggable');
+
+		$this->assertTrue($table->hasFinder('list'));
+		$this->assertTrue($table->hasFinder('noSlug'));
+		$this->assertFalse($table->hasFinder('noFind'));
+	}
 }


### PR DESCRIPTION
Adds a simple method for checking if a table has a finder available to use.

Usage:

``` php
$table->hasFinder('list');
```

Useful for something like

``` php
if ($table->hasFinder($customFinder)) {
    $table->find($customFinder);
}
```

Cleaner (imo) than having a no-op catch block for the `BadMethodCallException`
