### PR TITLE
Don't set content-length when serving assets.

### DIFF
--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -149,12 +149,11 @@ class AssetDispatcher extends DispatcherFilter {
 			}
 			$response->type($contentType);
 		}
-		if (!$compressionEnabled) {
-			$response->header('Content-Length', filesize($assetFile));
-		}
+		$response->length(false);
 		$response->cache(filemtime($assetFile));
 		$response->send();
 		ob_clean();
+
 		if ($ext === 'css' || $ext === 'js') {
 			include $assetFile;
 		} else {


### PR DESCRIPTION
Setting content-length on assets causes long pauses when fetching assets that contain PHP code. These assets are invariably larger than their response bodies. By not setting a content-length, we can allow the webserver to calculate it for us.

Refs #4916
