### PR TITLE
3.0: IntegrationTestCase::assertResponseOk()

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -389,6 +389,16 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Asserts that the response status code is in the 2xx/3xx range.
+     *
+     * @return void
+     */
+    public function assertResponseSuccess()
+    {
+        $this->_assertStatus(200, 308, 'Status code is not between 200 and 308');
+    }
+
+    /**
      * Asserts that the response status code is in the 4xx range.
      *
      * @return void

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -153,6 +153,12 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->_response->statusCode(204);
         $this->assertResponseOk();
 
+        $this->_response->statusCode(202);
+        $this->assertResponseSuccess();
+
+        $this->_response->statusCode(302);
+        $this->assertResponseSuccess();
+
         $this->_response->statusCode(400);
         $this->assertResponseError();
 


### PR DESCRIPTION
With the recent changes to properly assert 302 instead of 200 for redirects `assertResponseOk()` should also apply to 3xx as it then feels consistent:
- OK: 2xx/3xx
- ERROR: 4xx
- FAIL: 5xx

We currently had the case that a simple 302 redirect broke the `assertResponseOk()` assert.
Which would still not be a fail or error and as such is (the only remaining alternative) "ok" IMO. 
For anything more specific one should use the direct asserts for status codes, `assertResponseCode($code)`.
