### PR TITLE
Implemented Collection::toList() to avoid confusion when getting results

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -625,6 +625,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * @return \Cake\Collection\CollectionInterface
      */
     public function insert($path, $values);
+
     /**
      * Returns an array representation of the results
      *
@@ -635,6 +636,14 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * @return array
      */
     public function toArray($preserveKeys = true);
+
+    /**
+     * Returns an numerically-indexed array representation of the results.
+     * This is equivalent to calling `toArray(false)`
+     *
+     * @return array
+     */
+    public function toList();
 
     /**
      * Convert a result set into JSON.

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -418,6 +418,15 @@ trait CollectionTrait
      * {@inheritDoc}
      *
      */
+    public function toList()
+    {
+        return iterator_to_array($this, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     */
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -529,6 +529,18 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Test toList method
+     *
+     * @return void
+     */
+    public function testToList()
+    {
+        $data = [100 => 1, 300 => 2, 500 => 3, 1 => 4];
+        $collection = new Collection($data);
+        $this->assertEquals(array_values($data), $collection->toList());
+    }
+
+    /**
      * Test json enconding
      *
      * @return void


### PR DESCRIPTION
Motivated by the confusion in this ticket https://github.com/cakephp/docs/pull/2213 I thought that having a `toList()` method might help people understand that keys may be duplicated when using iterators.
