### PR TITLE
Object has App::uses('CakeLog', 'Log') twice

### DIFF
--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -18,7 +18,6 @@ App::uses('CakeLog', 'Log');
 App::uses('Dispatcher', 'Routing');
 App::uses('Router', 'Routing');
 App::uses('Set', 'Utility');
-App::uses('CakeLog', 'Log');
 
 /**
  * Object class provides a few generic methods used in several subclasses.


### PR DESCRIPTION
I think this was accidentally added twice?
