### PR TITLE
Make getLevel() accept an entity.

### DIFF
--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -797,15 +797,20 @@ class TreeBehavior extends Behavior
 /**
  * Returns the depth level of a node in the tree.
  *
- * @param int|string $id Primary key of the node.
+ * @param int|string|\Cake\Datasource\EntityInterface $entity The entity or primary key get the level of.
  * @return int|bool Integer of the level or false if the node does not exist.
  */
-    public function getLevel($id)
+    public function getLevel($entity)
     {
+        $primaryKey = $this->_getPrimaryKey();
+        $id = $entity;
+        if (!is_scalar($entity)) {
+            $id = $entity->get($primaryKey);
+        }
         $config = $this->config();
         $entity = $this->_table->find('all')
             ->select([$config['left'], $config['right']])
-            ->where([$this->_getPrimaryKey() => $id])
+            ->where([$primaryKey => $id])
             ->first();
 
         if ($entity === null) {

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\ORM\Behavior;
 
+use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
@@ -804,7 +805,7 @@ class TreeBehavior extends Behavior
     {
         $primaryKey = $this->_getPrimaryKey();
         $id = $entity;
-        if (!is_scalar($entity)) {
+        if ($entity instanceof EntityInterface) {
             $id = $entity->get($primaryKey);
         }
         $config = $this->config();

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -864,7 +864,11 @@ class TreeBehaviorTest extends TestCase
      */
     public function testGetLevel()
     {
-        $result = $this->table->getLevel(8);
+        $entity = $this->table->get(8);
+        $result = $this->table->getLevel($entity);
+        $this->assertEquals(3, $result);
+
+        $result = $this->table->getLevel($entity->id);
         $this->assertEquals(3, $result);
 
         $result = $this->table->getLevel(5);


### PR DESCRIPTION
This makes all the methods in TreeBehavior consistent in that they all accept an entity.
