### PR TITLE
Backport of 3.0 Session API hardening and clear().

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -137,7 +137,7 @@ class CakeSession {
 /**
  * Pseudo constructor.
  *
- * @param string $base The base path for the Session
+ * @param string|null $base The base path for the Session
  * @return void
  */
 	public static function init($base = null) {
@@ -160,7 +160,7 @@ class CakeSession {
 /**
  * Setup the Path variable
  *
- * @param string $base base path
+ * @param string|null $base base path
  * @return void
  */
 	protected static function _setPath($base = null) {
@@ -227,7 +227,7 @@ class CakeSession {
  * @param string $name Variable name to check for
  * @return bool True if variable is there
  */
-	public static function check($name = null) {
+	public static function check($name) {
 		if (empty($name) || !self::_hasSession() || !self::start()) {
 			return false;
 		}
@@ -246,7 +246,7 @@ class CakeSession {
  * within the session id. For example, the file session handler only allows
  * characters in the range a-z A-Z 0-9 , (comma) and - (minus).
  *
- * @param string $id Id to replace the current session id
+ * @param string|null $id Id to replace the current session id
  * @return string Session id
  */
 	public static function id($id = null) {
@@ -356,7 +356,7 @@ class CakeSession {
 /**
  * Get / Set the user agent
  *
- * @param string $userAgent Set the user agent
+ * @param string|null $userAgent Set the user agent
  * @return string Current user agent
  */
 	public static function userAgent($userAgent = null) {
@@ -372,7 +372,7 @@ class CakeSession {
 /**
  * Returns given session variable, or all of them, if no parameters given.
  *
- * @param string|array $name The name of the session variable (or a path as sent to Set.extract)
+ * @param string|null $name The name of the session variable (or a path as sent to Set.extract)
  * @return mixed The value of the session variable, null if session not available,
  *   session not started, or provided name not found in the session.
  */
@@ -468,14 +468,19 @@ class CakeSession {
 	}
 
 /**
- * Clears the session, the session id, and renews the session.
+ * Clears the session.
  *
+ * Optionally also clears the session id and renews the session.
+ *
+ * @param bool $renew If the session should also be renewed. Defaults to false.
  * @return void
  */
-	public static function clear() {
+	public static function clear($renew = false) {
 		$_SESSION = null;
-		self::$id = null;
-		self::renew();
+		if ($renew) {
+			self::$id = null;
+			self::renew();
+		}
 	}
 
 /**

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -472,10 +472,10 @@ class CakeSession {
  *
  * Optionally also clears the session id and renews the session.
  *
- * @param bool $renew If the session should also be renewed. Defaults to false.
+ * @param bool $renew If the session should also be renewed. Defaults to true.
  * @return void
  */
-	public static function clear($renew = false) {
+	public static function clear($renew = true) {
 		$_SESSION = null;
 		if ($renew) {
 			self::$id = null;

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -403,11 +403,11 @@ class CakeSessionTest extends CakeTestCase {
 		$this->assertFalse(TestCakeSession::check('Clearing'));
 	}
 
-	/**
-	 * testClear method
-	 *
-	 * @return void
-	 */
+/**
+ * testClear method
+ *
+ * @return void
+ */
 	public function testClear() {
 		$this->assertTrue(TestCakeSession::write('Delete.me', 'Clearing out'));
 		TestCakeSession::clear();

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -393,9 +393,26 @@ class CakeSessionTest extends CakeTestCase {
 		$this->assertTrue(TestCakeSession::check('Delete'));
 
 		$this->assertTrue(TestCakeSession::write('Clearing.sale', 'everything must go'));
+		$this->assertFalse(TestCakeSession::delete(''));
+		$this->assertTrue(TestCakeSession::check('Clearing.sale'));
+		$this->assertFalse(TestCakeSession::delete(null));
+		$this->assertTrue(TestCakeSession::check('Clearing.sale'));
+
 		$this->assertTrue(TestCakeSession::delete('Clearing'));
 		$this->assertFalse(TestCakeSession::check('Clearing.sale'));
 		$this->assertFalse(TestCakeSession::check('Clearing'));
+	}
+
+	/**
+	 * testClear method
+	 *
+	 * @return void
+	 */
+	public function testClear() {
+		$this->assertTrue(TestCakeSession::write('Delete.me', 'Clearing out'));
+		TestCakeSession::clear();
+		$this->assertFalse(TestCakeSession::check('Delete.me'));
+		$this->assertFalse(TestCakeSession::check('Delete'));
 	}
 
 /**
@@ -451,7 +468,8 @@ class CakeSessionTest extends CakeTestCase {
  * @return void
  */
 	public function testCheckEmpty() {
-		$this->assertFalse(TestCakeSession::check());
+		$this->assertFalse(TestCakeSession::check(''));
+		$this->assertFalse(TestCakeSession::check(null));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -410,7 +410,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testClear() {
 		$this->assertTrue(TestCakeSession::write('Delete.me', 'Clearing out'));
-		TestCakeSession::clear();
+		TestCakeSession::clear(false);
 		$this->assertFalse(TestCakeSession::check('Delete.me'));
 		$this->assertFalse(TestCakeSession::check('Delete'));
 	}


### PR DESCRIPTION
Backport of https://github.com/cakephp/cakephp/pull/5543 to allow clearing the whole session without always having to also renew it.

Also added more tests and fixed doc blocks.
