### PR TITLE
2.6 jsonView should throw exception if json_encode fails

### DIFF
--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -337,7 +337,7 @@ class JsonViewTest extends CakeTestCase {
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
 
-		// non utf-8 stuff
+		// encoding a false, ensure this doesn't trigger exception
 		$data = false;
 
 		$Controller->set($data);

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -351,12 +351,8 @@ class JsonViewTest extends CakeTestCase {
 			restore_error_handler();
 			$this->fail('Failed asserting that exception of type "CakeException" is thrown.');
 		} catch (CakeException $e) {
-			$expected = array(
-				'Failed to parse JSON', 
-				'Malformed UTF-8 characters, possibly incorrectly encoded'
-			);
-			$this->assertContains($e->getMessage(), $expected);
 			restore_error_handler();
+			$this->assertRegExp('/UTF-8/', $e->getMessage());
 			return;
 			
 		}

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -354,7 +354,6 @@ class JsonViewTest extends CakeTestCase {
 			restore_error_handler();
 			$this->assertRegExp('/UTF-8/', $e->getMessage());
 			return;
-			
 		}
 	}
 

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -28,9 +28,24 @@ App::uses('JsonView', 'View');
  */
 class JsonViewTest extends CakeTestCase {
 
+/**
+ * setUp method
+ *
+ * @return void
+ **/
 	public function setUp() {
 		parent::setUp();
 		Configure::write('debug', 0);
+	}
+
+/**
+ * tearDown method
+ *
+ * @return void
+ **/
+	public function tearDown() {
+		parent::tearDown();
+		restore_error_handler();
 	}
 
 /**
@@ -324,7 +339,7 @@ class JsonViewTest extends CakeTestCase {
 /**
  * JsonViewTest::testRenderInvalidJSON()
  *
- * expectedException CakeException
+ * @expectedException CakeException
  * @return void
  */
 	public function testRenderInvalidJSON() {
@@ -336,7 +351,7 @@ class JsonViewTest extends CakeTestCase {
 		$data = array('data' => array('foo' => 'bar' . chr('0x97')));
 
 		// Use a custom error handler
-		$phpUnitErrorHandler = set_error_handler(array($this, 'jsonEncodeErrorHandler'));
+		set_error_handler(array($this, 'jsonEncodeErrorHandler'));
 
 		$Controller->set($data);
 		$Controller->set('_serialize', 'data');

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -334,7 +334,7 @@ class JsonViewTest extends CakeTestCase {
 
 		// non utf-8 stuff
 		$data = array('data' => array('foo' => 'bar' . chr('0x97')));
-		
+
 		// Use a custom error handler
 		$phpUnitErrorHandler = set_error_handler(array($this, 'jsonEncodeErrorHandler'));
 

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -306,4 +306,25 @@ class JsonViewTest extends CakeTestCase {
 		$this->assertSame($expected, $output);
 		$this->assertSame('application/javascript', $Response->type());
 	}
+
+/**
+ * JsonViewTest::testRenderInvalidJSON()
+ *
+ * @expectedException CakeException
+ * @return void
+ */
+	public function testRenderInvalidJSON() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+
+		// non utf-8 stuff
+		$data = array('data' => array('foo' => 'bar' . chr('0x97')));
+
+		$Controller->set($data);
+		$Controller->set('_serialize', 'data');
+		$View = new JsonView($Controller);
+		$output = $View->render();
+	}
+	
 }

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -326,5 +326,25 @@ class JsonViewTest extends CakeTestCase {
 		$View = new JsonView($Controller);
 		$output = $View->render();
 	}
+
+/**
+ * JsonViewTest::testRenderJSONBoolFalse()
+ *
+ * @return void
+ */
+	public function testRenderJSONBoolFalse() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+
+		// non utf-8 stuff
+		$data = false;
+
+		$Controller->set($data);
+		$Controller->set('_serialize', 'data');
+		$View = new JsonView($Controller);
+		$output = $View->render();
+		$this->assertSame('null', $output);
+	}	
 	
 }

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -157,6 +157,20 @@ class JsonViewTest extends CakeTestCase {
 	}
 
 /**
+ * Custom error handler for use while testing methods that use json_encode
+ * @param int $errno
+ * @param string $errstr
+ * @param string $errfile
+ * @param int $errline
+ * @param array $errcontext
+ * @return void
+ * @throws CakeException
+ **/
+	public function jsonEncodeErrorHandler($errno, $errstr, $errfile, $errline, $errcontext) {
+		throw new CakeException($errstr, 0, $errno, $errfile, $errline);
+	}
+
+/**
  * Test render with a valid string in _serialize.
  *
  * @dataProvider renderWithoutViewProvider
@@ -310,7 +324,7 @@ class JsonViewTest extends CakeTestCase {
 /**
  * JsonViewTest::testRenderInvalidJSON()
  *
- * @expectedException CakeException
+ * expectedException CakeException
  * @return void
  */
 	public function testRenderInvalidJSON() {
@@ -320,6 +334,9 @@ class JsonViewTest extends CakeTestCase {
 
 		// non utf-8 stuff
 		$data = array('data' => array('foo' => 'bar' . chr('0x97')));
+		
+		// Use a custom error handler
+		$phpUnitErrorHandler = set_error_handler(array($this, 'jsonEncodeErrorHandler'));
 
 		$Controller->set($data);
 		$Controller->set('_serialize', 'data');

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -345,6 +345,6 @@ class JsonViewTest extends CakeTestCase {
 		$View = new JsonView($Controller);
 		$output = $View->render();
 		$this->assertSame('null', $output);
-	}	
-	
+	}
+
 }

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -150,9 +150,9 @@ class JsonView extends View {
 		}
 
 		if (version_compare(PHP_VERSION, '5.4.0', '>=') && Configure::read('debug')) {
-			$json = @json_encode($data, JSON_PRETTY_PRINT);
+			$json = json_encode($data, JSON_PRETTY_PRINT);
 		} else {
-			$json = @json_encode($data);
+			$json = json_encode($data);
 		}
 
 		if (function_exists('json_last_error') && json_last_error() !== JSON_ERROR_NONE) {

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -124,10 +124,6 @@ class JsonView extends View {
 
 /**
  * Serialize view vars
- * For JSON documents, any errors are output using;
- * PHP 5 >= 5.5.0 : json_last_error_msg()
- * PHP 5 >= 5.3.0 : json_last_error()
- * PHP 5 <= 5.2.9 : Generic fall back error
  *
  * @param array $serialize The viewVars that need to be serialized
  * @throws CakeException
@@ -156,12 +152,7 @@ class JsonView extends View {
 		}
 
 		if (function_exists('json_last_error') && json_last_error() !== JSON_ERROR_NONE) {
-			if (function_exists('json_last_error_msg')) {
-				$error = json_last_error_msg();
-			} else {
-				$error = sprintf('JSON encoding failed: Error code %s', json_last_error());
-			}
-			throw new CakeException($error);
+			throw new CakeException(sprintf('JSON_ERROR: %s', json_last_error_msg()));
 		} elseif ($json === false) {
 			throw new CakeException('Failed to parse JSON');
 		}

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -161,7 +161,7 @@ class JsonView extends View {
 				$error = __('JSON encoding failed: Error code %s', json_last_error());
 			}
 			throw new CakeException($error);
-		} else if ($json === false) {
+		} elseif ($json === false) {
 			throw new CakeException(__('Failed to parse JSON'));
 		}
 		return $json;

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -149,9 +149,9 @@ class JsonView extends View {
 		}
 
 		if (version_compare(PHP_VERSION, '5.4.0', '>=') && Configure::read('debug')) {
-			$json = json_encode($data, JSON_PRETTY_PRINT);
+			$json = @json_encode($data, JSON_PRETTY_PRINT);
 		} else {
-			$json = json_encode($data);
+			$json = @json_encode($data);
 		}
 
 		if (function_exists('json_last_error') && json_last_error() !== JSON_ERROR_NONE) {

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -158,11 +158,11 @@ class JsonView extends View {
 			if (function_exists('json_last_error_msg')) {
 				$error = json_last_error_msg();
 			} else {
-				$error = __('JSON encoding failed: Error code %s', json_last_error());
+				$error = sprintf('JSON encoding failed: Error code %s', json_last_error());
 			}
 			throw new CakeException($error);
 		} elseif ($json === false) {
-			throw new CakeException(__('Failed to parse JSON'));
+			throw new CakeException('Failed to parse JSON');
 		}
 		return $json;
 	}

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -130,6 +130,7 @@ class JsonView extends View {
  * PHP 5 <= 5.2.9 : Generic fall back error
  *
  * @param array $serialize The viewVars that need to be serialized
+ * @throws CakeException
  * @return string The serialized data
  */
 	protected function _serialize($serialize) {

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -152,7 +152,7 @@ class JsonView extends View {
 		}
 
 		if (function_exists('json_last_error') && json_last_error() !== JSON_ERROR_NONE) {
-			throw new CakeException(sprintf('JSON_ERROR: %s', json_last_error_msg()));
+			throw new CakeException(json_last_error_msg());
 		} elseif ($json === false) {
 			throw new CakeException('Failed to parse JSON');
 		}

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -1061,3 +1061,25 @@ if (!function_exists('convertSlash')) {
 	}
 
 }
+
+if (!function_exists('json_last_error_msg')) {
+
+/**
+ * Provides the fallback implementation of json_last_error_msg() available in PHP 5.5 and above.
+ *
+ * @return string Error message.
+ */
+	function json_last_error_msg() {
+		static $errors = array(
+			JSON_ERROR_NONE => '',
+			JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
+			JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
+			JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
+			JSON_ERROR_SYNTAX => 'Syntax error',
+			JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
+		);
+		$error = json_last_error();
+		return array_key_exists($error, $errors) ? $errors[$error] : "Unknown error ({$error})";
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/3141

Seems this issue lay dormant, but solution given by @dereuromark in https://github.com/dereuromark/cakephp/commit/7b6238613de79bb0135d557a182c663ad3e9f8a1 seems a good fix.

I've added extra catch for if `json_last_error()` nor `json_last_error_msg()` are present.
