### PR TITLE
Extract being less verbose until explicitly asked for.

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -366,7 +366,7 @@ class ExtractTask extends AppShell {
 
 			$this->_tokens = array();
 			foreach ($allTokens as $token) {
-				if (!is_array($token) || ($token[0] != T_WHITESPACE && $token[0] != T_INLINE_HTML)) {
+				if (!is_array($token) || ($token[0] !== T_WHITESPACE && $token[0] !== T_INLINE_HTML)) {
 					$this->_tokens[] = $token;
 				}
 			}

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -359,7 +359,7 @@ class ExtractTask extends AppShell {
 	protected function _extractTokens() {
 		foreach ($this->_files as $file) {
 			$this->_file = $file;
-			$this->out(__d('cake_console', 'Processing %s...', $file));
+			$this->out(__d('cake_console', 'Processing %s...', $file), 1, Shell::VERBOSE);
 
 			$code = file_get_contents($file);
 			$allTokens = token_get_all($code);


### PR DESCRIPTION
Lot of noise in the default case
Only `-v` should add that for each file IMO.

It also less likely closes relevant warnings like:

```
Invalid marker content in ...\app\Model\AppModel
php:525
* __(
$end['message'])
```

then.
