### PR TITLE
3.0 Finally prevent routing ambiguous URLs

### DIFF
--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -16,6 +16,7 @@ namespace Cake\Routing\Route;
 
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
+use Cake\Network\Exception\NotFoundException;
 
 /**
  * This route class will transparently inflect the controller, action and plugin
@@ -49,28 +50,44 @@ class DashedRoute extends Route
         if (!$params) {
             return false;
         }
-        if (!empty($params['controller'])) {
-            $params['controller'] = Inflector::camelize(str_replace(
-                '-',
-                '_',
-                $params['controller']
-            ));
-        }
         if (!empty($params['plugin'])) {
-            $params['plugin'] = Inflector::camelize(str_replace(
-                '-',
-                '_',
-                $params['plugin']
-            ));
+            $params['plugin'] = $this->_in($params['plugin']);
+        }
+        if (!empty($params['controller'])) {
+            $value = $params['controller'];
+            $params['controller'] = $this->_in($params['controller']);
+            if ($this->_out($params['controller']) !== $value) {
+                throw new NotFoundException();
+            }
         }
         if (!empty($params['action'])) {
-            $params['action'] = Inflector::variable(str_replace(
-                '-',
-                '_',
-                $params['action']
-            ));
+            $value = $params['action'];
+            $params['action'] = $this->_in($params['action']);
+            if ($this->_out($params['action']) !== $value) {
+                throw new NotFoundException();
+            }
         }
         return $params;
+    }
+
+    /**
+     * Formats URL part coming in
+     *
+     * @param $string String
+     * @return string Result
+     */
+    public function _in($string) {
+        return Inflector::camelize(str_replace('-', '_', $string));
+    }
+
+    /**
+     * Formats URL part going out
+     *
+     * @param $string String
+     * @return string Result
+     */
+    public function _out($string) {
+        return Inflector::dasherize($string);
     }
 
     /**

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -14,8 +14,10 @@
  */
 namespace Cake\Routing\Route;
 
+use Cake\Network\Exception\NotFoundException;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
+use Cake\Core\Configure;
 
 /**
  * This route class will transparently inflect the controller and plugin routing
@@ -48,7 +50,21 @@ class InflectedRoute extends Route
             return false;
         }
         if (!empty($params['controller'])) {
+            $value = $params['controller'];
             $params['controller'] = Inflector::camelize($params['controller']);
+            if (Inflector::underscore($params['controller']) !== $value) {
+                throw new NotFoundException();
+            }
+        }
+        if (!empty($params['action'])) {
+            $value = $params['action'];
+            $action = lcfirst(Inflector::camelize($params['action']));
+            if (Configure::read('InflectedRoute.camelizedAction')) {
+                $params['action'] = $action;
+            }
+            if (Inflector::underscore($action) !== $value) {
+                throw new NotFoundException();
+            }
         }
         if (!empty($params['plugin'])) {
             $params['plugin'] = Inflector::camelize($params['plugin']);
@@ -87,6 +103,11 @@ class InflectedRoute extends Route
         if (!empty($url['controller'])) {
             $url['controller'] = Inflector::underscore($url['controller']);
         }
+        /*
+        if (!empty($url['action'])) {
+            $url['action'] = Inflector::underscore($url['action']);
+        }
+        */
         if (!empty($url['plugin'])) {
             $url['plugin'] = Inflector::underscore($url['plugin']);
         }


### PR DESCRIPTION
For me, issue https://github.com/cakephp/cakephp/issues/2125 never really was resolved, neither in 2.x nor 3.x.
It can lead to duplicate content and SEO issues, if someone linked multiple URL versions and they are all followed by the search engine.

In 2.x, though, it wasn't that difficult to write a custom dispatcher ( https://github.com/dereuromark/cakephp-shim/blob/master/Routing/Filter/SeoDispatcher.php ) to either throw 404s or make 301 redirects when the wrong URL (which the core would still route through) is being called.

In 3.x. this would have to go into the specific route classes, though.

For me, there should always only be one possible way of routing, even with the Inflected or Dashed classes - as they only beautify the output. It costs 2 Inflections more per dispatching, but that is nothing compared to the total costs and the benefit of having a clean routing pattern IMO.
To outline the problematic behavior:
### Inflected

Correct:

```
/controller_name/action_name
```

Also routed:

```
/Controller_name/action_Name
```

and other variants.
### Dashed

Correct:

```
/controller-name/action-name
```

Also routed:

```
/Controller-name/action-Name
/controller-name/actionName
```

and other variants.
### default route

I didn't care about that one, as this is neither the old nor the new convention.
### Notes

This is mainly a first draft and maybe someone can come up with a better (and less test-failing^^) approach. Or feel free to add commits on top.
Just wanted to bring this up again.

I also added a way to switch the old convention to the "camelCased" action syntax, for people that want to upgrade the code, but cannot change the URLs for legacy (SEO) reasons that easily.
But we can also leave that out for now.
