### PR TITLE
Helper method to check if a view block exists or not

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -589,6 +589,17 @@ class View {
 	}
 
 /**
+ * Check if a block exists
+ *
+ * @param string $name Name of the block
+ *
+ * @return bool
+ */
+	public function exists($name) {
+		return $this->Blocks->exists($name);
+	}
+
+/**
  * Provides view or element extension/inheritance. Views can extends a
  * parent view and populate blocks in the parent template.
  *

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -155,6 +155,16 @@ class ViewBlock {
 	}
 
 /**
+ * Check if a block exists
+ *
+ * @param string $name Name of the block
+ * @return bool
+ */
+	public function exists($name) {
+		return isset($this->_blocks[$name]);
+	}
+
+/**
  * Get the names of all the existing blocks.
  *
  * @return array An array containing the blocks.

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1349,6 +1349,17 @@ class ViewTest extends TestCase {
 	}
 
 /**
+ * Test checking a block's existance.
+ *
+ * @return void
+ */
+	public function testBlockExist() {
+		$this->assertFalse($this->View->exists('test'));
+		$this->View->assign('test', 'Block content');
+		$this->assertTrue($this->View->exists('test'));
+	}
+
+	/**
  * Test setting a block's content to null
  *
  * @return void

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1359,7 +1359,7 @@ class ViewTest extends TestCase {
 		$this->assertTrue($this->View->exists('test'));
 	}
 
-	/**
+/**
  * Test setting a block's content to null
  *
  * @return void


### PR DESCRIPTION
Handy helper method to check if a block has been created.

Useful for if you are using a block inside a html element that cannot be empty and no default make sense:

``` php
<?php if($this->exists('table-footer')) :?>
    <tfoot>
        <?=$this->fetch('table-footer');?>
    </tfoot>
<?php endif;?>
```
