### PR TITLE
Fix error page when datasource config is missing.

### DIFF
--- a/src/Template/Error/missing_datasource_config.ctp
+++ b/src/Template/Error/missing_datasource_config.ctp
@@ -21,5 +21,9 @@ $this->assign('templateName', 'missing_datasource_config.ctp');
 $this->start('subheading');
 ?>
     <strong>Error: </strong>
-    The datasource configuration <em><?= h($name) ?></em> was not found in config<?= DS . 'app.php' ?>.
+    <?php if (isset($name)): ?>
+        The datasource configuration <em><?= h($name) ?></em> was not found in config<?= DS . 'app.php' ?>.
+    <?php else: ?>
+        <?= h($message) ?>
+    <?php endif; ?>
 <?php $this->end() ?>


### PR DESCRIPTION
When you try to alias undefined connections the error page should make sense.
