### PR TITLE
3.0 - Made Router::prefix() accept options

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -897,9 +897,9 @@ class Router
      */
     public static function prefix($name, $params = [], $callback = null)
     {
-        if($callback === null) {
+        if ($callback === null) {
             $callback = $params;
-            $params   = [];
+            $params = [];
         }
         $name = Inflector::underscore($name);
         $path = '/' . $name;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -890,14 +890,21 @@ class Router
      * to the `Controller\Admin\Api\` namespace.
      *
      * @param string $name The prefix name to use.
+     * @param array|callable $params An array of routing defaults to add to each connected route.
+     *   If you have no parameters, this argument can be a callable.
      * @param callable $callback The callback to invoke that builds the prefixed routes.
      * @return void
      */
-    public static function prefix($name, $callback)
+    public static function prefix($name, $params = [], $callback = null)
     {
+        if($callback === null) {
+            $callback = $params;
+            $params   = [];
+        }
         $name = Inflector::underscore($name);
         $path = '/' . $name;
-        static::scope($path, ['prefix' => $name], $callback);
+        $params = array_merge($params, ['prefix' => $name]);
+        static::scope($path, $params, $callback);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2814,6 +2814,20 @@ class RouterTest extends TestCase
     }
 
     /**
+     * Test that prefix() accepts options
+     *
+     * @return void
+     */
+    public function testPrefixOptions()
+    {
+        Router::prefix('admin', ['param' => 'value'], function ($routes) {
+            $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
+            $this->assertEquals('/admin', $routes->path());
+            $this->assertEquals(['prefix' => 'admin', 'param' => 'value'], $routes->params());
+        });
+    }
+
+    /**
      * Test that plugin() creates a scope.
      *
      * @return void


### PR DESCRIPTION
Made `Router::prefix()` consistent with `Router::scope()`, `Router::connect()` and `Router::plugin()` by letting it accept an array of routing defaults.
