### PR TITLE
select all fields which will be used for the list

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -900,9 +900,11 @@ class Table implements RepositoryInterface, EventListenerInterface
             'valueField' => $this->displayField(),
             'groupField' => null
         ];
-        $query->select([$options['idField'], $options['valueField']]);
-        if ($options['groupField'] !== null) {
-            $query->select([$options['groupField']]);
+        if ($query->clause('select') === []) {
+            $query->select([$options['idField'], $options['valueField']]);
+            if ($options['groupField'] !== null) {
+                $query->select([$options['groupField']]);
+            }
         }
         $options = $this->_setFieldMatchers(
             $options,

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -900,6 +900,10 @@ class Table implements RepositoryInterface, EventListenerInterface
             'valueField' => $this->displayField(),
             'groupField' => null
         ];
+        $query->select([$options['idField'], $options['valueField']]);
+        if ($options['groupField'] !== null) {
+            $query->select([$options['groupField']]);
+        }
         $options = $this->_setFieldMatchers(
             $options,
             ['idField', 'valueField', 'groupField']


### PR DESCRIPTION
At the moment all fields are selected if no ->select() is called.
I think it is the expected behavior to 'auto select' the idField, valueField and groupField.
If the 'auto selected' fields are not desired than $query->select($otherField, true) could be called to overwrite the 'auto selected' fields.
