### PR TITLE
Don't quit bake when a table is missing.

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -242,8 +242,8 @@ class FixtureTask extends BakeTask {
 		$this->_Schema = new CakeSchema();
 		$data = $this->_Schema->read(array('models' => false, 'connection' => $this->connection));
 		if (!isset($data['tables'][$useTable])) {
-			$this->error('Could not find your selected table ' . $useTable);
-			return false;
+			$this->err("<warning>Warning:</warning> Could not find the '${useTable}' table for ${model}.");
+			return;
 		}
 
 		$tableInfo = $data['tables'][$useTable];


### PR DESCRIPTION
When a table is missing print a warning to stderr but don't exit. This
allows people to use `bake fixture all` with non-conventional tables.

Refs #5377
