### PR TITLE
Session issue in 2.7

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -374,7 +374,7 @@ class CakeSession {
  *
  * @param string|null $name The name of the session variable (or a path as sent to Set.extract)
  * @return mixed The value of the session variable, null if session not available,
- *   session not started, or provided name not found in the session.
+ *   session not started, or provided name not found in the session, false on failure.
  */
 	public static function read($name = null) {
 		if (empty($name) && $name !== null) {
@@ -478,11 +478,14 @@ class CakeSession {
  * @return void
  */
 	public static function clear($renew = true) {
-		$_SESSION = null;
-		if ($renew) {
-			self::$id = null;
-			self::renew();
+		if (!$renew) {
+			$_SESSION = array();
+			return;
 		}
+
+		$_SESSION = null;
+		self::$id = null;
+		self::renew();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -413,6 +413,14 @@ class CakeSessionTest extends CakeTestCase {
 		TestCakeSession::clear(false);
 		$this->assertFalse(TestCakeSession::check('Delete.me'));
 		$this->assertFalse(TestCakeSession::check('Delete'));
+
+		TestCakeSession::write('Some.string', 'value');
+		TestCakeSession::clear(false);
+		$this->assertNull(TestCakeSession::read('Some'));
+
+		TestCakeSession::write('Some.string.array', array('values'));
+		TestCakeSession::clear(false);
+		$this->assertFalse(TestCakeSession::read());
 	}
 
 /**


### PR DESCRIPTION
The motivation behind clear() not renewing (
https://github.com/cakephp/cakephp/pull/5558/files#diff-bd8dc176fa0f41743dbaafa75f77b5aeR478 ) was that these lines

``` php
$keys = array_keys((array)CakeSession::read());
foreach ($keys as $key) {
    CakeSession::delete($key);
}
```

can be shortened to a simple

``` php
CakeSession::clear(false); // CakePHP 3.0: CakeSession::clear();
```

But, from these test cases https://travis-ci.org/dereuromark/cakephp-shim/builds/48677411 it looks like this is not what really happens. At least not in travis.
It looks like that without actually restarting, it needs to stay an array. Otherwise the class thinks it has not been started, and strange things happen.

//EDIT: In 3.x this isn't an issue as there it is always an array then. That makes me think if the other occurrences of `$_SESSION = null` should also be checked again.
