### PR TITLE
TimeHelper returns invalid if date is null - Issue #5807

### DIFF
--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -326,9 +326,9 @@ class TimeHelper extends Helper
      * @throws \InvalidArgumentException When the date cannot be parsed
      * @see \Cake\I18n\Time::i18nFormat()
      */
-    public function i18nFormat($date = null, $format = null, $invalid = false, $timezone = null)
+    public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
-        if (empty($date)) {
+        if (!isset($date)) {
             return $invalid;
         }
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -326,8 +326,12 @@ class TimeHelper extends Helper
      * @throws \InvalidArgumentException When the date cannot be parsed
      * @see \Cake\I18n\Time::i18nFormat()
      */
-    public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
+    public function i18nFormat($date = null, $format = null, $invalid = false, $timezone = null)
     {
+        if (empty($date)) {
+            return $invalid;
+        }
+
         try {
             $time = new Time($date, $timezone);
             return $time->i18nFormat($format, $timezone);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -448,4 +448,22 @@ class TimeHelperTest extends TestCase
             str_replace([',', '(', ')', ' at'], '', $result)
         );
     }
+
+    /**
+     * Test formatting in case the $time parameter is not set
+     *
+     * @return void
+     */
+    public function testNullDateFormat()
+    {
+        $time = null;
+
+        $result = $this->Time->format($time);
+        $expected = null;
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Time->format($time, \IntlDateFormatter::FULL, 'Date invalid or not set');
+        $expected = 'Date invalid or not set';
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
This PR patches the issue of the TimeHelper returning `Time::now()` if the date that's passed into the format method is null. It now returns the specified invalid parameter with this fix.
