### PR TITLE
Also autocreate session folder in debug mode

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -494,7 +494,12 @@ class CakeSession {
 
 		if (!empty($sessionConfig['handler'])) {
 			$sessionConfig['ini']['session.save_handler'] = 'user';
+		} elseif (!empty($sessionConfig['session.save_path']) && Configure::read('debug')) {
+			if (!is_dir($sessionConfig['session.save_path'])) {
+				mkdir($sessionConfig['session.save_path'], 0775, true);
+			}
 		}
+
 		if (!isset($sessionConfig['ini']['session.gc_maxlifetime'])) {
 			$sessionConfig['ini']['session.gc_maxlifetime'] = $sessionConfig['timeout'] * 60;
 		}


### PR DESCRIPTION
A small follow up for https://github.com/cakephp/cakephp/pull/1194/files

In IRC someone complained about cache and logs dirs being autocreated in debug mode, but sessions not.
While this can only happen with "cake" as engine (and no handler being present), it is still worth adding this little check IMO.

"cache" uses Cache internally and is fine, same for "database" and "php" which dont need such a folder.
