### PR TITLE
Automatically select the App ErrorController.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -15,7 +15,7 @@
 namespace Cake\Error;
 
 use Cake\Controller\Controller;
-use Cake\Controller\ErrorController;
+use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception as CakeException;
 use Cake\Core\Exception\MissingPluginException;
@@ -104,7 +104,8 @@ class ExceptionRenderer {
 		$response = new Response();
 
 		try {
-			$controller = new ErrorController($request, $response);
+			$class = App::className('Error', 'Controller', 'Controller');
+			$controller = new $class($request, $response);
 			$controller->startupProcess();
 		} catch (Exception $e) {
 			if (!empty($controller) && isset($controller->RequestHandler)) {


### PR DESCRIPTION
If the application implements an ErrorController, use that instead of the core one. This provides an easy convention based way for developers to customize error handling. If you need plugin controllers, you'll still have to override the renderer as well.

Refs cakephp/docs#2112
