### PR TITLE
Don't call App::path to find things in the core

### DIFF
--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -41,8 +41,7 @@ class CommandTask extends Shell {
 		$plugins = Plugin::loaded();
 		$shellList = array_fill_keys($plugins, null) + ['CORE' => null, 'app' => null];
 
-		$corePath = App::core('Shell');
-		$shells = $this->_scanDir($corePath[0]);
+		$shells = $this->_scanDir(dirname(__DIR__));
 		$shells = array_diff($shells, $skipFiles, $hiddenCommands);
 		$shellList = $this->_appendShells('CORE', $shells, $shellList);
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1023,7 +1023,13 @@ class View {
 				}
 			}
 		}
-		$paths = array_merge($themePaths, $pluginPaths, $viewPaths, App::core('Template'));
+
+		$paths = array_merge(
+			$themePaths,
+			$pluginPaths,
+			$viewPaths,
+			[dirname(__DIR__) . DS . 'Template' . DS]
+		);
 
 		if ($plugin !== null) {
 			return $this->_pathsForPlugin[$plugin] = $paths;


### PR DESCRIPTION
When _in_ the core. 

As a side effect this means the core doesn't use the constant CAKE itself any more.
