### PR TITLE
Allow testing of a specific status code.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -372,6 +372,16 @@ abstract class IntegrationTestCase extends TestCase {
 	}
 
 /**
+ * Assert a specific response status code.
+ *
+ * @return void
+ */
+	public function assertResponse($code) {
+		$actual = $this->_response->statusCode();
+		$this->_assertStatus($code, $code, 'Status code is not ' . $code . ' but ' . $actual);
+	}
+
+/**
  * Helper method for status assertions.
  *
  * @param int $min Min status code.

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -372,11 +372,12 @@ abstract class IntegrationTestCase extends TestCase {
 	}
 
 /**
- * Assert a specific response status code.
+ * Asserts a specific response status code.
  *
+ * @param int $code Status code to assert.
  * @return void
  */
-	public function assertResponse($code) {
+	public function assertResponseCode($code) {
 		$actual = $this->_response->statusCode();
 		$this->_assertStatus($code, $code, 'Status code is not ' . $code . ' but ' . $actual);
 	}


### PR DESCRIPTION
Asserts often times should be as specific as possible, if there was a specific code returned, for example, it should rather check on that one then instead of comparing to a wider range. Similar to assertSame() vs assertEquals(). E.g. when using 301/302 or 200/304.

What do you think of allowing

```
$this->assertResponse($specificCode);
```

here?

If generally accepted as feature, I will add a few tests.
