### PR TITLE
3.0 - Fix partial path being set for non existent paths

### DIFF
--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -391,7 +391,10 @@ class File
     public function pwd()
     {
         if ($this->path === null) {
-            $this->path = $this->Folder->slashTerm($this->Folder->pwd()) . $this->name;
+            $dir = $this->Folder->pwd();
+            if (is_dir($dir)) {
+                $this->path = $this->Folder->slashTerm($dir) . $this->name;
+            }
         }
         return $this->path;
     }

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -622,4 +622,17 @@ class FileTest extends TestCase
 
         $TmpFile->delete();
     }
+
+    /**
+     * Tests that no path is being set for passed file paths that
+     * do not exist.
+     *
+     * @return void
+     */
+    public function testNoPartialPathBeingSetForNonExistentPath()
+    {
+        $TmpFile = new File('/non/existent/file');
+        $this->assertNull($TmpFile->pwd());
+        $this->assertNull($TmpFile->path);
+    }
 }


### PR DESCRIPTION
In case the path passed to the `File` class doesn't exists, this will
cause `File::$path` to be set to a partial path, that is the filename
of the passed path with a slash prepended, ex with

`$file = new File('/non/existent/file');`

calling `$file->pwd()` will return/set `/file`, possibly causing that
file in the root to be accessed.
