### PR TITLE
Implement Table::name()

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -128,6 +128,13 @@ class Table implements RepositoryInterface, EventListenerInterface
     const DEFAULT_VALIDATOR = 'default';
 
     /**
+     * Name of the table object, accounting for auto-models
+     *
+     * @var string
+     */
+    protected $_name;
+
+    /**
      * Name of the table as it can be found in the database
      *
      * @var string
@@ -318,6 +325,24 @@ class Table implements RepositoryInterface, EventListenerInterface
     }
 
     /**
+     * Returns the name of the table object, accounting for automodels
+     *
+     * @return string
+     */
+    public function name()
+    {
+        if ($this->_name === null) {
+            $name = namespaceSplit(get_class($this));
+            $name = substr(end($name), 0, -5);
+            if (empty($name)) {
+                $name = $this->alias();
+            }
+            $this->_name = $name;
+        }
+        return $this->_name;
+    }
+
+    /**
      * Returns the database table name or sets a new one
      *
      * @param string|null $table the new table name
@@ -329,12 +354,7 @@ class Table implements RepositoryInterface, EventListenerInterface
             $this->_table = $table;
         }
         if ($this->_table === null) {
-            $table = namespaceSplit(get_class($this));
-            $table = substr(end($table), 0, -5);
-            if (empty($table)) {
-                $table = $this->alias();
-            }
-            $this->_table = Inflector::underscore($table);
+            $this->_table = Inflector::underscore($this->name());
         }
         return $this->_table;
     }
@@ -2174,6 +2194,7 @@ class Table implements RepositoryInterface, EventListenerInterface
         $conn = $this->connection();
         return [
             'registryAlias' => $this->registryAlias(),
+            'name' => $this->name(),
             'table' => $this->table(),
             'alias' => $this->alias(),
             'entityClass' => $this->entityClass(),

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -335,7 +335,12 @@ class Table implements RepositoryInterface, EventListenerInterface
             $name = namespaceSplit(get_class($this));
             $name = substr(end($name), 0, -5);
             if (empty($name)) {
-                $name = $this->alias();
+                if (isset($this->_table)) {
+                    $name = $this->_table;
+                } else {
+                    $name = $this->alias();
+                }
+                $name = Inflector::camelize($name);
             }
             $this->_name = $name;
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -135,6 +135,29 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests the name method
+     *
+     * @return void
+     */
+    public function testNameMethod()
+    {
+        $table = new Table(['alias' => 'users']);
+        $this->assertEquals('Users', $table->name(), 'Derived from the table, derived from the alias');
+
+        $table = new Table(['table' => 'some_stuffs']);
+        $this->assertEquals('SomeStuffs', $table->name(), 'Derived from the table');
+
+        $table = new Table(['table' => 'stuffs', 'alias' => 'MyStuffs']);
+        $this->assertEquals('Stuffs', $table->name(), 'Derived from the table, ignoring the alias');
+
+        $table = new UsersTable();
+        $this->assertEquals('Users', $table->name(), 'Derived from the class name');
+
+        $table = new UsersTable(['alias' => 'Friend']);
+        $this->assertEquals('Users', $table->name(), 'Derived from the class name, ignoring the alias');
+    }
+
+    /**
      * Tests the alias method
      *
      * @return void
@@ -3509,6 +3532,7 @@ class TableTest extends TestCase
         $result = $articles->__debugInfo();
         $expected = [
             'registryAlias' => 'articles',
+            'name' => 'Articles',
             'table' => 'articles',
             'alias' => 'articles',
             'entityClass' => 'TestApp\Model\Entity\Article',
@@ -3523,6 +3547,7 @@ class TableTest extends TestCase
         $result = $articles->__debugInfo();
         $expected = [
             'registryAlias' => 'Foo.Articles',
+            'name' => 'Articles',
             'table' => 'articles',
             'alias' => 'Articles',
             'entityClass' => '\Cake\ORM\Entity',


### PR DESCRIPTION
We don't currently have a means to know the table name, accounting for auto-table instances.
