### PR TITLE
Change output to show the difference between fixture data and fields

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -291,7 +291,7 @@ class CakeTestFixture {
 					$merge = array_values( $mergeData );
 					if (count($fields) !== count($merge)) {
 
-						$mergeFields = array_keys( $merge_data );
+						$mergeFields = array_keys( $mergeData );
 						$remove = array();
 
 						foreach ($fields as $k => $f) {
@@ -301,7 +301,7 @@ class CakeTestFixture {
 							}
 						}
 						$mergeFields = array_diff( $mergeFields, $remove );
-						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this)."\n";
+						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this) . "\n";
 						foreach ($mergeFields as $field) {
 							$message .= "The field '" . $field . "' is in the data fixture but not in the schema." . "\n";
 						}

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -287,25 +287,29 @@ class CakeTestFixture {
 				$fields = array_unique($fields);
 				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
-                                        $merge_data = array_merge( $default, $record );
-					$merge = array_values( $merge_data );                                        
+					$mergeData = array_merge( $default, $record );
+					$merge = array_values( $mergeData );
 					if (count($fields) !== count($merge)) {
 
-                                                $merge_fields = array_keys( $merge_data );
-                                                $remove = array();
-                                                
-                                                foreach( $fields as $f ) {
-                                                    if( in_array( $f, $merge_fields ) ) {
-                                                        $remove[] = $f;
-                                                    }
-                                                }
-                                                $merge_fields = array_diff( $merge_fields, $remove );
-                                                $message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this)."\n";
-                                                foreach( $merge_fields as $field ) {
-                                                    $message .= "The field '".$field."' is not in the fixture used in the schema."."\n";
-                                                }
-                                                
-                                                throw new CakeException( $message );
+						$mergeFields = array_keys( $merge_data );
+						$remove = array();
+
+						foreach ($fields as $k => $f) {
+							if (in_array( $f, $mergeFields )) {
+								$remove[] = $f;
+								unset( $fields[$k] );
+							}
+						}
+						$mergeFields = array_diff( $mergeFields, $remove );
+						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this)."\n";
+						foreach ($mergeFields as $field) {
+							$message .= "The field '" . $field . "' is in the data fixture but not in the schema." . "\n";
+						}
+						foreach ($fields as $field) {
+							$message .= "The field '" . $field . "' is in the fixture but not in the data." . "\n";
+						}
+
+						throw new CakeException( $message );
 					}
 					$values[] = $merge;
 				}

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -288,7 +288,7 @@ class CakeTestFixture {
 				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
                                         $merge_data = array_merge( $default, $record );
-					$merge = array_values( $temporal );                                        
+					$merge = array_values( $merge_data );                                        
 					if (count($fields) !== count($merge)) {
 
                                                 $merge_fields = array_keys( $merge_data );

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -295,7 +295,7 @@ class CakeTestFixture {
 
 						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this) . "\n";
 						foreach ($mergeFields as $field) {
-						    $message .= "The field '" . $field . "' is in the data fixture but not in the schema." . "\n";
+							$message .= "The field '" . $field . "' is in the data fixture but not in the schema." . "\n";
 						}
 
 						throw new CakeException( $message );

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -287,26 +287,15 @@ class CakeTestFixture {
 				$fields = array_unique($fields);
 				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
-					$mergeData = array_merge( $default, $record );
-					$merge = array_values( $mergeData );
+					$mergeData = array_merge($default, $record);
+					$merge = array_values($mergeData);
 					if (count($fields) !== count($merge)) {
 
-						$mergeFields = array_keys( $mergeData );
-						$remove = array();
+						$mergeFields = array_diff_key(array_keys($mergeData), $fields);
 
-						foreach ($fields as $k => $f) {
-							if (in_array( $f, $mergeFields )) {
-								$remove[] = $f;
-								unset( $fields[$k] );
-							}
-						}
-						$mergeFields = array_diff( $mergeFields, $remove );
-						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this) . "\n";
+						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this)."\n";
 						foreach ($mergeFields as $field) {
-							$message .= "The field '" . $field . "' is in the data fixture but not in the schema." . "\n";
-						}
-						foreach ($fields as $field) {
-							$message .= "The field '" . $field . "' is in the fixture but not in the data." . "\n";
+						    $message .= "The field '".$field."' is in the data fixture but not in the schema."."\n";
 						}
 
 						throw new CakeException( $message );

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -293,9 +293,9 @@ class CakeTestFixture {
 
 						$mergeFields = array_diff_key(array_keys($mergeData), $fields);
 
-						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this)."\n";
+						$message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this) . "\n";
 						foreach ($mergeFields as $field) {
-						    $message .= "The field '".$field."' is in the data fixture but not in the schema."."\n";
+						    $message .= "The field '" . $field . "' is in the data fixture but not in the schema." . "\n";
 						}
 
 						throw new CakeException( $message );

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -287,9 +287,25 @@ class CakeTestFixture {
 				$fields = array_unique($fields);
 				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
-					$merge = array_values(array_merge($default, $record));
+                                        $merge_data = array_merge( $default, $record );
+					$merge = array_values( $temporal );                                        
 					if (count($fields) !== count($merge)) {
-						throw new CakeException('Fixture invalid: Count of fields does not match count of values in ' . get_class($this));
+
+                                                $merge_fields = array_keys( $merge_data );
+                                                $remove = array();
+                                                
+                                                foreach( $fields as $f ) {
+                                                    if( in_array( $f, $merge_fields ) ) {
+                                                        $remove[] = $f;
+                                                    }
+                                                }
+                                                $merge_fields = array_diff( $merge_fields, $remove );
+                                                $message = 'Fixture invalid: Count of fields does not match count of values in ' . get_class($this)."\n";
+                                                foreach( $merge_fields as $field ) {
+                                                    $message .= "The field '".$field."' is not in the fixture used in the schema."."\n";
+                                                }
+                                                
+                                                throw new CakeException( $message );
 					}
 					$values[] = $merge;
 				}


### PR DESCRIPTION
This modificación makes easy to know why the fixtures fails when the amount of fields in the data is different form the amount of fields in the schema used in the fixture.
In my case, a fixture with model import and static records data gives error, but doesn't say which fields is to blame. The import model gets a new field but the data stills with old amount of fields, and the error is thrown.

Maybe some optimization could be maded in the comparation.
