### PR TITLE
Add assertNoRedirect method.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -437,6 +437,26 @@ abstract class IntegrationTestCase extends TestCase {
 	}
 
 /**
+ * Asserts that the Location header is not set.
+ *
+ * @param string $message The failure message that will be appended to the generated message.
+ * @return void
+ */
+	public function assertNoRedirect($message = '') {
+		if (!$this->_response) {
+			$this->fail('No response set, cannot assert location header. ' . $message);
+		}
+		$result = $this->_response->header();
+		if (!$message) {
+			$message = 'Redirect header set';
+		}
+		if (!empty($result['Location'])) {
+			$message .= ': ' . $result['Location'];
+		}
+		$this->assertEmpty($result['Location'], $message);
+	}
+
+/**
  * Asserts response headers
  *
  * @param string $header The header to check

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -453,7 +453,7 @@ abstract class IntegrationTestCase extends TestCase {
 		if (!empty($result['Location'])) {
 			$message .= ': ' . $result['Location'];
 		}
-		$this->assertEmpty($result['Location'], $message);
+		$this->assertTrue(!empty($result['Location']), $message);
 	}
 
 /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -453,7 +453,7 @@ abstract class IntegrationTestCase extends TestCase {
 		if (!empty($result['Location'])) {
 			$message .= ': ' . $result['Location'];
 		}
-		$this->assertTrue(!empty($result['Location']), $message);
+		$this->assertTrue(empty($result['Location']), $message);
 	}
 
 /**

--- a/tests/Fixture/AssertHtmlTestCase.php
+++ b/tests/Fixture/AssertHtmlTestCase.php
@@ -4,7 +4,7 @@ namespace Cake\Test\Fixture;
 use Cake\TestSuite\TestCase;
 
 /**
- * This class helps in indirectly testing the functionalities of CakeTestCase::assertHtml
+ * This class helps in indirectly testing the functionalities of TestCase::assertHtml
  *
  */
 class AssertHtmlTestCase extends TestCase {

--- a/tests/Fixture/AssertIntegrationTestCase.php
+++ b/tests/Fixture/AssertIntegrationTestCase.php
@@ -1,0 +1,25 @@
+<?php
+namespace Cake\Test\Fixture;
+
+use Cake\Network\Response;
+use Cake\TestSuite\IntegrationTestCase;
+
+/**
+ * This class helps in indirectly testing the functionalities of IntegrationTestCase
+ *
+ */
+class AssertIntegrationTestCase extends IntegrationTestCase {
+
+/**
+ * testBadAssertNoRedirect
+ *
+ * @return void
+ */
+	public function testBadAssertNoRedirect() {
+		$this->_response = new Response();
+		$this->_response->header('Location', 'http://localhost/tasks/index');
+
+		$this->assertNoRedirect();
+	}
+
+}

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -172,6 +172,17 @@ class IntegrationTestCaseTest extends IntegrationTestCase {
 	}
 
 /**
+ * Test the location header assertion.
+ *
+ * @return void
+ */
+	public function testAssertNoRedirect() {
+		$this->_response = new Response();
+
+		$this->assertNoRedirect();
+	}
+
+/**
  * Test the header assertion.
  *
  * @return void

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -20,6 +20,7 @@ use Cake\Network\Response;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\IntegrationTestCase;
+use Cake\Test\Fixture\AssertIntegrationTestCase;
 
 /**
  * Self test of the IntegrationTestCase
@@ -180,6 +181,19 @@ class IntegrationTestCaseTest extends IntegrationTestCase {
 		$this->_response = new Response();
 
 		$this->assertNoRedirect();
+	}
+
+/**
+ * Test the location header assertion.
+ *
+ * @return void
+ */
+	public function testAssertNoRedirectFail() {
+		$test = new AssertIntegrationTestCase('testBadAssertNoRedirect');
+		$result = $test->run();
+		ob_start();
+		$this->assertFalse($result->wasSuccessful());
+		$this->assertEquals(1, $result->failureCount());
 	}
 
 /**


### PR DESCRIPTION
Might be a useful addition to the test case.

I often check for redirects with

```
$this->assertResponseOk();
$this->assertRedirect($url);
```

But when some response should specifically not redirect, this is more difficult to assert.
This PR makes this possible quite easily:

```
$this->assertResponseOk();
$this->assertNoRedirect();
```
