### PR TITLE
Handle exception when RequestHandler::startup() fails.

### DIFF
--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -158,7 +158,7 @@ class ExceptionRenderer {
 				$startup = false;
 			}
 			// Retry RequestHandler, as another aspect of startupProcess()
-			// could have failed. Ignore any exceptions out of startup, as 
+			// could have failed. Ignore any exceptions out of startup, as
 			// there could be userland input data parsers.
 			if ($startup === false &&
 				!empty($controller) &&

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -153,9 +153,14 @@ class ExceptionRenderer {
 			try {
 				$controller = new CakeErrorController($request, $response);
 				$controller->startupProcess();
+				$startup = true;
 			} catch (Exception $e) {
-				if (!empty($controller) && $controller->Components->enabled('RequestHandler')) {
+				$startup = false;
+			}
+			if ($startup === false && !empty($controller) && $controller->Components->enabled('RequestHandler')) {
+				try {
 					$controller->RequestHandler->startup($controller);
+				} catch (Exception $e) {
 				}
 			}
 		}

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -157,7 +157,13 @@ class ExceptionRenderer {
 			} catch (Exception $e) {
 				$startup = false;
 			}
-			if ($startup === false && !empty($controller) && $controller->Components->enabled('RequestHandler')) {
+			// Retry RequestHandler, as another aspect of startupProcess()
+			// could have failed. Ignore any exceptions out of startup, as 
+			// there could be userland input data parsers.
+			if ($startup === false &&
+				!empty($controller) &&
+				$controller->Components->enabled('RequestHandler')
+			) {
 				try {
 					$controller->RequestHandler->startup($controller);
 				} catch (Exception $e) {


### PR DESCRIPTION
In the case that there is a request data type parser raises an exception, or startup() otherwise fails the error page should be created correctly. While I'm not able to write a test case for this, manual testing confirmed the fix.

Refs #5311
