### PR TITLE
Allow configuring Table objects with Validator(s)

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -121,6 +121,13 @@ class Table implements RepositoryInterface, EventListenerInterface
     use EventManagerTrait;
 
     /**
+     * Name of default validation set.
+     *
+     * @var string
+     */
+    const VALIDATOR_DEFAULT = 'default';
+
+    /**
      * Name of the table as it can be found in the database
      *
      * @var string
@@ -248,7 +255,7 @@ class Table implements RepositoryInterface, EventListenerInterface
         }
         if (!empty($config['validator'])) {
             if (!is_array($config['validator'])) {
-                $this->validator('default', $config['validator']);
+                $this->validator(self::VALIDATOR_DEFAULT, $config['validator']);
             } else {
                 foreach ($config['validator'] as $name => $validator) {
                     $this->validator($name, $validator);
@@ -1142,7 +1149,7 @@ class Table implements RepositoryInterface, EventListenerInterface
      *   use null to get a validator.
      * @return \Cake\Validation\Validator
      */
-    public function validator($name = 'default', Validator $validator = null)
+    public function validator($name = self::VALIDATOR_DEFAULT, Validator $validator = null)
     {
         if ($validator === null && isset($this->_validators[$name])) {
             return $this->_validators[$name];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -213,6 +213,10 @@ class Table implements RepositoryInterface, EventListenerInterface
      * - eventManager: An instance of an event manager to use for internal events
      * - behaviors: A BehaviorRegistry. Generally not used outside of tests.
      * - associations: An AssociationCollection instance.
+     * - validator: A Validator instance which is assigned as the "default"
+     *   validation set, or an associative array, where key is the name of the
+     *   validation set and value the Validator instance. If a key is omitted, then
+     *   the "default" validation set is assumed.
      *
      * @param array $config List of options for this table
      */
@@ -242,6 +246,16 @@ class Table implements RepositoryInterface, EventListenerInterface
         }
         if (!empty($config['associations'])) {
             $associations = $config['associations'];
+        }
+        if (!empty($config['validator'])) {
+            if (!is_array($config['validator'])) {
+                $this->validator(null, $config['validator']);
+            } else {
+                foreach ($config['validator'] as $key => $validator) {
+                    $name = (!is_int($key)) ? $key : null;
+                    $this->validator($name, $validator);
+                }
+            }
         }
         $this->_eventManager = $eventManager ?: new EventManager();
         $this->_behaviors = $behaviors ?: new BehaviorRegistry($this);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -248,7 +248,7 @@ class Table implements RepositoryInterface, EventListenerInterface
         }
         if (!empty($config['validator'])) {
             if (!is_array($config['validator'])) {
-                $this->validator(null, $config['validator']);
+                $this->validator('default', $config['validator']);
             } else {
                 foreach ($config['validator'] as $name => $validator) {
                     $this->validator($name, $validator);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -125,7 +125,7 @@ class Table implements RepositoryInterface, EventListenerInterface
      *
      * @var string
      */
-    const VALIDATOR_DEFAULT = 'default';
+    const DEFAULT_VALIDATOR = 'default';
 
     /**
      * Name of the table as it can be found in the database
@@ -255,7 +255,7 @@ class Table implements RepositoryInterface, EventListenerInterface
         }
         if (!empty($config['validator'])) {
             if (!is_array($config['validator'])) {
-                $this->validator(self::VALIDATOR_DEFAULT, $config['validator']);
+                $this->validator(self::DEFAULT_VALIDATOR, $config['validator']);
             } else {
                 foreach ($config['validator'] as $name => $validator) {
                     $this->validator($name, $validator);
@@ -1149,7 +1149,7 @@ class Table implements RepositoryInterface, EventListenerInterface
      *   use null to get a validator.
      * @return \Cake\Validation\Validator
      */
-    public function validator($name = self::VALIDATOR_DEFAULT, Validator $validator = null)
+    public function validator($name = self::DEFAULT_VALIDATOR, Validator $validator = null)
     {
         if ($validator === null && isset($this->_validators[$name])) {
             return $this->_validators[$name];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -215,8 +215,7 @@ class Table implements RepositoryInterface, EventListenerInterface
      * - associations: An AssociationCollection instance.
      * - validator: A Validator instance which is assigned as the "default"
      *   validation set, or an associative array, where key is the name of the
-     *   validation set and value the Validator instance. If a key is omitted, then
-     *   the "default" validation set is assumed.
+     *   validation set and value the Validator instance.
      *
      * @param array $config List of options for this table
      */
@@ -251,8 +250,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             if (!is_array($config['validator'])) {
                 $this->validator(null, $config['validator']);
             } else {
-                foreach ($config['validator'] as $key => $validator) {
-                    $name = (!is_int($key)) ? $key : null;
+                foreach ($config['validator'] as $name => $validator) {
                     $this->validator($name, $validator);
                 }
             }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -331,10 +331,12 @@ class TableRegistryTest extends TestCase
      */
     public function testConfigWithSingleValidator()
     {
-        TableRegistry::config('users', ['validator' => new Validator()]);
+        $validator = new Validator();
+
+        TableRegistry::config('users', ['validator' => $validator]);
         $table = TableRegistry::get('users');
 
-        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('default'));
+        $this->assertSame($table->validator('default'), $validator);
     }
 
     /**
@@ -344,18 +346,22 @@ class TableRegistryTest extends TestCase
      */
     public function testConfigWithMultipleValidators()
     {
+        $validator1 = new Validator();
+        $validator2 = new Validator();
+        $validator3 = new Validator();
+
         TableRegistry::config('users', [
             'validator' => [
-                'default' => new Validator(),
-                'secondary' => new Validator(),
-                'tertiary' => new Validator(),
+                'default' => $validator1,
+                'secondary' => $validator2,
+                'tertiary' => $validator3,
             ]
         ]);
         $table = TableRegistry::get('users');
 
-        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('default'));
-        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('secondary'));
-        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('tertiary'));
+        $this->assertSame($table->validator('default'), $validator1);
+        $this->assertSame($table->validator('secondary'), $validator2);
+        $this->assertSame($table->validator('tertiary'), $validator3);
     }
 
     /**

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -20,6 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
 
 /**
  * Used to test correct class is instantiated when using TableRegistry::get();
@@ -320,6 +321,41 @@ class TableRegistryTest extends TestCase
         $this->assertEquals('users', $table->alias());
         $this->assertSame($connection, $table->connection());
         $this->assertEquals(array_keys($schema), $table->schema()->columns());
+        $this->assertEquals($schema['id']['type'], $table->schema()->column('id')['type']);
+    }
+
+    /**
+     * Tests that table options can be pre-configured with a single validator
+     *
+     * @return void
+     */
+    public function testConfigWithSingleValidator()
+    {
+        TableRegistry::config('users', ['validator' => new Validator()]);
+        $table = TableRegistry::get('users');
+
+        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('default'));
+    }
+
+    /**
+     * Tests that table options can be pre-configured with multiple validators
+     *
+     * @return void
+     */
+    public function testConfigWithMultipleValidators()
+    {
+        TableRegistry::config('users', [
+            'validator' => [
+                'default' => new Validator(),
+                'secondary' => new Validator(),
+                'tertiary' => new Validator(),
+            ]
+        ]);
+        $table = TableRegistry::get('users');
+
+        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('default'));
+        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('secondary'));
+        $this->assertInstanceOf('Cake\Validation\Validator', $table->validator('tertiary'));
     }
 
     /**


### PR DESCRIPTION
This PR makes it possible to pass in [`Validator` object(s)](http://book.cakephp.org/3.0/en/core-libraries/validation.html#creating-validators) when [configuring `Table` objects](http://book.cakephp.org/3.0/en/orm/table-objects.html#configuring-table-objects).

``` php
$validatorObject1 = new Validator();
$validatorObject1->requirePresence('username');
$validatorObject2 = new Validator();

TableRegistry::config('Employees', [
    'table' => 'users',
    'validator' => [
        $validatorObject1,
        'secondary' => $validatorObject2
    ]
]);
$employees = TableRegistry::get('Employees');
debug($employees->validator('default')); // returns $validatorObject1
debug($employees->validator('secondary')); // returns $validatorObject2


$validatorObject = new Validator();

TableRegistry::config('Addresses', [
    'validator' => $validatorObject
]);
$addresses = TableRegistry::get('Addresses');
debug($addresses->validator('default')); // returns $validatorObject
```

Let me know if there are tests for [this functionality](https://github.com/cakephp/cakephp/blob/3.0/src/ORM/Table.php#L221-L245) and I can update these if needed.

(@jameswatts spoke to @lorenzo about this in IRC.)
