### PR TITLE
Fix first() failing on unbuffered queries.

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -226,21 +226,34 @@ class ResultSet implements ResultSetInterface
             }
         }
 
-        if (!$valid) {
-            if ($this->_statement !== null) {
-                $this->_statement->closeCursor();
-            }
-            return false;
-        }
-
         $this->_current = $this->_fetchResult();
         $valid = $this->_current !== false;
 
         if ($valid && $this->_useBuffering) {
             $this->_results[$this->_index] = $this->_current;
         }
+        if (!$valid && $this->_statement !== null) {
+            $this->_statement->closeCursor();
+        }
 
         return $valid;
+    }
+
+    /**
+     * Get the first record from a result set.
+     *
+     * This method will also close the underlying statement cursor.
+     *
+     * @return array|object
+     */
+    public function first()
+    {
+        foreach ($this as $result) {
+            if ($this->_statement) {
+                $this->_statement->closeCursor();
+            }
+            return $result;
+        }
     }
 
     /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -224,6 +224,9 @@ class ResultSet implements ResultSetInterface
                 $this->_current = $this->_results[$this->_index];
                 return true;
             }
+            if (!$valid) {
+                return $valid;
+            }
         }
 
         $this->_current = $this->_fetchResult();
@@ -249,7 +252,7 @@ class ResultSet implements ResultSetInterface
     public function first()
     {
         foreach ($this as $result) {
-            if ($this->_statement) {
+            if ($this->_statement && !$this->_useBuffering) {
                 $this->_statement->closeCursor();
             }
             return $result;

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -598,7 +598,7 @@ class QueryRegressionTest extends TestCase
         $results = TableRegistry::get('Articles')->find()->all();
         $this->assertEquals(3, $results->count());
         $this->assertNotNull($results->first());
-        $this->assertCount(1, $results->toArray());
+        $this->assertCount(3, $results->toArray());
     }
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -598,7 +598,7 @@ class QueryRegressionTest extends TestCase
         $results = TableRegistry::get('Articles')->find()->all();
         $this->assertEquals(3, $results->count());
         $this->assertNotNull($results->first());
-        $this->assertCount(3, $results->toArray());
+        $this->assertCount(1, $results->toArray());
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -997,9 +997,9 @@ class QueryTest extends TestCase
             '\Database\StatementInterface',
             ['fetch', 'closeCursor', 'rowCount']
         );
-        $statement->expects($this->exactly(2))
+        $statement->expects($this->exactly(3))
             ->method('fetch')
-            ->will($this->onConsecutiveCalls(['a' => 1], ['a' => 2]));
+            ->will($this->onConsecutiveCalls(['a' => 1], ['a' => 2], false));
 
         $statement->expects($this->once())
             ->method('rowCount')
@@ -1095,6 +1095,23 @@ class QueryTest extends TestCase
 
         $first = $query->first();
         $this->assertEquals(1, $first);
+    }
+
+    /**
+     * Tests that first can be called on an unbuffered query
+     *
+     * @return void
+     */
+    public function testFirstUnbuffered()
+    {
+        $table = TableRegistry::get('Articles');
+        $query = new Query($this->connection, $table);
+        $query->select(['id']);
+
+        $first = $query->hydrate(false)
+            ->bufferResults(false)->first();
+
+        $this->assertEquals(['id' => 1], $first);
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -997,9 +997,9 @@ class QueryTest extends TestCase
             '\Database\StatementInterface',
             ['fetch', 'closeCursor', 'rowCount']
         );
-        $statement->expects($this->exactly(3))
+        $statement->expects($this->exactly(2))
             ->method('fetch')
-            ->will($this->onConsecutiveCalls(['a' => 1], ['a' => 2], false));
+            ->will($this->onConsecutiveCalls(['a' => 1], ['a' => 2]));
 
         $statement->expects($this->once())
             ->method('rowCount')


### PR DESCRIPTION
Re-add first() to ResultSet. Because of how `LimitIterator` and unbuffered queries interact, valid() was being called multiple times, advancing the iterator position beyond the result set data.

By having a specific first() on ResultSet we can ensure that the statement is closed after the first record is read. This of course makes ResultSet forget any additional length they may have.

Refs #5720
