### PR TITLE
Ignore LC_TIME category when extracting messages.

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -432,6 +432,7 @@ class ExtractTask extends AppShell {
 					$category = isset($category) ? $category : 6;
 					$category = (int)$category;
 					$categoryName = $categories[$category];
+
 					$domain = isset($domain) ? $domain : 'default';
 					$details = array(
 						'file' => $this->_file,
@@ -443,7 +444,10 @@ class ExtractTask extends AppShell {
 					if (isset($context)) {
 						$details['msgctxt'] = $context;
 					}
-					$this->_addTranslation($categoryName, $domain, $singular, $details);
+					// Skip LC_TIME files as we use a special file format for them.
+					if ($categoryName !== 'LC_TIME') {
+						$this->_addTranslation($categoryName, $domain, $singular, $details);
+					}
 				} else {
 					$this->_markerError($this->_file, $line, $functionName, $count);
 				}

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -162,19 +162,19 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->assertContains('msgid "double \\"quoted\\""', $result, 'Strings with quotes not handled correctly');
 		$this->assertContains("msgid \"single 'quoted'\"", $result, 'Strings with quotes not handled correctly');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:34\nmsgid "letter"/';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:36\nmsgid "letter"/';
 		$this->assertRegExp($pattern, $result, 'Strings with context should not overwrite strings without context');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:35;37\nmsgctxt "A"\nmsgid "letter"/';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:37;39\nmsgctxt "A"\nmsgid "letter"/';
 		$this->assertRegExp($pattern, $result, 'Should contain string with context "A"');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:36\nmsgctxt "B"\nmsgid "letter"/';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:38\nmsgctxt "B"\nmsgid "letter"/';
 		$this->assertRegExp($pattern, $result, 'Should contain string with context "B"');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:38\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:40\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
 		$this->assertRegExp($pattern, $result, 'Plural strings with context should not overwrite strings without context');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:39\nmsgctxt "A"\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:41\nmsgctxt "A"\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
 		$this->assertRegExp($pattern, $result, 'Should contain plural string with context "A"');
 
 		// extract.ctp - reading the domain.pot
@@ -209,11 +209,15 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->Task->expects($this->never())->method('_stop');
 
 		$this->Task->execute();
-		$this->assertTrue(file_exists($this->path . DS . 'LC_TIME' . DS . 'default.pot'));
+		$this->assertTrue(file_exists($this->path . DS . 'LC_NUMERIC' . DS . 'default.pot'));
+		$this->assertFalse(file_exists($this->path . DS . 'LC_TIME' . DS . 'default.pot'));
 
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
 		$pattern = '/\#: .*extract\.ctp:31\n/';
+		$this->assertNotRegExp($pattern, $result);
+
+		$pattern = '/\#: .*extract\.ctp:33\n/';
 		$this->assertNotRegExp($pattern, $result);
 	}
 

--- a/lib/Cake/Test/test_app/View/Pages/extract.ctp
+++ b/lib/Cake/Test/test_app/View/Pages/extract.ctp
@@ -28,6 +28,8 @@ __('Hot features!'
 		. ' Join us #cakephp on IRC. We\'d love to help you get started');
 
 // Category
+echo __c('You have a new message (category: LC_NUMERIC).', 4);
+// LC_TIME is skipped.
 echo __c('You have a new message (category: LC_TIME).', 5);
 
 // Context


### PR DESCRIPTION
Given that we use the specific LC_TIME file format, it doesn't make much sense to extract translated strings into a PO file that cannot be used later on.

Refs #5933
