### PR TITLE
Add theme support to meta('icon')

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -232,7 +232,11 @@ class HtmlHelper extends Helper
             ];
 
             if ($type === 'icon' && $content === null) {
-                $types['icon']['link'] = 'favicon.ico';
+                if ($this->_View->Html->theme !== null && file_exists($this->Url->webroot . 'favicon.ico')) {
+                    $types['icon']['link'] = $this->Url->webroot . 'favicon.ico';
+                } else {
+                    $types['icon']['link'] = 'favicon.ico';
+                }
             }
 
             if (isset($types[$type])) {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1672,6 +1672,38 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
+     * Test theme support for meta('icon') method
+     *
+     * @return void
+     */
+    public function testMetaIconWithTheme()
+    {
+        $this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
+
+        $this->Html->Url->request->webroot = '/';
+        $this->Html->Url->theme = 'TestTheme';
+
+        $result = $this->Html->meta('icon');
+        $expected = [
+            'link' => ['href' => '/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'],
+            ['link' => ['href' => '/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'shortcut icon']]
+        ];
+        $this->assertHtml($expected, $result);
+
+        $testIcon = WWW_ROOT . 'test_theme/favicon.ico';
+        $File = new File($testIcon, true);
+
+        $result = $this->Html->meta('icon');
+        $expected = [
+            'link' => ['href' => '/test_theme/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'],
+            ['link' => ['href' => '/test_theme/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'shortcut icon']]
+        ];
+        $this->assertHtml($expected, $result);
+
+        $File->delete();
+    }
+
+    /**
      * Test the inline and block options for meta()
      *
      * @return void


### PR DESCRIPTION
As far as I could tell the issue mentioned in #5023 didn't work on Cake 3 either. This should fix that problem.
