### PR TITLE
Fix ControllerTestCase redirect assert by always using 302 for redirect()

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -788,9 +788,7 @@ class Controller extends Object implements CakeEventListener {
 		if ($status === null) {
 			$status = 302;
 		}
-		if ($status) {
-			$this->response->statusCode($status);
-		}
+		$this->response->statusCode($status);
 
 		if ($exit) {
 			$this->response->send();

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -751,7 +751,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
- * @param int $status Optional HTTP status code (eg: 404)
+ * @param int $status HTTP status code (eg: 301)
  * @param bool $exit If true, exit() will be called after the redirect
  * @return void
  * @triggers Controller.beforeRedirect $this, array($url, $status, $exit)
@@ -785,6 +785,9 @@ class Controller extends Object implements CakeEventListener {
 			}
 		}
 
+		if ($status === null) {
+			$status = 302;
+		}
 		if ($status) {
 			$this->response->statusCode($status);
 		}

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -751,7 +751,7 @@ class Controller extends Object implements CakeEventListener {
  *
  * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
- * @param int $status HTTP status code (eg: 301)
+ * @param int|array|null $status HTTP status code (eg: 301). Defaults to 302 when null is passed.
  * @param bool $exit If true, exit() will be called after the redirect
  * @return void
  * @triggers Controller.beforeRedirect $this, array($url, $status, $exit)

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -297,6 +297,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 			'Location' => 'http://cakephp.org'
 		);
 		$this->assertEquals($expected, $results);
+		$this->assertSame(302, $Controller->response->statusCode());
 	}
 
 /**


### PR DESCRIPTION
Backport of https://github.com/cakephp/cakephp/pull/5742

Without this the ControllerTestCase would always return 200 ( https://travis-ci.org/cakephp/cakephp/jobs/48320820 ) for the response->statusCode() instead of the 302 it would be in reality.
