### PR TITLE
Allowing specifying Table when translating

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -115,6 +115,7 @@ class TranslateBehavior extends Behavior
      */
     public function setupFieldAssociations($fields, $table, $model, $strategy)
     {
+        $targetTable = TableRegistry::get($table);
         $targetAlias = Inflector::slug($table);
         $alias = $this->_table->alias();
         $filter = $this->_config['onlyTranslated'];
@@ -122,13 +123,15 @@ class TranslateBehavior extends Behavior
         foreach ($fields as $field) {
             $name = $alias . '_' . $field . '_translation';
 
+            $fieldTable = TableRegistry::set($name, $targetTable);
             $this->_table->hasOne($name, [
                 'className' => $table,
                 'foreignKey' => 'foreign_key',
+                'targetTable' => $fieldTable,
                 'joinType' => $filter ? 'INNER' : 'LEFT',
                 'conditions' => [
-                    $name . '.model' => $model,
-                    $name . '.field' => $field,
+                    $fieldTable->alias() . '.model' => $model,
+                    $fieldTable->alias() . '.field' => $field,
                 ],
                 'propertyName' => $field . '_translation'
             ]);

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -112,7 +112,7 @@ class TranslateBehavior extends Behavior
      * @param string $table the table name to use for storing each field translation
      * @param string $model the model field value
      * @param string $strategy the strategy used in the _i18n association
-     * 
+     *
      * @return void
      */
     public function setupFieldAssociations($fields, $table, $model, $strategy)

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -23,6 +23,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
 
 /**
  * This behavior provides a way to translate dynamic data by keeping translations
@@ -65,10 +66,11 @@ class TranslateBehavior extends Behavior
         'implementedFinders' => ['translations' => 'findTranslations'],
         'implementedMethods' => ['locale' => 'locale'],
         'fields' => [],
-        'translationTable' => 'i18n',
+        'translationTable' => 'I18n',
         'defaultLocale' => '',
         'model' => '',
-        'onlyTranslated' => false
+        'onlyTranslated' => false,
+        'strategy' => 'subquery'
     ];
 
     /**
@@ -94,7 +96,8 @@ class TranslateBehavior extends Behavior
         $this->setupFieldAssociations(
             $this->_config['fields'],
             $this->_config['translationTable'],
-            $this->_config['model'] ? $this->_config['model'] : $this->_table->alias()
+            $this->_config['model'] ? $this->_config['model'] : $this->_table->alias(),
+            $this->_config['strategy']
         );
     }
 
@@ -110,16 +113,17 @@ class TranslateBehavior extends Behavior
      * @param string $model the model field value
      * @return void
      */
-    public function setupFieldAssociations($fields, $table, $model)
+    public function setupFieldAssociations($fields, $table, $model, $strategy)
     {
+        $targetAlias = Inflector::slug($table);
+        $alias = $this->_table->alias();
         $filter = $this->_config['onlyTranslated'];
+
         foreach ($fields as $field) {
-            $name = $this->_table->alias() . '_' . $field . '_translation';
-            $target = TableRegistry::get($name);
-            $target->table($table);
+            $name = $alias . '_' . $field . '_translation';
 
             $this->_table->hasOne($name, [
-                'targetTable' => $target,
+                'className' => $table,
                 'foreignKey' => 'foreign_key',
                 'joinType' => $filter ? 'INNER' : 'LEFT',
                 'conditions' => [
@@ -130,10 +134,11 @@ class TranslateBehavior extends Behavior
             ]);
         }
 
-        $this->_table->hasMany($table, [
+        $this->_table->hasMany($targetAlias, [
+            'className' => $table,
             'foreignKey' => 'foreign_key',
-            'strategy' => 'subquery',
-            'conditions' => ["$table.model" => $model],
+            'strategy' => $strategy,
+            'conditions' => ["$targetAlias.model" => $model],
             'propertyName' => '_i18n',
             'dependent' => true
         ]);
@@ -177,6 +182,7 @@ class TranslateBehavior extends Behavior
         $fields = $this->_config['fields'];
         $alias = $this->_table->alias();
         $select = $query->clause('select');
+
         $changeFilter = isset($options['filterByCurrentLocale']) &&
             $options['filterByCurrentLocale'] !== $this->_config['onlyTranslated'];
 
@@ -213,7 +219,8 @@ class TranslateBehavior extends Behavior
     {
         $locale = $entity->get('_locale') ?: $this->locale();
         $table = $this->_config['translationTable'];
-        $newOptions = [$table => ['validate' => false]];
+        $targetAlias = Inflector::slug($table);
+        $newOptions = [$targetAlias => ['validate' => false]];
         $options['associated'] = $newOptions + $options['associated'];
 
         $this->_bundleTranslatedFields($entity);
@@ -312,10 +319,12 @@ class TranslateBehavior extends Behavior
     {
         $locales = isset($options['locales']) ? $options['locales'] : [];
         $table = $this->_config['translationTable'];
+        $targetAlias = Inflector::slug($table);
+
         return $query
-            ->contain([$table => function ($q) use ($locales, $table) {
+            ->contain([$targetAlias => function ($q) use ($locales, $targetAlias) {
                 if ($locales) {
-                    $q->where(["$table.locale IN" => $locales]);
+                    $q->where(["$targetAlias.locale IN" => $locales]);
                 }
                 return $q;
             }])
@@ -458,7 +467,9 @@ class TranslateBehavior extends Behavior
      */
     protected function _findExistingTranslations($ruleSet)
     {
-        $association = $this->_table->association($this->_config['translationTable']);
+        $target = TableRegistry::get($this->_config['translationTable']);
+        $association = $this->_table->association($target->alias());
+
         $query = $association->find()
             ->select(['id', 'num' => 0])
             ->where(current($ruleSet))

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -125,11 +125,15 @@ class TranslateBehavior extends Behavior
         foreach ($fields as $field) {
             $name = $alias . '_' . $field . '_translation';
 
-            $fieldTable = TableRegistry::get($name, [
-                'className' => $table,
-                'alias' => $name,
-                'table' => $targetTable->table()
-            ]);
+            if (!TableRegistry::exists($name)) {
+                $fieldTable = TableRegistry::get($name, [
+                    'className' => $table,
+                    'alias' => $name,
+                    'table' => $targetTable->table()
+                ]);
+            } else {
+                $fieldTable = TableRegistry::get($name);
+            }
 
             $this->_table->hasOne($name, [
                 'targetTable' => $fieldTable,
@@ -361,7 +365,7 @@ class TranslateBehavior extends Behavior
             foreach ($this->_config['fields'] as $field) {
                 $name = $field . '_translation';
                 $translation = isset($row[$name]) ? $row[$name] : null;
-         
+
                 if ($translation === null || $translation === false) {
                     unset($row[$name]);
                     continue;

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -111,6 +111,8 @@ class TranslateBehavior extends Behavior
      * @param array $fields list of fields to create associations for
      * @param string $table the table name to use for storing each field translation
      * @param string $model the model field value
+     * @param string $strategy the strategy used in the _i18n association
+     * 
      * @return void
      */
     public function setupFieldAssociations($fields, $table, $model, $strategy)

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -362,7 +362,6 @@ class TranslateBehavior extends Behavior
                 $name = $field . '_translation';
                 $translation = isset($row[$name]) ? $row[$name] : null;
          
-
                 if ($translation === null || $translation === false) {
                     unset($row[$name]);
                     continue;
@@ -396,7 +395,6 @@ class TranslateBehavior extends Behavior
     {
         return $results->map(function ($row) {
             $translations = (array)$row->get('_i18n');
-
             $grouped = new Collection($translations);
 
             $result = [];
@@ -413,7 +411,6 @@ class TranslateBehavior extends Behavior
             $row->set('_translations', $result, $options);
             unset($row['_i18n']);
             $row->clean();
-
             return $row;
         });
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -77,6 +77,46 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
+     * Tests that custom translation tables are respected
+     * 
+     * @return void
+     */
+    public function testCustomTranslationTable() {
+        $table = TableRegistry::get('Articles');
+
+        $table->addBehavior('Translate', [
+            'translationTable' => '\TestApp\Model\Table\I18nTable',
+            'fields' => ['title', 'body']
+        ]);
+
+        $items = $table->associations();
+        $i18n = $items->getByProperty('_i18n');
+
+        $this->assertEquals('TestApp-Model-Table-I18nTable', $i18n->name());
+        $this->assertEquals('custom_i18n_table', $i18n->target()->table());
+        $this->assertEquals('test_custom_i18n_datasource', $i18n->target()->connection()->configName());
+    }
+
+    /**
+     * Tests that the strategy can be changed for i18n
+     * 
+     * @return void
+     */
+    public function testStrategy() {
+        $table = TableRegistry::get('Articles');
+
+        $table->addBehavior('Translate', [
+            'strategy' => 'select',
+            'fields' => ['title', 'body']
+        ]);
+
+        $items = $table->associations();
+        $i18n = $items->getByProperty('_i18n');
+
+        $this->assertEquals('select', $i18n->strategy());
+    }
+
+    /**
      * Tests that fields from a translated model are overriden
      *
      * @return void
@@ -926,4 +966,5 @@ class TranslateBehaviorTest extends TestCase
         $results = $table->find('translations')->all();
         $this->assertCount(1, $results);
     }
+
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -78,10 +78,11 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that custom translation tables are respected
-     * 
+     *
      * @return void
      */
-    public function testCustomTranslationTable() {
+    public function testCustomTranslationTable()
+    {
         $table = TableRegistry::get('Articles');
 
         $table->addBehavior('Translate', [
@@ -99,10 +100,11 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that the strategy can be changed for i18n
-     * 
+     *
      * @return void
      */
-    public function testStrategy() {
+    public function testStrategy()
+    {
         $table = TableRegistry::get('Articles');
 
         $table->addBehavior('Translate', [
@@ -966,5 +968,4 @@ class TranslateBehaviorTest extends TestCase
         $results = $table->find('translations')->all();
         $this->assertCount(1, $results);
     }
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -94,6 +94,7 @@ if (!getenv('db_dsn')) {
 }
 
 ConnectionManager::config('test', ['url' => getenv('db_dsn')]);
+ConnectionManager::config('test_custom_i18n_datasource', ['url' => getenv('db_dsn')]);
 
 Configure::write('Session', [
     'defaults' => 'php'

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright 2005-2013, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * I18n table class
+ *
+ */
+class I18nTable extends Table
+{
+
+    public function initialize(array $config)
+    {
+        $this->table('custom_i18n_table');
+    }
+
+    public static function defaultConnectionName()
+    {
+        return 'custom_i18n_datasource';
+    }
+
+}

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -29,5 +29,4 @@ class I18nTable extends Table
     {
         return 'custom_i18n_datasource';
     }
-
 }


### PR DESCRIPTION
Implementing translations with Table class declarations instead of the actual DB table. This gives the user the ability to specify the table and datasource used for the translation. I also added a strategy specifier to fix issues that arise when trying to search i18n'd Tables.

Refs #5369
