### PR TITLE
Consistent exception behavior for Table::get

### DIFF
--- a/src/Datasource/Exception/InvalidPrimaryKeyException.php
+++ b/src/Datasource/Exception/InvalidPrimaryKeyException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception raised when a particular record was not found
+ *
+ */
+class InvalidPrimaryKeyException extends RuntimeException {
+
+/**
+ * Constructor.
+ *
+ * @param string $message The error message
+ * @param int $code The code of the error, is also the HTTP status code for the error.
+ * @param \Exception|null $previous the previous exception.
+ */
+	public function __construct($message, $code = 404, $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+
+}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -957,7 +957,7 @@ class Table implements RepositoryInterface, EventListenerInterface {
 		$primaryKey = (array)$primaryKey;
 		if (count($key) !== count($primaryKey)) {
 			$primaryKey = $primaryKey ?: [null];
-			$primaryKey = array_map(function($key) {
+			$primaryKey = array_map(function ($key) {
 				return var_export($key, true);
 			}, $primaryKey);
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -19,6 +19,7 @@ use Cake\Core\App;
 use Cake\Database\Schema\Table as Schema;
 use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
@@ -944,7 +945,8 @@ class Table implements RepositoryInterface, EventListenerInterface {
 /**
  * {@inheritDoc}
  *
- * @throws \InvalidArgumentException When $primaryKey has an incorrect number of elements.
+ * @throws Cake\Datasource\Exception\RecordNotFoundException When $primaryKey has an
+ * 		incorrect number of elements.
  */
 	public function get($primaryKey, $options = []) {
 		$key = (array)$this->primaryKey();
@@ -954,10 +956,15 @@ class Table implements RepositoryInterface, EventListenerInterface {
 		}
 		$primaryKey = (array)$primaryKey;
 		if (count($key) !== count($primaryKey)) {
-			throw new \InvalidArgumentException(sprintf(
-				"Incorrect number of primary key values. Expected %d got %d.",
-				count($key),
-				count($primaryKey)
+			$primaryKey = $primaryKey ?: [null];
+			$primaryKey = array_map(function($key) {
+				return var_export($key, true);
+			}, $primaryKey);
+
+			throw new RecordNotFoundException(sprintf(
+				'Invalid primary key, record not found in table "%s" with primary key [%s]',
+				$this->table(),
+				implode($primaryKey, ', ')
 			));
 		}
 		$conditions = array_combine($key, $primaryKey);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -19,7 +19,7 @@ use Cake\Core\App;
 use Cake\Database\Schema\Table as Schema;
 use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
@@ -945,7 +945,7 @@ class Table implements RepositoryInterface, EventListenerInterface {
 /**
  * {@inheritDoc}
  *
- * @throws Cake\Datasource\Exception\RecordNotFoundException When $primaryKey has an
+ * @throws Cake\Datasource\Exception\InvalidPrimaryKeyException When $primaryKey has an
  * 		incorrect number of elements.
  */
 	public function get($primaryKey, $options = []) {
@@ -961,8 +961,8 @@ class Table implements RepositoryInterface, EventListenerInterface {
 				return var_export($key, true);
 			}, $primaryKey);
 
-			throw new RecordNotFoundException(sprintf(
-				'Invalid primary key, record not found in table "%s" with primary key [%s]',
+			throw new InvalidPrimaryKeyException(sprintf(
+				'Record not found in table "%s" with primary key [%s]',
 				$this->table(),
 				implode($primaryKey, ', ')
 			));

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3534,17 +3534,33 @@ class TableTest extends TestCase {
 /**
  * Test that an exception is raised when there are not enough keys.
  *
- * @expectedException \InvalidArgumentException
- * @expectedExceptionMessage Incorrect number of primary key values. Expected 1 got 0.
+ * @expectedException Cake\Datasource\Exception\RecordNotFoundException
+ * @expectedExceptionMessage Invalid primary key, record not found in table "articles" with primary key [NULL]
  * @return void
  */
-	public function testGetExceptionOnIncorrectData() {
+	public function testGetExceptionOnNoData() {
 		$table = new Table([
 			'name' => 'Articles',
 			'connection' => $this->connection,
 			'table' => 'articles',
 		]);
 		$table->get(null);
+	}
+
+/**
+ * Test that an exception is raised when there are too many keys.
+ *
+ * @expectedException Cake\Datasource\Exception\RecordNotFoundException
+ * @expectedExceptionMessage Invalid primary key, record not found in table "articles" with primary key [1, 'two']
+ * @return void
+ */
+	public function testGetExceptionOnTooMuchData() {
+		$table = new Table([
+			'name' => 'Articles',
+			'connection' => $this->connection,
+			'table' => 'articles',
+		]);
+		$table->get([1, 'two']);
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3534,8 +3534,8 @@ class TableTest extends TestCase {
 /**
  * Test that an exception is raised when there are not enough keys.
  *
- * @expectedException Cake\Datasource\Exception\RecordNotFoundException
- * @expectedExceptionMessage Invalid primary key, record not found in table "articles" with primary key [NULL]
+ * @expectedException Cake\Datasource\Exception\InvalidPrimaryKeyException
+ * @expectedExceptionMessage Record not found in table "articles" with primary key [NULL]
  * @return void
  */
 	public function testGetExceptionOnNoData() {
@@ -3550,8 +3550,8 @@ class TableTest extends TestCase {
 /**
  * Test that an exception is raised when there are too many keys.
  *
- * @expectedException Cake\Datasource\Exception\RecordNotFoundException
- * @expectedExceptionMessage Invalid primary key, record not found in table "articles" with primary key [1, 'two']
+ * @expectedException Cake\Datasource\Exception\InvalidPrimaryKeyException
+ * @expectedExceptionMessage Record not found in table "articles" with primary key [1, 'two']
  * @return void
  */
 	public function testGetExceptionOnTooMuchData() {


### PR DESCRIPTION
As highlighted in https://github.com/cakephp/cakephp/pull/5398 - get currently does not always throw a 404. Rather than deal with "sometimes 404, sometimes invalid args" - just always throw a 404.

Also account for the way that (array)null results in [] and not [null]
