### PR TITLE
Fix warnings when php://output is used with ConsoleOutput.

### DIFF
--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -162,6 +162,7 @@ class ConsoleOutput {
 		$this->_output = fopen($stream, 'w');
 
 		if ((DS === '\\' && !(bool)env('ANSICON')) ||
+			$stream === 'php://output' ||
 			(function_exists('posix_isatty') && !posix_isatty($this->_output))
 		) {
 			$this->_outputAs = self::PLAIN;

--- a/lib/Cake/Test/Case/Console/ConsoleOutputTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOutputTest.php
@@ -232,6 +232,17 @@ class ConsoleOutputTest extends CakeTestCase {
 	}
 
 /**
+ * test plain output when php://output, as php://output is
+ * not compatible with posix_ functions.
+ *
+ * @return void
+ */
+	public function testOutputAsPlainWhenOutputStream() {
+		$output = $this->getMock('ConsoleOutput', array('_write'), array('php://output'));
+		$this->assertEquals(ConsoleOutput::PLAIN, $output->outputAs());
+	}
+
+/**
  * test plain output only strips tags used for formatting.
  *
  * @return void


### PR DESCRIPTION
The php://output stream is not compatible with posix functions.

Refs #4901
