### PR TITLE
3.0  - WIP - Validation error messages

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -199,6 +199,13 @@ class Table implements RepositoryInterface, EventListenerInterface
     protected $_rulesChecker;
 
     /**
+     * I18n domain for validation messages.
+     *
+     * @var string
+     */
+    protected $_validationDomain = 'default';
+
+    /**
      * Initializes a new instance
      *
      * The $config array understands the following keys:
@@ -264,6 +271,21 @@ class Table implements RepositoryInterface, EventListenerInterface
     public static function defaultConnectionName()
     {
         return 'default';
+    }
+
+    /**
+     * Get/set the I18n domain for validation messages.
+     *
+     * @param string|null $domain The validation domain to be used. If null
+     *   returns currently set domain.
+     * @return string|null
+     */
+    public function validationDomain($domain = null)
+    {
+        if ($domain === null) {
+            return $this->_validationDomain;
+        }
+        $this->_validationDomain = $domain;
     }
 
     /**

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -193,4 +193,17 @@ class ValidationRule
             }
         }
     }
+
+    /**
+     * Returns the value of a property by name
+     *
+     * @param string $property The name of the property to retrieve.
+     * @return mixed
+     */
+    public function get($property)
+    {
+        if (isset($this->_{$property})) {
+            return $this->_{$property};
+        }
+    }
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -67,12 +67,34 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
     protected $_allowEmptyMessages = [];
 
     /**
+     * I18n domain for validation messages.
+     *
+     * @var string
+     */
+    protected $_validationDomain = 'default';
+
+    /**
      * Constructor
      *
      */
     public function __construct()
     {
         $this->_useI18n = function_exists('__d');
+    }
+
+    /**
+     * Get/set the I18n domain for validation messages.
+     *
+     * @param string|null $domain The validation domain to be used. If null
+     *   returns currently set domain.
+     * @return string|null
+     */
+    public function validationDomain($domain = null)
+    {
+        if ($domain === null) {
+            return $this->_validationDomain;
+        }
+        $this->_validationDomain = $domain;
     }
 
     /**
@@ -555,7 +577,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
                 $errors[$name] = $result;
             } elseif ($this->_useI18n) {
                 $args = $rule->get('pass');
-                $errors[$name] = __($name, $this->_translateArgs($args));
+                $errors[$name] = __d($this->_validationDomain, $name, $this->_translateArgs($args));
             } else {
                 $errors[$name] = $name;
             }
@@ -577,7 +599,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
     {
         foreach ((array)$args as $k => $arg) {
             if (is_string($arg)) {
-                $args[$k] = __($arg);
+                $args[$k] = __d($this->_validationDomain, $arg);
             }
         }
         return $args;

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -551,9 +551,13 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
                 continue;
             }
 
-            $errors[$name] = $name;
             if (is_string($result)) {
                 $errors[$name] = $result;
+            } elseif ($this->_useI18n) {
+                $args = $rule->get('pass');
+                $errors[$name] = __($name, $this->_translateArgs($args));
+            } else {
+                $errors[$name] = $name;
             }
 
             if ($rule->isLast()) {
@@ -561,5 +565,20 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
             }
         }
         return $errors;
+    }
+
+    /**
+     * Applies translations to validator arguments.
+     *
+     * @param array $args The args to translate
+     * @return array Translated args.
+     */
+    protected function _translateArgs($args) {
+        foreach ((array)$args as $k => $arg) {
+            if (is_string($arg)) {
+                $args[$k] = __($arg);
+            }
+        }
+        return $args;
     }
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -544,11 +544,6 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
         $errors = [];
         // Loading default provider in case there is none
         $this->provider('default');
-        $message = 'The provided value is invalid';
-
-        if ($this->_useI18n) {
-            $message = __d('cake', 'The provided value is invalid');
-        }
 
         foreach ($rules as $name => $rule) {
             $result = $rule->process($value, $this->_providers, compact('newRecord', 'data', 'field'));
@@ -556,7 +551,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
                 continue;
             }
 
-            $errors[$name] = $message;
+            $errors[$name] = $name;
             if (is_string($result)) {
                 $errors[$name] = $result;
             }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -573,7 +573,8 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
      * @param array $args The args to translate
      * @return array Translated args.
      */
-    protected function _translateArgs($args) {
+    protected function _translateArgs($args)
+    {
         foreach ((array)$args as $k => $arg) {
             if (is_string($arg)) {
                 $args[$k] = __($arg);

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -438,7 +438,7 @@ class ValidatorTest extends TestCase
         $errors = $validator->errors(['email' => 'not an email!']);
         $expected = [
             'email' => [
-                'alpha' => 'The provided value is invalid',
+                'alpha' => 'alpha',
                 'email' => 'Y u no write email?'
             ]
         ];
@@ -482,7 +482,7 @@ class ValidatorTest extends TestCase
         $validator->provider('thing', $thing);
         $errors = $validator->errors(['email' => '!', 'title' => 'bar']);
         $expected = [
-            'email' => ['alpha' => 'The provided value is invalid'],
+            'email' => ['alpha' => 'alpha'],
             'title' => ['cool' => "That ain't cool, yo"]
         ];
         $this->assertEquals($expected, $errors);
@@ -563,7 +563,7 @@ class ValidatorTest extends TestCase
         $errors = $validator->errors(['email' => 'not an email!']);
         $expected = [
             'email' => [
-                'alpha' => 'The provided value is invalid'
+                'alpha' => 'alpha'
             ]
         ];
 

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -183,8 +183,8 @@ class FormContextTest extends TestCase
 
         $context = new FormContext($this->request, ['entity' => $form]);
         $this->assertEquals([], $context->error('empty'));
-        $this->assertEquals(['The provided value is invalid'], $context->error('email'));
-        $this->assertEquals(['The provided value is invalid'], $context->error('name'));
+        $this->assertEquals(['format'], $context->error('email'));
+        $this->assertEquals(['length'], $context->error('name'));
 
         $this->assertEquals([], $context->error('Alias.name'));
         $this->assertEquals([], $context->error('nope.nope'));


### PR DESCRIPTION
Which this patch when a message is not set for a rule, the rule name is returned as message. Also the name and rule's arguments are translated as it's done in 2.x.

This is still WIP. Tests need to be added, also instead of using default domain ideally the translation domain should be configurable as in 2.x.
