### PR TITLE
Harden API for Configure, correct doc blocks.

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -129,7 +129,7 @@ class Configure
      * @param string $var Variable name to check for
      * @return bool True if variable is there
      */
-    public static function check($var = null)
+    public static function check($var)
     {
         if (empty($var)) {
             return false;
@@ -150,7 +150,7 @@ class Configure
      * @return void
      * @link http://book.cakephp.org/3.0/en/development/configuration.html#deleting-configuration-data
      */
-    public static function delete($var = null)
+    public static function delete($var)
     {
         static::$_values = Hash::remove(static::$_values, $var);
     }
@@ -202,7 +202,7 @@ class Configure
     /**
      * Gets the names of the configured Engine objects.
      *
-     * @param string $name Engine name.
+     * @param string|null $name Engine name.
      * @return array Array of the configured Engine objects.
      */
     public static function configured($name = null)

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -237,7 +237,8 @@ class ConfigureTest extends TestCase
      */
     public function testCheckEmpty()
     {
-        $this->assertFalse(Configure::check());
+        $this->assertFalse(Configure::check(''));
+        $this->assertFalse(Configure::check(null));
     }
 
     /**
@@ -550,5 +551,21 @@ class ConfigureTest extends TestCase
         $result = Configure::consume('Test');
         $expected = ['key2' => 'value2'];
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * testConsumeEmpty
+     *
+     * @return void
+     */
+    public function testConsumeEmpty()
+    {
+        Configure::write('Test', ['key' => 'value', 'key2' => 'value2']);
+
+        $result = Configure::consume('');
+        $this->assertNull($result);
+
+        $result = Configure::consume(null);
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
Originally, I wanted to adjust the Configure class similar to https://github.com/cakephp/cakephp/pull/5543 .
But then this method has a clear() method that does a simple "reset" already. No need have two ways for the exact same thing.

As such, having the `null`-defaults there is not necessary, and also not useful, as those methods currently _require_ a first non-nullish (trueish) argument to actually do something.

Also adjusted doc blocks.
