### PR TITLE
Fix notice error when invalid fixture types are used.

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -155,6 +155,7 @@ class FixtureManager
                 $baseNamespace = Inflector::camelize(str_replace('\\', '\ ', $path));
                 $additionalPath = null;
             } else {
+                $baseNamespace = '';
                 $name = $fixture;
             }
             $name = Inflector::camelize($name);

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -91,4 +91,17 @@ class FixtureManagerTest extends TestCase
             $fixtures['plugin.Company/TestPluginThree.articles']
         );
     }
+
+    /**
+     * Test that unknown types are handled gracefully.
+     *
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Referenced fixture class "Test\Fixture\Derp.derpFixture" not found. Fixture "derp.derp" was referenced
+     */
+    public function testFixturizeInvalidType()
+    {
+        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test->fixtures = ['derp.derp'];
+        $this->manager->fixturize($test);
+    }
 }


### PR DESCRIPTION
When an invalid fixture type is used, we should raise a useful
exception.

Refs #5579
