### PR TITLE
3.0 fix belongs to many with formatter

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -660,7 +660,7 @@ abstract class Association
     {
         $formatters = $surrogate->formatResults();
 
-        if (!$formatters) {
+        if (!$formatters || empty($options['propertyPath'])) {
             return;
         }
 


### PR DESCRIPTION
If a belongsToMany join data query has a formatter then a "Cannot get an empty property" will be thrown due the the `propertyPath` option not being set. The easiest way to replicate this is to attach the DebugKit Timed behavior to the join table object.

This PR ensures that the association formatter is not called if `propertyPath` is empty.
