### PR TITLE
Return `$default` url as expected

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -587,7 +587,7 @@ class Controller implements EventListenerInterface
     public function referer($default = null, $local = false)
     {
         if (!$this->request) {
-            return '/';
+            return Router::url($default, !$local);
         }
 
         $referer = $this->request->referer($local);


### PR DESCRIPTION
This case only applies to 'lazy' tests - where no request is mocked (the request check is weak - should check using `instanceof`? but that's another topic).

There are other ways to achieve the same (one would be by calling the `Router::url()` directly instead of wrapping it into a `function()` - the important things is to get it to return the `$default` url as expected (and described in docblock).
