### PR TITLE
Initial value for Collection::reduce is now optional

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -179,12 +179,14 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * applying the callback function to all elements. $zero is the initial state
      * of the reduction, and each successive step of it should be returned
      * by the callback function.
+     * If $zero is omitted the first value of the collection will be used in its place
+     * and reduction will start from the second item.
      *
      * @param callable $c The callback function to be called
      * @param mixed $zero The state of reduction
      * @return void
      */
-    public function reduce(callable $c, $zero);
+    public function reduce(callable $c, $zero = null);
 
     /**
      * Returns a new collection containing the column or property value found in each

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -135,10 +135,20 @@ trait CollectionTrait
      * {@inheritDoc}
      *
      */
-    public function reduce(callable $c, $zero)
+    public function reduce(callable $c, $zero = null)
     {
+        $isFirst = false;
+        if (func_num_args() < 2) {
+            $isFirst = true;
+        }
+
         $result = $zero;
         foreach ($this->_unwrap() as $k => $value) {
+            if ($isFirst) {
+                $result = $value;
+                $isFirst = false;
+                continue;
+            }
             $result = $c($result, $value, $k);
         }
         return $result;

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -252,11 +252,11 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * Tests reduce
+     * Tests reduce with initial value
      *
      * @return void
      */
-    public function testReduce()
+    public function testReduceWithInitialValue()
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
@@ -274,6 +274,31 @@ class CollectionTest extends TestCase
             ->with(13, 3, 'c')
             ->will($this->returnValue(16));
         $this->assertEquals(16, $collection->reduce($callable, 10));
+    }
+
+    /**
+     * Tests reduce without initial value
+     *
+     * @return void
+     */
+    public function testReduceWithoutInitialValue()
+    {
+        $items = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
+        $collection = new Collection($items);
+        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable->expects($this->at(0))
+            ->method('__invoke')
+            ->with(1, 2, 'b')
+            ->will($this->returnValue(3));
+        $callable->expects($this->at(1))
+            ->method('__invoke')
+            ->with(3, 3, 'c')
+            ->will($this->returnValue(6));
+        $callable->expects($this->at(2))
+            ->method('__invoke')
+            ->with(6, 4, 'd')
+            ->will($this->returnValue(10));
+        $this->assertEquals(10, $collection->reduce($callable));
     }
 
     /**


### PR DESCRIPTION
If initial value (`$zero`) is left out the first value in the collection will take its place, and the reduction will start with the second item.

``` php
(new Collection([1, 2, 3]))->reduce(function ($r, $n) { return $r + $n; }); // 6
(new Collection([1, 2, 3]))->reduce(function ($r, $n) { return $r + $n; }, 1); // 7
```
