### PR TITLE
Allow simple check on existence for assertRedirect()

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -441,17 +441,21 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the Location header is correct.
      *
-     * @param string|array $url The url you expected the client to go to. This
-     *   can either be a string URL or an array compatible with Router::url()
+     * @param string|array|null $url The URL you expected the client to go to. This
+     *   can either be a string URL or an array compatible with Router::url(). Use null to
+     *   simply check for the existence of this header.
      * @param string $message The failure message that will be appended to the generated message.
      * @return void
      */
-    public function assertRedirect($url, $message = '')
+    public function assertRedirect($url = null, $message = '')
     {
         if (!$this->_response) {
             $this->fail('No response set, cannot assert location header. ' . $message);
         }
         $result = $this->_response->header();
+        if ($url === null) {
+            return $this->assertNotEmpty($result['Location']);
+        }
         if (empty($result['Location'])) {
             $this->fail('No location header set. ' . $message);
         }

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -454,7 +454,8 @@ abstract class IntegrationTestCase extends TestCase
         }
         $result = $this->_response->header();
         if ($url === null) {
-            return $this->assertNotEmpty($result['Location']);
+            $this->assertTrue(!empty($result['Location']), $message);
+            return;
         }
         if (empty($result['Location'])) {
             $this->fail('No location header set. ' . $message);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -178,6 +178,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->_response = new Response();
         $this->_response->header('Location', 'http://localhost/tasks/index');
 
+        $this->assertRedirect();
         $this->assertRedirect('/tasks/index');
         $this->assertRedirect(['controller' => 'Tasks', 'action' => 'index']);
     }


### PR DESCRIPTION
When writing integration test cases, some redirect URLs contained a hash or a new primary key value that is not known beforehand.
In these cases it is useful (as a shortcut) to have assertRedirect() allow the exact opposite of assertNoRedirect() - simply checking on the existence of the Location header. Using null as argument this is easily possible with BC.
