### PR TITLE
Session::write lied about its return (value)

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -416,7 +416,6 @@ class Session
      *
      * @param string|array $name Name of variable
      * @param string|null $value Value to write
-     * @return bool True if the write was successful, false if the write failed
      */
     public function write($name, $value = null)
     {

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -416,6 +416,7 @@ class Session
      *
      * @param string|array $name Name of variable
      * @param string|null $value Value to write
+     * @return void
      */
     public function write($name, $value = null)
     {


### PR DESCRIPTION
I think removing it is correct.. following `_overwrite` no chance to get some return
