### PR TITLE
Only destroy active sessions.

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -509,7 +509,7 @@ class Session
             $this->start();
         }
 
-        if (!$this->_isCli) {
+        if (!$this->_isCli && session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }
 


### PR DESCRIPTION
Destroying sessions that failed to start only causes more errors.

Refs #5666
