### PR TITLE
Renamed String class to Text

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -15,4 +15,7 @@
 
 define('TIME_START', microtime(true));
 
+// @deprecated Backward compatibility with 2.x series
+class_alias('Cake\Utility\Text', 'Cake\Utility\String');
+
 require CAKE . 'basics.php';

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Console;
 
-use Cake\Utility\String;
+use Cake\Utility\Text;
 
 /**
  * HelpFormatter formats help for console shells. Can format to either
@@ -64,7 +64,7 @@ class HelpFormatter
         $out = [];
         $description = $parser->description();
         if (!empty($description)) {
-            $out[] = String::wrap($description, $width);
+            $out[] = Text::wrap($description, $width);
             $out[] = '';
         }
         $out[] = '<info>Usage:</info>';
@@ -76,7 +76,7 @@ class HelpFormatter
             $out[] = '';
             $max = $this->_getMaxLength($subcommands) + 2;
             foreach ($subcommands as $command) {
-                $out[] = String::wrap($command->help($max), [
+                $out[] = Text::wrap($command->help($max), [
                     'width' => $width,
                     'indent' => str_repeat(' ', $max),
                     'indentAt' => 1
@@ -93,7 +93,7 @@ class HelpFormatter
             $out[] = '<info>Options:</info>';
             $out[] = '';
             foreach ($options as $option) {
-                $out[] = String::wrap($option->help($max), [
+                $out[] = Text::wrap($option->help($max), [
                     'width' => $width,
                     'indent' => str_repeat(' ', $max),
                     'indentAt' => 1
@@ -108,7 +108,7 @@ class HelpFormatter
             $out[] = '<info>Arguments:</info>';
             $out[] = '';
             foreach ($arguments as $argument) {
-                $out[] = String::wrap($argument->help($max), [
+                $out[] = Text::wrap($argument->help($max), [
                     'width' => $width,
                     'indent' => str_repeat(' ', $max),
                     'indentAt' => 1
@@ -118,7 +118,7 @@ class HelpFormatter
         }
         $epilog = $parser->epilog();
         if (!empty($epilog)) {
-            $out[] = String::wrap($epilog, $width);
+            $out[] = Text::wrap($epilog, $width);
             $out[] = '';
         }
         return implode("\n", $out);

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -23,7 +23,7 @@ use Cake\Filesystem\File;
 use Cake\Log\LogTrait;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 
 /**
  * Base class for command-line utilities for automating programmer chores.
@@ -490,12 +490,12 @@ class Shell
      * @param string $text Text the text to format.
      * @param int|array $options Array of options to use, or an integer to wrap the text to.
      * @return string Wrapped / indented text
-     * @see String::wrap()
+     * @see \Cake\Utility\Text::wrap()
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#Shell::wrapText
      */
     public function wrapText($text, $options = [])
     {
-        return String::wrap($text, $options);
+        return Text::wrap($text, $options);
     }
 
     /**

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -20,7 +20,7 @@ use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Security;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 
 /**
  * Provides CSRF protection & validation.
@@ -120,7 +120,7 @@ class CsrfComponent extends Component
      */
     protected function _setCookie(Request $request, Response $response)
     {
-        $value = Security::hash(String::uuid(), 'sha1', true);
+        $value = Security::hash(Text::uuid(), 'sha1', true);
         $request->params['_csrfToken'] = $value;
         $response->cookie([
             'name' => $this->_config['cookieName'],

--- a/src/Database/Type/UuidType.php
+++ b/src/Database/Type/UuidType.php
@@ -15,7 +15,7 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 use PDO;
 
 /**
@@ -76,6 +76,6 @@ class UuidType extends \Cake\Database\Type
      */
     public function newId()
     {
-        return String::uuid();
+        return Text::uuid();
     }
 }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -17,7 +17,7 @@ namespace Cake\Error;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 use Exception;
 use InvalidArgumentException;
 
@@ -272,7 +272,7 @@ class Debugger
                 $trace['path'] = static::trimPath($trace['file']);
                 $trace['reference'] = $reference;
                 unset($trace['object'], $trace['args']);
-                $back[] = String::insert($tpl, $trace, ['before' => '{:', 'after' => '}']);
+                $back[] = Text::insert($tpl, $trace, ['before' => '{:', 'after' => '}']);
             }
         }
 
@@ -577,7 +577,7 @@ class Debugger
      *
      * `Debugger::addFormat('custom', $data);`
      *
-     * Where $data is an array of strings that use String::insert() variable
+     * Where $data is an array of strings that use Text::insert() variable
      * replacement. The template vars should be in a `{:id}` style.
      * An error formatter can have the following keys:
      *
@@ -685,7 +685,7 @@ class Debugger
 
         if (isset($tpl['links'])) {
             foreach ($tpl['links'] as $key => $val) {
-                $links[$key] = String::insert($val, $data, $insertOpts);
+                $links[$key] = Text::insert($val, $data, $insertOpts);
             }
         }
 
@@ -701,14 +701,14 @@ class Debugger
             if (is_array($value)) {
                 $value = implode("\n", $value);
             }
-            $info .= String::insert($tpl[$key], [$key => $value] + $data, $insertOpts);
+            $info .= Text::insert($tpl[$key], [$key => $value] + $data, $insertOpts);
         }
         $links = implode(' ', $links);
 
         if (isset($tpl['callback']) && is_callable($tpl['callback'])) {
             return call_user_func($tpl['callback'], $data, compact('links', 'info'));
         }
-        echo String::insert($tpl['error'], compact('links', 'info') + $data, $insertOpts);
+        echo Text::insert($tpl['error'], compact('links', 'info') + $data, $insertOpts);
     }
 
     /**

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -16,7 +16,7 @@ namespace Cake\Log\Engine;
 
 use Cake\Core\Configure;
 use Cake\Log\Engine\BaseLog;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 
 /**
  * File Storage stream for Logging. Writes logs to different files
@@ -106,7 +106,7 @@ class FileLog extends BaseLog
             if (is_numeric($this->_config['size'])) {
                 $this->_size = (int)$this->_config['size'];
             } else {
-                $this->_size = String::parseFileSize($this->_config['size']);
+                $this->_size = Text::parseFileSize($this->_config['size']);
             }
         }
     }

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -22,7 +22,7 @@ use Cake\Filesystem\File;
 use Cake\Log\Log;
 use Cake\Network\Http\FormData\Part;
 use Cake\Utility\Hash;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 use InvalidArgumentException;
 use LogicException;
 
@@ -809,7 +809,7 @@ class Email
         }
         if ($this->_messageId !== false) {
             if ($this->_messageId === true) {
-                $headers['Message-ID'] = '<' . str_replace('-', '', String::UUID()) . '@' . $this->_domain . '>';
+                $headers['Message-ID'] = '<' . str_replace('-', '', Text::uuid()) . '@' . $this->_domain . '>';
             } else {
                 $headers['Message-ID'] = $this->_messageId;
             }

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -125,7 +125,7 @@ class Hash
             }
             $tokens = explode('.', $path);
         } else {
-            $tokens = String::tokenize($path, '.', '[', ']');
+            $tokens = Text::tokenize($path, '.', '[', ']');
         }
 
         $_key = '__set_item__';
@@ -282,7 +282,7 @@ class Hash
         if ($noTokens) {
             $tokens = explode('.', $path);
         } else {
-            $tokens = String::tokenize($path, '.', '[', ']');
+            $tokens = Text::tokenize($path, '.', '[', ']');
         }
 
         if ($noTokens && strpos($path, '{') === false) {
@@ -374,7 +374,7 @@ class Hash
             return $data;
         }
 
-        $tokens = $noTokens ? explode('.', $path) : String::tokenize($path, '.', '[', ']');
+        $tokens = $noTokens ? explode('.', $path) : Text::tokenize($path, '.', '[', ']');
 
         if ($noExpansion && $noTokens) {
             return static::_simpleOp('remove', $data, $tokens);

--- a/src/Utility/README.md
+++ b/src/Utility/README.md
@@ -40,14 +40,14 @@ Check the [official Inflector class documentation](http://book.cakephp.org/3.0/e
 The String class includes convenience methods for creating and manipulating strings.
 
 ```php
-String::insert(
+Text::insert(
     'My name is :name and I am :age years old.',
     ['name' => 'Bob', 'age' => '65']
 );
 // Returns: "My name is Bob and I am 65 years old."
 
 $text = 'This is the song that never ends.';
-$result = String::wrap($text, 22);
+$result = Text::wrap($text, 22);
 
 // Returns
 This is the song

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -54,7 +54,7 @@ class Security
      */
     public static function generateAuthKey()
     {
-        return Security::hash(String::uuid());
+        return Security::hash(Text::uuid());
     }
 
     /**

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -17,10 +17,10 @@ namespace Cake\Utility;
 use InvalidArgumentException;
 
 /**
- * String handling methods.
+ * Text handling methods.
  *
  */
-class String
+class Text
 {
 
     /**
@@ -132,7 +132,7 @@ class String
     /**
      * Replaces variable placeholders inside a $str with any given $data. Each key in the $data array
      * corresponds to a variable placeholder name in $str.
-     * Example: `String::insert(':name is :age years old.', ['name' => 'Bob', '65']);`
+     * Example: `Text::insert(':name is :age years old.', ['name' => 'Bob', '65']);`
      * Returns: Bob is 65 years old.
      *
      * Available $options are:
@@ -142,7 +142,7 @@ class String
      * - escape: The character or string used to escape the before character / string (Defaults to `\`)
      * - format: A regex to use for matching variable placeholders. Default is: `/(?<!\\)\:%s/`
      *   (Overwrites before, after, breaks escape / clean)
-     * - clean: A boolean or array with instructions for String::cleanInsert
+     * - clean: A boolean or array with instructions for Text::cleanInsert
      *
      * @param string $str A string containing variable placeholders
      * @param array $data A key => val array where each key stands for a placeholder variable name
@@ -159,7 +159,7 @@ class String
         $format = $options['format'];
         $data = (array)$data;
         if (empty($data)) {
-            return ($options['clean']) ? String::cleanInsert($str, $options) : $str;
+            return ($options['clean']) ? static::cleanInsert($str, $options) : $str;
         }
 
         if (!isset($format)) {
@@ -178,7 +178,7 @@ class String
                 $offset = $pos + strlen($val);
                 $str = substr_replace($str, $val, $pos, 1);
             }
-            return ($options['clean']) ? String::cleanInsert($str, $options) : $str;
+            return ($options['clean']) ? static::cleanInsert($str, $options) : $str;
         }
 
         asort($data);
@@ -201,19 +201,19 @@ class String
         if (!isset($options['format']) && isset($options['before'])) {
             $str = str_replace($options['escape'] . $options['before'], $options['before'], $str);
         }
-        return ($options['clean']) ? String::cleanInsert($str, $options) : $str;
+        return ($options['clean']) ? static::cleanInsert($str, $options) : $str;
     }
 
     /**
-     * Cleans up a String::insert() formatted string with given $options depending on the 'clean' key in
+     * Cleans up a Text::insert() formatted string with given $options depending on the 'clean' key in
      * $options. The default method used is text but html is also available. The goal of this function
      * is to replace all whitespace and unneeded markup around placeholders that did not get replaced
-     * by String::insert().
+     * by Text::insert().
      *
      * @param string $str String to clean.
      * @param array $options Options list.
      * @return string
-     * @see String::insert()
+     * @see \Cake\Utility\Text::insert()
      */
     public static function cleanInsert($str, array $options)
     {
@@ -243,7 +243,7 @@ class String
                 $str = preg_replace($kleenex, $clean['replacement'], $str);
                 if ($clean['andText']) {
                     $options['clean'] = ['method' => 'text'];
-                    $str = String::cleanInsert($str, $options);
+                    $str = static::cleanInsert($str, $options);
                 }
                 break;
             case 'text':

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Validation;
 
-use Cake\Utility\String;
+use Cake\Utility\Text;
 use LogicException;
 use RuntimeException;
 
@@ -881,7 +881,7 @@ class Validation
         }
 
         if (is_string($size)) {
-            $size = String::parseFileSize($size);
+            $size = Text::parseFileSize($size);
         }
         $filesize = filesize($check);
 

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -26,7 +26,7 @@ use Cake\View\View;
  *
  * @property HtmlHelper $Html
  * @link http://book.cakephp.org/3.0/en/views/helpers/text.html
- * @see \Cake\Utility\String
+ * @see \Cake\Utility\Text
  */
 class TextHelper extends Helper
 {
@@ -44,7 +44,7 @@ class TextHelper extends Helper
      * @var array
      */
     protected $_defaultConfig = [
-        'engine' => 'Cake\Utility\String'
+        'engine' => 'Cake\Utility\Text'
     ];
 
     /**
@@ -240,7 +240,7 @@ class TextHelper extends Helper
      * @param string $phrase The phrase that will be searched
      * @param array $options An array of html attributes and options.
      * @return string The highlighted text
-     * @see String::highlight()
+     * @see \Cake\Utility\Text::highlight()
      * @link http://book.cakephp.org/3.0/en/views/helpers/text.html#highlighting-substrings
      */
     public function highlight($text, $phrase, array $options = [])
@@ -277,7 +277,7 @@ class TextHelper extends Helper
      *
      * @param string $text Text
      * @return string The text without links
-     * @see String::stripLinks()
+     * @see \Cake\Utility\Text::stripLinks()
      * @link http://book.cakephp.org/3.0/en/views/helpers/text.html#removing-links
      */
     public function stripLinks($text)
@@ -301,7 +301,7 @@ class TextHelper extends Helper
      * @param int $length Length of returned string, including ellipsis.
      * @param array $options An array of html attributes and options.
      * @return string Trimmed string.
-     * @see String::truncate()
+     * @see \Cake\Utility\Text::truncate()
      * @link http://book.cakephp.org/3.0/en/views/helpers/text.html#truncating-text
      */
     public function truncate($text, $length = 100, array $options = [])
@@ -324,7 +324,7 @@ class TextHelper extends Helper
      * @param int $length Length of returned string, including ellipsis.
      * @param array $options An array of html attributes and options.
      * @return string Trimmed string.
-     * @see \Cake\Utility\String::tail()
+     * @see \Cake\Utility\Text::tail()
      * @link http://book.cakephp.org/3.0/en/views/helpers/text.html#truncating-the-tail-of-a-string
      */
     public function tail($text, $length = 100, array $options = [])
@@ -341,7 +341,7 @@ class TextHelper extends Helper
      * @param int $radius The amount of characters that will be returned on each side of the founded phrase
      * @param string $ending Ending that will be appended
      * @return string Modified string
-     * @see \Cake\Utility\String::excerpt()
+     * @see \Cake\Utility\Text::excerpt()
      * @link http://book.cakephp.org/3.0/en/views/helpers/text.html#extracting-an-excerpt
      */
     public function excerpt($text, $phrase, $radius = 100, $ending = '...')
@@ -356,7 +356,7 @@ class TextHelper extends Helper
      * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.
      * @param string $separator The separator used to join all the other items together. Defaults to ', '.
      * @return string The glued together string.
-     * @see \Cake\Utility\String::toList()
+     * @see \Cake\Utility\Text::toList()
      * @link http://book.cakephp.org/3.0/en/views/helpers/text.html#converting-an-array-to-sentence-form
      */
     public function toList($list, $and = null, $separator = ', ')

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -20,7 +20,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\String;
 
 /**
  * Integration tests for Table class with uuid primary keys.

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -14,20 +14,20 @@
 namespace Cake\Test\TestCase\Utility;
 
 use Cake\TestSuite\TestCase;
-use Cake\Utility\String;
+use Cake\Utility\Text;
 
 /**
- * StringTest class
+ * TextTest class
  *
  */
-class StringTest extends TestCase
+class TextTest extends TestCase
 {
 
     public function setUp()
     {
         parent::setUp();
         $this->encoding = mb_internal_encoding();
-        $this->Text = new String();
+        $this->Text = new Text();
     }
 
     public function tearDown()
@@ -44,7 +44,7 @@ class StringTest extends TestCase
      */
     public function testUuidGeneration()
     {
-        $result = String::uuid();
+        $result = Text::uuid();
         $pattern = "/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/";
         $match = (bool)preg_match($pattern, $result);
         $this->assertTrue($match);
@@ -62,7 +62,7 @@ class StringTest extends TestCase
         $pattern = "/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/";
 
         for ($i = 0; $i < $count; $i++) {
-            $result = String::uuid();
+            $result = Text::uuid();
             $match = (bool)preg_match($pattern, $result);
             $this->assertTrue($match);
             $this->assertFalse(in_array($result, $check));
@@ -79,127 +79,127 @@ class StringTest extends TestCase
     {
         $string = 'some string';
         $expected = 'some string';
-        $result = String::insert($string, []);
+        $result = Text::insert($string, []);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = :sum. Cake is :adjective.';
         $expected = '2 + 2 = 4. Cake is yummy.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = %sum. Cake is %adjective.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '%']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '%']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = 2sum2. Cake is 9adjective9.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['format' => '/([\d])%s\\1/']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['format' => '/([\d])%s\\1/']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = 12sum21. Cake is 23adjective45.';
         $expected = '2 + 2 = 4. Cake is 23adjective45.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['format' => '/([\d])([\d])%s\\2\\1/']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['format' => '/([\d])([\d])%s\\2\\1/']);
         $this->assertEquals($expected, $result);
 
         $string = ':web :web_site';
         $expected = 'www http';
-        $result = String::insert($string, ['web' => 'www', 'web_site' => 'http']);
+        $result = Text::insert($string, ['web' => 'www', 'web_site' => 'http']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = <sum. Cake is <adjective>.';
         $expected = '2 + 2 = <sum. Cake is yummy.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '<', 'after' => '>']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '<', 'after' => '>']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = \:sum. Cake is :adjective.';
         $expected = '2 + 2 = :sum. Cake is yummy.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = !:sum. Cake is :adjective.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['escape' => '!']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['escape' => '!']);
         $this->assertEquals($expected, $result);
 
         $string = '2 + 2 = \%sum. Cake is %adjective.';
         $expected = '2 + 2 = %sum. Cake is yummy.';
-        $result = String::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '%']);
+        $result = Text::insert($string, ['sum' => '4', 'adjective' => 'yummy'], ['before' => '%']);
         $this->assertEquals($expected, $result);
 
         $string = ':a :b \:a :a';
         $expected = '1 2 :a 1';
-        $result = String::insert($string, ['a' => 1, 'b' => 2]);
+        $result = Text::insert($string, ['a' => 1, 'b' => 2]);
         $this->assertEquals($expected, $result);
 
         $string = ':a :b :c';
         $expected = '2 3';
-        $result = String::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
+        $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
         $this->assertEquals($expected, $result);
 
         $string = ':a :b :c';
         $expected = '1 3';
-        $result = String::insert($string, ['a' => 1, 'c' => 3], ['clean' => true]);
+        $result = Text::insert($string, ['a' => 1, 'c' => 3], ['clean' => true]);
         $this->assertEquals($expected, $result);
 
         $string = ':a :b :c';
         $expected = '2 3';
-        $result = String::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
+        $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
         $this->assertEquals($expected, $result);
 
         $string = ':a, :b and :c';
         $expected = '2 and 3';
-        $result = String::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
+        $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
         $this->assertEquals($expected, $result);
 
         $string = '":a, :b and :c"';
         $expected = '"1, 2"';
-        $result = String::insert($string, ['a' => 1, 'b' => 2], ['clean' => true]);
+        $result = Text::insert($string, ['a' => 1, 'b' => 2], ['clean' => true]);
         $this->assertEquals($expected, $result);
 
         $string = '"${a}, ${b} and ${c}"';
         $expected = '"1, 2"';
-        $result = String::insert($string, ['a' => 1, 'b' => 2], ['before' => '${', 'after' => '}', 'clean' => true]);
+        $result = Text::insert($string, ['a' => 1, 'b' => 2], ['before' => '${', 'after' => '}', 'clean' => true]);
         $this->assertEquals($expected, $result);
 
         $string = '<img src=":src" alt=":alt" class="foo :extra bar"/>';
         $expected = '<img src="foo" class="foo bar"/>';
-        $result = String::insert($string, ['src' => 'foo'], ['clean' => 'html']);
+        $result = Text::insert($string, ['src' => 'foo'], ['clean' => 'html']);
 
         $this->assertEquals($expected, $result);
 
         $string = '<img src=":src" class=":no :extra"/>';
         $expected = '<img src="foo"/>';
-        $result = String::insert($string, ['src' => 'foo'], ['clean' => 'html']);
+        $result = Text::insert($string, ['src' => 'foo'], ['clean' => 'html']);
         $this->assertEquals($expected, $result);
 
         $string = '<img src=":src" class=":no :extra"/>';
         $expected = '<img src="foo" class="bar"/>';
-        $result = String::insert($string, ['src' => 'foo', 'extra' => 'bar'], ['clean' => 'html']);
+        $result = Text::insert($string, ['src' => 'foo', 'extra' => 'bar'], ['clean' => 'html']);
         $this->assertEquals($expected, $result);
 
-        $result = String::insert("this is a ? string", "test");
+        $result = Text::insert("this is a ? string", "test");
         $expected = "this is a test string";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert("this is a ? string with a ? ? ?", ['long', 'few?', 'params', 'you know']);
+        $result = Text::insert("this is a ? string with a ? ? ?", ['long', 'few?', 'params', 'you know']);
         $expected = "this is a long string with a few? params you know";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert('update saved_urls set url = :url where id = :id', ['url' => 'http://www.testurl.com/param1:url/param2:id', 'id' => 1]);
+        $result = Text::insert('update saved_urls set url = :url where id = :id', ['url' => 'http://www.testurl.com/param1:url/param2:id', 'id' => 1]);
         $expected = "update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert('update saved_urls set url = :url where id = :id', ['id' => 1, 'url' => 'http://www.testurl.com/param1:url/param2:id']);
+        $result = Text::insert('update saved_urls set url = :url where id = :id', ['id' => 1, 'url' => 'http://www.testurl.com/param1:url/param2:id']);
         $expected = "update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert(':me cake. :subject :verb fantastic.', ['me' => 'I :verb', 'subject' => 'cake', 'verb' => 'is']);
+        $result = Text::insert(':me cake. :subject :verb fantastic.', ['me' => 'I :verb', 'subject' => 'cake', 'verb' => 'is']);
         $expected = "I :verb cake. cake is fantastic.";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert(':I.am: :not.yet: passing.', ['I.am' => 'We are'], ['before' => ':', 'after' => ':', 'clean' => ['replacement' => ' of course', 'method' => 'text']]);
+        $result = Text::insert(':I.am: :not.yet: passing.', ['I.am' => 'We are'], ['before' => ':', 'after' => ':', 'clean' => ['replacement' => ' of course', 'method' => 'text']]);
         $expected = "We are of course passing.";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert(
+        $result = Text::insert(
             ':I.am: :not.yet: passing.',
             ['I.am' => 'We are'],
             ['before' => ':', 'after' => ':', 'clean' => true]
@@ -207,28 +207,28 @@ class StringTest extends TestCase
         $expected = "We are passing.";
         $this->assertEquals($expected, $result);
 
-        $result = String::insert('?-pended result', ['Pre']);
+        $result = Text::insert('?-pended result', ['Pre']);
         $expected = "Pre-pended result";
         $this->assertEquals($expected, $result);
 
         $string = 'switching :timeout / :timeout_count';
         $expected = 'switching 5 / 10';
-        $result = String::insert($string, ['timeout' => 5, 'timeout_count' => 10]);
+        $result = Text::insert($string, ['timeout' => 5, 'timeout_count' => 10]);
         $this->assertEquals($expected, $result);
 
         $string = 'switching :timeout / :timeout_count';
         $expected = 'switching 5 / 10';
-        $result = String::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
+        $result = Text::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
         $this->assertEquals($expected, $result);
 
         $string = 'switching :timeout_count by :timeout';
         $expected = 'switching 10 by 5';
-        $result = String::insert($string, ['timeout' => 5, 'timeout_count' => 10]);
+        $result = Text::insert($string, ['timeout' => 5, 'timeout_count' => 10]);
         $this->assertEquals($expected, $result);
 
         $string = 'switching :timeout_count by :timeout';
         $expected = 'switching 10 by 5';
-        $result = String::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
+        $result = Text::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
         $this->assertEquals($expected, $result);
     }
 
@@ -239,12 +239,12 @@ class StringTest extends TestCase
      */
     public function testCleanInsert()
     {
-        $result = String::cleanInsert(':incomplete', [
+        $result = Text::cleanInsert(':incomplete', [
             'clean' => true, 'before' => ':', 'after' => ''
         ]);
         $this->assertEquals('', $result);
 
-        $result = String::cleanInsert(
+        $result = Text::cleanInsert(
             ':incomplete',
             [
             'clean' => ['method' => 'text', 'replacement' => 'complete'],
@@ -252,24 +252,24 @@ class StringTest extends TestCase
         );
         $this->assertEquals('complete', $result);
 
-        $result = String::cleanInsert(':in.complete', [
+        $result = Text::cleanInsert(':in.complete', [
             'clean' => true, 'before' => ':', 'after' => ''
         ]);
         $this->assertEquals('', $result);
 
-        $result = String::cleanInsert(
+        $result = Text::cleanInsert(
             ':in.complete and',
             [
             'clean' => true, 'before' => ':', 'after' => '']
         );
         $this->assertEquals('', $result);
 
-        $result = String::cleanInsert(':in.complete or stuff', [
+        $result = Text::cleanInsert(':in.complete or stuff', [
             'clean' => true, 'before' => ':', 'after' => ''
         ]);
         $this->assertEquals('stuff', $result);
 
-        $result = String::cleanInsert(
+        $result = Text::cleanInsert(
             '<p class=":missing" id=":missing">Text here</p>',
             ['clean' => 'html', 'before' => ':', 'after' => '']
         );
@@ -278,14 +278,14 @@ class StringTest extends TestCase
 
     /**
      * Tests that non-insertable variables (i.e. arrays) are skipped when used as values in
-     * String::insert().
+     * Text::insert().
      *
      * @return void
      */
     public function testAutoIgnoreBadInsertData()
     {
         $data = ['foo' => 'alpha', 'bar' => 'beta', 'fale' => []];
-        $result = String::insert('(:foo > :bar || :fale!)', $data, ['clean' => 'text']);
+        $result = Text::insert('(:foo > :bar || :fale!)', $data, ['clean' => 'text']);
         $this->assertEquals('(alpha > beta || !)', $result);
     }
 
@@ -296,23 +296,23 @@ class StringTest extends TestCase
      */
     public function testTokenize()
     {
-        $result = String::tokenize('A,(short,boring test)');
+        $result = Text::tokenize('A,(short,boring test)');
         $expected = ['A', '(short,boring test)'];
         $this->assertEquals($expected, $result);
 
-        $result = String::tokenize('A,(short,more interesting( test)');
+        $result = Text::tokenize('A,(short,more interesting( test)');
         $expected = ['A', '(short,more interesting( test)'];
         $this->assertEquals($expected, $result);
 
-        $result = String::tokenize('A,(short,very interesting( test))');
+        $result = Text::tokenize('A,(short,very interesting( test))');
         $expected = ['A', '(short,very interesting( test))'];
         $this->assertEquals($expected, $result);
 
-        $result = String::tokenize('"single tag"', ' ', '"', '"');
+        $result = Text::tokenize('"single tag"', ' ', '"', '"');
         $expected = ['"single tag"'];
         $this->assertEquals($expected, $result);
 
-        $result = String::tokenize('tagA "single tag" tagB', ' ', '"', '"');
+        $result = Text::tokenize('tagA "single tag" tagB', ' ', '"', '"');
         $expected = ['tagA', '"single tag"', 'tagB'];
         $this->assertEquals($expected, $result);
     }
@@ -321,7 +321,7 @@ class StringTest extends TestCase
     {
         $string = ':a, :b and :c?';
         $expected = '2 and 3?';
-        $result = String::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
+        $result = Text::insert($string, ['b' => 2, 'c' => 3], ['clean' => true]);
         $this->assertEquals($expected, $result);
     }
 
@@ -333,7 +333,7 @@ class StringTest extends TestCase
      */
     public function testWordWrap($text, $width, $break = "\n", $cut = false)
     {
-        $result = String::wordWrap($text, $width, $break, $cut);
+        $result = Text::wordWrap($text, $width, $break, $cut);
         $expected = wordwrap($text, $width, $break, $cut);
         $this->assertTextEquals($expected, $result, 'Text not wrapped same as built-in function.');
     }
@@ -369,7 +369,7 @@ class StringTest extends TestCase
     public function testWordWrapUnicodeAware()
     {
         $text = 'Но вим омниюм факёльиси элыктрам, мюнырэ лэгыры векж ыт. Выльёт квюандо нюмквуам ты кюм. Зыд эю рыбюм.';
-        $result = String::wordWrap($text, 33, "\n", true);
+        $result = Text::wordWrap($text, 33, "\n", true);
         $expected = <<<TEXT
 Но вим омниюм факёльиси элыктрам,
 мюнырэ лэгыры векж ыт. Выльёт квю
@@ -379,7 +379,7 @@ TEXT;
         $this->assertTextEquals($expected, $result, 'Text not wrapped.');
 
         $text = 'Но вим омниюм факёльиси элыктрам, мюнырэ лэгыры векж ыт. Выльёт квюандо нюмквуам ты кюм. Зыд эю рыбюм.';
-        $result = String::wordWrap($text, 33, "\n");
+        $result = Text::wordWrap($text, 33, "\n");
         $expected = <<<TEXT
 Но вим омниюм факёльиси элыктрам,
 мюнырэ лэгыры векж ыт. Выльёт
@@ -397,7 +397,7 @@ TEXT;
     public function testWrap()
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
-        $result = String::wrap($text, 33);
+        $result = Text::wrap($text, 33);
         $expected = <<<TEXT
 This is the song that never ends.
 This is the song that never ends.
@@ -405,7 +405,7 @@ This is the song that never ends.
 TEXT;
         $this->assertTextEquals($expected, $result, 'Text not wrapped.');
 
-        $result = String::wrap($text, ['width' => 20, 'wordWrap' => false]);
+        $result = Text::wrap($text, ['width' => 20, 'wordWrap' => false]);
         $expected = <<<TEXT
 This is the song th
 at never ends. This
@@ -425,7 +425,7 @@ TEXT;
     public function testWrapIndent()
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
-        $result = String::wrap($text, ['width' => 33, 'indent' => "\t", 'indentAt' => 1]);
+        $result = Text::wrap($text, ['width' => 33, 'indent' => "\t", 'indentAt' => 1]);
         $expected = <<<TEXT
 This is the song that never ends.
 	This is the song that never ends.
@@ -811,7 +811,7 @@ podeís adquirirla.</span></p>
     public function testUtf8()
     {
         $string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
                                 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82,
                                 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
@@ -819,13 +819,13 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
                                 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200];
         $this->assertEquals($expected, $result);
 
         $string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221,
                                 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242,
                                 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263,
@@ -834,7 +834,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
                                 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342,
                                 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363,
@@ -843,7 +843,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421,
                                 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442,
                                 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463,
@@ -852,7 +852,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621,
                                 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642,
                                 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663,
@@ -861,30 +861,30 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041,
                                 1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051];
         $this->assertEquals($expected, $result);
 
         $string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069,
                                 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087,
                                 1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100];
         $this->assertEquals($expected, $result);
 
         $string = 'չպջռսվտ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1401, 1402, 1403, 1404, 1405, 1406, 1407];
         $this->assertEquals($expected, $result);
 
         $string = 'فقكلمنهوىيًٌٍَُ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615];
         $this->assertEquals($expected, $result);
 
         $string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [10032, 10033, 10034, 10035, 10036, 10037, 10038, 10039, 10040, 10041, 10042, 10043, 10044,
                                 10045, 10046, 10047, 10048, 10049, 10050, 10051, 10052, 10053, 10054, 10055, 10056, 10057,
                                 10058, 10059, 10060, 10061, 10062, 10063, 10064, 10065, 10066, 10067, 10068, 10069, 10070,
@@ -892,7 +892,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [11904, 11905, 11906, 11907, 11908, 11909, 11910, 11911, 11912, 11913, 11914, 11915, 11916, 11917, 11918, 11919,
                                 11920, 11921, 11922, 11923, 11924, 11925, 11926, 11927, 11928, 11929, 11931, 11932, 11933, 11934, 11935, 11936,
                                 11937, 11938, 11939, 11940, 11941, 11942, 11943, 11944, 11945, 11946, 11947, 11948, 11949, 11950, 11951, 11952,
@@ -902,7 +902,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [12101, 12102, 12103, 12104, 12105, 12106, 12107, 12108, 12109, 12110, 12111, 12112, 12113, 12114, 12115, 12116,
                                 12117, 12118, 12119, 12120, 12121, 12122, 12123, 12124, 12125, 12126, 12127, 12128, 12129, 12130, 12131, 12132,
                                 12133, 12134, 12135, 12136, 12137, 12138, 12139, 12140, 12141, 12142, 12143, 12144, 12145, 12146, 12147, 12148,
@@ -910,7 +910,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [45601, 45602, 45603, 45604, 45605, 45606, 45607, 45608, 45609, 45610, 45611, 45612, 45613, 45614, 45615, 45616,
                                 45617, 45618, 45619, 45620, 45621, 45622, 45623, 45624, 45625, 45626, 45627, 45628, 45629, 45630, 45631, 45632,
                                 45633, 45634, 45635, 45636, 45637, 45638, 45639, 45640, 45641, 45642, 45643, 45644, 45645, 45646, 45647, 45648,
@@ -921,7 +921,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [65136, 65137, 65138, 65139, 65140, 65141, 65142, 65143, 65144, 65145, 65146, 65147, 65148, 65149, 65150, 65151,
                                 65152, 65153, 65154, 65155, 65156, 65157, 65158, 65159, 65160, 65161, 65162, 65163, 65164, 65165, 65166, 65167,
                                 65168, 65169, 65170, 65171, 65172, 65173, 65174, 65175, 65176, 65177, 65178, 65179, 65180, 65181, 65182, 65183,
@@ -930,7 +930,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [65201, 65202, 65203, 65204, 65205, 65206, 65207, 65208, 65209, 65210, 65211, 65212, 65213, 65214, 65215, 65216,
                                 65217, 65218, 65219, 65220, 65221, 65222, 65223, 65224, 65225, 65226, 65227, 65228, 65229, 65230, 65231, 65232,
                                 65233, 65234, 65235, 65236, 65237, 65238, 65239, 65240, 65241, 65242, 65243, 65244, 65245, 65246, 65247, 65248,
@@ -939,102 +939,102 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [65345, 65346, 65347, 65348, 65349, 65350, 65351, 65352, 65353, 65354, 65355, 65356, 65357, 65358, 65359, 65360,
                                 65361, 65362, 65363, 65364, 65365, 65366, 65367, 65368, 65369, 65370];
         $this->assertEquals($expected, $result);
 
         $string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [65377, 65378, 65379, 65380, 65381, 65382, 65383, 65384, 65385, 65386, 65387, 65388, 65389, 65390, 65391, 65392,
                                 65393, 65394, 65395, 65396, 65397, 65398, 65399, 65400];
         $this->assertEquals($expected, $result);
 
         $string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [65401, 65402, 65403, 65404, 65405, 65406, 65407, 65408, 65409, 65410, 65411, 65412, 65413, 65414, 65415, 65416,
                                 65417, 65418, 65419, 65420, 65421, 65422, 65423, 65424, 65425, 65426, 65427, 65428, 65429, 65430, 65431, 65432,
                                 65433, 65434, 65435, 65436, 65437, 65438];
         $this->assertEquals($expected, $result);
 
         $string = 'Ĥēĺļŏ, Ŵőřļď!';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [292, 275, 314, 316, 335, 44, 32, 372, 337, 345, 316, 271, 33];
         $this->assertEquals($expected, $result);
 
         $string = 'Hello, World!';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
         $this->assertEquals($expected, $result);
 
         $string = '¨';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [168];
         $this->assertEquals($expected, $result);
 
         $string = '¿';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [191];
         $this->assertEquals($expected, $result);
 
         $string = 'čini';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [269, 105, 110, 105];
         $this->assertEquals($expected, $result);
 
         $string = 'moći';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [109, 111, 263, 105];
         $this->assertEquals($expected, $result);
 
         $string = 'državni';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [100, 114, 382, 97, 118, 110, 105];
         $this->assertEquals($expected, $result);
 
         $string = '把百度设为首页';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [25226, 30334, 24230, 35774, 20026, 39318, 39029];
         $this->assertEquals($expected, $result);
 
         $string = '一二三周永龍';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [19968, 20108, 19977, 21608, 27704, 40845];
         $this->assertEquals($expected, $result);
 
         $string = 'ԀԂԄԆԈԊԌԎԐԒ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1280, 1282, 1284, 1286, 1288, 1290, 1292, 1294, 1296, 1298];
         $this->assertEquals($expected, $result);
 
         $string = 'ԁԃԅԇԉԋԍԏԐԒ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1281, 1283, 1285, 1287, 1289, 1291, 1293, 1295, 1296, 1298];
         $this->assertEquals($expected, $result);
 
         $string = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346,
                                 1347, 1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364,
                                 1365, 1366, 1415];
         $this->assertEquals($expected, $result);
 
         $string = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394,
                                 1395, 1396, 1397, 1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412,
                                 1413, 1414, 1415];
         $this->assertEquals($expected, $result);
 
         $string = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273,
                                 4274, 4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291,
                                 4292, 4293];
         $this->assertEquals($expected, $result);
 
         $string = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [7680, 7682, 7684, 7686, 7688, 7690, 7692, 7694, 7696, 7698, 7700, 7702, 7704, 7706, 7708, 7710, 7712, 7714,
                                 7716, 7718, 7720, 7722, 7724, 7726, 7728, 7730, 7732, 7734, 7736, 7738, 7740, 7742, 7744, 7746, 7748, 7750,
                                 7752, 7754, 7756, 7758, 7760, 7762, 7764, 7766, 7768, 7770, 7772, 7774, 7776, 7778, 7780, 7782, 7784, 7786,
@@ -1045,7 +1045,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [7681, 7683, 7685, 7687, 7689, 7691, 7693, 7695, 7697, 7699, 7701, 7703, 7705, 7707, 7709, 7711, 7713, 7715,
                                     7717, 7719, 7721, 7723, 7725, 7727, 7729, 7731, 7733, 7735, 7737, 7739, 7741, 7743, 7745, 7747, 7749, 7751,
                                     7753, 7755, 7757, 7759, 7761, 7763, 7765, 7767, 7769, 7771, 7773, 7775, 7777, 7779, 7781, 7783, 7785, 7787,
@@ -1056,39 +1056,39 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ΩKÅℲ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [8486, 8490, 8491, 8498];
         $this->assertEquals($expected, $result);
 
         $string = 'ωkåⅎ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [969, 107, 229, 8526];
         $this->assertEquals($expected, $result);
 
         $string = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [8544, 8545, 8546, 8547, 8548, 8549, 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8579];
         $this->assertEquals($expected, $result);
 
         $string = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [8560, 8561, 8562, 8563, 8564, 8565, 8566, 8567, 8568, 8569, 8570, 8571, 8572, 8573, 8574, 8575, 8580];
         $this->assertEquals($expected, $result);
 
         $string = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [9398, 9399, 9400, 9401, 9402, 9403, 9404, 9405, 9406, 9407, 9408, 9409, 9410, 9411, 9412, 9413, 9414,
                                 9415, 9416, 9417, 9418, 9419, 9420, 9421, 9422, 9423];
         $this->assertEquals($expected, $result);
 
         $string = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [9424, 9425, 9426, 9427, 9428, 9429, 9430, 9431, 9432, 9433, 9434, 9435, 9436, 9437, 9438, 9439, 9440, 9441,
                                 9442, 9443, 9444, 9445, 9446, 9447, 9448, 9449];
         $this->assertEquals($expected, $result);
 
         $string = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [11264, 11265, 11266, 11267, 11268, 11269, 11270, 11271, 11272, 11273, 11274, 11275, 11276, 11277, 11278,
                                 11279, 11280, 11281, 11282, 11283, 11284, 11285, 11286, 11287, 11288, 11289, 11290, 11291, 11292, 11293,
                                 11294, 11295, 11296, 11297, 11298, 11299, 11300, 11301, 11302, 11303, 11304, 11305, 11306, 11307, 11308,
@@ -1096,14 +1096,14 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [11312, 11313, 11314, 11315, 11316, 11317, 11318, 11319, 11320, 11321, 11322, 11323, 11324, 11325, 11326, 11327,
                                 11328, 11329, 11330, 11331, 11332, 11333, 11334, 11335, 11336, 11337, 11338, 11339, 11340, 11341, 11342, 11343,
                                 11344, 11345, 11346, 11347, 11348, 11349, 11350, 11351, 11352, 11353, 11354, 11355, 11356, 11357, 11358];
         $this->assertEquals($expected, $result);
 
         $string = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [11392, 11394, 11396, 11398, 11400, 11402, 11404, 11406, 11408, 11410, 11412, 11414, 11416, 11418, 11420,
                                     11422, 11424, 11426, 11428, 11430, 11432, 11434, 11436, 11438, 11440, 11442, 11444, 11446, 11448, 11450,
                                     11452, 11454, 11456, 11458, 11460, 11462, 11464, 11466, 11468, 11470, 11472, 11474, 11476, 11478, 11480,
@@ -1111,7 +1111,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [11393, 11395, 11397, 11399, 11401, 11403, 11405, 11407, 11409, 11411, 11413, 11415, 11417, 11419, 11421, 11423,
                                 11425, 11427, 11429, 11431, 11433, 11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
                                 11457, 11459, 11461, 11463, 11465, 11467, 11469, 11471, 11473, 11475, 11477, 11479, 11481, 11483, 11485, 11487,
@@ -1119,7 +1119,7 @@ podeís adquirirla.</span></p>
         $this->assertEquals($expected, $result);
 
         $string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-        $result = String::utf8($string);
+        $result = Text::utf8($string);
         $expected = [64256, 64257, 64258, 64259, 64260, 64261, 64262, 64275, 64276, 64277, 64278, 64279];
         $this->assertEquals($expected, $result);
     }
@@ -1135,14 +1135,14 @@ podeís adquirirla.</span></p>
                             58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82,
                             83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
                             106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
 
         $expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
         $this->assertEquals($expected, $result);
 
         $input = [161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
                                 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
 
         $expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
         $this->assertEquals($expected, $result);
@@ -1152,7 +1152,7 @@ podeís adquirirla.</span></p>
                                 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263,
                                 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
                                 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
         $this->assertEquals($expected, $result);
 
@@ -1162,7 +1162,7 @@ podeís adquirirla.</span></p>
                                 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384,
                                 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400];
         $expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421,
@@ -1171,7 +1171,7 @@ podeís adquirirla.</span></p>
                                 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484,
                                 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500];
         $expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621,
@@ -1180,30 +1180,30 @@ podeís adquirirla.</span></p>
                                 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683, 684,
                                 685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700];
         $expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041,
                                 1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051];
         $expected = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069,
                                 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087,
                                 1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100];
         $expected = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1401, 1402, 1403, 1404, 1405, 1406, 1407];
         $expected = 'չպջռսվտ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615];
         $expected = 'فقكلمنهوىيًٌٍَُ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [10032, 10033, 10034, 10035, 10036, 10037, 10038, 10039, 10040, 10041, 10042, 10043, 10044,
@@ -1211,7 +1211,7 @@ podeís adquirirla.</span></p>
                                 10058, 10059, 10060, 10061, 10062, 10063, 10064, 10065, 10066, 10067, 10068, 10069, 10070,
                                 10071, 10072, 10073, 10074, 10075, 10076, 10077, 10078];
         $expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [11904, 11905, 11906, 11907, 11908, 11909, 11910, 11911, 11912, 11913, 11914, 11915, 11916, 11917, 11918, 11919,
@@ -1221,7 +1221,7 @@ podeís adquirirla.</span></p>
                                 11969, 11970, 11971, 11972, 11973, 11974, 11975, 11976, 11977, 11978, 11979, 11980, 11981, 11982, 11983, 11984,
                                 11985, 11986, 11987, 11988, 11989, 11990, 11991, 11992, 11993, 11994, 11995, 11996, 11997, 11998, 11999, 12000];
         $expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [12101, 12102, 12103, 12104, 12105, 12106, 12107, 12108, 12109, 12110, 12111, 12112, 12113, 12114, 12115, 12116,
@@ -1229,7 +1229,7 @@ podeís adquirirla.</span></p>
                                 12133, 12134, 12135, 12136, 12137, 12138, 12139, 12140, 12141, 12142, 12143, 12144, 12145, 12146, 12147, 12148,
                                 12149, 12150, 12151, 12152, 12153, 12154, 12155, 12156, 12157, 12158, 12159];
         $expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [45601, 45602, 45603, 45604, 45605, 45606, 45607, 45608, 45609, 45610, 45611, 45612, 45613, 45614, 45615, 45616,
@@ -1240,7 +1240,7 @@ podeís adquirirla.</span></p>
                                 45681, 45682, 45683, 45684, 45685, 45686, 45687, 45688, 45689, 45690, 45691, 45692, 45693, 45694, 45695, 45696,
                                 45697, 45698, 45699, 45700];
         $expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [65136, 65137, 65138, 65139, 65140, 65141, 65142, 65143, 65144, 65145, 65146, 65147, 65148, 65149, 65150, 65151,
@@ -1249,7 +1249,7 @@ podeís adquirirla.</span></p>
                                 65184, 65185, 65186, 65187, 65188, 65189, 65190, 65191, 65192, 65193, 65194, 65195, 65196, 65197, 65198, 65199,
                                 65200];
         $expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [65201, 65202, 65203, 65204, 65205, 65206, 65207, 65208, 65209, 65210, 65211, 65212, 65213, 65214, 65215, 65216,
@@ -1258,100 +1258,100 @@ podeís adquirirla.</span></p>
                                 65249, 65250, 65251, 65252, 65253, 65254, 65255, 65256, 65257, 65258, 65259, 65260, 65261, 65262, 65263, 65264,
                                 65265, 65266, 65267, 65268, 65269, 65270, 65271, 65272, 65273, 65274, 65275, 65276];
         $expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [65345, 65346, 65347, 65348, 65349, 65350, 65351, 65352, 65353, 65354, 65355, 65356, 65357, 65358, 65359, 65360,
                                 65361, 65362, 65363, 65364, 65365, 65366, 65367, 65368, 65369, 65370];
         $expected = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [65377, 65378, 65379, 65380, 65381, 65382, 65383, 65384, 65385, 65386, 65387, 65388, 65389, 65390, 65391, 65392,
                                 65393, 65394, 65395, 65396, 65397, 65398, 65399, 65400];
         $expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [65401, 65402, 65403, 65404, 65405, 65406, 65407, 65408, 65409, 65410, 65411, 65412, 65413, 65414, 65415, 65416,
                                 65417, 65418, 65419, 65420, 65421, 65422, 65423, 65424, 65425, 65426, 65427, 65428, 65429, 65430, 65431, 65432,
                                 65433, 65434, 65435, 65436, 65437, 65438];
         $expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [292, 275, 314, 316, 335, 44, 32, 372, 337, 345, 316, 271, 33];
         $expected = 'Ĥēĺļŏ, Ŵőřļď!';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
         $expected = 'Hello, World!';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [168];
         $expected = '¨';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [191];
         $expected = '¿';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [269, 105, 110, 105];
         $expected = 'čini';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [109, 111, 263, 105];
         $expected = 'moći';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [100, 114, 382, 97, 118, 110, 105];
         $expected = 'državni';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [25226, 30334, 24230, 35774, 20026, 39318, 39029];
         $expected = '把百度设为首页';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [19968, 20108, 19977, 21608, 27704, 40845];
         $expected = '一二三周永龍';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1280, 1282, 1284, 1286, 1288, 1290, 1292, 1294, 1296, 1298];
         $expected = 'ԀԂԄԆԈԊԌԎԐԒ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1281, 1283, 1285, 1287, 1289, 1291, 1293, 1295, 1296, 1298];
         $expected = 'ԁԃԅԇԉԋԍԏԐԒ';
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $this->assertEquals($expected, $result);
 
         $input = [1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346, 1347,
                             1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364, 1365,
                             1366, 1415];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
         $this->assertEquals($expected, $result);
 
         $input = [1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394,
                                 1395, 1396, 1397, 1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412,
                                 1413, 1414, 1415];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
         $this->assertEquals($expected, $result);
 
         $input = [4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273, 4274,
                             4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291, 4292, 4293];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
         $this->assertEquals($expected, $result);
 
@@ -1362,7 +1362,7 @@ podeís adquirirla.</span></p>
                                 7824, 7826, 7828, 7830, 7831, 7832, 7833, 7834, 7840, 7842, 7844, 7846, 7848, 7850, 7852, 7854, 7856,
                                 7858, 7860, 7862, 7864, 7866, 7868, 7870, 7872, 7874, 7876, 7878, 7880, 7882, 7884, 7886, 7888, 7890, 7892,
                                 7894, 7896, 7898, 7900, 7902, 7904, 7906, 7908, 7910, 7912, 7914, 7916, 7918, 7920, 7922, 7924, 7926, 7928];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
         $this->assertEquals($expected, $result);
 
@@ -1373,53 +1373,53 @@ podeís adquirirla.</span></p>
                             7825, 7827, 7829, 7830, 7831, 7832, 7833, 7834, 7841, 7843, 7845, 7847, 7849, 7851, 7853, 7855, 7857, 7859,
                             7861, 7863, 7865, 7867, 7869, 7871, 7873, 7875, 7877, 7879, 7881, 7883, 7885, 7887, 7889, 7891, 7893, 7895,
                             7897, 7899, 7901, 7903, 7905, 7907, 7909, 7911, 7913, 7915, 7917, 7919, 7921, 7923, 7925, 7927, 7929];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
         $this->assertEquals($expected, $result);
 
         $input = [8486, 8490, 8491, 8498];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ΩKÅℲ';
         $this->assertEquals($expected, $result);
 
         $input = [969, 107, 229, 8526];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ωkåⅎ';
         $this->assertEquals($expected, $result);
 
         $input = [8544, 8545, 8546, 8547, 8548, 8549, 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8579];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
         $this->assertEquals($expected, $result);
 
         $input = [8560, 8561, 8562, 8563, 8564, 8565, 8566, 8567, 8568, 8569, 8570, 8571, 8572, 8573, 8574, 8575, 8580];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
         $this->assertEquals($expected, $result);
 
         $input = [9398, 9399, 9400, 9401, 9402, 9403, 9404, 9405, 9406, 9407, 9408, 9409, 9410, 9411, 9412, 9413, 9414,
                             9415, 9416, 9417, 9418, 9419, 9420, 9421, 9422, 9423];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
         $this->assertEquals($expected, $result);
 
         $input = [9424, 9425, 9426, 9427, 9428, 9429, 9430, 9431, 9432, 9433, 9434, 9435, 9436, 9437, 9438, 9439, 9440, 9441,
                             9442, 9443, 9444, 9445, 9446, 9447, 9448, 9449];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
         $this->assertEquals($expected, $result);
 
         $input = [11264, 11265, 11266, 11267, 11268, 11269, 11270, 11271, 11272, 11273, 11274, 11275, 11276, 11277, 11278, 11279,
                             11280, 11281, 11282, 11283, 11284, 11285, 11286, 11287, 11288, 11289, 11290, 11291, 11292, 11293, 11294, 11295,
                             11296, 11297, 11298, 11299, 11300, 11301, 11302, 11303, 11304, 11305, 11306, 11307, 11308, 11309, 11310];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
         $this->assertEquals($expected, $result);
 
         $input = [11312, 11313, 11314, 11315, 11316, 11317, 11318, 11319, 11320, 11321, 11322, 11323, 11324, 11325, 11326, 11327,
                             11328, 11329, 11330, 11331, 11332, 11333, 11334, 11335, 11336, 11337, 11338, 11339, 11340, 11341, 11342, 11343,
                             11344, 11345, 11346, 11347, 11348, 11349, 11350, 11351, 11352, 11353, 11354, 11355, 11356, 11357, 11358];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
         $this->assertEquals($expected, $result);
 
@@ -1427,7 +1427,7 @@ podeís adquirirla.</span></p>
                                     11422, 11424, 11426, 11428, 11430, 11432, 11434, 11436, 11438, 11440, 11442, 11444, 11446, 11448, 11450,
                                     11452, 11454, 11456, 11458, 11460, 11462, 11464, 11466, 11468, 11470, 11472, 11474, 11476, 11478, 11480,
                                     11482, 11484, 11486, 11488, 11490];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
         $this->assertEquals($expected, $result);
 
@@ -1435,12 +1435,12 @@ podeís adquirirla.</span></p>
                             11425, 11427, 11429, 11431, 11433, 11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
                             11457, 11459, 11461, 11463, 11465, 11467, 11469, 11471, 11473, 11475, 11477, 11479, 11481, 11483, 11485, 11487,
                             11489, 11491];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
         $this->assertEquals($expected, $result);
 
         $input = [64256, 64257, 64258, 64259, 64260, 64261, 64262, 64275, 64276, 64277, 64278, 64279];
-        $result = String::ascii($input);
+        $result = Text::ascii($input);
         $expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
         $this->assertEquals($expected, $result);
     }
@@ -1453,7 +1453,7 @@ podeís adquirirla.</span></p>
      */
     public function testparseFileSize($params, $expected)
     {
-        $result = String::parseFileSize($params['size'], $params['default']);
+        $result = Text::parseFileSize($params['size'], $params['default']);
         $this->assertEquals($expected, $result);
     }
 
@@ -1465,7 +1465,7 @@ podeís adquirirla.</span></p>
      */
     public function testparseFileSizeException()
     {
-        String::parseFileSize('bogus', false);
+        Text::parseFileSize('bogus', false);
     }
 
     /**


### PR DESCRIPTION
String may become invalid class name on PHP 7+, so avoiding issues upfront.

Closes #5537
