### PR TITLE
Correctly log false as 0 for query logger.

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -59,6 +59,8 @@ class QueryLogger {
 		$params = array_map(function ($p) {
 			if ($p === null) {
 				return 'NULL';
+			} elseif (is_bool($p)) {
+				return $p ? '1' : '0';
 			}
 			return is_string($p) ? "'$p'" : $p;
 		}, $query->params);

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -53,12 +53,12 @@ class QueryLoggerTest extends TestCase {
 	public function testStingInterpolation() {
 		$logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
 		$query = new LoggedQuery;
-		$query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3';
-		$query->params = ['p1' => 'string', 'p3' => null, 'p2' => 3];
+		$query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4 AND e = :p5 AND f = :p6';
+		$query->params = ['p1' => 'string', 'p3' => null, 'p2' => 3, 'p4' => true, 'p5' => false, 'p6' => 0];
 
 		$logger->expects($this->once())->method('_log')->with($query);
 		$logger->log($query);
-		$expected = "SELECT a FROM b where a = 'string' AND b = 3 AND c = NULL";
+		$expected = "SELECT a FROM b where a = 'string' AND b = 3 AND c = NULL AND d = 1 AND e = 0 AND f = 0";
 		$this->assertEquals($expected, (string)$query);
 	}
 
@@ -70,12 +70,12 @@ class QueryLoggerTest extends TestCase {
 	public function testStingInterpolation2() {
 		$logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
 		$query = new LoggedQuery;
-		$query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
-		$query->params = ['string', '3', null];
+		$query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ? AND d = ? AND e = ? AND f = ?';
+		$query->params = ['string', '3', null, true, false, 0];
 
 		$logger->expects($this->once())->method('_log')->with($query);
 		$logger->log($query);
-		$expected = "SELECT a FROM b where a = 'string' AND b = '3' AND c = NULL";
+		$expected = "SELECT a FROM b where a = 'string' AND b = '3' AND c = NULL AND d = 1 AND e = 0 AND f = 0";
 		$this->assertEquals($expected, (string)$query);
 	}
 


### PR DESCRIPTION
The query logger was replacing `false` and `0` values with an empty string. This corrects that by replacing bools and `0` with a php string representation.
