### PR TITLE
Fix whitelist being empty during afterSave.

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1941,9 +1941,8 @@ class Model extends Object implements CakeEventListener {
 			$this->_saveMulti($joined, $this->id, $db);
 		}
 
-		$this->whitelist = $_whitelist;
-
 		if (!$success) {
+			$this->whitelist = $_whitelist;
 			return $success;
 		}
 
@@ -1964,6 +1963,7 @@ class Model extends Object implements CakeEventListener {
 
 		$this->_clearCache();
 		$this->validationErrors = array();
+		$this->whitelist = $_whitelist;
 		$this->data = false;
 
 		return $success;

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -388,6 +388,38 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
+ * Test save() resets the whitelist after afterSave
+ *
+ * @return void
+ */
+	public function testSaveResetWhitelistOnSuccess() {
+		$this->loadFixtures('Post');
+
+		$callback = array($this, 'callbackForWhitelistReset');
+		$model = ClassRegistry::init('Post');
+		$model->whitelist = array('author_id', 'title', 'body');
+		$model->getEventManager()->attach($callback, 'Model.afterSave');
+		$data = array(
+			'title' => 'New post',
+			'body' => 'Post body',
+			'author_id' => 1
+		);
+		$result = $model->save($data);
+		$this->assertNotEmpty($result);
+	}
+
+/**
+ * Callback for testing whitelist in afterSave
+ *
+ * @param Model $model The model having save called.
+ * @return void
+ */
+	public function callbackForWhitelistReset($event) {
+		$expected = array('author_id', 'title', 'body', 'updated', 'created');
+		$this->assertEquals($expected, $event->subject()->whitelist);
+	}
+
+/**
  * testSaveWithCounterCache method
  *
  * @return void


### PR DESCRIPTION
whitelist should only be reset after afterSave event.

Refs #6028
