### PR TITLE
Skip Memcached and Redis tests when servers are not running.

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -115,7 +115,7 @@ class MemcachedEngine extends CacheEngine
         }
 
         parent::init($config);
-        
+
         if (!empty($config['host'])) {
             if (empty($config['port'])) {
                 $config['servers'] = [$config['host']];

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -66,6 +66,10 @@ class MemcachedEngineTest extends TestCase
         parent::setUp();
         $this->skipIf(!class_exists('Memcached'), 'Memcached is not installed or configured properly.');
 
+        $socket = @fsockopen('127.0.0.1', 11211, $errno, $errstr, 1);
+        $this->skipIf(!$socket, 'Memcached is not running.');
+        fclose($socket);
+
         $this->_configCache();
     }
 
@@ -831,8 +835,6 @@ class MemcachedEngineTest extends TestCase
      */
     public function testLongDurationEqualToZero()
     {
-        $this->markTestSkipped('Cannot run as Memcached cannot be reflected');
-
         $memcached = new TestMemcachedEngine();
         $memcached->init(['prefix' => 'Foo_', 'compress' => false, 'duration' => 50 * DAY]);
 

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -829,26 +829,6 @@ class MemcachedEngineTest extends TestCase
     }
 
     /**
-     * test that durations greater than 30 days never expire
-     *
-     * @return void
-     */
-    public function testLongDurationEqualToZero()
-    {
-        $memcached = new TestMemcachedEngine();
-        $memcached->init(['prefix' => 'Foo_', 'compress' => false, 'duration' => 50 * DAY]);
-
-        $mock = $this->getMock('Memcached');
-        $memcached->setMemcached($mock);
-        $mock->expects($this->once())
-            ->method('set')
-            ->with('Foo_key', 'value', 0);
-
-        $value = 'value';
-        $memcached->write('key', $value);
-    }
-
-    /**
      * Tests that configuring groups for stored keys return the correct values when read/written
      * Shows that altering the group value is equivalent to deleting all keys under the same
      * group

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -36,7 +36,11 @@ class RedisEngineTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->skipIf(!class_exists('Redis'), 'Redis is not installed or configured properly.');
+        $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
+
+        $socket = @fsockopen('127.0.0.1', 6379, $errno, $errstr, 1);
+        $this->skipIf(!$socket, 'Redis is not running.');
+        fclose($socket);
 
         Cache::enable();
         $this->_configCache();


### PR DESCRIPTION
When the extensions are present but memcached or redis are not running, tests should be skipped.

Refs #5993
