### PR TITLE
Reorder select parts in query compiler fixes #5769

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -160,7 +160,7 @@ class QueryCompiler
             $modifiers = implode(' ', $modifiers) . ' ';
         }
 
-        return sprintf($select, $modifiers, $distinct, implode(', ', $normalized));
+        return sprintf($select, $distinct, $modifiers, implode(', ', $normalized));
     }
 
     /**


### PR DESCRIPTION
Switching distinct and modifiers will generate proper syntax for SQL Server `SELECT DISTINCT TOP 1` instead of `SELECT TOP 1 DISTINCT`.

The distinct + limit query is being generated when using subquery after pull-request #5778 and will fix the issue mentioned in comment [#5769](https://github.com/cakephp/cakephp/issues/5769#issuecomment-72359647)
