### PR TITLE
put message in cake.pot file instead of default.pot

### DIFF
--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -75,7 +75,7 @@ class ViewBlock {
  */
 	public function start($name) {
 		if (in_array($name, $this->_active)) {
-			throw new CakeException(__("A view block with the name '%s' is already/still open.", $name));
+			throw new CakeException(__d('cake', "A view block with the name '%s' is already/still open.", $name));
 		}
 		$this->_active[] = $name;
 		ob_start();


### PR DESCRIPTION
ref https://github.com/cakephp/localized/pull/92

When generating pot files with bake, a `default.pot` is created with the single entry from ViewBlocks file.
I just changed it to be in `cake.pot` like others.
