### PR TITLE
Reset EagerLoader when cloning a query.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -479,6 +479,7 @@ class Query extends DatabaseQuery implements JsonSerializable
         $query = clone $this;
         $query->triggerBeforeFind();
         $query->autoFields(false);
+        $query->eagerLoader(clone $this->eagerLoader());
         $query->limit(null);
         $query->order([], true);
         $query->offset(null);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2361,6 +2361,8 @@ class QueryTest extends TestCase
         $copy = $query->cleanCopy();
 
         $this->assertNotSame($copy, $query);
+        $this->assertNotSame($copy->eagerLoader(), $query->eagerLoader());
+        $this->assertNotEmpty($copy->eagerLoader()->contain());
         $this->assertNull($copy->clause('offset'));
         $this->assertNull($copy->clause('limit'));
         $this->assertNull($copy->clause('order'));


### PR DESCRIPTION
When a 'clean' copy is made of a query we need to reset the eager loader so changes to associations are separate. Make sure to keep the contained associations around though.

An alternative to #6013

Refs #5961
