### PR TITLE
Fix for invalid dates being converted by the DateTimeWidget

### DIFF
--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -201,20 +201,34 @@ class DateTimeWidget implements WidgetInterface
             } elseif (is_int($value)) {
                 $date = new \DateTime('@' . $value);
             } elseif (is_array($value)) {
+                $dateArray = [
+                    'year' => '', 'month' => '', 'day' => '',
+                    'hour' => '', 'minute' => '', 'second' => '',
+                    'meridian' => 'pm',
+                ];
+                $validDate = false;
+                foreach ($dateArray as $key => $dateValue) {
+                    if (isset($value[$key])) {
+                        $dateArray[$key] = str_pad($value[$key], 2, '0', STR_PAD_LEFT);
+                        $validDate = true;
+                    }
+                }
+                if ($validDate) {
+                    if (empty($dateArray['second'])) {
+                        $dateArray['second'] = 0;
+                    }
+                    if (isset($value['meridian'])) {
+                        $isAm = strtolower($dateArray['meridian']) === 'am';
+                        $dateArray['hour'] = $isAm ? $dateArray['hour'] : $dateArray['hour'] + 12;
+                    }
+                    if (!empty($dateArray['minute']) && isset($options['minute']['interval'])) {
+                        $dateArray['minute'] += $this->_adjustValue($dateArray['minute'], $options['minute']);
+                    }
+
+                    return $dateArray;
+                }
+
                 $date = new \DateTime();
-                if (isset($value['year'], $value['month'], $value['day'])) {
-                    $date->setDate($value['year'], $value['month'], $value['day']);
-                }
-                if (!isset($value['second'])) {
-                    $value['second'] = 0;
-                }
-                if (isset($value['meridian'])) {
-                    $isAm = strtolower($value['meridian']) === 'am';
-                    $value['hour'] = $isAm ? $value['hour'] : $value['hour'] + 12;
-                }
-                if (isset($value['hour'], $value['minute'], $value['second'])) {
-                    $date->setTime($value['hour'], $value['minute'], $value['second']);
-                }
             } else {
                 $date = clone $value;
             }

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -115,6 +115,20 @@ class DateTimeWidgetTest extends TestCase
         $this->assertContains('<option value="45" selected="selected">45</option>', $result);
     }
 
+    public function testRenderInvalidDate() {
+        $selected = [
+            'year' => '2014', 'month' => '02', 'day' => '31',
+            'hour' => '12', 'minute' => '30', 'second' => '45',
+        ];
+        $result = $this->DateTime->render(['val' => $selected], $this->context);
+        $this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
+        $this->assertContains('<option value="02" selected="selected">2</option>', $result);
+        $this->assertContains('<option value="31" selected="selected">31</option>', $result);
+        $this->assertContains('<option value="12" selected="selected">12</option>', $result);
+        $this->assertContains('<option value="30" selected="selected">30</option>', $result);
+        $this->assertContains('<option value="45" selected="selected">45</option>', $result);
+    }
+
     /**
      * Test that render() works with an array for val that is missing seconds.
      *

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -115,7 +115,8 @@ class DateTimeWidgetTest extends TestCase
         $this->assertContains('<option value="45" selected="selected">45</option>', $result);
     }
 
-    public function testRenderInvalidDate() {
+    public function testRenderInvalidDate()
+    {
         $selected = [
             'year' => '2014', 'month' => '02', 'day' => '31',
             'hour' => '12', 'minute' => '30', 'second' => '45',


### PR DESCRIPTION
Resolves #5581 by ensuring that invalid dates are not converted on displaying the fields to the user.
