### PR TITLE
Add support for disabling of the "existing" check on save

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1203,6 +1203,8 @@ class Table implements RepositoryInterface, EventListenerInterface
      *   to be saved. It is possible to provide different options for saving on associated
      *   table objects using this key by making the custom options the array value.
      *   If false no associated records will be saved. (default: true)
+     * - checkExisting: Whether or not to check if the entity already exists, assuming that the
+     *   entity is marked as not new, and the primary key has been set.
      *
      * ### Events
      *

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1268,7 +1268,8 @@ class Table implements RepositoryInterface, EventListenerInterface
         $options = new ArrayObject($options + [
             'atomic' => true,
             'associated' => true,
-            'checkRules' => true
+            'checkRules' => true,
+            'checkExisting' => true
         ]);
 
         if ($entity->errors()) {
@@ -1303,7 +1304,7 @@ class Table implements RepositoryInterface, EventListenerInterface
     {
         $primaryColumns = (array)$this->primaryKey();
 
-        if ($primaryColumns && $entity->isNew() && $entity->has($primaryColumns)) {
+        if ($options['checkExisting'] && $primaryColumns && $entity->isNew() && $entity->has($primaryColumns)) {
             $alias = $this->alias();
             $conditions = [];
             foreach ($entity->extract($primaryColumns) as $k => $v) {

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -414,7 +414,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->eventManager()->attach(
             function ($event, Entity $entity, \ArrayObject $options, $operation) {
                 $this->assertEquals(
-                    ['atomic' => true, 'associated' => true, 'checkRules' => true],
+                    ['atomic' => true, 'associated' => true, 'checkRules' => true, 'checkExisting' => true],
                     $options->getArrayCopy()
                 );
                 $this->assertEquals('create', $operation);
@@ -447,7 +447,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->eventManager()->attach(
             function ($event, Entity $entity, \ArrayObject $options, $result, $operation) {
                 $this->assertEquals(
-                    ['atomic' => true, 'associated' => true, 'checkRules' => true],
+                    ['atomic' => true, 'associated' => true, 'checkRules' => true, 'checkExisting' => true],
                     $options->getArrayCopy()
                 );
                 $this->assertEquals('create', $operation);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1376,6 +1376,10 @@ class TableTest extends TestCase
      */
     public function testSavePrimaryKeyEntityExists()
     {
+        $this->skipIf(
+            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+            'SQLServer does not like setting an id on IDENTITY fields'
+        );
         $table = $this->getMock(
             'Cake\ORM\Table',
             ['exists'],
@@ -1402,6 +1406,10 @@ class TableTest extends TestCase
      */
     public function testSavePrimaryKeyEntityNoExists()
     {
+        $this->skipIf(
+            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+            'SQLServer does not like setting an id on IDENTITY fields'
+        );
         $table = $this->getMock(
             'Cake\ORM\Table',
             ['exists'],

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1369,6 +1369,58 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test that saving a new entity with a Primary Key set does call exists.
+     *
+     * @group save
+     * @return void
+     */
+    public function testSavePrimaryKeyEntityExists()
+    {
+        $table = $this->getMock(
+            'Cake\ORM\Table',
+            ['exists'],
+            [
+                [
+                    'connection' => $this->connection,
+                    'alias' => 'Users',
+                    'table' => 'users',
+                ]
+            ]
+        );
+        $entity = $table->newEntity(['id' => 20, 'username' => 'mark']);
+        $this->assertTrue($entity->isNew());
+
+        $table->expects($this->once())->method('exists');
+        $this->assertSame($entity, $table->save($entity));
+    }
+
+    /**
+     * Test that saving a new entity with a Primary Key set does not call exists when checkExisting is false.
+     *
+     * @group save
+     * @return void
+     */
+    public function testSavePrimaryKeyEntityNoExists()
+    {
+        $table = $this->getMock(
+            'Cake\ORM\Table',
+            ['exists'],
+            [
+                [
+                    'connection' => $this->connection,
+                    'alias' => 'Users',
+                    'table' => 'users',
+                ]
+            ]
+        );
+        $entity = $table->newEntity(['id' => 20, 'username' => 'mark']);
+        $this->assertTrue($entity->isNew());
+
+        $table->expects($this->never())->method('exists');
+        $this->assertSame($entity, $table->save($entity, ['checkExisting' => false]));
+    }
+
+    /**
      * Tests that saving an entity will filter out properties that
      * are not present in the table schema when saving
      *


### PR DESCRIPTION
Sometimes you may wish to save a record with a set primaryKey without doing the check if it exists. An example is if I am importing data into my database with pre-set ids. Skipping the check would save a select query for each data item, which can shorten the import a considerable amount for many records (We are importing around 5 million records from a legacy database)

This adds a save option for skipping the check.
