### PR TITLE
3.0 constants

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -46,7 +46,7 @@ class FileEngine extends CacheEngine {
  * - `isWindows` Automatically populated with whether the host is windows or not
  * - `lock` Used by FileCache. Should files be locked before writing to them?
  * - `mask` The mask used for created files
- * - `path` Path to where cachefiles should be saved.
+ * - `path` Path to where cachefiles should be saved. Defaults to system's temp dir.
  * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
  *    with either another cache config or another application.
  * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
@@ -61,7 +61,7 @@ class FileEngine extends CacheEngine {
 		'isWindows' => false,
 		'lock' => true,
 		'mask' => 0664,
-		'path' => CACHE,
+		'path' => null,
 		'prefix' => 'cake_',
 		'probability' => 100,
 		'serialize' => true
@@ -85,6 +85,9 @@ class FileEngine extends CacheEngine {
 	public function init(array $config = []) {
 		parent::init($config);
 
+		if ($this->_config['path'] === null) {
+			$this->_config['path'] = sys_get_temp_dir();
+		}
 		if (DS === '\\') {
 			$this->_config['isWindows'] = true;
 		}

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -14,6 +14,13 @@
  */
 use Cake\Core\Configure;
 
+if (!defined('DS')) {
+	/**
+	 * Define DS as short form of DIRECTORY_SEPARATOR.
+	 */
+	define('DS', DIRECTORY_SEPARATOR);
+}
+
 if (!function_exists('h')) {
 
 /**

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -15,10 +15,12 @@
 use Cake\Core\Configure;
 
 if (!defined('DS')) {
-	/**
-	 * Define DS as short form of DIRECTORY_SEPARATOR.
-	 */
+
+/**
+ * Define DS as short form of DIRECTORY_SEPARATOR.
+ */
 	define('DS', DIRECTORY_SEPARATOR);
+
 }
 
 if (!function_exists('h')) {

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -44,7 +44,7 @@ class FileLog extends BaseLog {
  * @var array
  */
 	protected $_defaultConfig = [
-		'path' => LOGS,
+		'path' => null,
 		'file' => null,
 		'types' => null,
 		'levels' => [],
@@ -86,7 +86,10 @@ class FileLog extends BaseLog {
 		if (!empty($this->_config['path'])) {
 			$this->_path = $this->_config['path'];
 		}
-		if (Configure::read('debug') && !is_dir($this->_path)) {
+		if ($this->_path !== null &&
+			Configure::read('debug') &&
+			!is_dir($this->_path)
+		) {
 			mkdir($this->_path, 0775, true);
 		}
 

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -68,7 +68,7 @@ class FileLogTest extends TestCase {
 	public function testLogFileWriting() {
 		$this->_deleteLogs(LOGS);
 
-		$log = new FileLog();
+		$log = new FileLog(['path' => LOGS]);
 		$log->log('warning', 'Test warning');
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -145,7 +145,7 @@ class LogTest extends TestCase {
 				'className' => 'File',
 				'path' => TMP . 'tests',
 			]],
-			'Direct instance' => [new FileLog()],
+			'Direct instance' => [new FileLog(['path' => LOGS])],
 		];
 	}
 
@@ -240,11 +240,13 @@ class LogTest extends TestCase {
 		}
 		Log::config('spam', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => 'debug',
 			'file' => 'spam',
 		));
 		Log::config('eggs', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('eggs', 'debug', 'error', 'warning'),
 			'file' => 'eggs',
 		));
@@ -274,11 +276,13 @@ class LogTest extends TestCase {
 	protected function _resetLogConfig() {
 		Log::config('debug', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
 		Log::config('error', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 			'file' => 'error',
 		));
@@ -315,6 +319,7 @@ class LogTest extends TestCase {
 		$this->_resetLogConfig();
 		Log::config('shops', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('info', 'debug', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops',
@@ -361,6 +366,7 @@ class LogTest extends TestCase {
 		$this->_resetLogConfig();
 		Log::config('shops', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('info', 'debug', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops',
@@ -400,12 +406,14 @@ class LogTest extends TestCase {
 
 		Log::config('shops', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('debug', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops.log',
 		));
 		Log::config('eggs', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('debug', 'notice', 'warning'),
 			'scopes' => array('eggs'),
 			'file' => 'eggs.log',
@@ -432,6 +440,7 @@ class LogTest extends TestCase {
 
 		Log::config('scope_test', [
 			'engine' => 'TestApp',
+			'path' => LOGS,
 			'types' => array('notice', 'info', 'debug'),
 			'scopes' => array('foo', 'bar'),
 		]);
@@ -457,11 +466,13 @@ class LogTest extends TestCase {
 
 		Log::config('debug', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
 		Log::config('error', array(
 			'engine' => 'File',
+			'path' => LOGS,
 			'types' => array('emergency', 'alert', 'critical', 'error', 'warning'),
 			'file' => 'error',
 		));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,9 @@ use Cake\Log\Log;
 
 require_once 'vendor/autoload.php';
 
-define('DS', DIRECTORY_SEPARATOR);
+if (!defined('DS')) {
+	define('DS', DIRECTORY_SEPARATOR);
+}
 define('ROOT', dirname(__DIR__));
 define('APP_DIR', 'TestApp');
 


### PR DESCRIPTION
Refs #5452, #5451 

This makes Cache packages usable as standalone without requiring constant CACHE. Since it depends on Core package I added DS constant there.

Another package which requires similar treatment is Log. I don't think system temp dir is a good default for logs so better to just remove use of LOGS constant and have user always specify path for FileLog.
