### PR TITLE
Correct CakeSocket docblocks.

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -119,7 +119,7 @@ class CakeSocket {
 	}
 
 /**
- * Connect the socket to the given host and port.
+ * Connects the socket to the given host and port.
  *
  * @return bool Success
  * @throws SocketException
@@ -188,7 +188,7 @@ class CakeSocket {
 	}
 
 /**
- * Get the connection context.
+ * Gets the connection context.
  *
  * @return null|array Null when there is no connection, an array when there is.
  */
@@ -200,7 +200,7 @@ class CakeSocket {
 	}
 
 /**
- * Get the host name of the current connection.
+ * Gets the host name of the current connection.
  *
  * @return string Host name
  */
@@ -212,7 +212,7 @@ class CakeSocket {
 	}
 
 /**
- * Get the IP address of the current connection.
+ * Gets the IP address of the current connection.
  *
  * @return string IP address
  */
@@ -224,7 +224,7 @@ class CakeSocket {
 	}
 
 /**
- * Get all IP addresses associated with the current connection.
+ * Gets all IP addresses associated with the current connection.
  *
  * @return array IP addresses
  */
@@ -236,7 +236,7 @@ class CakeSocket {
 	}
 
 /**
- * Get the last error as a string.
+ * Gets the last error as a string.
  *
  * @return string|null Last error
  */
@@ -248,7 +248,7 @@ class CakeSocket {
 	}
 
 /**
- * Set the last error.
+ * Sets the last error.
  *
  * @param int $errNum Error code
  * @param string $errStr Error string
@@ -259,7 +259,7 @@ class CakeSocket {
 	}
 
 /**
- * Write data to the socket.
+ * Writes data to the socket.
  *
  * @param string $data The data to write to the socket
  * @return bool Success
@@ -281,7 +281,7 @@ class CakeSocket {
 	}
 
 /**
- * Read data from the socket. Returns false if no data is available or no connection could be
+ * Reads data from the socket. Returns false if no data is available or no connection could be
  * established.
  *
  * @param int $length Optional buffer length to read; defaults to 1024
@@ -307,7 +307,7 @@ class CakeSocket {
 	}
 
 /**
- * Disconnect the socket from the current connection.
+ * Disconnects the socket from the current connection.
  *
  * @return bool Success
  */
@@ -353,14 +353,14 @@ class CakeSocket {
 	}
 
 /**
- * Encrypts current stream socket, using one of the defined encryption methods
+ * Encrypts current stream socket, using one of the defined encryption methods.
  *
- * @param string $type can be one of 'ssl2', 'ssl3', 'ssl23' or 'tls'
- * @param string $clientOrServer can be one of 'client', 'server'. Default is 'client'
- * @param bool $enable enable or disable encryption. Default is true (enable)
+ * @param string $type Type which can be one of 'sslv2', 'sslv3', 'sslv23' or 'tls'.
+ * @param string $clientOrServer Can be one of 'client', 'server'. Default is 'client'.
+ * @param bool $enable Enable or disable encryption. Default is true (enable)
  * @return bool True on success
  * @throws InvalidArgumentException When an invalid encryption scheme is chosen.
- * @throws SocketException When attempting to enable SSL/TLS fails
+ * @throws SocketException When attempting to enable SSL/TLS fails.
  * @see stream_socket_enable_crypto
  */
 	public function enableCrypto($type, $clientOrServer = 'client', $enable = true) {
@@ -369,7 +369,8 @@ class CakeSocket {
 		}
 		$enableCryptoResult = false;
 		try {
-			$enableCryptoResult = stream_socket_enable_crypto($this->connection, $enable, $this->_encryptMethods[$type . '_' . $clientOrServer]);
+			$enableCryptoResult = stream_socket_enable_crypto($this->connection, $enable,
+				$this->_encryptMethods[$type . '_' . $clientOrServer]);
 		} catch (Exception $e) {
 			$this->setLastError(null, $e->getMessage());
 			throw new SocketException($e->getMessage());


### PR DESCRIPTION
Extract doc block correction from https://github.com/cakephp/cakephp/pull/3461

```
'sslv2', 'sslv3', 'sslv23' or 'tls'
```
