### PR TITLE
Add support for IS NOT operator

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -539,8 +539,16 @@ class QueryExpression implements ExpressionInterface, Countable {
 			return new UnaryExpression('IS NULL', $expression, UnaryExpression::POSTFIX);
 		}
 
+		if ($operator === 'is not' && $value === null) {
+			return new UnaryExpression('IS NOT NULL', $expression, UnaryExpression::POSTFIX);
+		}
+
 		if ($operator === 'is' && $value !== null) {
 			$operator = '=';
+		}
+
+		if ($operator === 'is not' && $value !== null) {
+			$operator = '!=';
 		}
 
 		return new Comparison($expression, $value, $type, $operator);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2867,10 +2867,33 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that case statements work correctly for various use-cases.
+ * Tests that using the IS NOT operator will automatically translate to the best
+ * possible operator depending on the passed value
  *
  * @return void
  */
+	public function testDirectIsNotNull() {
+		$sql = (new Query($this->connection))
+			->select(['name'])
+			->from(['authors'])
+			->where(['name IS NOT' => null])
+			->sql();
+		$this->assertQuotedQuery('WHERE \(<name>\) IS NOT NULL', $sql, true);
+
+		$results = (new Query($this->connection))
+			->select(['name'])
+			->from(['authors'])
+			->where(['name IS NOT' => 'larry'])
+			->execute();
+		$this->assertCount(3, $results);
+		$this->assertNotEquals(['name' => 'larry'], $results->fetch('assoc'));
+	}
+
+	/**
+	 * Tests that case statements work correctly for various use-cases.
+	 *
+	 * @return void
+	 */
 	public function testSqlCaseStatement() {
 		$query = new Query($this->connection);
 		$publishedCase = $query

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2889,11 +2889,11 @@ class QueryTest extends TestCase {
 		$this->assertNotEquals(['name' => 'larry'], $results->fetch('assoc'));
 	}
 
-	/**
-	 * Tests that case statements work correctly for various use-cases.
-	 *
-	 * @return void
-	 */
+/**
+ * Tests that case statements work correctly for various use-cases.
+ *
+ * @return void
+ */
 	public function testSqlCaseStatement() {
 		$query = new Query($this->connection);
 		$publishedCase = $query


### PR DESCRIPTION
Allows for doing

``` php
$query->where(['field IS NOT' => null]);
```
