### PR TITLE
3.0 automodel alias confusion

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -176,7 +176,7 @@ class TableRegistry
         if ($className) {
             $options['className'] = $className;
         } else {
-            if (!isset($options['table'])) {
+            if (!isset($options['table']) && strpos($options['className'], '\\') === false) {
                 list(, $table) = pluginSplit($options['className']);
                 $options['table'] = Inflector::underscore($table);
             }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -173,7 +173,15 @@ class TableRegistry
             $options['className'] = Inflector::camelize($alias);
         }
         $className = App::className($options['className'], 'Model/Table', 'Table');
-        $options['className'] = $className ?: 'Cake\ORM\Table';
+        if ($className) {
+            $options['className'] = $className;
+        } else {
+            if (!isset($options['table'])) {
+                list(, $table) = pluginSplit($options['className']);
+                $options['table'] = Inflector::underscore($table);
+            }
+            $options['className'] = 'Cake\ORM\Table';
+        }
 
         if (isset(static::$_config[$alias])) {
             $options += static::$_config[$alias];

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -192,9 +192,19 @@ class TableRegistryTest extends TestCase
         $this->assertEquals('rebels', $result->table(), 'The table should be taken from options');
         $this->assertEquals('C3P0', $result->alias());
 
+        $result = TableRegistry::get('Funky.Chipmunks');
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('chipmunks', $result->table(), 'The table should be derived from the alias');
+        $this->assertEquals('Chipmunks', $result->alias());
+
+        $result = TableRegistry::get('Awesome', ['className' => 'Funky.Monkies']);
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('monkies', $result->table(), 'The table should be derived from the classname');
+        $this->assertEquals('Awesome', $result->alias());
+
         $result = TableRegistry::get('Stuff', ['className' => 'Cake\ORM\Table']);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('stuff', $result->table(), 'The table should be drived from the alias');
+        $this->assertEquals('stuff', $result->table(), 'The table should be derived from the alias');
         $this->assertEquals('Stuff', $result->alias());
     }
 

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -184,8 +184,18 @@ class TableRegistryTest extends TestCase
 
         $result = TableRegistry::get('R2D2', ['className' => 'Droids']);
         $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertEquals('droids', $result->table());
+        $this->assertEquals('droids', $result->table(), 'The table should be derived from the className');
         $this->assertEquals('R2D2', $result->alias());
+
+        $result = TableRegistry::get('C3P0', ['className' => 'Droids', 'table' => 'rebels']);
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('rebels', $result->table(), 'The table should be taken from options');
+        $this->assertEquals('C3P0', $result->alias());
+
+        $result = TableRegistry::get('Stuff', ['className' => 'Cake\ORM\Table']);
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('stuff', $result->table(), 'The table should be drived from the alias');
+        $this->assertEquals('Stuff', $result->alias());
     }
 
     /**

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -171,6 +171,24 @@ class TableRegistryTest extends TestCase
     }
 
     /**
+     * Are auto-models instanciated correctly? How about when they have an alias?
+     *
+     * @return void
+     */
+    public function testGetFallbacks()
+    {
+        $result = TableRegistry::get('Droids');
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('droids', $result->table());
+        $this->assertEquals('Droids', $result->alias());
+
+        $result = TableRegistry::get('R2D2', ['className' => 'Droids']);
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertEquals('droids', $result->table());
+        $this->assertEquals('R2D2', $result->alias());
+    }
+
+    /**
      * Test that get() uses config data set with config()
      *
      * @return void


### PR DESCRIPTION
One of the problems I've stumbled upon with the table registry changes is that, apparently, if you use an alias with a classname/table reference that doesn't exist - the auto-model gets a table name derived from the alias rather than the asked-for table class name.

There's actually no reference to the asked-for class name in the resultant table object at the moment, e.g. debugging this:

```
$result = TableRegistry::get('R2D2', ['className' => 'Droids']);
```

Yields:

```
tests/TestCase/ORM/TableRegistryTest.php (line 186)
########## DEBUG ##########
object(Cake\ORM\Table) {

    'table' => 'r2_d2',
    'alias' => 'R2D2',
    'entityClass' => '\Cake\ORM\Entity',
    'associations' => [],
    'behaviors' => [],
    'defaultConnection' => 'default',
    'connectionName' => 'test'

}
```
