### PR TITLE
RFC 3.0: Deprecate SessionHelper

### DIFF
--- a/src/View/Helper/SessionHelper.php
+++ b/src/View/Helper/SessionHelper.php
@@ -16,6 +16,7 @@ namespace Cake\View\Helper;
 
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
+use Cake\View\View;
 
 /**
  * Session Helper.
@@ -23,6 +24,7 @@ use Cake\View\StringTemplateTrait;
  * Session reading from the view.
  *
  * @link http://book.cakephp.org/3.0/en/views/helpers/session.html
+ * @deprecated 3.0.0 Use request->session() instead.
  */
 class SessionHelper extends Helper {
 
@@ -38,6 +40,17 @@ class SessionHelper extends Helper {
 			'flash' => '<div id="{{key}}-message" class="message-{{class}}">{{message}}</div>'
 		]
 	];
+
+/**
+ *  Constructor
+ *
+ * @param \Cake\View\View $View The View this helper is being attached to.
+ * @param array $config Configuration settings for the helper.
+ */
+	public function __construct(View $View, array $config = array()) {
+		trigger_error('SessionHelper has been deprecated. Use request->session() instead.', E_USER_WARNING);
+		parent::__construct($View, $config);
+	}
 
 /**
  * Reads a session value for a key or returns values for all keys.


### PR DESCRIPTION
**Current inconsistencies:**
- The Session component is deprecated, the helper not.
- The Cookie has not readonly access in the view, whereas the session does.

The way I see it we have two options here:

**a)**
Add CookieHelper as READ ONLY wrapper around `$this->request->cookie()` just as
SessionHelper is one for `$this->request->session()`.
This would allow shorter read-access to those in the view layer.

Additionally both helpers could get a new `consume()` method as mentioned in https://github.com/cakephp/cakephp/issues/5434#issuecomment-67584178 .

Advantage: People would be less inspired to abuse the write-access on the request objects in the View scope when using the read-only helpers.

But they both would be basically just very dumb wrappers.

**b) (this PR)**
The SessionHelper, just as the component, is not of too much use anymore.
The flash stuff is in the FlashHelper, and as such this helper can be removed in favor of

```
$this->request->session()
```

Advantage: Less helpers, unified interface., consume() methods on the source objects.

It is just slightly more to type.
But people can still build their own Session and Cookie helpers in userland code if desired.
One example is [this](https://github.com/dereuromark/cakephp-tools/blob/cake3/src/View/Helper/CookieHelper.php).

**Note:**
This change can be automated using the Upgrade app.

So what way should it go?
