### PR TITLE
Update Query.php

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -507,11 +507,13 @@ class Query extends DatabaseQuery implements JsonSerializable
         $complex = $complex || count($query->clause('union'));
 
         if (!$complex) {
+            $autoFieldsBefore = $query->eagerLoader()->autoFields();
             $query->eagerLoader()->autoFields(false);
             $statement = $query
                 ->select($count, true)
                 ->autoFields(false)
                 ->execute();
+            $query->eagerLoader()->autoFields($autoFieldsBefore);
         } else {
             $statement = $this->connection()->newQuery()
                 ->select($count)


### PR DESCRIPTION
When using a query object twice then all fields in associated tables are ignored -> therefore the "autoFields" flag must to be reset.
#5961 caused issues -> restore autofield value
