### PR TITLE
Fixes callable throwing RuntimeException

### DIFF
--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -66,6 +66,10 @@ class LogEngineRegistry extends ObjectRegistry {
  * @throws \RuntimeException when an object doesn't implement the correct interface.
  */
 	protected function _create($class, $alias, $settings) {
+		if (is_callable($class)) {
+			$class = $class();
+		}
+
 		if (is_object($class)) {
 			$instance = $class;
 		}


### PR DESCRIPTION
The example at http://book.cakephp.org/3.0/en/core-libraries/logging.html#using-monolog threw a runtimeException. This PR fixes that. Much obliged Mr. @lorenzo for troubleshooting this.
