### PR TITLE
3.0 - make appveyor happy

### DIFF
--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3144,10 +3144,10 @@ class QueryTest extends TestCase
             ->bufferResults(false)
             ->execute();
 
-        $this->skipIf(
-            !method_exists($result, 'bufferResults'),
-            'This driver does not support unbuffered queries'
-        );
+        if (!method_exists($result, 'bufferResults')) {
+            $result->closeCursor();
+            $this->skipIf(true, 'This driver does not support unbuffered queries');
+        }
 
         $this->assertCount(0, $result);
         $list = $result->fetchAll('assoc');


### PR DESCRIPTION
close cursor before skipping the tests to avoid SQL Server to throw an error "Connection is busy with results for another command".
