### PR TITLE
Update docblocks and readme to not use the file extension in load() and ...

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -279,11 +279,11 @@ class Configure
      * Given that the 'default' engine is an instance of PhpConfig.
      * Save all data in Configure to the file `my_config.php`:
      *
-     * `Configure::dump('my_config.php', 'default');`
+     * `Configure::dump('my_config', 'default');`
      *
      * Save only the error handling configuration:
      *
-     * `Configure::dump('error.php', 'default', ['Error', 'Exception'];`
+     * `Configure::dump('error', 'default', ['Error', 'Exception'];`
      *
      * @param string $key The identifier to create in the config adapter.
      *   This could be a filename or a cache key depending on the adapter being used.

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -19,14 +19,14 @@ It also possible to load configuration from external files:
 
 ```php
 Configure::config('default', new PhpConfig('/path/to/config/folder'));
-Configure::load('app.php', 'default', false);
-Configure::load('other_config.php', 'default');
+Configure::load('app', 'default', false);
+Configure::load('other_config', 'default');
 ```
 
 And Write the configuration back into files:
 
 ```php
-Configure::dump('my_config.php', 'default');
+Configure::dump('my_config', 'default');
 ```
 
 ## Documentation


### PR DESCRIPTION
...dump()
