### PR TITLE
Fixed issue of list() using same variable for PHP-7

### DIFF
--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -113,7 +113,8 @@ class Time extends Carbon implements JsonSerializable
     public function __construct($time = null, $tz = null)
     {
         if ($time instanceof \DateTime) {
-            list($time, $tz) = [$time->format('Y-m-d H:i:s'), $time->getTimeZone()];
+            $tz = $time->getTimeZone();
+            $time = $time->format('Y-m-d H:i:s');
         }
 
         if (is_numeric($time)) {
@@ -694,7 +695,8 @@ class Time extends Carbon implements JsonSerializable
         $timeFormat = $pattern = null;
 
         if (is_array($dateFormat)) {
-            list($dateFormat, $timeFormat) = $dateFormat;
+            list($newDateFormat, $timeFormat) = $dateFormat;
+            $dateFormat = $newDateFormat;
         } else {
             $pattern = $dateFormat;
             $dateFormat = null;


### PR DESCRIPTION
In PHP 7 the processing is made from right to left instead of left to right, causing an issue when the same variable is used on the list(). See https://wiki.php.net/rfc/abstract_syntax_tree

It is also documented on http://php.net/list.
