### PR TITLE
3.0 - update Controller viewPath for windows

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -259,7 +259,7 @@ class Controller implements EventListenerInterface {
 					'Cake\Utility\Inflector::camelize',
 					explode('/', $request->params['prefix'])
 				);
-				$viewPath = implode('/', $prefixes) . DS . $viewPath;
+				$viewPath = implode(DS, $prefixes) . DS . $viewPath;
 			}
 			$this->viewPath = $viewPath;
 		}


### PR DESCRIPTION
 this PR fixes the [ControllerTest::testViewPathConventions()](https://github.com/cakephp/cakephp/blob/3.0/tests/TestCase/Controller/ControllerTest.php#L806) on windows.
