### PR TITLE
Strawman for vendor plugins.

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -120,7 +120,7 @@ class Plugin
             return;
         }
 
-        if (!Configure::check('pluginPaths')) {
+        if (!Configure::check('plugins')) {
             try {
                 Configure::load('plugins');
             } catch (\Exception $e) {

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -15,6 +15,7 @@
 namespace Cake\Core;
 
 use Cake\Core\ClassLoader;
+use Cake\Core\Configure;
 use DirectoryIterator;
 
 /**
@@ -40,13 +41,6 @@ class Plugin
      * @var \Cake\Core\ClassLoader
      */
     protected static $_loader;
-
-    /**
-     * The config map of plugins and their paths.
-     *
-     * @var array
-     */
-    protected static $_config;
 
     /**
      * Loads a plugin and optionally loads bootstrapping,
@@ -125,8 +119,8 @@ class Plugin
             }
             return;
         }
-        if (static::$_config === null) {
-            static::_loadConfigMap();
+        if (!Configure::check('pluginPaths')) {
+            Configure::load('plugins');
         }
 
         $config += [
@@ -137,8 +131,8 @@ class Plugin
             'ignoreMissing' => false
         ];
 
-        if (!isset($config['path']) && isset(static::$_config[$plugin])) {
-            $config['path'] = static::$_config[$plugin];
+        if (!isset($config['path'])) {
+            $config['path'] = Configure::read('plugins.' . $plugin);
         }
 
         if (empty($config['path'])) {
@@ -146,7 +140,7 @@ class Plugin
             foreach ($paths as $path) {
                 $pluginPath = str_replace('/', DS, $plugin);
                 if (is_dir($path . $pluginPath)) {
-                    $config += ['path' => $path . $pluginPath . DS];
+                    $config['path'] = $path . $pluginPath . DS;
                     break;
                 }
             }
@@ -181,24 +175,6 @@ class Plugin
                 $config['path'] . 'tests' . DS
             );
         }
-    }
-
-    /**
-     * Loads the config mappings for plugins.
-     *
-     * The map data in CONFIG/plugins.php map data is used set default paths
-     * for where plugins are located.
-     *
-     * @return void
-     */
-    protected static function _loadConfigMap()
-    {
-        if (!file_exists(CONFIG . 'plugins.php')) {
-            static::$_config = [];
-            return;
-        }
-        $config = include CONFIG . 'plugins.php';
-        static::$_config = $config;
     }
 
     /**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -176,6 +176,11 @@ class Plugin
         }
     }
 
+    /**
+     * Load the plugin path configuration file.
+     *
+     * @return void
+     */
     protected static function _loadConfig()
     {
         if (Configure::check('plugins')) {

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -120,12 +120,7 @@ class Plugin
             return;
         }
 
-        if (!Configure::check('plugins')) {
-            try {
-                Configure::load('plugins');
-            } catch (\Exception $e) {
-            }
-        }
+        static::_loadConfig();
 
         $config += [
             'autoload' => false,
@@ -181,6 +176,17 @@ class Plugin
         }
     }
 
+    protected static function _loadConfig()
+    {
+        if (Configure::check('plugins')) {
+            return;
+        }
+        try {
+            Configure::load('plugins');
+        } catch (\Exception $e) {
+        }
+    }
+
     /**
      * Will load all the plugins located in the default plugin folder.
      *
@@ -204,6 +210,7 @@ class Plugin
      */
     public static function loadAll(array $options = [])
     {
+        static::_loadConfig();
         $plugins = [];
         foreach (App::path('Plugin') as $path) {
             if (!is_dir($path)) {
@@ -215,6 +222,10 @@ class Plugin
                     $plugins[] = $path->getBaseName();
                 }
             }
+        }
+        if (Configure::check('plugins')) {
+            $plugins = array_merge($plugins, array_keys(Configure::read('plugins')));
+            $plugins = array_unique($plugins);
         }
 
         foreach ($plugins as $p) {

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -42,6 +42,13 @@ class Plugin
     protected static $_loader;
 
     /**
+     * The config map of plugins and their paths.
+     *
+     * @var array
+     */
+    protected static $_config;
+
+    /**
      * Loads a plugin and optionally loads bootstrapping,
      * routing files or runs an initialization function.
      *
@@ -118,6 +125,9 @@ class Plugin
             }
             return;
         }
+        if (static::$_config === null) {
+            static::_loadConfigMap();
+        }
 
         $config += [
             'autoload' => false,
@@ -126,6 +136,10 @@ class Plugin
             'classBase' => 'src',
             'ignoreMissing' => false
         ];
+
+        if (!isset($config['path']) && isset(static::$_config[$plugin])) {
+            $config['path'] = static::$_config[$plugin];
+        }
 
         if (empty($config['path'])) {
             $paths = App::path('Plugin');
@@ -167,6 +181,24 @@ class Plugin
                 $config['path'] . 'tests' . DS
             );
         }
+    }
+
+    /**
+     * Loads the config mappings for plugins.
+     *
+     * The map data in CONFIG/plugins.php map data is used set default paths
+     * for where plugins are located.
+     *
+     * @return void
+     */
+    protected static function _loadConfigMap()
+    {
+        if (!file_exists(CONFIG . 'plugins.php')) {
+            static::$_config = [];
+            return;
+        }
+        $config = include CONFIG . 'plugins.php';
+        static::$_config = $config;
     }
 
     /**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -119,8 +119,12 @@ class Plugin
             }
             return;
         }
+
         if (!Configure::check('pluginPaths')) {
-            Configure::load('plugins');
+            try {
+                Configure::load('plugins');
+            } catch (\Exception $e) {
+            }
         }
 
         $config += [

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -120,6 +120,19 @@ class PluginTest extends TestCase
     }
 
     /**
+     * Test load() with path configuration data
+     *
+     * @return void
+     */
+    public function testLoadSingleWithPathConfig()
+    {
+        Configure::write('plugins.TestPlugin', APP);
+        Plugin::load('TestPlugin');
+        $this->assertEquals(APP . 'src' . DS, Plugin::classPath('TestPlugin'));
+    }
+
+
+    /**
      * Tests loading multiple plugins at once
      *
      * @return void

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -283,6 +283,18 @@ class PluginTest extends TestCase
     }
 
     /**
+     * Test loadAll() with path configuration data
+     *
+     * @return void
+     */
+    public function testLoadAllWithPathConfig()
+    {
+        Configure::write('plugins.FakePlugin', APP);
+        Plugin::loadAll();
+        $this->assertContains('FakePlugin', Plugin::loaded());
+    }
+
+    /**
      * Test that plugins don't reload using loadAll();
      *
      * @return void

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -131,7 +131,6 @@ class PluginTest extends TestCase
         $this->assertEquals(APP . 'src' . DS, Plugin::classPath('TestPlugin'));
     }
 
-
     /**
      * Tests loading multiple plugins at once
      *

--- a/tests/test_app/config/plugins.php
+++ b/tests/test_app/config/plugins.php
@@ -1,4 +1,0 @@
-<?php
-$config = [
-    'plugins' => []
-];

--- a/tests/test_app/config/plugins.php
+++ b/tests/test_app/config/plugins.php
@@ -1,0 +1,4 @@
+<?php
+$config = [
+    'plugins' => []
+];


### PR DESCRIPTION
This is a basic strawman for changing how plugins are installed. Instead of putting composer managed plugins into /plugins, this will allow a path configuration file to define where plugins are located. Having this configuration file, will allow the plugin-installer to update the file.

This will require additional changes in cakephp/app, and cakephp/plugin-installer.

Strawman for simpler approach to cakephp/app#206
