### PR TITLE
TableRegistry::remove()

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -242,4 +242,29 @@ class TableRegistry {
 		return static::$_fallbacked;
 	}
 
+/**
+ * Deletes an instance from the registry.
+ *
+ * Plugin name will be trimmed off of aliases as instances
+ * stored in the registry will be without the plugin name as well.
+ *
+ * @param string $alias The alias to delete.
+ * @return void
+ */
+	public static function delete($alias) {
+		list(, $alias) = pluginSplit($alias);
+
+		if (isset(static::$_instances[$alias])) {
+			unset(static::$_instances[$alias]);
+		}
+
+		if (isset(static::$_config[$alias])) {
+			unset(static::$_config[$alias]);
+		}
+
+		if (isset(static::$_fallbacked[$alias])) {
+			unset(static::$_fallbacked[$alias]);
+		}
+	}
+
 }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -243,15 +243,15 @@ class TableRegistry {
 	}
 
 /**
- * Deletes an instance from the registry.
+ * Removes an instance from the registry.
  *
  * Plugin name will be trimmed off of aliases as instances
  * stored in the registry will be without the plugin name as well.
  *
- * @param string $alias The alias to delete.
+ * @param string $alias The alias to remove.
  * @return void
  */
-	public static function delete($alias) {
+	public static function remove($alias) {
 		list(, $alias) = pluginSplit($alias);
 
 		if (isset(static::$_instances[$alias])) {

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -254,17 +254,9 @@ class TableRegistry {
 	public static function remove($alias) {
 		list(, $alias) = pluginSplit($alias);
 
-		if (isset(static::$_instances[$alias])) {
-			unset(static::$_instances[$alias]);
-		}
-
-		if (isset(static::$_config[$alias])) {
-			unset(static::$_config[$alias]);
-		}
-
-		if (isset(static::$_fallbacked[$alias])) {
-			unset(static::$_fallbacked[$alias]);
-		}
+		unset(static::$_instances[$alias]);
+		unset(static::$_config[$alias]);
+		unset(static::$_fallbacked[$alias]);
 	}
 
 }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -254,9 +254,11 @@ class TableRegistry {
 	public static function remove($alias) {
 		list(, $alias) = pluginSplit($alias);
 
-		unset(static::$_instances[$alias]);
-		unset(static::$_config[$alias]);
-		unset(static::$_fallbacked[$alias]);
+		unset(
+			static::$_instances[$alias],
+			static::$_config[$alias],
+			static::$_fallbacked[$alias]
+		);
 	}
 
 }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -345,4 +345,26 @@ class TableRegistryTest extends TestCase {
 		$this->assertEquals($expected, TableRegistry::genericInstances());
 	}
 
+/**
+ * Tests deleting an instance
+ *
+ * @return void
+ */
+	public function testDelete() {
+		Plugin::load('TestPlugin');
+
+		$pluginTable = TableRegistry::get('TestPlugin.Comments');
+		$cachedTable = TableRegistry::get('Comments');
+
+		$this->assertTrue(TableRegistry::exists('Comments'));
+		$this->assertSame($pluginTable, $cachedTable);
+
+		TableRegistry::delete('Comments');
+		$this->assertFalse(TableRegistry::exists('Comments'));
+
+		$appTable = TableRegistry::get('Comments');
+		$this->assertTrue(TableRegistry::exists('Comments'));
+		$this->assertNotSame($pluginTable, $appTable);
+	}
+
 }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -346,11 +346,11 @@ class TableRegistryTest extends TestCase {
 	}
 
 /**
- * Tests deleting an instance
+ * Tests remove an instance
  *
  * @return void
  */
-	public function testDelete() {
+	public function testRemove() {
 		Plugin::load('TestPlugin');
 
 		$pluginTable = TableRegistry::get('TestPlugin.Comments');
@@ -359,7 +359,7 @@ class TableRegistryTest extends TestCase {
 		$this->assertTrue(TableRegistry::exists('Comments'));
 		$this->assertSame($pluginTable, $cachedTable);
 
-		TableRegistry::delete('Comments');
+		TableRegistry::remove('Comments');
 		$this->assertFalse(TableRegistry::exists('Comments'));
 
 		$appTable = TableRegistry::get('Comments');


### PR DESCRIPTION
In some cases you want to be able to delete just one instance from the TableRegistry. 

For example, you have two separate databases with user info (one global database and one organization specific database). 

We have App\Model\Table\UsersTable for the global users table and 
Organization\Model\Table\UsersTable for the organization specific users

If we want to check the credentials on the organization database first we use TableRegistry::get('Organization.Users'). After this TableRegistry::get('Users') return the UsersTable from the Organization plugin. If we want to check the global database, we have to use TableRegistry::clear() to make TableRegistry::get('Users') return an instance of App\Model\Table\UsersTable. Now all configured instances are gone from the TableRegistry

TableRegistry::delete() makes it possible to remove just one instance from the TableRegistry.
