### PR TITLE
Make atomic updateAll / deleteAll return the affected rows instead of bool

### DIFF
--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -32,7 +32,7 @@ class SqliteStatement extends BufferedStatement {
 			$changes->execute();
 			$count = $changes->fetch()[0];
 			$changes->closeCursor();
-			return $count;
+			return (int)$count;
 		}
 		return parent::rowCount();
 	}

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -76,7 +76,7 @@ interface RepositoryInterface {
  * @param array $fields A hash of field => new value.
  * @param mixed $conditions Conditions to be used, accepts anything Query::where()
  * can take.
- * @return bool Success Returns true if one or more rows are affected.
+ * @return int Count Returns the affected rows.
  */
 	public function updateAll($fields, $conditions);
 
@@ -94,7 +94,7 @@ interface RepositoryInterface {
  *
  * @param mixed $conditions Conditions to be used, accepts anything Query::where()
  * can take.
- * @return bool Success Returns true if one or more rows are affected.
+ * @return int Count Returns the affected rows.
  * @see RepositoryInterface::delete()
  */
 	public function deleteAll($conditions);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1024,9 +1024,8 @@ class Table implements RepositoryInterface, EventListenerInterface {
 			->set($fields)
 			->where($conditions);
 		$statement = $query->execute();
-		$success = $statement->rowCount() > 0;
 		$statement->closeCursor();
-		return $success;
+		return $statement->rowCount();
 	}
 
 /**
@@ -1104,9 +1103,8 @@ class Table implements RepositoryInterface, EventListenerInterface {
 			->delete()
 			->where($conditions);
 		$statement = $query->execute();
-		$success = $statement->rowCount() > 0;
 		$statement->closeCursor();
-		return $success;
+		return $statement->rowCount();
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -571,7 +571,7 @@ class TableTest extends TestCase {
 		]);
 		$fields = ['username' => 'mark'];
 		$result = $table->updateAll($fields, ['id <' => 4]);
-		$this->assertTrue($result);
+		$this->assertSame(3, $result);
 
 		$result = $table->find('all')
 			->select(['username'])
@@ -617,7 +617,7 @@ class TableTest extends TestCase {
 			'connection' => $this->connection,
 		]);
 		$result = $table->deleteAll(['id <' => 4]);
-		$this->assertTrue($result);
+		$this->assertSame(3, $result);
 
 		$result = $table->find('all')->toArray();
 		$this->assertCount(1, $result, 'Only one record should remain');
@@ -636,7 +636,7 @@ class TableTest extends TestCase {
 			'connection' => $this->connection,
 		]);
 		$result = $table->deleteAll(['Managers.id <' => 4]);
-		$this->assertTrue($result);
+		$this->assertSame(3, $result);
 
 		$result = $table->find('all')->toArray();
 		$this->assertCount(1, $result, 'Only one record should remain');


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/5371

As side-effect of strict asserts I found out that sqlite doesnt really return int where it should:

```
Failed asserting that '3' is identical to 3.
```

 Fixed along with it.
