### PR TITLE
Fix radio buttons not being added to security hash.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1348,7 +1348,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->radio('Test.some', $options, array(
 			'disabled' => array('option1')
 		));
-		$expected = array('Test.test', 'Test.all' => '',  'Test.some');
+		$expected = array('Test.test', 'Test.all' => '', 'Test.some');
 		$this->assertEquals($expected, $this->Form->fields);
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1338,6 +1338,18 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->radio('Test.test', $options);
 		$expected = array('Test.test');
 		$this->assertEquals($expected, $this->Form->fields);
+
+		$this->Form->radio('Test.all', $options, array(
+			'disabled' => array('option1', 'option2')
+		));
+		$expected = array('Test.test', 'Test.all' => '');
+		$this->assertEquals($expected, $this->Form->fields);
+
+		$this->Form->radio('Test.some', $options, array(
+			'disabled' => array('option1')
+		));
+		$expected = array('Test.test', 'Test.all' => '',  'Test.some');
+		$this->assertEquals($expected, $this->Form->fields);
 	}
 
 /**
@@ -1372,9 +1384,11 @@ class FormHelperTest extends CakeTestCase {
 
 		$this->Form->checkbox('Model.checkbox', array('disabled' => true));
 		$this->Form->text('Model.text', array('disabled' => true));
-		$this->Form->password('Model.text', array('disabled' => true));
+		$this->Form->text('Model.text2', array('disabled' => 'disabled'));
+		$this->Form->password('Model.password', array('disabled' => true));
 		$this->Form->textarea('Model.textarea', array('disabled' => true));
 		$this->Form->select('Model.select', array(1, 2), array('disabled' => true));
+		$this->Form->select('Model.select', array(1, 2), array('disabled' => array(1, 2)));
 		$this->Form->radio('Model.radio', array(1, 2), array('disabled' => array(1, 2)));
 		$this->Form->year('Model.year', null, null, array('disabled' => true));
 		$this->Form->month('Model.month', array('disabled' => true));

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1491,7 +1491,9 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  */
 	public function radio($fieldName, $options = array(), $attributes = array()) {
+		$attributes['options'] = $options;
 		$attributes = $this->_initInputField($fieldName, $attributes);
+		unset($attributes['options']);
 
 		$showEmpty = $this->_extractOption('empty', $attributes);
 		if ($showEmpty) {
@@ -2955,7 +2957,18 @@ class FormHelper extends AppHelper {
 			$result = $this->addClass($result, 'form-error');
 		}
 
-		if (!empty($result['disabled'])) {
+		$isDisabled = false;
+		if (isset($result['disabled'])) {
+			$isDisabled = (
+				$result['disabled'] === true ||
+				$result['disabled'] === 'disabled' ||
+				(is_array($result['disabled']) &&
+					!empty($result['options']) &&
+					array_diff($result['options'], $result['disabled']) === array()
+				)
+			);
+		}
+		if ($isDisabled) {
 			return $result;
 		}
 


### PR DESCRIPTION
When some but not all inputs were disabled radio buttons were omitted from the security hash. This caused blackhole failures as the input was unexpected.

Refs #5603
