### PR TITLE
Fix entity->source() for hydrated results

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -472,7 +472,7 @@ class ResultSet implements ResultSetInterface
             $results[$defaultAlias]['_matchingData'] = $results['_matchingData'];
         }
 
-        $options['source'] = $defaultAlias;
+        $options['source'] = $this->_defaultTable->registryAlias();
         $results = $results[$defaultAlias];
         if ($this->_hydrate && !($results instanceof Entity)) {
             $results = new $this->_entityClass($results, $options);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2158,6 +2158,7 @@ class Table implements RepositoryInterface, EventListenerInterface
     {
         $conn = $this->connection();
         return [
+            'registryAlias' => $this->registryAlias(),
             'table' => $this->table(),
             'alias' => $this->alias(),
             'entityClass' => $this->entityClass(),

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2484,6 +2484,23 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that the source of an existing Entity is the same as a new one
+     *
+     * @return void
+     */
+    public function testEntitySourceExistingAndNew()
+    {
+        Plugin::load('TestPlugin');
+        $table = TableRegistry::get('TestPlugin.Authors');
+
+        $existingAuthor = $table->find()->first();
+        $newAuthor = $table->newEntity();
+
+        $this->assertEquals('TestPlugin.Authors', $existingAuthor->source());
+        $this->assertEquals('TestPlugin.Authors', $newAuthor->source());
+    }
+
+    /**
      * Tests that calling an entity with an empty array will run validation
      * whereas calling it with no parameters will not run any validation.
      *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3508,11 +3508,26 @@ class TableTest extends TestCase
         $articles->addBehavior('Timestamp');
         $result = $articles->__debugInfo();
         $expected = [
+            'registryAlias' => 'articles',
             'table' => 'articles',
             'alias' => 'articles',
             'entityClass' => 'TestApp\Model\Entity\Article',
             'associations' => ['authors', 'tags', 'articlestags'],
             'behaviors' => ['Timestamp'],
+            'defaultConnection' => 'default',
+            'connectionName' => 'test'
+        ];
+        $this->assertEquals($expected, $result);
+
+        $articles = TableRegistry::get('Foo.Articles');
+        $result = $articles->__debugInfo();
+        $expected = [
+            'registryAlias' => 'Foo.Articles',
+            'table' => 'articles',
+            'alias' => 'Articles',
+            'entityClass' => '\Cake\ORM\Entity',
+            'associations' => [],
+            'behaviors' => [],
             'defaultConnection' => 'default',
             'connectionName' => 'test'
         ];


### PR DESCRIPTION
The table alias is not the key used in the table registry when it's a plugin model. This allows entity objects created when hydrating results to know from which table object they came.

Also added registryAlias to the table object debugInfo.

Fixes/closes #5913 
