### PR TITLE
Show tables exception

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -221,7 +221,13 @@ class Mysql extends DboSource {
 		if ($cache) {
 			return $cache;
 		}
-		$result = $this->_execute('SHOW TABLES FROM ' . $this->name($this->config['database']));
+
+        try {
+            $result = $this->_execute('SHOW TABLES FROM ' . $this->name($this->config['database']));
+        } catch (\Exception $e) {
+            throw new \PDOException("Unable to connect to the database
+                {$this->name($this->config['database'])}. Please check your datasource database config.");
+        }
 
 		if (!$result) {
 			$result->closeCursor();


### PR DESCRIPTION
Currently if you try to connect to a datasource in which the `database` doesn't exist the \Model\Datasource\Database\Mysql class throws an exception whenever trying to run the `SHOW TABLES` on a database that doesn't exist.

```
Database Error
Error: SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database 'dbprefix_123missingdatabase'

SQL Query: SHOW TABLES FROM `dbprefix_123missingdatabase`
```

The idea behind this change is to wrap the error message being thrown from `_execute` function that will run the `SHOW TABLES FROM ' . $this->name($this->config['database'])` into an user friendly message informing where the error might be coming from. The ending exception should return something like this:

```
Database Error
Error: Unable to connect to the database `dbprefix_123missingdatabase`. Please check your datasource database config.
```

This is an approach for solving the issue of identifying a missing database, probably a better way would be testing the existence of the database whenever the datasource is being loaded / created.
### History  behind this change

The current project that the cake application is handing holds a series of databases that can be dynamically changed based on configuration. By the moment that the datasource is created a `default` database is loaded and then, whenever necessary, the datasource database is changed to load the correct database. The issue occurred when trying to load a database that didn't exist on the development server but did exist on production.
