### PR TITLE
Fix meridian tests failing around TZ offset issues.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2075,9 +2075,11 @@ class FormHelper extends Helper
         $options = $this->_singleDatetime($options, 'meridian');
 
         if (isset($options['val'])) {
+            $hour = date('H');
             $options['val'] = [
-                'hour' => date('H'),
+                'hour' => $hour,
                 'minute' => (int)$options['val'],
+                'meridian' => $hour > 11 ? 'pm' : 'am',
             ];
         }
         return $this->datetime($fieldName, $options);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5355,15 +5355,15 @@ class FormHelperTest extends TestCase
     {
         extract($this->dateRegex);
 
-        $now = time();
+        $now = new \DateTime();
         $result = $this->Form->meridian('Model.field', ['value' => 'am']);
         $expected = [
             ['select' => ['name' => 'Model[field][meridian]']],
             ['option' => ['value' => '']],
             '/option',
             $meridianRegex,
-            ['option' => ['value' => date('a', $now), 'selected' => 'selected']],
-            date('a', $now),
+            ['option' => ['value' => $now->format('a'), 'selected' => 'selected']],
+            $now->format('a'),
             '/option',
             '*/select'
         ];


### PR DESCRIPTION
When local time and UTC are in different halves of the meridian tests would fail as the new changes in DateTimeWidget would default the meridian to pm.
