### PR TITLE
Conditional truncating for method name

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -199,7 +199,7 @@ class ExceptionRenderer
     {
         list(, $baseClass) = namespaceSplit(get_class($exception));
         
-        if(strpos($baseClass, 'Exception')!==false) {
+        if(substr($baseClass, -9) === 'Exception') {
             $baseClass = substr($baseClass, 0, -9);
         }
         

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -198,7 +198,11 @@ class ExceptionRenderer
     protected function _method(\Exception $exception)
     {
         list(, $baseClass) = namespaceSplit(get_class($exception));
-        $baseClass = substr($baseClass, 0, -9);
+        
+        if(strpos($baseClass, 'Exception')!==false) {
+            $baseClass = substr($baseClass, 0, -9);
+        }
+        
         $method = Inflector::variable($baseClass) ?: 'error500';
         return $this->method = $method;
     }

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -199,7 +199,7 @@ class ExceptionRenderer
     {
         list(, $baseClass) = namespaceSplit(get_class($exception));
         
-        if(substr($baseClass, -9) === 'Exception') {
+        if (substr($baseClass, -9) === 'Exception') {
             $baseClass = substr($baseClass, 0, -9);
         }
         


### PR DESCRIPTION
Prevent base class truncation when not appropriate. See #5770.
