### PR TITLE
2.5: Fixing Mysql::describe() for timestamp.

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -353,7 +353,6 @@ class Mysql extends DboSource {
 			}
 			if ($fields[$column->Field]['type'] === 'timestamp' && strtoupper($column->Default) === 'CURRENT_TIMESTAMP') {
 				$fields[$column->Field]['default'] = null;
-				$fields[$column->Field]['null'] = true;
 			}
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {
 				$fields[$column->Field]['key'] = $this->index[$column->Key];

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -352,7 +352,8 @@ class Mysql extends DboSource {
 				$fields[$column->Field]['unsigned'] = $this->_unsigned($column->Type);
 			}
 			if ($fields[$column->Field]['type'] === 'timestamp' && strtoupper($column->Default) === 'CURRENT_TIMESTAMP') {
-				$fields[$column->Field]['default'] = '';
+				$fields[$column->Field]['default'] = null;
+				$fields[$column->Field]['null'] = true;
 			}
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {
 				$fields[$column->Field]['key'] = $this->index[$column->Key];

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -906,8 +906,17 @@ SQL;
 			'alias' => 'TimestampDefaultValue'
 		));
 		$result = $this->Dbo->describe($model);
-		$this->assertEquals('', $result['limit_date']['default']);
 		$this->Dbo->execute('DROP TABLE ' . $name);
+
+		$this->assertNull($result['limit_date']['default']);
+		$this->assertTrue($result['limit_date']['null']);
+
+		$schema = new CakeSchema(array(
+			'connection' => 'test',
+			'testdescribes' => $result
+		));
+		$result = $this->Dbo->createSchema($schema);
+		$this->assertContains('`limit_date` timestamp NULL,', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -909,14 +909,13 @@ SQL;
 		$this->Dbo->execute('DROP TABLE ' . $name);
 
 		$this->assertNull($result['limit_date']['default']);
-		$this->assertTrue($result['limit_date']['null']);
 
 		$schema = new CakeSchema(array(
 			'connection' => 'test',
 			'testdescribes' => $result
 		));
 		$result = $this->Dbo->createSchema($schema);
-		$this->assertContains('`limit_date` timestamp NULL,', $result);
+		$this->assertContains('`limit_date` timestamp NOT NULL,', $result);
 	}
 
 /**


### PR DESCRIPTION
CakeTestFixture could not import schema when it has CURRENT_TIMESTAMP as a default value.

For example:

``` sql
CREATE TABLE timestamp_default_values (
    id INT(11) NOT NULL AUTO_INCREMENT,
    phone VARCHAR(10),
    limit_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY(id)
);
```

Mysql::createSchema() contains `limit_date timestamp DEFAULT NULL NOT NULL`.
It is expected "NULL" or "NOT NULL" instead of "DEFAULT NULL NOT NULL".
