### PR TITLE
Make beforeMarhal $options an ArrayObject.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -198,6 +198,7 @@ class Marshaller
         }
 
         $dataObject = new \ArrayObject($data);
+        $options = new \ArrayObject($options);
         $this->_table->dispatchEvent('Model.beforeMarshal', compact('dataObject', 'options'));
 
         return (array)$dataObject;


### PR DESCRIPTION
Use consistent types across the various event methods.

Refs #5711
