### PR TITLE
3.0 - fix psr2 cs

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -250,8 +250,7 @@ class SecurityComponent extends Component
                 if ($this->session->check('_Token')) {
                     $tData = $this->session->read('_Token');
 
-                    if (
-                        !empty($tData['allowedControllers']) &&
+                    if (!empty($tData['allowedControllers']) &&
                         !in_array($this->request->params['controller'], $tData['allowedControllers']) ||
                         !empty($tData['allowedActions']) &&
                         !in_array($this->request->params['action'], $tData['allowedActions'])

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -76,8 +76,7 @@ class ValuesExpression implements ExpressionInterface
      */
     public function add($data)
     {
-        if (
-            (count($this->_values) && $data instanceof Query) ||
+        if ((count($this->_values) && $data instanceof Query) ||
             ($this->_query && is_array($data))
         ) {
             throw new Exception(

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -316,16 +316,14 @@ class MysqlSchema extends BaseSchema
         }
 
         $hasPrecision = ['float', 'decimal'];
-        if (
-            in_array($data['type'], $hasPrecision, true) &&
+        if (in_array($data['type'], $hasPrecision, true) &&
             (isset($data['length']) || isset($data['precision']))
         ) {
             $out .= '(' . (int)$data['length'] . ',' . (int)$data['precision'] . ')';
         }
 
         $hasUnsigned = ['float', 'decimal', 'integer', 'biginteger'];
-        if (
-            in_array($data['type'], $hasUnsigned, true) &&
+        if (in_array($data['type'], $hasUnsigned, true) &&
             isset($data['unsigned']) && $data['unsigned'] === true
         ) {
             $out .= ' UNSIGNED';
@@ -334,8 +332,7 @@ class MysqlSchema extends BaseSchema
         if (isset($data['null']) && $data['null'] === false) {
             $out .= ' NOT NULL';
         }
-        if (
-            in_array($data['type'], ['integer', 'biginteger']) &&
+        if (in_array($data['type'], ['integer', 'biginteger']) &&
             ([$name] == (array)$table->primaryKey() || $data['autoIncrement'] === true)
         ) {
             $out .= ' AUTO_INCREMENT';
@@ -347,8 +344,7 @@ class MysqlSchema extends BaseSchema
         if (isset($data['default']) && $data['type'] !== 'timestamp') {
             $out .= ' DEFAULT ' . $this->_driver->schemaValue($data['default']);
         }
-        if (
-            isset($data['default']) &&
+        if (isset($data['default']) &&
             $data['type'] === 'timestamp' &&
             strtolower($data['default']) === 'current_timestamp'
         ) {

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -115,8 +115,7 @@ class PostgresSchema extends BaseSchema
         if ($col === 'real' || strpos($col, 'double') !== false) {
             return ['type' => 'float', 'length' => null];
         }
-        if (
-            strpos($col, 'numeric') !== false ||
+        if (strpos($col, 'numeric') !== false ||
             strpos($col, 'money') !== false ||
             strpos($col, 'decimal') !== false
         ) {
@@ -232,8 +231,7 @@ class PostgresSchema extends BaseSchema
             // If there is only one column in the primary key and it is integery,
             // make it autoincrement.
             $columnDef = $table->column($columns[0]);
-            if (
-                count($columns) === 1 &&
+            if (count($columns) === 1 &&
                 in_array($columnDef['type'], ['integer', 'biginteger']) &&
                 $type === Table::CONSTRAINT_PRIMARY
             ) {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -239,8 +239,7 @@ class SqliteSchema extends BaseSchema
         $out = $this->_driver->quoteIdentifier($name);
         $hasUnsigned = ['biginteger', 'integer', 'float', 'decimal'];
 
-        if (
-            in_array($data['type'], $hasUnsigned, true) &&
+        if (in_array($data['type'], $hasUnsigned, true) &&
             isset($data['unsigned']) && $data['unsigned'] === true
         ) {
             $out .= ' UNSIGNED';
@@ -252,8 +251,7 @@ class SqliteSchema extends BaseSchema
             $out .= '(' . (int)$data['length'] . ')';
         }
         $hasPrecision = ['float', 'decimal'];
-        if (
-            in_array($data['type'], $hasPrecision, true) &&
+        if (in_array($data['type'], $hasPrecision, true) &&
             (isset($data['length']) || isset($data['precision']))
         ) {
             $out .= '(' . (int)$data['length'] . ',' . (int)$data['precision'] . ')';
@@ -287,8 +285,7 @@ class SqliteSchema extends BaseSchema
     public function constraintSql(Table $table, $name)
     {
         $data = $table->constraint($name);
-        if (
-            $data['type'] === Table::CONSTRAINT_PRIMARY &&
+        if ($data['type'] === Table::CONSTRAINT_PRIMARY &&
             count($data['columns']) === 1 &&
             $table->column($data['columns'][0])['type'] === 'integer'
         ) {

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -97,8 +97,7 @@ class SqlserverSchema extends BaseSchema
         if ($col === 'bit') {
             return ['type' => 'boolean', 'length' => null];
         }
-        if (
-            strpos($col, 'numeric') !== false ||
+        if (strpos($col, 'numeric') !== false ||
             strpos($col, 'money') !== false ||
             strpos($col, 'decimal') !== false
         ) {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -138,8 +138,7 @@ class DateTimeType extends \Cake\Database\Type
         $value += ['hour' => 0, 'minute' => 0, 'second' => 0];
 
         $format = '';
-        if (
-            isset($value['year'], $value['month'], $value['day']) &&
+        if (isset($value['year'], $value['month'], $value['day']) &&
             (is_numeric($value['year']) && is_numeric($value['month']) && is_numeric($value['day']))
         ) {
             $format .= sprintf('%d-%02d-%02d', $value['year'], $value['month'], $value['day']);
@@ -172,8 +171,7 @@ class DateTimeType extends \Cake\Database\Type
             $this->_useLocaleParser = $enable;
             return $this;
         }
-        if (
-            static::$dateTimeClass === 'Cake\I18n\Time' ||
+        if (static::$dateTimeClass === 'Cake\I18n\Time' ||
             is_subclass_of(static::$dateTimeClass, 'Cake\I18n\Time')
         ) {
             $this->_useLocaleParser = $enable;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -703,8 +703,7 @@ trait EntityTrait
                 $val = isset($entity[$part]) ? $entity[$part] : false;
             }
 
-            if (
-                is_array($val) ||
+            if (is_array($val) ||
                 $val instanceof Traversable ||
                 $val instanceof EntityInterface
             ) {

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1948,8 +1948,7 @@ class Email implements JsonSerializable, Serializable
             $item = (string)$item;
         }
 
-        if (
-            is_resource($item) ||
+        if (is_resource($item) ||
             $item instanceof Closure ||
             $item instanceof PDO
         ) {

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -99,8 +99,7 @@ class TimestampBehavior extends Behavior
                     sprintf('When should be one of "always", "new" or "existing". The passed value "%s" is invalid', $when)
                 );
             }
-            if (
-                $when === 'always' ||
+            if ($when === 'always' ||
                 ($when === 'new' && $new) ||
                 ($when === 'existing' && !$new)
             ) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -371,8 +371,7 @@ class Marshaller
                 $converter = Type::build($columnType);
                 $value = $converter->marshal($value);
                 $isObject = is_object($value);
-                if (
-                    (!$isObject && $original === $value) ||
+                if ((!$isObject && $original === $value) ||
                     ($isObject && $original == $value)
                 ) {
                     continue;

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -400,8 +400,7 @@ class Route
 
         // Check for properties that will cause an
         // absolute url. Copy the other properties over.
-        if (
-            isset($hostOptions['_scheme']) ||
+        if (isset($hostOptions['_scheme']) ||
             isset($hostOptions['_port']) ||
             isset($hostOptions['_host'])
         ) {
@@ -571,8 +570,7 @@ class Route
         }
 
         $out = str_replace('//', '/', $out);
-        if (
-            isset($params['_scheme']) ||
+        if (isset($params['_scheme']) ||
             isset($params['_host']) ||
             isset($params['_port'])
         ) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -582,8 +582,7 @@ class Router
 
             if (!isset($url['_name'])) {
                 // Copy the current action if the controller is the current one.
-                if (
-                    empty($url['action']) &&
+                if (empty($url['action']) &&
                     (empty($url['controller']) || $params['controller'] === $url['controller'])
                 ) {
                     $url['action'] = $params['action'];

--- a/src/Utility/MergeVariablesTrait.php
+++ b/src/Utility/MergeVariablesTrait.php
@@ -71,8 +71,7 @@ trait MergeVariablesTrait
     {
         $thisValue = $this->{$property};
         $isAssoc = false;
-        if (
-            isset($options['associative']) &&
+        if (isset($options['associative']) &&
             in_array($property, (array)$options['associative'])
         ) {
             $isAssoc = true;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -982,8 +982,7 @@ class Validation
     protected static function _getDateString($value)
     {
         $formatted = '';
-        if (
-            isset($value['year'], $value['month'], $value['day']) &&
+        if (isset($value['year'], $value['month'], $value['day']) &&
             (is_numeric($value['year']) && is_numeric($value['month']) && is_numeric($value['day']))
         ) {
             $formatted .= sprintf('%d-%02d-%02d ', $value['year'], $value['month'], $value['day']);

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -99,8 +99,7 @@ class ArrayContext implements ContextInterface
      */
     public function primaryKey()
     {
-        if (
-            empty($this->_context['schema']['_constraints']) ||
+        if (empty($this->_context['schema']['_constraints']) ||
             !is_array($this->_context['schema']['_constraints'])
         ) {
             return [];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -498,8 +498,7 @@ class FormHelper extends Helper
     public function end($secureAttributes = [])
     {
         $out = '';
-        if (
-            $this->requestType !== 'get' &&
+        if ($this->requestType !== 'get' &&
             !empty($this->request['_Token'])
         ) {
             $out .= $this->secure($this->fields, $secureAttributes);
@@ -1799,8 +1798,7 @@ class FormHelper extends Helper
 
         // Secure the field if there are options, or it's a multi select.
         // Single selects with no options don't submit, but multiselects do.
-        if (
-            $attributes['secure'] &&
+        if ($attributes['secure'] &&
             empty($options) &&
             empty($attributes['empty']) &&
             empty($attributes['multiple'])
@@ -2146,8 +2144,7 @@ class FormHelper extends Helper
             }
 
             // Pass empty boolean to each type.
-            if (
-                !empty($options['empty']) &&
+            if (!empty($options['empty']) &&
                 is_bool($options['empty']) &&
                 is_array($options[$type])
             ) {
@@ -2469,8 +2466,7 @@ class FormHelper extends Helper
     public function widget($name, array $data = [])
     {
         $widget = $this->_registry->get($name);
-        if (
-            isset($data['secure'], $data['name']) &&
+        if (isset($data['secure'], $data['name']) &&
             $data['secure'] !== self::SECURE_SKIP
         ) {
             foreach ($widget->secureFields($data) as $field) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -436,8 +436,7 @@ class PaginatorHelper extends Helper
         if (!empty($url['page']) && $url['page'] == 1) {
             $url['page'] = null;
         }
-        if (
-            isset($paging['sortDefault'], $paging['directionDefault'], $url['sort'], $url['direction']) &&
+        if (isset($paging['sortDefault'], $paging['directionDefault'], $url['sort'], $url['direction']) &&
             $url['sort'] === $paging['sortDefault'] &&
             $url['direction'] === $paging['directionDefault']
         ) {

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -66,8 +66,7 @@ class UrlHelper extends Helper
         if (!empty($options['pathPrefix']) && $path[0] !== '/') {
             $path = $options['pathPrefix'] . $path;
         }
-        if (
-            !empty($options['ext']) &&
+        if (!empty($options['ext']) &&
             strpos($path, '?') === false &&
             substr($path, -strlen($options['ext'])) !== $options['ext']
         ) {

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -192,8 +192,7 @@ class RadioWidget implements WidgetInterface
             $escape
         );
 
-        if (
-            $label === false &&
+        if ($label === false &&
             strpos($this->_templates->get('radioWrapper'), '{{input}}') === false
         ) {
             $label = $input;

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -227,8 +227,7 @@ class SelectBoxWidget implements WidgetInterface
         foreach ($options as $key => $val) {
             // Option groups
             $arrayVal = (is_array($val) || $val instanceof Traversable);
-            if (
-                (!is_int($key) && $arrayVal) ||
+            if ((!is_int($key) && $arrayVal) ||
                 (is_int($key) && $arrayVal && isset($val['options']))
             ) {
                 $out[] = $this->_renderOptgroup($key, $val, $disabled, $selected, $escape);

--- a/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
@@ -61,7 +61,7 @@ class TreeIteratorTest extends TestCase
      */
     public function testPrinterCustomKeyAndSpacer()
     {
-            $items = [
+        $items = [
             [
                 'id' => 1,
                 'name' => 'a',

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -202,8 +202,7 @@ class SqliteSchemaTest extends TestCase
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
-        if (
-            in_array('schema_articles', $result) &&
+        if (in_array('schema_articles', $result) &&
             in_array('schema_authors', $result)
         ) {
             return;

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -68,8 +68,7 @@ class ConsoleLogTest extends TestCase
      */
     public function testDefaultOutputAs()
     {
-        if (
-            (DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && !(bool)env('ANSICON')) ||
             (function_exists('posix_isatty') && !posix_isatty(null))
         ) {
             $expected = ConsoleOutput::PLAIN;

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3709,6 +3709,7 @@ class FormHelperTest extends TestCase
         ]);
 
         $result = $this->Form->radio('Model.field', ['option A', 'option B']);
+        //@codingStandardsIgnoreStart
         $expected = [
             ['input' => [
                 'type' => 'hidden',
@@ -3734,6 +3735,7 @@ class FormHelperTest extends TestCase
                 'option B',
             '/label',
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
     }
 
@@ -6505,6 +6507,7 @@ class FormHelperTest extends TestCase
         $article = new Article(['comments' => [$comment]]);
         $this->Form->create([$article]);
         $result = $this->Form->input('0.comments.1.comment');
+        //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
                 'label' => ['for' => '0-comments-1-comment'],
@@ -6517,9 +6520,11 @@ class FormHelperTest extends TestCase
                 '/textarea',
             '/div'
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->input('0.comments.0.comment');
+        //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
                 'label' => ['for' => '0-comments-0-comment'],
@@ -6533,10 +6538,12 @@ class FormHelperTest extends TestCase
                 '/textarea',
             '/div'
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
 
         $comment->errors('comment', ['Not valid']);
         $result = $this->Form->input('0.comments.0.comment');
+        //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea error'],
                 'label' => ['for' => '0-comments-0-comment'],
@@ -6554,12 +6561,14 @@ class FormHelperTest extends TestCase
                 '/div',
             '/div'
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
 
         TableRegistry::get('Comments')
             ->validator('default')
             ->allowEmpty('comment', false);
         $result = $this->Form->input('0.comments.1.comment');
+        //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea required'],
                 'label' => ['for' => '0-comments-1-comment'],
@@ -6573,6 +6582,7 @@ class FormHelperTest extends TestCase
                 '/textarea',
             '/div'
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -145,6 +145,7 @@ class RssHelperTest extends TestCase
         ];
         $content = 'content-here';
         $result = $this->Rss->channel($attrib, $elements, $content);
+        //@codingStandardsIgnoreStart
         $expected = [
             '<channel',
                 '<title', 'Title of RSS Feed', '/title',
@@ -165,6 +166,7 @@ class RssHelperTest extends TestCase
             'content-here',
             '/channel',
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
     }
 
@@ -189,6 +191,7 @@ class RssHelperTest extends TestCase
         ];
         $content = 'content-here';
         $result = $this->Rss->channel($attrib, $elements, $content);
+        //@codingStandardsIgnoreStart
         $expected = [
             '<channel',
                 '<title', 'Title of RSS Feed', '/title',
@@ -208,6 +211,7 @@ class RssHelperTest extends TestCase
             'content-here',
             '/channel',
         ];
+        //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
     }
 


### PR DESCRIPTION
after squizlabs/PHP_CodeSniffer 2.2.0 release we had several CS errors.

I choose to use the `//@codingStandardsIgnore` annotation to keep he better readabilty of arrays in the tests but i can flatten them if you prefer.
