### PR TITLE
3.0 stricter inflector

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -665,10 +665,13 @@ class Inflector
      */
     public static function tableize($className)
     {
-        if (!($result = static::_cache(__FUNCTION__, $className))) {
+        $result = static::_cache(__FUNCTION__, $className);
+
+        if ($result === false) {
             $result = static::pluralize(static::underscore($className));
             static::_cache(__FUNCTION__, $className, $result);
         }
+
         return $result;
     }
 
@@ -681,10 +684,13 @@ class Inflector
      */
     public static function classify($tableName)
     {
-        if (!($result = static::_cache(__FUNCTION__, $tableName))) {
+        $result = static::_cache(__FUNCTION__, $tableName);
+
+        if ($result === false) {
             $result = static::camelize(static::singularize($tableName));
             static::_cache(__FUNCTION__, $tableName, $result);
         }
+
         return $result;
     }
 
@@ -697,12 +703,15 @@ class Inflector
      */
     public static function variable($string)
     {
-        if (!($result = static::_cache(__FUNCTION__, $string))) {
+        $result = static::_cache(__FUNCTION__, $string);
+
+        if ($result === false) {
             $camelized = static::camelize(static::underscore($string));
             $replace = strtolower(substr($camelized, 0, 1));
             $result = preg_replace('/\\w/', $replace, $camelized, 1);
             static::_cache(__FUNCTION__, $string, $result);
         }
+
         return $result;
     }
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -631,7 +631,16 @@ class Inflector
      */
     public static function humanize($string, $replacement = '_')
     {
-        return ucwords(str_replace($replacement, ' ', static::normalize($string, $replacement)));
+        $cacheKey = __FUNCTION__ . $replacement;
+
+        $result = static::_cache($cacheKey, $string);
+
+        if ($result === false) {
+            $result = ucwords(str_replace($replacement, ' ', $string));
+            static::_cache($cacheKey, $string, $result);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -606,7 +606,7 @@ class Inflector
      */
     public static function underscore($string)
     {
-        return static::normalize($string, '_');
+        return static::delimit(str_replace('-', '_', $string), '_');
     }
 
     /**
@@ -617,7 +617,7 @@ class Inflector
      */
     public static function dasherize($string)
     {
-        return static::normalize($string, '-');
+        return static::delimit(str_replace('_', '-', $string), '-');
     }
 
     /**
@@ -644,13 +644,13 @@ class Inflector
     }
 
     /**
-     * Takes the input string, and based on the replacement character converts to a normalized string
+     * Takes the input string, and based on the replacement character converts to a delimited string
      *
-     * @param string $string String to normalize
+     * @param string $string String to delimit
      * @param string $replacement the character to use as a delimiter
-     * @return string normalized string
+     * @return string delimited string
      */
-    public static function normalize($string, $replacement = '_')
+    public static function delimit($string, $replacement = '_')
     {
         $cacheKey = __FUNCTION__ . $replacement;
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -576,21 +576,21 @@ class Inflector
     }
 
     /**
-     * Returns the given lower_case_and_underscored_word as a CamelCased word.
+     * Returns the input lower_case_delimited_string as a CamelCasedString.
      *
-     * @param string $string Word to camelize
-     * @param string $replacement the delimiter in the input string
-     * @return string Camelized word. LikeThis.
+     * @param string $string String to camelize
+     * @param string $delimiter the delimiter in the input string
+     * @return string CamelizedStringLikeThis.
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-camelcase-and-under-scored-forms
      */
-    public static function camelize($string, $replacement = '_')
+    public static function camelize($string, $delimiter = '_')
     {
-        $cacheKey = __FUNCTION__ . $replacement;
+        $cacheKey = __FUNCTION__ . $delimiter;
 
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = str_replace(' ', '', static::humanize($string, $replacement));
+            $result = str_replace(' ', '', static::humanize($string, $delimiter));
             static::_cache(__FUNCTION__, $string, $result);
         }
 
@@ -598,10 +598,12 @@ class Inflector
     }
 
     /**
-     * Returns the given camelCasedWord as an underscored_word.
+     * Returns the input CamelCasedString as an underscored_string.
      *
-     * @param string $camelCasedWord Camel-cased word to be "underscorized"
-     * @return string Underscore-syntaxed version of the $camelCasedWord
+     * Also replaces dashes with underscores
+     *
+     * @param string $string CamelCasedString to be "underscorized"
+     * @return string underscore_version of the input string
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-camelcase-and-under-scored-forms
      */
     public static function underscore($string)
@@ -610,10 +612,12 @@ class Inflector
     }
 
     /**
-     * Returns the given CamelCasedWordGroup as an dashed-word-group.
+     * Returns the input CamelCasedString as an dashed-string.
+     *
+     * Also replaces underscores with dashes
      *
      * @param string $string The string to dasherize.
-     * @return string Dashed version of the word group
+     * @return string Dashed version of the input string
      */
     public static function dasherize($string)
     {
@@ -621,22 +625,22 @@ class Inflector
     }
 
     /**
-     * Returns the given underscored_word_group as a Human Readable Word Group.
+     * Returns the input lower_case_delimited_string as 'A Human Readable String'.
      * (Underscores are replaced by spaces and capitalized following words.)
      *
-     * @param string $string String to be made more readable
-     * @param string $replacement the character to replace with a space
+     * @param string $string String to be humanized
+     * @param string $delimiter the character to replace with a space
      * @return string Human-readable string
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-human-readable-forms
      */
-    public static function humanize($string, $replacement = '_')
+    public static function humanize($string, $delimiter = '_')
     {
-        $cacheKey = __FUNCTION__ . $replacement;
+        $cacheKey = __FUNCTION__ . $delimiter;
 
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = ucwords(str_replace($replacement, ' ', $string));
+            $result = ucwords(str_replace($delimiter, ' ', $string));
             static::_cache($cacheKey, $string, $result);
         }
 
@@ -644,20 +648,20 @@ class Inflector
     }
 
     /**
-     * Takes the input string, and based on the replacement character converts to a delimited string
+     * Expects a CamelCasedInputString, and produces a lower_case_delimited_string
      *
      * @param string $string String to delimit
-     * @param string $replacement the character to use as a delimiter
+     * @param string $delimiter the character to use as a delimiter
      * @return string delimited string
      */
-    public static function delimit($string, $replacement = '_')
+    public static function delimit($string, $delimiter = '_')
     {
-        $cacheKey = __FUNCTION__ . $replacement;
+        $cacheKey = __FUNCTION__ . $delimiter;
 
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', $replacement . '\\1', $string));
+            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', $delimiter . '\\1', $string));
             static::_cache($cacheKey, $string, $result);
         }
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -578,15 +578,15 @@ class Inflector
     /**
      * Returns the given lower_case_and_underscored_word as a CamelCased word.
      *
-     * @param string $lowerCaseAndUnderscoredWord Word to camelize
+     * @param string $string Word to camelize
      * @return string Camelized word. LikeThis.
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-camelcase-and-under-scored-forms
      */
-    public static function camelize($lowerCaseAndUnderscoredWord)
+    public static function camelize($string)
     {
-        if (!($result = static::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord))) {
-            $result = str_replace(' ', '', static::humanize($lowerCaseAndUnderscoredWord));
-            static::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord, $result);
+        if (!($result = static::_cache(__FUNCTION__, $string))) {
+            $result = str_replace(' ', '', static::humanize($string));
+            static::_cache(__FUNCTION__, $string, $result);
         }
         return $result;
     }
@@ -598,47 +598,55 @@ class Inflector
      * @return string Underscore-syntaxed version of the $camelCasedWord
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-camelcase-and-under-scored-forms
      */
-    public static function underscore($camelCasedWord)
+    public static function underscore($string)
     {
-        if (!($result = static::_cache(__FUNCTION__, $camelCasedWord))) {
-            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $camelCasedWord));
-            static::_cache(__FUNCTION__, $camelCasedWord, $result);
-        }
-        return $result;
+        return static::normalize($string, '_');
     }
 
     /**
      * Returns the given CamelCasedWordGroup as an dashed-word-group.
      *
-     * @param string $wordGroup The string to dasherize.
+     * @param string $string The string to dasherize.
      * @return string Dashed version of the word group
      */
-    public static function dasherize($wordGroup)
+    public static function dasherize($string)
     {
-        $result = static::_cache(__FUNCTION__, $wordGroup);
-        if ($result !== false) {
-            return $result;
-        }
-
-        $result = str_replace('_', '-', static::underscore($wordGroup));
-        static::_cache(__FUNCTION__, $wordGroup, $result);
-        return $result;
+        return static::normalize($string, '-');
     }
 
     /**
      * Returns the given underscored_word_group as a Human Readable Word Group.
      * (Underscores are replaced by spaces and capitalized following words.)
      *
-     * @param string $lowerCaseAndUnderscoredWord String to be made more readable
+     * @param string $string String to be made more readable
+     * @param string $replacement
      * @return string Human-readable string
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-human-readable-forms
      */
-    public static function humanize($lowerCaseAndUnderscoredWord)
+    public static function humanize($string, $replacement = '_')
     {
-        if (!($result = static::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord))) {
-            $result = ucwords(str_replace('_', ' ', $lowerCaseAndUnderscoredWord));
-            static::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord, $result);
+        return ucwords(str_replace($replacement, ' ', static::normalize($string, $replacement)));
+    }
+
+    /**
+     * Returns the given CamelCasedWordGroup as lower cased words, separated by the replacement
+     * character
+     *
+     * @param string $string
+     * @param string $replacement
+     * @return string normalized stringd
+     */
+    public static function normalize($string, $replacement = '_')
+    {
+        $cacheKey = __FUNCTION__ . $replacement;
+
+        $result = static::_cache($cacheKey, $string);
+
+        if ($result === false) {
+            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', $replacement .'\\1', $string));
+            static::_cache($cacheKey, $string, $result);
         }
+
         return $result;
     }
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -657,7 +657,7 @@ class Inflector
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', $replacement .'\\1', $string));
+            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', $replacement . '\\1', $string));
             static::_cache($cacheKey, $string, $result);
         }
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -579,15 +579,21 @@ class Inflector
      * Returns the given lower_case_and_underscored_word as a CamelCased word.
      *
      * @param string $string Word to camelize
+     * @param string $replacement the delimiter in the input string
      * @return string Camelized word. LikeThis.
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-camelcase-and-under-scored-forms
      */
-    public static function camelize($string)
+    public static function camelize($string, $replacement = '_')
     {
-        if (!($result = static::_cache(__FUNCTION__, $string))) {
-            $result = str_replace(' ', '', static::humanize($string));
+        $cacheKey = __FUNCTION__ . $replacement;
+
+        $result = static::_cache($cacheKey, $string);
+
+        if ($result === false) {
+            $result = str_replace(' ', '', static::humanize($string, $replacement));
             static::_cache(__FUNCTION__, $string, $result);
         }
+
         return $result;
     }
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -625,7 +625,7 @@ class Inflector
      * (Underscores are replaced by spaces and capitalized following words.)
      *
      * @param string $string String to be made more readable
-     * @param string $replacement
+     * @param string $replacement the character to replace with a space
      * @return string Human-readable string
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-human-readable-forms
      */
@@ -644,12 +644,11 @@ class Inflector
     }
 
     /**
-     * Returns the given CamelCasedWordGroup as lower cased words, separated by the replacement
-     * character
+     * Takes the input string, and based on the replacement character converts to a normalized string
      *
-     * @param string $string
-     * @param string $replacement
-     * @return string normalized stringd
+     * @param string $string String to normalize
+     * @param string $replacement the character to use as a delimiter
+     * @return string normalized string
      */
     public static function normalize($string, $replacement = '_')
     {

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -411,6 +411,26 @@ class InflectorTest extends TestCase
     }
 
     /**
+     * Demonstrate the expected output for bad inputs
+     *
+     * @return void
+     */
+    public function testCamelize()
+    {
+        $this->assertSame('TestThing', Inflector::camelize('test_thing'));
+        $this->assertSame('Test-thing', Inflector::camelize('test-thing'));
+        $this->assertSame('TestThing', Inflector::camelize('test thing'));
+
+        $this->assertSame('Test_thing', Inflector::camelize('test_thing', '-'));
+        $this->assertSame('TestThing', Inflector::camelize('test-thing', '-'));
+        $this->assertSame('TestThing', Inflector::camelize('test thing', '-'));
+
+        $this->assertSame('Test_thing', Inflector::camelize('test_thing', ' '));
+        $this->assertSame('Test-thing', Inflector::camelize('test-thing', ' '));
+        $this->assertSame('TestThing', Inflector::camelize('test thing', ' '));
+    }
+
+    /**
      * testVariableNaming method
      *
      * @return void

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -428,6 +428,8 @@ class InflectorTest extends TestCase
         $this->assertSame('Test_thing', Inflector::camelize('test_thing', ' '));
         $this->assertSame('Test-thing', Inflector::camelize('test-thing', ' '));
         $this->assertSame('TestThing', Inflector::camelize('test thing', ' '));
+
+        $this->assertSame('TestPlugin.TestPluginComments', Inflector::camelize('TestPlugin.TestPluginComments'));
     }
 
     /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -377,6 +377,7 @@ class InflectorTest extends TestCase
         $this->assertSame('test_thing', Inflector::underscore('testThing'));
         $this->assertSame('test_thing_extra', Inflector::underscore('TestThingExtra'));
         $this->assertSame('test_thing_extra', Inflector::underscore('testThingExtra'));
+        $this->assertSame('test_this_thing', Inflector::underscore('test-this-thing'));
 
         // Identical checks test the cache code path.
         $this->assertSame('test_thing', Inflector::underscore('TestThing'));
@@ -401,7 +402,7 @@ class InflectorTest extends TestCase
         $this->assertSame('test-thing', Inflector::dasherize('testThing'));
         $this->assertSame('test-thing-extra', Inflector::dasherize('TestThingExtra'));
         $this->assertSame('test-thing-extra', Inflector::dasherize('testThingExtra'));
-        $this->assertSame('test_this_thing', Inflector::dasherize('test_this_thing'), 'Should be unchanged');
+        $this->assertSame('test-this-thing', Inflector::dasherize('test_this_thing'));
 
         // Test stupid values
         $this->assertSame('', Inflector::dasherize(null));

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -401,7 +401,7 @@ class InflectorTest extends TestCase
         $this->assertSame('test-thing', Inflector::dasherize('testThing'));
         $this->assertSame('test-thing-extra', Inflector::dasherize('TestThingExtra'));
         $this->assertSame('test-thing-extra', Inflector::dasherize('testThingExtra'));
-        $this->assertSame('test-this-thing', Inflector::dasherize('test_this_thing'));
+        $this->assertSame('test_this_thing', Inflector::dasherize('test_this_thing'), 'Should be unchanged');
 
         // Test stupid values
         $this->assertSame('', Inflector::dasherize(null));

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -255,11 +255,11 @@ class InflectorTest extends TestCase
     }
 
     /**
-     * testInflectorSlug method
+     * testSlug method
      *
      * @return void
      */
-    public function testInflectorSlug()
+    public function testSlug()
     {
         $result = Inflector::slug('Foo Bar: Not just for breakfast any-more');
         $expected = 'Foo-Bar-Not-just-for-breakfast-any-more';
@@ -326,7 +326,7 @@ class InflectorTest extends TestCase
      *
      * @return void
      */
-    public function testInflectorSlugCharList()
+    public function testSlugCharList()
     {
         foreach (self::$maps as $language => $list) {
             foreach ($list as $from => $to) {
@@ -337,11 +337,11 @@ class InflectorTest extends TestCase
     }
 
     /**
-     * testInflectorSlugWithMap method
+     * testSlugWithMap method
      *
      * @return void
      */
-    public function testInflectorSlugWithMap()
+    public function testSlugWithMap()
     {
         Inflector::rules('transliteration', ['r' => '1']);
         $result = Inflector::slug('replace every r');
@@ -354,11 +354,11 @@ class InflectorTest extends TestCase
     }
 
     /**
-     * testInflectorSlugWithMapOverridingDefault method
+     * testSlugWithMapOverridingDefault method
      *
      * @return void
      */
-    public function testInflectorSlugWithMapOverridingDefault()
+    public function testSlugWithMapOverridingDefault()
     {
         Inflector::rules('transliteration', ['å' => 'aa', 'ø' => 'oe']);
         $result = Inflector::slug('Testing æ ø å', '-');
@@ -367,11 +367,11 @@ class InflectorTest extends TestCase
     }
 
     /**
-     * testInflectorUnderscore method
+     * testUnderscore method
      *
      * @return void
      */
-    public function testInflectorUnderscore()
+    public function testUnderscore()
     {
         $this->assertSame('test_thing', Inflector::underscore('TestThing'));
         $this->assertSame('test_thing', Inflector::underscore('testThing'));


### PR DESCRIPTION
Following discussions related to #5851 - These changes make the inflector methods more strict/consistent.

E.g.:

```
 $this->assertSame('test_this_thing', Inflector::dasherize('test_this_thing'), 'Should be unchanged');
```

Because dasherize previously wrapped underscore, it could be (ab)used to accept underscored input even if that wasn't desired.
