### PR TITLE
Allow an array for URLs to be consistent with assertRedirect().

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -174,7 +174,7 @@ abstract class IntegrationTestCase extends TestCase {
  * a property. You can use various assert methods to check the
  * response.
  *
- * @param string $url The url to request.
+ * @param string|array $url The URL to request.
  * @return void
  */
 	public function get($url) {
@@ -188,7 +188,7 @@ abstract class IntegrationTestCase extends TestCase {
  * a property. You can use various assert methods to check the
  * response.
  *
- * @param string $url The url to request.
+ * @param string|array $url The URL to request.
  * @param array $data The data for the request.
  * @return void
  */
@@ -203,7 +203,7 @@ abstract class IntegrationTestCase extends TestCase {
  * a property. You can use various assert methods to check the
  * response.
  *
- * @param string $url The url to request.
+ * @param string|array $url The URL to request.
  * @param array $data The data for the request.
  * @return void
  */
@@ -218,7 +218,7 @@ abstract class IntegrationTestCase extends TestCase {
  * a property. You can use various assert methods to check the
  * response.
  *
- * @param string $url The url to request.
+ * @param string|array $url The URL to request.
  * @param array $data The data for the request.
  * @return void
  */
@@ -233,7 +233,7 @@ abstract class IntegrationTestCase extends TestCase {
  * a property. You can use various assert methods to check the
  * response.
  *
- * @param string $url The url to request.
+ * @param string|array $url The URL to request.
  * @return void
  */
 	public function delete($url) {
@@ -245,7 +245,7 @@ abstract class IntegrationTestCase extends TestCase {
  *
  * Receives and stores the response for future inspection.
  *
- * @param string $url The url
+ * @param string|array $url The URL
  * @param string $method The HTTP method
  * @param array|null $data The request data.
  * @return void
@@ -313,7 +313,7 @@ abstract class IntegrationTestCase extends TestCase {
 /**
  * Create a request object with the configured options and parameters.
  *
- * @param string $url The url
+ * @param string|array $url The URL
  * @param string $method The HTTP method
  * @param array|null $data The request data.
  * @return \Cake\Network\Request The built request.
@@ -326,7 +326,7 @@ abstract class IntegrationTestCase extends TestCase {
 		$session->write($this->_session);
 
 		$props = [
-			'url' => $url,
+			'url' => Router::url($url),
 			'post' => $data,
 			'cookies' => $this->_cookie,
 			'session' => $session,

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -93,6 +93,16 @@ class IntegrationTestCaseTest extends IntegrationTestCase {
 	}
 
 /**
+ * Test array URLs
+ *
+ * @return void
+ */
+	public function testArrayUrls() {
+		$this->post(['controller' => 'Posts', 'action' => 'index']);
+		$this->assertEquals('value', $this->viewVariable('test'));
+	}
+
+/**
  * Test flash and cookie assertions
  *
  * @return void
@@ -196,10 +206,10 @@ class IntegrationTestCaseTest extends IntegrationTestCase {
 	}
 
 /**
- * Test that works in tandem with testEventManagerReset2 to 
+ * Test that works in tandem with testEventManagerReset2 to
  * test the EventManager reset.
  *
- * The return value is passed to testEventManagerReset2 as 
+ * The return value is passed to testEventManagerReset2 as
  * an arguments.
  *
  * @return \Cake\Event\EventManager


### PR DESCRIPTION
post(), get() in the IntegrationTestCase etc should also allow an array, just as in 2.x.
This also unifies it regarding assertRedirect() and in most cases does not require an additional "Router" use  statement then in the application's test files.

``` php
    $url = ['controller' => 'Posts', 'action' => 'add'];
    $this->post($url, $data);
    $anotherUrl = ['controller' => 'Posts', 'action' => 'index'];
    $this->assertRedirect($anotherUrl);
```

So far I [shimmed this on plugin level](https://github.com/dereuromark/cakephp-tools/blob/cake3/src/TestSuite/IntegrationTestCase.php#L28). But it would probably be useful to more.
