### PR TITLE
Backport array support for testAction()

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -300,6 +300,17 @@ class ControllerTestCaseTest extends CakeTestCase {
 	}
 
 /**
+ * Test array URLs with testAction()
+ *
+ * @return void
+ */
+	public function testTestActionArrayUrls() {
+		$Controller = $this->Case->generate('TestsApps');
+		$this->Case->testAction(array('controller' => 'tests_apps', 'action' => 'index'));
+		$this->assertInternalType('array', $this->Case->controller->viewVars);
+	}
+
+/**
  * Make sure testAction() can hit plugin controllers.
  *
  * @return void

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -210,12 +210,12 @@ abstract class ControllerTestCase extends CakeTestCase {
  *     - `result` Get the return value of the controller action. Useful
  *       for testing requestAction methods.
  *
- * @param string $url The url to test
+ * @param string|array $url The url to test
  * @param array $options See options
  * @return mixed The specified return type.
  * @triggers ControllerTestCase $Dispatch, array('request' => $request)
  */
-	protected function _testAction($url = '', $options = array()) {
+	protected function _testAction($url, $options = array()) {
 		$this->vars = $this->result = $this->view = $this->contents = $this->headers = null;
 
 		$options += array(
@@ -223,6 +223,10 @@ abstract class ControllerTestCase extends CakeTestCase {
 			'method' => 'POST',
 			'return' => 'result'
 		);
+
+		if (is_array($url)) {
+			$url = Router::url($url);
+		}
 
 		$restore = array('get' => $_GET, 'post' => $_POST);
 

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -210,7 +210,7 @@ abstract class ControllerTestCase extends CakeTestCase {
  *     - `result` Get the return value of the controller action. Useful
  *       for testing requestAction methods.
  *
- * @param string|array $url The url to test
+ * @param string|array $url The URL to test.
  * @param array $options See options
  * @return mixed The specified return type.
  * @triggers ControllerTestCase $Dispatch, array('request' => $request)


### PR DESCRIPTION
Backports array support for testing actions - https://github.com/cakephp/cakephp/pull/5411
Makes upgrading to 3.x and IntegrationTestCase then a little bit smoother.

Also fixed the first argument, as it should not default to empty string (must be set):

```
protected function _testAction($url, $options = array()) {}
```
