### PR TITLE
Backport of 3.x flash messages #5823

### DIFF
--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Flash Component
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       Cake.Controller.Component
+ * @since         CakePHP(tm) v 2.7.0-dev
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('Component', 'Controller');
+App::uses('Inflector', 'Utility');
+App::uses('CakeSession', 'Model/Datasource');
+
+/**
+ * The CakePHP FlashComponent provides a way for you to write a flash variable
+ * to the session from your controllers, to be rendered in a view with the
+ * FlashHelper.
+ *
+ * @package       Cake.Controller.Component
+ */
+class FlashComponent extends Component {
+
+/**
+ * Default configuration
+ *
+ * @var array
+ */
+	protected $_defaultConfig = array(
+		'key' => 'flash',
+		'element' => 'default',
+		'params' => array(),
+	);
+
+/**
+ * Constructor
+ *
+ * @param ComponentCollection $collection
+ * @param array $settings
+ */
+	public function __construct(ComponentCollection $collection, $settings = array()) {
+		$this->_defaultConfig = Hash::merge($this->_defaultConfig, $settings);
+	}
+
+/**
+ * Used to set a session variable that can be used to output messages in the view.
+ *
+ * In your controller: $this->Flash->set('This has been saved');
+ *
+ * ### Options:
+ *
+ * - `key` The key to set under the session's Flash key
+ * - `element` The element used to render the flash message. Default to 'default'.
+ * - `params` An array of variables to make available when using an element
+ *
+ * @param string $message Message to be flashed. If an instance
+ *   of Exception the exception message will be used and code will be set
+ *   in params.
+ * @param array $options An array of options.
+ * @return void
+ */
+
+	public function set($message, $options = array()) {
+		$options += $this->_defaultConfig;
+
+		if ($message instanceof Exception) {
+			$options['params'] += array('code' => $message->getCode());
+			$message = $message->getMessage();
+		}
+
+		list($plugin, $element) = pluginSplit($options['element']);
+
+		if ($plugin) {
+			$options['element'] = $plugin . '.Flash/' . $element;
+		} else {
+			$options['element'] = 'Flash/' . $element;
+		}
+
+		CakeSession::write('Flash.' . $options['key'], array(
+			'message' => $message,
+			'key' => $options['key'],
+			'element' => $options['element'],
+			'params' => $options['params']
+		));
+	}
+
+/**
+ * Magic method for verbose flash methods based on element names.
+ *
+ * For example: $this->Flash->success('My message') would use the
+ * success.ctp element under `app/View/Element/Flash` for rendering the
+ * flash message.
+ *
+ * @param string $name Element name to use.
+ * @param array $args Parameters to pass when calling `FlashComponent::set()`.
+ * @return void
+ * @throws InternalErrorException If missing the flash message.
+ */
+	public function __call($name, $args) {
+		$options = array('element' => Inflector::underscore($name));
+
+		if (count($args) < 1) {
+			throw new InternalErrorException(__('Flash message missing.'));
+		}
+
+		if (!empty($args[1])) {
+			$options += (array)$args[1];
+		}
+
+		$this->set($args[0], $options);
+	}
+}

--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -108,7 +108,7 @@ class FlashComponent extends Component {
 		$options = array('element' => Inflector::underscore($name));
 
 		if (count($args) < 1) {
-			throw new InternalErrorException(__('Flash message missing.'));
+			throw new InternalErrorException('Flash message missing.');
 		}
 
 		if (!empty($args[1])) {

--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -43,8 +43,8 @@ class FlashComponent extends Component {
 /**
  * Constructor
  *
- * @param ComponentCollection $collection
- * @param array $settings
+ * @param ComponentCollection $collection The ComponentCollection object
+ * @param array $settings Settings passed via controller
  */
 	public function __construct(ComponentCollection $collection, $settings = array()) {
 		$this->_defaultConfig = Hash::merge($this->_defaultConfig, $settings);

--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -133,6 +133,7 @@ class SessionComponent extends Component {
  * @param string $key Message key, default is 'flash'
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#creating-notification-messages
+ * @deprecated 3.0.0 Since 2.7, use the FlashComponent instead.
  */
 	public function setFlash($message, $element = 'default', $params = array(), $key = 'flash') {
 		CakeSession::write('Message.' . $key, compact('message', 'element', 'params'));

--- a/lib/Cake/Test/Case/Controller/Component/FlashComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/FlashComponentTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * FlashComponentTest file
+ *
+ * Series of tests for flash component.
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Case.Controller.Component
+ * @since         CakePHP(tm) v 2.7.0-dev
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('FlashComponent', 'Controller/Component');
+App::uses('ComponentCollection', 'Controller');
+
+/**
+* FlashComponentTest class
+*
+* @package		Cake.Test.Case.Controller.Component
+*/
+class FlashComponentTest extends CakeTestCase {
+
+/**
+* setUp method
+*
+* @return void
+*/
+	public function setUp() {
+		parent::setUp();
+		$this->Components = new ComponentCollection();
+		$this->Flash = new FlashComponent($this->Components);
+	}
+
+/**
+* tearDown method
+*
+* @return void
+*/
+	public function tearDown() {
+		parent::tearDown();
+		CakeSession::destroy();
+	}
+
+/**
+* testSet method
+*
+* @return void
+*/
+	public function testSet() {
+		$this->assertNull(CakeSession::read('Flash.flash'));
+
+		$this->Flash->set('This is a test message');
+		$expected = array(
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'Flash/default',
+			'params' => array()
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('This is a test message', array(
+			'element' => 'test',
+			'params' => array('foo' => 'bar')
+		));
+		$expected = array(
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'Flash/test',
+			'params' => array('foo' => 'bar')
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('This is a test message', array('element' => 'MyPlugin.alert'));
+		$expected = array(
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'MyPlugin.Flash/alert',
+			'params' => array()
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('This is a test message', array('key' => 'foobar'));
+		$expected = array(
+			'message' => 'This is a test message',
+			'key' => 'foobar',
+			'element' => 'Flash/default',
+			'params' => array()
+		);
+		$result = CakeSession::read('Flash.foobar');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+* testSetWithException method
+*
+* @return void
+*/
+	public function testSetWithException() {
+		$this->assertNull(CakeSession::read('Flash.flash'));
+
+		$this->Flash->set(new Exception('This is a test message', 404));
+		$expected = array(
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'Flash/default',
+			'params' => array('code' => 404)
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+* testSetWithComponentConfiguration method
+*
+* @return void
+*/
+	public function testSetWithComponentConfiguration() {
+		$this->assertNull(CakeSession::read('Flash.flash'));
+
+		$FlashWithSettings = $this->Components->load('Flash', array('element' => 'test'));
+		$FlashWithSettings->set('This is a test message');
+		$expected = array(
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'Flash/test',
+			'params' => array()
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+* Test magic call method.
+*
+* @return void
+*/
+	public function testCall() {
+		$this->assertNull(CakeSession::read('Flash.flash'));
+
+		$this->Flash->success('It worked');
+		$expected = array(
+			'message' => 'It worked',
+			'key' => 'flash',
+			'element' => 'Flash/success',
+			'params' => array()
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->error('It did not work', array('element' => 'error_thing'));
+		$expected = array(
+			'message' => 'It did not work',
+			'key' => 'flash',
+			'element' => 'Flash/error',
+			'params' => array()
+		);
+		$result = CakeSession::read('Flash.flash');
+		$this->assertEquals($expected, $result, 'Element is ignored in magic call.');
+	}
+}

--- a/lib/Cake/Test/Case/Controller/Component/FlashComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/FlashComponentTest.php
@@ -22,17 +22,17 @@ App::uses('FlashComponent', 'Controller/Component');
 App::uses('ComponentCollection', 'Controller');
 
 /**
-* FlashComponentTest class
-*
-* @package		Cake.Test.Case.Controller.Component
-*/
+ * FlashComponentTest class
+ *
+ * @package		Cake.Test.Case.Controller.Component
+ */
 class FlashComponentTest extends CakeTestCase {
 
 /**
-* setUp method
-*
-* @return void
-*/
+ * setUp method
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$this->Components = new ComponentCollection();
@@ -40,20 +40,20 @@ class FlashComponentTest extends CakeTestCase {
 	}
 
 /**
-* tearDown method
-*
-* @return void
-*/
+ * tearDown method
+ *
+ * @return void
+ */
 	public function tearDown() {
 		parent::tearDown();
 		CakeSession::destroy();
 	}
 
 /**
-* testSet method
-*
-* @return void
-*/
+ * testSet method
+ *
+ * @return void
+ */
 	public function testSet() {
 		$this->assertNull(CakeSession::read('Flash.flash'));
 
@@ -102,10 +102,10 @@ class FlashComponentTest extends CakeTestCase {
 	}
 
 /**
-* testSetWithException method
-*
-* @return void
-*/
+ * testSetWithException method
+ *
+ * @return void
+ */
 	public function testSetWithException() {
 		$this->assertNull(CakeSession::read('Flash.flash'));
 
@@ -121,10 +121,10 @@ class FlashComponentTest extends CakeTestCase {
 	}
 
 /**
-* testSetWithComponentConfiguration method
-*
-* @return void
-*/
+ * testSetWithComponentConfiguration method
+ *
+ * @return void
+ */
 	public function testSetWithComponentConfiguration() {
 		$this->assertNull(CakeSession::read('Flash.flash'));
 
@@ -141,10 +141,10 @@ class FlashComponentTest extends CakeTestCase {
 	}
 
 /**
-* Test magic call method.
-*
-* @return void
-*/
+ * Test magic call method.
+ *
+ * @return void
+ */
 	public function testCall() {
 		$this->assertNull(CakeSession::read('Flash.flash'));
 

--- a/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * FlashHelperTest file
+ *
+ * Series of tests for flash helper.
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Case.View.Helper
+ * @since         CakePHP(tm) v 2.7.0-dev
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('FlashHelper', 'View/Helper');
+App::uses('View', 'View');
+App::uses('CakePlugin', 'Core');
+
+/**
+* FlashHelperTest class
+*
+* @package		Cake.Test.Case.View.Helper
+*/
+class FlashHelperTest extends CakeTestCase {
+
+	public static function setupBeforeClass() {
+		App::build(array(
+			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
+		));
+	}
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		$controller = null;
+		$this->View = new View($controller);
+		$this->Flash = new FlashHelper($this->View);
+
+		if (!CakeSession::started()) {
+			CakeSession::start();
+		}
+		CakeSession::write(array(
+			'Flash' => array(
+				'flash' => array(
+					'key' => 'flash',
+					'message' => 'This is a calling',
+					'element' => 'Flash/default',
+					'params' => array()
+				),
+				'notification' => array(
+					'key' => 'notification',
+					'message' => 'Broadcast message testing',
+					'element' => 'flash_helper',
+					'params' => array(
+						'title' => 'Notice!',
+						'name' => 'Alert!'
+					)
+				),
+				'classy' => array(
+					'key' => 'classy',
+					'message' => 'Recorded',
+					'element' => 'flash_classy',
+					'params' => array()
+				)
+			)
+		));
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		unset($this->View, $this->Flash);
+		CakeSession::destroy();
+	}
+
+	/**
+	 * testFlash method
+	 *
+	 * @return void
+	 */
+	public function testFlash() {
+		$result = $this->Flash->render();
+		$expected = '<div class="message">This is a calling</div>';
+		$this->assertContains($expected, $result);
+
+		$expected = '<div id="classy-message">Recorded</div>';
+		$result = $this->Flash->render('classy');
+		$this->assertContains($expected, $result);
+
+		$result = $this->Flash->render('notification');
+		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>Broadcast message testing</p>\n</div>";
+
+		$this->assertContains($expected, $result);
+
+		$this->assertNull($this->Flash->render('non-existent'));
+	}
+
+	/**
+	 * testFlashThrowsException
+	 *
+	 * @expectedException UnexpectedValueException
+	 */
+	public function testFlashThrowsException() {
+		CakeSession::write('Flash.foo', 'bar');
+		$this->Flash->render('foo');
+	}
+
+	/**
+	 * test setting the element from the attrs.
+	 *
+	 * @return void
+	 */
+	public function testFlashElementInAttrs() {
+		$result = $this->Flash->render('notification', array(
+			'element' => 'flash_helper',
+			'params' => array('title' => 'Alert!', 'name' => 'Notice!')
+		));
+
+		$expected = "<div id=\"notificationLayout\">\n\t<h1>Notice!</h1>\n\t<h3>Alert!</h3>\n\t<p>Broadcast message testing</p>\n</div>";
+
+		$this->assertContains($expected, $result);
+	}
+
+	/**
+	 * test using elements in plugins.
+	 *
+	 * @return void
+	 */
+	public function testFlashWithPluginElement() {
+		App::build(array(
+			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
+		));
+		CakePlugin::load('TestPlugin');
+
+		$result = $this->Flash->render('flash', array('element' => 'TestPlugin.plugin_element'));
+		$expected = 'this is the plugin element';
+		$this->assertContains($expected, $result);
+	}
+}

--- a/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
@@ -23,23 +23,28 @@ App::uses('View', 'View');
 App::uses('CakePlugin', 'Core');
 
 /**
-* FlashHelperTest class
-*
-* @package		Cake.Test.Case.View.Helper
-*/
+ * FlashHelperTest class
+ *
+ * @package		Cake.Test.Case.View.Helper
+ */
 class FlashHelperTest extends CakeTestCase {
 
+/**
+ * setupBeforeClass method
+ *
+ * @return void
+ */
 	public static function setupBeforeClass() {
 		App::build(array(
 			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
 		));
 	}
 
-	/**
-	 * setUp method
-	 *
-	 * @return void
-	 */
+/**
+ * setUp method
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$controller = null;
@@ -76,22 +81,22 @@ class FlashHelperTest extends CakeTestCase {
 		));
 	}
 
-	/**
-	 * tearDown method
-	 *
-	 * @return void
-	 */
+/**
+ * tearDown method
+ *
+ * @return void
+ */
 	public function tearDown() {
 		parent::tearDown();
 		unset($this->View, $this->Flash);
 		CakeSession::destroy();
 	}
 
-	/**
-	 * testFlash method
-	 *
-	 * @return void
-	 */
+/**
+ * testFlash method
+ *
+ * @return void
+ */
 	public function testFlash() {
 		$result = $this->Flash->render();
 		$expected = '<div class="message">This is a calling</div>';
@@ -109,21 +114,21 @@ class FlashHelperTest extends CakeTestCase {
 		$this->assertNull($this->Flash->render('non-existent'));
 	}
 
-	/**
-	 * testFlashThrowsException
-	 *
-	 * @expectedException UnexpectedValueException
-	 */
+/**
+ * testFlashThrowsException
+ *
+ * @expectedException UnexpectedValueException
+ */
 	public function testFlashThrowsException() {
 		CakeSession::write('Flash.foo', 'bar');
 		$this->Flash->render('foo');
 	}
 
-	/**
-	 * test setting the element from the attrs.
-	 *
-	 * @return void
-	 */
+/**
+ * test setting the element from the attrs.
+ *
+ * @return void
+ */
 	public function testFlashElementInAttrs() {
 		$result = $this->Flash->render('notification', array(
 			'element' => 'flash_helper',
@@ -135,11 +140,11 @@ class FlashHelperTest extends CakeTestCase {
 		$this->assertContains($expected, $result);
 	}
 
-	/**
-	 * test using elements in plugins.
-	 *
-	 * @return void
-	 */
+/**
+ * test using elements in plugins.
+ *
+ * @return void
+ */
 	public function testFlashWithPluginElement() {
 		App::build(array(
 			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)

--- a/lib/Cake/Test/test_app/View/Elements/Flash/default.ctp
+++ b/lib/Cake/Test/test_app/View/Elements/Flash/default.ctp
@@ -1,0 +1,1 @@
+<div class="message"><?php echo $message ?></div>

--- a/lib/Cake/Test/test_app/View/Elements/flash_classy.ctp
+++ b/lib/Cake/Test/test_app/View/Elements/flash_classy.ctp
@@ -1,0 +1,1 @@
+<div id="<?php echo $key ?>-message"><?php echo $message; ?></div>

--- a/lib/Cake/Test/test_app/View/Elements/flash_helper.ctp
+++ b/lib/Cake/Test/test_app/View/Elements/flash_helper.ctp
@@ -1,0 +1,5 @@
+<div id="notificationLayout">
+	<h1><?php echo $params['name']; ?></h1>
+	<h3><?php echo $params['title']; ?></h3>
+	<p><?php echo $message; ?></p>
+</div>

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       Cake.View.Helper
+ * @since         CakePHP(tm) v 2.7.0-dev
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('AppHelper', 'View/Helper');
+App::uses('CakeSession', 'Model/Datasource');
+
+/**
+ * FlashHelper class to render flash messages.
+ *
+ * After setting messages in your controllers with FlashComponent, you can use
+ * this class to output your flash messages in your views.
+ *
+ * @package       Cake.View.Helper
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html
+ */
+class FlashHelper extends AppHelper {
+
+/**
+ * Used to render the message set in FlashComponent::set()
+ *
+ * In your view: $this->Flash->render('somekey');
+ * Will default to flash if no param is passed
+ *
+ * You can pass additional information into the flash message generation. This allows you
+ * to consolidate all the parameters for a given type of flash message into the view.
+ *
+ * ```
+ * echo $this->Flash->render('flash', ['params' => ['name' => $user['User']['name']]]);
+ * ```
+ *
+ * This would pass the current user's name into the flash message, so you could create personalized
+ * messages without the controller needing access to that data.
+ *
+ * Lastly you can choose the element that is used for rendering the flash message. Using
+ * custom elements allows you to fully customize how flash messages are generated.
+ *
+ * ```
+ * echo $this->Flash->render('flash', ['element' => 'my_custom_element']);
+ * ```
+ *
+ * If you want to use an element from a plugin for rendering your flash message
+ * you can use the dot notation for the plugin's element name:
+ *
+ * ```
+ * echo $this->Flash->render('flash', [
+ *   'element' => 'MyPlugin.my_custom_element',
+ * ]);
+ * ```
+ *
+ * @param string $key The [Flash.]key you are rendering in the view.
+ * @param array $options Additional options to use for the creation of this flash message.
+ *    Supports the 'params', and 'element' keys that are used in the helper.
+ * @return string|null Rendered flash message or null if flash key does not exist
+ *   in session.
+ * @throws UnexpectedValueException If value for flash settings key is not an array.
+ */
+	public function render($key = 'flash', $options = array()) {
+
+		if (!CakeSession::check("Message.$key")) {
+			return;
+		}
+
+		$flash = CakeSession::read("Message.$key");
+
+		if (!is_array($flash)) {
+			throw new UnexpectedValueException(sprintf(
+				'Value for flash setting key "%s" must be an array.',
+				$key
+			));
+		}
+
+		$flash = $options + $flash;
+		CakeSession::delete("Flash.$key");
+
+		return $this->_View->element($flash['element'], $flash);
+	}
+}

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * Flash Helper
+ *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -24,7 +26,6 @@ App::uses('CakeSession', 'Model/Datasource');
  * this class to output your flash messages in your views.
  *
  * @package       Cake.View.Helper
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html
  */
 class FlashHelper extends AppHelper {
 
@@ -38,7 +39,7 @@ class FlashHelper extends AppHelper {
  * to consolidate all the parameters for a given type of flash message into the view.
  *
  * ```
- * echo $this->Flash->render('flash', ['params' => ['name' => $user['User']['name']]]);
+ * echo $this->Flash->render('flash', array('params' => array('name' => $user['User']['name'])));
  * ```
  *
  * This would pass the current user's name into the flash message, so you could create personalized
@@ -48,16 +49,16 @@ class FlashHelper extends AppHelper {
  * custom elements allows you to fully customize how flash messages are generated.
  *
  * ```
- * echo $this->Flash->render('flash', ['element' => 'my_custom_element']);
+ * echo $this->Flash->render('flash', array('element' => 'my_custom_element'));
  * ```
  *
  * If you want to use an element from a plugin for rendering your flash message
  * you can use the dot notation for the plugin's element name:
  *
  * ```
- * echo $this->Flash->render('flash', [
+ * echo $this->Flash->render('flash', array(
  *   'element' => 'MyPlugin.my_custom_element',
- * ]);
+ * ));
  * ```
  *
  * @param string $key The [Flash.]key you are rendering in the view.
@@ -68,12 +69,11 @@ class FlashHelper extends AppHelper {
  * @throws UnexpectedValueException If value for flash settings key is not an array.
  */
 	public function render($key = 'flash', $options = array()) {
-
-		if (!CakeSession::check("Message.$key")) {
+		if (!CakeSession::check("Flash.$key")) {
 			return;
 		}
 
-		$flash = CakeSession::read("Message.$key");
+		$flash = CakeSession::read("Flash.$key");
 
 		if (!is_array($flash)) {
 			throw new UnexpectedValueException(sprintf(

--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -126,6 +126,7 @@ class SessionHelper extends AppHelper {
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::flash
+ * @deprecated 3.0.0 Since 2.7, use FlashHelper::render() instead.
  */
 	public function flash($key = 'flash', $attrs = array()) {
 		$out = false;


### PR DESCRIPTION
Had a quick attempt to make the Flash component & helper from 3.x compatible for 2.7. 

Few things I was unsure of though:
- The message data is stored under the Flash session index, as in 3.x. Should it use the Message index like the Session component?
- Seen as it is not the only option for flash message creation, I haven't included example element files in the app/View/Element directory. Thoughts?
