### PR TITLE
Make maxLimit and limit settings independent.

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -333,15 +333,13 @@ class PaginatorComponent extends Component {
 		if (isset($this->settings[$alias])) {
 			$defaults = $this->settings[$alias];
 		}
-		if (isset($defaults['limit']) &&
-			(empty($defaults['maxLimit']) || $defaults['limit'] > $defaults['maxLimit'])
-		) {
-			$defaults['maxLimit'] = $defaults['limit'];
-		}
-		return array_merge(
-			array('page' => 1, 'limit' => 20, 'maxLimit' => 100, 'paramType' => 'named'),
-			$defaults
+		$defaults += array(
+			'page' => 1,
+			'limit' => 20,
+			'maxLimit' => 100,
+			'paramType' => 'named'
 		);
+		return $defaults;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -853,7 +853,7 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named',
 		);
 		$result = $this->Paginator->mergeOptions('Post');
-		$expected = array('page' => 1, 'limit' => 200, 'maxLimit' => 200, 'paramType' => 'named');
+		$expected = array('page' => 1, 'limit' => 200, 'maxLimit' => 100, 'paramType' => 'named');
 		$this->assertEquals($expected, $result);
 
 		$this->Paginator->settings = array(
@@ -872,7 +872,7 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named',
 		);
 		$result = $this->Paginator->mergeOptions('Post');
-		$expected = array('page' => 1, 'limit' => 500, 'maxLimit' => 150, 'paramType' => 'named');
+		$expected = array('page' => 1, 'limit' => 500, 'maxLimit' => 100, 'paramType' => 'named');
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
Having maxLimit infer what it should be based on limit was not a very transparent default behavior. The documentation states that maxLimit will default to 100, but the code would default it to 'limit' if set. This created confusing behavior when only one setting was defined.

Refs #5973
