### PR TITLE
Remove hard dependency on mcrypt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
 	"require": {
 		"php": ">=5.4.16",
 		"ext-intl": "*",
-		"ext-mcrypt": "*",
 		"ext-mbstring": "*",
 		"nesbot/Carbon": "1.13.*",
 		"ircmaxell/password-compat": "1.0.*",

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -25,8 +25,7 @@ class Mcrypt {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
- * @throws \InvalidArgumentException When there are errors.
- * @return string Encrypted/Decrypted string
+ * @throws \LogicException When there are errors.
  */
 	public static function rijndael($text, $key, $operation) {
 		$algorithm = MCRYPT_RIJNDAEL_256;
@@ -53,7 +52,6 @@ class Mcrypt {
  *
  * @param string $plain The value to encrypt.
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
- * @param string|null $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Encrypted data.
  * @throws \InvalidArgumentException On invalid data or key.
  */
@@ -73,7 +71,6 @@ class Mcrypt {
  *
  * @param string $cipher The ciphertext to decrypt.
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
- * @param string|null $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Decrypted data. Any trailing null bytes will be removed.
  * @throws InvalidArgumentException On invalid data or key.
  */
@@ -99,4 +96,3 @@ class Mcrypt {
 		return rtrim($plain, "\0");
 	}
 }
-

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -31,6 +31,7 @@ class Mcrypt {
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
  * @throws \LogicException When there are errors.
+ * @return string Encrytped binary string data, or decrypted data depending on operation.
  */
 	public static function rijndael($text, $key, $operation) {
 		$algorithm = MCRYPT_RIJNDAEL_256;

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         0.10.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Utility\Crypto;

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.10.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Utility\Crypto;
+
+/**
+ * Mcrypt implementation of crypto features for Cake\Utility\Security
+ */
+class Mcrypt {
+
+/**
+ * Encrypts/Decrypts a text using the given key using rijndael method.
+ *
+ * @param string $text Encrypted string to decrypt, normal string to encrypt
+ * @param string $key Key to use as the encryption key for encrypted data.
+ * @param string $operation Operation to perform, encrypt or decrypt
+ * @throws \InvalidArgumentException When there are errors.
+ * @return string Encrypted/Decrypted string
+ */
+	public static function rijndael($text, $key, $operation) {
+		$algorithm = MCRYPT_RIJNDAEL_256;
+		$mode = MCRYPT_MODE_CBC;
+		$ivSize = mcrypt_get_iv_size($algorithm, $mode);
+
+		$cryptKey = substr($key, 0, 32);
+
+		if ($operation === 'encrypt') {
+			$iv = mcrypt_create_iv($ivSize, MCRYPT_DEV_URANDOM);
+			return $iv . '$$' . mcrypt_encrypt($algorithm, $cryptKey, $text, $mode, $iv);
+		}
+		$iv = substr($text, 0, $ivSize);
+		$text = substr($text, $ivSize + 2);
+		return rtrim(mcrypt_decrypt($algorithm, $cryptKey, $text, $mode, $iv), "\0");
+	}
+
+/**
+ * Encrypt a value using AES-256.
+ *
+ * *Caveat* You cannot properly encrypt/decrypt data with trailing null bytes.
+ * Any trailing null bytes will be removed on decryption due to how PHP pads messages
+ * with nulls prior to encryption.
+ *
+ * @param string $plain The value to encrypt.
+ * @param string $key The 256 bit/32 byte key to use as a cipher key.
+ * @param string|null $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
+ * @return string Encrypted data.
+ * @throws \InvalidArgumentException On invalid data or key.
+ */
+	public static function encrypt($plain, $key, $hmacSalt = null) {
+		$algorithm = MCRYPT_RIJNDAEL_128;
+		$mode = MCRYPT_MODE_CBC;
+
+		$ivSize = mcrypt_get_iv_size($algorithm, $mode);
+		$iv = mcrypt_create_iv($ivSize, MCRYPT_DEV_URANDOM);
+		$ciphertext = $iv . mcrypt_encrypt($algorithm, $key, $plain, $mode, $iv);
+		$hmac = hash_hmac('sha256', $ciphertext, $key);
+		return $hmac . $ciphertext;
+	}
+
+/**
+ * Decrypt a value using AES-256.
+ *
+ * @param string $cipher The ciphertext to decrypt.
+ * @param string $key The 256 bit/32 byte key to use as a cipher key.
+ * @param string|null $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
+ * @return string Decrypted data. Any trailing null bytes will be removed.
+ * @throws InvalidArgumentException On invalid data or key.
+ */
+	public static function decrypt($cipher, $key) {
+		// Split out hmac for comparison
+		$macSize = 64;
+		$hmac = substr($cipher, 0, $macSize);
+		$cipher = substr($cipher, $macSize);
+
+		$compareHmac = hash_hmac('sha256', $cipher, $key);
+		// TODO time constant comparison?
+		if ($hmac !== $compareHmac) {
+			return false;
+		}
+
+		$algorithm = MCRYPT_RIJNDAEL_128;
+		$mode = MCRYPT_MODE_CBC;
+		$ivSize = mcrypt_get_iv_size($algorithm, $mode);
+
+		$iv = substr($cipher, 0, $ivSize);
+		$cipher = substr($cipher, $ivSize);
+		$plain = mcrypt_decrypt($algorithm, $key, $cipher, $mode, $iv);
+		return rtrim($plain, "\0");
+	}
+}
+

--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -91,8 +91,13 @@ class Mcrypt {
 		$cipher = substr($cipher, $ivSize);
 		$plain = mcrypt_decrypt($algorithm, $key, $cipher, $mode, $iv);
 
-		// Remove PKCS#7 padding
+		// Remove PKCS#7 padding or Null bytes
+		// Newer values will be PKCS#7 padded, while old
+		// mcrypt values will be null byte padded.
 		$padChar = substr($plain, -1);
+		if ($padChar === "\0") {
+			return trim($plain, "\0");
+		}
 		$padLen = ord($padChar);
 		return substr($plain, 0, -$padLen);
 	}

--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -67,10 +67,10 @@ class OpenSsl {
  * @param string $cipher The ciphertext to decrypt.
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @return string Decrypted data. Any trailing null bytes will be removed.
- * @throws InvalidArgumentException On invalid data or key.
+ * @throws \InvalidArgumentException On invalid data or key.
  */
 	public static function decrypt($cipher, $key) {
-		$method = 'aes-256-cbc';
+		$method = 'AES-256-CBC';
 		$ivSize = openssl_cipher_iv_length($method);
 
 		$iv = substr($cipher, 0, $ivSize);

--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.10.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Utility\Crypto;
+
+/**
+ * OpenSSL implementation of crypto features for Cake\Utility\Security
+ *
+ * OpenSSL should be favored over mcrypt as it is actively maintained and
+ * more widely available.
+ */
+class OpenSsl {
+
+/**
+ * Encrypts/Decrypts a text using the given key using rijndael method.
+ *
+ * @param string $text Encrypted string to decrypt, normal string to encrypt
+ * @param string $key Key to use as the encryption key for encrypted data.
+ * @param string $operation Operation to perform, encrypt or decrypt
+ * @throws \InvalidArgumentException When there are errors.
+ * @return string Encrypted/Decrypted string
+ */
+	public static function rijndael($text, $key, $operation) {
+		throw new \LogicException('rijndael is not compatible with OpenSSL. Use mcrypt instead.');
+	}
+
+/**
+ * Encrypt a value using AES-256.
+ *
+ * *Caveat* You cannot properly encrypt/decrypt data with trailing null bytes.
+ * Any trailing null bytes will be removed on decryption due to how PHP pads messages
+ * with nulls prior to encryption.
+ *
+ * @param string $plain The value to encrypt.
+ * @param string $key The 256 bit/32 byte key to use as a cipher key.
+ * @param string|null $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
+ * @return string Encrypted data.
+ * @throws \InvalidArgumentException On invalid data or key.
+ */
+	public static function encrypt($plain, $key, $hmacSalt = null) {
+		$method = 'AES-128-CBC';
+		$ivSize = openssl_cipher_iv_length($method);
+		$iv = openssl_random_pseudo_bytes($ivSize);
+		$ciphertext = $iv . openssl_encrypt($plain, $method, $key, 0, $iv);
+		$hmac = hash_hmac('sha256', $ciphertext, $key);
+		return $hmac . $ciphertext;
+	}
+
+/**
+ * Decrypt a value using AES-256.
+ *
+ * @param string $cipher The ciphertext to decrypt.
+ * @param string $key The 256 bit/32 byte key to use as a cipher key.
+ * @return string Decrypted data. Any trailing null bytes will be removed.
+ * @throws InvalidArgumentException On invalid data or key.
+ */
+	public static function decrypt($cipher, $key) {
+		// Split out hmac for comparison
+		$macSize = 64;
+		$hmac = substr($cipher, 0, $macSize);
+		$cipher = substr($cipher, $macSize);
+
+		$compareHmac = hash_hmac('sha256', $cipher, $key);
+		// TODO time constant comparison?
+		if ($hmac !== $compareHmac) {
+			return false;
+		}
+		$method = 'AES-128-CBC';
+		$ivSize = openssl_cipher_iv_length($method);
+
+		$iv = substr($cipher, 0, $ivSize);
+		$cipher = substr($cipher, $ivSize);
+		$plain = openssl_decrypt($cipher, $method, $key, 0, $iv);
+		return rtrim($plain, "\0");
+	}
+}
+

--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -28,13 +28,13 @@ namespace Cake\Utility\Crypto;
 class OpenSsl {
 
 /**
- * Encrypts/Decrypts a text using the given key using rijndael method.
+ * Not implemented
  *
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
- * @throws \InvalidArgumentException When there are errors.
- * @return string Encrypted/Decrypted string
+ * @throws \LogicException Rijndael compatibility does not exist with Openssl.
+ * @return void
  */
 	public static function rijndael($text, $key, $operation) {
 		throw new \LogicException('rijndael is not compatible with OpenSSL. Use mcrypt instead.');

--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         0.10.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Utility\Crypto;

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -40,6 +40,13 @@ class Security {
 	protected static $_salt;
 
 /**
+ * The crypto implementation to use.
+ *
+ * @var object
+ */
+	protected static $_instance;
+
+/**
  * Generate authorization hash.
  *
  * @return string Hash
@@ -91,14 +98,22 @@ class Security {
 /**
  * Get the crypto implementation based on the loaded extensions.
  *
+ * @param object $instance The crypto instance to use.
  * @return object Crypto instance.
  */
-	public static function engine() {
-		if (extension_loaded('openssl')) {
-			// return new Openssl();
+	public static function engine($instance = null) {
+		if ($instance === null && static::$_instance === null) {
+			if (extension_loaded('openssl')) {
+				$instance = new Openssl();
+			} elseif (extension_loaded('mcrypt')) {
+				$instance = new Mcrypt();
+			}
 		}
-		if (extension_loaded('mcrypt')) {
-			return new Mcrypt();
+		if ($instance) {
+			static::$_instance = $instance;
+		}
+		if (isset(static::$_instance)) {
+			return static::$_instance;
 		}
 		throw new InvalidArgumentException('No compatible crypto engine loaded. Load either mcrypt or openssl');
 	}

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -106,10 +106,10 @@ class Security {
  */
 	public static function engine($instance = null) {
 		if ($instance === null && static::$_instance === null) {
-			if (extension_loaded('mcrypt')) {
+			if (extension_loaded('openssl')) {
+				$instance = new OpenSsl();
+			} elseif (extension_loaded('mcrypt')) {
 				$instance = new Mcrypt();
-			} elseif (extension_loaded('openssl')) {
-				$instance = new Openssl();
 			}
 		}
 		if ($instance) {

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -105,10 +105,10 @@ class Security {
  */
 	public static function engine($instance = null) {
 		if ($instance === null && static::$_instance === null) {
-			if (extension_loaded('openssl')) {
-				$instance = new Openssl();
-			} elseif (extension_loaded('mcrypt')) {
+			if (extension_loaded('mcrypt')) {
 				$instance = new Mcrypt();
+			} elseif (extension_loaded('openssl')) {
+				$instance = new Openssl();
 			}
 		}
 		if ($instance) {

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -102,6 +102,7 @@ class Security {
  *
  * @param object $instance The crypto instance to use.
  * @return object Crypto instance.
+ * @throws \InvalidArgumentException When no compatible crypto extension is available.
  */
 	public static function engine($instance = null) {
 		if ($instance === null && static::$_instance === null) {

--- a/tests/TestCase/Utility/Crypto/McryptTest.php
+++ b/tests/TestCase/Utility/Crypto/McryptTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.10.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Utility\Crypto;
+
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Crypto\Mcrypt;
+
+/**
+ * Mcrypt engine tests.
+ */
+class McryptTest extends TestCase {
+
+/**
+ * Setup function.
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->skipIf(!function_exists('mcrypt_encrypt'), 'No mcrypt skipping tests');
+		$this->crypt = new Mcrypt();
+	}
+
+/**
+ * testRijndael method
+ *
+ * @return void
+ */
+	public function testRijndael() {
+		$txt = 'The quick brown fox jumped over the lazy dog.';
+		$key = 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi';
+
+		$result = $this->crypt->rijndael($txt, $key, 'encrypt');
+		$this->assertEquals($txt, $this->crypt->rijndael($result, $key, 'decrypt'));
+
+		$result = $this->crypt->rijndael($key, $txt, 'encrypt');
+		$this->assertEquals($key, $this->crypt->rijndael($result, $txt, 'decrypt'));
+
+		$result = $this->crypt->rijndael('', $key, 'encrypt');
+		$this->assertEquals('', $this->crypt->rijndael($result, $key, 'decrypt'));
+
+		$key = 'this is my key of over 32 chars, yes it is';
+		$result = $this->crypt->rijndael($txt, $key, 'encrypt');
+		$this->assertEquals($txt, $this->crypt->rijndael($result, $key, 'decrypt'));
+	}
+
+/**
+ * Test encrypt/decrypt.
+ *
+ * @return void
+ */
+	public function testEncryptDecrypt() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is enough bytes';
+		$result = $this->crypt->encrypt($txt, $key);
+		$this->assertNotEquals($txt, $result, 'Should be encrypted.');
+		$this->assertNotEquals($result, $this->crypt->encrypt($txt, $key), 'Each result is unique.');
+		$this->assertEquals($txt, $this->crypt->decrypt($result, $key));
+	}
+
+/**
+ * Test that changing the key causes decryption to fail.
+ *
+ * @return void
+ */
+	public function testDecryptKeyFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is enough bytes';
+		$result = $this->crypt->encrypt($txt, $key);
+
+		$key = 'Not the same key.';
+		$this->assertFalse($this->crypt->decrypt($txt, $key), 'Modified key will fail.');
+	}
+
+/**
+ * Test that decrypt fails when there is an hmac error.
+ *
+ * @return void
+ */
+	public function testDecryptHmacFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is long enough';
+		$salt = 'this is a delicious salt!';
+		$result = $this->crypt->encrypt($txt, $key, $salt);
+
+		// Change one of the bytes in the hmac.
+		$result[10] = 'x';
+		$this->assertFalse($this->crypt->decrypt($result, $key, $salt), 'Modified hmac causes failure.');
+	}
+
+/**
+ * Ensure that data encrypted with 2.x encrypt() function can be decrypted with mcrypt engine.
+ *
+ * The $cipher variable is base64 encoded data from 2.x encrypt()
+ *
+ * @return
+ */
+	public function testDecryptOldData() {
+		$key = 'My password is nice and long really it is';
+		$cipher = 'ZmFkMjdmY2U2NjgzOTkwMGZmMWJiMzY0ZDA5ZDUwZmNjYTdjNWVkZThkMzhmNzdiY' .
+			'Tg3ZDFjMzNjNmViMDljMnk9k0LmYpwSZH5eq7GmDozMwHxzh37YaXFQ2TK5gXb5OfTKXv83K+NjAS9lIo/Zvw==';
+		$salt = '';
+
+		$result = $this->crypt->encrypt($txt, $key, $salt);
+		$this->assertEquals('This is a secret message', $result);
+	}
+
+}

--- a/tests/TestCase/Utility/Crypto/McryptTest.php
+++ b/tests/TestCase/Utility/Crypto/McryptTest.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         0.10.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Utility\Crypto;

--- a/tests/TestCase/Utility/Crypto/McryptTest.php
+++ b/tests/TestCase/Utility/Crypto/McryptTest.php
@@ -77,27 +77,12 @@ class McryptTest extends TestCase {
  */
 	public function testDecryptKeyFailure() {
 		$txt = 'The quick brown fox';
-		$key = 'This key is enough bytes';
+
+		$key = substr(hash('sha256', 'This key is enough bytes'), 0, 32);
 		$result = $this->crypt->encrypt($txt, $key);
 
-		$key = 'Not the same key.';
+		$key = substr(hash('sha256', 'Not the same key.'), 0, 32);
 		$this->assertFalse($this->crypt->decrypt($txt, $key), 'Modified key will fail.');
-	}
-
-/**
- * Test that decrypt fails when there is an hmac error.
- *
- * @return void
- */
-	public function testDecryptHmacFailure() {
-		$txt = 'The quick brown fox';
-		$key = 'This key is long enough';
-		$salt = 'this is a delicious salt!';
-		$result = $this->crypt->encrypt($txt, $key, $salt);
-
-		// Change one of the bytes in the hmac.
-		$result[10] = 'x';
-		$this->assertFalse($this->crypt->decrypt($result, $key, $salt), 'Modified hmac causes failure.');
 	}
 
 /**
@@ -109,11 +94,14 @@ class McryptTest extends TestCase {
  */
 	public function testDecryptOldData() {
 		$key = 'My password is nice and long really it is';
+		$key = substr(hash('sha256', $key), 0, 32);
+
 		$cipher = 'ZmFkMjdmY2U2NjgzOTkwMGZmMWJiMzY0ZDA5ZDUwZmNjYTdjNWVkZThkMzhmNzdiY' .
 			'Tg3ZDFjMzNjNmViMDljMnk9k0LmYpwSZH5eq7GmDozMwHxzh37YaXFQ2TK5gXb5OfTKXv83K+NjAS9lIo/Zvw==';
-		$salt = '';
+		$data = base64_decode($cipher);
+		$cipher = substr($data, 64);
 
-		$result = $this->crypt->encrypt($txt, $key, $salt);
+		$result = $this->crypt->decrypt($cipher, $key);
 		$this->assertEquals('This is a secret message', $result);
 	}
 

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.10.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Utility\Crypto;
+
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Crypto\OpenSsl;
+
+/**
+ * Openssl engine tests.
+ */
+class OpenSslTest extends TestCase {
+
+/**
+ * Setup function.
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->skipIf(!function_exists('openssl_encrypt'), 'No openssl skipping tests');
+		$this->crypt = new OpenSsl();
+	}
+
+/**
+ * testRijndael method
+ *
+ * @expectedException \LogicException
+ * @return void
+ */
+	public function testRijndael() {
+		$txt = 'The quick brown fox jumped over the lazy dog.';
+		$key = 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi';
+
+		$this->crypt->rijndael($txt, $key, 'encrypt');
+	}
+
+/**
+ * Test encrypt/decrypt.
+ *
+ * @return void
+ */
+	public function testEncryptDecrypt() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is enough bytes';
+		$result = $this->crypt->encrypt($txt, $key);
+		$this->assertNotEquals($txt, $result, 'Should be encrypted.');
+		$this->assertNotEquals($result, $this->crypt->encrypt($txt, $key), 'Each result is unique.');
+		$this->assertEquals($txt, $this->crypt->decrypt($result, $key));
+	}
+
+/**
+ * Test that changing the key causes decryption to fail.
+ *
+ * @return void
+ */
+	public function testDecryptKeyFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is enough bytes';
+		$result = $this->crypt->encrypt($txt, $key);
+
+		$key = 'Not the same key.';
+		$this->assertFalse($this->crypt->decrypt($txt, $key), 'Modified key will fail.');
+	}
+
+/**
+ * Test that decrypt fails when there is an hmac error.
+ *
+ * @return void
+ */
+	public function testDecryptHmacFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is long enough';
+		$salt = 'this is a delicious salt!';
+		$result = $this->crypt->encrypt($txt, $key, $salt);
+
+		// Change one of the bytes in the hmac.
+		$result[10] = 'x';
+		$this->assertFalse($this->crypt->decrypt($result, $key, $salt), 'Modified hmac causes failure.');
+	}
+
+}

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         0.10.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Utility\Crypto;

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -74,20 +74,4 @@ class OpenSslTest extends TestCase {
 		$this->assertFalse($this->crypt->decrypt($txt, $key), 'Modified key will fail.');
 	}
 
-/**
- * Test that decrypt fails when there is an hmac error.
- *
- * @return void
- */
-	public function testDecryptHmacFailure() {
-		$txt = 'The quick brown fox';
-		$key = 'This key is long enough';
-		$salt = 'this is a delicious salt!';
-		$result = $this->crypt->encrypt($txt, $key, $salt);
-
-		// Change one of the bytes in the hmac.
-		$result[10] = 'x';
-		$this->assertFalse($this->crypt->decrypt($result, $key, $salt), 'Modified hmac causes failure.');
-	}
-
 }


### PR DESCRIPTION
From #5440 a few key distros (redhat) will be dropping mcrypt support. We can and should switch to openssl earlier. openssl is more widely maintained and easier to use.

I've left the default to be mcrypt mostly out of backwards compatibility issues. Because our earlier implementation of `encrypt()` did not use PKCS#7 the data encrypted by it cannot be decrypted with openssl. For people with both extensions, it would be best if their code didn't break.
