### PR TITLE
[3.0] Correct autoloading/bootstrapping order for plugins

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -156,10 +156,6 @@ class Plugin
 
         static::$_plugins[$plugin] = $config;
 
-        if ($config['bootstrap'] === true) {
-            static::bootstrap($plugin);
-        }
-
         if ($config['autoload'] === true) {
             if (empty(static::$_loader)) {
                 static::$_loader = new ClassLoader;
@@ -173,6 +169,10 @@ class Plugin
                 str_replace('/', '\\', $plugin) . '\Test',
                 $config['path'] . 'tests' . DS
             );
+        }
+
+        if ($config['bootstrap'] === true) {
+            static::bootstrap($plugin);
         }
     }
 

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -95,18 +95,18 @@ class PluginTest extends TestCase
      */
     public function testLoadSingleWithAutoloadAndBootstrap()
     {
-        $this->assertFalse(class_exists('Company\TestPluginThree\Utility\Hello'));
+        $this->assertFalse(class_exists('Company\TestPluginFive\Utility\Hello'));
         Plugin::load(
-            'Company/TestPluginThree',
+            'Company/TestPluginFive',
             [
                 'autoload' => true,
                 'bootstrap' => true
             ]
         );
-        $this->assertTrue(Configure::read('PluginTest.test_plugin_three.autoload'));
-        $this->assertEquals('loaded plugin three bootstrap', Configure::read('PluginTest.test_plugin_three.bootstrap'));
+        $this->assertTrue(Configure::read('PluginTest.test_plugin_five.autoload'));
+        $this->assertEquals('loaded plugin five bootstrap', Configure::read('PluginTest.test_plugin_five.bootstrap'));
         $this->assertTrue(
-            class_exists('Company\TestPluginThree\Utility\Hello'),
+            class_exists('Company\TestPluginFive\Utility\Hello'),
             'Class should be loaded'
         );
     }

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -89,6 +89,29 @@ class PluginTest extends TestCase
     }
 
     /**
+     * Test load() with the autoload option.
+     *
+     * @return void
+     */
+    public function testLoadSingleWithAutoloadAndBootstrap()
+    {
+        $this->assertFalse(class_exists('Company\TestPluginThree\Utility\Hello'));
+        Plugin::load(
+            'Company/TestPluginThree',
+            [
+                'autoload' => true,
+                'bootstrap' => true
+            ]
+        );
+        $this->assertTrue(Configure::read('PluginTest.test_plugin_three.autoload'));
+        $this->assertEquals('loaded plugin three bootstrap', Configure::read('PluginTest.test_plugin_three.bootstrap'));
+        $this->assertTrue(
+            class_exists('Company\TestPluginThree\Utility\Hello'),
+            'Class should be loaded'
+        );
+    }
+
+    /**
      * Tests loading a plugin and its bootstrap file
      *
      * @return void

--- a/tests/test_app/Plugin/Company/TestPluginFive/config/bootstrap.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/config/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+use Cake\Core\Configure;
+
+Configure::write('PluginTest.test_plugin_five.bootstrap', 'loaded plugin five bootstrap');
+Configure::write('PluginTest.test_plugin_five.autoload', class_exists('Company\TestPluginFive\Utility\Hello'));

--- a/tests/test_app/Plugin/Company/TestPluginFive/config/bootstrap.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/config/bootstrap.php
@@ -3,3 +3,4 @@ use Cake\Core\Configure;
 
 Configure::write('PluginTest.test_plugin_five.bootstrap', 'loaded plugin five bootstrap');
 Configure::write('PluginTest.test_plugin_five.autoload', class_exists('Company\TestPluginFive\Utility\Hello'));
+

--- a/tests/test_app/Plugin/Company/TestPluginFive/config/bootstrap.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/config/bootstrap.php
@@ -3,4 +3,3 @@ use Cake\Core\Configure;
 
 Configure::write('PluginTest.test_plugin_five.bootstrap', 'loaded plugin five bootstrap');
 Configure::write('PluginTest.test_plugin_five.autoload', class_exists('Company\TestPluginFive\Utility\Hello'));
-

--- a/tests/test_app/Plugin/Company/TestPluginFive/src/Utility/Hello.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/src/Utility/Hello.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Company\TestPluginFive\Utility;
+
+class Hello
+{
+
+    /**
+     * foo method
+     *
+     * @return string
+     */
+    public function foo()
+    {
+        return 'bar';
+    }
+}

--- a/tests/test_app/Plugin/Company/TestPluginThree/config/bootstrap.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/config/bootstrap.php
@@ -3,3 +3,4 @@ use Cake\Core\Configure;
 
 Configure::write('PluginTest.test_plugin_three.bootstrap', 'loaded plugin three bootstrap');
 Configure::write('PluginTest.test_plugin_three.autoload', class_exists('Company\TestPluginThree\Utility\Hello'));
+

--- a/tests/test_app/Plugin/Company/TestPluginThree/config/bootstrap.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/config/bootstrap.php
@@ -2,5 +2,3 @@
 use Cake\Core\Configure;
 
 Configure::write('PluginTest.test_plugin_three.bootstrap', 'loaded plugin three bootstrap');
-Configure::write('PluginTest.test_plugin_three.autoload', class_exists('Company\TestPluginThree\Utility\Hello'));
-

--- a/tests/test_app/Plugin/Company/TestPluginThree/config/bootstrap.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/config/bootstrap.php
@@ -2,3 +2,4 @@
 use Cake\Core\Configure;
 
 Configure::write('PluginTest.test_plugin_three.bootstrap', 'loaded plugin three bootstrap');
+Configure::write('PluginTest.test_plugin_three.autoload', class_exists('Company\TestPluginThree\Utility\Hello'));


### PR DESCRIPTION
When loading a plugin using

``` php
Plugin::load('Test', ['autoload' => true, 'bootstrap' => true]);
```

The bootstrap was loaded before the plugin was added to the autoloader. This creates problems when the plugin bootstrap refers to a class contained within the plugin.

Moved the bootstrap to after the autoload and added a test to ensure that autoloading is done correctly.
