### PR TITLE
Don't generate maxlength properties for decimal columns.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -782,7 +782,6 @@ class FormHelperTest extends CakeTestCase {
 				'type' => 'text',
 				'name' => 'data[ValidateUser][cost_decimal]',
 				'id' => 'ValidateUserCostDecimal',
-				'maxlength' => 6,
 			)),
 			'/div'
 		);

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1287,6 +1287,7 @@ class FormHelper extends AppHelper {
 			isset($fieldDef['length']) &&
 			is_scalar($fieldDef['length']) &&
 			$fieldDef['length'] < 1000000 &&
+			$fieldDef['type'] !== 'decimal' &&
 			$options['type'] !== 'select'
 		);
 		if ($autoLength &&


### PR DESCRIPTION
Int casting the decimal scale isn't going to work in a number of situations as users may end up trying to include decimal points, commas or spaces in larger amounts.

Fixes #5977
