### PR TITLE
Allow specifying name for application rules.

### DIFF
--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -321,7 +321,7 @@ class RulesChecker
         }
 
         $errorField = current($fields);
-        return $this->_addError(new IsUnique($fields), 'isUnique', compact('errorField', 'message'));
+        return $this->_addError(new IsUnique($fields), '_isUnique', compact('errorField', 'message'));
     }
 
     /**
@@ -355,7 +355,7 @@ class RulesChecker
         }
 
         $errorField = $field;
-        return $this->_addError(new ExistsIn($field, $table), 'existsIn', compact('errorField', 'message'));
+        return $this->_addError(new ExistsIn($field, $table), '_existsIn', compact('errorField', 'message'));
     }
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -280,6 +280,32 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
+     * Test adding rule with name
+     *
+     * @group save
+     * @return void
+     */
+    public function testAddingRuleWithName()
+    {
+        $entity = new Entity([
+            'name' => 'larry'
+        ]);
+
+        $table = TableRegistry::get('Authors');
+        $rules = $table->rulesChecker();
+        $rules->add(
+            function () {
+                return false;
+            },
+            'ruleName',
+            ['errorField' => 'name']
+        );
+
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['ruleName' => 'invalid'], $entity->errors('name'));
+    }
+
+    /**
      * Tests the isUnique domain rule
      *
      * @group save
@@ -296,7 +322,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->isUnique(['name']));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['This value is already in use'], $entity->errors('name'));
+        $this->assertEquals(['isUnique' => 'This value is already in use'], $entity->errors('name'));
 
         $entity->name = 'jose';
         $this->assertSame($entity, $table->save($entity));
@@ -324,7 +350,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->isUnique(['title', 'author_id'], 'Nope'));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['title' => ['Nope']], $entity->errors());
+        $this->assertEquals(['title' => ['isUnique' => 'Nope']], $entity->errors());
 
         $entity->clean();
         $entity->author_id = 2;
@@ -350,7 +376,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->existsIn('author_id', 'Authors'));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['This value does not exist'], $entity->errors('author_id'));
+        $this->assertEquals(['existsIn' => 'This value does not exist'], $entity->errors('author_id'));
     }
 
     /**
@@ -371,7 +397,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->existsIn('author_id', TableRegistry::get('Authors'), 'Nope'));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['Nope'], $entity->errors('author_id'));
+        $this->assertEquals(['existsIn' => 'Nope'], $entity->errors('author_id'));
     }
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -322,7 +322,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->isUnique(['name']));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['isUnique' => 'This value is already in use'], $entity->errors('name'));
+        $this->assertEquals(['_isUnique' => 'This value is already in use'], $entity->errors('name'));
 
         $entity->name = 'jose';
         $this->assertSame($entity, $table->save($entity));
@@ -350,7 +350,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->isUnique(['title', 'author_id'], 'Nope'));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['title' => ['isUnique' => 'Nope']], $entity->errors());
+        $this->assertEquals(['title' => ['_isUnique' => 'Nope']], $entity->errors());
 
         $entity->clean();
         $entity->author_id = 2;
@@ -376,7 +376,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->existsIn('author_id', 'Authors'));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['existsIn' => 'This value does not exist'], $entity->errors('author_id'));
+        $this->assertEquals(['_existsIn' => 'This value does not exist'], $entity->errors('author_id'));
     }
 
     /**
@@ -397,7 +397,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules->add($rules->existsIn('author_id', TableRegistry::get('Authors'), 'Nope'));
 
         $this->assertFalse($table->save($entity));
-        $this->assertEquals(['existsIn' => 'Nope'], $entity->errors('author_id'));
+        $this->assertEquals(['_existsIn' => 'Nope'], $entity->errors('author_id'));
     }
 
     /**


### PR DESCRIPTION
Refs #5779

This maintains backwards compatibility. Existing usage like `->add(function () {..})` and `->add(function () {..}, ['option' => 'value'])` will still work fine.
