### PR TITLE
Remove fields from count() queries when associations are contained.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -640,6 +640,11 @@ abstract class Association
         $fields = $surrogate->clause('select') ?: $options['fields'];
         $target = $this->_targetTable;
         $autoFields = $surrogate->autoFields();
+
+        if ($query->eagerLoader()->autoFields() === false) {
+            return false;
+        }
+
         if (empty($fields) && !$autoFields) {
             if ($options['includeFields'] && ($fields === null || $fields !== false)) {
                 $fields = $target->schema()->columns();

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -642,7 +642,7 @@ abstract class Association
         $autoFields = $surrogate->autoFields();
 
         if ($query->eagerLoader()->autoFields() === false) {
-            return false;
+            return;
         }
 
         if (empty($fields) && !$autoFields) {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -96,6 +96,15 @@ class EagerLoader
     protected $_joinsMap = [];
 
     /**
+     * Controls whether or not fields from associated tables
+     * will be eagerly loaded. When set to false, no fields will
+     * be loaded from associations.
+     *
+     * @var bool
+     */
+    protected $_autoFields = true;
+
+    /**
      * Sets the list of associations that should be eagerly loaded along for a
      * specific table using when a query is provided. The list of associated tables
      * passed to this method must have been previously set as associations using the
@@ -132,6 +141,20 @@ class EagerLoader
         $this->_normalized = $this->_loadExternal = null;
         $this->_aliasList = [];
         return $this->_containments = $associations;
+    }
+
+    /**
+     * Set whether or not contained associations will load fields automatically.
+     *
+     * @param bool $value The value to set.
+     * @return bool The current value.
+     */
+    public function autoFields($value = null)
+    {
+        if ($value !== null) {
+            $this->_autoFields = (bool)$value;
+        }
+        return $this->_autoFields;
     }
 
     /**
@@ -294,7 +317,7 @@ class EagerLoader
             $config = $loadable->config() + [
                 'aliasPath' => $loadable->aliasPath(),
                 'propertyPath' => $loadable->propertyPath(),
-                'includeFields' => $includeFields
+                'includeFields' => $includeFields,
             ];
             $loadable->instance()->attachTo($query, $config);
         }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -507,16 +507,9 @@ class Query extends DatabaseQuery implements JsonSerializable
         $complex = $complex || count($query->clause('union'));
 
         if (!$complex) {
-            $cleanContain = [];
-            foreach ($query->contain() as $alias => $contain) {
-                unset($contain['fields']);
-                $cleanContain[$alias] = $contain;
-            }
-            $query->contain(null, true);
-
+            $query->eagerLoader()->autoFields(false);
             $statement = $query
                 ->select($count, true)
-                ->contain($cleanContain)
                 ->autoFields(false)
                 ->execute();
         } else {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -507,8 +507,16 @@ class Query extends DatabaseQuery implements JsonSerializable
         $complex = $complex || count($query->clause('union'));
 
         if (!$complex) {
+            $cleanContain = [];
+            foreach ($query->contain() as $alias => $contain) {
+                unset($contain['fields']);
+                $cleanContain[$alias] = $contain;
+            }
+            $query->contain(null, true);
+
             $statement = $query
                 ->select($count, true)
+                ->contain($cleanContain)
                 ->autoFields(false)
                 ->execute();
         } else {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1446,6 +1446,27 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test getting counts from queries with contain.
+     *
+     * @return void
+     */
+    public function testCountWithContain()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsTo('Authors');
+
+        $result = $table->find('all')
+            ->contain([
+                'Authors' => [
+                    'fields' => ['name']
+                ]
+            ])
+            ->count();
+        $this->assertSame(3, $result);
+    }
+
+
+    /**
      * test count with a beforeFind.
      *
      * @return void
@@ -1871,7 +1892,7 @@ class QueryTest extends TestCase
 
     /**
      * Tests that getting results from a query having a contained association
-     * will no attach joins twice if count() is called on it afterwards
+     * will not attach joins twice if count() is called on it afterwards
      *
      * @return void
      */


### PR DESCRIPTION
Strip out any fields defined in contained associations as fetching fields and throwing away the results is wasteful and can lead to slow downs in larger datasets.

Refs #5955
