### PR TITLE
Simplifying how the translation table is handled

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -23,7 +23,6 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Inflector;
 
 /**
  * This behavior provides a way to translate dynamic data by keeping translations
@@ -101,16 +100,8 @@ class TranslateBehavior extends Behavior
      */
     public function initialize(array $config)
     {
-        $translationAlias = Inflector::slug($this->_config['translationTable'], '_');
+        $this->_translationTable = TableRegistry::get($this->_config['translationTable']);
 
-        if (!TableRegistry::exists($translationAlias)) {
-            $this->_translationTable = TableRegistry::get($translationAlias, [
-                'className' => $this->_config['translationTable']
-            ]);
-        } else {
-            $this->_translationTable = TableRegistry::get($translationAlias);
-        }
-        
         if ($this->config('model')) {
             $model = $this->config('model');
         } elseif ($this->config('conditions.model')) {

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -93,7 +93,7 @@ class TranslateBehaviorTest extends TestCase
         $items = $table->associations();
         $i18n = $items->getByProperty('_i18n');
 
-        $this->assertEquals('TestApp_Model_Table_I18nTable', $i18n->name());
+        $this->assertEquals('\TestApp\Model\Table\I18nTable', $i18n->name());
         $this->assertEquals('custom_i18n_table', $i18n->target()->table());
         $this->assertEquals('test_custom_i18n_datasource', $i18n->target()->connection()->configName());
     }


### PR DESCRIPTION
Since the change happened for respecting the plugin prefix in table definitions, the hack in i18n for allowing multiple `Whatever.I18n` classes can go away.
