### PR TITLE
Enhancement Issue #5737 "Router 2.5.4 multiple extensions in route"

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -619,7 +619,7 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if(!empty($ext) && (!isset($out['ext']) || gettype($out['ext']))) {
+		if (!empty($ext) && (!isset($out['ext']) || gettype($out['ext']))) {
 			$out['ext'] = $ext;
 		}
 

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -619,7 +619,7 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if (!empty($ext) && !isset($out['ext'])) {
+		if(!empty($ext) && (!isset($out['ext']) || gettype($out['ext']))) {
 			$out['ext'] = $ext;
 		}
 

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1465,7 +1465,7 @@ class RouterTest extends CakeTestCase {
 
 		Router::reload();
 		Router::parseExtensions('rss','atom');
-		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => array('rss','atom')));
+		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => array('rss', 'atom')));
 		$result = Router::parse('/controller/action.rss');
 		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
 		$this->assertEquals($expected, $result);

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1464,7 +1464,7 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::parseExtensions('rss','atom');
+		Router::parseExtensions('rss', 'atom');
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => array('rss', 'atom')));
 		$result = Router::parse('/controller/action.rss');
 		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1462,6 +1462,16 @@ class RouterTest extends CakeTestCase {
 		$result = Router::parse('/controller/action');
 		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
 		$this->assertEquals($expected, $result);
+
+		Router::reload();
+		Router::parseExtensions('rss','atom');
+		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => array('rss','atom')));
+		$result = Router::parse('/controller/action.rss');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
+		$this->assertEquals($expected, $result);
+		$result = Router::parse('/controller/action.atom');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'atom', 'named' => array(), 'pass' => array());
+		$this->assertEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
see https://github.com/cakephp/cakephp/issues/5737
Changed ext parse in Router where it was copying the 'ext' arg of
Router::connect.

So if you gave array('rss','atom') then the array was putted in controller->ext
insetead of "choosing the correct ext in the array"
