### PR TITLE
Lazily setting locale name to translators.

### DIFF
--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -215,7 +215,9 @@ class I18n
 
         if (!empty($locale)) {
             Locale::setDefault($locale);
-            static::translators()->setLocale($locale);
+            if (isset(static::$_collection)) {
+                static::translators()->setLocale($locale);
+            }
             return;
         }
 


### PR DESCRIPTION
This helps prevent fatal errors during bootstrap when cache engines are
not yet configured.
