### PR TITLE
Allow numeric sorts in PaginatorComponent.

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -388,6 +388,10 @@ class PaginatorComponent extends Component {
 		if (!empty($options['order']) && is_array($options['order'])) {
 			$order = array();
 			foreach ($options['order'] as $key => $value) {
+				if (is_int($key)) {
+					$key = $value;
+					$value = 'asc';
+				}
 				$field = $key;
 				$alias = $object->alias;
 				if (strpos($key, '.') !== false) {

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -454,6 +454,13 @@ class PaginatorComponentTest extends CakeTestCase {
 		$this->assertEquals(array(1, 2, 3), Hash::extract($result, '{n}.PaginatorControllerPost.id'));
 		$this->assertTrue(!isset($Controller->PaginatorControllerPost->lastQueries[1]['contain']));
 
+		$Controller->Paginator->settings = array(
+			'order' => array('PaginatorControllerPost.author_id')
+		);
+		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(1, 3, 2), Hash::extract($result, '{n}.PaginatorControllerPost.id'));
+
 		$Controller->request->params['named'] = array('page' => '-1');
 		$Controller->Paginator->settings = array(
 			'PaginatorControllerPost' => array(
@@ -606,7 +613,7 @@ class PaginatorComponentTest extends CakeTestCase {
 
 		$Controller->PaginatorControllerPost->order = array('PaginatorControllerPost.id');
 		$result = $Controller->Paginator->validateSort($Controller->PaginatorControllerPost, array());
-		$this->assertEmpty($result['order']);
+		$this->assertEquals(array('PaginatorControllerPost.id' => 'asc'), $result['order']);
 
 		$Controller->PaginatorControllerPost->order = 'PaginatorControllerPost.id';
 		$result = $Controller->Paginator->validateSort($Controller->PaginatorControllerPost, array());
@@ -617,7 +624,10 @@ class PaginatorComponentTest extends CakeTestCase {
 			'PaginatorControllerPost.created' => 'asc'
 		);
 		$result = $Controller->Paginator->validateSort($Controller->PaginatorControllerPost, array());
-		$expected = array('PaginatorControllerPost.created' => 'asc');
+		$expected = array(
+			'PaginatorControllerPost.id' => 'asc',
+			'PaginatorControllerPost.created' => 'asc'
+		);
 		$this->assertEquals($expected, $result['order']);
 	}
 


### PR DESCRIPTION
When paginating data, we should not ignore numerically indexed order conditions. Instead they should be handled similar to Model::find().

This creates a slightly different behavior when model's have default sorting applied as more default sort options forms will be honoured.

I'm open to moving this to 2.7 if people feel it warrants that.

Refs #5964
