### PR TITLE
3.0 faster collections

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -46,7 +46,11 @@ trait CollectionTrait
      */
     public function each(callable $c)
     {
-        foreach ($this as $k => $v) {
+        $iterator = $this;
+        while (get_class($iterator) === 'Cake\Collection\Collection') {
+            $iterator = $iterator->getInnerIterator();
+        }
+        foreach ($iterator as $k => $v) {
             $c($v, $k);
         }
         return $this;

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -46,11 +46,7 @@ trait CollectionTrait
      */
     public function each(callable $c)
     {
-        $iterator = $this;
-        while (get_class($iterator) === 'Cake\Collection\Collection') {
-            $iterator = $iterator->getInnerIterator();
-        }
-        foreach ($iterator as $k => $v) {
+        foreach ($this->_unwrap() as $k => $v) {
             $c($v, $k);
         }
         return $this;
@@ -414,15 +410,10 @@ trait CollectionTrait
      */
     public function toArray($preserveKeys = true)
     {
-        if (get_class($this) === 'Cake\Collection\Collection') {
-            $inner = $this->getInnerIterator();
-            if ($inner instanceof ArrayIterator) {
-                $items = $this->getInnerIterator()->getArrayCopy();
-                return $preserveKeys ? $items : array_values($items);
-            }
-            if ($inner instanceof CollectionInterface) {
-                return $inner->toArray($preserveKeys);
-            }
+        $iterator = $this->_unwrap();
+        if ($iterator instanceof ArrayIterator) {
+            $items = $iterator->getArrayCopy();
+            return $preserveKeys ? $items : array_values($items);
         }
         return iterator_to_array($this, $preserveKeys);
     }
@@ -515,4 +506,19 @@ trait CollectionTrait
             )
         );
     }
+
+    /**
+     * Returns the closest nested iterator that can be safely traversed without
+     * losing any possible transformations.
+     *
+     * @return \Iterator
+     */
+    protected function _unwrap() {
+        $iterator = $this;
+        while (get_class($iterator) === 'Cake\Collection\Collection') {
+            $iterator = $iterator->getInnerIterator();
+        }
+        return $iterator;
+    }
+
 }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -15,6 +15,7 @@
 namespace Cake\Collection;
 
 use AppendIterator;
+use ArrayIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Collection\Iterator\BufferedIterator;
@@ -409,6 +410,16 @@ trait CollectionTrait
      */
     public function toArray($preserveKeys = true)
     {
+        if (get_class($this) === 'Cake\Collection\Collection') {
+            $inner = $this->getInnerIterator();
+            if ($inner instanceof ArrayIterator) {
+                $items = $this->getInnerIterator()->getArrayCopy();
+                return $preserveKeys ? $items : array_values($items);
+            }
+            if ($inner instanceof CollectionInterface) {
+                return $inner->toArray($preserveKeys);
+            }
+        }
         return iterator_to_array($this, $preserveKeys);
     }
 
@@ -418,7 +429,7 @@ trait CollectionTrait
      */
     public function toList()
     {
-        return iterator_to_array($this, false);
+        return $this->toArray(false);
     }
 
     /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -514,12 +514,12 @@ trait CollectionTrait
      *
      * @return \Iterator
      */
-    protected function _unwrap() {
+    protected function _unwrap()
+    {
         $iterator = $this;
         while (get_class($iterator) === 'Cake\Collection\Collection') {
             $iterator = $iterator->getInnerIterator();
         }
         return $iterator;
     }
-
 }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -159,8 +159,7 @@ trait CollectionTrait
      */
     public function max($callback, $type = SORT_NUMERIC)
     {
-        $sorted = new SortIterator($this, $callback, SORT_DESC, $type);
-        return $sorted->top();
+        return (new SortIterator($this, $callback, SORT_DESC, $type))->first();
     }
 
     /**
@@ -169,8 +168,7 @@ trait CollectionTrait
      */
     public function min($callback, $type = SORT_NUMERIC)
     {
-        $sorted = new SortIterator($this, $callback, SORT_ASC, $type);
-        return $sorted->top();
+        return (new SortIterator($this, $callback, SORT_ASC, $type))->first();
     }
 
     /**
@@ -179,7 +177,7 @@ trait CollectionTrait
      */
     public function sortBy($callback, $dir = SORT_DESC, $type = SORT_NUMERIC)
     {
-        return new Collection(new SortIterator($this, $callback, $dir, $type));
+        return new SortIterator($this, $callback, $dir, $type);
     }
 
     /**

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -31,6 +31,13 @@ class ReplaceIterator extends Collection
     protected $_callback;
 
     /**
+     * A reference to the internal iterator this object is wrapping.
+     *
+     * @var \Iterator
+     */
+    protected $_innerIterator;
+
+    /**
      * Creates an iterator from another iterator that will modify each of the values
      * by converting them using a callback function.
      *
@@ -45,6 +52,7 @@ class ReplaceIterator extends Collection
     {
         $this->_callback = $callback;
         parent::__construct($items);
+        $this->_innerIterator = $this->getInnerIterator();
     }
 
     /**
@@ -56,6 +64,6 @@ class ReplaceIterator extends Collection
     public function current()
     {
         $callback = $this->_callback;
-        return $callback(parent::current(), $this->key(), $this->getInnerIterator());
+        return $callback(parent::current(), $this->key(), $this->_innerIterator);
     }
 }

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Collection\Iterator;
 
-use Cake\Collection\CollectionInterface;
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 
 /**
  * An iterator that will return the passed items in order. The order is given by
@@ -76,5 +76,4 @@ class SortIterator extends Collection
         }
         parent::__construct($results);
     }
-
 }

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -35,6 +35,13 @@ class StoppableIterator extends Collection
     protected $_condition;
 
     /**
+     * A reference to the internal iterator this object is wrapping.
+     *
+     * @var \Iterator
+     */
+    protected $_innerIterator;
+
+    /**
      * Creates an iterator that can be stopped based on a condition provided by a callback.
      *
      * Each time the condition callback is executed it will receive the value of the element
@@ -50,6 +57,7 @@ class StoppableIterator extends Collection
     {
         $this->_condition = $condition;
         parent::__construct($items);
+        $this->_innnerIterator = $this->getInnerIterator();
     }
 
     /**
@@ -67,6 +75,6 @@ class StoppableIterator extends Collection
         $current = $this->current();
         $key = $this->key();
         $condition = $this->_condition;
-        return !$condition($current, $key, $this);
+        return !$condition($current, $key, $this->_innerIterator);
     }
 }

--- a/src/Collection/Iterator/UnfoldIterator.php
+++ b/src/Collection/Iterator/UnfoldIterator.php
@@ -37,6 +37,13 @@ class UnfoldIterator extends IteratorIterator implements RecursiveIterator
     protected $_unfolder;
 
     /**
+     * A reference to the internal iterator this object is wrapping.
+     *
+     * @var \Iterator
+     */
+    protected $_innerIterator;
+
+    /**
      * Creates the iterator that will generate child iterators from each of the
      * elements it was constructed with.
      *
@@ -49,6 +56,7 @@ class UnfoldIterator extends IteratorIterator implements RecursiveIterator
     {
         $this->_unfolder = $unfolder;
         parent::__construct($items);
+        $this->_innerIterator = $this->getInnerIterator();
     }
 
     /**
@@ -74,6 +82,6 @@ class UnfoldIterator extends IteratorIterator implements RecursiveIterator
         $key = $this->key();
         $unfolder = $this->_unfolder;
 
-        return new NoChildrenIterator($unfolder($current, $key, $this));
+        return new NoChildrenIterator($unfolder($current, $key, $this->_innerIterator));
     }
 }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -306,11 +306,11 @@ class CollectionTest extends TestCase
         $map = $collection->sortBy('a.b.c');
         $this->assertInstanceOf('Cake\Collection\Collection', $map);
         $expected = [
-            2 => ['a' => ['b' => ['c' => 10]]],
-            1 => ['a' => ['b' => ['c' => 6]]],
-            0 => ['a' => ['b' => ['c' => 4]]],
+            ['a' => ['b' => ['c' => 10]]],
+            ['a' => ['b' => ['c' => 6]]],
+            ['a' => ['b' => ['c' => 4]]],
         ];
-        $this->assertEquals($expected, iterator_to_array($map));
+        $this->assertEquals($expected, $map->toList());
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -118,7 +118,7 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $result = $collection->reject(function ($v, $k, $items) use ($collection) {
-            $this->assertSame($collection, $items);
+            $this->assertSame($collection->getInnerIterator(), $items);
             return $v > 2;
         });
         $this->assertEquals(['a' => 1, 'b' => 2], iterator_to_array($result));
@@ -244,7 +244,7 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $map = $collection->map(function ($v, $k, $it) use ($collection) {
-            $this->assertSame($collection, $it);
+            $this->assertSame($collection->getInnerIterator(), $it);
             return $v * $v;
         });
         $this->assertInstanceOf('Cake\Collection\Iterator\ReplaceIterator', $map);

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -191,5 +191,4 @@ class SortIteratorTest extends TestCase
         ];
         $this->assertEquals($expected, $sorted->toList());
     }
-
 }

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -37,12 +37,12 @@ class SortIteratorTest extends TestCase
             return $a;
         };
         $sorted = new SortIterator($items, $identity);
-        $expected = array_combine(range(4, 0), range(5, 1));
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $expected = range(5, 1);
+        $this->assertEquals($expected, $sorted->toList());
 
         $sorted = new SortIterator($items, $identity, SORT_ASC);
-        $expected = array_combine(range(4, 0), range(1, 5));
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $expected = range(1, 5);
+        $this->assertEquals($expected, $sorted->toList());
     }
 
     /**
@@ -57,12 +57,12 @@ class SortIteratorTest extends TestCase
             return $a * -1;
         };
         $sorted = new SortIterator($items, $callback);
-        $expected = array_combine(range(4, 0), [1, 2, 3, 4, 5]);
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $expected = range(1, 5);
+        $this->assertEquals($expected, $sorted->toList());
 
         $sorted = new SortIterator($items, $callback, SORT_ASC);
-        $expected = array_combine(range(4, 0), [5, 4, 3, 2, 1]);
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $expected = range(5, 1);
+        $this->assertEquals($expected, $sorted->toList());
     }
 
     /**
@@ -83,21 +83,21 @@ class SortIteratorTest extends TestCase
         };
         $sorted = new SortIterator($items, $callback, SORT_DESC, SORT_NUMERIC);
         $expected = [
-            3 => ['foo' => 13, 'bar' => 'a'],
-            2 => ['foo' => 10, 'bar' => 'a'],
-            1 => ['foo' => 2, 'bar' => 'a'],
-            0 => ['foo' => 1, 'bar' => 'a'],
+            ['foo' => 13, 'bar' => 'a'],
+            ['foo' => 10, 'bar' => 'a'],
+            ['foo' => 2, 'bar' => 'a'],
+            ['foo' => 1, 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $this->assertEquals($expected, $sorted->toList());
 
         $sorted = new SortIterator($items, $callback, SORT_ASC, SORT_NUMERIC);
         $expected = [
-            3 => ['foo' => 1, 'bar' => 'a'],
-            2 => ['foo' => 2, 'bar' => 'a'],
-            1 => ['foo' => 10, 'bar' => 'a'],
-            0 => ['foo' => 13, 'bar' => 'a'],
+            ['foo' => 1, 'bar' => 'a'],
+            ['foo' => 2, 'bar' => 'a'],
+            ['foo' => 10, 'bar' => 'a'],
+            ['foo' => 13, 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $this->assertEquals($expected, $sorted->toList());
     }
 
     /**
@@ -118,22 +118,22 @@ class SortIteratorTest extends TestCase
         };
         $sorted = new SortIterator($items, $callback, SORT_DESC, SORT_NATURAL);
         $expected = [
-            3 => ['foo' => 'foo_13', 'bar' => 'a'],
-            2 => ['foo' => 'foo_10', 'bar' => 'a'],
-            1 => ['foo' => 'foo_2', 'bar' => 'a'],
-            0 => ['foo' => 'foo_1', 'bar' => 'a'],
+            ['foo' => 'foo_13', 'bar' => 'a'],
+            ['foo' => 'foo_10', 'bar' => 'a'],
+            ['foo' => 'foo_2', 'bar' => 'a'],
+            ['foo' => 'foo_1', 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $this->assertEquals($expected, $sorted->toList());
 
         $sorted = new SortIterator($items, $callback, SORT_ASC, SORT_NATURAL);
         $expected = [
-            3 => ['foo' => 'foo_1', 'bar' => 'a'],
-            2 => ['foo' => 'foo_2', 'bar' => 'a'],
-            1 => ['foo' => 'foo_10', 'bar' => 'a'],
-            0 => ['foo' => 'foo_13', 'bar' => 'a'],
+            ['foo' => 'foo_1', 'bar' => 'a'],
+            ['foo' => 'foo_2', 'bar' => 'a'],
+            ['foo' => 'foo_10', 'bar' => 'a'],
+            ['foo' => 'foo_13', 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
-        $this->assertEquals($expected, iterator_to_array($sorted), 'Iterator should rewind');
+        $this->assertEquals($expected, $sorted->toList());
+        $this->assertEquals($expected, $sorted->toList(), 'Iterator should rewind');
     }
 
     /**
@@ -151,22 +151,22 @@ class SortIteratorTest extends TestCase
         ]);
         $sorted = new SortIterator($items, 'foo', SORT_DESC, SORT_NATURAL);
         $expected = [
-            3 => ['foo' => 'foo_13', 'bar' => 'a'],
-            2 => ['foo' => 'foo_10', 'bar' => 'a'],
-            1 => ['foo' => 'foo_2', 'bar' => 'a'],
-            0 => ['foo' => 'foo_1', 'bar' => 'a'],
+            ['foo' => 'foo_13', 'bar' => 'a'],
+            ['foo' => 'foo_10', 'bar' => 'a'],
+            ['foo' => 'foo_2', 'bar' => 'a'],
+            ['foo' => 'foo_1', 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $this->assertEquals($expected, $sorted->toList());
 
         $sorted = new SortIterator($items, 'foo', SORT_ASC, SORT_NATURAL);
         $expected = [
-            3 => ['foo' => 'foo_1', 'bar' => 'a'],
-            2 => ['foo' => 'foo_2', 'bar' => 'a'],
-            1 => ['foo' => 'foo_10', 'bar' => 'a'],
-            0 => ['foo' => 'foo_13', 'bar' => 'a'],
+            ['foo' => 'foo_1', 'bar' => 'a'],
+            ['foo' => 'foo_2', 'bar' => 'a'],
+            ['foo' => 'foo_10', 'bar' => 'a'],
+            ['foo' => 'foo_13', 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
-        $this->assertEquals($expected, iterator_to_array($sorted), 'Iterator should rewind');
+        $this->assertEquals($expected, $sorted->toList());
+        $this->assertEquals($expected, $sorted->toList(), 'Iterator should rewind');
     }
 
     /**
@@ -184,29 +184,12 @@ class SortIteratorTest extends TestCase
         ]);
         $sorted = new SortIterator($items, 'foo.bar', SORT_ASC, SORT_NUMERIC);
         $expected = [
-            3 => ['foo' => ['bar' => 1], 'bar' => 'a'],
-            2 => ['foo' => ['bar' => 2], 'bar' => 'a'],
-            1 => ['foo' => ['bar' => 10], 'bar' => 'a'],
-            0 => ['foo' => ['bar' => 12], 'bar' => 'a'],
+            ['foo' => ['bar' => 1], 'bar' => 'a'],
+            ['foo' => ['bar' => 2], 'bar' => 'a'],
+            ['foo' => ['bar' => 10], 'bar' => 'a'],
+            ['foo' => ['bar' => 12], 'bar' => 'a'],
         ];
-        $this->assertEquals($expected, iterator_to_array($sorted));
+        $this->assertEquals($expected, $sorted->toList());
     }
 
-    /**
-     * Tests top
-     *
-     * @return void
-     */
-    public function testTop()
-    {
-        $items = new ArrayObject([3, 5, 1, 2, 4]);
-        $identity = function ($a) {
-            return $a;
-        };
-        $sorted = new SortIterator($items, $identity);
-        $this->assertEquals(5, $sorted->top());
-
-        $sorted = new SortIterator([], $identity);
-        $this->assertNull($sorted->top());
-    }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -839,7 +839,7 @@ class TranslateBehaviorTest extends TestCase
         $query = $table->find()->where(['Comments.id' => 6]);
         $query2 = $table->find()->where(['Comments.id' => 5]);
         $query->union($query2);
-        $results = $query->sortBy('id')->toArray();
+        $results = $query->sortBy('id', SORT_ASC)->toList();
         $this->assertCount(2, $results);
 
         $this->assertEquals('First Comment for Second Article', $results[0]->comment);


### PR DESCRIPTION
I started to profile collections and results were kind of discouraging. This fixes some of the recurrent performance issues in the collections library. Most of the fixes revolve around unwrapping nested iterators to remove unneeded nesting.

Also made `sortyBy()` 1000% faster by choosing a different implementation.
