### PR TITLE
Correct use statement

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -15,7 +15,7 @@
 namespace Cake\Core;
 
 use Cake\Core\ClassLoader;
-use \DirectoryIterator;
+use DirectoryIterator;
 
 /**
  * Plugin is used to load and locate plugins.

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -16,7 +16,7 @@ namespace Cake\Datasource;
 
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
-use \Traversable;
+use Traversable;
 
 /**
  * An entity represents a single result row from a repository. It exposes the

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -18,7 +18,7 @@ use Aura\Intl\Package;
 use Cake\Core\App;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
-use \Locale;
+use Locale;
 
 /**
  * A generic translations package factory that will load translations files

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -15,7 +15,7 @@
 namespace Cake\Utility;
 
 use Cake\Utility\Exception\XmlException;
-use \DOMDocument;
+use DOMDocument;
 
 /**
  * XML handling for CakePHP.

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -19,7 +19,7 @@ use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\View\StringTemplate;
 use Cake\View\View;
 use Cake\View\Widget\WidgetInterface;
-use \ReflectionClass;
+use ReflectionClass;
 
 /**
  * A registry/factory for input widgets.


### PR DESCRIPTION
Resolves/Clarifies https://github.com/cakephp/cakephp/issues/5341

It both unifies it (both with and without \ are currently in the code) and it provides a clearer way of saying that this is a PHP class instead of a CakePHP core one.
