### PR TITLE
Support host/port args in all applicable Cache Engines

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -68,9 +68,11 @@ class MemcachedEngine extends CacheEngine
         'compress' => false,
         'duration' => 3600,
         'groups' => [],
+        'host' => null,
         'username' => null,
         'password' => null,
         'persistent' => false,
+        'port' => null,
         'prefix' => 'cake_',
         'probability' => 100,
         'serialize' => 'php',
@@ -113,6 +115,14 @@ class MemcachedEngine extends CacheEngine
         }
 
         parent::init($config);
+        
+        if (!empty($config['host'])) {
+            if (empty($config['port'])) {
+                $config['servers'] = [$config['host']];
+            } else {
+                $config['servers'] = [sprintf('%s:%d', $config['host'], $config['port'])];
+            }
+        }
 
         if (isset($config['servers'])) {
             $this->config('servers', $config['servers'], false);

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -60,6 +60,7 @@ class RedisEngine extends CacheEngine
         'port' => 6379,
         'prefix' => 'cake_',
         'probability' => 100,
+        'host' => null,
         'server' => '127.0.0.1',
         'timeout' => 0,
         'unix_socket' => false,
@@ -91,6 +92,11 @@ class RedisEngine extends CacheEngine
     protected function _connect()
     {
         try {
+            $server = $this->_config['host'];
+            if (empty($server) && !empty($this->_config['server'])) {
+                $server = $this->_config['server'];
+            }
+
             $this->_Redis = new \Redis();
             if (!empty($this->settings['unix_socket'])) {
                 $return = $this->_Redis->connect($this->settings['unix_socket']);

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -123,7 +123,9 @@ class MemcachedEngineTest extends TestCase
             'password' => null,
             'groups' => [],
             'serialize' => 'php',
-            'options' => []
+            'options' => [],
+            'host' => null,
+            'port' => null,
         ];
         $this->assertEquals($expecting, $config);
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -92,6 +92,7 @@ class RedisEngineTest extends TestCase
             'password' => false,
             'database' => 0,
             'unix_socket' => false,
+            'host' => null,
         ];
         $this->assertEquals($expecting, $config);
     }


### PR DESCRIPTION
When configuring using a DSN, we were previously incapable of supporting the `host` key for the RedisEngine, and both the `host` and `port` keys for MemcachedEngine. This PR adds support for both, allowing us to use DSNs for configuring cache support.
