### PR TITLE
CakeSession::destroy() should check for existence of session

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -442,7 +442,9 @@ class CakeSession {
 			self::_startSession();
 		}
 
-		session_destroy();
+		if (self::started()) {
+			session_destroy();
+		}
 
 		$_SESSION = null;
 		self::$id = null;


### PR DESCRIPTION
I did not provide a test case, but something like this would probably suffice:

``` php
// PHPUnit will fail if there's emitted a PHP warning
public function testDestroyNotStarted() {
    TestCakeSession::destroy();
}
```
