### PR TITLE
3.0 locale marshal

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -47,7 +47,7 @@ class DateTimeType extends \Cake\Database\Type
     protected $_useLocaleParser = false;
 
     /**
-     * The date formate to use for parsing incoming dates for marshalling.
+     * The date format to use for parsing incoming dates for marshalling.
      *
      * @var string|array|int
      */
@@ -160,14 +160,14 @@ class DateTimeType extends \Cake\Database\Type
     }
 
     /**
-     * Sets whether or not to pase dates passed to the marshal() function
+     * Sets whether or not to parse dates passed to the marshal() function
      * by using a locale aware parser.
      *
      * @param bool $enable Whether or not to enable
      * @return $this
      */
-	public function useLocaleParser($enable = true)
-	{
+    public function useLocaleParser($enable = true)
+    {
         if ($enable === false) {
             $this->_useLocaleParser = $enable;
             return $this;

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -159,6 +159,13 @@ class DateTimeType extends \Cake\Database\Type
         return new $class($format);
     }
 
+    /**
+     * Sets whether or not to pase dates passed to the marshal() function
+     * by using a locale aware parser.
+     *
+     * @param bool $enable Whether or not to enable
+     * @return $this
+     */
 	public function useLocaleParser($enable = true)
 	{
         if ($enable === false) {
@@ -177,12 +184,28 @@ class DateTimeType extends \Cake\Database\Type
         );
     }
 
+    /**
+     * Sets the format string to use for parsing dates in this class. The formats
+     * that are accepted are documented in the `Cake\I18n\Time::parseDateTime()`
+     * function.
+     *
+     * @param string|array $format The format in which the string are passed.
+     * @see \Cake\I18n\Time::parseDateTime()
+     * @return $this
+     */
     public function setLocaleFormat($format)
     {
         $this->_localeFormat = $format;
         return $this;
     }
 
+    /**
+     * Converts a string into a DateTime object after parseing it using the locale
+     * aware parser with the specified format.
+     *
+     * @param string $value The value to parse and convert to an object.
+     * @return \Cake\I18n\Time|null
+     */
     protected function _parseValue($value)
     {
         $class = static::$dateTimeClass;

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -159,7 +159,8 @@ class DateTimeType extends \Cake\Database\Type
         return new $class($format);
     }
 
-    public function useLocaleParser($enable = true) {
+	public function useLocaleParser($enable = true)
+	{
         if ($enable === false) {
             $this->_useLocaleParser = $enable;
             return $this;
@@ -176,7 +177,8 @@ class DateTimeType extends \Cake\Database\Type
         );
     }
 
-    public function setLocaleFormat($format) {
+    public function setLocaleFormat($format)
+    {
         $this->_localeFormat = $format;
         return $this;
     }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -120,7 +120,7 @@ class DateTimeType extends \Cake\Database\Type
             } elseif (is_numeric($value)) {
                 $date = new $class('@' . $value);
             } elseif (is_string($value) && $this->_useLocaleParser) {
-                $date = $this->_parseValue($date);
+                return $this->_parseValue($value);
             } elseif (is_string($value)) {
                 $date = new $class($value);
                 $compare = true;
@@ -184,6 +184,6 @@ class DateTimeType extends \Cake\Database\Type
     protected function _parseValue($value)
     {
         $class = static::$dateTimeClass;
-        return $class::parseDateTime($value);
+        return $class::parseDateTime($value, $this->_localeFormat);
     }
 }

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -56,4 +56,13 @@ class DateType extends \Cake\Database\Type\DateTimeType
         }
         return $date;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _parseValue($value)
+    {
+        $class = static::$dateTimeClass;
+        return $class::parseDate($value, $this->_localeFormat);
+    }
 }

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -28,4 +28,13 @@ class TimeType extends \Cake\Database\Type\DateTimeType
      * @var string
      */
     protected $_format = 'H:i:s';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _parseValue($value)
+    {
+        $class = static::$dateTimeClass;
+        return $class::parseTime($value, $this->_localeFormat);
+    }
 }

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -766,7 +766,8 @@ class Time extends Carbon implements JsonSerializable
      * @param string|int $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
-    public static function parseTime($time, $format = null) {
+    public static function parseTime($time, $format = null)
+    {
         if (is_int($format)) {
             $format = [-1, $format];
         }

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -669,7 +669,7 @@ class Time extends Carbon implements JsonSerializable
     /**
      * Returns a new Time object after parsing the provided time string based on
      * the passed or configured date time format. This method is locale dependent,
-     * Any string that is passed to this function will be intepreted as a locale
+     * Any string that is passed to this function will be interpreted as a locale
      * dependent string.
      *
      * When no $format is provided, the `toString` format will be used.
@@ -678,11 +678,11 @@ class Time extends Carbon implements JsonSerializable
      *
      * Example:
      *
-     * {{{
+     * ```
      *  $time = Time::parseDateTime('10/13/2013 12:54am');
      *  $time = Time::parseDateTime('13 Oct, 2013 13:54', 'dd MMM, y H:mm');
      *  $time = Time::parseDateTime('10/10/2015', [IntlDateFormatter::SHORT, -1]);
-     * }}}
+     * ```
      *
      * @param string $time The time string to parse.
      * @param string|array $format Any format accepted by IntlDateFormatter.
@@ -718,7 +718,7 @@ class Time extends Carbon implements JsonSerializable
     /**
      * Returns a new Time object after parsing the provided $date string based on
      * the passed or configured date time format. This method is locale dependent,
-     * Any string that is passed to this function will be intepreted as a locale
+     * Any string that is passed to this function will be interpreted as a locale
      * dependent string.
      *
      * When no $format is provided, the `wordFormat` format will be used.
@@ -727,11 +727,11 @@ class Time extends Carbon implements JsonSerializable
      *
      * Example:
      *
-     * {{{
+     * ```
      *  $time = Time::parseDate('10/13/2013');
      *  $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
      *  $time = Time::parseDate('13 Oct, 2013', IntlDateFormatter::SHORT);
-     * }}}
+     * ```
      *
      * @param string $date The date string to parse.
      * @param string|int $format Any format accepted by IntlDateFormatter.
@@ -749,7 +749,7 @@ class Time extends Carbon implements JsonSerializable
     /**
      * Returns a new Time object after parsing the provided $time string based on
      * the passed or configured date time format. This method is locale dependent,
-     * Any string that is passed to this function will be intepreted as a locale
+     * Any string that is passed to this function will be interpreted as a locale
      * dependent string.
      *
      * When no $format is provided, the IntlDateFormatter::SHORT format will be used.
@@ -758,9 +758,9 @@ class Time extends Carbon implements JsonSerializable
      *
      * Example:
      *
-     * {{{
+     * ```
      *  $time = Time::parseDate('11:23pm');
-     * }}}
+     * ```
      *
      * @param string $time The time string to parse.
      * @param string|int $format Any format accepted by IntlDateFormatter.

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -716,6 +716,37 @@ class Time extends Carbon implements JsonSerializable
     }
 
     /**
+     * Returns a new Time object after parsing the provided $date string based on
+     * the passed or configured date time format. This method is locale dependent,
+     * Any string that is passed to this function will be intepreted as a locale
+     * dependent string.
+     *
+     * When no $format is provided, the `wordFormat` format will be used.
+     *
+     * If it was impossible to parse the provided time, null will be returned.
+     *
+     * Example:
+     *
+     * {{{
+     *  $time = Time::parseDate('10/13/2013');
+     *  $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
+     *  $time = Time::parseDate('13 Oct, 2013', IntlDateFormatter::SHORT);
+     * }}}
+     *
+     * @param string $date The date string to parse.
+     * @param string|array|int $format Any format accepted by IntlDateFormatter.
+     * @return static|null
+     */
+    public static function parseDate($date, $format = null)
+    {
+        if (is_int($format)) {
+            $format = [$format, -1];
+        }
+        $format = $format ?: static::$wordFormat;
+        return static::parseDateTime($date, $format);
+    }
+
+    /**
      * Returns a string that should be serialized when converting this object to json
      *
      * @return string

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -747,6 +747,34 @@ class Time extends Carbon implements JsonSerializable
     }
 
     /**
+     * Returns a new Time object after parsing the provided $time string based on
+     * the passed or configured date time format. This method is locale dependent,
+     * Any string that is passed to this function will be intepreted as a locale
+     * dependent string.
+     *
+     * When no $format is provided, the IntlDateFormatter::SHORT format will be used.
+     *
+     * If it was impossible to parse the provided time, null will be returned.
+     *
+     * Example:
+     *
+     * {{{
+     *  $time = Time::parseDate('11:23pm');
+     * }}}
+     *
+     * @param string $time The time string to parse.
+     * @param string|int $format Any format accepted by IntlDateFormatter.
+     * @return static|null
+     */
+    public static function parseTime($time, $format = null) {
+        if (is_int($format)) {
+            $format = [-1, $format];
+        }
+        $format = $format ?: [-1, IntlDateFormatter::SHORT];
+        return static::parseDateTime($time, $format);
+    }
+
+    /**
      * Returns a string that should be serialized when converting this object to json
      *
      * @return string

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -734,7 +734,7 @@ class Time extends Carbon implements JsonSerializable
      * }}}
      *
      * @param string $date The date string to parse.
-     * @param string|array|int $format Any format accepted by IntlDateFormatter.
+     * @param string|int $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDate($date, $format = null)

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -180,4 +180,32 @@ class DateTimeTypeTest extends TestCase
             $this->assertSame($expected, $result);
         }
     }
+
+    /**
+     * Tests marshalling dates using the locale aware parser
+     *
+     * @return void
+     */
+    public function testMarshalWithLocaleParsing()
+    {
+        $this->type->useLocaleParser();
+        $expected = new Time('13-10-2013 23:28:00');
+        $result = $this->type->marshal('10/13/2013 11:28pm');
+        $this->assertEquals($expected, $result);
+
+        $this->assertNull($this->type->marshal('11/derp/2013 11:28pm'));
+    }
+
+    /**
+     * Tests marshalling dates using the locale aware parser and custom format
+     *
+     * @return void
+     */
+    public function testMarshalWithLocaleParsingWithFormat()
+    {
+        $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y hh:mma');
+        $expected = new Time('13-10-2013 13:54:00');
+        $result = $this->type->marshal('13 Oct, 2013 01:54pm');
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -172,4 +172,32 @@ class DateTypeTest extends TestCase
             $this->assertSame($expected, $result);
         }
     }
+
+    /**
+     * Tests marshalling dates using the locale aware parser
+     *
+     * @return void
+     */
+    public function testMarshalWithLocaleParsing()
+    {
+        $this->type->useLocaleParser();
+        $expected = new Time('13-10-2013');
+        $result = $this->type->marshal('10/13/2013');
+        $this->assertEquals($expected->format('Y-m-d'), $result->format('Y-m-d'));
+
+        $this->assertNull($this->type->marshal('11/derp/2013'));
+    }
+
+    /**
+     * Tests marshalling dates using the locale aware parser and custom format
+     *
+     * @return void
+     */
+    public function testMarshalWithLocaleParsingWithFormat()
+    {
+        $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y');
+        $expected = new Time('13-10-2013');
+        $result = $this->type->marshal('13 Oct, 2013');
+        $this->assertEquals($expected->format('Y-m-d'), $result->format('Y-m-d'));
+    }
 }

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -167,4 +167,19 @@ class TimeTypeTest extends TestCase
             $this->assertSame($expected, $result);
         }
     }
+
+    /**
+     * Tests marshalling dates using the locale aware parser
+     *
+     * @return void
+     */
+    public function testMarshalWithLocaleParsing()
+    {
+        $this->type->useLocaleParser();
+        $expected = new Time('23:23:00');
+        $result = $this->type->marshal('11:23pm');
+        $this->assertEquals($expected->format('H:i'), $result->format('H:i'));
+
+        $this->assertNull($this->type->marshal('derp:23'));
+    }
 }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -688,6 +688,33 @@ class TimeTest extends TestCase
     }
 
     /**
+     * Tests parsing a string into a Time object based on the locale format.
+     *
+     * @return void
+     */
+    public function testParseDate() {
+        $time = Time::parseDate('10/13/2013 12:54am');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+
+        $time = Time::parseDate('10/13/2013');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+
+        Time::$defaultLocale = 'fr-FR';
+        $time = Time::parseDate('13 10, 2013 12:54');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+
+        $time = Time::parseDate('13 foo 10 2013 12:54');
+        $this->assertNull($time);
+
+        $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+    }
+
+    /**
      * Custom assert to allow for variation in the version of the intl library, where
      * some translations contain a few extra commas.
      *

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -707,9 +707,9 @@ class TimeTest extends TestCase
         $time = Time::parseDate('13 foo 10 2013 12:54');
         $this->assertNull($time);
 
-        $time = Time::parseDate('13 10, 2013', 'dd m, y');
+        $time = Time::parseDate('13 10, 2013', 'dd M, y');
         $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
+        $this->assertEquals('2013-10-13', $time->format('Y-m-d'));
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -682,10 +682,6 @@ class TimeTest extends TestCase
 
         $time = Time::parseDateTime('13 foo 10 2013 12:54');
         $this->assertNull($time);
-
-        $time = Time::parseDateTime('13 Oct, 2013 13:54', 'dd MMM, y H:mm');
-        $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 13:54', $time->format('Y-m-d H:i'));
     }
 
     /**
@@ -710,6 +706,10 @@ class TimeTest extends TestCase
 
         $time = Time::parseDate('13 foo 10 2013 12:54');
         $this->assertNull($time);
+
+        $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -665,6 +665,29 @@ class TimeTest extends TestCase
     }
 
     /**
+     * Tests parsing a string into a Time object based on the locale format.
+     *
+     * @return void
+     */
+    public function testParseDateTime() {
+        $time = Time::parseDateTime('10/13/2013 12:54am');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 00:54', $time->format('Y-m-d H:i'));
+
+        Time::$defaultLocale = 'fr-FR';
+        $time = Time::parseDateTime('13 10, 2013 12:54');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 12:54', $time->format('Y-m-d H:i'));
+
+        $time = Time::parseDateTime('13 foo 10 2013 12:54');
+        $this->assertNull($time);
+
+        $time = Time::parseDateTime('13 Oct, 2013 13:54', 'dd MMM, y H:mm');
+        $this->assertNotNull($time);
+        $this->assertEquals('2013-10-13 13:54', $time->format('Y-m-d H:i'));
+    }
+
+    /**
      * Custom assert to allow for variation in the version of the intl library, where
      * some translations contain a few extra commas.
      *

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -707,7 +707,7 @@ class TimeTest extends TestCase
         $time = Time::parseDate('13 foo 10 2013 12:54');
         $this->assertNull($time);
 
-        $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
+        $time = Time::parseDate('13 10, 2013', 'dd m, y');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
     }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -669,7 +669,8 @@ class TimeTest extends TestCase
      *
      * @return void
      */
-    public function testParseDateTime() {
+    public function testParseDateTime()
+    {
         $time = Time::parseDateTime('10/13/2013 12:54am');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:54', $time->format('Y-m-d H:i'));
@@ -692,7 +693,8 @@ class TimeTest extends TestCase
      *
      * @return void
      */
-    public function testParseDate() {
+    public function testParseDate()
+    {
         $time = Time::parseDate('10/13/2013 12:54am');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
@@ -709,7 +711,7 @@ class TimeTest extends TestCase
         $time = Time::parseDate('13 foo 10 2013 12:54');
         $this->assertNull($time);
 
-        $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
+        $time = Time::parseDate('13 10, 2013', 'dd M, y');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
     }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -710,10 +710,6 @@ class TimeTest extends TestCase
 
         $time = Time::parseDate('13 foo 10 2013 12:54');
         $this->assertNull($time);
-
-        $time = Time::parseDate('13 10, 2013', 'dd M, y');
-        $this->assertNotNull($time);
-        $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -715,6 +715,26 @@ class TimeTest extends TestCase
     }
 
     /**
+     * Tests parsing times using the parseTime function
+     *
+     * @return void
+     */
+    public function testParseTime()
+    {
+        $time = Time::parseTime('12:54am');
+        $this->assertNotNull($time);
+        $this->assertEquals('00:54:00', $time->format('H:i:s'));
+
+        Time::$defaultLocale = 'fr-FR';
+        $time = Time::parseTime('23:54');
+        $this->assertNotNull($time);
+        $this->assertEquals('23:54:00', $time->format('H:i:s'));
+
+        $time = Time::parseTime('31c2:54');
+        $this->assertNull($time);
+    }
+
+    /**
      * Custom assert to allow for variation in the version of the intl library, where
      * some translations contain a few extra commas.
      *


### PR DESCRIPTION
This adds the ability to marshal datetimes, dates and time objects by passing locale specifc strings. In order to do that, the `Time` class got 3 new methods `parseDate`, `parseTime` and `parseDateTime`.

The `DateTimeType` class and friends now have 2 setters that can control whether to parse strings using the locale aware parser and the preferred format to use. By default dates are not parsed by taking the locale in consideration.

Fixes https://github.com/cakephp/cakephp/issues/5567
