### PR TITLE
3.0 - Adding failing test to compare Entity sources

### DIFF
--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Core\Plugin;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -41,6 +42,7 @@ class EntityTest extends TestCase
      */
     public function testEntitySourceExistingAndNew()
     {
+        Plugin::load('TestPlugin');
         $this->loadFixtures('Authors');
         $table = TableRegistry::get('TestPlugin.Authors');
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -47,7 +47,8 @@ class EntityTest extends TestCase
         $existingAuthor = $table->find()->first();
         $newAuthor = $table->newEntity();
 
-        $this->assertSame($existingAuthor->source(), $newAuthor->source());
+        $this->assertEquals('TestPlugin.Authors', $existingAuthor->source());
+        $this->assertEquals('TestPlugin.Authors', $newAuthor->source());
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use TestApp\Model\Entity\Extending;
@@ -25,6 +26,29 @@ use TestApp\Model\Entity\NonExtending;
  */
 class EntityTest extends TestCase
 {
+
+    /**
+     * Fixtures to be used
+     *
+     * @var array
+     */
+    public $fixtures = ['core.authors'];
+
+    /**
+     * Tests that the source of an existing Entity is the same as a new one
+     *
+     * @return void
+     */
+    public function testEntitySourceExistingAndNew()
+    {
+        $this->loadFixtures('Authors');
+        $table = TableRegistry::get('TestPlugin.Authors');
+
+        $existingAuthor = $table->find()->first();
+        $newAuthor = $table->newEntity();
+
+        $this->assertSame($existingAuthor->source(), $newAuthor->source());
+    }
 
     /**
      * Tests setting a single property in an entity without custom setters


### PR DESCRIPTION
If this test fails it means that EntityContext::_prepare uses the incorrect string for the table alias.

When `Cake\View\Form\EntityContext::_prepare` does this:

```
if ($isEntity) {
    $table = $entity->source();
}
```

It returns the wrong string, and attempts to get something from the TR that doesn't necessarily match the Table that was used to create the Entity.

cc @AD7six 
Refs #5836
