### PR TITLE
Fix assertResponseContains and add assertResponseEquals.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -561,7 +561,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertNotContains($content, $this->_response->body(), $message);
+        $this->assertNotContains($content, (string)$this->_response->body(), $message);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -522,6 +522,21 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts content exists in the response body.
      *
+     * @param mixed $content The content to check for.
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertResponseEquals($content, $message = '')
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert content. ' . $message);
+        }
+        $this->assertEquals($content, $this->_response->body(), $message);
+    }
+
+    /**
+     * Asserts content exists in the response body.
+     *
      * @param string $content The content to check for.
      * @param string $message The failure message that will be appended to the generated message.
      * @return void
@@ -531,7 +546,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertContains($content, $this->_response->body(), $message);
+        $this->assertContains($content, (string)$this->_response->body(), $message);
     }
 
     /**


### PR DESCRIPTION
There is bug with assertResponseContains() when you set

```
$this->response->body(1);
```

for example.
So casting to string for the contains check is required.

Also added assertResponseEquals() to easily check on a specific and complete response body.
