### PR TITLE
3.0 beforeMarshal event

### DIFF
--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1745,4 +1745,27 @@ class MarshallerTest extends TestCase
         $this->assertNotEmpty($result->errors('author_id'));
         $this->assertNotEmpty($result->errors('thing'));
     }
+
+    /**
+     * Test Model.beforeMarshal event.
+     *
+     * @return void
+     */
+    public function testBeforeMarshalEvent()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content'
+        ];
+
+        $marshall = new Marshaller($this->articles);
+
+        $this->articles->eventManager()->attach(function ($e, $data) {
+            $data['title'] = 'Modified title';
+        }, 'Model.beforeMarshal');
+
+        $entity = $marshall->one($data);
+
+        $this->assertEquals('Modified title', $entity->title);
+    }
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1755,17 +1755,27 @@ class MarshallerTest extends TestCase
     {
         $data = [
             'title' => 'My title',
-            'body' => 'My content'
+            'body' => 'My content',
+            'user' => [
+                'name' => 'Robert',
+                'username' => 'rob'
+            ]
         ];
 
         $marshall = new Marshaller($this->articles);
 
         $this->articles->eventManager()->attach(function ($e, $data) {
             $data['title'] = 'Modified title';
+            $data['user']['username'] = 'robert';
         }, 'Model.beforeMarshal');
 
-        $entity = $marshall->one($data);
+        $entity = $marshall->one($data, [
+            'associated' => ['Users']
+        ]);
 
         $this->assertEquals('Modified title', $entity->title);
+        $this->assertEquals('My content', $entity->body);
+        $this->assertEquals('Robert', $entity->user->name);
+        $this->assertEquals('robert', $entity->user->username);
     }
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1778,4 +1778,60 @@ class MarshallerTest extends TestCase
         $this->assertEquals('Robert', $entity->user->name);
         $this->assertEquals('robert', $entity->user->username);
     }
+
+    /**
+     * Test Model.beforeMarshal event on associated tables.
+     *
+     * @return void
+     */
+    public function testBeforeMarshalEventOnAssociations()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'author_id' => 1,
+            'user' => [
+                'username' => 'mark',
+                'password' => 'secret'
+            ],
+            'comments' => [
+                ['comment' => 'First post', 'user_id' => 2],
+                ['comment' => 'Second post', 'user_id' => 2],
+            ],
+            'tags' => [
+                ['tag' => 'news', '_joinData' => ['active' => 1]],
+                ['tag' => 'cakephp', '_joinData' => ['active' => 0]],
+            ],
+        ];
+
+        $marshall = new Marshaller($this->articles);
+
+        $this->articles->users->eventManager()->attach(function ($e, $data) {
+            $data['secret'] = 'h45h3d';
+        }, 'Model.beforeMarshal');
+
+        $this->articles->comments->eventManager()->attach(function ($e, $data) {
+            $data['comment'] .= ' (modified)';
+        }, 'Model.beforeMarshal');
+
+        $this->articles->tags->eventManager()->attach(function ($e, $data) {
+            $data['tag'] .= ' (modified)';
+        }, 'Model.beforeMarshal');
+
+        $this->articles->tags->junction()->eventManager()->attach(function ($e, $data) {
+            $data['modified_by'] = 1;
+        }, 'Model.beforeMarshal');
+
+        $entity = $marshall->one($data, [
+            'associated' => ['Users', 'Comments', 'Tags']
+        ]);
+
+        $this->assertEquals('h45h3d', $entity->user->secret);
+        $this->assertEquals('First post (modified)', $entity->comments[0]->comment);
+        $this->assertEquals('Second post (modified)', $entity->comments[1]->comment);
+        $this->assertEquals('news (modified)', $entity->tags[0]->tag);
+        $this->assertEquals('cakephp (modified)', $entity->tags[1]->tag);
+        $this->assertEquals(1, $entity->tags[0]->_joinData->modified_by);
+        $this->assertEquals(1, $entity->tags[1]->_joinData->modified_by);
+    }
 }


### PR DESCRIPTION
I like the idea of having `Model.beforeMarshal` event hinted in #5622 

Here is my take on this issue.

`$data` passed to marshaller is converted to `ArrayObject` for easy manipulation inside listeners and then casted back to array.
