### PR TITLE
2.7 - Short plugin alias in shells

### DIFF
--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -247,9 +247,9 @@ class ShellDispatcher {
 		App::uses($class, $plugin . 'Console/Command');
 
 		if (!class_exists($class)) {
-            $plugin = Inflector::camelize($shell) . '.';
-            App::uses($class, $plugin . 'Console/Command');
-        }
+			$plugin = Inflector::camelize($shell) . '.';
+			App::uses($class, $plugin . 'Console/Command');
+		}
 
 		if (!class_exists($class)) {
 			throw new MissingShellException(array(

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -247,6 +247,11 @@ class ShellDispatcher {
 		App::uses($class, $plugin . 'Console/Command');
 
 		if (!class_exists($class)) {
+            $plugin = Inflector::camelize($shell) . '.';
+            App::uses($class, $plugin . 'Console/Command');
+        }
+
+		if (!class_exists($class)) {
 			throw new MissingShellException(array(
 				'class' => $class
 			));

--- a/lib/Cake/Test/Case/Console/Command/CompletionShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CompletionShellTest.php
@@ -125,7 +125,7 @@ class CompletionShellTest extends CakeTestCase {
 		$this->Shell->runCommand('commands', array());
 		$output = $this->Shell->stdout->output;
 
-		$expected = "TestPlugin.example TestPluginTwo.example TestPluginTwo.welcome acl api bake command_list completion console i18n schema server test testsuite upgrade sample\n";
+		$expected = "TestPlugin.example TestPlugin.test_plugin TestPluginTwo.example TestPluginTwo.welcome acl api bake command_list completion console i18n schema server test testsuite upgrade sample\n";
 		$this->assertEquals($expected, $output);
 	}
 

--- a/lib/Cake/Test/Case/Console/Command/Task/CommandTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/CommandTaskTest.php
@@ -85,9 +85,10 @@ class CommandTaskTest extends CakeTestCase {
 				'upgrade'
 			),
 			'TestPlugin' => array(
-				'example'
+				'example',
+				'test_plugin'
 			),
-				'TestPluginTwo' => array(
+			'TestPluginTwo' => array(
 				'example',
 				'welcome'
 			),
@@ -108,6 +109,7 @@ class CommandTaskTest extends CakeTestCase {
 
 		$expected = array(
 			'TestPlugin.example',
+			'TestPlugin.test_plugin',
 			'TestPluginTwo.example',
 			'TestPluginTwo.welcome',
 			'acl',

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -427,6 +427,14 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestShellDispatcher();
 		$result = $Dispatcher->getShell('TestPlugin.example');
 		$this->assertInstanceOf('ExampleShell', $result);
+
+		$Dispatcher = new TestShellDispatcher();
+		$result = $Dispatcher->getShell('test_plugin');
+		$this->assertInstanceOf('TestPluginShell', $result);
+
+		$Dispatcher = new TestShellDispatcher();
+		$result = $Dispatcher->getShell('TestPlugin');
+		$this->assertInstanceOf('TestPluginShell', $result);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/TestPluginShell.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/TestPluginShell.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Short description for file.
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -12,7 +10,7 @@
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @package       Cake.Test.TestApp.Plugin.TestPlugin.Console.Command
- * @since         CakePHP(tm) v 1.2.0.7871
+ * @since         CakePHP(tm) v 2.7.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/TestPluginShell.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/TestPluginShell.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.TestApp.Plugin.TestPlugin.Console.Command
+ * @since         CakePHP(tm) v 1.2.0.7871
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class TestPluginShell
+ * @package       Cake.Test.TestApp.Plugin.TestPlugin.Console.Command
+ */
+class TestPluginShell extends Shell {
+
+/**
+ * main method
+ *
+ * @return void
+ */
+	public function main() {
+		$this->out('This is the main method called from TestPlugin.TestPluginShell');
+	}
+}


### PR DESCRIPTION
Here is an attempt to implement a feature mentioned in #5679 

Simple check for shell class existence in a plugin with the same name.
