### PR TITLE
Enhancement Issue #5737 "Router 2.5.4 multiple extensions in route"

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -619,8 +619,12 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if ((!empty($ext) && !isset($out['ext'])) || (gettype($out['ext']) == 'array')) {
-			$out['ext'] = $ext;
+		if (!empty($ext)) {
+			if (!isset($out['ext'])) {
+				$out['ext'] = $ext;
+			} elseif (gettype($out['ext']) == 'array') {
+				$out['ext'] = $ext;
+			}
 		}
 
 		if (!empty($queryParameters) && !isset($out['?'])) {

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -619,7 +619,7 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if (!empty($ext) && (!isset($out['ext']) || gettype($out['ext']))) {
+		if ((!empty($ext) && !isset($out['ext'])) || (gettype($out['ext']) == 'array')) {
 			$out['ext'] = $ext;
 		}
 

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -622,10 +622,6 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if (!empty($ext) && !isset($out['ext'])) {
-			$out['ext'] = $ext;
-		}
-
 		if (!empty($queryParameters) && !isset($out['?'])) {
 			$out['?'] = $queryParameters;
 		}

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -610,6 +610,9 @@ class Router {
 
 		foreach (self::$routes as $route) {
 			if (($r = $route->parse($url)) !== false) {
+				if(isset($ext)) {
+					$r['ext'] = $ext;
+				}
 				self::$_currentRoute[] = $route;
 				$out = $r;
 				break;
@@ -619,12 +622,8 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if (!empty($ext)) {
-			if (!isset($out['ext'])) {
-				$out['ext'] = $ext;
-			} elseif (is_array($out['ext'])) {
-				$out['ext'] = $ext;
-			}
+		if (!empty($ext) && !isset($out['ext'])) {
+			$out['ext'] = $ext;
 		}
 
 		if (!empty($queryParameters) && !isset($out['?'])) {

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -622,7 +622,7 @@ class Router {
 		if (!empty($ext)) {
 			if (!isset($out['ext'])) {
 				$out['ext'] = $ext;
-			} elseif (gettype($out['ext']) == 'array') {
+			} elseif (is_array($out['ext'])) {
 				$out['ext'] = $ext;
 			}
 		}

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -619,7 +619,7 @@ class Router {
 			$out['action'] = $out['prefix'] . '_' . $out['action'];
 		}
 
-		if (!empty($ext) && !isset($out['ext'])) {
+		if (!empty($ext) && (!isset($out['ext']) || gettype($out['ext']))) {
 			$out['ext'] = $ext;
 		}
 

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1462,6 +1462,16 @@ class RouterTest extends CakeTestCase {
 		$result = Router::parse('/controller/action');
 		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
 		$this->assertEquals($expected, $result);
+
+		Router::reload();
+		Router::parseExtensions('rss', 'atom');
+		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => array('rss', 'atom')));
+		$result = Router::parse('/controller/action.rss');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
+		$this->assertEquals($expected, $result);
+		$result = Router::parse('/controller/action.atom');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'atom', 'named' => array(), 'pass' => array());
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1464,6 +1464,20 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
+		require CAKE . 'Config' . DS . 'routes.php';
+
+		Router::parseExtensions('rss', 'atom');
+		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => 'rss'));
+		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => 'atom'));
+		$result = Router::parse('/controller/action.rss');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
+		$this->assertEquals($expected, $result);
+		$result = Router::parse('/controller/action.atom');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'atom', 'named' => array(), 'pass' => array());
+		$this->assertEquals($expected, $result);
+
+		Router::reload();
+		require CAKE . 'Config' . DS . 'routes.php';
 		Router::parseExtensions('rss', 'atom');
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => array('rss', 'atom')));
 		$result = Router::parse('/controller/action.rss');


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/5737

Changed ext parse in Router where it was copying the 'ext' arg of
Router::connect.

So if you gave array('rss','atom') then the array was putted in controller->ext
instead of "choosing the correct ext in the array"
