### PR TITLE
Fix incorrect marshalling of _joinData.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -159,7 +159,7 @@ class Type
      */
     public function toDatabase($value, Driver $driver)
     {
-        return $this->_basicTypeCast($value, $driver);
+        return $this->_basicTypeCast($value);
     }
 
     /**
@@ -171,7 +171,7 @@ class Type
      */
     public function toPHP($value, Driver $driver)
     {
-        return $this->_basicTypeCast($value, $driver);
+        return $this->_basicTypeCast($value);
     }
 
     /**
@@ -179,10 +179,9 @@ class Type
      * If it is, returns converted value
      *
      * @param mixed $value value to be converted to PHP equivalent
-     * @param Driver $driver object from which database preferences and configuration will be extracted
      * @return mixed
      */
-    protected function _basicTypeCast($value, Driver $driver)
+    protected function _basicTypeCast($value)
     {
         if ($value === null) {
             return null;
@@ -259,6 +258,6 @@ class Type
      */
     public function marshal($value)
     {
-        return $value;
+        return $this->_basicTypeCast($value);
     }
 }

--- a/src/ORM/AssociationsNormalizerTrait.php
+++ b/src/ORM/AssociationsNormalizerTrait.php
@@ -31,7 +31,7 @@ trait AssociationsNormalizerTrait
     protected function _normalizeAssociations($associations)
     {
         $result = [];
-        foreach ($associations as $table => $options) {
+        foreach ((array)$associations as $table => $options) {
             $pointer =& $result;
 
             if (is_int($table)) {

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -368,6 +368,27 @@ class TypeTest extends TestCase
     }
 
     /**
+     * Test marshalling booleans
+     *
+     * @return void
+     */
+    public function testBooleanMarshal()
+    {
+        $type = Type::build('boolean');
+        $this->assertTrue($type->marshal(true));
+        $this->assertTrue($type->marshal(1));
+        $this->assertTrue($type->marshal('1'));
+        $this->assertTrue($type->marshal('true'));
+
+        $this->assertFalse($type->marshal('false'));
+        $this->assertFalse($type->marshal('0'));
+        $this->assertFalse($type->marshal(0));
+        $this->assertFalse($type->marshal(''));
+        $this->assertFalse($type->marshal('invalid'));
+    }
+
+
+    /**
      * Tests uuid from database are converted correctly to PHP
      *
      * @return void


### PR DESCRIPTION
This fixes _joinData not being correctly marshaled when entities do not have _joinData marked as accessible. I've also:
- Stripped out invalid scalar data.
- Fixed a potential error when defining `associated` options.
- Fixed boolean values not being marshaled correctly.

Refs #5542
