### PR TITLE
Improve support for unioned queries on MySQL.

### DIFF
--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -18,6 +18,7 @@ use Cake\Database\Dialect\TupleComparisonTranslatorTrait;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\SqlDialectTrait;
+use Cake\Database\SqliteCompiler;
 
 /**
  * SQLite dialect trait
@@ -184,5 +185,15 @@ trait SqliteDialectTrait
     public function enableForeignKeySQL()
     {
         return 'PRAGMA foreign_keys = ON';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return \Cake\Database\SqliteCompiler
+     */
+    public function newCompiler()
+    {
+        return new SqliteCompiler();
     }
 }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -253,7 +253,8 @@ class QueryCompiler
         $parts = array_map(function ($p) use ($generator) {
             $p['query'] = $p['query']->sql($generator);
             $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
-            return $p['all'] ? 'ALL ' . $p['query'] : $p['query'];
+            $prefix = $p['all'] ? 'ALL' : '';
+            return sprintf('%s (%s)', $prefix, $p['query']);
         }, $parts);
         return sprintf("\nUNION %s", implode("\nUNION ", $parts));
     }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -135,6 +135,9 @@ class QueryCompiler
     {
         $driver = $query->connection()->driver();
         $select = 'SELECT %s%s%s';
+        if ($query->clause('union')) {
+            $select = '(SELECT %s%s%s';
+        }
         $distinct = $query->clause('distinct');
         $modifiers = $query->clause('modifier') ?: null;
 
@@ -253,10 +256,10 @@ class QueryCompiler
         $parts = array_map(function ($p) use ($generator) {
             $p['query'] = $p['query']->sql($generator);
             $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
-            $prefix = $p['all'] ? 'ALL' : '';
-            return sprintf('%s (%s)', $prefix, $p['query']);
+            $prefix = $p['all'] ? 'ALL ' : '';
+            return sprintf('%s(%s)', $prefix, $p['query']);
         }, $parts);
-        return sprintf("\nUNION %s", implode("\nUNION ", $parts));
+        return sprintf(")\nUNION %s", implode("\nUNION ", $parts));
     }
 
     /**

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -24,6 +24,25 @@ use Cake\Database\QueryCompiler;
  */
 class SqliteCompiler extends QueryCompiler
 {
+    /**
+     * Helper function used to build the string representation of a SELECT clause,
+     * it constructs the field list taking care of aliasing and
+     * converting expression objects to string. This function also constructs the
+     * DISTINCT clause for the query.
+     *
+     * @param array $parts list of fields to be transformed to string
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+     * @return string
+     */
+    protected function _buildSelectPart($parts, $query, $generator)
+    {
+        $clause = parent::_buildSelectPart($parts, $query, $generator);
+        if ($clause[0] === '(') {
+            return substr($clause, 1);
+        }
+        return $clause;
+    }
 
     /**
      * Builds the SQL string for all the UNION clauses in this query, when dealing

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database;
+
+use Cake\Database\QueryCompiler;
+
+/**
+ * Responsible for compiling a Query object into its SQL representation
+ * for SQLite
+ *
+ * @internal
+ */
+class SqliteCompiler extends QueryCompiler
+{
+
+    /**
+     * Builds the SQL string for all the UNION clauses in this query, when dealing
+     * with query objects it will also transform them using their configured SQL
+     * dialect.
+     *
+     * @param array $parts list of queries to be operated with UNION
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+     * @return string
+     */
+    protected function _buildUnionPart($parts, $query, $generator)
+    {
+        $parts = array_map(function ($p) use ($generator) {
+            $p['query'] = $p['query']->sql($generator);
+            $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
+            $prefix = $p['all'] ? 'ALL' : '';
+            return sprintf('%s %s', $prefix, $p['query']);
+        }, $parts);
+        return sprintf("\nUNION %s", implode("\nUNION ", $parts));
+    }
+}

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -25,43 +25,9 @@ use Cake\Database\QueryCompiler;
 class SqliteCompiler extends QueryCompiler
 {
     /**
-     * Helper function used to build the string representation of a SELECT clause,
-     * it constructs the field list taking care of aliasing and
-     * converting expression objects to string. This function also constructs the
-     * DISTINCT clause for the query.
+     * SQLite does not support ORDER BY in UNION queries.
      *
-     * @param array $parts list of fields to be transformed to string
-     * @param \Cake\Database\Query $query The query that is being compiled
-     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
-     * @return string
+     * @var bool
      */
-    protected function _buildSelectPart($parts, $query, $generator)
-    {
-        $clause = parent::_buildSelectPart($parts, $query, $generator);
-        if ($clause[0] === '(') {
-            return substr($clause, 1);
-        }
-        return $clause;
-    }
-
-    /**
-     * Builds the SQL string for all the UNION clauses in this query, when dealing
-     * with query objects it will also transform them using their configured SQL
-     * dialect.
-     *
-     * @param array $parts list of queries to be operated with UNION
-     * @param \Cake\Database\Query $query The query that is being compiled
-     * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
-     * @return string
-     */
-    protected function _buildUnionPart($parts, $query, $generator)
-    {
-        $parts = array_map(function ($p) use ($generator) {
-            $p['query'] = $p['query']->sql($generator);
-            $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
-            $prefix = $p['all'] ? 'ALL' : '';
-            return sprintf('%s %s', $prefix, $p['query']);
-        }, $parts);
-        return sprintf("\nUNION %s", implode("\nUNION ", $parts));
-    }
+    protected $_orderedUnion = false;
 }

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -24,6 +24,12 @@ use Cake\Database\QueryCompiler;
  */
 class SqlserverCompiler extends QueryCompiler
 {
+    /**
+     * SQLserver does not support ORDER BY in UNION queries.
+     *
+     * @var bool
+     */
+    protected $_orderedUnion = false;
 
     /**
      * {@inheritDoc}

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1945,6 +1945,31 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Tests that it is possible to run unions with order statements
+     *
+     * @return void
+     */
+    public function testUnionOrderBy()
+    {
+        $this->skipIf(
+            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlite,
+            'SQLite does not support ORDER BY in UNIONed queries.'
+        );
+        $union = (new Query($this->connection))
+            ->select(['id', 'title'])
+            ->from(['a' => 'articles'])
+            ->order(['a.id' => 'asc']);
+
+        $query = new Query($this->connection);
+        $result = $query->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->order(['c.id' => 'asc'])
+            ->union($union)
+            ->execute();
+        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
+    }
+
+    /**
      * Tests that UNION ALL can be built by setting the second param of union() to true
      *
      * @return void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1952,8 +1952,9 @@ class QueryTest extends TestCase
     public function testUnionOrderBy()
     {
         $this->skipIf(
-            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlite,
-            'SQLite does not support ORDER BY in UNIONed queries.'
+            ($this->connection->driver() instanceof \Cake\Database\Driver\Sqlite ||
+            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver),
+            'Driver does not support ORDER BY in UNIONed queries.'
         );
         $union = (new Query($this->connection))
             ->select(['id', 'title'])

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1967,6 +1967,9 @@ class QueryTest extends TestCase
             ->union($union)
             ->execute();
         $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
+
+        $rows = $result->fetchAll();
+        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
     }
 
     /**


### PR DESCRIPTION
By wrapping unioned queries with () each arm in an union can have an order clause. I've created a specialized compiler for SQLite as it seems to be the only rdbms that does not support () in UNION from what I could see.

Refs #5962
