### PR TITLE
3.0 real unbuffered

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -269,8 +269,7 @@ class Connection
      */
     public function run(Query $query)
     {
-        $sql = $query->sql();
-        $statement = $this->prepare($sql);
+        $statement = $this->prepare($query);
         $query->valueBinder()->attachTo($statement);
         $statement->execute();
 
@@ -487,7 +486,7 @@ class Connection
      */
     public function createSavePoint($name)
     {
-        $this->execute($this->_driver->savePointSQL($name));
+        $this->execute($this->_driver->savePointSQL($name))->closeCursor();
     }
 
     /**
@@ -498,7 +497,7 @@ class Connection
      */
     public function releaseSavePoint($name)
     {
-        $this->execute($this->_driver->releaseSavePointSQL($name));
+        $this->execute($this->_driver->releaseSavePointSQL($name))->closeCursor();
     }
 
     /**
@@ -509,7 +508,7 @@ class Connection
      */
     public function rollbackSavepoint($name)
     {
-        $this->execute($this->_driver->rollbackSavePointSQL($name));
+        $this->execute($this->_driver->rollbackSavePointSQL($name))->closeCursor();
     }
 
     /**
@@ -519,7 +518,7 @@ class Connection
      */
     public function disableForeignKeys()
     {
-        $this->execute($this->_driver->disableForeignKeySql());
+        $this->execute($this->_driver->disableForeignKeySql())->closeCursor();
     }
 
     /**
@@ -529,7 +528,7 @@ class Connection
      */
     public function enableForeignKeys()
     {
-        $this->execute($this->_driver->enableForeignKeySql());
+        $this->execute($this->_driver->enableForeignKeySql())->closeCursor();
     }
 
     /**

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -15,6 +15,8 @@
 namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\MysqlDialectTrait;
+use Cake\Database\Query;
+use Cake\Database\Statement\MysqlStatement;
 use PDO;
 
 class Mysql extends \Cake\Database\Driver
@@ -100,4 +102,22 @@ class Mysql extends \Cake\Database\Driver
     {
         return in_array('mysql', PDO::getAvailableDrivers());
     }
+
+    /**
+     * Prepares a sql statement to be executed
+     *
+     * @param string|\Cake\Database\Query $query The query to prepare.
+     * @return \Cake\Database\StatementInterface
+     */
+    public function prepare($query)
+    {
+        $this->connect();
+        $statement = $this->_connection->prepare((string)$query);
+        $result = new MysqlStatement($statement, $this);
+        if ($query instanceof Query && $query->bufferResults() === false) {
+            $result->bufferResults(false);
+        }
+        return $result;
+    }
+
 }

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -119,5 +119,4 @@ class Mysql extends \Cake\Database\Driver
         }
         return $result;
     }
-
 }

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\SqliteDialectTrait;
+use Cake\Database\Query;
 use Cake\Database\Statement\PDOStatement;
 use Cake\Database\Statement\SqliteStatement;
 use PDO;
@@ -87,6 +88,10 @@ class Sqlite extends \Cake\Database\Driver
     {
         $this->connect();
         $statement = $this->_connection->prepare((string)$query);
-        return new SqliteStatement(new PDOStatement($statement, $this), $this);
+        $result = new SqliteStatement(new PDOStatement($statement, $this), $this);
+        if ($query instanceof Query && $query->bufferResults() === false) {
+            $result->bufferResults(false);
+        }
+        return $result;
     }
 }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -100,7 +100,11 @@ class Sqlserver extends \Cake\Database\Driver
     public function prepare($query)
     {
         $this->connect();
-        $statement = $this->_connection->prepare((string)$query, [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+        $options = [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL];
+        if ($query instanceof Query && $query->bufferResults() === false) {
+            $options = [];
+        }
+        $statement = $this->_connection->prepare((string)$query, $options);
         return new SqlserverStatement($statement, $this);
     }
 }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -114,6 +114,14 @@ class Query implements ExpressionInterface, IteratorAggregate
     protected $_functionsBuilder;
 
     /**
+     * Boolean for tracking whether or not buffered results
+     * are enabled.
+     *
+     * @var bool
+     */
+    protected $_useBufferedResults = true;
+
+    /**
      * Constructor.
      *
      * @param \Cake\Database\Connection $connection The connection
@@ -1578,6 +1586,33 @@ class Query implements ExpressionInterface, IteratorAggregate
             return $this->_valueBinder;
         }
         $this->_valueBinder = $binder;
+        return $this;
+    }
+
+    /**
+     * Enable/Disable buffered results.
+     *
+     * When enabled the results returned by this Query will be
+     * buffered. This enables you to iterate a result set multiple times, or
+     * both cache and iterate it.
+     *
+     * When disabled it will consume less memory as fetched results are not
+     * remembered for future iterations.
+     *
+     * If called with no arguments, it will return whether or not buffering is
+     * enabled.
+     *
+     * @param bool $enable whether or not to enable buffering
+     * @return bool|$this
+     */
+    public function bufferResults($enable = null)
+    {
+        if ($enable === null) {
+            return $this->_useBufferedResults;
+        }
+
+        $this->_dirty();
+        $this->_useBufferedResults = (bool)$enable;
         return $this;
     }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1602,7 +1602,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If called with no arguments, it will return whether or not buffering is
      * enabled.
      *
-     * @param bool $enable whether or not to enable buffering
+     * @param bool|null $enable whether or not to enable buffering
      * @return bool|$this
      */
     public function bufferResults($enable = null)

--- a/src/Database/Statement/BufferResultsTrait.php
+++ b/src/Database/Statement/BufferResultsTrait.php
@@ -14,28 +14,29 @@
  */
 namespace Cake\Database\Statement;
 
-use PDO;
-
 /**
- * Statement class meant to be used by a Mysql PDO driver
+ * Contains a setter for marking a Statement as buffered
  *
  * @internal
  */
-class MysqlStatement extends PDOStatement
-{
-
-    use BufferResultsTrait;
+trait BufferResultsTrait {
 
     /**
-     * {@inheritDoc}
+     * Whether or not to buffer results in php
      *
+     * @var bool
      */
-    public function execute($params = null)
-    {
-        $this->_driver->connection()->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, $this->_bufferResults);
-        $result = $this->_statement->execute($params);
-        $this->_driver->connection()->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
-        return $result;
-    }
+    protected $_bufferResults = true;
 
+    /**
+     * Whether or not to buffer results in php
+     *
+     * @param bool $buffer Toggle buffering
+     * @return $this
+     */
+    public function bufferResults($buffer)
+    {
+        $this->_bufferResults = (bool)$buffer;
+        return $this;
+    }
 }

--- a/src/Database/Statement/BufferResultsTrait.php
+++ b/src/Database/Statement/BufferResultsTrait.php
@@ -19,7 +19,8 @@ namespace Cake\Database\Statement;
  *
  * @internal
  */
-trait BufferResultsTrait {
+trait BufferResultsTrait
+{
 
     /**
      * Whether or not to buffer results in php

--- a/src/Database/Statement/MysqlStatement.php
+++ b/src/Database/Statement/MysqlStatement.php
@@ -37,5 +37,4 @@ class MysqlStatement extends PDOStatement
         $this->_driver->connection()->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
         return $result;
     }
-
 }

--- a/src/Database/Statement/MysqlStatement.php
+++ b/src/Database/Statement/MysqlStatement.php
@@ -24,7 +24,7 @@ use PDO;
 class MysqlStatement extends PDOStatement
 {
 
-     /**
+    /**
      * Whether or not to buffer results in php
      *
      * @var bool
@@ -43,7 +43,7 @@ class MysqlStatement extends PDOStatement
         return $result;
     }
 
-     /**
+    /**
      * Whether or not to buffer results in php
      *
      * @param bool $buffer Toggle buffering

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -38,8 +38,7 @@ class SqliteStatement extends StatementDecorator
             $this->_statement = new BufferedStatement($this->_statement, $this->_driver);
         }
 
-        $result = $this->_statement->execute($params);
-        return $result;
+        return $this->_statement->execute($params);
     }
 
     /**

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -57,5 +57,4 @@ class SqliteStatement extends StatementDecorator
         }
         return parent::rowCount();
     }
-
 }

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -22,12 +22,7 @@ namespace Cake\Database\Statement;
 class SqliteStatement extends StatementDecorator
 {
 
-    /**
-     * Whether or not to buffer results in php
-     *
-     * @var bool
-     */
-    protected $_bufferResults = true;
+    use BufferResultsTrait;
 
     /**
      * {@inheritDoc}
@@ -64,15 +59,4 @@ class SqliteStatement extends StatementDecorator
         return parent::rowCount();
     }
 
-     /**
-     * Whether or not to buffer results in php
-     *
-     * @param bool $buffer Toggle buffering
-     * @return $this
-     */
-    public function bufferResults($buffer)
-    {
-        $this->_bufferResults = (bool)$buffer;
-        return $this;
-    }
 }

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -238,6 +238,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
      */
     public function getIterator()
     {
+        $this->execute();
         return $this->_statement;
     }
 
@@ -296,5 +297,14 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
             return $row[$column];
         }
         return $this->_driver->lastInsertId($table, $column);
+    }
+
+    /**
+     * Returns the statement object that was decorated by this class.
+     *
+     * @return \Cake\Database\StatementInterface
+     */
+    public function getInnerStatement() {
+        return $this->_statement;
     }
 }

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -304,7 +304,8 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
      *
      * @return \Cake\Database\StatementInterface
      */
-    public function getInnerStatement() {
+    public function getInnerStatement()
+    {
         return $this->_statement;
     }
 }

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -665,8 +665,7 @@ class TreeBehavior extends Behavior
             ->select($pk)
             ->where([$parent . ' IS' => $parentId])
             ->order($pk)
-            ->hydrate(false)
-            ->bufferResults(false);
+            ->hydrate(false);
 
         $leftCounter = $counter;
         foreach ($query as $row) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -77,14 +77,6 @@ class Query extends DatabaseQuery implements JsonSerializable
     protected $_autoFields;
 
     /**
-     * Boolean for tracking whether or not buffered results
-     * are enabled.
-     *
-     * @var bool
-     */
-    protected $_useBufferedResults = true;
-
-    /**
      * Whether to hydrate results into entity objects
      *
      * @var bool
@@ -340,33 +332,6 @@ class Query extends DatabaseQuery implements JsonSerializable
     {
         $this->eagerLoader()->matching($assoc, $builder);
         $this->_dirty();
-        return $this;
-    }
-
-    /**
-     * Enable/Disable buffered results.
-     *
-     * When enabled the ResultSet returned by this Query will be
-     * buffered. This enables you to iterate a ResultSet multiple times, or
-     * both cache and iterate the ResultSet.
-     *
-     * When disabled it will consume less memory as fetched results are not
-     * remembered in the ResultSet.
-     *
-     * If called with no arguments, it will return whether or not buffering is
-     * enabled.
-     *
-     * @param bool $enable whether or not to enable buffering
-     * @return bool|$this
-     */
-    public function bufferResults($enable = null)
-    {
-        if ($enable === null) {
-            return $this->_useBufferedResults;
-        }
-
-        $this->_dirty();
-        $this->_useBufferedResults = (bool)$enable;
         return $this;
     }
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -274,6 +274,11 @@ class ConnectionTest extends TestCase
         $this->assertEquals(2, $result['total']);
         $total->closeCursor();
 
+        $total->execute();
+        $result = $total->fetch('assoc');
+        $this->assertEquals(2, $result['total']);
+        $total->closeCursor();
+
         $result = $this->connection->execute('SELECT title, body  FROM things');
         $row = $result->fetch('assoc');
         $this->assertEquals('a title', $row['title']);
@@ -283,6 +288,11 @@ class ConnectionTest extends TestCase
         $result->closeCursor();
         $this->assertEquals('another title', $row['title']);
         $this->assertEquals('another body', $row['body']);
+
+        $result->execute();
+        $row = $result->fetch('assoc');
+        $result->closeCursor();
+        $this->assertEquals('a title', $row['title']);
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3144,6 +3144,11 @@ class QueryTest extends TestCase
             ->bufferResults(false)
             ->execute();
 
+        $this->skipIf(
+            !method_exists($result, 'bufferResults'),
+            'This driver does not support unbuffered queries'
+        );
+
         $this->assertCount(0, $result);
         $list = $result->fetchAll('assoc');
         $this->assertCount(3, $list);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3143,22 +3143,20 @@ class QueryTest extends TestCase
             ->bufferResults(false)
             ->execute();
 
+        $this->assertCount(0, $result);
         $list = $result->fetchAll('assoc');
         $this->assertCount(3, $list);
-
-        $list = $result->fetchAll('assoc');
-        $this->assertCount(0, $list);
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query->select(['body', 'author_id'])
             ->from('articles')
             ->execute();
 
+        $this->assertCount(3, $result);
         $list = $result->fetchAll('assoc');
         $this->assertCount(3, $list);
-
-        $list = $result->fetchAll('assoc');
-        $this->assertCount(3, $list);
+        $result->closeCursor();
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3136,7 +3136,8 @@ class QueryTest extends TestCase
      *
      * @return void
      */
-    public function testUnbufferedQuery() {
+    public function testUnbufferedQuery()
+    {
         $query = new Query($this->connection);
         $result = $query->select(['body', 'author_id'])
             ->from('articles')

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3132,6 +3132,36 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Shows that bufferResults(false) will prevent client-side results buffering
+     *
+     * @return void
+     */
+    public function testUnbufferedQuery() {
+        $query = new Query($this->connection);
+        $result = $query->select(['body', 'author_id'])
+            ->from('articles')
+            ->bufferResults(false)
+            ->execute();
+
+        $list = $result->fetchAll('assoc');
+        $this->assertCount(3, $list);
+
+        $list = $result->fetchAll('assoc');
+        $this->assertCount(0, $list);
+
+        $query = new Query($this->connection);
+        $result = $query->select(['body', 'author_id'])
+            ->from('articles')
+            ->execute();
+
+        $list = $result->fetchAll('assoc');
+        $this->assertCount(3, $list);
+
+        $list = $result->fetchAll('assoc');
+        $this->assertCount(3, $list);
+    }
+
+    /**
      * Assertion for comparing a table's contents with what is in it.
      *
      * @param string $table


### PR DESCRIPTION
Implemented real non-buffered Database statements.
The old implementation was secretly relying on PHP results buffering for MySQL and it was impossible to turn off.

Also improved the Sqlite driver to only buffer results optionally as mysql does.

I haven't tried yet with Postgres and will see how it fails in SQL Server so I can see if it is implementable at all. Treat this as a WIP
