### PR TITLE
Allowing numeric literals in FunctionExpression, closes #5211

### DIFF
--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -92,7 +92,7 @@ class FunctionExpression extends QueryExpression {
 	public function add($params, $types = [], $prepend = false) {
 		$put = $prepend ? 'array_unshift' : 'array_push';
 		foreach ($params as $k => $p) {
-			if (is_string($k) && $p === 'literal') {
+			if ($p === 'literal') {
 				$put($this->_conditions, $k);
 				continue;
 			}

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -76,4 +76,19 @@ class FunctionExpressionTest extends TestCase {
 		$g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
 		$this->assertEquals("Wrapper(bar, MyFunction(:c0, :c1))", $g->sql($binder));
 	}
+
+/**
+ * Tests that it is possible to use a number as a literal in a function.
+ *
+ * @return void
+ */
+	public function testNumericLiteral() {
+		$binder = new ValueBinder;
+		$f = new FunctionExpression('MyFunction', ['a_field' => 'literal', '32' => 'literal']);
+		$this->assertEquals('MyFunction(a_field, 32)', $f->sql($binder));
+
+		$f = new FunctionExpression('MyFunction', ['a_field' => 'literal', 32 => 'literal']);
+		$this->assertEquals('MyFunction(a_field, 32)', $f->sql($binder));
+	}
+
 }


### PR DESCRIPTION
fixes #5211
