### PR TITLE
Don't send response from view.

### DIFF
--- a/lib/Cake/Test/Case/View/MediaViewTest.php
+++ b/lib/Cake/Test/Case/View/MediaViewTest.php
@@ -77,9 +77,6 @@ class MediaViewTest extends CakeTestCase {
 				array('name' => null, 'download' => null)
 			);
 
-		$this->MediaView->response->expects($this->once())
-			->method('send');
-
 		$this->MediaView->render();
 	}
 
@@ -115,9 +112,6 @@ class MediaViewTest extends CakeTestCase {
 				)
 			);
 
-		$this->MediaView->response->expects($this->once())
-			->method('send');
-
 		$this->MediaView->render();
 	}
 
@@ -136,10 +130,6 @@ class MediaViewTest extends CakeTestCase {
 			->method('type')
 			->with('jpg')
 			->will($this->returnArgument(0));
-
-		$this->MediaView->response->expects($this->at(0))
-			->method('send')
-			->will($this->returnValue(true));
 
 		$this->MediaView->render();
 	}

--- a/lib/Cake/View/MediaView.php
+++ b/lib/Cake/View/MediaView.php
@@ -93,7 +93,6 @@ class MediaView extends View {
 		if ($compress) {
 			$this->response->compress();
 		}
-		$this->response->send();
 	}
 
 }


### PR DESCRIPTION
When replacing a core from an older app (2.5) with 2.6, I noticed that the MediaView (fatal)errors now with

```
Error(256): [CakeException] Headers already sent in ...\lib\Cake\Network\CakeResponse.php on line 1475
```

This probably came with the addition of `@throws CakeException When headers have already been sent` in 2.6.
When removing the send() part, it worked fine again.

I think the view itself should not send either way.
Just render it, and the response will be sent from the controller layer automatically.
