### PR TITLE
Allow empty date and file fields.

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -525,6 +525,10 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
         if (empty($data) && $data !== '0' && $data !== false && $data !== 0 && $data !== 0.0) {
             return true;
         }
+        if (is_array($data) && (isset($data['year']) || isset($data['hour']))) {
+            $value = implode('', $data);
+            return strlen($value) === 0;
+        }
         return false;
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -369,6 +369,8 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
      * });
      * ```
      *
+     * This method will correctly detect empty file uploads and date/time/datetime fields.
+     *
      * Because this and `notEmpty()` modify the same internal state, the last
      * method called will take precedence.
      *
@@ -525,9 +527,13 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable
         if (empty($data) && $data !== '0' && $data !== false && $data !== 0 && $data !== 0.0) {
             return true;
         }
-        if (is_array($data) && (isset($data['year']) || isset($data['hour']))) {
+        $isArray = is_array($data);
+        if ($isArray && (isset($data['year']) || isset($data['hour']))) {
             $value = implode('', $data);
             return strlen($value) === 0;
+        }
+        if ($isArray && isset($data['name'], $data['type'], $data['tmp_name'], $data['error'])) {
+            return (int)$data['error'] === UPLOAD_ERR_NO_FILE;
         }
         return false;
     }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -242,6 +242,40 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the allowEmpty method with file fields.
+     *
+     * @return void
+     */
+    public function testAllowEmptyFileFields()
+    {
+        $validator = new Validator;
+        $validator->allowEmpty('picture')
+            ->add('picture', 'file', ['rule' => 'uploadedFile']);
+
+        $data = [
+            'picture' => [
+                'name' => '',
+                'type' => '',
+                'tmp_name' => '',
+                'error' => UPLOAD_ERR_NO_FILE,
+            ]
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result, 'No errors on empty date');
+
+        $data = [
+            'picture' => [
+                'name' => 'fake.png',
+                'type' => '',
+                'tmp_name' => '',
+                'error' => UPLOAD_ERR_OK,
+            ]
+        ];
+        $result = $validator->errors($data);
+        $this->assertNotEmpty($result, 'Invalid file should be caught still.');
+    }
+
+    /**
      * Test the notEmpty() method.
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -196,6 +196,52 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the allowEmpty method with date/time fields.
+     *
+     * @return void
+     */
+    public function testAllowEmptyDateTime()
+    {
+        $validator = new Validator;
+        $validator->allowEmpty('created')
+            ->add('created', 'date', ['rule' => 'date']);
+
+        $data = [
+            'created' => [
+                'year' => '',
+                'month' => '',
+                'day' => ''
+            ]
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result, 'No errors on empty date');
+
+        $data = [
+            'created' => [
+                'year' => '',
+                'month' => '',
+                'day' => '',
+                'hour' => '',
+                'minute' => '',
+                'second' => '',
+                'meridian' => '',
+            ]
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result, 'No errors on empty datetime');
+
+        $data = [
+            'created' => [
+                'hour' => '',
+                'minute' => '',
+                'meridian' => '',
+            ]
+        ];
+        $result = $validator->errors($data);
+        $this->assertEmpty($result, 'No errors on empty time');
+    }
+
+    /**
      * Test the notEmpty() method.
      *
      * @return void


### PR DESCRIPTION
Make allowEmpty() work with date/datetime/time fields. This lets baked validators work well with optional/nullable date columns.

Refs #5611
