### PR TITLE
Hotfix to not throw errors even though class exists.

### DIFF
--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -95,7 +95,7 @@ class ConnectionManager {
 		$conn = self::$_connectionsEnum[$name];
 		$class = $conn['classname'];
 
-		if (strpos(App::location($class), 'Datasource') === false) {
+		if (!class_exists($class) && strpos(App::location($class), 'Datasource') === false) {
 			throw new MissingDatasourceException(array(
 				'class' => $class,
 				'plugin' => null,


### PR DESCRIPTION
I have run into this before, but now I make the PR for it.

When running test code with an [inline class](https://github.com/shama/cakeftp/blob/master/Test/Case/Model/FtpTest.php#L16) `class FtpTestSource extends FtpSource {}`, it would throw the following error:

```
MissingDatasourceException: Datasource class FtpTestSource could not be found.
```

Even though the class actually exists (in the very same file).
Since class names need to be unique througout the code, and flushing the ClassRegistry should also not change anything, it is best to have the class_exists() check here.

Note: This is not necessary for 3.x, as there it is easier to create Test classes, and also it is handled differently anyway.
