### PR TITLE
Include virtual fields in authenication data.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -119,7 +119,6 @@ abstract class BaseAuthenticate implements EventListenerInterface {
 
 		$result = $table
 			->where($conditions)
-			->hydrate(false)
 			->first();
 
 		if (empty($result)) {
@@ -128,16 +127,16 @@ abstract class BaseAuthenticate implements EventListenerInterface {
 
 		if ($password !== null) {
 			$hasher = $this->passwordHasher();
-			$hashedPassword = $result[$fields['password']];
+			$hashedPassword = $result->get($fields['password']);
 			if (!$hasher->check($password, $hashedPassword)) {
 				return false;
 			}
 
 			$this->_needsPasswordRehash = $hasher->needsRehash($hashedPassword);
-			unset($result[$fields['password']]);
+			$result->unsetProperty($fields['password']);
 		}
 
-		return $result;
+		return $result->toArray();
 	}
 
 /**

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -51,6 +51,8 @@ class FormAuthenticateTest extends TestCase {
 			'userModel' => 'Users'
 		]);
 		$password = password_hash('password', PASSWORD_DEFAULT);
+
+		TableRegistry::clear();
 		$Users = TableRegistry::get('Users');
 		$Users->updateAll(['password' => $password], []);
 		$this->response = $this->getMock('Cake\Network\Response');
@@ -198,6 +200,31 @@ class FormAuthenticateTest extends TestCase {
 		$expected = [
 			'id' => 1,
 			'username' => 'mariano',
+			'created' => new Time('2007-03-17 01:16:23'),
+			'updated' => new Time('2007-03-17 01:18:31')
+		];
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Test that authenticate() includes virtual fields.
+ *
+ * @return void
+ */
+	public function testAuthenticateIncludesVirtualFields() {
+		$users = TableRegistry::get('Users');
+		$users->entityClass('TestApp\Model\Entity\VirtualUser');
+
+		$request = new Request('posts/index');
+		$request->data = [
+			'username' => 'mariano',
+			'password' => 'password'
+		];
+		$result = $this->auth->authenticate($request, $this->response);
+		$expected = [
+			'id' => 1,
+			'username' => 'mariano',
+			'bonus' => 'bonus',
 			'created' => new Time('2007-03-17 01:16:23'),
 			'updated' => new Time('2007-03-17 01:18:31')
 		];

--- a/tests/test_app/TestApp/Model/Entity/VirtualUser.php
+++ b/tests/test_app/TestApp/Model/Entity/VirtualUser.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class VirtualUser extends Entity {
+
+	protected $_virtual = [
+		'bonus'
+	];
+
+	protected function _getBonus() {
+		return 'bonus';
+	}
+}


### PR DESCRIPTION
When a user is authenticated, the session data should include any virtual fields defined on the entity.

Refs #5420
