### PR TITLE
3.0 - Start ORM-less forms

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -22,13 +22,51 @@ use Cake\Validation\Validator;
  * or to other permanent datastores. Ideal for implement forms on top of
  * API services, or contact forms.
  *
+ * ### Building a form
+ *
+ * This class is most useful when subclassed. In a subclass you
+ * should define the `_buildSchema`, `_buildValidator` and optionally,
+ * the `_execute` methods. These allow you to declare your form's
+ * fields, validation and primary action respectively.
+ *
+ * You can also define the validation and schema by chaining method
+ * calls off of `$form->schema()` and `$form->validator()`.
+ *
+ * Forms are conventionally placed in the `App\Form` namespace.
  */
 class Form {
 
+/**
+ * The schema used by this form.
+ *
+ * @var \Cake\Form\Schema;
+ */
 	protected $_schema;
+
+/**
+ * The errors if any
+ *
+ * @var array
+ */
 	protected $_errors = [];
+
+/**
+ * The validator used by this form.
+ *
+ * @var \Cake\Valiation\Validator;
+ */
 	protected $_validator;
 
+/**
+ * Get/Set the schema for this form.
+ *
+ * This method will call `_buildSchema()` when the schema
+ * is first built. This hook method lets you configure the
+ * schema or load a pre-defined one.
+ *
+ * @param \Cake\Form\Schema $schema The schema to set, or null.
+ * @return \Cake\Form\Schema the schema instance.
+ */
 	public function schema(Schema $schema = null) {
 		if ($schema === null && empty($this->_schema)) {
 			$schema = $this->_buildSchema(new Schema());
@@ -39,10 +77,30 @@ class Form {
 		return $this->_schema;
 	}
 
+/**
+ * A hook method intended to be implemented by subclasses.
+ *
+ * You can use this method to define the schema using
+ * the methods on Cake\Form\Schema, or loads a pre-defined
+ * schema from a concrete class.
+ *
+ * @param \Cake\Form\Schema $schema The schema to customize.
+ * @return \Cake\Form\Schema The schema to use.
+ */
 	protected function _buildSchema($schema) {
 		return $schema;
 	}
 
+/**
+ * Get/Set the validator for this form.
+ *
+ * This method will call `_buildValidator()` when the validator
+ * is first built. This hook method lets you configure the
+ * validator or load a pre-defined one.
+ *
+ * @param \Cake\Validation\Validator $validator The validator to set, or null.
+ * @return \Cake\Validation\Validator the validator instance.
+ */
 	public function validator(Validator $validator = null) {
 		if ($validator === null && empty($this->_validator)) {
 			$validator = $this->_buildValidator(new Validator());
@@ -53,20 +111,55 @@ class Form {
 		return $this->_validator;
 	}
 
+/**
+ * A hook method intended to be implemented by subclasses.
+ *
+ * You can use this method to define the validator using
+ * the methods on Cake\Validation\Validator or loads a pre-defined
+ * validator from a concrete class.
+ *
+ * @param \Cake\Validation\Validator $validator The validator to customize.
+ * @return \Cake\Validation\Validator The validator to use.
+ */
 	protected function _buildValidator($validator) {
 		return $validator;
 	}
 
+/**
+ * Used to check if $data passes this form's validation.
+ *
+ * @param array $data The data to check.
+ * @return bool Whether or not the data is valid.
+ */
 	public function isValid($data) {
 		$validator = $this->validator();
 		$this->_errors = $validator->errors($data);
 		return count($this->_errors) === 0;
 	}
 
+/**
+ * Get the errors in the form
+ *
+ * Will return the errors from the last call
+ * to `isValid()` or `execute()`.
+ *
+ * @return array Last set validation errors.
+ */
 	public function errors() {
 		return $this->_errors;
 	}
 
+/**
+ * Execute the form if it is valid.
+ *
+ * First validates the form, then calls the `_execute()` hook method.
+ * This hook method can be implemented in subclasses to perform
+ * the action of the form. This may be sending email, interacting
+ * with a remote API, or anything else you may need.
+ *
+ * @return bool False on validation failure, otherwise returns the
+ *   result of the `_execute()` method.
+ */
 	public function execute($data) {
 		if (!$this->isValid($data)) {
 			return false;
@@ -74,7 +167,15 @@ class Form {
 		return $this->_execute($data);
 	}
 
+/**
+ * Hook method to be implemented in subclasses.
+ *
+ * Used by `execute()` to execute the form's action.
+ *
+ * @return bool
+ */
 	protected function _execute($data) {
+		return true;
 	}
 
 }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -19,7 +19,7 @@ use Cake\Validation\Validator;
 
 /**
  * Form abstraction used to create forms not tied to ORM backed models,
- * or to other permanent datastores. Ideal for implement forms on top of
+ * or to other permanent datastores. Ideal for implementing forms on top of
  * API services, or contact forms.
  *
  * ### Building a form
@@ -53,7 +53,7 @@ class Form {
 /**
  * The validator used by this form.
  *
- * @var \Cake\Valiation\Validator;
+ * @var \Cake\Validation\Validator;
  */
 	protected $_validator;
 
@@ -87,7 +87,7 @@ class Form {
  * @param \Cake\Form\Schema $schema The schema to customize.
  * @return \Cake\Form\Schema The schema to use.
  */
-	protected function _buildSchema($schema) {
+	protected function _buildSchema(Schema $schema) {
 		return $schema;
 	}
 
@@ -121,7 +121,7 @@ class Form {
  * @param \Cake\Validation\Validator $validator The validator to customize.
  * @return \Cake\Validation\Validator The validator to use.
  */
-	protected function _buildValidator($validator) {
+	protected function _buildValidator(Validator $validator) {
 		return $validator;
 	}
 
@@ -131,7 +131,7 @@ class Form {
  * @param array $data The data to check.
  * @return bool Whether or not the data is valid.
  */
-	public function isValid($data) {
+	public function isValid(array $data) {
 		$validator = $this->validator();
 		$this->_errors = $validator->errors($data);
 		return count($this->_errors) === 0;
@@ -157,10 +157,11 @@ class Form {
  * the action of the form. This may be sending email, interacting
  * with a remote API, or anything else you may need.
  *
+ * @param array $data Form data.
  * @return bool False on validation failure, otherwise returns the
  *   result of the `_execute()` method.
  */
-	public function execute($data) {
+	public function execute(array $data) {
 		if (!$this->isValid($data)) {
 			return false;
 		}
@@ -172,9 +173,10 @@ class Form {
  *
  * Used by `execute()` to execute the form's action.
  *
+ * @param array $data Form data.
  * @return bool
  */
-	protected function _execute($data) {
+	protected function _execute(array $data) {
 		return true;
 	}
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Form;
+
+use Cake\Form\Schema;
+use Cake\Validation\Validator;
+
+/**
+ * Form abstraction used to create forms not tied to ORM backed models,
+ * or to other permanent datastores. Ideal for implement forms on top of
+ * API services, or contact forms.
+ *
+ */
+class Form {
+
+	protected $_schema;
+	protected $_errors = [];
+	protected $_validator;
+
+	public function schema(Schema $schema = null) {
+		if ($schema === null && empty($this->_schema)) {
+			$schema = $this->_buildSchema(new Schema());
+		}
+		if ($schema) {
+			$this->_schema = $schema;
+		}
+		return $this->_schema;
+	}
+
+	protected function _buildSchema($schema) {
+		return $schema;
+	}
+
+	public function validator(Validator $validator = null) {
+		if ($validator === null && empty($this->_validator)) {
+			$validator = $this->_buildValidator(new Validator());
+		}
+		if ($validator) {
+			$this->_validator = $validator;
+		}
+		return $this->_validator;
+	}
+
+	protected function _buildValidator($validator) {
+		return $validator;
+	}
+
+	public function isValid($data) {
+		$validator = $this->validator();
+		$this->_errors = $validator->errors($data);
+		return count($this->_errors) === 0;
+	}
+
+	public function errors() {
+		return $this->_errors;
+	}
+
+	public function execute($data) {
+	}
+
+}

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -131,7 +131,7 @@ class Form {
  * @param array $data The data to check.
  * @return bool Whether or not the data is valid.
  */
-	public function isValid(array $data) {
+	public function validate(array $data) {
 		$validator = $this->validator();
 		$this->_errors = $validator->errors($data);
 		return count($this->_errors) === 0;
@@ -141,7 +141,7 @@ class Form {
  * Get the errors in the form
  *
  * Will return the errors from the last call
- * to `isValid()` or `execute()`.
+ * to `validate()` or `execute()`.
  *
  * @return array Last set validation errors.
  */
@@ -162,7 +162,7 @@ class Form {
  *   result of the `_execute()` method.
  */
 	public function execute(array $data) {
-		if (!$this->isValid($data)) {
+		if (!$this->validate($data)) {
 			return false;
 		}
 		return $this->_execute($data);

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -68,6 +68,13 @@ class Form {
 	}
 
 	public function execute($data) {
+		if (!$this->isValid($data)) {
+			return false;
+		}
+		return $this->_execute($data);
+	}
+
+	protected function _execute($data) {
 	}
 
 }

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -19,33 +19,72 @@ namespace Cake\Form;
  */
 class Schema {
 
+/**
+ * The fields in this schema.
+ *
+ * @var array
+ */
 	protected $_fields = [];
 
+/**
+ * The default values for fields.
+ *
+ * @var array
+ */
 	protected $_fieldDefaults = [
 		'type' => null,
 		'length' => null,
 		'required' => false,
 	];
 
+/**
+ * Adds a field to the schema.
+ *
+ * @param string $name The field name.
+ * @param string|array $attrs The attributes for the field, or the type
+ *   as a string.
+ * @return $this
+ */
 	public function addField($name, $attrs) {
+		if (is_string($attrs)) {
+			$attrs = ['type' => $attrs];
+		}
 		$attrs = array_intersect_key($attrs, $this->_fieldDefaults);
 		$this->_fields[$name] = $attrs + $this->_fieldDefaults;
 		return $this;
 	}
 
+/**
+ * Removes a field to the schema.
+ *
+ * @param string $name The field to remove.
+ * @return $this
+ */
 	public function removeField($name) {
 		unset($this->_fields[$name]);
 		return $this;
 	}
 
+/**
+ * Get the list of fields in the schema.
+ *
+ * @return array The list of field names.
+ */
 	public function fields() {
 		return array_keys($this->_fields);
 	}
 
+/**
+ * Get the attributes for a given field.
+ *
+ * @param string $name The field name.
+ * @return null|array The attributes for a field, or null.
+ */
 	public function field($name) {
 		if (!isset($this->_fields[$name])) {
 			return null;
 		}
 		return $this->_fields[$name];
 	}
+
 }

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Form;
+
+/**
+ * Contains the schema information for Form instances.
+ */
+class Schema {
+
+	protected $_fields = [];
+
+	protected $_fieldDefaults = [
+		'type' => null,
+		'length' => null,
+		'required' => false,
+	];
+
+	public function addField($name, $attrs) {
+		$attrs = array_intersect_key($attrs, $this->_fieldDefaults);
+		$this->_fields[$name] = $attrs + $this->_fieldDefaults;
+		return $this;
+	}
+
+	public function removeField($name) {
+		unset($this->_fields[$name]);
+		return $this;
+	}
+
+	public function fields() {
+		return array_keys($this->_fields);
+	}
+
+	public function field($name) {
+		if (!isset($this->_fields[$name])) {
+			return null;
+		}
+		return $this->_fields[$name];
+	}
+}

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -38,6 +38,19 @@ class Schema {
 	];
 
 /**
+ * Add multiple fields to the schema.
+ *
+ * @param array $fields The fields to add.
+ * @return $this
+ */
+	public function addFields(array $fields) {
+		foreach ($fields as $name => $attrs) {
+			$this->addField($name, $attrs);
+		}
+		return $this;
+	}
+
+/**
  * Adds a field to the schema.
  *
  * @param string $name The field name.

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -82,10 +82,64 @@ class FormTest extends TestCase {
 		$this->assertCount(0, $form->errors());
 	}
 
+/**
+ * Test the errors methods.
+ *
+ * @return void
+ */
+	public function testErrors() {
+		$form = new Form();
+		$form->validator()
+			->add('email', 'format', [
+				'message' => 'Must be a valid email',
+				'rule' => 'email'
+			])
+			->add('body', 'length', [
+				'message' => 'Must be so long',
+				'rule' => ['minLength', 12],
+			]);
+
+		$data = [
+			'email' => 'rong',
+			'body' => 'too short'
+		];
+		$form->isValid($data);
+		$errors = $form->errors();
+		$this->assertCount(2, $errors);
+		$this->assertEquals('Must be a valid email', $errors['email']['format']);
+		$this->assertEquals('Must be so long', $errors['body']['length']);
+	}
+
+/**
+ * Test _execute is skipped on validation failure.
+ *
+ * @return void
+ */
 	public function testExecuteInvalid() {
+		$form = $this->getMock('Cake\Form\Form', ['_execute']);
+		$form->validator()
+			->add('email', 'format', ['rule' => 'email']);
+		$data = [
+			'email' => 'rong'
+		];
+		$form->expects($this->never())
+			->method('_execute');
+
+		$this->assertFalse($form->execute($data));
 	}
 
 	public function testExecuteValid() {
+		$form = $this->getMock('Cake\Form\Form', ['_execute']);
+		$form->validator()
+			->add('email', 'format', ['rule' => 'email']);
+		$data = [
+			'email' => 'test@example.com'
+		];
+		$form->expects($this->once())
+			->method('_execute')
+			->with($data);
+
+		$this->assertNull($form->execute($data));
 	}
 
 }

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -128,6 +128,11 @@ class FormTest extends TestCase {
 		$this->assertFalse($form->execute($data));
 	}
 
+/**
+ * test execute() when data is valid.
+ *
+ * @return void
+ */
 	public function testExecuteValid() {
 		$form = $this->getMock('Cake\Form\Form', ['_execute']);
 		$form->validator()
@@ -137,9 +142,10 @@ class FormTest extends TestCase {
 		];
 		$form->expects($this->once())
 			->method('_execute')
-			->with($data);
+			->with($data)
+			->will($this->returnValue(true));
 
-		$this->assertNull($form->execute($data));
+		$this->assertTrue($form->execute($data));
 	}
 
 }

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -51,7 +51,7 @@ class FormTest extends TestCase {
 		$this->assertInstanceOf('Cake\Validation\Validator', $validator);
 		$this->assertSame($validator, $form->validator(), 'Same instance each time');
 
-		$schema = $this->getMock('Cake\Validation\Validator');
+		$validator = $this->getMock('Cake\Validation\Validator');
 		$this->assertSame($validator, $form->validator($validator));
 		$this->assertSame($validator, $form->validator());
 	}

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Form;
+
+use Cake\Form\Form;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Form test case.
+ */
+class FormTest extends TestCase {
+
+/**
+ * Test schema()
+ *
+ * @return void
+ */
+	public function testSchema() {
+		$form = new Form();
+		$schema = $form->schema();
+
+		$this->assertInstanceOf('Cake\Form\Schema', $schema);
+		$this->assertSame($schema, $form->schema(), 'Same instance each time');
+
+		$schema = $this->getMock('Cake\Form\Schema');
+		$this->assertSame($schema, $form->schema($schema));
+		$this->assertSame($schema, $form->schema());
+	}
+
+/**
+ * Test validator()
+ *
+ * @return void
+ */
+	public function testValidator() {
+		$form = new Form();
+		$validator = $form->validator();
+
+		$this->assertInstanceOf('Cake\Validation\Validator', $validator);
+		$this->assertSame($validator, $form->validator(), 'Same instance each time');
+
+		$schema = $this->getMock('Cake\Validation\Validator');
+		$this->assertSame($validator, $form->validator($validator));
+		$this->assertSame($validator, $form->validator());
+	}
+
+/**
+ * Test isValid method.
+ *
+ * @return void
+ */
+	public function testIsValid() {
+		$form = new Form();
+		$form->validator()
+			->add('email', 'format', ['rule' => 'email'])
+			->add('body', 'length', ['rule' => ['minLength', 12]]);
+
+		$data = [
+			'email' => 'rong',
+			'body' => 'too short'
+		];
+		$this->assertFalse($form->isValid($data));
+		$this->assertCount(2, $form->errors());
+
+		$data = [
+			'email' => 'test@example.com',
+			'body' => 'Some content goes here'
+		];
+		$this->assertTrue($form->isValid($data));
+		$this->assertCount(0, $form->errors());
+	}
+
+	public function testExecuteInvalid() {
+	}
+
+	public function testExecuteValid() {
+	}
+
+}

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -57,11 +57,11 @@ class FormTest extends TestCase {
 	}
 
 /**
- * Test isValid method.
+ * Test validate method.
  *
  * @return void
  */
-	public function testIsValid() {
+	public function testValidate() {
 		$form = new Form();
 		$form->validator()
 			->add('email', 'format', ['rule' => 'email'])
@@ -71,14 +71,14 @@ class FormTest extends TestCase {
 			'email' => 'rong',
 			'body' => 'too short'
 		];
-		$this->assertFalse($form->isValid($data));
+		$this->assertFalse($form->validate($data));
 		$this->assertCount(2, $form->errors());
 
 		$data = [
 			'email' => 'test@example.com',
 			'body' => 'Some content goes here'
 		];
-		$this->assertTrue($form->isValid($data));
+		$this->assertTrue($form->validate($data));
 		$this->assertCount(0, $form->errors());
 	}
 
@@ -103,7 +103,7 @@ class FormTest extends TestCase {
 			'email' => 'rong',
 			'body' => 'too short'
 		];
-		$form->isValid($data);
+		$form->validate($data);
 		$errors = $form->errors();
 		$this->assertCount(2, $errors);
 		$this->assertEquals('Must be a valid email', $errors['email']['format']);

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -23,6 +23,22 @@ use Cake\TestSuite\TestCase;
 class SchemaTest extends TestCase {
 
 /**
+ * Test adding multiple fields.
+ *
+ * @return void
+ */
+	public function testAddingMultipleFields() {
+		$schema = new Schema();
+		$schema->addFields([
+			'email' => 'string',
+			'body' => ['type' => 'string', 'length' => 1000]
+		]);
+		$this->assertEquals(['email', 'body'], $schema->fields());
+		$this->assertEquals('string', $schema->field('email')['type']);
+		$this->assertEquals('string', $schema->field('body')['type']);
+	}
+
+/**
  * test adding fields.
  *
  * @return void

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -37,6 +37,14 @@ class SchemaTest extends TestCase {
 		$res = $schema->field('name');
 		$expected = ['type' => 'string', 'length' => null, 'required' => false];
 		$this->assertEquals($expected, $res);
+
+		$res = $schema->addField('email', 'string');
+		$this->assertSame($schema, $res, 'Should be chainable');
+
+		$this->assertEquals(['name', 'email'], $schema->fields());
+		$res = $schema->field('email');
+		$expected = ['type' => 'string', 'length' => null, 'required' => false];
+		$this->assertEquals($expected, $res);
 	}
 
 /**

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Form;
+
+use Cake\Form\Schema;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Form schema test case.
+ */
+class SchemaTest extends TestCase {
+
+/**
+ * test adding fields.
+ *
+ * @return void
+ */
+	public function testAddingFields() {
+		$schema = new Schema();
+
+		$res = $schema->addField('name', ['type' => 'string']);
+		$this->assertSame($schema, $res, 'Should be chainable');
+
+		$this->assertEquals(['name'], $schema->fields());
+		$res = $schema->field('name');
+		$expected = ['type' => 'string', 'length' => null, 'required' => false];
+		$this->assertEquals($expected, $res);
+	}
+
+/**
+ * test adding field whitelist attrs
+ *
+ * @return void
+ */
+	public function testAddingFieldsWhitelist() {
+		$schema = new Schema();
+
+		$schema->addField('name', ['derp' => 'derp', 'type' => 'string']);
+		$expected = ['type' => 'string', 'length' => null, 'required' => false];
+		$this->assertEquals($expected, $schema->field('name'));
+	}
+
+/**
+ * Test removing fields.
+ *
+ * @return void
+ */
+	public function testRemovingFields() {
+		$schema = new Schema();
+
+		$schema->addField('name', ['type' => 'string']);
+		$this->assertEquals(['name'], $schema->fields());
+
+		$res = $schema->removeField('name');
+		$this->assertSame($schema, $res, 'Should be chainable');
+		$this->assertEquals([], $schema->fields());
+		$this->assertNull($schema->field('name'));
+	}
+
+}


### PR DESCRIPTION
This starts the changes discussed in #5390. I've not started the FormHelper context but I will shortly. I figured this was a first step and separate from the FormHelper integration.

I've intentionally not addressed embedding validators, and schema instances in each other. I'd rather get an end to end form workflow complete for simple forms, and then layer in complex forms. I also don't have a solid grasp on how embedded validators/schema/forms should work yet.
