### PR TITLE
3.0 - Marshalling of null values with fieldList

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -147,7 +147,7 @@ class Marshaller
         }
 
         foreach ((array)$options['fieldList'] as $field) {
-            if (isset($properties[$field])) {
+            if (array_key_exists($field, $properties)) {
                 $entity->set($field, $properties[$field]);
             }
         }
@@ -374,7 +374,7 @@ class Marshaller
         }
 
         foreach ((array)$options['fieldList'] as $field) {
-            if (isset($properties[$field])) {
+            if (array_key_exists($field, $properties)) {
                 $entity->set($field, $properties[$field]);
             }
         }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1245,7 +1245,7 @@ class MarshallerTest extends TestCase
         $data = [
             'title' => 'My title',
             'body' => 'My content',
-            'author_id' => 1
+            'author_id' => null
         ];
         $marshall = new Marshaller($this->articles);
         $result = $marshall->one($data, ['fieldList' => ['title', 'author_id']]);
@@ -1264,12 +1264,13 @@ class MarshallerTest extends TestCase
     {
         $data = [
             'title' => 'My title',
+            'body' => null,
             'author_id' => 1
         ];
         $marshall = new Marshaller($this->articles);
         $entity = new Entity([
             'title' => 'Foo',
-            'body' => 'My Content',
+            'body' => 'My content',
             'author_id' => 2
         ]);
         $entity->accessible('*', false);
@@ -1279,7 +1280,7 @@ class MarshallerTest extends TestCase
 
         $expected = [
             'title' => 'My title',
-            'body' => 'My Content',
+            'body' => null,
             'author_id' => 2
         ];
 


### PR DESCRIPTION
Due to the use of `isset()` on marshalling, any null values would be ignored when using the fieldList option. This corrects that problem with the use of `array_key_exists()` instead.
