### PR TITLE
Issue 5400 - paginate conditions applied twice

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -159,9 +159,10 @@ class PaginatorComponent extends Component {
 
 		if (empty($query)) {
 			$query = $object->find($finder, $options);
+		} else {
+			$query->applyOptions($options);
 		}
 
-		$query->applyOptions($options);
 		$results = $query->all();
 		$numResults = count($results);
 		$count = $numResults ? $query->count() : 0;

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -121,11 +121,11 @@ class PaginatorComponentTest extends TestCase {
 				'order' => array('PaginatorPosts.id' => 'ASC')
 			),
 		);
-		$table = $this->_getMockPosts(['find']);
+		$table = $this->_getMockPosts(['query']);
 		$query = $this->_getMockFindQuery();
+
 		$table->expects($this->once())
-			->method('find')
-			->with('all')
+			->method('query')
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())
@@ -203,13 +203,13 @@ class PaginatorComponentTest extends TestCase {
 			'maxLimit' => 10,
 		);
 
-		$table = $this->_getMockPosts(['find']);
+		$table = $this->_getMockPosts(['query']);
 		$query = $this->_getMockFindQuery();
 
 		$table->expects($this->once())
-			->method('find')
-			->with('all')
+			->method('query')
 			->will($this->returnValue($query));
+
 		$query->expects($this->once())
 			->method('applyOptions')
 			->with([
@@ -233,13 +233,13 @@ class PaginatorComponentTest extends TestCase {
 			'maxLimit' => 10,
 		);
 
-		$table = $this->_getMockPosts(['find']);
+		$table = $this->_getMockPosts(['query']);
 		$query = $this->_getMockFindQuery();
 
 		$table->expects($this->once())
-			->method('find')
-			->with('all')
+			->method('query')
 			->will($this->returnValue($query));
+
 		$query->expects($this->once())
 			->method('applyOptions')
 			->with([
@@ -418,13 +418,13 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testValidateSortInvalid() {
-		$table = $this->_getMockPosts(['find']);
+		$table = $this->_getMockPosts(['query']);
 		$query = $this->_getMockFindQuery();
 
 		$table->expects($this->once())
-			->method('find')
-			->with('all')
+			->method('query')
 			->will($this->returnValue($query));
+
 		$query->expects($this->once())->method('applyOptions')
 			->with([
 				'limit' => 20,
@@ -789,13 +789,13 @@ class PaginatorComponentTest extends TestCase {
 			'finder' => 'published',
 			'limit' => 2
 		);
-		$table = $this->_getMockPosts(['find']);
+		$table = $this->_getMockPosts(['query']);
 		$query = $this->_getMockFindQuery();
-		$table->expects($this->once())
-			->method('find')
-			->with('published')
-			->will($this->returnValue($query));
 
+		$table->expects($this->once())
+			->method('query')
+			->will($this->returnValue($query));
+		
 		$query->expects($this->once())->method('applyOptions')
 			->with(['limit' => 2, 'page' => 1, 'order' => [], 'whitelist' => ['limit', 'sort', 'page', 'direction']]);
 		$this->Paginator->paginate($table, $settings);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -795,7 +795,7 @@ class PaginatorComponentTest extends TestCase {
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
-		
+
 		$query->expects($this->once())->method('applyOptions')
 			->with(['limit' => 2, 'page' => 1, 'order' => [], 'whitelist' => ['limit', 'sort', 'page', 'direction']]);
 		$this->Paginator->paginate($table, $settings);


### PR DESCRIPTION
Hi, 

Where conditions were being applied twice when using pagination. (as described in support ticket)

This was because $query->applyOptions was being called both in the $object->find method and then directly after. 

By only calling applyOptions if $object->find is not called, we ensure that applyOptions is only called once.

The modifications to the unittest are ensuring that applyOptions is being called with correct params in the table context instead of the pagination context.

Thank you, loving CakePHP 3.0 so far.

Refs: #5400
