### PR TITLE
Fix composite primary key support when inserting data.

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -235,8 +235,8 @@ class PostgresSchema extends BaseSchema
             // If there is only one column in the primary key and it is integery,
             // make it autoincrement.
             $columnDef = $table->column($columns[0]);
-            if (
-                $type === Table::CONSTRAINT_PRIMARY &&
+
+            if ($type === Table::CONSTRAINT_PRIMARY &&
                 count($columns) === 1 &&
                 in_array($columnDef['type'], ['integer', 'biginteger'])
             ) {

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -40,17 +40,17 @@ class PostgresSchema extends BaseSchema
     {
         $sql =
         'SELECT DISTINCT table_schema AS schema, column_name AS name, data_type AS type,
-			is_nullable AS null, column_default AS default,
-			character_maximum_length AS char_length,
-			d.description as comment,
-			ordinal_position
-		FROM information_schema.columns c
-		INNER JOIN pg_catalog.pg_namespace ns ON (ns.nspname = table_schema)
-		INNER JOIN pg_catalog.pg_class cl ON (cl.relnamespace = ns.oid AND cl.relname = table_name)
-		LEFT JOIN pg_catalog.pg_index i ON (i.indrelid = cl.oid AND i.indkey[0] = c.ordinal_position)
-		LEFT JOIN pg_catalog.pg_description d on (cl.oid = d.objoid AND d.objsubid = c.ordinal_position)
-		WHERE table_name = ? AND table_schema = ? AND table_catalog = ?
-		ORDER BY ordinal_position';
+            is_nullable AS null, column_default AS default,
+            character_maximum_length AS char_length,
+            d.description as comment,
+            ordinal_position
+        FROM information_schema.columns c
+        INNER JOIN pg_catalog.pg_namespace ns ON (ns.nspname = table_schema)
+        INNER JOIN pg_catalog.pg_class cl ON (cl.relnamespace = ns.oid AND cl.relname = table_name)
+        LEFT JOIN pg_catalog.pg_index i ON (i.indrelid = cl.oid AND i.indkey[0] = c.ordinal_position)
+        LEFT JOIN pg_catalog.pg_description d on (cl.oid = d.objoid AND d.objsubid = c.ordinal_position)
+        WHERE table_name = ? AND table_schema = ? AND table_catalog = ?
+        ORDER BY ordinal_position';
 
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
         return [$sql, [$tableName, $schema, $config['database']]];
@@ -181,24 +181,24 @@ class PostgresSchema extends BaseSchema
     public function describeIndexSql($tableName, $config)
     {
         $sql = 'SELECT
-			c2.relname,
-			i.indisprimary,
-			i.indisunique,
-			i.indisvalid,
-			pg_catalog.pg_get_indexdef(i.indexrelid, 0, true) AS statement
-		FROM pg_catalog.pg_class AS c,
-			pg_catalog.pg_class AS c2,
-			pg_catalog.pg_index AS i
-		WHERE c.oid  = (
-			SELECT c.oid
-			FROM pg_catalog.pg_class c
-			LEFT JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-			WHERE c.relname = ?
-				AND n.nspname = ?
-		)
-		AND c.oid = i.indrelid
-		AND i.indexrelid = c2.oid
-		ORDER BY i.indisprimary DESC, i.indisunique DESC, c2.relname';
+            c2.relname,
+            i.indisprimary,
+            i.indisunique,
+            i.indisvalid,
+            pg_catalog.pg_get_indexdef(i.indexrelid, 0, true) AS statement
+        FROM pg_catalog.pg_class AS c,
+            pg_catalog.pg_class AS c2,
+            pg_catalog.pg_index AS i
+        WHERE c.oid  = (
+            SELECT c.oid
+            FROM pg_catalog.pg_class c
+            LEFT JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+            WHERE c.relname = ?
+                AND n.nspname = ?
+        )
+        AND c.oid = i.indrelid
+        AND i.indexrelid = c2.oid
+        ORDER BY i.indisprimary DESC, i.indisunique DESC, c2.relname';
 
         $schema = 'public';
         if (!empty($config['schema'])) {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -122,10 +122,19 @@ class SqliteSchema extends BaseSchema
             'null' => !$row['notnull'],
             'default' => $row['dflt_value'] === null ? null : trim($row['dflt_value'], "'"),
         ];
-        if ($row['pk']) {
+        $primary = $table->constraint('primary');
+
+        if ($row['pk'] && empty($primary)) {
             $field['null'] = false;
             $field['autoIncrement'] = true;
         }
+
+        // SQLite does not support autoincrement on composite keys.
+        if ($row['pk'] && !empty($primary)) {
+            $existingColumn = $primary['columns'][0];
+            $table->addColumn($existingColumn, ['autoIncrement' => null] + $table->column($existingColumn));
+        }
+
         $table->addColumn($row['name'], $field);
         if ($row['pk']) {
             $constraint = (array)$table->constraint('primary') + [

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -29,12 +29,10 @@ class SqlserverSchema extends BaseSchema
      */
     public function listTablesSql($config)
     {
-        $sql = '
-			SELECT TABLE_NAME
-			FROM INFORMATION_SCHEMA.TABLES
-			WHERE TABLE_SCHEMA = ?
-			ORDER BY TABLE_NAME
-		';
+        $sql = 'SELECT TABLE_NAME
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA = ?
+            ORDER BY TABLE_NAME';
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
         return [$sql, [$schema]];
     }
@@ -44,16 +42,15 @@ class SqlserverSchema extends BaseSchema
      */
     public function describeColumnSql($tableName, $config)
     {
-        $sql =
-        "SELECT DISTINCT TABLE_SCHEMA AS [schema], COLUMN_NAME AS [name], DATA_TYPE AS [type],
-			IS_NULLABLE AS [null], COLUMN_DEFAULT AS [default],
-			CHARACTER_MAXIMUM_LENGTH AS [char_length],
-			NUMERIC_PRECISION AS [precision],
-			NUMERIC_SCALE AS [scale],
-			'' AS [comment], ORDINAL_POSITION AS [ordinal_position]
-		FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?
-		ORDER BY ordinal_position";
+        $sql = "SELECT DISTINCT TABLE_SCHEMA AS [schema], COLUMN_NAME AS [name], DATA_TYPE AS [type],
+            IS_NULLABLE AS [null], COLUMN_DEFAULT AS [default],
+            CHARACTER_MAXIMUM_LENGTH AS [char_length],
+            NUMERIC_PRECISION AS [precision],
+            NUMERIC_SCALE AS [scale],
+            '' AS [comment], ORDINAL_POSITION AS [ordinal_position]
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?
+        ORDER BY ordinal_position";
 
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
         return [$sql, [$tableName, $schema]];
@@ -166,21 +163,19 @@ class SqlserverSchema extends BaseSchema
      */
     public function describeIndexSql($tableName, $config)
     {
-        $sql = "
-			SELECT
-				I.[name] AS [index_name],
-				IC.[index_column_id] AS [index_order],
-				AC.[name] AS [column_name],
-				I.[is_unique], I.[is_primary_key],
-				I.[is_unique_constraint]
-			FROM sys.[tables] AS T
-			INNER JOIN sys.[schemas] S ON S.[schema_id] = T.[schema_id]
-			INNER JOIN sys.[indexes] I ON T.[object_id] = I.[object_id]
-			INNER JOIN sys.[index_columns] IC ON I.[object_id] = IC.[object_id] AND I.[index_id] = IC.[index_id]
-			INNER JOIN sys.[all_columns] AC ON T.[object_id] = AC.[object_id] AND IC.[column_id] = AC.[column_id]
-			WHERE T.[is_ms_shipped] = 0 AND I.[type_desc] <> 'HEAP' AND T.[name] = ? AND S.[name] = ?
-			ORDER BY I.[index_id], IC.[index_column_id]
-		";
+        $sql = "SELECT
+                I.[name] AS [index_name],
+                IC.[index_column_id] AS [index_order],
+                AC.[name] AS [column_name],
+                I.[is_unique], I.[is_primary_key],
+                I.[is_unique_constraint]
+            FROM sys.[tables] AS T
+            INNER JOIN sys.[schemas] S ON S.[schema_id] = T.[schema_id]
+            INNER JOIN sys.[indexes] I ON T.[object_id] = I.[object_id]
+            INNER JOIN sys.[index_columns] IC ON I.[object_id] = IC.[object_id] AND I.[index_id] = IC.[index_id]
+            INNER JOIN sys.[all_columns] AC ON T.[object_id] = AC.[object_id] AND IC.[column_id] = AC.[column_id]
+            WHERE T.[is_ms_shipped] = 0 AND I.[type_desc] <> 'HEAP' AND T.[name] = ? AND S.[name] = ?
+            ORDER BY I.[index_id], IC.[index_column_id]";
 
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
         return [$sql, [$tableName, $schema]];
@@ -229,19 +224,17 @@ class SqlserverSchema extends BaseSchema
      */
     public function describeForeignKeySql($tableName, $config)
     {
-        $sql = "
-			SELECT FK.[name] AS [foreign_key_name], FK.[delete_referential_action_desc] AS [delete_type],
-				FK.[update_referential_action_desc] AS [update_type], C.name AS [column], RT.name AS [reference_table],
-				RC.name AS [reference_column]
-			FROM sys.foreign_keys FK
-			INNER JOIN sys.foreign_key_columns FKC ON FKC.constraint_object_id = FK.object_id
-			INNER JOIN sys.tables T ON T.object_id = FKC.parent_object_id
-			INNER JOIN sys.tables RT ON RT.object_id = FKC.referenced_object_id
-			INNER JOIN sys.schemas S ON S.schema_id = T.schema_id AND S.schema_id = RT.schema_id
-			INNER JOIN sys.columns C ON C.column_id = FKC.parent_column_id AND C.object_id = FKC.parent_object_id
-			INNER JOIN sys.columns RC ON RC.column_id = FKC.referenced_column_id AND RC.object_id = FKC.referenced_object_id
-			WHERE FK.is_ms_shipped = 0 AND T.name = ? AND S.name = ?
-		";
+        $sql = "SELECT FK.[name] AS [foreign_key_name], FK.[delete_referential_action_desc] AS [delete_type],
+                FK.[update_referential_action_desc] AS [update_type], C.name AS [column], RT.name AS [reference_table],
+                RC.name AS [reference_column]
+            FROM sys.foreign_keys FK
+            INNER JOIN sys.foreign_key_columns FKC ON FKC.constraint_object_id = FK.object_id
+            INNER JOIN sys.tables T ON T.object_id = FKC.parent_object_id
+            INNER JOIN sys.tables RT ON RT.object_id = FKC.referenced_object_id
+            INNER JOIN sys.schemas S ON S.schema_id = T.schema_id AND S.schema_id = RT.schema_id
+            INNER JOIN sys.columns C ON C.column_id = FKC.parent_column_id AND C.object_id = FKC.parent_object_id
+            INNER JOIN sys.columns RC ON RC.column_id = FKC.referenced_column_id AND RC.object_id = FKC.referenced_object_id
+            WHERE FK.is_ms_shipped = 0 AND T.name = ? AND S.name = ?";
 
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
         return [$sql, [$tableName, $schema]];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1479,8 +1479,9 @@ class Table implements RepositoryInterface, EventListenerInterface
         $data = $filteredKeys + $data;
 
         if (count($primary) > 1) {
+            $schema = $this->schema();
             foreach ($primary as $k => $v) {
-                if (!isset($data[$k])) {
+                if (!isset($data[$k]) && empty($schema->column($k)['autoIncrement'])) {
                     $msg = 'Cannot insert row, some of the primary key values are missing. ';
                     $msg .= sprintf(
                         'Got (%s), expecting (%s)',

--- a/tests/Fixture/CompositeIncrementsFixture.php
+++ b/tests/Fixture/CompositeIncrementsFixture.php
@@ -16,7 +16,7 @@ namespace Cake\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
-class SiteAuthorsFixture extends TestFixture
+class CompositeIncrementsFixture extends TestFixture
 {
 
     /**
@@ -25,10 +25,10 @@ class SiteAuthorsFixture extends TestFixture
      * @var array
      */
     public $fields = [
-        'id' => ['type' => 'integer'],
+        'id' => ['type' => 'integer', 'null' => false, 'autoIncrement' => true],
+        'account_id' => ['type' => 'integer', 'null' => false],
         'name' => ['type' => 'string', 'default' => null],
-        'site_id' => ['type' => 'integer', 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'site_id']]]
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'account_id']]]
     ];
 
     /**
@@ -37,9 +37,5 @@ class SiteAuthorsFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['id' => 1, 'name' => 'mark', 'site_id' => 1],
-        ['id' => 2, 'name' => 'juan', 'site_id' => 2],
-        ['id' => 3, 'name' => 'jose', 'site_id' => 2],
-        ['id' => 4, 'name' => 'andy', 'site_id' => 1]
     ];
 }

--- a/tests/Fixture/SiteAuthorsFixture.php
+++ b/tests/Fixture/SiteAuthorsFixture.php
@@ -25,7 +25,7 @@ class SiteAuthorsFixture extends TestFixture
      * @var array
      */
     public $fields = [
-        'id' => ['type' => 'integer'],
+        'id' => ['type' => 'integer', 'autoIncrement' => true],
         'name' => ['type' => 'string', 'default' => null],
         'site_id' => ['type' => 'integer', 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'site_id']]]

--- a/tests/Fixture/SiteAuthorsFixture.php
+++ b/tests/Fixture/SiteAuthorsFixture.php
@@ -37,9 +37,9 @@ class SiteAuthorsFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['id' => 1, 'name' => 'mark', 'site_id' => 1],
-        ['id' => 2, 'name' => 'juan', 'site_id' => 2],
-        ['id' => 3, 'name' => 'jose', 'site_id' => 2],
-        ['id' => 4, 'name' => 'andy', 'site_id' => 1]
+        ['name' => 'mark', 'site_id' => 1],
+        ['name' => 'juan', 'site_id' => 2],
+        ['name' => 'jose', 'site_id' => 2],
+        ['name' => 'andy', 'site_id' => 1]
     ];
 }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -346,6 +346,34 @@ SQL;
     }
 
     /**
+     * Test describing a table with postgres and composite keys
+     *
+     * @return void
+     */
+    public function testDescribeTableCompositeKey()
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE schema_composite (
+    "id" SERIAL,
+    "site_id" INTEGER NOT NULL,
+    "name" VARCHAR(255),
+    PRIMARY KEY("id", "site_id")
+);
+SQL;
+        $connection->execute($sql);
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('schema_composite');
+        $connection->execute('DROP TABLE schema_composite');
+
+        $this->assertEquals(['id', 'site_id'], $result->primaryKey());
+        $this->assertNull($result->column('site_id')['autoIncrement'], 'site_id should not be autoincrement');
+        $this->assertTrue($result->column('id')['autoIncrement'], 'id should be autoincrement');
+    }
+
+
+    /**
      * Test describing a table containing defaults with Postgres
      *
      * @return void

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -372,7 +372,6 @@ SQL;
         $this->assertTrue($result->column('id')['autoIncrement'], 'id should be autoincrement');
     }
 
-
     /**
      * Test describing a table containing defaults with Postgres
      *

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -153,7 +153,7 @@ class SqliteSchemaTest extends TestCase
         $dialect = new SqliteSchema($driver);
 
         $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
-        $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
+        $table->expects($this->at(1))->method('addColumn')->with('field', $expected);
 
         $dialect->convertColumnDescription($table, $field);
     }
@@ -324,6 +324,36 @@ SQL;
         foreach ($expected as $field => $definition) {
             $this->assertEquals($definition, $result->column($field));
         }
+    }
+
+    /**
+     * Test describing a table with Sqlite and composite keys
+     *
+     * Composite keys in SQLite are never autoincrement, and shouldn't be marked
+     * as such.
+     *
+     * @return void
+     */
+    public function testDescribeTableCompositeKey()
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE schema_composite (
+    "id" INTEGER NOT NULL,
+    "site_id" INTEGER NOT NULL,
+    "name" VARCHAR(255),
+    PRIMARY KEY("id", "site_id")
+);
+SQL;
+        $connection->execute($sql);
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('schema_composite');
+        $connection->execute('DROP TABLE schema_composite');
+
+        $this->assertEquals(['id', 'site_id'], $result->primaryKey());
+        $this->assertNull($result->column('site_id')['autoIncrement'], 'site_id should not be autoincrement');
+        $this->assertNull($result->column('id')['autoIncrement'], 'id should not be autoincrement');
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -232,6 +232,16 @@ CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("
 SQL;
         $connection->execute($table);
         $connection->execute('CREATE INDEX "created_idx" ON "schema_articles" ("created")');
+
+        $sql = <<<SQL
+CREATE TABLE schema_composite (
+    "id" INTEGER NOT NULL,
+    "site_id" INTEGER NOT NULL,
+    "name" VARCHAR(255),
+    PRIMARY KEY("id", "site_id")
+);
+SQL;
+        $connection->execute($sql);
     }
 
     /**
@@ -336,20 +346,10 @@ SQL;
      */
     public function testDescribeTableCompositeKey()
     {
-        $this->_needsConnection();
         $connection = ConnectionManager::get('test');
-        $sql = <<<SQL
-CREATE TABLE schema_composite (
-    "id" INTEGER NOT NULL,
-    "site_id" INTEGER NOT NULL,
-    "name" VARCHAR(255),
-    PRIMARY KEY("id", "site_id")
-);
-SQL;
-        $connection->execute($sql);
+        $this->_createTables($connection);
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_composite');
-        $connection->execute('DROP TABLE schema_composite');
 
         $this->assertEquals(['id', 'site_id'], $result->primaryKey());
         $this->assertNull($result->column('site_id')['autoIncrement'], 'site_id should not be autoincrement');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -55,7 +55,7 @@ class TableTest extends TestCase
         'core.authors',
         'core.tags',
         'core.articles_tags',
-        'core.site_authors',
+        'core.composite_increments',
         'core.site_articles',
     ];
 
@@ -2000,11 +2000,11 @@ class TableTest extends TestCase
     public function testSaveNewCompositeKeyIncrement()
     {
         $this->skipIfSqlite();
-        $articles = TableRegistry::get('SiteAuthors');
-        $article = $articles->newEntity(['site_id' => 3, 'name' => 'new guy']);
-        $this->assertSame($article, $articles->save($article));
-        $this->assertNotEmpty($article->id, 'Primary key should have been populated');
-        $this->assertSame(3, $article->site_id);
+        $table = TableRegistry::get('CompositeIncrements');
+        $thing = $table->newEntity(['account_id' => 3, 'name' => 'new guy']);
+        $this->assertSame($thing, $table->save($thing));
+        $this->assertNotEmpty($thing->id, 'Primary key should have been populated');
+        $this->assertSame(3, $thing->account_id);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2004,10 +2004,10 @@ class TableTest extends TestCase
     public function testSaveNewCompositeKeyIncrement()
     {
         $articles = TableRegistry::get('SiteAuthors');
-        $article = $articles->newEntity(['site_id' => 1, 'name' => 'new guy']);
+        $article = $articles->newEntity(['site_id' => 3, 'name' => 'new guy']);
         $this->assertSame($article, $articles->save($article));
         $this->assertNotEmpty($article->id, 'Primary key should have been populated');
-        $this->assertSame(1, $article->site_id);
+        $this->assertSame(3, $article->site_id);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4063,7 +4063,8 @@ class TableTest extends TestCase
      *
      * @return void
      */
-    public function skipIfSqlite() {
+    public function skipIfSqlite()
+    {
         $this->skipIf(
             $this->connection->driver() instanceof \Cake\Database\Driver\Sqlite,
             'SQLite does not support the requrirements of this test.'
@@ -4075,7 +4076,8 @@ class TableTest extends TestCase
      *
      * @return void
      */
-    public function skipIfSqlServer() {
+    public function skipIfSqlServer()
+    {
         $this->skipIf(
             $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
             'SQLServer does not support the requirements of this test.'

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1593,10 +1593,7 @@ class TableTest extends TestCase
      */
     public function testSavePrimaryKeyEntityExists()
     {
-        $this->skipIf(
-            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
-            'SQLServer does not like setting an id on IDENTITY fields'
-        );
+        $this->skipIfSqlServer();
         $table = $this->getMock(
             'Cake\ORM\Table',
             ['exists'],
@@ -1623,10 +1620,7 @@ class TableTest extends TestCase
      */
     public function testSavePrimaryKeyEntityNoExists()
     {
-        $this->skipIf(
-            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
-            'SQLServer does not like setting an id on IDENTITY fields'
-        );
+        $this->skipIfSqlServer();
         $table = $this->getMock(
             'Cake\ORM\Table',
             ['exists'],
@@ -1998,11 +1992,14 @@ class TableTest extends TestCase
     /**
      * Test that saving into composite primary keys where one column is missing & autoIncrement works.
      *
+     * SQLite is skipped because it doesn't support autoincrement composite keys.
+     *
      * @group save
      * @return void
      */
     public function testSaveNewCompositeKeyIncrement()
     {
+        $this->skipIfSqlite();
         $articles = TableRegistry::get('SiteAuthors');
         $article = $articles->newEntity(['site_id' => 3, 'name' => 'new guy']);
         $this->assertSame($article, $articles->save($article));
@@ -4059,5 +4056,29 @@ class TableTest extends TestCase
         Plugin::load('TestPlugin');
         $table = TableRegistry::get('TestPlugin.Comments');
         $this->assertEquals('TestPlugin.Comments', $table->newEntity()->source());
+    }
+
+    /**
+     * Helper method to skip tests when connection is SQLite.
+     *
+     * @return void
+     */
+    public function skipIfSqlite() {
+        $this->skipIf(
+            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlite,
+            'SQLite does not support the requrirements of this test.'
+        );
+    }
+
+    /**
+     * Helper method to skip tests when connection is SQLServer.
+     *
+     * @return void
+     */
+    public function skipIfSqlServer() {
+        $this->skipIf(
+            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+            'SQLServer does not support the requirements of this test.'
+        );
     }
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -54,7 +54,9 @@ class TableTest extends TestCase
         'core.articles',
         'core.authors',
         'core.tags',
-        'core.articles_tags'
+        'core.articles_tags',
+        'core.site_authors',
+        'core.site_articles',
     ];
 
     /**
@@ -1976,6 +1978,36 @@ class TableTest extends TestCase
             ]
         ]);
         $table->save($entity);
+    }
+
+    /**
+     * Test that you cannot save rows with composite keys if some columns are missing.
+     *
+     * @group save
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cannot insert row, some of the primary key values are missing
+     * @return void
+     */
+    public function testSaveNewErrorCompositeKeyNoIncrement()
+    {
+        $articles = TableRegistry::get('SiteArticles');
+        $article = $articles->newEntity(['site_id' => 1, 'author_id' => 1, 'title' => 'testing']);
+        $articles->save($article);
+    }
+
+    /**
+     * Test that saving into composite primary keys where one column is missing & autoIncrement works.
+     *
+     * @group save
+     * @return void
+     */
+    public function testSaveNewCompositeKeyIncrement()
+    {
+        $articles = TableRegistry::get('SiteAuthors');
+        $article = $articles->newEntity(['site_id' => 1, 'name' => 'new guy']);
+        $this->assertSame($article, $articles->save($article));
+        $this->assertNotEmpty($article->id, 'Primary key should have been populated');
+        $this->assertSame(1, $article->site_id);
     }
 
     /**


### PR DESCRIPTION
When inserting data into tables that have composite keys that involve an autoincrement column we should not require the autoincrement column to be populated as the database server will populate it on insert.
