### PR TITLE
Handling ResultSet::first() through collection functions

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -248,33 +248,6 @@ class ResultSet implements ResultSetInterface {
 	}
 
 /**
- * Returns the first result in this set and blocks the set so that no other
- * results can be fetched.
- *
- * When using serialized results, the index will be incremented past the
- * end of the results simulating the behavior when the result set is backed
- * by a statement.
- *
- * @return array|object|null
- */
-	public function first() {
-		if (isset($this->_results[0])) {
-			return $this->_results[0];
-		}
-
-		if ($this->valid()) {
-			if ($this->_statement) {
-				$this->_statement->closeCursor();
-			}
-			if (!$this->_statement && $this->_results) {
-				$this->_index = count($this->_results);
-			}
-			return $this->_current;
-		}
-		return null;
-	}
-
-/**
  * Gives the number of rows in the result set.
  *
  * Part of the Countable interface.

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -563,4 +563,17 @@ class QueryRegressionTest extends TestCase {
 		$this->assertCount(3, $results);
 	}
 
+/**
+ * Tests that calling first on the query results will not remove all other results
+ * from the set.
+ *
+ * @return void
+ */
+	public function testFirstOnResultSet() {
+		$results = TableRegistry::get('Articles')->find()->all();
+		$this->assertEquals(3, $results->count());
+		$this->assertNotNull($results->first());
+		$this->assertCount(3, $results->toArray());
+	}
+
 }


### PR DESCRIPTION
In the past we had to handle the first() function differently so we could close the statement and avoid segmentation faults in php. Due to improvements in how the statement is closed in the query and the connection, this is no longer required.

This has the nice side effect that calling `first()` on a ResultSet will not prevent you from getting the rest of the results.
