### PR TITLE
Added plugin shell: load and unload

### DIFF
--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -28,6 +28,7 @@ class PluginShell extends Shell
      * @var array
      */
     public $tasks = [
+        'Assets',
         'Load',
         'Unload',
     ];
@@ -40,20 +41,20 @@ class PluginShell extends Shell
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
-        $parser->addSubcommand(
-                'load', [
-            'help' => 'Loads a plugin',
-            'parser' => $this->Load->getOptionParser(),
-                ]
-        );
-        $parser->addSubcommand(
-                'unload', [
-            'help' => 'Unloads a plugin',
-            'parser' => $this->Unload->getOptionParser(),
-                ]
-        );
+        
+        $parser->description('Plugin Shell perform various tasks related to plugin.')
+                ->addSubcommand('assets', [
+                    'help' => 'Symlink / copy plugin assets to app\'s webroot',
+                    'parser' => $this->Assets->getOptionParser()
+                ])->addSubcommand('load', [
+                    'help' => 'Loads a plugin',
+                    'parser' => $this->Load->getOptionParser(),
+                ])
+                ->addSubcommand('unload', [
+                    'help' => 'Unloads a plugin',
+                    'parser' => $this->Unload->getOptionParser(),
+                ]);
 
         return $parser;
     }
-
 }

--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @author        Bob Mulder <bobmulder@outlook.com>
+ */
+
+namespace Cake\Shell;
+
+use Cake\Console\Shell;
+
+/**
+ * Shell for tasks related to plugins.
+ *
+ */
+class PluginShell extends Shell
+{
+    /**
+     * Tasks to load
+     *
+     * @var array
+     */
+    public $tasks = [
+        'Load',
+        'Unload',
+    ];
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->addSubcommand(
+            'load',
+            [
+            'help' => 'Loads a plugin',
+            'parser' => $this->Load->getOptionParser(),
+            ]
+        );
+        $parser->addSubcommand(
+            'unload',
+            [
+            'help' => 'Unloads a plugin',
+            'parser' => $this->Unload->getOptionParser(),
+            ]
+        );
+
+        return $parser;
+    }
+}

--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -11,7 +11,6 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
- * @author        Bob Mulder <bobmulder@outlook.com>
  */
 
 namespace Cake\Shell;

--- a/src/Shell/PluginShell.php
+++ b/src/Shell/PluginShell.php
@@ -12,7 +12,6 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Shell;
 
 use Cake\Console\Shell;
@@ -42,20 +41,19 @@ class PluginShell extends Shell
     {
         $parser = parent::getOptionParser();
         $parser->addSubcommand(
-            'load',
-            [
+                'load', [
             'help' => 'Loads a plugin',
             'parser' => $this->Load->getOptionParser(),
-            ]
+                ]
         );
         $parser->addSubcommand(
-            'unload',
-            [
+                'unload', [
             'help' => 'Unloads a plugin',
             'parser' => $this->Unload->getOptionParser(),
-            ]
+                ]
         );
 
         return $parser;
     }
+
 }

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -12,11 +12,9 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Shell\Task;
 
 use Cake\Console\Shell;
-use Cake\Core\App;
 use Cake\Filesystem\File;
 
 /**
@@ -25,20 +23,22 @@ use Cake\Filesystem\File;
  */
 class LoadTask extends Shell
 {
-
-    public $path = null;
+    /**
+     * Path to the bootstrap file.
+     *
+     * @var string
+     */
     public $bootstrap = null;
 
     /**
-     * Execution method always used for tasks
+     * Execution method always used for tasks.
      *
-     * @return boolean if action passed
+     * @param string $plugin The plugin name.
+     * @return bool if action passed.
      *
      */
     public function main($plugin = null)
     {
-
-        $this->path = current(App::path('Plugin'));
         $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
 
         if (empty($plugin)) {
@@ -60,22 +60,25 @@ class LoadTask extends Shell
     /**
      * Update the applications bootstrap.php file.
      *
-     * @param string $plugin Name of plugin
+     * @param string $plugin Name of plugin.
+     * @param bool $hasBootstrap Whether or not bootstrap should be loaded.
+     * @param bool $hasRoutes Whether or not routes should be loaded.
      * @param bool $hasAutoloader Whether or not there is an autoloader configured for
-     * the plugin
-     * @return void
+     * the plugin.
+     * @return bool If modify passed.
      */
     protected function _modifyBootstrap($plugin, $hasBootstrap, $hasRoutes, $hasAutoloader)
     {
         $bootstrap = new File($this->bootstrap, false);
         $contents = $bootstrap->read();
         if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
-            $autoload = $hasAutoloader ? null : "'autoload' => true, ";
-            $bootstrap->append(sprintf(
-                "\nPlugin::load('%s', [%s'bootstrap' => " . ($hasBootstrap ? 'true' : 'false') . ", 'routes' => " . ($hasRoutes ? 'true' : 'false') . "]);\n",
-                $plugin,
-                $autoload
-            ));
+            $_autoload = $hasAutoloader ? null : "'autoload' => true, ";
+            $_bootstrap = $hasBootstrap ? "'bootstrap' => true, " : "'bootstrap' => false, ";
+            $_routes = $hasRoutes ? "'routes' => true" : "'routes' => false";
+
+            $append = "\nPlugin::load('%s', [%s%s%s]);\n";
+
+            $bootstrap->append(sprintf($append, $plugin, $_autoload, $_bootstrap, $_routes));
             $this->out('');
             $this->out(sprintf('%s modified', $this->bootstrap));
             return true;
@@ -86,22 +89,22 @@ class LoadTask extends Shell
     /**
      * GetOptionParser method.
      *
-     * @return type
+     * @return \Cake\Console\ConsoleOptionParser
      */
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
 
         $parser->addOption('bootstrap', [
-            'short'   => 'b',
-            'help'    => 'Will load bootstrap.php from plugin.',
+            'short' => 'b',
+            'help' => 'Will load bootstrap.php from plugin.',
             'boolean' => true,
             'default' => false,
         ]);
 
         $parser->addOption('routes', [
-            'short'   => 'r',
-            'help'    => 'Will load routes.php from plugin.',
+            'short' => 'r',
+            'help' => 'Will load routes.php from plugin.',
             'boolean' => true,
             'default' => false,
         ]);

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -11,7 +11,6 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
- * @author        Bob Mulder <bobmulder@outlook.com>
  */
 
 namespace Cake\Shell\Task;

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -46,14 +46,7 @@ class LoadTask extends Shell
             return false;
         }
 
-
-        $write = $this->_modifyBootstrap($plugin, $this->params['bootstrap'], $this->params['routes'], false);
-
-        if ($write) {
-            return true;
-        }
-
-        return false;
+        return (bool)$this->_modifyBootstrap($plugin, $this->params['bootstrap'], $this->params['routes'], false);
     }
 
     /**

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -34,8 +34,7 @@ class LoadTask extends Shell
      * Execution method always used for tasks.
      *
      * @param string $plugin The plugin name.
-     * @return bool if action passed.
-     *
+     * @return bool
      */
     public function main($plugin = null)
     {
@@ -72,13 +71,13 @@ class LoadTask extends Shell
         $bootstrap = new File($this->bootstrap, false);
         $contents = $bootstrap->read();
         if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
-            $_autoload = $hasAutoloader ? null : "'autoload' => true, ";
-            $_bootstrap = $hasBootstrap ? "'bootstrap' => true, " : "'bootstrap' => false, ";
-            $_routes = $hasRoutes ? "'routes' => true" : "'routes' => false";
+            $autoloadString = $hasAutoloader ? null : "'autoload' => true, ";
+            $bootstrapString = $hasBootstrap ? "'bootstrap' => true, " : "'bootstrap' => false, ";
+            $routesString = $hasRoutes ? "'routes' => true" : "'routes' => false";
 
             $append = "\nPlugin::load('%s', [%s%s%s]);\n";
 
-            $bootstrap->append(sprintf($append, $plugin, $_autoload, $_bootstrap, $_routes));
+            $bootstrap->append(sprintf($append, $plugin, $autoloadString, $bootstrapString, $routesString));
             $this->out('');
             $this->out(sprintf('%s modified', $this->bootstrap));
             return true;
@@ -96,22 +95,20 @@ class LoadTask extends Shell
         $parser = parent::getOptionParser();
 
         $parser->addOption('bootstrap', [
-            'short' => 'b',
-            'help' => 'Will load bootstrap.php from plugin.',
-            'boolean' => true,
-            'default' => false,
-        ]);
-
-        $parser->addOption('routes', [
-            'short' => 'r',
-            'help' => 'Will load routes.php from plugin.',
-            'boolean' => true,
-            'default' => false,
-        ]);
-
-        $parser->addArgument('plugin', [
-            'help' => 'Name of the plugin to load.',
-        ]);
+                    'short' => 'b',
+                    'help' => 'Will load bootstrap.php from plugin.',
+                    'boolean' => true,
+                    'default' => false,
+                ])
+                ->addOption('routes', [
+                    'short' => 'r',
+                    'help' => 'Will load routes.php from plugin.',
+                    'boolean' => true,
+                    'default' => false,
+                ])
+                ->addArgument('plugin', [
+                    'help' => 'Name of the plugin to load.',
+                ]);
 
         return $parser;
     }

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @author        Bob Mulder <bobmulder@outlook.com>
+ */
+
+namespace Cake\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\Core\App;
+use Cake\Filesystem\File;
+
+/**
+ * Task for loading plugins.
+ *
+ */
+class LoadTask extends Shell
+{
+
+    public $path = null;
+    public $bootstrap = null;
+
+    /**
+     * Execution method always used for tasks
+     *
+     * @return boolean if action passed
+     *
+     */
+    public function main($plugin = null)
+    {
+
+        $this->path = current(App::path('Plugin'));
+        $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
+
+        if (empty($plugin)) {
+            $this->err('<error>You must provide a plugin name in CamelCase format.</error>');
+            $this->err('To load an "Example" plugin, run <info>`cake plugin load Example`</info>.');
+            return false;
+        }
+
+
+        $write = $this->_modifyBootstrap($plugin, $this->params['bootstrap'], $this->params['routes'], false);
+
+        if ($write) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Update the applications bootstrap.php file.
+     *
+     * @param string $plugin Name of plugin
+     * @param bool $hasAutoloader Whether or not there is an autoloader configured for
+     * the plugin
+     * @return void
+     */
+    protected function _modifyBootstrap($plugin, $hasBootstrap, $hasRoutes, $hasAutoloader)
+    {
+        $bootstrap = new File($this->bootstrap, false);
+        $contents = $bootstrap->read();
+        if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
+            $autoload = $hasAutoloader ? null : "'autoload' => true, ";
+            $bootstrap->append(sprintf(
+                "\nPlugin::load('%s', [%s'bootstrap' => " . ($hasBootstrap ? 'true' : 'false') . ", 'routes' => " . ($hasRoutes ? 'true' : 'false') . "]);\n",
+                $plugin,
+                $autoload
+            ));
+            $this->out('');
+            $this->out(sprintf('%s modified', $this->bootstrap));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * GetOptionParser method.
+     *
+     * @return type
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        $parser->addOption('bootstrap', [
+            'short'   => 'b',
+            'help'    => 'Will load bootstrap.php from plugin.',
+            'boolean' => true,
+            'default' => false,
+        ]);
+
+        $parser->addOption('routes', [
+            'short'   => 'r',
+            'help'    => 'Will load routes.php from plugin.',
+            'boolean' => true,
+            'default' => false,
+        ]);
+
+        $parser->addArgument('plugin', [
+            'help' => 'Name of the plugin to load.',
+        ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -46,14 +46,7 @@ class UnloadTask extends Shell
             return false;
         }
 
-
-        $write = $this->_modifyBootstrap($plugin);
-
-        if ($write) {
-            return true;
-        }
-
-        return false;
+        return (bool)$this->_modifyBootstrap($plugin);
     }
 
     /**
@@ -65,7 +58,7 @@ class UnloadTask extends Shell
     protected function _modifyBootstrap($plugin)
     {
         $finder = "/\nPlugin::load\((.|.\n|\n\s\s|\n\t|)+'$plugin'(.|.\n|)+\);\n/";
-        
+
         $bootstrap = new File($this->bootstrap, false);
         $contents = $bootstrap->read();
 

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -64,13 +64,13 @@ class UnloadTask extends Shell
      */
     protected function _modifyBootstrap($plugin)
     {
-        $bool = "(false|true)";
-        $finder = "/Plugin::load\('$plugin', \['autoload' => $bool, 'bootstrap' => $bool, 'routes' => $bool]\);\n/";
+        $finder = "/\nPlugin::load\('$plugin'(.|.\n|)+\);\n/";
 
         $bootstrap = new File($this->bootstrap, false);
         $contents = $bootstrap->read();
 
         if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
+            
             $contents = preg_replace($finder, "", $contents);
 
             $bootstrap->write($contents);

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -11,7 +11,6 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
- * @author        Bob Mulder <bobmulder@outlook.com>
  */
 
 namespace Cake\Shell\Task;

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @author        Bob Mulder <bobmulder@outlook.com>
+ */
+
+namespace Cake\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\Core\App;
+use Cake\Filesystem\File;
+
+/**
+ * Task for unloading plugins.
+ *
+ */
+class UnloadTask extends Shell
+{
+    public $path      = null;
+    public $bootstrap = null;
+
+    /**
+     * Execution method always used for tasks
+     *
+     * @return boolean if action passed
+     *
+     */
+    public function main($plugin = null)
+    {
+
+        $this->path      = current(App::path('Plugin'));
+        $this->bootstrap = ROOT.DS.'config'.DS.'bootstrap.php';
+
+        if (empty($plugin)) {
+            $this->err('<error>You must provide a plugin name in CamelCase format.</error>');
+            $this->err('To unload an "Example" plugin, run <info>`cake plugin unload Example`</info>.');
+            return false;
+        }
+
+
+        $write = $this->_modifyBootstrap($plugin);
+
+        if ($write) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Update the applications bootstrap.php file.
+     *
+     * @param string $plugin Name of plugin
+     * @param bool $hasAutoloader Whether or not there is an autoloader configured for
+     * the plugin
+     * @return void
+     */
+    protected function _modifyBootstrap($plugin)
+    {
+        $finder = "Plugin::load('".$plugin."',";
+
+        $bootstrap = new File($this->bootstrap, false);
+        $contents  = $bootstrap->read();
+        if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
+            $_contents = explode("\n", $contents);
+
+            foreach ($_contents as $content) {
+                if (strpos($content, $finder) !== false) {
+                    $loadString = $content;
+                    $loadString .= "\n";
+
+                    $bootstrap->replaceText(sprintf($loadString), null);
+                }
+            }
+
+            $this->out('');
+            $this->out(sprintf('%s modified', $this->bootstrap));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * GetOptionParser method.
+     *
+     * @return type
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        $parser->addArgument('plugin', [
+            'help' => 'Name of the plugin to load.',
+        ]);
+
+        return $parser;
+    }
+}

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -35,7 +35,6 @@ class UnloadTask extends Shell
      *
      * @param string $plugin The plugin name.
      * @return boolean if action passed.
-     *
      */
     public function main($plugin = null)
     {

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -64,8 +64,8 @@ class UnloadTask extends Shell
      */
     protected function _modifyBootstrap($plugin)
     {
-        $finder = "/\nPlugin::load\('$plugin'(.|.\n|)+\);\n/";
-
+        $finder = "/\nPlugin::load\((.|.\n|\n\s\s|\n\t|)+'$plugin'(.|.\n|)+\);\n/";
+        
         $bootstrap = new File($this->bootstrap, false);
         $contents = $bootstrap->read();
 

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -70,7 +70,6 @@ class UnloadTask extends Shell
         $contents = $bootstrap->read();
 
         if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
-            
             $contents = preg_replace($finder, "", $contents);
 
             $bootstrap->write($contents);

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -23,6 +23,7 @@ use Cake\TestSuite\TestCase;
  */
 class LoadTaskTest extends TestCase
 {
+
     /**
      * setUp method
      *
@@ -42,8 +43,9 @@ class LoadTaskTest extends TestCase
 
         $bootstrap = new File($this->bootstrap, false);
 
-        $this->original_bootstrap_content = $bootstrap->read();
+        $this->originalBootstrapContent = $bootstrap->read();
     }
+
     /**
      * tearDown method
      *
@@ -57,8 +59,9 @@ class LoadTaskTest extends TestCase
 
         $bootstrap = new File($this->bootstrap, false);
 
-        $bootstrap->write($this->original_bootstrap_content);
+        $bootstrap->write($this->originalBootstrapContent);
     }
+
     /**
      * testLoad
      *
@@ -79,6 +82,7 @@ class LoadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $this->assertContains($expected, $bootstrap->read());
     }
+
     /**
      * testLoadWithBootstrap
      *
@@ -99,6 +103,7 @@ class LoadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $this->assertContains($expected, $bootstrap->read());
     }
+
     /**
      * testLoadWithRoutes
      *
@@ -118,25 +123,5 @@ class LoadTaskTest extends TestCase
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => true]);";
         $bootstrap = new File($this->bootstrap, false);
         $this->assertContains($expected, $bootstrap->read());
-    }
-    /**
-     * testLoadNoName
-     *
-     * @return void
-     */
-    public function testLoadNoName()
-    {
-        $this->Task->params = [
-            'bootstrap' => false,
-            'routes' => true,
-        ];
-
-        $action = $this->Task->main();
-
-        $this->assertFalse($action);
-
-        $expected = "Plugin::load(";
-        $bootstrap = new File($this->bootstrap, false);
-        $this->assertNotContains($expected, $bootstrap->read());
     }
 }

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * CakePHP :  Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP Project
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\Shell\Task;
+
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+use Cake\Filesystem\File;
+
+/**
+ * LoadTaskTest class
+ *
+ */
+class LoadTaskTest extends TestCase
+{
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+
+        $this->Task = $this->getMock(
+                'Cake\Shell\Task\LoadTask', ['in', 'out', 'err', '_stop'], [$this->io]
+        );
+
+        $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
+
+        $bootstrap = new File($this->bootstrap, false);
+
+        $this->original_bootstrap_content = $bootstrap->read();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->shell);
+        Plugin::unload();
+
+        $bootstrap = new File($this->bootstrap, false);
+
+        $bootstrap->write($this->original_bootstrap_content);
+    }
+
+    /**
+     * testLoad
+     *
+     * @return void
+     */
+    public function testLoad()
+    {
+        $this->Task->params = [
+            'bootstrap' => false,
+            'routes'    => false,
+        ];
+
+        $action = $this->Task->main('TestPlugin');
+
+        $this->assertTrue($action);
+
+        $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
+        $bootstrap = new File($this->bootstrap, false);
+        $this->assertContains($expected, $bootstrap->read());
+    }
+
+    /**
+     * testLoadWithBootstrap
+     *
+     * @return void
+     */
+    public function testLoadWithBootstrap()
+    {
+        $this->Task->params = [
+            'bootstrap' => true,
+            'routes'    => false,
+        ];
+
+        $action = $this->Task->main('TestPlugin');
+
+        $this->assertTrue($action);
+
+        $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => true, 'routes' => false]);";
+        $bootstrap = new File($this->bootstrap, false);
+        $this->assertContains($expected, $bootstrap->read());
+    }
+
+    /**
+     * testLoadWithRoutes
+     *
+     * @return void
+     */
+    public function testLoadWithRoutes()
+    {
+        $this->Task->params = [
+            'bootstrap' => false,
+            'routes'    => true,
+        ];
+
+        $action = $this->Task->main('TestPlugin');
+
+        $this->assertTrue($action);
+
+        $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => true]);";
+        $bootstrap = new File($this->bootstrap, false);
+        $this->assertContains($expected, $bootstrap->read());
+    }
+
+    /**
+     * testLoadNoName
+     *
+     * @return void
+     */
+    public function testLoadNoName()
+    {
+        $this->Task->params = [
+            'bootstrap' => false,
+            'routes'    => true,
+        ];
+
+        $action = $this->Task->main();
+
+        $this->assertFalse($action);
+
+        $expected = "Plugin::load(";
+        $bootstrap = new File($this->bootstrap, false);
+        $this->assertNotContains($expected, $bootstrap->read());
+    }
+
+}

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -9,23 +9,20 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP Project
- * @since         1.2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\Shell\Task;
 
 use Cake\Core\Plugin;
-use Cake\TestSuite\TestCase;
 use Cake\Filesystem\File;
+use Cake\TestSuite\TestCase;
 
 /**
- * LoadTaskTest class
+ * LoadTaskTest class.
  *
  */
 class LoadTaskTest extends TestCase
 {
-
     /**
      * setUp method
      *
@@ -47,7 +44,6 @@ class LoadTaskTest extends TestCase
 
         $this->original_bootstrap_content = $bootstrap->read();
     }
-
     /**
      * tearDown method
      *
@@ -63,7 +59,6 @@ class LoadTaskTest extends TestCase
 
         $bootstrap->write($this->original_bootstrap_content);
     }
-
     /**
      * testLoad
      *
@@ -73,7 +68,7 @@ class LoadTaskTest extends TestCase
     {
         $this->Task->params = [
             'bootstrap' => false,
-            'routes'    => false,
+            'routes' => false,
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -84,7 +79,6 @@ class LoadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $this->assertContains($expected, $bootstrap->read());
     }
-
     /**
      * testLoadWithBootstrap
      *
@@ -94,7 +88,7 @@ class LoadTaskTest extends TestCase
     {
         $this->Task->params = [
             'bootstrap' => true,
-            'routes'    => false,
+            'routes' => false,
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -105,7 +99,6 @@ class LoadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $this->assertContains($expected, $bootstrap->read());
     }
-
     /**
      * testLoadWithRoutes
      *
@@ -115,7 +108,7 @@ class LoadTaskTest extends TestCase
     {
         $this->Task->params = [
             'bootstrap' => false,
-            'routes'    => true,
+            'routes' => true,
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -126,7 +119,6 @@ class LoadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $this->assertContains($expected, $bootstrap->read());
     }
-
     /**
      * testLoadNoName
      *
@@ -136,7 +128,7 @@ class LoadTaskTest extends TestCase
     {
         $this->Task->params = [
             'bootstrap' => false,
-            'routes'    => true,
+            'routes' => true,
         ];
 
         $action = $this->Task->main();
@@ -147,5 +139,4 @@ class LoadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $this->assertNotContains($expected, $bootstrap->read());
     }
-
 }

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -35,9 +35,7 @@ class LoadTaskTest extends TestCase
 
         $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
 
-        $this->Task = $this->getMock(
-                'Cake\Shell\Task\LoadTask', ['in', 'out', 'err', '_stop'], [$this->io]
-        );
+        $this->Task = $this->getMock('Cake\Shell\Task\LoadTask', ['in', 'out', 'err', '_stop'], [$this->io]);
 
         $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
 

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -73,6 +73,8 @@ class UnloadTaskTest extends TestCase
 
         $this->_addPluginToBootstrap("TestPlugin");
 
+        $this->_addPluginToBootstrap("TestPluginSecond");
+
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
         $this->assertContains($expected, $bootstrap->read());
 
@@ -81,6 +83,8 @@ class UnloadTaskTest extends TestCase
         $this->assertTrue($action);
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
         $this->assertNotContains($expected, $bootstrap->read());
+        $expected = "Plugin::load('TestPluginSecond', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
+        $this->assertContains($expected, $bootstrap->read());
     }
 
     /**
@@ -94,6 +98,6 @@ class UnloadTaskTest extends TestCase
     protected function _addPluginToBootstrap($name)
     {
         $bootstrap = new File($this->bootstrap, false);
-        $bootstrap->append("Plugin::load('" . $name . "', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);\n");
+        $bootstrap->append("\nPlugin::load('" . $name . "', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);");
     }
 }

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -86,6 +86,86 @@ class UnloadTaskTest extends TestCase
     }
 
     /**
+     * testRegularExpressions
+     *
+     * This method will tests multiple notations of plugin loading.
+     */
+    public function testRegularExpressions()
+    {
+        $bootstrap = new File($this->bootstrap, false);
+
+        //  Plugin::load('TestPlugin', [
+        //      'boostrap' => false
+        //  ]);
+        $bootstrap->append("\nPlugin::load('TestPlugin', [\n\t'boostrap' => false\n]);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load('TestPlugin', [\n\t'boostrap' => false\n]);", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load(
+        //      'TestPlugin',
+        //      [ 'boostrap' => false]
+        //  );
+        $bootstrap->append("\nPlugin::load(\n\t'TestPlugin',\n\t[ 'boostrap' => false]\n);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load(\n\t'TestPlugin',\n\t[ 'boostrap' => false]\n);", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load(
+        //      'Foo',
+        //      [
+        //          'boostrap' => false
+        //      ]
+        //  );
+        $bootstrap->append("\nPlugin::load(\n\t'TestPlugin',\n\t[\n\t\t'boostrap' => false\n\t]\n);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load(\n\t'TestPlugin',\n\t[\n\t\t'boostrap' => false\n\t]\n);", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load('Test', [
+        //      'autoload' => false,
+        //      'bootstrap' => true,
+        //      'routes' => true
+        //  ]);
+        $bootstrap->append("\nPlugin::load('TestPlugin', [\n\t'autoload' => false,\n\t'bootstrap' => true,\n\t'routes' => true\n]);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load('TestPlugin', [\n\t'autoload' => false,\n\t'bootstrap' => true,\n\t'routes' => true\n]);", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load('Test',
+        //      [
+        //          'bootstrap' => true,
+        //          'routes' => true
+        //      ]
+        //  );
+        $bootstrap->append("\nPlugin::load('TestPlugin',\n\t[\n\t\t'bootstrap' => true,\n\t\t'routes' => true\n\t]\n);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load('TestPlugin',\n\t[\n\t\t'bootstrap' => true,\n\t\t'routes' => true\n\t]\n);", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load('Test',
+        //      [
+        //
+        //      ]
+        //  );
+        $bootstrap->append("\nPlugin::load('TestPlugin',\n\t[\n\t\n\t]\n);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load('TestPlugin',\n\t[\n\t\n\t]\n);", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load('Test');
+        $bootstrap->append("\nPlugin::load('TestPlugin');\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load('TestPlugin');", $bootstrap->read());
+        $this->_clearBootstrap();
+
+        //  Plugin::load('Test', ['bootstrap' => true, 'route' => false]);
+        $bootstrap->append("\nPlugin::load('TestPlugin', ['bootstrap' => true, 'route' => false]);\n");
+        $this->Task->main('TestPlugin');
+        $this->assertNotContains("Plugin::load('TestPlugin', ['bootstrap' => true, 'route' => false]);", $bootstrap->read());
+    }
+
+    /**
      * _addPluginToBootstrap
      *
      * Quick method to add a plugin to the bootstrap file.
@@ -96,6 +176,20 @@ class UnloadTaskTest extends TestCase
     protected function _addPluginToBootstrap($name)
     {
         $bootstrap = new File($this->bootstrap, false);
-        $bootstrap->append("\nPlugin::load('$name', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);");
+        $bootstrap->append("\n\nPlugin::load('$name', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);\n");
+    }
+
+    /**
+     * clearBootstrap
+     *
+     * Helper to clear the bootstrap file.
+     *
+     * @return void
+     */
+    protected function _clearBootstrap()
+    {
+        $bootstrap = new File($this->bootstrap, false);
+
+        $bootstrap->write($this->originalBootstrapContent);
     }
 }

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -14,8 +14,8 @@
 namespace Cake\Test\TestCase\Shell\Task;
 
 use Cake\Core\Plugin;
-use Cake\TestSuite\TestCase;
 use Cake\Filesystem\File;
+use Cake\TestSuite\TestCase;
 
 /**
  * UnloadTaskTest class
@@ -35,9 +35,7 @@ class UnloadTaskTest extends TestCase
 
         $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
 
-        $this->Task = $this->getMock(
-                'Cake\Shell\Task\UnloadTask', ['in', 'out', 'err', '_stop'], [$this->io]
-        );
+        $this->Task = $this->getMock('Cake\Shell\Task\UnloadTask', ['in', 'out', 'err', '_stop'], [$this->io]);
 
         $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
 
@@ -98,6 +96,6 @@ class UnloadTaskTest extends TestCase
     protected function _addPluginToBootstrap($name)
     {
         $bootstrap = new File($this->bootstrap, false);
-        $bootstrap->append("\nPlugin::load('" . $name . "', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);");
+        $bootstrap->append("\nPlugin::load('$name', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);");
     }
 }

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -9,10 +9,8 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP Project
- * @since         1.2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Test\TestCase\Shell\Task;
 
 use Cake\Core\Plugin;
@@ -81,7 +79,6 @@ class UnloadTaskTest extends TestCase
         $action = $this->Task->main('TestPlugin');
 
         $this->assertTrue($action);
-
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
         $this->assertNotContains($expected, $bootstrap->read());
     }
@@ -113,5 +110,4 @@ class UnloadTaskTest extends TestCase
         $bootstrap = new File($this->bootstrap, false);
         $bootstrap->append("Plugin::load('" . $name . "', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);\n");
     }
-
 }

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * CakePHP :  Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP Project
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\Shell\Task;
+
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+use Cake\Filesystem\File;
+
+/**
+ * UnloadTaskTest class
+ *
+ */
+class UnloadTaskTest extends TestCase
+{
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+
+        $this->Task = $this->getMock(
+                'Cake\Shell\Task\UnloadTask', ['in', 'out', 'err', '_stop'], [$this->io]
+        );
+
+        $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
+
+        $bootstrap = new File($this->bootstrap, false);
+
+        $this->original_bootstrap_content = $bootstrap->read();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->shell);
+        Plugin::unload();
+
+        $bootstrap = new File($this->bootstrap, false);
+
+        $bootstrap->write($this->original_bootstrap_content);
+    }
+
+    /**
+     * testUnload
+     *
+     * @return void
+     */
+    public function testUnload()
+    {
+        $bootstrap = new File($this->bootstrap, false);
+
+        $this->_addPluginToBootstrap("TestPlugin");
+
+        $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
+        $this->assertContains($expected, $bootstrap->read());
+
+        $action = $this->Task->main('TestPlugin');
+
+        $this->assertTrue($action);
+
+        $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
+        $this->assertNotContains($expected, $bootstrap->read());
+    }
+
+    /**
+     * testUnloadNoName
+     *
+     * @return void
+     */
+    public function testUnloadNoName()
+    {
+        $bootstrap = new File($this->bootstrap, false);
+
+        $action = $this->Task->main();
+
+        $this->assertFalse($action);
+    }
+
+    /**
+     * _addPluginToBootstrap
+     *
+     * Quick method to add a plugin to the bootstrap file.
+     * This is useful for the tests
+     *
+     * @param string $name
+     */
+    protected function _addPluginToBootstrap($name)
+    {
+        $bootstrap = new File($this->bootstrap, false);
+        $bootstrap->append("Plugin::load('" . $name . "', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);\n");
+    }
+
+}

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -43,7 +43,7 @@ class UnloadTaskTest extends TestCase
 
         $bootstrap = new File($this->bootstrap, false);
 
-        $this->original_bootstrap_content = $bootstrap->read();
+        $this->originalBootstrapContent = $bootstrap->read();
     }
 
     /**
@@ -59,7 +59,7 @@ class UnloadTaskTest extends TestCase
 
         $bootstrap = new File($this->bootstrap, false);
 
-        $bootstrap->write($this->original_bootstrap_content);
+        $bootstrap->write($this->originalBootstrapContent);
     }
 
     /**
@@ -81,20 +81,6 @@ class UnloadTaskTest extends TestCase
         $this->assertTrue($action);
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
         $this->assertNotContains($expected, $bootstrap->read());
-    }
-
-    /**
-     * testUnloadNoName
-     *
-     * @return void
-     */
-    public function testUnloadNoName()
-    {
-        $bootstrap = new File($this->bootstrap, false);
-
-        $action = $this->Task->main();
-
-        $this->assertFalse($action);
     }
 
     /**


### PR DESCRIPTION
Implemented the Plugin Shell (https://github.com/cakephp/plugin-installer/issues/28).

The idea was to rebuild the PluginAssets Shell but @ADmad and I decided to do it this way for now.

Example:

```
// loading a plugin
bin/cake plugin load MyPlugin

// loading a plugin including bootstrap and routes
bin/cake plugin load -b -r MyPlugin

// unloading plugin
bin/cake plugin unload MyPlugin
```

I will fork the docs and add this to the documentation.

Tests for the tasks are working.
