### PR TITLE
Fix empty datetime inputs.

### DIFF
--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -208,13 +208,16 @@ class DateTimeWidget implements WidgetInterface
                 ];
                 $validDate = false;
                 foreach ($dateArray as $key => $dateValue) {
-                    if (isset($value[$key])) {
-                        $dateArray[$key] = str_pad($value[$key], 2, '0', STR_PAD_LEFT);
+                    $exists = isset($value[$key]);
+                    if ($exists) {
                         $validDate = true;
+                    }
+                    if ($exists && $value[$key] !== '') {
+                        $dateArray[$key] = str_pad($value[$key], 2, '0', STR_PAD_LEFT);
                     }
                 }
                 if ($validDate) {
-                    if (empty($dateArray['second'])) {
+                    if (!isset($dateArray['second'])) {
                         $dateArray['second'] = 0;
                     }
                     if (isset($value['meridian'])) {

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -80,6 +80,36 @@ class DateTimeWidgetTest extends TestCase
     }
 
     /**
+     * test rendering empty selected.
+     *
+     * @return void
+     */
+    public function testRenderSelectedEmpty()
+    {
+        $result = $this->DateTime->render([
+            'val' => '',
+            'year' => ['empty' => true],
+            'month' => ['empty' => true],
+            'day' => ['empty' => true],
+            'hour' => ['empty' => true],
+            'minute' => ['empty' => true],
+        ], $this->context);
+        $this->assertContains('<option value="" selected="selected"></option>', $result);
+        $this->assertNotRegExp('/value="\d+" selected="selected"/', $result);
+
+        $result = $this->DateTime->render([
+            'val' => ['year' => '', 'month' => '', 'day' => '', 'hour' => '', 'minute' => ''],
+            'year' => ['empty' => true],
+            'month' => ['empty' => true],
+            'day' => ['empty' => true],
+            'hour' => ['empty' => true],
+            'minute' => ['empty' => true],
+        ], $this->context);
+        $this->assertContains('<option value="" selected="selected"></option>', $result);
+        $this->assertNotRegExp('/value="\d+" selected="selected"/', $result);
+    }
+
+    /**
      * Data provider for testing various acceptable selected values.
      *
      * @return array


### PR DESCRIPTION
Empty '' should be accepted as datetime input, and not modified when re-rendering an input.

Fixes #5613
