### PR TITLE
Changed the translate behavior to support translation engines.

### DIFF
--- a/src/ORM/Behavior/Translate/EavEngine.php
+++ b/src/ORM/Behavior/Translate/EavEngine.php
@@ -18,12 +18,9 @@ namespace Cake\ORM\Behavior\Translate;
 use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Event\Event;
-use Cake\I18n\I18n;
-use Cake\Core\InstanceConfigTrait;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -38,67 +35,11 @@ use Cake\ORM\TableRegistry;
  * If you want to bring all or certain languages for each of the fetched records,
  * you can use the custom `translations` finders that is exposed to the table.
  */
-class EavEngine
+class EavEngine extends TranslationEngine
 {
 
-    use InstanceConfigTrait;
-
     /**
-     * Table instance
-     *
-     * @var \Cake\ORM\Table
-     */
-    protected $_table;
-
-    /**
-     * The locale name that will be used to override fields in the bound table
-     * from the translations table
-     *
-     * @var string
-     */
-    protected $_locale;
-
-    /**
-     * Instance of Table responsible for translating
-     *
-     * @var \Cake\ORM\Table
-     */
-    protected $_translationTable;
-
-    /**
-     * Default config
-     *
-     * These are merged with user-provided configuration when the behavior is used.
-     *
-     * @var array
-     */
-    protected $_defaultConfig = [
-        'implementedFinders' => ['translations' => 'findTranslations'],
-        'implementedMethods' => ['locale' => 'locale'],
-        'fields' => [],
-        'translationTable' => 'I18n',
-        'defaultLocale' => '',
-        'model' => '',
-        'onlyTranslated' => false,
-        'strategy' => 'subquery',
-        'conditions' => ['model' => '']
-    ];
-
-    /**
-     * Constructor
-     *
-     * @param \Cake\ORM\Table $table The table this behavior is attached to.
-     * @param array $config The config for this behavior.
-     */
-    public function __construct(Table $table, array $config = [])
-    {
-        $config += ['defaultLocale' => I18n::defaultLocale()];
-        $this->config($config);
-        $this->_table = $table;
-    }
-
-    /**
-     * Initialize hook
+     * {@inheritDoc}
      *
      * @param array $config The config for this behavior.
      * @return void
@@ -183,9 +124,7 @@ class EavEngine
     }
 
     /**
-     * Callback method that listens to the `beforeFind` event in the bound
-     * table. It modifies the passed query by eager loading the translated fields
-     * and adding a formatter to copy the values into the main table records.
+     * {@inheritDoc}
      *
      * @param \Cake\Event\Event $event The beforeFind event that was fired.
      * @param \Cake\ORM\Query $query Query
@@ -247,8 +186,7 @@ class EavEngine
     }
 
     /**
-     * Modifies the entity before it is saved so that translated fields are persisted
-     * in the database too.
+     * {@inheritDoc}
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
      * @param \Cake\ORM\Entity $entity The entity that is going to be saved
@@ -304,7 +242,7 @@ class EavEngine
     }
 
     /**
-     * Unsets the temporary `_i18n` property after the entity has been saved
+     * {@inheritDoc}
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
      * @param \Cake\ORM\Entity $entity The entity that is going to be saved
@@ -316,38 +254,7 @@ class EavEngine
     }
 
     /**
-     * Sets all future finds for the bound table to also fetch translated fields for
-     * the passed locale. If no value is passed, it returns the currently configured
-     * locale
-     *
-     * @param string|null $locale The locale to use for fetching translated records
-     * @return string
-     */
-    public function locale($locale = null)
-    {
-        if ($locale === null) {
-            return $this->_locale ?: I18n::locale();
-        }
-        return $this->_locale = (string)$locale;
-    }
-
-    /**
-     * Custom finder method used to retrieve all translations for the found records.
-     * Fetched translations can be filtered by locale by passing the `locales` key
-     * in the options array.
-     *
-     * Translated values will be found for each entity under the property `_translations`,
-     * containing an array indexed by locale name.
-     *
-     * ### Example:
-     *
-     * ```
-     * $article = $articles->find('translations', ['locales' => ['eng', 'deu'])->first();
-     * $englishTranslatedFields = $article->get('_translations')['eng'];
-     * ```
-     *
-     * If the `locales` array is not passed, it will bring all translations found
-     * for each record.
+     * {@inheritDoc}
      *
      * @param \Cake\ORM\Query $query The original query to modify
      * @param array $options Options

--- a/src/ORM/Behavior/Translate/EavEngine.php
+++ b/src/ORM/Behavior/Translate/EavEngine.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\ORM\Behavior\Translate;
+
+use ArrayObject;
+use Cake\Collection\Collection;
+use Cake\Event\Event;
+use Cake\I18n\I18n;
+use Cake\Core\InstanceConfigTrait;
+use Cake\ORM\Behavior;
+use Cake\ORM\Entity;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+/**
+ * This behavior provides a way to translate dynamic data by keeping translations
+ * in a separate table linked to the original record from another one. Translated
+ * fields can be configured to override those in the main table when fetched or
+ * put aside into another property for the same entity.
+ *
+ * If you wish to override fields, you need to call the `locale` method in this
+ * behavior for setting the language you want to fetch from the translations table.
+ *
+ * If you want to bring all or certain languages for each of the fetched records,
+ * you can use the custom `translations` finders that is exposed to the table.
+ */
+class EavEngine
+{
+
+    use InstanceConfigTrait;
+
+    /**
+     * Table instance
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $_table;
+
+    /**
+     * The locale name that will be used to override fields in the bound table
+     * from the translations table
+     *
+     * @var string
+     */
+    protected $_locale;
+
+    /**
+     * Instance of Table responsible for translating
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $_translationTable;
+
+    /**
+     * Default config
+     *
+     * These are merged with user-provided configuration when the behavior is used.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'implementedFinders' => ['translations' => 'findTranslations'],
+        'implementedMethods' => ['locale' => 'locale'],
+        'fields' => [],
+        'translationTable' => 'I18n',
+        'defaultLocale' => '',
+        'model' => '',
+        'onlyTranslated' => false,
+        'strategy' => 'subquery',
+        'conditions' => ['model' => '']
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\ORM\Table $table The table this behavior is attached to.
+     * @param array $config The config for this behavior.
+     */
+    public function __construct(Table $table, array $config = [])
+    {
+        $config += ['defaultLocale' => I18n::defaultLocale()];
+        $this->config($config);
+        $this->_table = $table;
+    }
+
+    /**
+     * Initialize hook
+     *
+     * @param array $config The config for this behavior.
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+        $this->_translationTable = TableRegistry::get($this->_config['translationTable']);
+
+        if ($this->config('model')) {
+            $model = $this->config('model');
+        } elseif ($this->config('conditions.model')) {
+            $model = $this->config('conditions.model');
+        } else {
+            $model = $this->_table->alias();
+        }
+        $this->config('conditions.model', $model);
+
+        $this->setupFieldAssociations(
+            $this->_config['fields'],
+            $this->_config['translationTable'],
+            $this->_config['conditions'],
+            $this->_config['strategy']
+        );
+    }
+
+    /**
+     * Creates the associations between the bound table and every field passed to
+     * this method.
+     *
+     * Additionally it creates a `i18n` HasMany association that will be
+     * used for fetching all translations for each record in the bound table
+     *
+     * @param array $fields list of fields to create associations for
+     * @param string $table the table name to use for storing each field translation
+     * @param array $fieldConditions conditions for finding fields
+     * @param string $strategy the strategy used in the _i18n association
+     *
+     * @return void
+     */
+    public function setupFieldAssociations($fields, $table, $fieldConditions, $strategy)
+    {
+        $targetAlias = $this->_translationTable->alias();
+        $alias = $this->_table->alias();
+        $filter = $this->_config['onlyTranslated'];
+
+        foreach ($fields as $field) {
+            $name = $alias . '_' . $field . '_translation';
+            $conditions = [
+                $name . '.model' => $fieldConditions['model'],
+                $name . '.field' => $field,
+            ];
+            foreach ($fieldConditions as $fieldName => $fieldValue) {
+                $conditions[$name . '.' . $fieldName] = $fieldValue;
+            }
+            if (!TableRegistry::exists($name)) {
+                $fieldTable = TableRegistry::get($name, [
+                    'className' => $table,
+                    'alias' => $name,
+                    'table' => $this->_translationTable->table()
+                ]);
+            } else {
+                $fieldTable = TableRegistry::get($name);
+            }
+
+            $this->_table->hasOne($name, [
+                'targetTable' => $fieldTable,
+                'foreignKey' => 'foreign_key',
+                'joinType' => $filter ? 'INNER' : 'LEFT',
+                'conditions' => $conditions,
+                'propertyName' => $field . '_translation'
+            ]);
+        }
+
+        $this->_table->hasMany($targetAlias, [
+            'className' => $table,
+            'foreignKey' => 'foreign_key',
+            'strategy' => $strategy,
+            'conditions' => ["$targetAlias.model" => $fieldConditions['model']],
+            'propertyName' => '_i18n',
+            'dependent' => true
+        ]);
+    }
+
+    /**
+     * Callback method that listens to the `beforeFind` event in the bound
+     * table. It modifies the passed query by eager loading the translated fields
+     * and adding a formatter to copy the values into the main table records.
+     *
+     * @param \Cake\Event\Event $event The beforeFind event that was fired.
+     * @param \Cake\ORM\Query $query Query
+     * @param \ArrayObject $options The options for the query
+     * @return void
+     */
+    public function beforeFind(Event $event, Query $query, $options)
+    {
+        $locale = $this->locale();
+
+        if ($locale === $this->config('defaultLocale')) {
+            return;
+        }
+
+        $conditions = function ($field, $locale, $query, $select) {
+            return function ($q) use ($field, $locale, $query, $select) {
+                $q->where([$q->repository()->alias() . '.locale' => $locale]);
+                $alias = $this->_table->alias();
+
+                if ($query->autoFields() ||
+                    in_array($field, $select, true) ||
+                    in_array("$alias.$field", $select, true)
+                ) {
+                    $q->select(['id', 'content']);
+                }
+
+                return $q;
+            };
+        };
+
+        $contain = [];
+        $fields = $this->_config['fields'];
+        $alias = $this->_table->alias();
+        $select = $query->clause('select');
+
+        $changeFilter = isset($options['filterByCurrentLocale']) &&
+            $options['filterByCurrentLocale'] !== $this->_config['onlyTranslated'];
+
+        foreach ($fields as $field) {
+            $name = $alias . '_' . $field . '_translation';
+
+            $contain[$name]['queryBuilder'] = $conditions(
+            $field,
+            $locale,
+            $query,
+            $select
+            );
+
+            if ($changeFilter) {
+                $filter = $options['filterByCurrentLocale'] ? 'INNER' : 'LEFT';
+                $contain[$name]['joinType'] = $filter;
+            }
+        }
+
+        $query->contain($contain);
+        $query->formatResults(function ($results) use ($locale) {
+            return $this->_rowMapper($results, $locale);
+        }, $query::PREPEND);
+    }
+
+    /**
+     * Modifies the entity before it is saved so that translated fields are persisted
+     * in the database too.
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @param \ArrayObject $options the options passed to the save method
+     * @return void
+     */
+    public function beforeSave(Event $event, Entity $entity, ArrayObject $options)
+    {
+        $locale = $entity->get('_locale') ?: $this->locale();
+        $newOptions = [$this->_translationTable->alias() => ['validate' => false]];
+        $options['associated'] = $newOptions + $options['associated'];
+
+        $this->_bundleTranslatedFields($entity);
+        $bundled = $entity->get('_i18n') ?: [];
+
+        if ($locale === $this->config('defaultLocale')) {
+            return;
+        }
+
+        $values = $entity->extract($this->_config['fields'], true);
+        $fields = array_keys($values);
+        $primaryKey = (array)$this->_table->primaryKey();
+        $key = $entity->get(current($primaryKey));
+        $model = $this->config('conditions.model');
+
+        $preexistent = $this->_translationTable->find()
+            ->select(['id', 'field'])
+            ->where(['field IN' => $fields, 'locale' => $locale, 'foreign_key' => $key, 'model' => $model])
+            ->bufferResults(false)
+            ->indexBy('field');
+
+        $modified = [];
+        foreach ($preexistent as $field => $translation) {
+            $translation->set('content', $values[$field]);
+            $modified[$field] = $translation;
+        }
+
+        $new = array_diff_key($values, $modified);
+        foreach ($new as $field => $content) {
+            $new[$field] = new Entity(compact('locale', 'field', 'content', 'model'), [
+                'useSetters' => false,
+                'markNew' => true
+            ]);
+        }
+
+        $entity->set('_i18n', array_merge($bundled, array_values($modified + $new)));
+        $entity->set('_locale', $locale, ['setter' => false]);
+        $entity->dirty('_locale', false);
+
+        foreach ($fields as $field) {
+            $entity->dirty($field, false);
+        }
+    }
+
+    /**
+     * Unsets the temporary `_i18n` property after the entity has been saved
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @return void
+     */
+    public function afterSave(Event $event, Entity $entity)
+    {
+        $entity->unsetProperty('_i18n');
+    }
+
+    /**
+     * Sets all future finds for the bound table to also fetch translated fields for
+     * the passed locale. If no value is passed, it returns the currently configured
+     * locale
+     *
+     * @param string|null $locale The locale to use for fetching translated records
+     * @return string
+     */
+    public function locale($locale = null)
+    {
+        if ($locale === null) {
+            return $this->_locale ?: I18n::locale();
+        }
+        return $this->_locale = (string)$locale;
+    }
+
+    /**
+     * Custom finder method used to retrieve all translations for the found records.
+     * Fetched translations can be filtered by locale by passing the `locales` key
+     * in the options array.
+     *
+     * Translated values will be found for each entity under the property `_translations`,
+     * containing an array indexed by locale name.
+     *
+     * ### Example:
+     *
+     * ```
+     * $article = $articles->find('translations', ['locales' => ['eng', 'deu'])->first();
+     * $englishTranslatedFields = $article->get('_translations')['eng'];
+     * ```
+     *
+     * If the `locales` array is not passed, it will bring all translations found
+     * for each record.
+     *
+     * @param \Cake\ORM\Query $query The original query to modify
+     * @param array $options Options
+     * @return \Cake\ORM\Query
+     */
+    public function findTranslations(Query $query, array $options)
+    {
+        $locales = isset($options['locales']) ? $options['locales'] : [];
+        $targetAlias = $this->_translationTable->alias();
+        return $query
+            ->contain([$targetAlias => function ($q) use ($locales, $targetAlias) {
+                if ($locales) {
+                    $q->where(["$targetAlias.locale IN" => $locales]);
+                }
+                return $q;
+            }])
+            ->formatResults([$this, 'groupTranslations'], $query::PREPEND);
+    }
+
+    /**
+     * Modifies the results from a table find in order to merge the translated fields
+     * into each entity for a given locale.
+     *
+     * @param \Cake\Datasource\ResultSetInterface $results Results to map.
+     * @param string $locale Locale string
+     * @return \Cake\Collection\Collection
+     */
+    protected function _rowMapper($results, $locale)
+    {
+        return $results->map(function ($row) use ($locale) {
+            if ($row === null) {
+                return $row;
+            }
+            $hydrated = !is_array($row);
+
+            foreach ($this->_config['fields'] as $field) {
+                $name = $field . '_translation';
+                $translation = isset($row[$name]) ? $row[$name] : null;
+
+                if ($translation === null || $translation === false) {
+                    unset($row[$name]);
+                    continue;
+                }
+
+                $content = isset($translation['content']) ? $translation['content'] : null;
+                if ($content !== null) {
+                    $row[$field] = $content;
+                }
+
+                unset($row[$name]);
+            }
+
+            $row['_locale'] = $locale;
+            if ($hydrated) {
+                $row->clean();
+            }
+
+            return $row;
+        });
+    }
+
+    /**
+     * Modifies the results from a table find in order to merge full translation records
+     * into each entity under the `_translations` key
+     *
+     * @param \Cake\Datasource\ResultSetInterface $results Results to modify.
+     * @return \Cake\Collection\Collection
+     */
+    public function groupTranslations($results)
+    {
+        return $results->map(function ($row) {
+            $translations = (array)$row->get('_i18n');
+            $grouped = new Collection($translations);
+
+            $result = [];
+            foreach ($grouped->combine('field', 'content', 'locale') as $locale => $keys) {
+                $translation = new Entity($keys + ['locale' => $locale], [
+                    'markNew' => false,
+                    'useSetters' => false,
+                    'markClean' => true
+                ]);
+                $result[$locale] = $translation;
+            }
+
+            $options = ['setter' => false, 'guard' => false];
+            $row->set('_translations', $result, $options);
+            unset($row['_i18n']);
+            $row->clean();
+            return $row;
+        });
+    }
+
+    /**
+     * Helper method used to generated multiple translated field entities
+     * out of the data found in the `_translations` property in the passed
+     * entity. The result will be put into its `_i18n` property
+     *
+     * @param \Cake\ORM\Entity $entity Entity
+     * @return void
+     */
+    protected function _bundleTranslatedFields($entity)
+    {
+        $translations = (array)$entity->get('_translations');
+
+        if (empty($translations) && !$entity->dirty('_translations')) {
+            return;
+        }
+
+        $fields = $this->_config['fields'];
+        $primaryKey = (array)$this->_table->primaryKey();
+        $key = $entity->get(current($primaryKey));
+        $find = [];
+
+        foreach ($translations as $lang => $translation) {
+            foreach ($fields as $field) {
+                if (!$translation->dirty($field)) {
+                    continue;
+                }
+                $find[] = ['locale' => $lang, 'field' => $field, 'foreign_key' => $key];
+                $contents[] = new Entity(['content' => $translation->get($field)], [
+                    'useSetters' => false
+                ]);
+            }
+        }
+
+        if (empty($find)) {
+            return;
+        }
+
+        $results = $this->_findExistingTranslations($find);
+        $model = $this->config('conditions.model');
+
+        foreach ($find as $i => $translation) {
+            if (!empty($results[$i])) {
+                $contents[$i]->set('id', $results[$i], ['setter' => false]);
+                $contents[$i]->isNew(false);
+            } else {
+                $translation['model'] = $model;
+                $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
+                $contents[$i]->isNew(true);
+            }
+        }
+
+        $entity->set('_i18n', $contents);
+    }
+
+    /**
+     * Returns the ids found for each of the condition arrays passed for the translations
+     * table. Each records is indexed by the corresponding position to the conditions array
+     *
+     * @param array $ruleSet an array of arary of conditions to be used for finding each
+     * @return array
+     */
+    protected function _findExistingTranslations($ruleSet)
+    {
+        $association = $this->_table->association($this->_translationTable->alias());
+
+        $query = $association->find()
+            ->select(['id', 'num' => 0])
+            ->where(current($ruleSet))
+            ->hydrate(false)
+            ->bufferResults(false);
+
+        unset($ruleSet[0]);
+        foreach ($ruleSet as $i => $conditions) {
+            $q = $association->find()
+                ->select(['id', 'num' => $i])
+                ->where($conditions);
+            $query->unionAll($q);
+        }
+
+        return $query->combine('num', 'id')->toArray();
+    }
+}

--- a/src/ORM/Behavior/Translate/ShadowTableEngine.php
+++ b/src/ORM/Behavior/Translate/ShadowTableEngine.php
@@ -1,0 +1,479 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\ORM\Behavior\Translate;
+
+use ArrayObject;
+use Cake\Database\Expression\FieldInterface;
+use Cake\Event\Event;
+use Cake\ORM\Behavior;
+use Cake\ORM\Entity;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+/**
+ * ShadowTranslate behavior
+ */
+class ShadowTableEngine extends EavEngine
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\ORM\Table $table Table instance
+     * @param array $config Configuration
+     */
+    public function __construct(Table $table, array $config = [])
+    {
+        $config += [
+            'mainTableAlias' => $table->alias(),
+            'alias' => $table->alias() . 'Translations',
+            'translationTable' => $table->table() . '_translations',
+            'fields' => [],
+            'onlyTranslated' => false,
+        ];
+        parent::__construct($table, $config);
+    }
+
+    /**
+     * Create a hasMany association for all records
+     *
+     * Don't create a hasOne association here as the join conditions are modified
+     * in before find - so create/modify it there
+     *
+     * @param array $fields - ignored
+     * @param string $table - ignored
+     * @param string $model - ignored
+     * @param string $strategy the strategy used in the _i18n association
+     *
+     * @return void
+     */
+    public function setupFieldAssociations($fields, $table, $model, $strategy)
+    {
+        $targetAlias = $this->_translationTable->alias();
+        $this->_table->hasMany($targetAlias, [
+            'foreignKey' => 'id',
+            'strategy' => $strategy,
+            'propertyName' => '_i18n',
+            'dependent' => true
+        ]);
+    }
+
+    /**
+     * Callback method that listens to the `beforeFind` event in the bound
+     * table. It modifies the passed query by eager loading the translated fields
+     * and adding a formatter to copy the values into the main table records.
+     *
+     * @param \Cake\Event\Event $event The beforeFind event that was fired.
+     * @param \Cake\ORM\Query $query Query
+     * @param \ArrayObject $options The options for the query
+     * @return void
+     */
+    public function beforeFind(Event $event, Query $query, $options)
+    {
+        $locale = $this->locale();
+
+        if ($locale === $this->config('defaultLocale')) {
+            return;
+        }
+
+        $config = $this->config();
+
+        if (isset($options['filterByCurrentLocale'])) {
+            $joinType = $options['filterByCurrentLocale'] ? 'INNER' : 'LEFT';
+        } else {
+            $joinType = $config['onlyTranslated'] ? 'INNER' : 'LEFT';
+        }
+
+        $this->_table->hasOne($config['alias'], [
+            'foreignKey' => ['id'],
+            'joinType' => $joinType,
+            'propertyName' => 'translation',
+            'conditions' => [
+                $config['alias'] . '.locale' => $locale,
+            ],
+        ]);
+        $query->contain([$config['alias']]);
+
+        $this->_addFieldsToQuery($query, $config);
+        $this->_iterateClause($query, 'order', $config);
+        $this->_traverseClause($query, 'where', $config);
+
+        $query->formatResults(function ($results) use ($locale) {
+            return $this->_rowMapper($results, $locale);
+        }, $query::PREPEND);
+    }
+
+    /**
+     * Add translation fields to query
+     *
+     * If the query is using autofields (directly or implicitly) add the
+     * main table's fields to the query first.
+     *
+     * Only add translations for fields that are in the main table, always
+     * add the locale field though.
+     *
+     * @param \Cake\ORM\Query $query the query to check
+     * @param array $config the config to use for adding fields
+     * @return void
+     */
+    protected function _addFieldsToQuery(Query $query, array $config)
+    {
+        $select = $query->clause('select');
+        $addAll = false;
+
+        if (!count($select) || $query->autoFields() === true) {
+            $addAll = true;
+            $query->select($query->repository()->schema()->columns());
+            $select = $query->clause('select');
+        }
+
+        $alias = $config['mainTableAlias'];
+        foreach ($this->_translationFields() as $field) {
+            if ($addAll ||
+                in_array($field, $select, true) ||
+                in_array("$alias.$field", $select, true)
+            ) {
+                $query->select($query->aliasField($field, $config['alias']));
+            }
+        }
+        $query->select($query->aliasField('locale', $config['alias']));
+    }
+
+    /**
+     * Iterate over a clause to alias fields
+     *
+     * The objective here is to transparently prevent ambiguous field errors by
+     * prefixing fields with the appropriate table alias. This method currently
+     * expects to receive an order clause only.
+     *
+     * @param \Cake\ORM\Query $query the query to check
+     * @param string $name The clause name
+     * @param array $config the config to use for adding fields
+     * @return void
+     */
+    protected function _iterateClause(Query $query, $name = '', $config = [])
+    {
+        $clause = $query->clause($name);
+        if (!$clause || !$clause->count()) {
+            return;
+        }
+
+        $alias = $config['alias'];
+        $fields = $this->_translationFields();
+        $mainTableAlias = $config['mainTableAlias'];
+        $mainTableFields = $this->_mainFields();
+
+        $clause->iterateParts(function ($c, $field) use ($fields, $alias, $mainTableAlias, $mainTableFields) {
+            if (!is_string($field) || strpos($field, '.')) {
+                return;
+            }
+
+            if (in_array($field, $fields)) {
+                $field = "$alias.$field";
+
+                return;
+            }
+
+            if (in_array($field, $mainTableFields)) {
+                $field = "$mainTableAlias.$field";
+            }
+        });
+    }
+
+    /**
+     * Traverse over a clause to alias fields
+     *
+     * The objective here is to transparently prevent ambiguous field errors by
+     * prefixing fields with the appropriate table alias. This method currently
+     * expects to receive a where clause only.
+     *
+     * @param \Cake\ORM\Query $query the query to check
+     * @param string $name The clause name
+     * @param array $config the config to use for adding fields
+     * @return void
+     */
+    protected function _traverseClause(Query $query, $name = '', $config = [])
+    {
+        $clause = $query->clause($name);
+        if (!$clause || !$clause->count()) {
+            return;
+        }
+
+        $alias = $config['alias'];
+        $fields = $this->_translationFields();
+        $mainTableAlias = $config['mainTableAlias'];
+        $mainTableFields = $this->_mainFields();
+
+        $clause->traverse(function ($expression) use ($fields, $alias, $mainTableAlias, $mainTableFields) {
+            if (!($expression instanceof FieldInterface)) {
+                return;
+            }
+            $field = $expression->getField();
+            if (!$field || strpos($field, '.')) {
+                return;
+            }
+
+            if (in_array($field, $fields)) {
+                $expression->setField("$alias.$field");
+
+                return;
+            }
+
+            if (in_array($field, $mainTableFields)) {
+                $expression->setField("$mainTableAlias.$field");
+            }
+        });
+    }
+
+    /**
+     * Modifies the entity before it is saved so that translated fields are persisted
+     * in the database too.
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @param \ArrayObject $options the options passed to the save method
+     * @return void
+     */
+    public function beforeSave(Event $event, Entity $entity, ArrayObject $options)
+    {
+        $locale = $entity->get('_locale') ?: $this->locale();
+        $table = $this->_config['translationTable'];
+        $newOptions = [$table => ['validate' => false]];
+        $options['associated'] = $newOptions + $options['associated'];
+
+        $this->_bundleTranslatedFields($entity);
+        $bundled = $entity->get('_i18n') ?: [];
+
+        if ($locale === $this->config('defaultLocale')) {
+            return;
+        }
+
+        $values = $entity->extract($this->_config['fields'], true);
+        $fields = array_keys($values);
+        $primaryKey = (array)$this->_table->primaryKey();
+        $key = $entity->get(current($primaryKey));
+
+        $translation = $this->_translationTable()->find()
+            ->select(array_merge(['id', 'locale'], $fields))
+            ->where(['locale' => $locale, 'id' => $key])
+            ->bufferResults(false)
+            ->first();
+
+        if ($translation) {
+            foreach ($fields as $field) {
+                $translation->set($field, $values[$field]);
+            }
+        } else {
+            $translation = new Entity(['id' => $key, 'locale' => $locale] + $values, [
+                'useSetters' => false,
+                'markNew' => true
+            ]);
+        }
+
+        $entity->set('_i18n', array_merge($bundled, [$translation]));
+        $entity->set('_locale', $locale, ['setter' => false]);
+        $entity->dirty('_locale', false);
+
+        foreach ($fields as $field) {
+            $entity->dirty($field, false);
+        }
+    }
+
+    /**
+     * Modifies the results from a table find in order to merge the translated fields
+     * into each entity for a given locale.
+     *
+     * @param \Cake\Datasource\ResultSetInterface $results Results to map.
+     * @param string $locale Locale string
+     * @return \Cake\Collection\Collection
+     */
+    protected function _rowMapper($results, $locale)
+    {
+        return $results->map(function ($row) {
+            if ($row === null) {
+                return $row;
+            }
+
+            $hydrated = !is_array($row);
+
+            if (empty($row['translation'])) {
+                $row['_locale'] = $this->locale();
+                unset($row['translation']);
+
+                if ($hydrated) {
+                    $row->clean();
+                }
+
+                return $row;
+            }
+
+            $translation = $row['translation'];
+
+            $keys = $hydrated ? $translation->visibleProperties() : array_keys($translation);
+
+            foreach ($keys as $field) {
+                if ($field === 'locale') {
+                    $row['_locale'] = $translation[$field];
+                    continue;
+                }
+
+                if ($translation[$field] !== null) {
+                    $row[$field] = $translation[$field];
+                }
+            }
+
+            unset($row['translation']);
+
+            if ($hydrated) {
+                $row->clean();
+            }
+
+            return $row;
+        });
+    }
+
+    /**
+     * Modifies the results from a table find in order to merge full translation records
+     * into each entity under the `_translations` key
+     *
+     * @param \Cake\Datasource\ResultSetInterface $results Results to modify.
+     * @return \Cake\Collection\Collection
+     */
+    public function groupTranslations($results)
+    {
+        return $results->map(function ($row) {
+            $translations = (array)$row->get('_i18n');
+
+            $result = [];
+            foreach ($translations as $translation) {
+                unset($translation['id']);
+                $result[$translation['locale']] = $translation;
+            }
+
+            $options = ['setter' => false, 'guard' => false];
+            $row->set('_translations', $result, $options);
+            unset($row['_i18n']);
+            $row->clean();
+
+            return $row;
+        });
+    }
+
+    public function afterSave(Event $event, Entity $entity) {
+
+    }
+
+    /**
+     * Helper method used to generated multiple translated field entities
+     * out of the data found in the `_translations` property in the passed
+     * entity. The result will be put into its `_i18n` property
+     *
+     * @param \Cake\ORM\Entity $entity Entity
+     * @return void
+     */
+    protected function _bundleTranslatedFields($entity)
+    {
+        $translations = (array)$entity->get('_translations');
+
+        if (empty($translations) && !$entity->dirty('_translations')) {
+            return;
+        }
+
+        $primaryKey = (array)$this->_table->primaryKey();
+        $key = $entity->get(current($primaryKey));
+
+        foreach ($translations as $lang => $translation) {
+            if (!$translation->id) {
+                $update = [
+                    'id' => $key,
+                    'locale' => $lang,
+                ];
+                $translation->set($update, ['setter' => false]);
+            }
+        }
+
+        $entity->set('_i18n', $translations);
+    }
+
+    /**
+     * Based on the passed config, return the translation table instance
+     *
+     * If the table already exists in the registry - don't pass any config
+     * as that'll just lead to an exception trying to reconfigure an existing
+     * table.
+     *
+     * @param array $config behavior config to use
+     * @return \Cake\ORM\Table Translation table instance
+     */
+    protected function _translationTable($config = [])
+    {
+        if (!$config) {
+            $config = $this->config();
+        }
+
+        if (TableRegistry::exists($config['alias'])) {
+            return TableRegistry::get($config['alias']);
+        }
+
+        return TableRegistry::get(
+            $config['alias'],
+            ['table' => $config['translationTable']]
+        );
+    }
+
+    /**
+     * Lazy define and return the main table fields
+     *
+     * @return array
+     */
+    protected function _mainFields()
+    {
+        $fields = $this->config('mainTableFields');
+
+        if ($fields) {
+            return $fields;
+        }
+
+        $table = $this->_table;
+        $fields = $table->schema()->columns();
+
+        $this->config('mainTableFields', $fields);
+
+        return $fields;
+    }
+
+    /**
+     * Lazy define and return the translation table fields
+     *
+     * @return array
+     */
+    protected function _translationFields()
+    {
+        $fields = $this->config('fields');
+
+        if ($fields) {
+            return $fields;
+        }
+
+        $table = $this->_translationTable();
+        $fields = $table->schema()->columns();
+        $fields = array_values(array_diff($fields, ['id', 'locale']));
+
+        $this->config('fields', $fields);
+
+        return $fields;
+    }
+}

--- a/src/ORM/Behavior/Translate/TranslationEngine.php
+++ b/src/ORM/Behavior/Translate/TranslationEngine.php
@@ -16,14 +16,15 @@
 namespace Cake\ORM\Behavior\Translate;
 
 use ArrayObject;
+use Cake\Core\InstanceConfigTrait;
 use Cake\Event\Event;
 use Cake\I18n\I18n;
-use Cake\Core\InstanceConfigTrait;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 
-abstract class TranslationEngine {
+abstract class TranslationEngine
+{
 
     use InstanceConfigTrait;
 

--- a/src/ORM/Behavior/Translate/TranslationEngine.php
+++ b/src/ORM/Behavior/Translate/TranslationEngine.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\ORM\Behavior\Translate;
+
+use ArrayObject;
+use Cake\Event\Event;
+use Cake\I18n\I18n;
+use Cake\Core\InstanceConfigTrait;
+use Cake\ORM\Entity;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+
+abstract class TranslationEngine {
+
+    use InstanceConfigTrait;
+
+    /**
+     * Table instance
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $_table;
+
+    /**
+     * The locale name that will be used to override fields in the bound table
+     * from the translations table
+     *
+     * @var string
+     */
+    protected $_locale;
+
+    /**
+     * Instance of Table responsible for translating
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $_translationTable;
+
+    /**
+     * Initialize hook
+     *
+     * @param array $config The config for this behavior.
+     * @return void
+     */
+    abstract public function initialize(array $config);
+
+    /**
+     * Callback method that listens to the `beforeFind` event in the bound
+     * table. It modifies the passed query by eager loading the translated fields
+     * and adding a formatter to copy the values into the main table records.
+     *
+     * @param \Cake\Event\Event $event The beforeFind event that was fired.
+     * @param \Cake\ORM\Query $query Query
+     * @param \ArrayObject $options The options for the query
+     * @return void
+     */
+    abstract public function beforeFind(Event $event, Query $query, $options);
+
+    /**
+     * Modifies the entity before it is saved so that translated fields are persisted
+     * in the database too.
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @param \ArrayObject $options the options passed to the save method
+     * @return void
+     */
+    abstract public function beforeSave(Event $event, Entity $entity, ArrayObject $options);
+
+    /**
+     * Unsets the temporary `_i18n` property after the entity has been saved
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @return void
+     */
+    abstract public function afterSave(Event $event, Entity $entity);
+
+    /**
+     * Custom finder method used to retrieve all translations for the found records.
+     * Fetched translations can be filtered by locale by passing the `locales` key
+     * in the options array.
+     *
+     * Translated values will be found for each entity under the property `_translations`,
+     * containing an array indexed by locale name.
+     *
+     * ### Example:
+     *
+     * ```
+     * $article = $articles->find('translations', ['locales' => ['eng', 'deu'])->first();
+     * $englishTranslatedFields = $article->get('_translations')['eng'];
+     * ```
+     *
+     * If the `locales` array is not passed, it will bring all translations found
+     * for each record.
+     *
+     * @param \Cake\ORM\Query $query The original query to modify
+     * @param array $options Options
+     * @return \Cake\ORM\Query
+     */
+    abstract public function findTranslations(Query $query, array $options);
+
+    /**
+     * Default config
+     *
+     * These are merged with user-provided configuration when the behavior is used.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'implementedFinders' => ['translations' => 'findTranslations'],
+        'implementedMethods' => ['locale' => 'locale'],
+        'fields' => [],
+        'translationTable' => 'I18n',
+        'defaultLocale' => '',
+        'model' => '',
+        'onlyTranslated' => false,
+        'strategy' => 'subquery',
+        'conditions' => ['model' => '']
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\ORM\Table $table The table this behavior is attached to.
+     * @param array $config The config for this behavior.
+     */
+    public function __construct(Table $table, array $config = [])
+    {
+        $config += ['defaultLocale' => I18n::defaultLocale()];
+        $this->config($config);
+        $this->_table = $table;
+    }
+
+    /**
+     * Sets all future finds for the bound table to also fetch translated fields for
+     * the passed locale. If no value is passed, it returns the currently configured
+     * locale
+     *
+     * @param string|null $locale The locale to use for fetching translated records
+     * @return string
+     */
+    public function locale($locale = null)
+    {
+        if ($locale === null) {
+            return $this->_locale ?: I18n::locale();
+        }
+        return $this->_locale = (string)$locale;
+    }
+}

--- a/src/ORM/Behavior/Translate/TranslationEngine.php
+++ b/src/ORM/Behavior/Translate/TranslationEngine.php
@@ -122,8 +122,6 @@ abstract class TranslationEngine
      * @var array
      */
     protected $_defaultConfig = [
-        'implementedFinders' => ['translations' => 'findTranslations'],
-        'implementedMethods' => ['locale' => 'locale'],
         'fields' => [],
         'translationTable' => 'I18n',
         'defaultLocale' => '',

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -77,13 +77,6 @@ class TranslateBehavior extends Behavior
         'engine' => '\Cake\ORM\Behavior\Translate\EavEngine',
         'implementedFinders' => ['translations' => 'findTranslations'],
         'implementedMethods' => ['locale' => 'locale'],
-        'fields' => [],
-        'translationTable' => 'I18n',
-        'defaultLocale' => '',
-        'model' => '',
-        'onlyTranslated' => false,
-        'strategy' => 'subquery',
-        'conditions' => ['model' => '']
     ];
 
     /**

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -123,7 +123,7 @@ class TranslateBehavior extends Behavior
      */
     public function beforeFind(Event $event, Query $query, $options)
     {
-        $this->_engine->beforeFind($event, $query,  $options);
+        $this->_engine->beforeFind($event, $query, $options);
     }
 
     /**
@@ -137,7 +137,7 @@ class TranslateBehavior extends Behavior
      */
     public function beforeSave(Event $event, Entity $entity, ArrayObject $options)
     {
-        $this->_engine->beforeSave($event, $entity,  $options);
+        $this->_engine->beforeSave($event, $entity, $options);
     }
 
     /**
@@ -191,5 +191,4 @@ class TranslateBehavior extends Behavior
     {
         return $this->_engine->findTranslations($query, $options);
     }
-
 }

--- a/tests/Fixture/ArticlesMoreTranslationsFixture.php
+++ b/tests/Fixture/ArticlesMoreTranslationsFixture.php
@@ -1,0 +1,42 @@
+<?php
+namespace Cake\Test\Fixture;;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class ArticlesTranslationsFixture
+ *
+ */
+class ArticlesMoreTranslationsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'locale' => ['type' => 'string', 'null' => false],
+        'title' => ['type' => 'string', 'null' => false],
+        'subtitle' => ['type' => 'string', 'null' => false],
+        'body' => 'text',
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['locale' => 'eng', 'id' => 1, 'title' => 'Title #1', 'subtitle' => 'SubTitle #1', 'body' => 'Content #1'],
+        ['locale' => 'deu', 'id' => 1, 'title' => 'Titel #1', 'subtitle' => 'SubTitel #1', 'body' => 'Inhalt #1'],
+        ['locale' => 'cze', 'id' => 1, 'title' => 'Titulek #1', 'subtitle' => 'SubTitulek #1', 'body' => 'Obsah #1'],
+        ['locale' => 'eng', 'id' => 2, 'title' => 'Title #2', 'subtitle' => 'SubTitle #2', 'body' => 'Content #2'],
+        ['locale' => 'deu', 'id' => 2, 'title' => 'Titel #2', 'subtitle' => 'SubTitel #2', 'body' => 'Inhalt #2'],
+        ['locale' => 'cze', 'id' => 2, 'title' => 'Titulek #2', 'subtitle' => 'SubTitulek #2', 'body' => 'Obsah #2'],
+        ['locale' => 'eng', 'id' => 3, 'title' => 'Title #3', 'subtitle' => 'SubTitle #3', 'body' => 'Content #3'],
+        ['locale' => 'deu', 'id' => 3, 'title' => 'Titel #3', 'subtitle' => 'SubTitel #3', 'body' => 'Inhalt #3'],
+        ['locale' => 'cze', 'id' => 3, 'title' => 'Titulek #3', 'subtitle' => 'SubTitulek #3', 'body' => 'Obsah #3'],
+    ];
+}

--- a/tests/Fixture/ArticlesTranslationsFixture.php
+++ b/tests/Fixture/ArticlesTranslationsFixture.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class ArticlesTranslationsFixture
+ *
+ */
+class ArticlesTranslationsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'locale' => ['type' => 'string', 'null' => false],
+        'title' => ['type' => 'string', 'null' => false],
+        'body' => 'text',
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['locale' => 'eng', 'id' => 1, 'title' => 'Title #1', 'body' => 'Content #1'],
+        ['locale' => 'deu', 'id' => 1, 'title' => 'Titel #1', 'body' => 'Inhalt #1'],
+        ['locale' => 'cze', 'id' => 1, 'title' => 'Titulek #1', 'body' => 'Obsah #1'],
+        ['locale' => 'spa', 'id' => 1, 'title' => 'First Article', 'body' => 'Contenido #1'],
+        ['locale' => 'eng', 'id' => 2, 'title' => 'Title #2', 'body' => 'Content #2'],
+        ['locale' => 'deu', 'id' => 2, 'title' => 'Titel #2', 'body' => 'Inhalt #2'],
+        ['locale' => 'cze', 'id' => 2, 'title' => 'Titulek #2', 'body' => 'Obsah #2'],
+        ['locale' => 'eng', 'id' => 3, 'title' => 'Title #3', 'body' => 'Content #3'],
+        ['locale' => 'deu', 'id' => 3, 'title' => 'Titel #3', 'body' => 'Inhalt #3'],
+        ['locale' => 'cze', 'id' => 3, 'title' => 'Titulek #3', 'body' => 'Obsah #3'],
+    ];
+}

--- a/tests/Fixture/AuthorsTranslationsFixture.php
+++ b/tests/Fixture/AuthorsTranslationsFixture.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class AuthorsTranslationsFixture
+ *
+ */
+class AuthorsTranslationsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'locale' => ['type' => 'string', 'null' => false],
+        'name' => ['type' => 'string', 'null' => false],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['locale' => 'eng', 'id' => 1, 'name' => 'May-rianoh'],
+    ];
+}

--- a/tests/Fixture/CommentsTranslationsFixture.php
+++ b/tests/Fixture/CommentsTranslationsFixture.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class CommentsTranslationsFixture
+ *
+ */
+class CommentsTranslationsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'locale' => ['type' => 'string', 'null' => false],
+        'comment' => 'text',
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['locale' => 'eng', 'id' => 1, 'comment' => 'Comment #1'],
+        ['locale' => 'eng', 'id' => 2, 'comment' => 'Comment #2'],
+        ['locale' => 'eng', 'id' => 3, 'comment' => 'Comment #3'],
+        ['locale' => 'eng', 'id' => 4, 'comment' => 'Comment #4'],
+        ['locale' => 'spa', 'id' => 4, 'comment' => 'Comentario #4'],
+    ];
+}

--- a/tests/TestCase/ORM/Behavior/Translate/ShadowTranslateEngineTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/ShadowTranslateEngineTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM\Behavior\Translate;
+
+use Cake\ORM\TableRegistry;
+use Cake\Test\TestCase\ORM\Behavior\TranslateBehaviorTest;
+
+/**
+ * Translate behavior test case
+ */
+class ShadowTranslateEngineTest extends TranslateBehaviorTest
+{
+
+    /**
+     * fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'core.translates',
+        'core.articles',
+        'core.comments',
+        'core.authors',
+        'core.ArticlesTranslations',
+        'core.ArticlesMoreTranslations',
+        'core.AuthorsTranslations',
+        'core.CommentsTranslations'
+    ];
+
+    /**
+     * Default behavior settings for all tests.
+     *
+     * @var array
+     */
+    protected $_behaviorDefaults = [
+        'engine' => '\Cake\ORM\Behavior\Translate\ShadowTableEngine',
+    ];
+
+    /**
+     * Tests the use of `model` config option.
+     *
+     * Overloading the inherited method with an empty body because this engine does not use the model option.
+     *
+     * @return void
+     */
+    public function testChangingModelFieldValue()
+    {
+    }
+
+    /**
+     * Tests that after deleting a translated entity, all translations are also removed.
+     *
+     * @return void
+     */
+    public function testDelete()
+    {
+        $table = TableRegistry::get('Articles');
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
+        $article = $table->find()->first();
+        $this->assertTrue($table->delete($article));
+
+        $translations = TableRegistry::get('ArticlesTranslations')->find()
+            ->where(['id' => 1])
+            ->count();
+        $this->assertEquals(0, $translations);
+    }
+
+    /**
+     * testFindTranslations
+     *
+     * The parent test expects description translations in only some of the records
+     * that's incompatible with the shadow-translate behavior, since the schema
+     * dictates what fields to expect to be translated and doesnt permit any EAV
+     * style translations.
+     *
+     * @return void
+     */
+    public function testFindTranslations() {
+        $this->markTestSkipped();
+    }
+
+    /**
+     * testConditions
+     *
+     * The parent test applies conditions to the translation table; the tested
+     * example is `content <> ''`. This is not necessary/inappropriate for
+     * the shadow translate behavior, as any conditions would apply to the
+     * translation record as a whole, and not a single translated field's value.
+     *
+     * @return void.
+     */
+    public function testConditions() {
+        $this->markTestSkipped();
+    }
+}

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -20,6 +20,7 @@ use Cake\I18n\I18n;
 use Cake\ORM\Behavior\TranslateBehavior;
 use Cake\ORM\Behavior\Translate\TranslateTrait;
 use Cake\ORM\Entity;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -50,11 +51,33 @@ class TranslateBehaviorTest extends TestCase
         'core.authors'
     ];
 
+    /**
+     * Default behavior settings for all tests.
+     *
+     * @var array
+     */
+    protected $_behaviorDefaults = [
+        'engine' => '\Cake\ORM\Behavior\Translate\EavEngine',
+    ];
+
     public function tearDown()
     {
         parent::tearDown();
         I18n::locale(I18n::defaultLocale());
         TableRegistry::clear();
+    }
+
+    /**
+     * Helper method to attach the translate behavior with certain defaults.
+     *
+     * @param mixed $table Table object.
+     * @param array $options Behavior options.
+     * @return void
+     */
+    protected function _addBehavior($table, array $options = [])
+    {
+        $options += $this->_behaviorDefaults;
+        $table->addBehavior('Translate', $options);
     }
 
     /**
@@ -84,8 +107,7 @@ class TranslateBehaviorTest extends TestCase
     public function testCustomTranslationTable()
     {
         $table = TableRegistry::get('Articles');
-
-        $table->addBehavior('Translate', [
+        $this->_addBehavior($table, [ 
             'translationTable' => '\TestApp\Model\Table\I18nTable',
             'fields' => ['title', 'body']
         ]);
@@ -107,7 +129,7 @@ class TranslateBehaviorTest extends TestCase
     {
         $table = TableRegistry::get('Articles');
 
-        $table->addBehavior('Translate', [
+        $this->_addBehavior($table, [
             'strategy' => 'select',
             'fields' => ['title', 'body']
         ]);
@@ -126,7 +148,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindSingleLocale()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('eng');
         $results = $table->find()->combine('title', 'body', 'id')->toArray();
         $expected = [
@@ -148,10 +170,10 @@ class TranslateBehaviorTest extends TestCase
         I18n::locale('eng');
 
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
 
         $table->hasMany('Comments');
-        $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
+        $this->_addBehavior($table->Comments, ['fields' => ['comment']]);
 
         $results = $table->find()
             ->select(['id', 'title', 'body'])
@@ -248,7 +270,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindSingleLocaleWithNullTranslation()
     {
         $table = TableRegistry::get('Comments');
-        $table->addBehavior('Translate', ['fields' => ['comment']]);
+        $this->_addBehavior($table, ['fields' => ['comment']]);
         $table->locale('spa');
         $results = $table->find()
             ->where(['Comments.id' => 6])
@@ -266,7 +288,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindSingleLocaleWithConditions()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('eng');
         $results = $table->find()
             ->where(['Articles.id' => 2])
@@ -294,7 +316,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindList()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('eng');
 
         $results = $table->find('list')->toArray();
@@ -310,7 +332,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindCount()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('eng');
 
         $this->assertEquals(3, $table->find()->count());
@@ -324,7 +346,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindTranslations()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $results = $table->find('translations');
         $expected = [
             [
@@ -365,7 +387,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindFilteredTranslations()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $results = $table->find('translations', ['locales' => ['deu', 'cze']]);
         $expected = [
             [
@@ -403,7 +425,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindTranslationsList()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $results = $table
             ->find('list', [
                 'keyField' => 'title',
@@ -428,7 +450,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFindTranslationsWithFieldOverriding()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('cze');
         $results = $table->find('translations', ['locales' => ['deu', 'cze']]);
         $expected = [
@@ -467,10 +489,10 @@ class TranslateBehaviorTest extends TestCase
     public function testFindSingleLocaleHasMany()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
         $comments = $table->hasMany('Comments')->target();
-        $comments->addBehavior('Translate', ['fields' => ['comment']]);
+        $this->_addBehavior($comments, ['fields' => ['comment']]);
 
         $table->locale('eng');
         $comments->locale('eng');
@@ -497,10 +519,10 @@ class TranslateBehaviorTest extends TestCase
     public function testTranslationsHasMany()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
         $comments = $table->hasMany('Comments')->target();
-        $comments->addBehavior('Translate', ['fields' => ['comment']]);
+        $this->_addBehavior($comments, ['fields' => ['comment']]);
 
         $results = $table->find('translations')->contain([
             'Comments' => function ($q) {
@@ -538,10 +560,10 @@ class TranslateBehaviorTest extends TestCase
     public function testTranslationsHasManyWithOverride()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
         $comments = $table->hasMany('Comments')->target();
-        $comments->addBehavior('Translate', ['fields' => ['comment']]);
+        $this->_addBehavior($comments, ['fields' => ['comment']]);
 
         $table->locale('cze');
         $comments->locale('eng');
@@ -588,12 +610,12 @@ class TranslateBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testFindSingleLocaleBelongsto()
+    public function testFindSingleLocaleBelongsTo()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $authors = $table->belongsTo('Authors')->target();
-        $authors->addBehavior('Translate', ['fields' => ['name']]);
+        $this->_addBehavior($authors, ['fields' => ['name']]);
 
         $table->locale('eng');
         $authors->locale('eng');
@@ -639,7 +661,7 @@ class TranslateBehaviorTest extends TestCase
     public function testUpdateSingleLocale()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('eng');
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
@@ -677,7 +699,7 @@ class TranslateBehaviorTest extends TestCase
     public function testInsertNewTranslations()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('fra');
 
         $article = $table->find()->first();
@@ -710,7 +732,7 @@ class TranslateBehaviorTest extends TestCase
     public function testUpdateTranslationWithLocaleInEntity()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $article = $table->find()->first();
         $this->assertEquals(1, $article->get('id'));
         $article->set('_locale', 'fra');
@@ -740,7 +762,7 @@ class TranslateBehaviorTest extends TestCase
     {
         $table = TableRegistry::get('Articles');
         $table->hasMany('Comments');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->locale('fra');
 
         $article = $table->find()->first();
@@ -761,7 +783,7 @@ class TranslateBehaviorTest extends TestCase
     public function testDelete()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $article = $table->find()->first();
         $this->assertTrue($table->delete($article));
 
@@ -780,7 +802,7 @@ class TranslateBehaviorTest extends TestCase
     public function testSaveMultipleTranslations()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $article = $results = $table->find('translations')->first();
 
         $translations = $article->get('_translations');
@@ -804,7 +826,7 @@ class TranslateBehaviorTest extends TestCase
     public function testSaveMultipleNewTranslations()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $article = $results = $table->find('translations')->first();
 
         $translations = $article->get('_translations');
@@ -833,7 +855,7 @@ class TranslateBehaviorTest extends TestCase
     public function testUseCountInFindTranslations()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $articles = $results = $table->find('translations');
         $all = $articles->all();
         $this->assertCount(3, $all);
@@ -850,7 +872,7 @@ class TranslateBehaviorTest extends TestCase
     public function testSavingWithNonDefaultLocale()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $this->_addBehavior($table, ['fields' => ['title', 'body']]);
         $table->entityClass(__NAMESPACE__ . '\Article');
         I18n::locale('fra');
         $translations = [
@@ -877,7 +899,7 @@ class TranslateBehaviorTest extends TestCase
     public function testTranslationWithUnionQuery()
     {
         $table = TableRegistry::get('Comments');
-        $table->addBehavior('Translate', ['fields' => ['comment']]);
+        $this->_addBehavior($table, ['fields' => ['comment']]);
         $table->locale('spa');
         $query = $table->find()->where(['Comments.id' => 6]);
         $query2 = $table->find()->where(['Comments.id' => 5]);
@@ -899,7 +921,7 @@ class TranslateBehaviorTest extends TestCase
         $table = TableRegistry::get('Articles');
 
         $table->hasMany('OtherComments', ['className' => 'Comments']);
-        $table->OtherComments->addBehavior('Translate', ['fields' => ['comment'], 'model' => 'Comments']);
+        $this->_addBehavior($table->OtherComments, ['fields' => ['comment'], 'model' => 'Comments']);
 
         $items = $table->OtherComments->associations();
         $association = $items->getByProperty('comment_translation');
@@ -926,7 +948,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFilterUntranslated()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', [
+        $this->_addBehavior($table, [
             'fields' => ['title', 'body'],
             'onlyTranslated' => true
         ]);
@@ -949,7 +971,7 @@ class TranslateBehaviorTest extends TestCase
     public function testFilterUntranslatedWithFinder()
     {
         $table = TableRegistry::get('Comments');
-        $table->addBehavior('Translate', [
+        $this->_addBehavior($table, [
             'fields' => ['comment'],
             'onlyTranslated' => true
         ]);
@@ -978,7 +1000,7 @@ class TranslateBehaviorTest extends TestCase
     public function testConditions()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', [
+        $this->_addBehavior($table, [
             'fields' => ['title', 'body', 'description'],
             'conditions' => ['content <>' => '']
         ]);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -15,12 +15,9 @@
 namespace Cake\Test\TestCase\ORM\Behavior;
 
 use Cake\Collection\Collection;
-use Cake\Event\Event;
 use Cake\I18n\I18n;
-use Cake\ORM\Behavior\TranslateBehavior;
 use Cake\ORM\Behavior\Translate\TranslateTrait;
 use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -107,7 +107,7 @@ class TranslateBehaviorTest extends TestCase
     public function testCustomTranslationTable()
     {
         $table = TableRegistry::get('Articles');
-        $this->_addBehavior($table, [ 
+        $this->_addBehavior($table, [
             'translationTable' => '\TestApp\Model\Table\I18nTable',
             'fields' => ['title', 'body']
         ]);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1001,7 +1001,7 @@ class TranslateBehaviorTest extends TestCase
     {
         $table = TableRegistry::get('Articles');
         $this->_addBehavior($table, [
-            'fields' => ['title', 'body', 'description'],
+            'fields' => ['title', 'body'],
             'conditions' => ['content <>' => '']
         ]);
         $table->locale('spa');


### PR DESCRIPTION
This is the base to implement other translation engines like [shadow table translations](https://github.com/AD7six/cakephp-shadow-translate) that perform better than the existing key / value lookup when you have a lot of data.
