### PR TITLE
Fix Extract task to correctly extract messages with context

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -70,7 +70,7 @@ class ExtractTask extends AppShell {
 	protected $_tokens = array();
 
 /**
- * Extracted strings indexed by category and domain.
+ * Extracted strings indexed by category, domain, msgid and context.
  *
  * @var array
  */
@@ -249,26 +249,26 @@ class ExtractTask extends AppShell {
  * @return void
  */
 	protected function _addTranslation($category, $domain, $msgid, $details = array()) {
-		if (empty($this->_translations[$category][$domain][$msgid])) {
-			$this->_translations[$category][$domain][$msgid] = array(
+		$context = '';
+		if (isset($details['msgctxt'])) {
+			$context = $details['msgctxt'];
+		}
+
+		if (empty($this->_translations[$category][$domain][$msgid][$context])) {
+			$this->_translations[$category][$domain][$msgid][$context] = array(
 				'msgid_plural' => false,
-				'msgctxt' => ''
 			);
 		}
 
 		if (isset($details['msgid_plural'])) {
-			$this->_translations[$category][$domain][$msgid]['msgid_plural'] = $details['msgid_plural'];
+			$this->_translations[$category][$domain][$msgid][$context]['msgid_plural'] = $details['msgid_plural'];
 		}
-		if (isset($details['msgctxt'])) {
-			$this->_translations[$category][$domain][$msgid]['msgctxt'] = $details['msgctxt'];
-		}
-
 		if (isset($details['file'])) {
 			$line = 0;
 			if (isset($details['line'])) {
 				$line = $details['line'];
 			}
-			$this->_translations[$category][$domain][$msgid]['references'][$details['file']][] = $line;
+			$this->_translations[$category][$domain][$msgid][$context]['references'][$details['file']][] = $line;
 		}
 	}
 
@@ -565,35 +565,36 @@ class ExtractTask extends AppShell {
 		$paths[] = realpath(APP) . DS;
 		foreach ($this->_translations as $category => $domains) {
 			foreach ($domains as $domain => $translations) {
-				foreach ($translations as $msgid => $details) {
-					$plural = $details['msgid_plural'];
-					$context = $details['msgctxt'];
-					$files = $details['references'];
-					$occurrences = array();
-					foreach ($files as $file => $lines) {
-						$lines = array_unique($lines);
-						$occurrences[] = $file . ':' . implode(';', $lines);
-					}
-					$occurrences = implode("\n#: ", $occurrences);
-					$header = '#: ' . str_replace(DS, '/', str_replace($paths, '', $occurrences)) . "\n";
+				foreach ($translations as $msgid => $contexts) {
+					foreach ($contexts as $context => $details) {
+						$plural = $details['msgid_plural'];
+						$files = $details['references'];
+						$occurrences = array();
+						foreach ($files as $file => $lines) {
+							$lines = array_unique($lines);
+							$occurrences[] = $file . ':' . implode(';', $lines);
+						}
+						$occurrences = implode("\n#: ", $occurrences);
+						$header = '#: ' . str_replace(DS, '/', str_replace($paths, '', $occurrences)) . "\n";
 
-					$sentence = '';
-					if ($context) {
-						$sentence .= "msgctxt \"{$context}\"\n";
-					}
-					if ($plural === false) {
-						$sentence .= "msgid \"{$msgid}\"\n";
-						$sentence .= "msgstr \"\"\n\n";
-					} else {
-						$sentence .= "msgid \"{$msgid}\"\n";
-						$sentence .= "msgid_plural \"{$plural}\"\n";
-						$sentence .= "msgstr[0] \"\"\n";
-						$sentence .= "msgstr[1] \"\"\n\n";
-					}
+						$sentence = '';
+						if ($context) {
+							$sentence .= "msgctxt \"{$context}\"\n";
+						}
+						if ($plural === false) {
+							$sentence .= "msgid \"{$msgid}\"\n";
+							$sentence .= "msgstr \"\"\n\n";
+						} else {
+							$sentence .= "msgid \"{$msgid}\"\n";
+							$sentence .= "msgid_plural \"{$plural}\"\n";
+							$sentence .= "msgstr[0] \"\"\n";
+							$sentence .= "msgstr[1] \"\"\n\n";
+						}
 
-					$this->_store($category, $domain, $header, $sentence);
-					if (($category !== 'LC_MESSAGES' || $domain !== 'default') && $this->_merge) {
-						$this->_store('LC_MESSAGES', 'default', $header, $sentence);
+						$this->_store($category, $domain, $header, $sentence);
+						if (($category !== 'LC_MESSAGES' || $domain !== 'default') && $this->_merge) {
+							$this->_store('LC_MESSAGES', 'default', $header, $sentence);
+						}
 					}
 				}
 			}

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -162,9 +162,20 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->assertContains('msgid "double \\"quoted\\""', $result, 'Strings with quotes not handled correctly');
 		$this->assertContains("msgid \"single 'quoted'\"", $result, 'Strings with quotes not handled correctly');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:33\n';
-		$pattern .= 'msgctxt "mail"/';
-		$this->assertRegExp($pattern, $result);
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:34\nmsgid "letter"/';
+		$this->assertRegExp($pattern, $result, 'Strings with context should not overwrite strings without context');
+
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:35;37\nmsgctxt "A"\nmsgid "letter"/';
+		$this->assertRegExp($pattern, $result, 'Should contain string with context "A"');
+
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:36\nmsgctxt "B"\nmsgid "letter"/';
+		$this->assertRegExp($pattern, $result, 'Should contain string with context "B"');
+
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:38\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
+		$this->assertRegExp($pattern, $result, 'Plural strings with context should not overwrite strings without context');
+
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:39\nmsgctxt "A"\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
+		$this->assertRegExp($pattern, $result, 'Should contain plural string with context "A"');
 
 		// extract.ctp - reading the domain.pot
 		$result = file_get_contents($this->path . DS . 'domain.pot');

--- a/lib/Cake/Test/test_app/View/Pages/extract.ctp
+++ b/lib/Cake/Test/test_app/View/Pages/extract.ctp
@@ -30,4 +30,10 @@ __('Hot features!'
 // Category
 echo __c('You have a new message (category: LC_TIME).', 5);
 
-echo __x('mail', 'letter');
+// Context
+echo __('letter');
+echo __x('A', 'letter');
+echo __x('B', 'letter');
+echo __x('A', 'letter');
+echo __n('%d letter', '%d letters', $count);
+echo __xn('A', '%d letter', '%d letters', $count);


### PR DESCRIPTION
Currently ExtractTask overwrites previously found messages even if message has different context.

``` PHP
echo __('letter');
echo __x('A', 'letter'); // overwrites message without context
echo __x('B', 'letter'); // overwrites  message with context "A"
echo __x('A', 'letter'); // overwrites  message with context "B"
/*
Actual result:
message "letter" with context "A" at lines 1,2,3,4

Expected result:
message "letter" with no context at line 1
message "letter" with context "A" at lines 2,4
message "letter" with context "B" at line 3
*/
```

The fix is to group messages also by context.
