### PR TITLE
Remove query as an argument to result formatter methods.

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -432,7 +432,7 @@ trait QueryTrait
         }
 
         foreach ($this->_formatters as $formatter) {
-            $result = $formatter($result, $this);
+            $result = $formatter($result);
         }
 
         if (!empty($this->_formatters) && !($result instanceof $decorator)) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1815,8 +1815,7 @@ class QueryTest extends TestCase
     {
         $table = TableRegistry::get('authors');
         $query = new Query($this->connection, $table);
-        $query->select()->formatResults(function ($results, $q) use ($query) {
-            $this->assertSame($query, $q);
+        $query->select()->formatResults(function ($results) {
             $this->assertInstanceOf('Cake\ORM\ResultSet', $results);
             return $results->indexBy('id');
         });
@@ -1832,8 +1831,7 @@ class QueryTest extends TestCase
     {
         $table = TableRegistry::get('authors');
         $query = new Query($this->connection, $table);
-        $query->select()->formatResults(function ($results, $q) use ($query) {
-            $this->assertSame($query, $q);
+        $query->select()->formatResults(function ($results) {
             $this->assertInstanceOf('Cake\ORM\ResultSet', $results);
             return $results->indexBy('id');
         });


### PR DESCRIPTION
The Query argument is not always passed consistently, and is a bit unnecessary as one can always close over the query argument if it is needed.

Refs #5689
