### PR TITLE
Read content type in a more compatible way.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -276,7 +276,7 @@ class Request implements \ArrayAccess
     {
         $method = $this->env('REQUEST_METHOD');
         if (in_array($method, ['PUT', 'DELETE', 'PATCH']) &&
-            strpos($this->env('CONTENT_TYPE'), 'application/x-www-form-urlencoded') === 0
+            strpos($this->contentType(), 'application/x-www-form-urlencoded') === 0
         ) {
             $data = $this->input();
             parse_str($data, $data);
@@ -470,6 +470,20 @@ class Request implements \ArrayAccess
             }
         }
         return $data;
+    }
+
+    /**
+     * Get the content type used in this request.
+     *
+     * @return string
+     */
+    public function contentType()
+    {
+        $type = $this->env('CONTENT_TYPE');
+        if ($type) {
+            return $type;
+        }
+        return $this->env('HTTP_CONTENT_TYPE');
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2399,6 +2399,22 @@ XML;
     }
 
     /**
+     * Test the content type method.
+     *
+     * @return void
+     */
+    public function testContentType()
+    {
+        $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
+        $request = Request::createFromGlobals();
+        $this->assertEquals('application/json', $request->contentType());
+
+        $_SERVER['CONTENT_TYPE'] = 'application/xml';
+        $request = Request::createFromGlobals();
+        $this->assertEquals('application/xml', $request->contentType(), 'prefer non http header.');
+    }
+
+    /**
      * loadEnvironment method
      *
      * @param array $env


### PR DESCRIPTION
Not all webservers set CONTENT_TYPE. The built-in PHP webserver for example sets HTTP_CONTENT_TYPE instead. Add a public method to the request object to smooth over this difference.

Refs #6051
