### PR TITLE
3.0 fix marshall error

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -322,7 +322,7 @@ class Marshaller {
 			$data = $data[$tableName];
 		}
 
-		$errors = $this->_validate($data, $options, false);
+		$errors = $this->_validate($data, $options, $entity->isNew());
 		$schema = $this->_table->schema();
 		$properties = [];
 		foreach ($data as $key => $value) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -317,12 +317,18 @@ class Marshaller {
 		$options += ['validate' => true];
 		$propertyMap = $this->_buildPropertyMap($options);
 		$tableName = $this->_table->alias();
+		$isNew = $entity->isNew();
+		$keys = [];
 
 		if (isset($data[$tableName])) {
 			$data = $data[$tableName];
 		}
 
-		$errors = $this->_validate($data, $options, $entity->isNew());
+		if (!$isNew) {
+			$keys = $entity->extract((array)$this->_table->primaryKey());
+		}
+
+		$errors = $this->_validate($data + $keys, $options, $isNew);
 		$schema = $this->_table->schema();
 		$properties = [];
 		foreach ($data as $key => $value) {

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -53,7 +53,10 @@ class IsUnique {
 		$conditions = $entity->extract($this->_fields);
 		if ($entity->isNew() === false) {
 			$keys = (array)$options['repository']->primaryKey();
-			$conditions['NOT'] = $entity->extract($keys);
+			$keys = $entity->extract($keys);
+			if (array_filter($keys, 'strlen')) {
+				$conditions['NOT'] = $keys;
+			}
 		}
 
 		return !$options['repository']->exists($conditions);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1629,6 +1629,7 @@ class MarshallerTest extends TestCase {
 		];
 		$marshall = new Marshaller($this->articles);
 		$entity = new Entity([
+			'id' => 1,
 			'title' => 'Foo',
 			'body' => 'My Content',
 			'author_id' => 1
@@ -1639,7 +1640,9 @@ class MarshallerTest extends TestCase {
 
 		$this->articles->validator()
 			->requirePresence('thing', 'update')
-			->add('author_id', 'numeric', ['rule' => 'numeric']);
+			->requirePresence('id', 'update')
+			->add('author_id', 'numeric', ['rule' => 'numeric'])
+			->add('id', 'numeric', ['rule' => 'numeric', 'on' => 'update']);
 
 		$expected = clone $entity;
 		$result = $marshall->merge($expected, $data, []);
@@ -1647,6 +1650,7 @@ class MarshallerTest extends TestCase {
 		$this->assertSame($expected, $result);
 		$this->assertSame(1, $result->author_id);
 		$this->assertNotEmpty($result->errors('thing'));
+		$this->assertEmpty($result->errors('id'));
 
 		$this->articles->validator()->requirePresence('thing', 'create');
 		$result = $marshall->merge($entity, $data, []);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1653,4 +1653,41 @@ class MarshallerTest extends TestCase {
 		$this->assertEmpty($result->errors('thing'));
 	}
 
+/**
+ * Test merge with validation and create or update validation rules
+ *
+ * @return void
+ */
+	public function testMergeWithCreate() {
+		$data = [
+			'title' => 'My title',
+			'author_id' => 'foo',
+		];
+		$marshall = new Marshaller($this->articles);
+		$entity = new Entity([
+			'title' => 'Foo',
+			'body' => 'My Content',
+			'author_id' => 1
+		]);
+		$entity->accessible('*', true);
+		$entity->isNew(true);
+		$entity->clean();
+
+		$this->articles->validator()
+			->requirePresence('thing', 'update')
+			->add('author_id', 'numeric', ['rule' => 'numeric', 'on' => 'update']);
+
+		$expected = clone $entity;
+		$result = $marshall->merge($expected, $data, []);
+
+		$this->assertEmpty($result->errors('author_id'));
+		$this->assertEmpty($result->errors('thing'));
+
+		$entity->clean();
+		$entity->isNew(false);
+		$result = $marshall->merge($entity, $data, []);
+		$this->assertNotEmpty($result->errors('author_id'));
+		$this->assertNotEmpty($result->errors('thing'));
+	}
+
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3168,4 +3168,36 @@ class TableTest extends TestCase {
 		$this->assertEquals(1, $count, 'Callback should be called only once');
 	}
 
+/**
+ * Tests the validateUnique method with different combinations
+ *
+ * @return void
+ */
+	public function testValidateUnique() {
+		$table = TableRegistry::get('Users');
+		$validator = new Validator;
+		$validator->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
+		$validator->provider('table', $table);
+		$data = ['username' => 'larry'];
+		$this->assertNotEmpty($validator->errors($data));
+
+		$data = ['username' => 'jose'];
+		$this->assertEmpty($validator->errors($data));
+
+		$data = ['username' => 'larry', 'id' => 3];
+		$this->assertEmpty($validator->errors($data, false));
+
+		$data = ['username' => 'larry', 'id' => 3];
+		$this->assertNotEmpty($validator->errors($data));
+
+		$data = ['username' => 'larry'];
+		$this->assertNotEmpty($validator->errors($data, false));
+
+		$validator->add('username', 'unique', [
+			'rule' => 'validateUnique', 'provider' => 'table'
+		]);
+		$data = ['username' => 'larry'];
+		$this->assertNotEmpty($validator->errors($data, false));
+	}
+
 }


### PR DESCRIPTION
Fixes the error reported in #5519

Also re-implemented `Table::validateUnique` to reuse logic from the Rules subsystem.
