### PR TITLE
3.0 afterSaveCommit

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -574,6 +574,16 @@ class Connection
     }
 
     /**
+     * Checks if a transaction is running.
+     *
+     * @return bool True is a transaction is runnning else false.
+     */
+    public function inTransaction()
+    {
+        return $this->_transactionStarted;
+    }
+
+    /**
      * Quotes value to be used safely in database query.
      *
      * @param mixed $value The value to quote.

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -576,7 +576,7 @@ class Connection
     /**
      * Checks if a transaction is running.
      *
-     * @return bool True is a transaction is runnning else false.
+     * @return bool True if a transaction is runnning else false.
      */
     public function inTransaction()
     {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1333,7 +1333,8 @@ class Table implements RepositoryInterface, EventListenerInterface
             'atomic' => true,
             'associated' => true,
             'checkRules' => true,
-            'checkExisting' => true
+            'checkExisting' => true,
+            '_primary' => true
         ]);
 
         if ($entity->errors()) {
@@ -1350,7 +1351,9 @@ class Table implements RepositoryInterface, EventListenerInterface
                 return $this->_processSave($entity, $options);
             });
             if ($success) {
-                $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
+                if ($options['_primary']) {
+                    $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
+                }
                 $entity->isNew(false);
                 $entity->source($this->registryAlias());
             }
@@ -1398,7 +1401,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             $this,
             $entity,
             $options['associated'],
-            $options->getArrayCopy()
+            ['_primary' => false] + $options->getArrayCopy()
         );
 
         if (!$saved && $options['atomic']) {
@@ -1419,7 +1422,7 @@ class Table implements RepositoryInterface, EventListenerInterface
                 $this,
                 $entity,
                 $options['associated'],
-                $options->getArrayCopy()
+                ['_primary' => false] + $options->getArrayCopy()
             );
             if ($success || !$options['atomic']) {
                 $entity->clean();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1334,7 +1334,6 @@ class Table implements RepositoryInterface, EventListenerInterface
             'associated' => true,
             'checkRules' => true,
             'checkExisting' => true,
-            '_primary' => true
         ]);
 
         if ($entity->errors()) {
@@ -1351,7 +1350,7 @@ class Table implements RepositoryInterface, EventListenerInterface
                 return $this->_processSave($entity, $options);
             });
             if ($success) {
-                if ($options['_primary']) {
+                if (!$connection->inTransaction()) {
                     $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
                 }
                 $entity->isNew(false);
@@ -1401,7 +1400,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             $this,
             $entity,
             $options['associated'],
-            ['_primary' => false] + $options->getArrayCopy()
+            $options->getArrayCopy()
         );
 
         if (!$saved && $options['atomic']) {
@@ -1422,7 +1421,7 @@ class Table implements RepositoryInterface, EventListenerInterface
                 $this,
                 $entity,
                 $options['associated'],
-                ['_primary' => false] + $options->getArrayCopy()
+                $options->getArrayCopy()
             );
             if ($success || !$options['atomic']) {
                 $entity->clean();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1294,6 +1294,9 @@ class Table implements RepositoryInterface, EventListenerInterface
      *   listeners will receive the entity and the options array as arguments. The type
      *   of operation performed (insert or update) can be determined by checking the
      *   entity's method `isNew`, true meaning an insert and false an update.
+     * - Model.afterSaveCommit: Will be triggered after the transaction is commited
+     *   for atomic save, listeners will receive the entity and the options array
+     *   as arguments.
      *
      * This method will determine whether the passed entity needs to be
      * inserted or updated in the database. It does that by checking the `isNew`
@@ -1579,10 +1582,14 @@ class Table implements RepositoryInterface, EventListenerInterface
      *
      * ### Events
      *
-     * - `beforeDelete` Fired before the delete occurs. If stopped the delete
+     * - `Model.beforeDelete` Fired before the delete occurs. If stopped the delete
      *   will be aborted. Receives the event, entity, and options.
-     * - `afterDelete` Fired after the delete has been successful. Receives
+     * - `Model.afterDelete` Fired after the delete has been successful. Receives
      *   the event, entity, and options.
+     * - `Model.afterDelete` Fired after the delete has been successful. Receives
+     *   the event, entity, and options.
+     * - `Model.afterDeleteCommit` Fired after the transaction is committed for
+     *   an atomic delete. Receives the event, entity, and options.
      *
      * The options argument will be converted into an \ArrayObject instance
      * for the duration of the callbacks, this allows listeners to modify

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1598,7 +1598,15 @@ class Table implements RepositoryInterface, EventListenerInterface
         };
 
         if ($options['atomic']) {
-            return $this->connection()->transactional($process);
+            $connection = $this->connection();
+            $success = $connection->transactional($process);
+            if ($success && !$connection->inTransaction()) {
+                $this->dispatchEvent('Model.afterDeleteCommit', [
+                    'entity' => $entity,
+                    'options' => $options
+                ]);
+            }
+            return $success;
         }
         return $process();
     }
@@ -2158,6 +2166,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             'Model.afterSaveCommit' => 'afterSaveCommit',
             'Model.beforeDelete' => 'beforeDelete',
             'Model.afterDelete' => 'afterDelete',
+            'Model.afterDeleteCommit' => 'afterDeleteCommit',
             'Model.beforeRules' => 'beforeRules',
             'Model.afterRules' => 'afterRules',
         ];

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -578,6 +578,64 @@ class ConnectionTest extends TestCase
     }
 
     /**
+     * Tests inTransaction()
+     *
+     * @return void
+     */
+    public function testInTransaction()
+    {
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->commit();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->commit();
+        $this->assertFalse($this->connection->inTransaction());
+
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->begin();
+        $this->connection->rollback();
+        $this->assertFalse($this->connection->inTransaction());
+    }
+
+    /**
+     * Tests inTransaction() with save points
+     *
+     * @return void
+     */
+    public function testInTransactionWithSavePoints()
+    {
+        $this->skipIf(!$this->connection->useSavePoints(true));
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->commit();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->commit();
+        $this->assertFalse($this->connection->inTransaction());
+
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->begin();
+        $this->connection->rollback();
+        $this->assertTrue($this->connection->inTransaction());
+
+        $this->connection->rollback();
+        $this->assertFalse($this->connection->inTransaction());
+    }
+
+    /**
      * Tests connection can quote values to be safely used in query strings
      *
      * @return void

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -466,6 +466,7 @@ class RulesCheckerIntegrationTest extends TestCase
                         'associated' => true,
                         'checkRules' => true,
                         'checkExisting' => true,
+                        '_primary' => true,
                     ],
                     $options->getArrayCopy()
                 );
@@ -504,6 +505,7 @@ class RulesCheckerIntegrationTest extends TestCase
                         'associated' => true,
                         'checkRules' => true,
                         'checkExisting' => true,
+                        '_primary' => true,
                     ],
                     $options->getArrayCopy()
                 );

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -461,7 +461,13 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->eventManager()->attach(
             function ($event, Entity $entity, \ArrayObject $options, $operation) {
                 $this->assertEquals(
-                    ['atomic' => true, 'associated' => true, 'checkRules' => true, 'checkExisting' => true],
+                    [
+                        'atomic' => true,
+                        'associated' => true,
+                        'checkRules' => true,
+                        'checkExisting' => true,
+                        '_primary' => true
+                    ],
                     $options->getArrayCopy()
                 );
                 $this->assertEquals('create', $operation);
@@ -494,7 +500,13 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->eventManager()->attach(
             function ($event, Entity $entity, \ArrayObject $options, $result, $operation) {
                 $this->assertEquals(
-                    ['atomic' => true, 'associated' => true, 'checkRules' => true, 'checkExisting' => true],
+                    [
+                        'atomic' => true,
+                        'associated' => true,
+                        'checkRules' => true,
+                        'checkExisting' => true,
+                        '_primary' => true
+                    ],
                     $options->getArrayCopy()
                 );
                 $this->assertEquals('create', $operation);

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -466,7 +466,6 @@ class RulesCheckerIntegrationTest extends TestCase
                         'associated' => true,
                         'checkRules' => true,
                         'checkExisting' => true,
-                        '_primary' => true
                     ],
                     $options->getArrayCopy()
                 );
@@ -505,7 +504,6 @@ class RulesCheckerIntegrationTest extends TestCase
                         'associated' => true,
                         'checkRules' => true,
                         'checkExisting' => true,
-                        '_primary' => true
                     ],
                     $options->getArrayCopy()
                 );

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2461,7 +2461,7 @@ class TableTest extends TestCase
     public function testDeleteCallbacks()
     {
         $entity = new \Cake\ORM\Entity(['id' => 1, 'name' => 'mark']);
-        $options = new \ArrayObject(['atomic' => true, 'checkRules' => false]);
+        $options = new \ArrayObject(['atomic' => true, 'checkRules' => false, '_primary' => true]);
 
         $mock = $this->getMock('Cake\Event\EventManager');
 
@@ -2507,7 +2507,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Test afterDeleteCommit not called for non-atomic delete
+     * Test afterDeleteCommit is also called for non-atomic delete
      *
      * @return void
      */
@@ -2533,7 +2533,7 @@ class TableTest extends TestCase
 
         $table->delete($data, ['atomic' => false]);
         $this->assertTrue($called);
-        $this->assertFalse($calledAfterCommit);
+        $this->assertTrue($calledAfterCommit);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1812,6 +1812,32 @@ class TableTest extends TestCase
     }
 
     /**
+     * Asserts the afterSaveCommit is not triggered if transaction is running.
+     *
+     * @return [type]
+     */
+    public function testAfterSaveCommitWithTransactionRunning()
+    {
+        $table = TableRegistry::get('users');
+        $data = new \Cake\ORM\Entity([
+            'username' => 'superuser',
+            'created' => new Time('2013-10-10 00:00'),
+            'updated' => new Time('2013-10-10 00:00')
+        ]);
+
+        $called = false;
+        $listener = function ($e, $entity, $options) use (&$called) {
+            $called = true;
+        };
+        $table->eventManager()->attach($listener, 'Model.afterSaveCommit');
+
+        $this->connection->begin();
+        $this->assertSame($data, $table->save($data));
+        $this->assertFalse($called);
+        $this->connection->commit();
+    }
+
+    /**
      * Asserts that afterSave callback not is called on unsuccessful save
      *
      * @group save


### PR DESCRIPTION
Added a new `Model.afterSaveCommit` event. As per its name it's triggered after a save has been committed.

The reason for this that `Model.afterSave` is triggered before operations are commited and not useful if you wanted to perform some task only after it's guaranteed that the changes have been persisted to db.
