### PR TITLE
Give a little more info than "borken"

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -516,7 +516,8 @@ class Debugger
                     substr(static::_array($var->__debugInfo(), $depth - 1, $indent), 1, -1) .
                     $end . '}';
             } catch (Exception $e) {
-                return $out . "\n(unable to export object)\n }";
+                $message = $e->getMessage();
+                return $out . "\n(unable to export object: $message)\n }";
             }
         }
 


### PR DESCRIPTION
If there's an exception when attempting to dump an object - say what the problem is.

E.g. before:

```
########## DEBUG ##########
object(Cake\ORM\Query) {
(unable to export object)
}
```

after:

```
########## DEBUG ##########
object(Cake\ORM\Query) {
(unable to export object: Articles is not associated with Authors)
}
```

We could also just dump the exception as a string instead.
