### PR TITLE
Including a option for calling plugin flash elements through magic method

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -103,8 +103,15 @@ class FlashComponent extends Component
      * Magic method for verbose flash methods based on element names.
      *
      * For example: $this->Flash->success('My message') would use the
-     * success.ctp element under `App/Template/Element/Flash` for rendering the
+     * success.ctp element under `src/Template/Element/Flash` for rendering the
      * flash message.
+     * 
+     * Note that the parameter `element` will be always overridden. In order to call a
+     * specific element from a plugin, you should set the `plugin` option in $args.
+     * 
+     * For example: $this->Flash->warning('My message', ['plugin' => 'PluginName']) would
+     * use the warning.ctp element under `plugins/src/Template/Element/Flash` for rendering
+     * the flash message.
      *
      * @param string $name Element name to use.
      * @param array $args Parameters to pass when calling `FlashComponent::set()`.

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -113,13 +113,19 @@ class FlashComponent extends Component
      */
     public function __call($name, $args)
     {
-        $options = ['element' => Inflector::underscore($name)];
+        $element = Inflector::underscore($name);
 
         if (count($args) < 1) {
             throw new InternalErrorException('Flash message missing.');
         }
 
+        $options = ['element' => $element];
+
         if (!empty($args[1])) {
+            if (!empty($args[1]['plugin'])) {
+                $options = ['element' => $args[1]['plugin'] . '.' . $element];
+                unset($args[1]['plugin']);
+            }
             $options += (array)$args[1];
         }
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -110,8 +110,8 @@ class FlashComponent extends Component
      * specific element from a plugin, you should set the `plugin` option in $args.
      * 
      * For example: $this->Flash->warning('My message', ['plugin' => 'PluginName']) would
-     * use the warning.ctp element under `plugins/src/Template/Element/Flash` for rendering
-     * the flash message.
+     * use the warning.ctp element under `plugins/PluginName/src/Template/Element/Flash` for
+     * rendering the flash message.
      *
      * @param string $name Element name to use.
      * @param array $args Parameters to pass when calling `FlashComponent::set()`.

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -178,5 +178,16 @@ class FlashComponentTest extends TestCase
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result, 'Element is ignored in magic call.');
+        
+        $this->Flash->success('It worked', ['plugin' => 'MyPlugin']);
+
+        $expected = [
+            'message' => 'It worked',
+            'key' => 'flash',
+            'element' => 'MyPlugin.Flash/success',
+            'params' => []
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
What happens? __call() always override $options['element'] to instantiate set()
What I did? I added a check for a plugin key in $args

Now there are two options for calling plugin flash elements:
- `$this->Flash->set('Message', ['element' => 'PluginName.element_name']);`
- `$this->Flash->elementName('Message', ['plugin' => 'PluginName']);`
