### PR TITLE
Decimal validate based on Intl not setlocale

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -479,9 +479,13 @@ class Validation
         }
 
         // account for localized floats.
-        $data = localeconv();
-        $check = str_replace($data['thousands_sep'], '', $check);
-        $check = str_replace($data['decimal_point'], '.', $check);
+        $locale = ini_get('intl.default_locale') ?: 'en_US';
+        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
+        $decimalPoint = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        $groupingSep = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
+
+        $check = str_replace($groupingSep, '', $check);
+        $check = str_replace($decimalPoint, '.', $check);
 
         return static::_check($check, $regex);
     }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -16,6 +16,7 @@ namespace Cake\Validation;
 
 use Cake\Utility\Text;
 use LogicException;
+use NumberFormatter;
 use RuntimeException;
 
 /**
@@ -480,9 +481,9 @@ class Validation
 
         // account for localized floats.
         $locale = ini_get('intl.default_locale') ?: 'en_US';
-        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
-        $decimalPoint = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
-        $groupingSep = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
+        $formatter = new NumberFormatter($locale, NumberFormatter::DECIMAL);
+        $decimalPoint = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        $groupingSep = $formatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
 
         $check = str_replace($groupingSep, '', $check);
         $check = str_replace($decimalPoint, '.', $check);

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Filesystem\File;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
+use Locale;
 
 /**
  * CustomValidator class
@@ -56,11 +57,8 @@ class ValidationTest extends TestCase
     {
         parent::setUp();
         $this->_appEncoding = Configure::read('App.encoding');
-        $this->_appLocale = [];
-        foreach ([LC_MONETARY, LC_NUMERIC, LC_TIME] as $category) {
-            $this->_appLocale[$category] = setlocale($category, 0);
-            setlocale($category, 'en_US');
-        }
+        $this->locale = Locale::getDefault();
+        Locale::setDefault('en_US');
     }
 
     /**
@@ -72,9 +70,7 @@ class ValidationTest extends TestCase
     {
         parent::tearDown();
         Configure::write('App.encoding', $this->_appEncoding);
-        foreach ($this->_appLocale as $category => $locale) {
-            setlocale($category, $locale);
-        }
+        Locale::setDefault($this->locale);
     }
 
     /**
@@ -1751,16 +1747,13 @@ class ValidationTest extends TestCase
     public function testDecimalLocaleSet()
     {
         $this->skipIf(DS === '\\', 'The locale is not supported in Windows and affects other tests.');
-        $restore = setlocale(LC_NUMERIC, 0);
-        $this->skipIf(setlocale(LC_NUMERIC, 'da_DK') === false, "The Danish locale isn't available.");
+        $this->skipIf(Locale::setDefault('da_DK') === false, "The Danish locale isn't available.");
 
         $this->assertTrue(Validation::decimal(1.54), '1.54 should be considered a valid float');
         $this->assertTrue(Validation::decimal('1.54'), '"1.54" should be considered a valid float');
 
         $this->assertTrue(Validation::decimal(12345.67), '12345.67 should be considered a valid float');
         $this->assertTrue(Validation::decimal('12,345.67'), '"12,345.67" should be considered a valid float');
-
-        setlocale(LC_NUMERIC, $restore);
     }
 
     /**


### PR DESCRIPTION
Refs #5876 

Change validation from using setlocale, to recommended intl.default_locale
