### PR TITLE
Get the original query in ResultSet

### DIFF
--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -60,6 +60,7 @@ class QueryCacher {
 		if (empty($result)) {
 			return null;
 		}
+		$result->query($query);
 		return $result;
 	}
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -276,11 +276,11 @@ class ResultSet implements ResultSetInterface {
 /**
  * Set or get the original query
  *
- * @param Query $query The query to be set as the original query for the results
- * @return Query Original query from where results were generated
+ * @param \Cake\ORM\Query $query The query to be set as the original query for the results
+ * @return \Cake\ORM\Query Original query from where results were generated
  */
 	public function query($query = null) {
-		if($query != null) {
+		if ($query != null) {
 			$this->_query = $query;
 		}
 		return $this->_query;

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -274,6 +274,15 @@ class ResultSet implements ResultSetInterface {
 	}
 
 /**
+ * Return the original query
+ *
+ * @return Query Original query from where results were generated
+ */
+	public function query() {
+		return $this->_query;
+	}
+
+/**
  * Calculates the list of associations that should get eager loaded
  * when fetching each record
  *

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -280,7 +280,7 @@ class ResultSet implements ResultSetInterface {
  * @return \Cake\ORM\Query Original query from where results were generated
  */
 	public function query($query = null) {
-		if ($query != null) {
+		if ($query !== null) {
 			$this->_query = $query;
 		}
 		return $this->_query;

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -274,11 +274,15 @@ class ResultSet implements ResultSetInterface {
 	}
 
 /**
- * Return the original query
+ * Set or get the original query
  *
+ * @param Query $query The query to be set as the original query for the results
  * @return Query Original query from where results were generated
  */
-	public function query() {
+	public function query($query = null) {
+		if($query != null) {
+			$this->_query = $query;
+		}
 		return $this->_query;
 	}
 


### PR DESCRIPTION
Make the original `Query` available from the ResultSet.

My usecase is that I would like to access the original query table from the cell. So I can pass various ResultSets to the cell

``` PHP
$this->cell('MyCell', [$articles]);
$this->cell('MyCell', [$comments]);
```

and then in the cell I can access for example the original table and make some decisions:

``` PHP
public function display($results) {
    $table = $results->query()->repository();
    $table->someCommonTableMethod();
}
```

my current workaround is

``` PHP
    $table = $results->__debugInfo()['query']->repository();
```

which doesn't look good.

But I am not sure if this works if the query was cached, because when the results are read from the cache it looks like the `$_query` in the `ResultSet` property is empty.

I know I can pass the table to the cell, for example:

``` PHP
$this->cell('MyCell', [ \Cake\ORM\TableRegistry::get('Articles') ]);
$this->cell('MyCell', [ \Cake\ORM\TableRegistry::get('Comments') ]);
```

but this looks bad to me and I think I shouldn't manipulate with TableRegistry or with the Model in the View.
