### PR TITLE
Add allow empty translations config to translate behavior

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -76,8 +76,7 @@ class TranslateBehavior extends Behavior
         'defaultLocale' => '',
         'model' => '',
         'onlyTranslated' => false,
-        'strategy' => 'subquery',
-        'conditions' => ['model' => '']
+        'strategy' => 'subquery'
     ];
 
     /**
@@ -102,19 +101,10 @@ class TranslateBehavior extends Behavior
     {
         $this->_translationTable = TableRegistry::get($this->_config['translationTable']);
 
-        if ($this->config('model')) {
-            $model = $this->config('model');
-        } elseif ($this->config('conditions.model')) {
-            $model = $this->config('conditions.model');
-        } else {
-            $model = $this->_table->alias();
-        }
-        $this->config('conditions.model', $model);
-
         $this->setupFieldAssociations(
             $this->_config['fields'],
             $this->_config['translationTable'],
-            $this->_config['conditions'],
+            $this->_config['model'] ? $this->_config['model'] : $this->_table->alias(),
             $this->_config['strategy']
         );
     }
@@ -128,12 +118,12 @@ class TranslateBehavior extends Behavior
      *
      * @param array $fields list of fields to create associations for
      * @param string $table the table name to use for storing each field translation
-     * @param array $fieldConditions conditions for finding fields
+     * @param string $model the model field value
      * @param string $strategy the strategy used in the _i18n association
      *
      * @return void
      */
-    public function setupFieldAssociations($fields, $table, $fieldConditions, $strategy)
+    public function setupFieldAssociations($fields, $table, $model, $strategy)
     {
         $targetAlias = $this->_translationTable->alias();
         $alias = $this->_table->alias();
@@ -141,13 +131,7 @@ class TranslateBehavior extends Behavior
 
         foreach ($fields as $field) {
             $name = $alias . '_' . $field . '_translation';
-            $conditions = [
-                $name . '.model' => $fieldConditions['model'],
-                $name . '.field' => $field,
-            ];
-            foreach ($fieldConditions as $fieldName => $fieldValue) {
-                $conditions[$name . '.' . $fieldName] = $fieldValue;
-            }
+
             if (!TableRegistry::exists($name)) {
                 $fieldTable = TableRegistry::get($name, [
                     'className' => $table,
@@ -162,7 +146,10 @@ class TranslateBehavior extends Behavior
                 'targetTable' => $fieldTable,
                 'foreignKey' => 'foreign_key',
                 'joinType' => $filter ? 'INNER' : 'LEFT',
-                'conditions' => $conditions,
+                'conditions' => [
+                    $name . '.model' => $model,
+                    $name . '.field' => $field,
+                ],
                 'propertyName' => $field . '_translation'
             ]);
         }
@@ -171,7 +158,7 @@ class TranslateBehavior extends Behavior
             'className' => $table,
             'foreignKey' => 'foreign_key',
             'strategy' => $strategy,
-            'conditions' => ["$targetAlias.model" => $fieldConditions['model']],
+            'conditions' => ["$targetAlias.model" => $model],
             'propertyName' => '_i18n',
             'dependent' => true
         ]);
@@ -267,7 +254,7 @@ class TranslateBehavior extends Behavior
         $fields = array_keys($values);
         $primaryKey = (array)$this->_table->primaryKey();
         $key = $entity->get(current($primaryKey));
-        $model = $this->config('conditions.model');
+        $model = $this->_table->alias();
 
         $preexistent = $this->_translationTable->find()
             ->select(['id', 'field'])
@@ -473,14 +460,14 @@ class TranslateBehavior extends Behavior
         }
 
         $results = $this->_findExistingTranslations($find);
-        $model = $this->config('conditions.model');
+        $alias = $this->_table->alias();
 
         foreach ($find as $i => $translation) {
             if (!empty($results[$i])) {
                 $contents[$i]->set('id', $results[$i], ['setter' => false]);
                 $contents[$i]->isNew(false);
             } else {
-                $translation['model'] = $model;
+                $translation['model'] = $alias;
                 $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
                 $contents[$i]->isNew(true);
             }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -23,6 +23,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
 
 /**
  * This behavior provides a way to translate dynamic data by keeping translations
@@ -90,7 +91,7 @@ class TranslateBehavior extends Behavior
     {
         $config += [
             'defaultLocale' => I18n::defaultLocale(),
-            'referenceName' => $table->alias()
+            'referenceName' => $this->_referenceName($table)
         ];
         parent::__construct($table, $config);
     }
@@ -361,6 +362,29 @@ class TranslateBehavior extends Behavior
                 return $q;
             }])
             ->formatResults([$this, 'groupTranslations'], $query::PREPEND);
+    }
+
+    /**
+     * Determine the reference name to use for a given table
+     *
+     * The reference name is usually derived from the class name of the table object
+     * (PostsTable -> Posts), however for autotable instances it is derived from
+     * the database table the object points at - or as a last resort, the alias
+     * of the autotable instance.
+     *
+     * @param Table $table
+     * @return string
+     */
+    protected function _referenceName(Table $table)
+    {
+        $name = namespaceSplit(get_class($table));
+        $name = substr(end($name), 0, -5);
+        if (empty($name)) {
+            $name = $table->table() ?: $table->alias();
+            $name = Inflector::camelize($name);
+        }
+
+        return $name;
     }
 
     /**

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -105,7 +105,7 @@ class TranslateBehavior extends Behavior
         $this->setupFieldAssociations(
             $this->_config['fields'],
             $this->_config['translationTable'],
-            $this->_config['model'] ? $this->_config['model'] : $this->_table->alias(),
+            $this->_config['model'] ?: $this->_table->alias(),
             $this->_config['strategy']
         );
     }
@@ -471,14 +471,14 @@ class TranslateBehavior extends Behavior
         }
 
         $results = $this->_findExistingTranslations($find);
-        $alias = $this->_table->alias();
+        $model = $this->_config['model'] ?: $this->_table->alias();
 
         foreach ($find as $i => $translation) {
             if (!empty($results[$i])) {
                 $contents[$i]->set('id', $results[$i], ['setter' => false]);
                 $contents[$i]->isNew(false);
             } else {
-                $translation['model'] = $alias;
+                $translation['model'] = $model;
                 $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
                 $contents[$i]->isNew(true);
             }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -265,7 +265,7 @@ class TranslateBehavior extends Behavior
         $fields = array_keys($values);
         $primaryKey = (array)$this->_table->primaryKey();
         $key = $entity->get(current($primaryKey));
-        $model = $this->_table->alias();
+        $model = $this->_config['model'] ?: $this->_table->alias();
 
         $preexistent = $this->_translationTable->find()
             ->select(['id', 'field'])

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -75,6 +75,7 @@ class TranslateBehavior extends Behavior
         'translationTable' => 'I18n',
         'defaultLocale' => '',
         'model' => '',
+        'allowEmptyTranslations' => true,
         'onlyTranslated' => false,
         'strategy' => 'subquery'
     ];
@@ -142,23 +143,33 @@ class TranslateBehavior extends Behavior
                 $fieldTable = TableRegistry::get($name);
             }
 
+            $conditions = [
+                $name . '.model' => $model,
+                $name . '.field' => $field,
+            ];
+            if (!$this->_config['allowEmptyTranslations']) {
+                $conditions[$name . '.content !='] = '';
+            }
+
             $this->_table->hasOne($name, [
                 'targetTable' => $fieldTable,
                 'foreignKey' => 'foreign_key',
                 'joinType' => $filter ? 'INNER' : 'LEFT',
-                'conditions' => [
-                    $name . '.model' => $model,
-                    $name . '.field' => $field,
-                ],
+                'conditions' => $conditions,
                 'propertyName' => $field . '_translation'
             ]);
+        }
+
+        $conditions = ["$targetAlias.model" => $model];
+        if (!$this->_config['allowEmptyTranslations']) {
+            $conditions["$targetAlias.content !="] = '';
         }
 
         $this->_table->hasMany($targetAlias, [
             'className' => $table,
             'foreignKey' => 'foreign_key',
             'strategy' => $strategy,
-            'conditions' => ["$targetAlias.model" => $model],
+            'conditions' => $conditions,
             'propertyName' => '_i18n',
             'dependent' => true
         ]);

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -74,7 +74,7 @@ class TranslateBehavior extends Behavior
         'fields' => [],
         'translationTable' => 'I18n',
         'defaultLocale' => '',
-        'model' => '',
+        'referenceName' => '',
         'allowEmptyTranslations' => true,
         'onlyTranslated' => false,
         'strategy' => 'subquery'
@@ -90,7 +90,7 @@ class TranslateBehavior extends Behavior
     {
         $config += [
             'defaultLocale' => I18n::defaultLocale(),
-            'model' => $table->alias()
+            'referenceName' => $table->alias()
         ];
         parent::__construct($table, $config);
     }
@@ -108,7 +108,7 @@ class TranslateBehavior extends Behavior
         $this->setupFieldAssociations(
             $this->_config['fields'],
             $this->_config['translationTable'],
-            $this->_config['model'],
+            $this->_config['referenceName'],
             $this->_config['strategy']
         );
     }
@@ -268,7 +268,7 @@ class TranslateBehavior extends Behavior
         $fields = array_keys($values);
         $primaryKey = (array)$this->_table->primaryKey();
         $key = $entity->get(current($primaryKey));
-        $model = $this->_config['model'];
+        $model = $this->_config['referenceName'];
 
         $preexistent = $this->_translationTable->find()
             ->select(['id', 'field'])
@@ -480,7 +480,7 @@ class TranslateBehavior extends Behavior
                 $contents[$i]->set('id', $results[$i], ['setter' => false]);
                 $contents[$i]->isNew(false);
             } else {
-                $translation['model'] = $this->_config['model'];
+                $translation['model'] = $this->_config['referenceName'];
                 $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
                 $contents[$i]->isNew(true);
             }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -88,7 +88,10 @@ class TranslateBehavior extends Behavior
      */
     public function __construct(Table $table, array $config = [])
     {
-        $config += ['defaultLocale' => I18n::defaultLocale()];
+        $config += [
+            'defaultLocale' => I18n::defaultLocale(),
+            'model' => $table->alias()
+        ];
         parent::__construct($table, $config);
     }
 
@@ -105,7 +108,7 @@ class TranslateBehavior extends Behavior
         $this->setupFieldAssociations(
             $this->_config['fields'],
             $this->_config['translationTable'],
-            $this->_config['model'] ?: $this->_table->alias(),
+            $this->_config['model'],
             $this->_config['strategy']
         );
     }
@@ -265,7 +268,7 @@ class TranslateBehavior extends Behavior
         $fields = array_keys($values);
         $primaryKey = (array)$this->_table->primaryKey();
         $key = $entity->get(current($primaryKey));
-        $model = $this->_config['model'] ?: $this->_table->alias();
+        $model = $this->_config['model'];
 
         $preexistent = $this->_translationTable->find()
             ->select(['id', 'field'])
@@ -471,14 +474,13 @@ class TranslateBehavior extends Behavior
         }
 
         $results = $this->_findExistingTranslations($find);
-        $model = $this->_config['model'] ?: $this->_table->alias();
 
         foreach ($find as $i => $translation) {
             if (!empty($results[$i])) {
                 $contents[$i]->set('id', $results[$i], ['setter' => false]);
                 $contents[$i]->isNew(false);
             } else {
-                $translation['model'] = $model;
+                $translation['model'] = $this->_config['model'];
                 $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
                 $contents[$i]->isNew(true);
             }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -890,18 +890,18 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
-     * Tests the use of `model` config option.
+     * Tests the use of `referenceName` config option.
      *
      * @return void
      */
-    public function testChangingModelFieldValue()
+    public function testAutoReferenceName()
     {
         $table = TableRegistry::get('Articles');
 
         $table->hasMany('OtherComments', ['className' => 'Comments']);
         $table->OtherComments->addBehavior(
             'Translate',
-            ['fields' => ['comment'], 'referenceName' => 'Comments']
+            ['fields' => ['comment']]
         );
 
         $items = $table->OtherComments->associations();
@@ -917,7 +917,37 @@ class TranslateBehaviorTest extends TestCase
             }
         }
 
-        $this->assertTrue($found, '`model` field condition on a Translation association was not found');
+        $this->assertTrue($found, '`referenceName` field condition on a Translation association was not found');
+    }
+
+    /**
+     * Tests the use of unconventional `referenceName` config option.
+     *
+     * @return void
+     */
+    public function testChangingReferenceName()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->alias('FavoritePost');
+        $table->addBehavior(
+            'Translate',
+            ['fields' => ['body'], 'referenceName' => 'Posts']
+        );
+
+        $items = $table->associations();
+        $association = $items->getByProperty('body_translation');
+        $this->assertNotEmpty($association, 'Translation association not found');
+
+        $found = false;
+        foreach ($association->conditions() as $key => $value) {
+            if (strpos($key, 'body_translation.model') !== false) {
+                $found = true;
+                $this->assertEquals('Posts', $value);
+                break;
+            }
+        }
+
+        $this->assertTrue($found, '`referenceName` field condition on a Translation association was not found');
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -971,16 +971,16 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
-     * Tests that conditions set when defining the behavior are applied correctly
+     * Tests that allowEmptyTranslations takes effect
      *
      * @return void
      */
-    public function testConditions()
+    public function testEmptyTranslations()
     {
         $table = TableRegistry::get('Articles');
         $table->addBehavior('Translate', [
             'fields' => ['title', 'body', 'description'],
-            'conditions' => ['content <>' => '']
+            'allowEmptyTranslations' => false,
         ]);
         $table->locale('spa');
         $result = $table->find()->first();

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -899,7 +899,10 @@ class TranslateBehaviorTest extends TestCase
         $table = TableRegistry::get('Articles');
 
         $table->hasMany('OtherComments', ['className' => 'Comments']);
-        $table->OtherComments->addBehavior('Translate', ['fields' => ['comment'], 'model' => 'Comments']);
+        $table->OtherComments->addBehavior(
+            'Translate',
+            ['fields' => ['comment'], 'referenceName' => 'Comments']
+        );
 
         $items = $table->OtherComments->associations();
         $association = $items->getByProperty('comment_translation');


### PR DESCRIPTION
This reverts the behavior changes (but not the tests) introduced in #5822, to address #5795.

I've defaulted the config value to `true` - as that's how it currently works. I think the default is effectively an arbitrary choice, as it's equally expected/valid to want or not want empty translations to be retrieved.
