### PR TITLE
Made Cake\Database\Type\DateTimeType::marshal handle timezones

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -157,8 +157,9 @@ class DateTimeType extends \Cake\Database\Type
             $value['minute'],
             $value['second']
         );
+        $tz = isset($value['timezone']) ? $value['timezone'] : null;
 
-        return new $class($format);
+        return new $class($format, $tz);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -145,6 +145,12 @@ class DateTimeTypeTest extends TestCase
                 ],
                 new Time('2014-02-14 00:00:00')
             ],
+            [
+                [
+                    'year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 12, 'minute' => 30, 'timezone' => 'Europe/Paris'
+                ],
+                new Time('2014-02-14 11:30:00', 'UTC')
+            ],
 
             // Invalid array types
             [


### PR DESCRIPTION
Let's say that

```
$this->request->data = ['date' => [
    'year' => 2014, 
    'month' => 2, 
    'day' => 14, 
    'hour' => 10, 
    'minute' => 30, 
    'timezone' => 'Europe/Paris'
]];
```

Let's create an entity with $table->newEntity($this->request->data).

Before the pull request, $entity->date would be equal to:

```
object(Cake\I18n\Time) { 
    'time' => '2015-02-14T10:30:00+0000', 
    'timezone' => 'UTC', 
    'fixedNowTime' => false 
} 
```

which is not the correct time.

After the pull request: 

```
object(Cake\I18n\Time) { 
    'time' => '2015-02-14T10:30:00+0000', 
    'timezone' => 'Europe/Paris', 
    'fixedNowTime' => false 
} 
```

I've updated the test case to add this case.
