### PR TITLE
3.0 - PostgreSQL & quoting identifier

### DIFF
--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1413,6 +1413,24 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test that should be failing on Postgre but pass for SQLite
+     * and MySQL
+     *
+     * @return void
+     */
+    public function testFailingOnPostgre() {
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['total' => 'count(author_id)', 'author_id'])
+            ->from(['Articles' => 'articles'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'Articles.author_id = a.id'])
+            ->group('Articles.author_id')
+            ->execute();
+        $expected = [['total' => 2, 'author_id' => 1], ['total' => '1', 'author_id' => 3]];
+        $this->assertEquals($expected, $result->fetchAll('assoc'));
+    }
+
+    /**
      * Tests that group by fields can be passed similar to select fields
      * and that it sends the correct query to the database
      *


### PR DESCRIPTION
I am waiting for Travis to see if the error reported on #5871 is not just from my local set up
(I actually wanted to do that on my fork to confirm what I initially observed without creating a PR just for the failing test but I'm quite tired and messed up when chosing my target, sorry about that).

Extract from my issue ticket :

Hi there.

I don't know if it's a bug since I basically know nothing about PostgreSQL, but I found a strange behavior when making a query on PostgreSQL with the `quoteIdentifiers` option set to `true` on on my connection config.

Consider the following test (based on the QueryTest::testSelectGroup() from the core) :

``` php
ConnectionManager::config('test', [
    'className' => 'Cake\Database\Connection',
    'driver' => 'Cake\Database\Driver\Postgres',
    //[...]
    'quoteIdentifiers' => true
]);

$query = new Query(ConnectionManager::get('test'));
$result = $query
            ->select(['total' => 'count(author_id)', 'author_id'])
            ->from(['Articles' => 'articles'])
            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'Articles.author_id = a.id'])
            ->group('Articles.author_id')
            ->execute();
$expected = [['total' => 2, 'author_id' => 1], ['total' => '1', 'author_id' => 3]];
$this->assertEquals($expected, $result->fetchAll('assoc'));
```

This test pass on SQLite, MySQL but triggers an error on PostgreSQL.
On PostgreSQL, the resulting query looks like this :

``` sql
SELECT count("author_id") AS "total", "author_id" FROM "articles" "Articles" INNER JOIN "authors" "a" ON Articles.author_id = a.id GROUP BY "Articles"."author_id"
```

which triggers the following error and hint `ERROR:  invalid reference to FROM-clause entry for table "articles"` ;  `HINT:  Perhaps you meant to reference the table alias "Articles".`

However, if I wrap the `Articles` with a `"` from `[...] ON Articles.[...]`, the query does not trigger the error.

I created a failing and am waiting for Travis to see if it's just on my local set up
