### PR TITLE
Make sure default datasource is not used for mock

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -414,7 +414,7 @@ class CakeTestCaseTest extends CakeTestCase {
 			)
 		), App::RESET);
 		$Post = $this->getMockForModel('Post');
-
+		$this->assertEquals('test', $Post->useDbConfig);
 		$this->assertInstanceOf('Post', $Post);
 		$this->assertNull($Post->save(array()));
 		$this->assertNull($Post->find('all'));

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -732,12 +732,12 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 		$mock = $this->getMock($name, $methods, array($config));
 
 		$availableDs = array_keys(ConnectionManager::enumConnectionObjects());
-		if ($mock->useDbConfig === 'default') {
-			$mock->useDbConfig = null;
-			$mock->setDataSource('test');
-		}
+
 		if ($mock->useDbConfig !== 'test' && in_array('test_' . $mock->useDbConfig, $availableDs)) {
 			$mock->setDataSource('test_' . $mock->useDbConfig);
+		} else {
+			$mock->useDbConfig = 'test';
+			$mock->setDataSource('test');
 		}
 
 		ClassRegistry::removeObject($name);


### PR DESCRIPTION
When a non-default datasource is used for a model and no test_ version of
that datasource is available, the getMockForModel method used the
models standard datasource, rahter than 'test'.
