### PR TITLE
Let IDE work better with ClassRegistry::init()

### DIFF
--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -91,7 +91,7 @@ class ClassRegistry {
  *  stored in the registry and returned.
  * @param bool $strict if set to true it will return false if the class was not found instead
  *	of trying to create an AppModel
- * @return object instance of ClassName.
+ * @return $class instance of ClassName.
  * @throws CakeException when you try to construct an interface or abstract class.
  */
 	public static function init($class, $strict = false) {


### PR DESCRIPTION
This small change will allow some IDEs like NetBeans to work with returned object like with a instance of $class parameter.
I`m sure, this will help Cake users a lot!
