### PR TITLE
3.0 - Strategy lockdown

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -408,7 +408,7 @@ abstract class Association
     public function strategy($name = null)
     {
         if ($name !== null) {
-            if (!$this->validStrategy($name)) {
+            if (!in_array($name, $this->_validStrategies)) {
                 throw new \InvalidArgumentException(
                     sprintf('Invalid strategy "%s" was provided', $name)
                 );
@@ -416,17 +416,6 @@ abstract class Association
             $this->_strategy = $name;
         }
         return $this->_strategy;
-    }
-
-    /**
-     * Checks if a given strategy is valid for the association type.
-     *
-     * @param string $name The strategy type.
-     * @return bool
-     */
-    public function validStrategy($name)
-    {
-        return in_array($name, $this->_validStrategies);
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -422,7 +422,7 @@ abstract class Association
      * Checks if a given strategy is valid for the association type.
      *
      * @param string $name The strategy type.
-     * @return boolean
+     * @return bool
      */
     public function validStrategy($name)
     {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -173,6 +173,13 @@ abstract class Association
     protected $_finder = 'all';
 
     /**
+     * Valid strategies for this association. Subclasses can narrow this down.
+     *
+     * @var array
+     */
+    protected $_validStrategies = [self::STRATEGY_JOIN, self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
+
+    /**
      * Constructor. Subclasses can override _options function to get the original
      * list of passed options if expecting any other special key
      *
@@ -401,8 +408,7 @@ abstract class Association
     public function strategy($name = null)
     {
         if ($name !== null) {
-            $valid = [self::STRATEGY_JOIN, self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
-            if (!in_array($name, $valid)) {
+            if (!$this->validStrategy($name)) {
                 throw new \InvalidArgumentException(
                     sprintf('Invalid strategy "%s" was provided', $name)
                 );
@@ -410,6 +416,20 @@ abstract class Association
             $this->_strategy = $name;
         }
         return $this->_strategy;
+    }
+
+    /**
+     * Checks if a given strategy is valid for the association type.
+     *
+     * @param string $name The strategy type.
+     * @return boolean
+     */
+    public function validStrategy($name)
+    {
+        if (in_array($name, $this->_validStrategies)) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -426,10 +426,7 @@ abstract class Association
      */
     public function validStrategy($name)
     {
-        if (in_array($name, $this->_validStrategies)) {
-            return true;
-        }
-        return false;
+        return in_array($name, $this->_validStrategies);
     }
 
     /**

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -33,6 +33,13 @@ class BelongsTo extends Association
     use SelectableAssociationTrait;
 
     /**
+     * Valid strategies for this type of association
+     *
+     * @var array
+     */
+    protected $_validStrategies = [parent::STRATEGY_JOIN, parent::STRATEGY_SELECT];
+
+    /**
      * Sets the name of the field representing the foreign key to the target table.
      * If no parameters are passed current field is returned
      *

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -37,7 +37,7 @@ class BelongsTo extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_JOIN, parent::STRATEGY_SELECT];
+    protected $_validStrategies = [parent::STRATEGY_JOIN];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -37,7 +37,7 @@ class BelongsTo extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_JOIN, parent::STRATEGY_SELECT];
+    protected $_validStrategies = [self::STRATEGY_JOIN, self::STRATEGY_SELECT];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -37,7 +37,7 @@ class BelongsTo extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_JOIN];
+    protected $_validStrategies = [parent::STRATEGY_JOIN, parent::STRATEGY_SELECT];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -61,7 +61,7 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected $_strategy = parent::STRATEGY_SELECT;
+    protected $_strategy = self::STRATEGY_SELECT;
 
     /**
      * Junction table instance
@@ -119,7 +119,7 @@ class BelongsToMany extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_SELECT, parent::STRATEGY_SUBQUERY];
+    protected $_validStrategies = [self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -115,6 +115,13 @@ class BelongsToMany extends Association
     protected $_through;
 
     /**
+     * Valid strategies for this type of association
+     *
+     * @var array
+     */
+    protected $_validStrategies = [parent::STRATEGY_SELECT, parent::STRATEGY_SUBQUERY];
+
+    /**
      * Sets the name of the field representing the foreign key to the target table.
      * If no parameters are passed current field is returned
      *

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -48,6 +48,13 @@ class HasMany extends Association
     protected $_strategy = parent::STRATEGY_SELECT;
 
     /**
+     * Valid strategies for this type of association
+     *
+     * @var array
+     */
+    protected $_validStrategies = [parent::STRATEGY_SELECT, parent::STRATEGY_SUBQUERY];
+
+    /**
      * Returns whether or not the passed table is the owning side for this
      * association. This means that rows in the 'target' table would miss important
      * or required information if the row in 'source' did not exist.

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -45,14 +45,14 @@ class HasMany extends Association
      *
      * @var string
      */
-    protected $_strategy = parent::STRATEGY_SELECT;
+    protected $_strategy = self::STRATEGY_SELECT;
 
     /**
      * Valid strategies for this type of association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_SELECT, parent::STRATEGY_SUBQUERY];
+    protected $_validStrategies = [self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
 
     /**
      * Returns whether or not the passed table is the owning side for this

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -38,7 +38,7 @@ class HasOne extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_JOIN];
+    protected $_validStrategies = [parent::STRATEGY_JOIN, parent::STRATEGY_SELECT];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -38,7 +38,7 @@ class HasOne extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [parent::STRATEGY_JOIN, parent::STRATEGY_SELECT];
+    protected $_validStrategies = [self::STRATEGY_JOIN, self::STRATEGY_SELECT];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -34,6 +34,13 @@ class HasOne extends Association
     use SelectableAssociationTrait;
 
     /**
+     * Valid strategies for this type of association
+     *
+     * @var array
+     */
+    protected $_validStrategies = [parent::STRATEGY_JOIN];
+
+    /**
      * Sets the name of the field representing the foreign key to the target table.
      * If no parameters are passed current field is returned
      *

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -138,6 +138,13 @@ class BelongsToManyTest extends TestCase
         $this->assertFalse($assoc->requiresKeys());
         $assoc->strategy(BelongsToMany::STRATEGY_SELECT);
         $this->assertTrue($assoc->requiresKeys());
+        $errorUsingJoin = false;
+        try {
+            $assoc->strategy(BelongsToMany::STRATEGY_JOIN);
+        } catch (\InvalidArgumentException $e) {
+            $errorUsingJoin = true;
+        }
+        $this->assertTrue($errorUsingJoin);   
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -144,7 +144,7 @@ class BelongsToManyTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $errorUsingJoin = true;
         }
-        $this->assertTrue($errorUsingJoin);   
+        $this->assertTrue($errorUsingJoin);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -138,13 +138,19 @@ class BelongsToManyTest extends TestCase
         $this->assertFalse($assoc->requiresKeys());
         $assoc->strategy(BelongsToMany::STRATEGY_SELECT);
         $this->assertTrue($assoc->requiresKeys());
-        $errorUsingJoin = false;
-        try {
-            $assoc->strategy(BelongsToMany::STRATEGY_JOIN);
-        } catch (\InvalidArgumentException $e) {
-            $errorUsingJoin = true;
-        }
-        $this->assertTrue($errorUsingJoin);
+    }
+
+    /**
+     * Tests that BelongsToMany can't use the join strategy
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid strategy "join" was provided
+     * @return void
+     */
+    public function testStrategyFailure()
+    {
+        $assoc = new BelongsToMany('Test');
+        $assoc->strategy(BelongsToMany::STRATEGY_JOIN);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -120,6 +120,13 @@ class HasManyTest extends TestCase
         $this->assertFalse($assoc->requiresKeys());
         $assoc->strategy(HasMany::STRATEGY_SELECT);
         $this->assertTrue($assoc->requiresKeys());
+        $errorUsingJoin = false;
+        try {
+            $assoc->strategy(HasMany::STRATEGY_JOIN);
+        } catch (\InvalidArgumentException $e) {
+            $errorUsingJoin = true;
+        }
+        $this->assertTrue($errorUsingJoin);   
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -126,7 +126,7 @@ class HasManyTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $errorUsingJoin = true;
         }
-        $this->assertTrue($errorUsingJoin);   
+        $this->assertTrue($errorUsingJoin);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -120,13 +120,19 @@ class HasManyTest extends TestCase
         $this->assertFalse($assoc->requiresKeys());
         $assoc->strategy(HasMany::STRATEGY_SELECT);
         $this->assertTrue($assoc->requiresKeys());
-        $errorUsingJoin = false;
-        try {
-            $assoc->strategy(HasMany::STRATEGY_JOIN);
-        } catch (\InvalidArgumentException $e) {
-            $errorUsingJoin = true;
-        }
-        $this->assertTrue($errorUsingJoin);
+    }
+
+    /**
+     * Tests that HasMany can't use the join strategy
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid strategy "join" was provided
+     * @return void
+     */
+    public function testStrategyFailure()
+    {
+        $assoc = new HasMany('Test');
+        $assoc->strategy(HasMany::STRATEGY_JOIN);
     }
 
     /**

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -15,8 +15,6 @@
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Datasource\ConnectionManager;
-use Cake\ORM\Association\BelongsTo;
-use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\ORM\Marshaller;
 use Cake\ORM\Query;

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -65,11 +65,41 @@ class CompositeKeyTest extends TestCase
     }
 
     /**
+     * Data provider for the two types of strategies HasOne implements
+     *
+     * @return void
+     */
+    public function strategiesProviderHasOne()
+    {
+        return [['join'], ['select']];
+    }
+
+    /**
      * Data provider for the two types of strategies HasMany implements
      *
      * @return void
      */
-    public function strategiesProvider()
+    public function strategiesProviderHasMany()
+    {
+        return [['subquery'], ['select']];
+    }
+
+    /**
+     * Data provider for the two types of strategies BelongsTo implements
+     *
+     * @return void
+     */
+    public function strategiesProviderBelongsTo()
+    {
+        return [['join'], ['select']];
+    }
+
+    /**
+     * Data provider for the two types of strategies BelongsToMany implements
+     *
+     * @return void
+     */
+    public function strategiesProviderBelongsToMany()
     {
         return [['subquery'], ['select']];
     }
@@ -78,7 +108,7 @@ class CompositeKeyTest extends TestCase
      * Tests that HasMany associations are correctly eager loaded and results
      * correctly nested when multiple foreignKeys are used
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderHasMany
      * @return void
      */
     public function testHasManyEager($strategy)
@@ -154,7 +184,7 @@ class CompositeKeyTest extends TestCase
      * Tests that BelongsToMany associations are correctly eager loaded when multiple
      * foreignKeys are used
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderBelongsToMany
      * @return void
      */
     public function testBelongsToManyEager($strategy)
@@ -239,27 +269,13 @@ class CompositeKeyTest extends TestCase
     }
 
     /**
-     * Provides strategies for associations that can be joined
-     *
-     * @return void
-     */
-    public function internalStategiesProvider()
-    {
-        return [['join'], ['select'], ['subquery']];
-    }
-
-    /**
      * Tests loding belongsTo with composite keys
      *
-     * @dataProvider internalStategiesProvider
+     * @dataProvider strategiesProviderBelongsTo
      * @return void
      */
     public function testBelongsToEager($strategy)
     {
-        $assoc = new BelongsTo('Test');
-        if (!$assoc->validStrategy($strategy)) {
-            return;
-        }
         $table = TableRegistry::get('SiteArticles');
         $table->belongsTo('SiteAuthors', [
             'propertyName' => 'author',
@@ -304,15 +320,11 @@ class CompositeKeyTest extends TestCase
     /**
      * Tests loding hasOne with composite keys
      *
-     * @dataProvider internalStategiesProvider
+     * @dataProvider strategiesProviderHasOne
      * @return void
      */
     public function testHasOneEager($strategy)
     {
-        $assoc = new HasOne('Test');
-        if (!$assoc->validStrategy($strategy)) {
-            return;
-        }
         $table = TableRegistry::get('SiteAuthors');
         $table->hasOne('SiteArticles', [
             'propertyName' => 'first_article',

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -256,7 +256,7 @@ class CompositeKeyTest extends TestCase
      */
     public function testBelongsToEager($strategy)
     {
-        $assoc = new HasOne('Test');
+        $assoc = new BelongsTo('Test');
         if (!$assoc->validStrategy($strategy)) {
             return;
         }

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -15,6 +15,8 @@
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\ORM\Marshaller;
 use Cake\ORM\Query;
@@ -254,6 +256,10 @@ class CompositeKeyTest extends TestCase
      */
     public function testBelongsToEager($strategy)
     {
+        $assoc = new HasOne('Test');
+        if (!$assoc->validStrategy($strategy)) {
+            return;
+        }
         $table = TableRegistry::get('SiteArticles');
         $table->belongsTo('SiteAuthors', [
             'propertyName' => 'author',
@@ -303,6 +309,10 @@ class CompositeKeyTest extends TestCase
      */
     public function testHasOneEager($strategy)
     {
+        $assoc = new HasOne('Test');
+        if (!$assoc->validStrategy($strategy)) {
+            return;
+        }
         $table = TableRegistry::get('SiteAuthors');
         $table->hasOne('SiteArticles', [
             'propertyName' => 'first_article',

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -780,7 +780,9 @@ class QueryRegressionTest extends TestCase
     public function testHasManyEagerLoadingUniqueKey()
     {
         $table = TableRegistry::get('ArticlesTags');
-        $table->belongsTo('Articles');
+        $table->belongsTo('Articles', [
+            'strategy' => 'select'
+        ]);
 
         $result = $table->find()
             ->contain(['Articles' => function ($q) {

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -780,9 +780,7 @@ class QueryRegressionTest extends TestCase
     public function testHasManyEagerLoadingUniqueKey()
     {
         $table = TableRegistry::get('ArticlesTags');
-        $table->belongsTo('Articles', [
-            'strategy' => 'select'
-        ]);
+        $table->belongsTo('Articles');
 
         $result = $table->find()
             ->contain(['Articles' => function ($q) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -19,8 +19,6 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
-use Cake\ORM\Association\BelongsTo;
-use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -105,28 +105,44 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Provides strategies for associations that can be joined
+     * Data provider for the two types of strategies HasMany implements
      *
      * @return void
      */
-    public function internalStategiesProvider()
+    public function strategiesProviderHasMany()
     {
-        return [['join'], ['select'], ['subquery']];
+        return [['subquery'], ['select']];
+    }
+
+    /**
+     * Data provider for the two types of strategies BelongsTo implements
+     *
+     * @return void
+     */
+    public function strategiesProviderBelongsTo()
+    {
+        return [['join'], ['select']];
+    }
+
+    /**
+     * Data provider for the two types of strategies BelongsToMany implements
+     *
+     * @return void
+     */
+    public function strategiesProviderBelongsToMany()
+    {
+        return [['subquery'], ['select']];
     }
 
     /**
      * Tests that results are grouped correctly when using contain()
      * and results are not hydrated
      *
-     * @dataProvider internalStategiesProvider
+     * @dataProvider strategiesProviderBelongsTo
      * @return void
      */
     public function testContainResultFetchingOneLevel($strategy)
     {
-        $assoc = new BelongsTo('Test');
-        if (!$assoc->validStrategy($strategy)) {
-            return;
-        }
         $table = TableRegistry::get('articles', ['table' => 'articles']);
         $table->belongsTo('authors', ['strategy' => $strategy]);
 
@@ -175,22 +191,12 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Data provider for the two types of strategies HasMany implements
-     *
-     * @return void
-     */
-    public function strategiesProvider()
-    {
-        return [['subquery'], ['select']];
-    }
-
-    /**
      * Tests that HasMany associations are correctly eager loaded and results
      * correctly nested when no hydration is used
      * Also that the query object passes the correct parent model keys to the
      * association objects in order to perform eager loading with select strategy
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderHasMany
      * @return void
      */
     public function testHasManyEagerLoadingNoHydration($strategy)
@@ -269,7 +275,7 @@ class QueryTest extends TestCase
      * Tests that it is possible to count results containing hasMany associations
      * both hydrating and not hydrating the results.
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderHasMany
      * @return void
      */
     public function testHasManyEagerLoadingCount($strategy)
@@ -300,7 +306,7 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to set fields & order in a hasMany result set
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderHasMany
      * @return void
      */
     public function testHasManyEagerLoadingFieldsAndOrderNoHydration($strategy)
@@ -352,7 +358,7 @@ class QueryTest extends TestCase
     /**
      * Tests that deep associations can be eagerly loaded
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderHasMany
      * @return void
      */
     public function testHasManyEagerLoadingDeep($strategy)
@@ -426,7 +432,7 @@ class QueryTest extends TestCase
      * Tests that hasMany associations can be loaded even when related to a secondary
      * model in the query
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderHasMany
      * @return void
      */
     public function testHasManyEagerLoadingFromSecondaryTable($strategy)
@@ -532,7 +538,7 @@ class QueryTest extends TestCase
      * Also that the query object passes the correct parent model keys to the
      * association objects in order to perform eager loading with select strategy
      *
-     * @dataProvider strategiesProvider
+     * @dataProvider strategiesProviderBelongsToMany
      * @return void
      */
     public function testBelongsToManyEagerLoadingNoHydration($strategy)
@@ -1284,15 +1290,11 @@ class QueryTest extends TestCase
     /**
      * Tests that belongsTo relations are correctly hydrated
      *
-     * @dataProvider internalStategiesProvider
+     * @dataProvider strategiesProviderBelongsTo
      * @return void
      */
     public function testHydrateBelongsTo($strategy)
     {
-        $assoc = new BelongsTo('Test');
-        if (!$assoc->validStrategy($strategy)) {
-            return;
-        }
         $table = TableRegistry::get('articles');
         TableRegistry::get('authors');
         $table->belongsTo('authors', ['strategy' => $strategy]);
@@ -1313,15 +1315,11 @@ class QueryTest extends TestCase
     /**
      * Tests that deeply nested associations are also hydrated correctly
      *
-     * @dataProvider internalStategiesProvider
+     * @dataProvider strategiesProviderBelongsTo
      * @return void
      */
     public function testHydrateDeep($strategy)
     {
-        $assoc = new BelongsTo('Test');
-        if (!$assoc->validStrategy($strategy)) {
-            return;
-        }
         $table = TableRegistry::get('authors');
         $article = TableRegistry::get('articles');
         $table->hasMany('articles', [
@@ -2215,15 +2213,11 @@ class QueryTest extends TestCase
      * Tests that it is possible to use the same association aliases in the association
      * chain for contain
      *
-     * @dataProvider internalStategiesProvider
+     * @dataProvider strategiesProviderBelongsTo
      * @return void
      */
     public function testRepeatedAssociationAliases($strategy)
     {
-        $assoc = new BelongsTo('Test');
-        if (!$assoc->validStrategy($strategy)) {
-            return;
-        }
         $table = TableRegistry::get('ArticlesTags');
         $table->belongsTo('Articles', ['strategy' => $strategy]);
         $table->belongsTo('Tags', ['strategy' => $strategy]);
@@ -2249,10 +2243,6 @@ class QueryTest extends TestCase
      */
     public function testAssociationKeyPresent()
     {
-        $assoc = new HasOne('Test');
-        if (!$assoc->validStrategy('select')) {
-            return;
-        }
         $table = TableRegistry::get('Articles');
         $table->hasOne('ArticlesTags', ['strategy' => 'select']);
         $article = $table->find()->where(['id' => 3])

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -19,6 +19,8 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
@@ -121,6 +123,10 @@ class QueryTest extends TestCase
      */
     public function testContainResultFetchingOneLevel($strategy)
     {
+        $assoc = new BelongsTo('Test');
+        if (!$assoc->validStrategy($strategy)) {
+            return;
+        }
         $table = TableRegistry::get('articles', ['table' => 'articles']);
         $table->belongsTo('authors', ['strategy' => $strategy]);
 
@@ -1283,6 +1289,10 @@ class QueryTest extends TestCase
      */
     public function testHydrateBelongsTo($strategy)
     {
+        $assoc = new BelongsTo('Test');
+        if (!$assoc->validStrategy($strategy)) {
+            return;
+        }
         $table = TableRegistry::get('articles');
         TableRegistry::get('authors');
         $table->belongsTo('authors', ['strategy' => $strategy]);
@@ -1308,6 +1318,10 @@ class QueryTest extends TestCase
      */
     public function testHydrateDeep($strategy)
     {
+        $assoc = new BelongsTo('Test');
+        if (!$assoc->validStrategy($strategy)) {
+            return;
+        }
         $table = TableRegistry::get('authors');
         $article = TableRegistry::get('articles');
         $table->hasMany('articles', [
@@ -2206,6 +2220,10 @@ class QueryTest extends TestCase
      */
     public function testRepeatedAssociationAliases($strategy)
     {
+        $assoc = new BelongsTo('Test');
+        if (!$assoc->validStrategy($strategy)) {
+            return;
+        }
         $table = TableRegistry::get('ArticlesTags');
         $table->belongsTo('Articles', ['strategy' => $strategy]);
         $table->belongsTo('Tags', ['strategy' => $strategy]);
@@ -2231,6 +2249,10 @@ class QueryTest extends TestCase
      */
     public function testAssociationKeyPresent()
     {
+        $assoc = new HasOne('Test');
+        if (!$assoc->validStrategy('select')) {
+            return;
+        }
         $table = TableRegistry::get('Articles');
         $table->hasOne('ArticlesTags', ['strategy' => 'select']);
         $article = $table->find()->where(['id' => 3])


### PR DESCRIPTION
This PR came up from the discussion on https://github.com/cakephp/docs/issues/2476 .. Right now the core has a confusing implementation of 3 different strategies for the 4 types of Associations. Since the docs were updated, this PR locks each association down to only the possible strategies they can use.
The `HasOne` / `BelongsTo` associations are locked to only `'join'` right now. Should that also include `'select'`? It was removed from the docs, but I'm not sure if that was an oversight. I can't imagine when you'd _want_ two queries instead of one for those types of associations, but it's possible if those types allow it.
This might get thrown out, but for me the associations should reflect what the docs say, and disallow strategies that aren't listed on http://book.cakephp.org/3.0/en/orm/associations.html
