### PR TITLE
3.0: Convenience methods for asserting response body empty / not empty.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -570,6 +570,33 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Assert response content is not empty.
+     *
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertResponseNotEmpty($message = '')
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert content. ' . $message);
+        }
+        $this->assertNotEmpty((string)$this->_response->body(), $message);
+    }
+    /**
+     * Assert response content is empty.
+     *
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertResponseEmpty($message = '')
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert content. ' . $message);
+        }
+        $this->assertEmpty((string)$this->_response->body(), $message);
+    }
+
+    /**
      * Asserts that the search string was in the template name.
      *
      * @param string $content The content to check for.

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -130,6 +130,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     public function testPostAndErrorHandling()
     {
         $this->post('/request_action/error_method');
+        $this->assertResponseNotEmpty();
         $this->assertResponseContains('Not there or here');
         $this->assertResponseContains('<!DOCTYPE html>');
     }
@@ -181,6 +182,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertRedirect();
         $this->assertRedirect('/tasks/index');
         $this->assertRedirect(['controller' => 'Tasks', 'action' => 'index']);
+
+        $this->assertResponseEmpty();
     }
 
     /**


### PR DESCRIPTION
We had a `$this->autoRender = false` somewhere in the code and no manuel render() call.
Using such a convenience method here without the need to actual verify the details of the body was helpful in order to quickly assert that at least some output is available.
For all specific asserts one should use the assertResponseContains() or assertResponseEquals() of course.
