### PR TITLE
Implement a map option for resources().

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -232,6 +232,7 @@ class RouteBuilder
      *
      * - 'id' - The regular expression fragment to use when matching IDs. By default, matches
      *    integer values and UUIDs.
+     * - 'inflect' - Choose the inflection method used on the resource name. Defaults to 'underscore'.
      * - 'only' - Only connect the specific list of actions.
      * - 'actions' - Override the method names used for connecting actions.
      * - 'map' - Additional resource routes that should be connected. If you define 'only' and 'map',
@@ -251,6 +252,7 @@ class RouteBuilder
         }
         $options += [
             'connectOptions' => [],
+            'inflect' => 'underscore',
             'id' => static::ID . '|' . static::UUID,
             'only' => [],
             'actions' => [],
@@ -267,7 +269,7 @@ class RouteBuilder
         }
 
         $connectOptions = $options['connectOptions'];
-        $urlName = Inflector::underscore($name);
+        $urlName = Inflector::{$options['inflect']}($name);
         $resourceMap = array_merge(static::$_resourceMap, $options['map']);
 
         $only = (array)$options['only'];

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -269,9 +269,14 @@ class Router
      *    integer values and UUIDs.
      * - 'prefix' - Routing prefix to use for the generated routes. Defaults to ''.
      *   Using this option will create prefixed routes, similar to using Routing.prefixes.
+     * - 'only' - Only connect the specific list of actions.
+     * - 'actions' - Override the method names used for connecting actions.
+     * - 'map' - Additional resource routes that should be connected. If you define 'only' and 'map',
+     *   make sure that your mapped methods are also in the 'only' list.
      *
      * @param string|array $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
      * @param array $options Options to use when generating REST routes
+     * @see \Cake\Routing\RouteBuilder::resources()
      * @return void
      */
     public static function mapResources($controller, $options = [])

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -345,6 +345,27 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test connecting resources with the inflection option
+     *
+     * @return void
+     */
+    public function testResourcesInflection()
+    {
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes->resources('BlogPosts', ['_ext' => 'json', 'inflect' => 'dasherize']);
+
+        $all = $this->collection->routes();
+        $this->assertCount(5, $all);
+
+        $this->assertEquals('/api/blog-posts', $all[0]->template);
+        $this->assertEquals(
+            ['controller', 'action', '_method', 'prefix', 'plugin'],
+            array_keys($all[0]->defaults)
+        );
+        $this->assertEquals('BlogPosts', $all[0]->defaults['controller']);
+    }
+
+    /**
      * Test connecting resources with additional mappings
      *
      * @return void

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -345,6 +345,42 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test connecting resources with additional mappings
+     *
+     * @return void
+     */
+    public function testResourcesMappings()
+    {
+        $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'api']);
+        $routes->resources('Articles', [
+            '_ext' => 'json',
+            'map' => [
+                'delete_all' => ['action' => 'deleteAll', 'method' => 'DELETE'],
+                'update_many' => ['action' => 'updateAll', 'method' => 'DELETE', 'path' => '/updateAll'],
+            ]
+        ]);
+
+        $all = $this->collection->routes();
+        $this->assertCount(7, $all);
+
+        $this->assertEquals('/api/articles/delete_all', $all[5]->template, 'Path defaults to key name.');
+        $this->assertEquals(
+            ['controller', 'action', '_method', 'prefix', 'plugin'],
+            array_keys($all[5]->defaults)
+        );
+        $this->assertEquals('Articles', $all[5]->defaults['controller']);
+        $this->assertEquals('deleteAll', $all[5]->defaults['action']);
+
+        $this->assertEquals('/api/articles/updateAll', $all[6]->template, 'Explicit path option');
+        $this->assertEquals(
+            ['controller', 'action', '_method', 'prefix', 'plugin'],
+            array_keys($all[6]->defaults)
+        );
+        $this->assertEquals('Articles', $all[6]->defaults['controller']);
+        $this->assertEquals('updateAll', $all[6]->defaults['action']);
+    }
+
+    /**
      * Test connecting resources.
      *
      * @return void


### PR DESCRIPTION
Having a map option allows users to map additional resource methods into their routes. This is handy when apps have custom actions they want mapped onto resources.

Refs #5929
