### PR TITLE
Fixes logging to scope is ignored for default listeners.

### DIFF
--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -46,7 +46,7 @@ abstract class BaseLog extends AbstractLogger
     {
         $this->config($config);
 
-        if (!is_array($this->_config['scopes'])) {
+        if (!is_array($this->_config['scopes']) && $this->_config['scopes'] !== false) {
             $this->_config['scopes'] = (array)$this->_config['scopes'];
         }
 

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -367,9 +367,13 @@ class Log
                 $levels = $logger->levels();
                 $scopes = $logger->scopes();
             }
+            if ($scopes === null) {
+                $scopes = [];
+            }
 
             $correctLevel = empty($levels) || in_array($level, $levels);
-            $inScope = empty($scopes) || array_intersect($context['scope'], $scopes);
+            $inScope = $scopes === false && empty($context['scope']) || $scopes === [] ||
+                is_array($scopes) && array_intersect($context['scope'], $scopes);
 
             if ($correctLevel && $inScope) {
                 $logger->log($level, $message, $context);

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -369,6 +369,45 @@ class LogTest extends TestCase
     }
 
     /**
+     * Test scoped logging without the default loggers catching everything
+     *
+     * @return void
+     */
+    public function testScopedLoggingStrict()
+    {
+        $this->_deleteLogs();
+
+        Log::config('debug', [
+            'engine' => 'File',
+            'path' => LOGS,
+            'types' => ['notice', 'info', 'debug'],
+            'file' => 'debug',
+            'scopes' => false
+        ]);
+        Log::config('shops', [
+            'engine' => 'File',
+            'path' => LOGS,
+            'types' => ['info', 'debug', 'warning'],
+            'file' => 'shops',
+            'scopes' => ['transactions', 'orders'],
+        ]);
+
+        Log::write('debug', 'debug message');
+        $this->assertFileNotExists(LOGS . 'shops.log');
+        $this->assertFileExists(LOGS . 'debug.log');
+
+        $this->_deleteLogs();
+
+        Log::write('debug', 'debug message', 'orders');
+        $this->assertFileExists(LOGS . 'shops.log');
+        $this->assertFileNotExists(LOGS . 'debug.log');
+
+        $this->_deleteLogs();
+
+        Log::drop('shops');
+    }
+
+    /**
      * test scoped logging with convenience methods
      */
     public function testConvenienceScopedLogging()


### PR DESCRIPTION
Currently scope of `[]` defaults to `*`, which is derp. Found that out trying to script [executionorder demo app](https://github.com/dereuromark/executionorder). Can be reproduced there, as well.

When a scope is defined, the default listeners always now also always get to log, resulting in duplicate logs, no matter what.
This resolves it.
