### PR TITLE
Fixed return type of toQuarter in CakeTime and TimeHelper

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -72,13 +72,13 @@ class CakeTimeTest extends CakeTestCase {
  */
 	public function testToQuarter() {
 		$result = $this->Time->toQuarter('2007-12-25');
-		$this->assertEquals(4, $result);
+		$this->assertSame(4, $result);
 
 		$result = $this->Time->toQuarter('2007-9-25');
-		$this->assertEquals(3, $result);
+		$this->assertSame(3, $result);
 
 		$result = $this->Time->toQuarter('2007-3-25');
-		$this->assertEquals(1, $result);
+		$this->assertSame(1, $result);
 
 		$result = $this->Time->toQuarter('2007-3-25', true);
 		$this->assertEquals(array('2007-01-01', '2007-03-31'), $result);

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -575,12 +575,12 @@ class CakeTime {
  *
  * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param bool $range if true returns a range in Y-m-d format
- * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
+ * @return int|array 1, 2, 3, or 4 quarter of year or array if $range true
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::toQuarter
  */
 	public static function toQuarter($dateString, $range = false) {
 		$time = self::fromString($dateString);
-		$date = ceil(date('m', $time) / 3);
+		$date = (int)ceil(date('m', $time) / 3);
 		if ($range === false) {
 			return $date;
 		}

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -316,7 +316,7 @@ class TimeHelper extends AppHelper {
  *
  * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param bool $range if true returns a range in Y-m-d format
- * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
+ * @return int|array 1, 2, 3, or 4 quarter of year or array if $range true
  * @see CakeTime::toQuarter()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */


### PR DESCRIPTION
php ceil() returns a float, because "the value range of float is usually bigger than that of integer" (source: http://php.net/manual/en/function.ceil.php).
I suppose a type cast is correct in this situation.
