### PR TITLE
3.0 isolate failling test for insert on sqlServer

### DIFF
--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2195,6 +2195,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testInsertSimple() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$query = new Query($this->connection);
 		$query->insert(['title', 'body'])
 			->into('articles')
@@ -2232,6 +2236,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testInsertSparseRow() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$query = new Query($this->connection);
 		$query->insert(['title', 'body'])
 			->into('articles')
@@ -2267,6 +2275,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testInsertMultipleRowsSparse() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$query = new Query($this->connection);
 		$query->insert(['title', 'body'])
 			->into('articles')
@@ -2305,6 +2317,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testInsertFromSelect() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$select = (new Query($this->connection))->select(['name', "'some text'", 99])
 			->from('authors')
 			->where(['id' => 1]);
@@ -2375,6 +2391,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testInsertExpressionValues() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$query = new Query($this->connection);
 		$query->insert(['title'])
 			->into('articles')
@@ -2895,6 +2915,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testSqlCaseStatement() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$query = new Query($this->connection);
 		$publishedCase = $query
 			->newExpr()

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1405,6 +1405,10 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testInsert() {
+		$this->skipIf(
+			$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+			'Isolated for SqlServer'
+		);
 		$table = TableRegistry::get('articles');
 
 		$result = $table->query()


### PR DESCRIPTION
Not sure you'll find this helpfull but I isolated all the falling tests on sql server so the appveyor build can pass again.
I'm not sure how to fix those tests, the major problem is an error saying that 
`Connection is busy with results for another command`.
It seems linked to the `INSERT INTO %s (%s) OUTPUT INSERTED.` and sql server driver not able to perform two command on the same connection.

If we don't care at this point and/or someone want to handle this in a better way, feel free to just close the PR.
