### PR TITLE
Fix length reflection in SQLServer

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -474,6 +474,9 @@ class Sqlserver extends DboSource {
 			if (in_array($length->Type, array('nchar', 'nvarchar'))) {
 				return floor($length->Length / 2);
 			}
+			if ($length->Type === 'text') {
+				return null;
+			}
 			return $length->Length;
 		}
 		return parent::length($length);

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -449,6 +449,15 @@ class SqlserverTest extends CakeTestCase {
 				'Null' => 'YES',
 				'Size' => '0',
 			),
+			(object)array(
+				'Default' => null,
+				'Field' => 'description',
+				'Key' => '0',
+				'Type' => 'text',
+				'Length' => 16,
+				'Null' => 'YES',
+				'Size' => '0',
+			),
 		));
 		$this->db->executeResultsStack = array($SqlserverTableDescription);
 		$dummyModel = $this->model;
@@ -485,6 +494,12 @@ class SqlserverTest extends CakeTestCase {
 				'default' => null,
 				'length' => 8,
 			),
+			'description' => array(
+				'type' => 'text',
+				'null' => true,
+				'default' => null,
+				'length' => null,
+			)
 		);
 		$this->assertEquals($expected, $result);
 		$this->assertSame($expected['parent_id'], $result['parent_id']);


### PR DESCRIPTION
Don't reflect TEXT column lengths in SQLServer. Because SQLServer text columns hold ~2GB of data there is no meaningful length to them.

Refs #5506
