### PR TITLE
3.0 - Allow matching() and contain() on the same alias

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -664,15 +664,15 @@ abstract class Association {
  * @return void
  */
 	protected function _bindNewAssociations($query, $surrogate, $options) {
-		$contain = $surrogate->contain();
-		$matching = $surrogate->eagerLoader()->matching();
+		$loader = $surrogate->eagerLoader();
+		$contain = $loader->contain();
+		$matching = $loader->matching();
 		$target = $this->_targetTable;
 
 		if (!$contain && !$matching) {
 			return;
 		}
 
-		$loader = $surrogate->eagerLoader();
 		$loader->attachAssociations($query, $target, $options['includeFields']);
 		$newContain = [];
 		foreach ($contain as $alias => $value) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -665,19 +665,25 @@ abstract class Association {
  */
 	protected function _bindNewAssociations($query, $surrogate, $options) {
 		$contain = $surrogate->contain();
+		$matching = $surrogate->eagerLoader()->matching();
 		$target = $this->_targetTable;
 
-		if (!$contain) {
+		if (!$contain && !$matching) {
 			return;
 		}
 
 		$loader = $surrogate->eagerLoader();
 		$loader->attachAssociations($query, $target, $options['includeFields']);
-		$newBinds = [];
+		$newContain = [];
 		foreach ($contain as $alias => $value) {
-			$newBinds[$options['aliasPath'] . '.' . $alias] = $value;
+			$newContain[$options['aliasPath'] . '.' . $alias] = $value;
 		}
-		$query->contain($newBinds);
+
+		$query->contain($newContain);
+
+		foreach ($matching as $alias => $value) {
+			$query->matching($options['aliasPath'] . '.' . $alias, $value['queryBuilder']);
+		}
 	}
 
 /**

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -868,7 +868,9 @@ class BelongsToMany extends Association {
 /**
  * Auxiliary function to construct a new Query object to return all the records
  * in the target table that are associated to those specified in $options from
- * the source table
+ * the source table.
+ *
+ * This is used for eager loading records on the target table based on conditions.
  *
  * @param array $options options accepted by eagerLoader()
  * @return \Cake\ORM\Query
@@ -888,8 +890,14 @@ class BelongsToMany extends Association {
 			]
 		];
 
-		$joins = $matching + $joins;
-		$query->join($joins, [], true)->matching($name);
+		$assoc = $this->target()->association($name);
+		$query
+			->join($matching + $joins, [], true)
+			->autoFields(empty($query->clause('select')))
+			->select($query->aliasFields((array)$assoc->foreignKey(), $name));
+
+		$query->eagerLoader()->addToJoinsMap($name, $assoc);
+		$assoc->attachTo($query);
 		return $query;
 	}
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -233,9 +233,9 @@ class BelongsToMany extends Association {
 		unset($options['queryBuilder']);
 		$options = ['conditions' => [$cond]] + compact('includeFields');
 		$options['foreignKey'] = $this->targetForeignKey();
-		$this->_targetTable
-			->association($junction->alias())
-			->attachTo($query, $options);
+		$assoc = $this->_targetTable->association($junction->alias());
+		$assoc->attachTo($query, $options);
+		$query->eagerLoader()->addToJoinsMap($junction->alias(), $assoc);
 	}
 
 /**

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -235,7 +235,7 @@ class BelongsToMany extends Association {
 		$options['foreignKey'] = $this->targetForeignKey();
 		$assoc = $this->_targetTable->association($junction->alias());
 		$assoc->attachTo($query, $options);
-		$query->eagerLoader()->addToJoinsMap($junction->alias(), $assoc);
+		$query->eagerLoader()->addToJoinsMap($junction->alias(), $assoc, true);
 	}
 
 /**

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -893,7 +893,7 @@ class BelongsToMany extends Association {
 		$assoc = $this->target()->association($name);
 		$query
 			->join($matching + $joins, [], true)
-			->autoFields(empty($query->clause('select')))
+			->autoFields($query->clause('select') === [])
 			->select($query->aliasFields((array)$assoc->foreignKey(), $name));
 
 		$query->eagerLoader()->addToJoinsMap($name, $assoc);

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -140,7 +140,7 @@ class EagerLoader {
  * If called with no arguments it will return the current tree of associations to
  * be matched.
  *
- * @param string $assoc|null A single association or a dot separated path of associations.
+ * @param string|null $assoc A single association or a dot separated path of associations.
  * @param callable|null $builder the callback function to be used for setting extra
  * options to the filtering query
  * @return array The resulting containments array

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -409,13 +409,6 @@ class EagerLoader {
 			return $config;
 		}
 
-		if (!empty($config['config']['matching'])) {
-			throw new \RuntimeException(sprintf(
-				'Cannot use "matching" on "%s" as there is another association with the same alias',
-				$alias
-			));
-		}
-
 		$config['canBeJoined'] = false;
 		$config['config']['strategy'] = $config['instance']::STRATEGY_SELECT;
 	}

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -128,9 +128,13 @@ class EagerLoader {
  * options to the filtering query
  * @return array The resulting containments array
  */
-	public function matching($assoc, callable $builder = null) {
+	public function matching($assoc = null, callable $builder = null) {
 		if ($this->_matching === null) {
 			$this->_matching = new self();
+		}
+
+		if ($assoc === null) {
+			return $this->_matching->contain();
 		}
 
 		$assocs = explode('.', $assoc);

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -424,7 +424,8 @@ class EagerLoader {
  * Helper function used to compile a list of all associations that can be
  * joined in the query.
  *
- * @param array $associations list of associations for $source
+ * @param array $associations list of associations from which to obtain joins
+ * @param array $matching list of associations that should be forcedly joined
  * @return array
  */
 	protected function _resolveJoins($associations, $matching = []) {
@@ -496,7 +497,7 @@ class EagerLoader {
  * - entityClass: The entity that should be used for hydrating the results
  * - nestKey: A dotted path that can be used to inserting the data in the correct nesting.
  *
- * @param \Cake\ORM\Table $repository The table containing the association that
+ * @param \Cake\ORM\Table $table The table containing the association that
  * will be normalized
  * @return array
  */

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -16,6 +16,7 @@ namespace Cake\ORM;
 
 use Cake\Database\Statement\BufferedStatement;
 use Cake\Database\Statement\CallbackStatement;
+use Cake\ORM\Association;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Closure;
@@ -84,6 +85,12 @@ class EagerLoader {
  */
 	protected $_matching;
 
+/**
+ * A map of table aliases pointing to the association objects they represent
+ * for the query.
+ *
+ * @var array
+ */
 	protected $_joinsMap = [];
 
 /**
@@ -521,7 +528,17 @@ class EagerLoader {
 		return $map;
 	}
 
-	public function addToJoinsMap($alias, $assoc) {
+/**
+ * Registers a table alias, typically loaded as a join in a query, as belonging to
+ * an association. This helps hydrators know what to do with the columns coming
+ * from such joined table.
+ *
+ * @param string $alias The table alias as it appears in the query.
+ * @param \Cake\ORM\Association $assoc The association object the alias represents.
+ * will be normalized
+ * @return void
+ */
+	public function addToJoinsMap($alias, Association $assoc) {
 		$this->_joinsMap[$alias] = [
 			'aliasPath' => $alias,
 			'instance' => $assoc,

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -77,7 +77,12 @@ class EagerLoader {
  */
 	protected $_aliasList = [];
 
-	public $_matching = null;
+/**
+ * Another EagerLoader instance that will be used for 'matching' associations.
+ *
+ * @var \Cake\ORM\EagerLoader
+ */
+	protected $_matching;
 
 /**
  * Sets the list of associations that should be eagerly loaded along for a
@@ -486,8 +491,8 @@ class EagerLoader {
  * - alias: The association alias
  * - instance: The association instance
  * - canBeJoined: Whether or not the association will be loaded using a JOIN
- * - entityClass: The entity that should eb used for hydrating the results
- * - nestKey: A dottet path that can be used to inserting the data in the correct nesting.
+ * - entityClass: The entity that should be used for hydrating the results
+ * - nestKey: A dotted path that can be used to inserting the data in the correct nesting.
  *
  * @param \Cake\ORM\Table $repository The table containing the association that
  * will be normalized

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -516,7 +516,7 @@ class EagerLoader {
 					'canBeJoined' => $meta['canBeJoined'],
 					'entityClass' => $meta['instance']->target()->entityClass(),
 					'nestKey' => $meta['canBeJoined'] ? $assoc : $meta['aliasPath'],
-					'matching' => $matching
+					'matching' => isset($meta['matching']) ? $meta['matching'] : $matching
 				];
 				if ($meta['canBeJoined'] && !empty($meta['associations'])) {
 					$visitor($meta['associations'], $matching);
@@ -537,13 +537,16 @@ class EagerLoader {
  * @param string $alias The table alias as it appears in the query.
  * @param \Cake\ORM\Association $assoc The association object the alias represents.
  * will be normalized
+ * @param bool $asMatching Whether or not this join results should be treated as a
+ * 'matching' association.
  * @return void
  */
-	public function addToJoinsMap($alias, Association $assoc) {
+	public function addToJoinsMap($alias, Association $assoc, $asMatching = false) {
 		$this->_joinsMap[$alias] = [
 			'aliasPath' => $alias,
 			'instance' => $assoc,
 			'canBeJoined' => true,
+			'matching' => $asMatching,
 			'associations' => []
 		];
 	}

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -424,8 +424,8 @@ class EagerLoader {
  * Helper function used to compile a list of all associations that can be
  * joined in the query.
  *
- * @param array $associations list of associations from which to obtain joins
- * @param array $matching list of associations that should be forcedly joined
+ * @param array $associations list of associations from which to obtain joins.
+ * @param array $matching list of associations that should be forcibly joined.
  * @return array
  */
 	protected function _resolveJoins($associations, $matching = []) {
@@ -495,7 +495,7 @@ class EagerLoader {
  * - instance: The association instance
  * - canBeJoined: Whether or not the association will be loaded using a JOIN
  * - entityClass: The entity that should be used for hydrating the results
- * - nestKey: A dotted path that can be used to inserting the data in the correct nesting.
+ * - nestKey: A dotted path that can be used to correctly insert the data into the results.
  *
  * @param \Cake\ORM\Table $table The table containing the association that
  * will be normalized
@@ -535,7 +535,7 @@ class EagerLoader {
  * from such joined table.
  *
  * @param string $alias The table alias as it appears in the query.
- * @param \Cake\ORM\Association $assoc The association object the alias represents.
+ * @param \Cake\ORM\Association $assoc The association object the alias represents;
  * will be normalized
  * @return void
  */

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -510,7 +510,7 @@ class EagerLoader {
 
 		$visitor = function ($level, $matching = false) use (&$visitor, &$map) {
 			foreach ($level as $assoc => $meta) {
-				$map[$meta['aliasPath']] = [
+				$map[] = [
 					'alias' => $assoc,
 					'instance' => $meta['instance'],
 					'canBeJoined' => $meta['canBeJoined'],

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -137,7 +137,10 @@ class EagerLoader {
  * parameter, this will translate in setting all those associations with the
  * `matching` option.
  *
- * @param string $assoc A single association or a dot separated path of associations.
+ * If called with no arguments it will return the current tree of associations to
+ * be matched.
+ *
+ * @param string $assoc|null A single association or a dot separated path of associations.
  * @param callable|null $builder the callback function to be used for setting extra
  * options to the filtering query
  * @return array The resulting containments array
@@ -496,6 +499,7 @@ class EagerLoader {
  * - canBeJoined: Whether or not the association will be loaded using a JOIN
  * - entityClass: The entity that should be used for hydrating the results
  * - nestKey: A dotted path that can be used to correctly insert the data into the results.
+ * - mathcing: Whether or not it is an association loaded through `matching()`.
  *
  * @param \Cake\ORM\Table $table The table containing the association that
  * will be normalized

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -796,12 +796,14 @@ class Query extends DatabaseQuery implements JsonSerializable {
  * {@inheritDoc}
  */
 	public function __debugInfo() {
+		$eagerLoader = $this->eagerLoader();
 		return parent::__debugInfo() + [
 			'hydrate' => $this->_hydrate,
 			'buffered' => $this->_useBufferedResults,
 			'formatters' => count($this->_formatters),
 			'mapReducers' => count($this->_mapReduce),
-			'contain' => $this->contain(),
+			'contain' => $eagerLoader->contain(),
+			'matching' => $eagerLoader->matching(),
 			'extraOptions' => $this->_options,
 			'repository' => $this->_repository
 		];

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -298,30 +298,7 @@ class ResultSet implements ResultSetInterface {
  * @return void
  */
 	protected function _calculateAssociationMap() {
-		$contain = $this->_query->eagerLoader()->normalized($this->_defaultTable);
-		$contain = $contain ?: [];
-		if (!$contain) {
-			//return;
-		}
-
-		$map = [];
-		$visitor = function ($level) use (&$visitor, &$map) {
-			foreach ($level as $assoc => $meta) {
-				$map[$meta['aliasPath']] = [
-					'alias' => $assoc,
-					'instance' => $meta['instance'],
-					'canBeJoined' => $meta['canBeJoined'],
-					'entityClass' => $meta['instance']->target()->entityClass(),
-					'nestKey' => $meta['canBeJoined'] ? $assoc : $meta['aliasPath']
-				];
-				if ($meta['canBeJoined'] && !empty($meta['associations'])) {
-					$visitor($meta['associations']);
-				}
-			}
-		};
-		$visitor($contain, []);
-		$this->_query->eagerLoader()->_matching ? $visitor($this->_query->eagerLoader()->_matching->normalized($this->_defaultTable), []) : [];
-		$this->_associationMap = $map;
+		return $this->_associationMap = $this->_query->eagerLoader()->associationsMap($this->_defaultTable);
 	}
 
 /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -401,6 +401,7 @@ class ResultSet implements ResultSetInterface {
 				$entity->clean();
 				$results[$alias] = $entity;
 			}
+
 			$results = $instance->transformRow($results, $alias, $assoc['canBeJoined']);
 		}
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -402,6 +402,12 @@ class ResultSet implements ResultSetInterface {
 				$results[$alias] = $entity;
 			}
 
+			if ($assoc['matching']) {
+				$results['_matchingData'][$alias] = $results[$alias];
+				unset($results[$alias]);
+				continue;
+			}
+
 			$results = $instance->transformRow($results, $alias, $assoc['canBeJoined']);
 		}
 
@@ -410,6 +416,10 @@ class ResultSet implements ResultSetInterface {
 				continue;
 			}
 			$results[$defaultAlias][$alias] = $results[$alias];
+		}
+
+		if (isset($results['_matchingData'])) {
+			$results[$defaultAlias]['_matchingData'] = $results['_matchingData'];
 		}
 
 		$options['source'] = $defaultAlias;

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -83,7 +83,6 @@ class ResultSet implements ResultSetInterface {
  */
 	protected $_containMap = [];
 
-
 /**
  * Map of fields that are fetched from the statement with
  * their type and the table they belong to

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -299,8 +299,9 @@ class ResultSet implements ResultSetInterface {
  */
 	protected function _calculateAssociationMap() {
 		$contain = $this->_query->eagerLoader()->normalized($this->_defaultTable);
+		$contain = $contain ?: [];
 		if (!$contain) {
-			return;
+			//return;
 		}
 
 		$map = [];
@@ -319,6 +320,7 @@ class ResultSet implements ResultSetInterface {
 			}
 		};
 		$visitor($contain, []);
+		$this->_query->eagerLoader()->_matching ? $visitor($this->_query->eagerLoader()->_matching->normalized($this->_defaultTable), []) : [];
 		$this->_associationMap = $map;
 	}
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2287,7 +2287,7 @@ class QueryTest extends TestCase {
 
 /**
  * Tests that it is possible to call matching and contain on the same
- * association with only onle level of depth.
+ * association with only one level of depth.
  *
  * @return void
  */
@@ -2295,13 +2295,12 @@ class QueryTest extends TestCase {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
 
-		$result = $table
-			->find()
+		$result = $table->find()
 			->matching('tags', function ($q) {
 				return $q->where(['tags.id' => 2]);
 			})
-				->contain('tags')
-				->first();
+			->contain('tags')
+			->first();
 
 		$this->assertEquals(1, $result->id);
 		$this->assertCount(2, $result->tags);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2280,4 +2280,29 @@ class QueryTest extends TestCase {
 		$this->assertNull($articles[2]->author);
 	}
 
+/**
+ * Tests that it is possible to call matching and contain on the same
+ * association.
+ *
+ * @return void
+ */
+	public function testMatchingWithContain() {
+		$query = new Query($this->connection, $this->table);
+		$table = TableRegistry::get('authors');
+		$table->hasMany('articles');
+		TableRegistry::get('articles')->belongsToMany('tags');
+
+		$result = $query->repository($table)
+			->select()
+			->matching('articles.tags', function ($q) {
+				return $q->where(['tags.id' => 2]);
+			})
+			->contain('articles')
+			->first();
+
+		$this->assertEquals(1, $result->id);
+		$this->assertCount(2, $result->articles);
+		$this->assertEquals(2, $result->_matchingData['tags']->id);
+	}
+
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -684,8 +684,8 @@ class QueryTest extends TestCase {
 					'Tags' => [
 						'id' => 3,
 						'name' => 'tag3',
-						'articles_tags' => ['article_id' => 2, 'tag_id' => 3]
-					]
+					],
+					'ArticlesTags' => ['article_id' => 2, 'tag_id' => 3]
 				]
 			]
 		];
@@ -709,8 +709,8 @@ class QueryTest extends TestCase {
 					'Tags' => [
 						'id' => 2,
 						'name' => 'tag2',
-						'articles_tags' => ['article_id' => 1, 'tag_id' => 2]
-					]
+					],
+					'ArticlesTags' => ['article_id' => 1, 'tag_id' => 2]
 				]
 			]
 		];
@@ -744,10 +744,6 @@ class QueryTest extends TestCase {
 					'tags' => [
 						'id' => 2,
 						'name' => 'tag2',
-						'articles_tags' => [
-							'article_id' => 1,
-							'tag_id' => 2
-						]
 					],
 					'articles' => [
 						'id' => 1,
@@ -755,7 +751,11 @@ class QueryTest extends TestCase {
 						'title' => 'First Article',
 						'body' => 'First Article Body',
 						'published' => 'Y'
-					]
+					],
+					'ArticlesTags' => [
+							'article_id' => 1,
+							'tag_id' => 2
+						]
 				]
 			]
 		];

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2285,4 +2285,27 @@ class QueryTest extends TestCase {
 		$this->assertEquals(2, $result->_matchingData['tags']->id);
 	}
 
+/**
+ * Tests that it is possible to call matching and contain on the same
+ * association with only onle level of depth.
+ *
+ * @return void
+ */
+	public function testNotSoFarMatchingWithContainOnTheSameAssociation() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+
+		$result = $table
+			->find()
+			->matching('tags', function ($q) {
+				return $q->where(['tags.id' => 2]);
+			})
+				->contain('tags')
+				->first();
+
+		$this->assertEquals(1, $result->id);
+		$this->assertCount(2, $result->tags);
+		$this->assertEquals(2, $result->_matchingData['tags']->id);
+	}
+
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1993,6 +1993,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testConflitingAliases() {
+		$this->markTestIncomplete('Needs an actual conflicting case');
 		$table = TableRegistry::get('ArticlesTags');
 		$table->belongsTo('Articles')->target()->belongsTo('Authors');
 		$table->belongsTo('Tags');
@@ -2000,7 +2001,7 @@ class QueryTest extends TestCase {
 		$table->find()
 			->contain(['Articles.Authors'])
 			->matching('Tags.Authors')
-			->all();
+			->sql();
 	}
 
 /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1997,26 +1997,6 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that it is not allowed to use matching on an association
- * that is already added to containments.
- *
- * @expectedException \RuntimeException
- * @expectedExceptionMessage Cannot use "matching" on "Authors" as there is another association with the same alias
- * @return void
- */
-	public function testConflitingAliases() {
-		$this->markTestIncomplete('Needs an actual conflicting case');
-		$table = TableRegistry::get('ArticlesTags');
-		$table->belongsTo('Articles')->target()->belongsTo('Authors');
-		$table->belongsTo('Tags');
-		$table->Tags->target()->hasOne('Authors');
-		$table->find()
-			->contain(['Articles.Authors'])
-			->matching('Tags.Authors')
-			->sql();
-	}
-
-/**
  * Tests that a hasOne association using the select strategy will still have the
  * key present in the results when no match is found
  *

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -637,12 +637,14 @@ class QueryTest extends TestCase {
 			[
 				'id' => 3,
 				'name' => 'larry',
-				'articles' => [
-					'id' => 2,
-					'title' => 'Second Article',
-					'body' => 'Second Article Body',
-					'author_id' => 3,
-					'published' => 'Y',
+				'_matchingData' => [
+					'articles' => [
+						'id' => 2,
+						'title' => 'Second Article',
+						'body' => 'Second Article Body',
+						'author_id' => 3,
+						'published' => 'Y',
+					]
 				]
 			]
 		];
@@ -678,10 +680,12 @@ class QueryTest extends TestCase {
 				'title' => 'Second Article',
 				'body' => 'Second Article Body',
 				'published' => 'Y',
-				'tags' => [
-					'id' => 3,
-					'name' => 'tag3',
-					'_joinData' => ['article_id' => 2, 'tag_id' => 3]
+				'_matchingData' => [
+					'Tags' => [
+						'id' => 3,
+						'name' => 'tag3',
+						'articles_tags' => ['article_id' => 2, 'tag_id' => 3]
+					]
 				]
 			]
 		];
@@ -701,10 +705,12 @@ class QueryTest extends TestCase {
 				'body' => 'First Article Body',
 				'author_id' => 1,
 				'published' => 'Y',
-				'tags' => [
-					'id' => 2,
-					'name' => 'tag2',
-					'_joinData' => ['article_id' => 1, 'tag_id' => 2]
+				'_matchingData' => [
+					'Tags' => [
+						'id' => 2,
+						'name' => 'tag2',
+						'articles_tags' => ['article_id' => 1, 'tag_id' => 2]
+					]
 				]
 			]
 		];
@@ -734,16 +740,21 @@ class QueryTest extends TestCase {
 			[
 				'id' => 1,
 				'name' => 'mariano',
-				'articles' => [
-					'id' => 1,
-					'title' => 'First Article',
-					'body' => 'First Article Body',
-					'author_id' => 1,
-					'published' => 'Y',
+				'_matchingData' => [
 					'tags' => [
 						'id' => 2,
 						'name' => 'tag2',
-						'_joinData' => ['article_id' => 1, 'tag_id' => 2]
+						'articles_tags' => [
+							'article_id' => 1,
+							'tag_id' => 2
+						]
+					],
+					'articles' => [
+						'id' => 1,
+						'author_id' => 1,
+						'title' => 'First Article',
+						'body' => 'First Article Body',
+						'published' => 'Y'
 					]
 				]
 			]
@@ -1856,7 +1867,7 @@ class QueryTest extends TestCase {
 
 		$results = $query->toArray();
 		$this->assertCount(1, $results);
-		$this->assertEquals('tag3', $results[0]->articles->articles_tags->tag->name);
+		$this->assertEquals('tag3', $results[0]->_matchingData['tags']->name);
 	}
 
 /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1895,7 +1895,8 @@ class QueryTest extends TestCase {
 			'buffered' => false,
 			'formatters' => 1,
 			'mapReducers' => 1,
-			'contain' => [
+			'contain' => [],
+			'matching' => [
 				'articles' => [
 					'queryBuilder' => null,
 					'matching' => true


### PR DESCRIPTION
One of the most annoying limitations of the ORM was that it was impossible to both filter by an association and get all records for it using `contain()`.

This PR solves this limitation, but has the side effect that any data generated by `matching()` will be put into a separate key into the results:

Before:

``` php
['id' => 1, 'name' => 'Foo', 'tags' => ['id' => 100, 'name' => 'Cake']]
```

``` php
['id' => 1, 'name' => 'Foo',  '_matchingData' => ['Tags' => ['id' => 100, 'name' => 'Cake']]]
```

Personally, I think this is good change as the way data from `matching()` was nested made absolutely no sense with the rest of what the ORM did for returning results. To be honest,  that inconsistency was for me one of the sad parts of the library.

Also closes #5381, #5214 and #3457 
