### PR TITLE
The plugin alias should not be ignored

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -112,7 +112,7 @@ trait EntityTrait
      *
      * @var string
      */
-    protected $_repositoryAlias;
+    protected $_registryAlias;
 
     /**
      * Magic getter to access properties that have been set in this entity
@@ -812,9 +812,9 @@ trait EntityTrait
     public function source($alias = null)
     {
         if ($alias === null) {
-            return $this->_repositoryAlias;
+            return $this->_registryAlias;
         }
-        $this->_repositoryAlias = $alias;
+        $this->_registryAlias = $alias;
     }
 
     /**
@@ -843,7 +843,7 @@ trait EntityTrait
             'original' => $this->_original,
             'virtual' => $this->_virtual,
             'errors' => $this->_errors,
-            'repository' => $this->_repositoryAlias
+            'repository' => $this->_registryAlias
         ];
     }
 }

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -83,11 +83,11 @@ trait ModelAwareTrait
             $modelClass = $this->modelClass;
         }
 
-        if (isset($this->{$modelClass})) {
-            return $this->{$modelClass};
-        }
+        list($plugin, $alias) = pluginSplit($modelClass, true);
 
-        list($plugin, $modelClass) = pluginSplit($modelClass, true);
+        if (isset($this->{$alias})) {
+            return $this->{$alias};
+        }
 
         if (!isset($this->_modelFactories[$type])) {
             throw new InvalidArgumentException(sprintf(
@@ -96,11 +96,11 @@ trait ModelAwareTrait
             ));
         }
         $factory = $this->_modelFactories[$type];
-        $this->{$modelClass} = $factory($plugin . $modelClass);
-        if (!$this->{$modelClass}) {
+        $this->{$alias} = $factory($modelClass);
+        if (!$this->{$alias}) {
             throw new MissingModelException([$modelClass, $type]);
         }
-        return $this->{$modelClass};
+        return $this->{$alias};
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -269,12 +269,8 @@ abstract class Association
             return $this->_targetTable = $table;
         }
 
-        if ($this->_className) {
-            if (strpos($this->_className, '\\') !== false) {
-                $tableAlias = $this->_name;
-            } else {
-                $tableAlias = $this->_className;
-            }
+        if ($this->_className && strpos($this->_className, '\\') === false) {
+            $tableAlias = $this->_className;
         } else {
             $tableAlias = $this->_name;
         }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -269,11 +269,21 @@ abstract class Association
             return $this->_targetTable = $table;
         }
 
+        if ($this->_className) {
+            if (strpos($this->_className, '\\') !== false) {
+                $tableAlias = $this->_name;
+            } else {
+                $tableAlias = $this->_className;
+            }
+        } else {
+            $tableAlias = $this->_name;
+        }
+
         $config = [];
-        if (!TableRegistry::exists($this->_name)) {
+        if (!TableRegistry::exists($tableAlias)) {
             $config = ['className' => $this->_className];
         }
-        $this->_targetTable = TableRegistry::get($this->_name, $config);
+        $this->_targetTable = TableRegistry::get($tableAlias, $config);
 
         return $this->_targetTable;
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -269,13 +269,12 @@ abstract class Association
             return $this->_targetTable = $table;
         }
 
-        if ($table === null) {
-            $config = [];
-            if (!TableRegistry::exists($this->_name)) {
-                $config = ['className' => $this->_className];
-            }
-            $this->_targetTable = TableRegistry::get($this->_name, $config);
+        $config = [];
+        if (!TableRegistry::exists($this->_name)) {
+            $config = ['className' => $this->_className];
         }
+        $this->_targetTable = TableRegistry::get($this->_name, $config);
+
         return $this->_targetTable;
     }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -107,7 +107,7 @@ class Marshaller
         $schema = $this->_table->schema();
         $entityClass = $this->_table->entityClass();
         $entity = new $entityClass();
-        $entity->source($this->_table->alias());
+        $entity->source($this->_table->repositoryAlias());
 
         if (isset($options['accessibleFields'])) {
             foreach ((array)$options['accessibleFields'] as $key => $value) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -107,7 +107,7 @@ class Marshaller
         $schema = $this->_table->schema();
         $entityClass = $this->_table->entityClass();
         $entity = new $entityClass();
-        $entity->source($this->_table->repositoryAlias());
+        $entity->source($this->_table->registryAlias());
 
         if (isset($options['accessibleFields'])) {
             foreach ((array)$options['accessibleFields'] as $key => $value) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -370,7 +370,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             $this->_repositoryAlias = $repositoryAlias;
         }
         if ($this->_repositoryAlias === null) {
-            $this->_repositoryAlias = Inflector::camelize($this->alias());
+            $this->_repositoryAlias = $this->alias();
         }
         return $this->_repositoryAlias;
     }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -196,7 +196,7 @@ class Table implements RepositoryInterface, EventListenerInterface
      *
      * @var string
      */
-    protected $_repositoryAlias;
+    protected $_registryAlias;
 
     /**
      * A list of validation objects indexed by name
@@ -235,8 +235,8 @@ class Table implements RepositoryInterface, EventListenerInterface
      */
     public function __construct(array $config = [])
     {
-        if (!empty($config['repositoryAlias'])) {
-            $this->repositoryAlias($config['repositoryAlias']);
+        if (!empty($config['registryAlias'])) {
+            $this->registryAlias($config['registryAlias']);
         }
         if (!empty($config['table'])) {
             $this->table($config['table']);
@@ -361,18 +361,18 @@ class Table implements RepositoryInterface, EventListenerInterface
     /**
      * Returns the table registry key used to create this table instance
      *
-     * @param string|null $repositoryAlias the key used to access this object
+     * @param string|null $registryAlias the key used to access this object
      * @return string
      */
-    public function repositoryAlias($repositoryAlias = null)
+    public function registryAlias($registryAlias = null)
     {
-        if ($repositoryAlias !== null) {
-            $this->_repositoryAlias = $repositoryAlias;
+        if ($registryAlias !== null) {
+            $this->_registryAlias = $registryAlias;
         }
-        if ($this->_repositoryAlias === null) {
-            $this->_repositoryAlias = $this->alias();
+        if ($this->_registryAlias === null) {
+            $this->_registryAlias = $this->alias();
         }
-        return $this->_repositoryAlias;
+        return $this->_registryAlias;
     }
 
     /**
@@ -1406,7 +1406,7 @@ class Table implements RepositoryInterface, EventListenerInterface
                 $entity->clean();
                 $this->dispatchEvent('Model.afterSave', compact('entity', 'options'));
                 $entity->isNew(false);
-                $entity->source($this->repositoryAlias());
+                $entity->source($this->registryAlias());
                 $success = true;
             }
         }
@@ -1872,7 +1872,7 @@ class Table implements RepositoryInterface, EventListenerInterface
     {
         if ($data === null) {
             $class = $this->entityClass();
-            $entity = new $class(['source' => $this->repositoryAlias()]);
+            $entity = new $class(['source' => $this->registryAlias()]);
             return $entity;
         }
         if (!isset($options['associated'])) {
@@ -2036,7 +2036,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             [
                 'useSetters' => false,
                 'markNew' => $options['newRecord'],
-                'source' => $this->repositoryAlias()
+                'source' => $this->registryAlias()
             ]
         );
         $fields = array_merge(

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -254,4 +254,6 @@ class TableRegistry
             static::$_fallbacked[$alias]
         );
     }
+
+    public static function keys() { return array_keys(static::$_instances); }
 }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -101,7 +101,6 @@ class TableRegistry
      */
     public static function config($alias = null, $options = null)
     {
-        list(, $alias) = pluginSplit($alias);
         if ($alias === null) {
             return static::$_config;
         }
@@ -154,9 +153,9 @@ class TableRegistry
      * @return \Cake\ORM\Table
      * @throws RuntimeException When you try to configure an alias that already exists.
      */
-    public static function get($name, array $options = [])
+    public static function get($alias, array $options = [])
     {
-        list(, $alias) = pluginSplit($name);
+        list(, $classAlias) = pluginSplit($alias);
         $exists = isset(static::$_instances[$alias]);
 
         if ($exists && !empty($options)) {
@@ -171,10 +170,10 @@ class TableRegistry
             return static::$_instances[$alias];
         }
         static::$_options[$alias] = $options;
-        $options = ['alias' => $alias] + $options;
+        $options = ['alias' => $classAlias] + $options;
 
         if (empty($options['className'])) {
-            $options['className'] = Inflector::camelize($name);
+            $options['className'] = Inflector::camelize($alias);
         }
         $className = App::className($options['className'], 'Model/Table', 'Table');
         $options['className'] = $className ?: 'Cake\ORM\Table';
@@ -199,15 +198,11 @@ class TableRegistry
     /**
      * Check to see if an instance exists in the registry.
      *
-     * Plugin names will be trimmed off of aliases as instances
-     * stored in the registry will be without the plugin name as well.
-     *
      * @param string $alias The alias to check for.
      * @return bool
      */
     public static function exists($alias)
     {
-        list(, $alias) = pluginSplit($alias);
         return isset(static::$_instances[$alias]);
     }
 
@@ -220,7 +215,6 @@ class TableRegistry
      */
     public static function set($alias, Table $object)
     {
-        list(, $alias) = pluginSplit($alias);
         return static::$_instances[$alias] = $object;
     }
 
@@ -252,16 +246,11 @@ class TableRegistry
     /**
      * Removes an instance from the registry.
      *
-     * Plugin name will be trimmed off of aliases as instances
-     * stored in the registry will be without the plugin name as well.
-     *
      * @param string $alias The alias to remove.
      * @return void
      */
     public static function remove($alias)
     {
-        list(, $alias) = pluginSplit($alias);
-
         unset(
             static::$_instances[$alias],
             static::$_config[$alias],

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -254,6 +254,4 @@ class TableRegistry
             static::$_fallbacked[$alias]
         );
     }
-
-    public static function keys() { return array_keys(static::$_instances); }
 }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -183,6 +183,7 @@ class TableRegistry
             $options['connection'] = ConnectionManager::get($connectionName);
         }
 
+        $options['source'] = $alias;
         static::$_instances[$alias] = new $options['className']($options);
 
         if ($options['className'] === 'Cake\ORM\Table') {

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -183,7 +183,7 @@ class TableRegistry
             $options['connection'] = ConnectionManager::get($connectionName);
         }
 
-        $options['source'] = $alias;
+        $options['registryAlias'] = $alias;
         static::$_instances[$alias] = new $options['className']($options);
 
         if ($options['className'] === 'Cake\ORM\Table') {

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -155,21 +155,18 @@ class TableRegistry
      */
     public static function get($alias, array $options = [])
     {
-        list(, $classAlias) = pluginSplit($alias);
-        $exists = isset(static::$_instances[$alias]);
-
-        if ($exists && !empty($options)) {
-            if (static::$_options[$alias] !== $options) {
+        if (isset(static::$_instances[$alias])) {
+            if (!empty($options) && static::$_options[$alias] !== $options) {
                 throw new RuntimeException(sprintf(
                     'You cannot configure "%s", it already exists in the registry.',
                     $alias
                 ));
             }
-        }
-        if ($exists) {
             return static::$_instances[$alias];
         }
+
         static::$_options[$alias] = $options;
+        list(, $classAlias) = pluginSplit($alias);
         $options = ['alias' => $classAlias] + $options;
 
         if (empty($options['className'])) {

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -71,6 +71,29 @@ class ModelAwareTraitTest extends TestCase
     }
 
     /**
+     * test loadModel() with plugin prefixed models
+     *
+     * Load model should not be called with Foo.Model Bar.Model Model
+     * But if it is, the first call wins.
+     *
+     * @return void
+     */
+    public function testLoadModelPlugin()
+    {
+        $stub = new Stub();
+        $stub->setProps('Articles');
+        $stub->modelFactory('Table', ['\Cake\ORM\TableRegistry', 'get']);
+
+        $result = $stub->loadModel('TestPlugin.Comments');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
+
+        $result = $stub->loadModel('Comments');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
+    }
+
+    /**
      * test alternate model factories.
      *
      * @return void

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -199,11 +199,11 @@ class AssociationTest extends TestCase
         $table = $this->association->target();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $table);
 
-        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
+        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
         $this->assertFalse(TableRegistry::exists('Comments'));
-        $this->assertTrue(TableRegistry::exists('ThisAssociationName'));
+        $this->assertFalse(TableRegistry::exists('ThisAssociationName'));
 
-        $plugin = TableRegistry::get('ThisAssociationName');
+        $plugin = TableRegistry::get('TestPlugin.Comments');
         $this->assertSame($table, $plugin, 'Should be the same TestPlugin.Comments object');
     }
 

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -187,7 +187,8 @@ class AssociationTest extends TestCase
             'sourceTable' => $this->source,
             'joinType' => 'INNER'
         ];
-        $this->association = $this->getMock('\Cake\ORM\Association',
+        $this->association = $this->getMock(
+            '\Cake\ORM\Association',
             [
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type'

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -187,12 +187,10 @@ class AssociationTest extends TestCase
             'sourceTable' => $this->source,
             'joinType' => 'INNER'
         ];
+
         $this->association = $this->getMock(
             '\Cake\ORM\Association',
-            [
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-                'saveAssociated', 'eagerLoader', 'type'
-            ],
+            ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
             ['ThisAssociationName', $config]
         );
 
@@ -302,10 +300,7 @@ class AssociationTest extends TestCase
         ];
         $assoc = $this->getMock(
             '\Cake\ORM\Association',
-            [
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-                'saveAssociated', 'eagerLoader', 'type'
-            ],
+            ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
             ['Foo', $config]
         );
         $this->assertEquals('published', $assoc->finder());

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -134,6 +134,25 @@ class TableRegistryTest extends TestCase
     }
 
     /**
+     * Test the exists() method with plugin-prefixed models.
+     *
+     * @return void
+     */
+    public function testExistsPlugin()
+    {
+        $this->assertFalse(TableRegistry::exists('Comments'));
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
+
+        TableRegistry::config('TestPlugin.Comments', ['table' => 'comments']);
+        $this->assertFalse(TableRegistry::exists('Comments'), 'The Comments key should not be populated');
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'), 'The plugin.alias key should not be populated');
+
+        TableRegistry::get('TestPlugin.Comments', ['table' => 'comments']);
+        $this->assertFalse(TableRegistry::exists('Comments'), 'The Comments key should not be populated');
+        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'), 'The plugin.alias key should now be populated');
+    }
+
+    /**
      * Test getting instances from the registry.
      *
      * @return void

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -275,6 +275,33 @@ class TableRegistryTest extends TestCase
     }
 
     /**
+     * Test get() with same-alias models in different plugins
+     *
+     * @return void
+     */
+    public function testGetMultiplePlugins()
+    {
+        Plugin::load('TestPlugin');
+        Plugin::load('TestPluginTwo');
+
+        $app = TableRegistry::get('Comments');
+        $plugin1 = TableRegistry::get('TestPlugin.Comments');
+        $plugin2 = TableRegistry::get('TestPluginTwo.Comments');
+
+        $this->assertInstanceOf('Cake\ORM\Table', $app, 'Should be an app table instance');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $plugin1, 'Should be a plugin 1 table instance');
+        $this->assertInstanceOf('TestPluginTwo\Model\Table\CommentsTable', $plugin2, 'Should be a plugin 2 table instance');
+
+        $plugin2 = TableRegistry::get('TestPluginTwo.Comments');
+        $plugin1 = TableRegistry::get('TestPlugin.Comments');
+        $app = TableRegistry::get('Comments');
+
+        $this->assertInstanceOf('Cake\ORM\Table', $app, 'Should still be an app table instance');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $plugin1, 'Should still be a plugin 1 table instance');
+        $this->assertInstanceOf('TestPluginTwo\Model\Table\CommentsTable', $plugin2, 'Should still be a plugin 2 table instance');
+    }
+
+    /**
      * Tests that table options can be pre-configured for the factory method
      *
      * @return void

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -102,10 +102,6 @@ class TableRegistryTest extends TestCase
 
         $result = TableRegistry::config('TestPlugin.TestPluginComments', $data);
         $this->assertEquals($data, $result, 'Returns config data.');
-
-        $result = TableRegistry::config();
-        $expected = ['TestPluginComments' => $data];
-        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -226,9 +222,9 @@ class TableRegistryTest extends TestCase
 
         $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
         $this->assertInstanceOf($class, $table);
-        $this->assertTrue(
+        $this->assertFalse(
             TableRegistry::exists('TestPluginComments'),
-            'Short form should exist'
+            'Short form should NOT exist'
         );
         $this->assertTrue(
             TableRegistry::exists('TestPlugin.TestPluginComments'),
@@ -237,9 +233,6 @@ class TableRegistryTest extends TestCase
 
         $second = TableRegistry::get('TestPlugin.TestPluginComments');
         $this->assertSame($table, $second, 'Can fetch long form');
-
-        $second = TableRegistry::get('TestPluginComments');
-        $this->assertSame($table, $second);
     }
 
     /**
@@ -389,7 +382,6 @@ class TableRegistryTest extends TestCase
 
         $this->assertSame($mock, TableRegistry::set('TestPlugin.Comments', $mock));
         $this->assertSame($mock, TableRegistry::get('TestPlugin.Comments'));
-        $this->assertSame($mock, TableRegistry::get('Comments'));
     }
 
     /**
@@ -418,14 +410,23 @@ class TableRegistryTest extends TestCase
         $pluginTable = TableRegistry::get('TestPlugin.Comments');
         $cachedTable = TableRegistry::get('Comments');
 
+        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
         $this->assertTrue(TableRegistry::exists('Comments'));
-        $this->assertSame($pluginTable, $cachedTable);
+        $this->assertNotSame($pluginTable, $cachedTable);
+
+        TableRegistry::remove('TestPlugin.Comments');
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
+        $this->assertTrue(TableRegistry::exists('Comments'));
 
         TableRegistry::remove('Comments');
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
         $this->assertFalse(TableRegistry::exists('Comments'));
 
-        $appTable = TableRegistry::get('Comments');
-        $this->assertTrue(TableRegistry::exists('Comments'));
-        $this->assertNotSame($pluginTable, $appTable);
+        $pluginTable = TableRegistry::get('TestPlugin.Comments');
+        $cachedTable = TableRegistry::get('Comments');
+
+        TableRegistry::remove('Comments');
+        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
+        $this->assertFalse(TableRegistry::exists('Comments'));
     }
 }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -466,4 +466,51 @@ class TableRegistryTest extends TestCase
         $this->assertNotSame($first, $second, 'Should be different objects, as the reference to the first was destroyed');
         $this->assertTrue(TableRegistry::exists('Comments'));
     }
+
+    /**
+     * testRemovePlugin
+     *
+     * Removing a plugin-prefixed model should not affect any other
+     * plugin-prefixed model, or app model.
+     * Removing an app model should not affect any other
+     * plugin-prefixed model.
+     *
+     * @return void
+     */
+    public function testRemovePlugin()
+    {
+        Plugin::load('TestPlugin');
+        Plugin::load('TestPluginTwo');
+
+        $app = TableRegistry::get('Comments');
+        TableRegistry::get('TestPlugin.Comments');
+        $plugin = TableRegistry::get('TestPluginTwo.Comments');
+
+        $this->assertTrue(TableRegistry::exists('Comments'));
+        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
+        $this->assertTrue(TableRegistry::exists('TestPluginTwo.Comments'));
+
+        TableRegistry::remove('TestPlugin.Comments');
+
+        $this->assertTrue(TableRegistry::exists('Comments'));
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
+        $this->assertTrue(TableRegistry::exists('TestPluginTwo.Comments'));
+
+        $app2 = TableRegistry::get('Comments');
+        $plugin2 = TableRegistry::get('TestPluginTwo.Comments');
+
+        $this->assertSame($app, $app2, 'Should be the same Comments object');
+        $this->assertSame($plugin, $plugin2, 'Should be the same TestPluginTwo.Comments object');
+
+        TableRegistry::remove('Comments');
+
+        $this->assertFalse(TableRegistry::exists('Comments'));
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
+        $this->assertTrue(TableRegistry::exists('TestPluginTwo.Comments'));
+
+        $plugin3 = TableRegistry::get('TestPluginTwo.Comments');
+
+        $this->assertSame($plugin, $plugin3, 'Should be the same TestPluginTwo.Comments object');
+    }
+
 }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -454,28 +454,16 @@ class TableRegistryTest extends TestCase
      */
     public function testRemove()
     {
-        Plugin::load('TestPlugin');
+        $first = TableRegistry::get('Comments');
 
-        $pluginTable = TableRegistry::get('TestPlugin.Comments');
-        $cachedTable = TableRegistry::get('Comments');
-
-        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
-        $this->assertTrue(TableRegistry::exists('Comments'));
-        $this->assertNotSame($pluginTable, $cachedTable);
-
-        TableRegistry::remove('TestPlugin.Comments');
-        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
         $this->assertTrue(TableRegistry::exists('Comments'));
 
         TableRegistry::remove('Comments');
-        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments'));
         $this->assertFalse(TableRegistry::exists('Comments'));
 
-        $pluginTable = TableRegistry::get('TestPlugin.Comments');
-        $cachedTable = TableRegistry::get('Comments');
+        $second = TableRegistry::get('Comments');
 
-        TableRegistry::remove('Comments');
-        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
-        $this->assertFalse(TableRegistry::exists('Comments'));
+        $this->assertNotSame($first, $second, 'Should be different objects, as the reference to the first was destroyed');
+        $this->assertTrue(TableRegistry::exists('Comments'));
     }
 }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -512,5 +512,4 @@ class TableRegistryTest extends TestCase
 
         $this->assertSame($plugin, $plugin3, 'Should be the same TestPluginTwo.Comments object');
     }
-
 }

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -239,8 +239,7 @@ class TableRegistryTest extends TestCase
         Plugin::load('TestPlugin');
         $table = TableRegistry::get('TestPlugin.TestPluginComments', ['connection' => 'test']);
 
-        $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
-        $this->assertInstanceOf($class, $table);
+        $this->assertInstanceOf('TestPlugin\Model\Table\TestPluginCommentsTable', $table);
         $this->assertFalse(
             TableRegistry::exists('TestPluginComments'),
             'Short form should NOT exist'
@@ -255,46 +254,9 @@ class TableRegistryTest extends TestCase
     }
 
     /**
-     * Test get() with plugin aliases + className option.
-     *
-     * @return void
-     */
-    public function testGetPluginWithClassNameOption()
-    {
-        Plugin::load('TestPlugin');
-        $table = TableRegistry::get('Comments', [
-            'className' => 'TestPlugin.TestPluginComments',
-            'connection' => 'test'
-        ]);
-        $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
-        $this->assertInstanceOf($class, $table);
-        $this->assertFalse(TableRegistry::exists('TestPluginComments'), 'Class name should not exist');
-        $this->assertTrue(TableRegistry::exists('Comments'), 'Class name should exist');
-
-        $second = TableRegistry::get('Comments');
-        $this->assertSame($table, $second);
-    }
-
-    /**
-     * Test get() with full namespaced classname
-     *
-     * @return void
-     */
-    public function testGetPluginWithFullNamespaceName()
-    {
-        Plugin::load('TestPlugin');
-        $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
-        $table = TableRegistry::get('Comments', [
-            'className' => $class,
-            'connection' => 'test'
-        ]);
-        $this->assertInstanceOf($class, $table);
-        $this->assertFalse(TableRegistry::exists('TestPluginComments'), 'Class name should not exist');
-        $this->assertTrue(TableRegistry::exists('Comments'), 'Class name should exist');
-    }
-
-    /**
      * Test get() with same-alias models in different plugins
+     *
+     * There should be no internal cache-confusion
      *
      * @return void
      */
@@ -318,6 +280,47 @@ class TableRegistryTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Table', $app, 'Should still be an app table instance');
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $plugin1, 'Should still be a plugin 1 table instance');
         $this->assertInstanceOf('TestPluginTwo\Model\Table\CommentsTable', $plugin2, 'Should still be a plugin 2 table instance');
+    }
+
+    /**
+     * Test get() with plugin aliases + className option.
+     *
+     * @return void
+     */
+    public function testGetPluginWithClassNameOption()
+    {
+        Plugin::load('TestPlugin');
+        $table = TableRegistry::get('Comments', [
+            'className' => 'TestPlugin.TestPluginComments',
+            'connection' => 'test'
+        ]);
+        $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
+        $this->assertInstanceOf($class, $table);
+        $this->assertFalse(TableRegistry::exists('TestPluginComments'), 'Class name should not exist');
+        $this->assertFalse(TableRegistry::exists('TestPlugin.TestPluginComments'), 'Full class alias should not exist');
+        $this->assertTrue(TableRegistry::exists('Comments'), 'Class name should exist');
+
+        $second = TableRegistry::get('Comments');
+        $this->assertSame($table, $second);
+    }
+
+    /**
+     * Test get() with full namespaced classname
+     *
+     * @return void
+     */
+    public function testGetPluginWithFullNamespaceName()
+    {
+        Plugin::load('TestPlugin');
+        $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
+        $table = TableRegistry::get('Comments', [
+            'className' => $class,
+            'connection' => 'test'
+        ]);
+        $this->assertInstanceOf($class, $table);
+        $this->assertFalse(TableRegistry::exists('TestPluginComments'), 'Class name should not exist');
+        $this->assertFalse(TableRegistry::exists('TestPlugin.TestPluginComments'), 'Full class alias should not exist');
+        $this->assertTrue(TableRegistry::exists('Comments'), 'Class name should exist');
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
@@ -517,6 +518,28 @@ class TableTest extends TestCase
         $this->assertEquals(['b' => 'c'], $hasMany->conditions());
         $this->assertEquals(['foo' => 'asc'], $hasMany->sort());
         $this->assertSame($table, $hasMany->source());
+    }
+
+    /**
+     * Should a dupicate short-named association be defined, the earlier
+     * association will be inaccessible via the __get method
+     *
+     * @return void
+     */
+    public function testHasManyPluginOverlap()
+    {
+        TableRegistry::get('Comments');
+        Plugin::load('TestPlugin');
+
+        $table = new Table(['table' => 'authors']);
+
+        $table->hasOne('Comments');
+        $comments = $table->Comments->target();
+        $this->assertInstanceOf('Cake\ORM\Table', $comments);
+
+        $table->hasMany('TestPlugin.Comments');
+        $comments = $table->Comments->target();
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $comments);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -521,8 +521,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Should a dupicate short-named association be defined, the earlier
-     * association will be inaccessible via the __get method
+     * Ensure associations use the plugin-prefixed model
      *
      * @return void
      */
@@ -533,11 +532,25 @@ class TableTest extends TestCase
 
         $table = new Table(['table' => 'authors']);
 
-        $table->hasOne('Comments');
-        $comments = $table->Comments->target();
-        $this->assertInstanceOf('Cake\ORM\Table', $comments);
-
         $table->hasMany('TestPlugin.Comments');
+        $comments = $table->Comments->target();
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $comments);
+    }
+
+    /**
+     * Ensure associations use the plugin-prefixed model
+     * even if specified with config
+     *
+     * @return void
+     */
+    public function testHasManyPluginOverlapConfig()
+    {
+        TableRegistry::get('Comments');
+        Plugin::load('TestPlugin');
+
+        $table = new Table(['table' => 'authors']);
+
+        $table->hasMany('Comments', ['className' => 'TestPlugin.Comments']);
         $comments = $table->Comments->target();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $comments);
     }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Model/Table/CommentsTable.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Model/Table/CommentsTable.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP :  Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakefoundation.org/projects/info/cakephp CakePHP Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPluginTwo\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Class CommentsTable
+ */
+class CommentsTable extends Table
+{
+
+}


### PR DESCRIPTION
I realize this might be contested (since it was intentional functionality), but allowing fuzzy-alias matching is problematic, and IMO propogating developer error - which the framework shouldn't be doing.

The scenario which brought me here was this:

![gc](https://cloud.githubusercontent.com/assets/33387/6059085/f73b2d70-ad2d-11e4-93b6-ed7a5013f17f.png)

The error actually came from debug kit:

```
2015-02-05 10:22:07 Error: [BadMethodCallException] Unknown method "gc"
Request URL: /
Stack Trace:
#0 vendor/cakephp/debug_kit/src/Routing/Filter/DebugBarFilter.php(187): Cake\ORM\Table->__call('gc', Array)
#1 vendor/cakephp/debug_kit/src/Routing/Filter/DebugBarFilter.php(187): Api\Model\Table\RequestsTable->gc()
#2 vendor/cakephp/cakephp/src/Event/EventManager.php(380): DebugKit\Routing\Filter\DebugBarFilter->afterDispatch(Object(Cake\Event\Event), Object(Cake\Network\Request), Object(Cake\Network\Response))
#3 vendor/cakephp/cakephp/src/Event/EventManager.php(346): Cake\Event\EventManager->_callListener(Array, Object(Cake\Event\Event))
#4 vendor/cakephp/cakephp/src/Event/EventManagerTrait.php(78): Cake\Event\EventManager->dispatch(Object(Cake\Event\Event))
#5 vendor/cakephp/cakephp/src/Routing/Dispatcher.php(92): Cake\Routing\Dispatcher->dispatchEvent('Dispatcher.afte...', Array)
#6 webroot/index.php(37): Cake\Routing\Dispatcher->dispatch(Object(Cake\Network\Request), Object(Cake\Network\Response))
#7 {main}
```

Because [these lines of code](https://github.com/cakephp/debug_kit/blob/3.0/src/Routing/Filter/DebugBarFilter.php#L186-L187):

```
$requests = TableRegistry::get('DebugKit.Requests');
$requests->gc();
```

Did _not_ return the table class from debug kit, but instead from my own Api plugin. I would expect this to be an ongoing problem since namespaces aught to eliminate the need for loose-alias matching.

So, should we use table aliases plugin-prefixed within the table registry?
