### PR TITLE
2.7 session concurrency

### DIFF
--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -103,6 +103,9 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Helper function called on write for database sessions.
  *
+ * Will retry, once, if the save triggers a PDOException which
+ * can happen if a race condition is encountered
+ *
  * @param int $id ID that uniquely identifies session in database
  * @param mixed $data The value of the data to be saved.
  * @return bool True for successful write, false otherwise.
@@ -114,7 +117,12 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 		$expires = time() + $this->_timeout;
 		$record = compact('id', 'data', 'expires');
 		$record[$this->_model->primaryKey] = $id;
-		return $this->_model->save($record);
+
+		try {
+			return $this->_model->save($record);
+		} catch (PDOException $e) {
+			return $this->_model->save($record);
+		}
 	}
 
 /**

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -118,10 +118,11 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 		$record = compact('id', 'data', 'expires');
 		$record[$this->_model->primaryKey] = $id;
 
+		$options = array('validate' => false, 'callbacks' => false);
 		try {
-			return $this->_model->save($record, array('validate' => false));
+			return $this->_model->save($record, $options);
 		} catch (PDOException $e) {
-			return $this->_model->save($record, array('validate' => false));
+			return $this->_model->save($record, $options);
 		}
 	}
 

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -118,7 +118,11 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 		$record = compact('id', 'data', 'expires');
 		$record[$this->_model->primaryKey] = $id;
 
-		$options = array('validate' => false, 'callbacks' => false);
+		$options = array(
+			'validate' => false,
+			'callbacks' => false,
+			'counterCache' => false
+		);
 		try {
 			return $this->_model->save($record, $options);
 		} catch (PDOException $e) {

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -119,9 +119,9 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 		$record[$this->_model->primaryKey] = $id;
 
 		try {
-			return $this->_model->save($record);
+			return $this->_model->save($record, array('validate' => false));
 		} catch (PDOException $e) {
-			return $this->_model->save($record);
+			return $this->_model->save($record, array('validate' => false));
 		}
 	}
 

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -213,17 +213,7 @@ class DatabaseSessionTest extends CakeTestCase {
 			->method('exists')
 			->will($this->returnValue(false));
 
-		// First validate
-		$mockedModel->expects($this->at($counter++))
-			->method('exists')
-			->will($this->returnValue(false));
-
 		// Second save
-		$mockedModel->expects($this->at($counter++))
-			->method('exists')
-			->will($this->returnValue(false));
-
-		// Second validate
 		$mockedModel->expects($this->at($counter++))
 			->method('exists')
 			->will($this->returnValue(false));
@@ -232,11 +222,6 @@ class DatabaseSessionTest extends CakeTestCase {
 		$mockedModel->expects($this->at($counter++))
 			->method('exists')
 			->will($this->returnValue(true));
-
-		// Second validate retry
-		$mockedModel->expects($this->at($counter++))
-			->method('exists')
-			->will($this->returnValue(false));
 
 		// Datasource exists check
 		$mockedModel->expects($this->at($counter++))

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -191,4 +191,34 @@ class DatabaseSessionTest extends CakeTestCase {
 		$storage->gc();
 		$this->assertFalse($storage->read('foo'));
 	}
+
+/**
+ * testConcurrentInsert
+ *
+ * @return void
+ */
+	public function testConcurrentInsert() {
+		ClassRegistry::removeObject('Session');
+
+		$mockedModel = $this->getMockForModel(
+			'SessionTestModel',
+			array('exists'),
+			array('alias' => 'MockedSessionTestModel', 'table' => 'sessions')
+		);
+		Configure::write('Session.handler.model', 'MockedSessionTestModel');
+
+		$mockedModel->expects($this->any())
+			->method('exists')
+			->will($this->returnValue(false));
+
+		$this->storage = new DatabaseSession();
+
+		$this->storage->write('foo', 'Some value');
+		$return = $this->storage->read('foo');
+		$this->assertSame('Some value', $return);
+
+		$this->storage->write('foo', 'Some other value');
+		$return = $this->storage->read('foo');
+		$this->assertSame('Some other value', $return);
+	}
 }

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -207,9 +207,41 @@ class DatabaseSessionTest extends CakeTestCase {
 		);
 		Configure::write('Session.handler.model', 'MockedSessionTestModel');
 
-		$mockedModel->expects($this->any())
+		$counter = 0;
+		// First save
+		$mockedModel->expects($this->at($counter++))
 			->method('exists')
 			->will($this->returnValue(false));
+
+		// First validate
+		$mockedModel->expects($this->at($counter++))
+			->method('exists')
+			->will($this->returnValue(false));
+
+		// Second save
+		$mockedModel->expects($this->at($counter++))
+			->method('exists')
+			->will($this->returnValue(false));
+
+		// Second validate
+		$mockedModel->expects($this->at($counter++))
+			->method('exists')
+			->will($this->returnValue(false));
+
+		// Second save retry
+		$mockedModel->expects($this->at($counter++))
+			->method('exists')
+			->will($this->returnValue(true));
+
+		// Second validate retry
+		$mockedModel->expects($this->at($counter++))
+			->method('exists')
+			->will($this->returnValue(false));
+
+		// Datasource exists check
+		$mockedModel->expects($this->at($counter++))
+			->method('exists')
+			->will($this->returnValue(true));
 
 		$this->storage = new DatabaseSession();
 

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -198,6 +198,11 @@ class DatabaseSessionTest extends CakeTestCase {
  * @return void
  */
 	public function testConcurrentInsert() {
+		$this->skipIf(
+			$this->db instanceof Sqlite,
+			'Sqlite does not throw exceptions when attempting to insert a duplicate primary key'
+		);
+
 		ClassRegistry::removeObject('Session');
 
 		$mockedModel = $this->getMockForModel(


### PR DESCRIPTION
This starts with a failing test, fixes the test and then adjusts the options to reduce the code execution time.

We _could_ rework the write method to be of the form:

```
$db = x
$db->update($this->_model, ...) || $db->create($this->_model, ...)
```

But that's maybe not really necessary (or rather, not worth the maintenance of effectively re-implementing the model save method)

Fixes #2808
