### PR TITLE
3.0 cell cache

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -185,7 +185,7 @@ abstract class Cell {
 		};
 
 		if ($cache) {
-			return $this->View->cache(function() use ($render) {
+			return $this->View->cache(function () use ($render) {
 				echo $render();
 			}, $cache);
 		}

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -29,6 +29,7 @@ use Cake\View\CellTrait;
 use Cake\View\ViewVarsTrait;
 use InvalidArgumentException;
 use LogicException;
+use RuntimeException;
 
 /**
  * View, the V in the MVC triad. View interacts with Helpers and view variables passed
@@ -358,7 +359,7 @@ class View {
 
 		$file = $this->_getElementFilename($name);
 		if ($file && $options['cache']) {
-			return $this->cache(function() use ($file, $data, $options) {
+			return $this->cache(function () use ($file, $data, $options) {
 				echo $this->_renderElement($file, $data, $options);
 			}, $options['cache']);
 		}
@@ -386,11 +387,12 @@ class View {
  * @param callable $block The block of code that you want to cache the output of.
  * @param array $options The options defining the cache key etc.
  * @return string The rendered content.
+ * @throws \RuntimeException When $options is lacking a 'key' option.
  */
 	public function cache(callable $block, array $options = []) {
 		$options += ['key' => '', 'config' => $this->elementCache];
 		if (empty($options['key'])) {
-			throw new \RuntimeException('Cannot cache content with an empty key');
+			throw new RuntimeException('Cannot cache content with an empty key');
 		}
 		$result = Cache::read($options['key'], $options['config']);
 		if ($result) {

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -346,7 +346,6 @@ object(Cake\View\View) {
 	request => object(Cake\Network\Request) {}
 	response => object(Cake\Network\Response) {}
 	elementCache => 'default'
-	elementCacheSettings => []
 	viewVars => []
 	Html => object(Cake\View\Helper\HtmlHelper) {}
 	Form => object(Cake\View\Helper\FormHelper) {}

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Cache\Cache;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -245,6 +246,52 @@ class CellTest extends TestCase {
 		$view = new CustomJsonView($request, $response);
 		$cell = $view->cell('Articles');
 		$this->assertSame('TestApp\View\CustomJsonView', $cell->viewClass);
+	}
+
+/**
+ * Test cached render.
+ *
+ * @return void
+ */
+	public function testCachedRenderSimple() {
+		$mock = $this->getMock('Cake\Cache\CacheEngine');
+		$mock->method('init')
+			->will($this->returnValue(true));
+		$mock->method('read')
+			->will($this->returnValue(false));
+		$mock->expects($this->once())
+			->method('write')
+			->with('cell_test_app_view_cell_articles_cell_display', "dummy\n");
+		Cache::config('default', $mock);
+
+		$cell = $this->View->cell('Articles', [], ['cache' => true]);
+		$result = $cell->render();
+		$this->assertEquals("dummy\n", $result);
+		Cache::drop('default');
+	}
+
+/**
+ * Test cached render array config
+ *
+ * @return void
+ */
+	public function testCachedRenderArrayConfig() {
+		$mock = $this->getMock('Cake\Cache\CacheEngine');
+		$mock->method('init')
+			->will($this->returnValue(true));
+		$mock->method('read')
+			->will($this->returnValue(false));
+		$mock->expects($this->once())
+			->method('write')
+			->with('my_key', "dummy\n");
+		Cache::config('cell', $mock);
+
+		$cell = $this->View->cell('Articles', [], [
+			'cache' => ['key' => 'my_key', 'config' => 'cell']
+		]);
+		$result = $cell->render();
+		$this->assertEquals("dummy\n", $result);
+		Cache::drop('cell');
 	}
 
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -861,7 +861,7 @@ class ViewTest extends TestCase {
 			'path' => CACHE . 'views/',
 			'prefix' => ''
 		]);
-		Cache::clear(true, 'test_view');
+		Cache::clear(false, 'test_view');
 
 		$View = $this->PostsController->createView();
 		$View->elementCache = 'test_view';


### PR DESCRIPTION
Add caching to cells using the interface proposed in #5414. I've also added a new generic `cache()` method to View. I figured it could be useful to userland code to provide flexible fragment caching that covers many of the gaps left by the removal of full page caching.
