### PR TITLE
Guard against missing new entities.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -471,11 +471,13 @@ class Marshaller
                 return $query->orWhere($query->newExpr()->and_(array_combine($primary, $keys)));
             }, $this->_table->find());
 
-        if (count($maybeExistentQuery->clause('where'))) {
+        if (!empty($indexed) && count($maybeExistentQuery->clause('where'))) {
             foreach ($maybeExistentQuery as $entity) {
                 $key = implode(';', $entity->extract($primary));
-                $output[] = $this->merge($entity, $indexed[$key], $options);
-                unset($indexed[$key]);
+                if (isset($indexed[$key])) {
+                    $output[] = $this->merge($entity, $indexed[$key], $options);
+                    unset($indexed[$key]);
+                }
             }
         }
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1270,6 +1270,7 @@ class MarshallerTest extends TestCase
         $marshall = new Marshaller($comments);
         $result = $marshall->mergeMany($entities, $data);
 
+        $this->assertCount(3, $result);
         $this->assertEquals('Changed 1', $result[0]->comment);
         $this->assertEquals(1, $result[0]->user_id);
         $this->assertEquals('Changed 2', $result[1]->comment);


### PR DESCRIPTION
If a find operation has been modified via an event listener or overloaded find method we should avoid trying to marshal data that doesn't exist.

Refs #5922
