### PR TITLE
Add missing use statement

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database\Driver;
 
+use Cake\Database\Query;
 use Cake\Database\Dialect\SqlserverDialectTrait;
 use Cake\Database\Statement\SqlserverStatement;
 use PDO;


### PR DESCRIPTION
Refs #5756 - AppVeyor test was failing due to missing use statement
