### PR TITLE
RFC - 3.0 EventManager - on & off

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -110,6 +110,64 @@ class EventManager
     }
 
     /**
+     * Adds a new listener to an event.
+     *
+     * A variadic interface to add listeners that emulates jQuery.on().
+     *
+     * Binding an EventListenerInterface:
+     *
+     * ```
+     * $eventManager->on($listener);
+     * ```
+     *
+     * Binding with no options:
+     *
+     * ```
+     * $eventManager->on('Model.beforeSave', $callable);
+     * ```
+     *
+     * Binding with options:
+     *
+     * ```
+     * $eventManager->on('Model.beforeSave', ['priority' => 90], $callable);
+     * ```
+     *
+     * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name
+     * with which the callback will be associated. If $eventKey is an instance of
+     * Cake\Event\EventListenerInterface its events will be bound using the `implementedEvents` methods.
+     *
+     * @param array|callable $options Either an array of options or the callable you wish to
+     * bind to $eventKey. If an array of options, the `priority` key can be used to define the order.
+     * Priorities are treated as queues. Lower values are called before higher ones, and multiple attachments
+     * added to the same priority queue will be treated in the order of insertion.
+     *
+     * @param callable $callable The callable function you want invoked.
+     *
+     * @return void
+     * @throws \InvalidArgumentException When event key is missing or callable is not an
+     *   instance of Cake\Event\EventListenerInterface.
+     */
+    public function on($eventKey = null, $options = [], $callable = null) {
+        if ($eventKey instanceof EventListenerInterface) {
+            $this->_attachSubscriber($eventKey);
+            return;
+        }
+        $argCount = func_num_args();
+        if ($argCount === 2) {
+            $this->_listeners[$eventKey][static::$defaultPriority][] = [
+                'callable' => $options
+            ];
+        }
+        if ($argCount === 3) {
+            $priority = isset($options['priority']) ? $options['priority'] : static::$defaultPriority;
+            $this->_listeners[$eventKey][$priority][] = [
+                'callable' => $callable
+            ];
+        }
+        throw new InvalidArgumentException('Invalid arguments for EventManager::on().');
+    }
+
+    /**
      * Auxiliary function to attach all implemented callbacks of a Cake\Event\EventListenerInterface class instance
      * as individual methods on this manager
      *

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Event;
 
+use \InvalidArgumentException;
+
 /**
  * The event manager is responsible for keeping track of event listeners, passing the correct
  * data to them, and firing them in the correct order, when associated events are triggered. You
@@ -157,12 +159,14 @@ class EventManager
             $this->_listeners[$eventKey][static::$defaultPriority][] = [
                 'callable' => $options
             ];
+            return;
         }
         if ($argCount === 3) {
             $priority = isset($options['priority']) ? $options['priority'] : static::$defaultPriority;
             $this->_listeners[$eventKey][$priority][] = [
                 'callable' => $callable
             ];
+            return;
         }
         throw new InvalidArgumentException('Invalid arguments for EventManager::on().');
     }
@@ -243,6 +247,22 @@ class EventManager
                 }
             }
         }
+    }
+
+    /**
+     * Removes a listener from the active listeners.
+     *
+     * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name 
+     * with which the callback has been associated, or the $listener you want to remove.
+     * @param callback $callable The callback you want to detach.
+     * @return void
+     */
+    public function off($eventKey, $callable = null)
+    {
+        if ($callable === null) {
+            return $this->detach($eventKey);
+        }
+        return $this->detach($callable, $eventKey);
     }
 
     /**

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -149,7 +149,8 @@ class EventManager
      * @throws \InvalidArgumentException When event key is missing or callable is not an
      *   instance of Cake\Event\EventListenerInterface.
      */
-    public function on($eventKey = null, $options = [], $callable = null) {
+    public function on($eventKey = null, $options = [], $callable = null)
+    {
         if ($eventKey instanceof EventListenerInterface) {
             $this->_attachSubscriber($eventKey);
             return;
@@ -252,8 +253,8 @@ class EventManager
     /**
      * Removes a listener from the active listeners.
      *
-     * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name 
-     * with which the callback has been associated, or the $listener you want to remove.
+     * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name
+     *   with which the callback has been associated, or the $listener you want to remove.
      * @param callback $callable The callback you want to detach.
      * @return void
      */

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -182,6 +182,51 @@ class EventManagerTest extends TestCase
     }
 
     /**
+     * Tests off'ing an event from a event key queue
+     *
+     * @return void
+     */
+    public function testOff()
+    {
+        $manager = new EventManager();
+        $manager->on('fake.event', ['AClass', 'aMethod']);
+        $manager->on('another.event', ['AClass', 'anotherMethod']);
+        $manager->on('another.event',  ['priority' => 1], 'fakeFunction');
+
+        $manager->off('fake.event', ['AClass', 'aMethod']);
+        $this->assertEquals([], $manager->listeners('fake.event'));
+
+        $manager->off('another.event', ['AClass', 'anotherMethod']);
+        $expected = [
+            ['callable' => 'fakeFunction']
+        ];
+        $this->assertEquals($expected, $manager->listeners('another.event'));
+
+        $manager->off('another.event', 'fakeFunction');
+        $this->assertEquals([], $manager->listeners('another.event'));
+    }
+
+    /**
+     * Tests off'ing an event from all event queues
+     *
+     * @return void
+     */
+    public function testOffFromAll()
+    {
+        $manager = new EventManager();
+        $manager->on('fake.event', ['AClass', 'aMethod']);
+        $manager->on('another.event', ['AClass', 'aMethod']);
+        $manager->on('another.event',  ['priority' => 1], 'fakeFunction');
+
+        $manager->off(['AClass', 'aMethod']);
+        $expected = [
+            ['callable' => 'fakeFunction']
+        ];
+        $this->assertEquals($expected, $manager->listeners('another.event'));
+        $this->assertEquals([], $manager->listeners('fake.event'));
+    }
+
+    /**
      * Tests detaching an event from a event key queue
      *
      * @return void

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -152,6 +152,36 @@ class EventManagerTest extends TestCase
     }
 
     /**
+     * Test the on() method for basic callable types.
+     *
+     * @return void
+     */
+    public function testOn()
+    {
+        $count = 1;
+        $manager = new EventManager();
+        $manager->on('my.event', 'myfunc');
+        $expected = [
+            ['callable' => 'myfunc']
+        ];
+        $this->assertSame($expected, $manager->listeners('my.event'));
+
+        $manager->on('my.event', ['priority' => 1], 'func2');
+        $expected = [
+            ['callable' => 'func2'],
+            ['callable' => 'myfunc'],
+        ];
+        $this->assertSame($expected, $manager->listeners('my.event'));
+
+        $listener = new CustomTestEventListenerInterface();
+        $manager->on($listener);
+        $expected = [
+            ['callable' => [$listener, 'listenerFunction']],
+        ];
+        $this->assertEquals($expected, $manager->listeners('fake.event'));
+    }
+
+    /**
      * Tests detaching an event from a event key queue
      *
      * @return void

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -191,7 +191,7 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $manager->on('fake.event', ['AClass', 'aMethod']);
         $manager->on('another.event', ['AClass', 'anotherMethod']);
-        $manager->on('another.event',  ['priority' => 1], 'fakeFunction');
+        $manager->on('another.event', ['priority' => 1], 'fakeFunction');
 
         $manager->off('fake.event', ['AClass', 'aMethod']);
         $this->assertEquals([], $manager->listeners('fake.event'));
@@ -216,7 +216,7 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $manager->on('fake.event', ['AClass', 'aMethod']);
         $manager->on('another.event', ['AClass', 'aMethod']);
-        $manager->on('another.event',  ['priority' => 1], 'fakeFunction');
+        $manager->on('another.event', ['priority' => 1], 'fakeFunction');
 
         $manager->off(['AClass', 'aMethod']);
         $expected = [


### PR DESCRIPTION
This may not be well received but I thought I'd propose it anyways. I've always found the attach/detach methods a bit cumbersome to use, as the event name comes at the end of the argument list. Instead, I think we should follow the interface that jQuery and node.js use where the event name is first. This does create some additional argument juggling when priorities are involved, but I think the additional library code is worth it as the developer facing interface is nicer to use.
