### PR TITLE
Make global paths for vendors and plugins based on ROOT.

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -874,11 +874,11 @@ class App {
 				),
 				'Vendor' => array(
 					'%s' . 'Vendor' . DS,
-					dirname(dirname(CAKE)) . DS . 'vendors' . DS,
+					ROOT . DS . 'vendors' . DS,
 				),
 				'Plugin' => array(
 					APP . 'Plugin' . DS,
-					dirname(dirname(CAKE)) . DS . 'plugins' . DS
+					ROOT . DS . 'plugins' . DS
 				)
 			);
 		}


### PR DESCRIPTION
Using CAKE means that composer installed CakePHP will generate incorrect 'global' paths.

:notebook: I didn't have a chance to run the tests on this, so they may fail.

Refs #5838
