### PR TITLE
allow table object with no physical table

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -274,6 +274,9 @@ class Table implements RepositoryInterface, EventListenerInterface {
 	public function table($table = null) {
 		if ($table !== null) {
 			$this->_table = $table;
+			if ($table === false) {
+		        	$this->schema([]);
+		        }
 		}
 		if ($this->_table === null) {
 			$table = namespaceSplit(get_class($this));


### PR DESCRIPTION
this allows by calling "$this->table(false);" to have an physical table
this you can use for example for login or contact or feedback form validation

```
public function initialize(array $config)
{
        parent::initialize($config);
        $this->table(false);
}
```

you could even do decimal validation by specifying the exact column type

for example:

```
public function initialize(array $config)
{
        parent::initialize($config);
        $this->table(false);
        $this->schema()->addColumn('length', [
            'type' => 'decimal',
            'length' => 10,
            'precision' => 2,
            'unsigned' => true,
            'null' => false,
            'default' => null
        ]);
}
```
