### PR TITLE
Adding webfont formats as binary in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,6 @@
 *.ico binary
 *.mo binary
 *.pdf binary
+*.woff binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
With the current state, our Linux workstations with default configs convert fonts' line endings, and that screws them up. These lines fix this.
