### PR TITLE
Move some request functionality into a more generic scope.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -19,6 +19,7 @@ use Cake\Core\Configure;
 use Cake\Network\Exception\MethodNotAllowedException;
 use Cake\Network\Session;
 use Cake\Utility\Hash;
+use Cake\Utility\RequestUtility;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.
@@ -980,7 +981,7 @@ class Request implements \ArrayAccess {
  * @return array An array of prefValue => array(content/types)
  */
 	public function parseAccept() {
-		return $this->_parseAcceptWithQualifier($this->header('accept'));
+		return RequestUtility::parseAcceptWithQualifier($this->header('accept'));
 	}
 
 /**
@@ -998,60 +999,7 @@ class Request implements \ArrayAccess {
  * @return mixed If a $language is provided, a boolean. Otherwise the array of accepted languages.
  */
 	public function acceptLanguage($language = null) {
-		$raw = $this->_parseAcceptWithQualifier($this->header('Accept-Language'));
-		$accept = array();
-		foreach ($raw as $languages) {
-			foreach ($languages as &$lang) {
-				if (strpos($lang, '_')) {
-					$lang = str_replace('_', '-', $lang);
-				}
-				$lang = strtolower($lang);
-			}
-			$accept = array_merge($accept, $languages);
-		}
-		if ($language === null) {
-			return $accept;
-		}
-		return in_array(strtolower($language), $accept);
-	}
-
-/**
- * Parse Accept* headers with qualifier options.
- *
- * Only qualifiers will be extracted, any other accept extensions will be
- * discarded as they are not frequently used.
- *
- * @param string $header Header to parse.
- * @return array
- */
-	protected function _parseAcceptWithQualifier($header) {
-		$accept = array();
-		$header = explode(',', $header);
-		foreach (array_filter($header) as $value) {
-			$prefValue = '1.0';
-			$value = trim($value);
-
-			$semiPos = strpos($value, ';');
-			if ($semiPos !== false) {
-				$params = explode(';', $value);
-				$value = trim($params[0]);
-				foreach ($params as $param) {
-					$qPos = strpos($param, 'q=');
-					if ($qPos !== false) {
-						$prefValue = substr($param, $qPos + 2);
-					}
-				}
-			}
-
-			if (!isset($accept[$prefValue])) {
-				$accept[$prefValue] = array();
-			}
-			if ($prefValue) {
-				$accept[$prefValue][] = $value;
-			}
-		}
-		krsort($accept);
-		return $accept;
+		return RequestUtility::acceptLanguage($this->header('Accept-Language'), $language);
 	}
 
 /**

--- a/src/Utility/RequestUtility.php
+++ b/src/Utility/RequestUtility.php
@@ -30,7 +30,8 @@ class RequestUtility {
  *
  * {{{ \Cake\Network\Request::acceptLanguage('es-es'); }}}
  *
- * @param string|null $language The language to test.
+ * @param string $acceptLanguage Header to parse.
+ * @param string|null $checkLanguage The language to test.
  * @return mixed If a $language is provided, a boolean. Otherwise the array of accepted languages.
  */
 	public static function acceptLanguage($acceptLanguage, $checkLanguage = null) {

--- a/src/Utility/RequestUtility.php
+++ b/src/Utility/RequestUtility.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Utility;
+
+/**
+ * Helper functionality for Request class.
+ */
+class RequestUtility {
+
+/**
+ * Get the languages accepted by the client, or check if a specific language is accepted.
+ *
+ * Get the list of accepted languages:
+ *
+ * {{{ \Cake\Network\Request::acceptLanguage(); }}}
+ *
+ * Check if a specific language is accepted:
+ *
+ * {{{ \Cake\Network\Request::acceptLanguage('es-es'); }}}
+ *
+ * @param string|null $language The language to test.
+ * @return mixed If a $language is provided, a boolean. Otherwise the array of accepted languages.
+ */
+	public static function acceptLanguage($acceptLanguage, $checkLanguage = null) {
+		$raw = static::parseAcceptWithQualifier($acceptLanguage);
+		$accept = array();
+		foreach ($raw as $languages) {
+			foreach ($languages as &$lang) {
+				if (strpos($lang, '_')) {
+					$lang = str_replace('_', '-', $lang);
+				}
+				$lang = strtolower($lang);
+			}
+			$accept = array_merge($accept, $languages);
+		}
+		if ($checkLanguage === null) {
+			return $accept;
+		}
+		return in_array(strtolower($checkLanguage), $accept);
+	}
+
+/**
+ * Parse Accept* headers with qualifier options.
+ *
+ * Only qualifiers will be extracted, any other accept extensions will be
+ * discarded as they are not frequently used.
+ *
+ * @param string $header Header to parse.
+ * @return array
+ */
+	public static function parseAcceptWithQualifier($header) {
+		$accept = array();
+		$header = explode(',', $header);
+		foreach (array_filter($header) as $value) {
+			$prefValue = '1.0';
+			$value = trim($value);
+
+			$semiPos = strpos($value, ';');
+			if ($semiPos !== false) {
+				$params = explode(';', $value);
+				$value = trim($params[0]);
+				foreach ($params as $param) {
+					$qPos = strpos($param, 'q=');
+					if ($qPos !== false) {
+						$prefValue = substr($param, $qPos + 2);
+					}
+				}
+			}
+
+			if (!isset($accept[$prefValue])) {
+				$accept[$prefValue] = array();
+			}
+			if ($prefValue) {
+				$accept[$prefValue][] = $value;
+			}
+		}
+		krsort($accept);
+		return $accept;
+	}
+
+}


### PR DESCRIPTION
Can we move some of the functionality of the Request class into its own?
This would cut down on the complexity of the main class (having 1240 lines even after this change).

Alternative for class name right now: "Language"

Easy move:
- parseAcceptWithQualifier()
- acceptLanguage()

Not so easy (and maybe not necessary/possible) due to some non static env() access:
- clientIp()
- referer() (optional)
