### PR TITLE
Fix double encoding time strings (CakeTime)

### DIFF
--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -1138,7 +1138,7 @@ class CakeTime {
 			if (function_exists('mb_check_encoding')) {
 				$valid = mb_check_encoding($format, $encoding);
 			} else {
-				$valid = !Multibyte::checkMultibyte($format);
+				$valid = Multibyte::checkMultibyte($format);
 			}
 			if (!$valid) {
 				$format = utf8_encode($format);


### PR DESCRIPTION
Fix mulitibyte time strings being double encoded when mb_string is not installed.

Steps to reproduce:
1) Check, that mb_string functions are not available;
2) setlocale's LC_TIME to any encoding, which produces multibyte time strings (eg. ru_RU.utf8);
3) Watch time strings being unreadable: `'Ð§ÑÐ², Ð¯Ð½Ð² 8th 1970, 03:00'` (expected to see `'Чтв, Янв 8th 1970, 03:00'`).

Reproduced on CakePHP versions: _2.4.10_, _2.6.0_ & _master_.

Environment:

```
CentOS release 6.6 (Final)
PHP 5.6.4
php-mbstring not installed
```
