### PR TITLE
Fixing entity source after recent changes

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1872,7 +1872,7 @@ class Table implements RepositoryInterface, EventListenerInterface
     {
         if ($data === null) {
             $class = $this->entityClass();
-            $entity = new $class(['source' => $this->registryAlias()]);
+            $entity = new $class([], ['source' => $this->registryAlias()]);
             return $entity;
         }
         if (!isset($options['associated'])) {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3587,4 +3587,19 @@ class TableTest extends TestCase
         $this->assertEquals(1, $beforeDeleteCount);
         $this->assertEquals(1, $afterDeleteCount);
     }
+
+    /**
+     * Tests that calling newEntity() on a table sets the right source alias
+     *
+     * @return void
+     */
+    public function testEntitySource()
+    {
+        $table = TableRegistry::get('Articles');
+        $this->assertEquals('Articles', $table->newEntity()->source());
+
+        Plugin::load('TestPlugin');
+        $table = TableRegistry::get('TestPlugin.Comments');
+        $this->assertEquals('TestPlugin.Comments', $table->newEntity()->source());
+    }
 }


### PR DESCRIPTION
The entity source was being set as a property and not as entity metadata
