### PR TITLE
3.0: Session::clear()

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -471,7 +471,7 @@ class Session
      * Removes a variable from session.
      *
      * @param string $name Session variable to remove
-     * @return bool Success
+     * @return void
      */
     public function delete($name)
     {
@@ -521,11 +521,14 @@ class Session
     }
 
     /**
-     * Clears the session, the session id, and renews the session.
+     * Clears the session.
      *
+     * Optionally it also clears the session id and renews the session.
+     *
+     * @param bool $renew If session should be renewed, as well. Defaults to false.
      * @return void
      */
-    public function clear()
+    public function clear($renew = false)
     {
         $_SESSION = [];
         $this->renew();

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -531,7 +531,9 @@ class Session
     public function clear($renew = false)
     {
         $_SESSION = [];
-        $this->renew();
+        if ($renew) {
+            $this->renew();
+        }
     }
 
     /**

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -302,7 +302,22 @@ class SessionTest extends TestCase
     }
 
     /**
-     * testDel method
+     * testClear method
+     *
+     * @return void
+     */
+    public function testClear()
+    {
+        $session = new Session();
+        $session->write('Delete.me', 'Clearing out');
+
+        $session->clear();
+        $this->assertFalse($session->check('Delete.me'));
+        $this->assertFalse($session->check('Delete'));
+    }
+
+    /**
+     * testDelete method
      *
      * @return void
      */
@@ -315,6 +330,11 @@ class SessionTest extends TestCase
         $this->assertTrue($session->check('Delete'));
 
         $session->write('Clearing.sale', 'everything must go');
+        $session->delete('');
+        $this->assertTrue($session->check('Clearing.sale'));
+        $session->delete(null);
+        $this->assertTrue($session->check('Clearing.sale'));
+
         $session->delete('Clearing');
         $this->assertFalse($session->check('Clearing.sale'));
         $this->assertFalse($session->check('Clearing'));


### PR DESCRIPTION
Currently
- Session::check($name = null)
- Session::read($name = null)

work with `$name = null`, as well, reading all the session content.

I propose to also allow `Session::consume()` and `Session::delete()` to do that.
This would allow using those methods to work on the whole session (e.g. for setUp emptying) instead of having to workaround it using `clear()` or even `destroy()` where not even necessary, and no new session id has to be generated.

So this allows for a more consistent API.

Since only strict null allows that to happen, using falsely values like empty strings have no effect (allowing this to be BC as well) which should be the case IMO.

Also fixed a doc block statement.
