### PR TITLE
Set 302 as default argument for redirects.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -506,7 +506,7 @@ class Controller implements EventListenerInterface
         $this->autoRender = false;
 
         $response = $this->response;
-        if ($status && $response->statusCode() === 200) {
+        if ($status) {
             $response->statusCode($status);
         }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -501,7 +501,7 @@ class Controller implements EventListenerInterface
      * @return void|\Cake\Network\Response
      * @link http://book.cakephp.org/3.0/en/controllers.html#Controller::redirect
      */
-    public function redirect($url, $status = null)
+    public function redirect($url, $status = 302)
     {
         $this->autoRender = false;
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -497,7 +497,7 @@ class Controller implements EventListenerInterface
      *
      * @param string|array $url A string or array-based URL pointing to another location within the app,
      *     or an absolute URL
-     * @param int $status Optional HTTP status code (eg: 301)
+     * @param int $status HTTP status code (eg: 301)
      * @return void|\Cake\Network\Response
      * @link http://book.cakephp.org/3.0/en/controllers.html#Controller::redirect
      */

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -497,7 +497,7 @@ class Controller implements EventListenerInterface
      *
      * @param string|array $url A string or array-based URL pointing to another location within the app,
      *     or an absolute URL
-     * @param int $status Optional HTTP status code (eg: 404)
+     * @param int $status Optional HTTP status code (eg: 301)
      * @return void|\Cake\Network\Response
      * @link http://book.cakephp.org/3.0/en/controllers.html#Controller::redirect
      */


### PR DESCRIPTION
Currently in 2.x and 3.x the integration (controller) testing is faulty regarding redirects.
The problem is that a "200 OK" is being set along with the "Location" header until the very end, when [send()](https://github.com/cakephp/cakephp/blob/3.0/src/Network/Response.php#L417-L419) is called (where it is too late for testing).

This test passes:
https://github.com/dereuromark/cakefest/blob/3.0/tests/TestCase/Controller/AccountControllerTest.php#L46
But instead of 200 this should be 302 (as it would be in reality).

The easiest way would be to make the signature change here as outlined.
What do you think?
It will not, however, fix all cases totally correctly, e.g. when a 200 is passed in manually (that is nonsense however), this would still show up in a test as 200, whereas in reality would be 302 then.

If we decide on how to approach this, this also needs to be backported to 2.x then.
