### PR TITLE
Change the way autolink handles brackets

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -156,6 +156,11 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'This is a test text with URL [<a href="http://www.cakephp.org/page/4">http://www.cakephp.org/page/4</a>] in square brackets';
 		$result = $this->Text->autoLink($text);
 		$this->assertEquals($expected, $result);
+
+		$text = 'This is a test text with URL [http://www.example.com?aParam[]=value1&aParam[]=value2&aParam[]=value3] in square brackets';
+		$expected = 'This is a test text with URL [<a href="http://www.example.com?aParam[]=value1&amp;aParam[]=value2&amp;aParam[]=value3">http://www.example.com?aParam[]=value1&amp;aParam[]=value2&amp;aParam[]=value3</a>] in square brackets';
+		$result = $this->Text->autoLink($text);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -146,6 +146,16 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>(and some more text)';
 		$result = $this->Text->autoLink($text);
 		$this->assertEquals($expected, $result);
+
+		$text = 'This is a test text with URL (http://www.cakephp.org/page/4) in brackets';
+		$expected = 'This is a test text with URL (<a href="http://www.cakephp.org/page/4>http://www.cakephp.org/page/4</a>) in brackets';
+		$result = $this->Text->autoLink($text);
+		$this->assertEquals($expected, $result);
+
+		$text = 'This is a test text with URL [http://www.cakephp.org/page/4] in square brackets';
+		$expected = 'This is a test text with URL [<a href="http://www.cakephp.org/page/4">http://www.cakephp.org/page/4</a>] in square brackets';
+		$result = $this->Text->autoLink($text);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -148,7 +148,7 @@ class TextHelperTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test text with URL (http://www.cakephp.org/page/4) in brackets';
-		$expected = 'This is a test text with URL (<a href="http://www.cakephp.org/page/4>http://www.cakephp.org/page/4</a>) in brackets';
+		$expected = 'This is a test text with URL (<a href="http://www.cakephp.org/page/4">http://www.cakephp.org/page/4</a>) in brackets';
 		$result = $this->Text->autoLink($text);
 		$this->assertEquals($expected, $result);
 

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -107,7 +107,7 @@ class TextHelper extends AppHelper {
 		$this->_placeholders = array();
 		$options += array('escape' => true);
 
-		$pattern = '#(?<!href="|src="|">)((?:https?|ftp|nntp)://[\p{L}0-9.\-_:]+(?:[/?][^\s<]*)?)#ui';
+		$pattern = '#(?<!href="|src="|">)((?:https?|ftp|nntp)://[\p{L}0-9.\-_:]+(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#i';
 		$text = preg_replace_callback(
 			$pattern,
 			array(&$this, '_insertPlaceHolder'),


### PR DESCRIPTION
For e.g.

``` text
My name's Bob (http://www.about.com/bobthewebmaster) and I'm a webmaster from 1992.
```

Autolink will incorrectly add markup as follows;

``` html
<a href="http://www.about.com/bobthewebmaster)">http://www.about.com/bobthewebmaster)</a>
```
