### PR TITLE
Construct engines before getting groups.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -423,7 +423,8 @@ class Cache
      * $configs = Cache::groupConfigs('posts');
      * ```
      *
-     * $config will equal to `['posts' => ['daily', 'weekly']]`
+     * $configs will equal to `['posts' => ['daily', 'weekly']]`
+     * Calling this method will load all the configured engines.
      *
      * @param string|null $group group name or null to retrieve all group mappings
      * @return array map of group and all configuration that has the same group
@@ -431,6 +432,9 @@ class Cache
      */
     public static function groupConfigs($group = null)
     {
+        foreach (array_keys(static::$_config) as $config) {
+            static::engine($config);
+        }
         if ($group === null) {
             return static::$_groups;
         }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -255,6 +255,7 @@ class CacheTest extends TestCase
      */
     public function testGroupConfigs()
     {
+        Cache::drop('test');
         Cache::config('latest', [
             'duration' => 300,
             'engine' => 'File',
@@ -265,7 +266,6 @@ class CacheTest extends TestCase
             'posts' => ['latest'],
             'comments' => ['latest'],
         ];
-        $engine = Cache::engine('latest');
         $result = Cache::groupConfigs();
         $this->assertEquals($expected, $result);
 
@@ -278,7 +278,6 @@ class CacheTest extends TestCase
             'groups' => ['posts', 'archive'],
         ]);
 
-        $engine = Cache::engine('page');
         $result = Cache::groupConfigs();
         $expected = [
             'posts' => ['latest', 'page'],
@@ -296,7 +295,6 @@ class CacheTest extends TestCase
             'groups' => ['posts', 'archive', 'comments'],
         ]);
 
-        $engine = Cache::engine('archive');
         $result = Cache::groupConfigs('archive');
         $this->assertEquals(['archive' => ['archive', 'page']], $result);
     }


### PR DESCRIPTION
Without this groupConfigs() will only return groups from engines that have been constructed. This makes groupConfigs() non-deterministic and awkward to use.

Refs #5894
