### PR TITLE
Prevent association classes confusing classname/alias

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -275,17 +275,18 @@ abstract class Association
             return $this->_targetTable = $table;
         }
 
-        if (strpos($this->_className, '\\') === false) {
-            $tableAlias = $this->_className;
+        if (strpos($this->_className, '.')) {
+            list($plugin) = pluginSplit($this->_className, true);
+            $registryAlias = $plugin . $this->_name;
         } else {
-            $tableAlias = $this->_name;
+            $registryAlias = $this->_name;
         }
 
         $config = [];
-        if (!TableRegistry::exists($tableAlias)) {
+        if (!TableRegistry::exists($registryAlias)) {
             $config = ['className' => $this->_className];
         }
-        $this->_targetTable = TableRegistry::get($tableAlias, $config);
+        $this->_targetTable = TableRegistry::get($registryAlias, $config);
 
         return $this->_targetTable;
     }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -36,7 +36,7 @@ class BelongsToTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.comments'];
+    public $fixtures = ['core.articles', 'core.comments', 'core.authors'];
 
     /**
      * Don't autoload fixtures as most tests uses mocks.
@@ -100,6 +100,28 @@ class BelongsToTest extends TestCase
     {
         $assoc = new BelongsTo('Test');
         $this->assertTrue($assoc->canBeJoined());
+    }
+
+    /**
+     * Tests that the alias set on associations is actually on the Entity
+     *
+     * @return void
+     */
+    public function testCustomAlias()
+    {
+        $table = TableRegistry::get('Articles', [
+            'className' => 'TestPlugin.Articles'
+        ]);
+        $table->addAssociations([
+            'belongsTo' => [
+                'FooAuthors' => ['className' => 'TestPlugin.Authors', 'foreignKey' => 'author_id']
+            ]
+        ]);
+        $article = $table->find()->contain(['FooAuthors'])->first();
+
+        $this->assertTrue(isset($article->foo_author));
+        $this->assertEquals($article->foo_author->name, 'mariano');
+        $this->assertNull($article->Authors);
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -178,7 +178,6 @@ class AssociationTest extends TestCase
     public function testTargetPlugin()
     {
         Plugin::load('TestPlugin');
-
         $config = [
             'className' => 'TestPlugin.Comments',
             'foreignKey' => 'a_key',

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -196,12 +196,16 @@ class AssociationTest extends TestCase
         $table = $this->association->target();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $table);
 
-        $this->assertTrue(TableRegistry::exists('TestPlugin.Comments'));
-        $this->assertFalse(TableRegistry::exists('Comments'));
-        $this->assertFalse(TableRegistry::exists('ThisAssociationName'));
+        $this->assertTrue(TableRegistry::exists('TestPlugin.ThisAssociationName'), 'The association class will use this registry key');
+        $this->assertFalse(TableRegistry::exists('TestPlugin.Comments', 'The association clas will NOT use this key'));
+        $this->assertFalse(TableRegistry::exists('Comments', 'Should also not be set'));
+        $this->assertFalse(TableRegistry::exists('ThisAssociationName', 'Should also not be set'));
 
-        $plugin = TableRegistry::get('TestPlugin.Comments');
-        $this->assertSame($table, $plugin, 'Should be the same TestPlugin.Comments object');
+        $plugin = TableRegistry::get('TestPlugin.ThisAssociationName');
+        $this->assertSame($table, $plugin, 'Should be an instance of TestPlugin.Comments');
+        $this->assertSame('TestPlugin.ThisAssociationName', $table->registryAlias());
+        $this->assertSame('comments', $table->table());
+        $this->assertSame('ThisAssociationName', $table->alias());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -533,6 +533,49 @@ class TableTest extends TestCase
     }
 
     /**
+     * testNoneUniqueAssociationsSameClass
+     *
+     * @return void
+     */
+    public function testNoneUniqueAssociationsSameClass()
+    {
+        $Users = new Table(['table' => 'users']);
+        $options = ['className' => 'Comments'];
+        $Users->hasMany('Comments', $options);
+
+        $Articles = new Table(['table' => 'articles']);
+        $options = ['className' => 'Comments'];
+        $Articles->hasMany('Comments', $options);
+
+        $Categories = new Table(['table' => 'categories']);
+        $options = ['className' => 'TestPlugin.Comments'];
+        $Categories->hasMany('Comments', $options);
+
+        $this->assertInstanceOf('Cake\ORM\Table', $Users->Comments->target());
+        $this->assertInstanceOf('Cake\ORM\Table', $Articles->Comments->target());
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $Categories->Comments->target());
+    }
+
+    /**
+     * testMultipleAssociationsSameClass
+     *
+     * @return void
+     */
+    public function testMultipleAssociationsSameClass()
+    {
+        $Comments = new Table(['table' => 'comments']);
+        $options = ['className' => 'Comments'];
+        $Comments->hasMany('Children', $options);
+        $Comments->belongsTo('Parent', $options);
+
+        $this->assertSame('Children', $Comments->Children->alias());
+        $this->assertSame('Children', $Comments->Children->target()->alias());
+
+        $this->assertSame('Parent', $Comments->Parent->alias());
+        $this->assertSame('Parent', $Comments->Parent->target()->alias());
+    }
+
+    /**
      * Tests that hasMany() creates and configures correctly the association
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -568,6 +568,9 @@ class TableTest extends TestCase
         $Comments->hasMany('Children', $options);
         $Comments->belongsTo('Parent', $options);
 
+        $this->assertSame('comments', $Comments->Children->target()->table());
+        $this->assertSame('comments', $Comments->Parent->target()->table());
+
         $this->assertSame('Children', $Comments->Children->alias());
         $this->assertSame('Children', $Comments->Children->target()->alias());
 


### PR DESCRIPTION
After much folly, by changing the association object to use a plugin-prefixed (if necessary) alias, always, we can prevent association objects finding an already-registered table instance of the right class with the wrong alias set _without_ borking any existing use cases such as `DebugKit.Requests` and `MyPlugin.Requests` getting confused.

Closes #5898 

Are there any reported use cases missed, that need a test case? let me know =).
