### PR TITLE
3.0 phpcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 
 before_script:
   - composer self-update
-  - composer install --prefer-dist --no-interaction --dev
+  - composer install --prefer-dist --no-interaction
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test3;'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
 
 script:
   - sh -c "if [ '$PHPCS' != '1' ]; then phpunit; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p -n --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -1,68 +1,68 @@
 {
-	"name": "cakephp/cakephp",
-	"description": "The CakePHP framework",
-	"type": "library",
-	"keywords": ["framework"],
-	"homepage": "http://cakephp.org",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "CakePHP Community",
-			"homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
-		}
-	],
-	"support": {
-		"issues": "https://github.com/cakephp/cakephp/issues",
-		"forum": "http://stackoverflow.com/tags/cakephp",
-		"irc": "irc://irc.freenode.org/cakephp",
-		"source": "https://github.com/cakephp/cakephp"
-	},
-	"require": {
-		"php": ">=5.4.16",
-		"ext-intl": "*",
-		"ext-mbstring": "*",
-		"nesbot/Carbon": "1.13.*",
-		"ircmaxell/password-compat": "1.0.*",
-		"aura/intl": "1.1.*",
-		"psr/log": "1.0"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "*",
-		"cakephp/cakephp-codesniffer": "dev-master"
-	},
-	"autoload": {
-		"psr-4": {
-			"Cake\\": "src"
-		},
-		"files": [
-			"src/Core/functions.php",
-			"src/Collection/functions.php",
-			"src/I18n/functions.php",
+    "name": "cakephp/cakephp",
+    "description": "The CakePHP framework",
+    "type": "library",
+    "keywords": ["framework"],
+    "homepage": "http://cakephp.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/cakephp/cakephp/issues",
+        "forum": "http://stackoverflow.com/tags/cakephp",
+        "irc": "irc://irc.freenode.org/cakephp",
+        "source": "https://github.com/cakephp/cakephp"
+    },
+    "require": {
+        "php": ">=5.4.16",
+        "ext-intl": "*",
+        "ext-mbstring": "*",
+        "nesbot/Carbon": "1.13.*",
+        "ircmaxell/password-compat": "1.0.*",
+        "aura/intl": "1.1.*",
+        "psr/log": "1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "*",
+        "cakephp/cakephp-codesniffer": "dev-master"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cake\\": "src"
+        },
+        "files": [
+            "src/Core/functions.php",
+            "src/Collection/functions.php",
+            "src/I18n/functions.php",
             "src/Utility/bootstrap.php"
-		]
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Cake\\Test\\": "tests",
-			"Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests",
-			"TestApp\\": "tests/test_app/TestApp",
-			"TestPlugin\\": "tests/test_app/Plugin/TestPlugin/src",
-			"TestPlugin\\Test\\": "tests/test_app/Plugin/TestPlugin/tests",
-			"TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src",
-			"PluginJs\\": "tests/test_app/Plugin/PluginJs/src"
-		}
-	},
-	"replace": {
-		"cakephp/cache": "self.version",
-		"cakephp/collection": "self.version",
-		"cakephp/core": "self.version",
-		"cakephp/datasource": "self.version",
-		"cakephp/database": "self.version",
-		"cakephp/event": "self.version",
-		"cakephp/i18n": "self.version",
-		"cakephp/log": "self.version",
-		"cakephp/orm": "self.version",
-		"cakephp/utility": "self.version",
-		"cakephp/validation": "self.version"
-	}
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Cake\\Test\\": "tests",
+            "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests",
+            "TestApp\\": "tests/test_app/TestApp",
+            "TestPlugin\\": "tests/test_app/Plugin/TestPlugin/src",
+            "TestPlugin\\Test\\": "tests/test_app/Plugin/TestPlugin/tests",
+            "TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src",
+            "PluginJs\\": "tests/test_app/Plugin/PluginJs/src"
+        }
+    },
+    "replace": {
+        "cakephp/cache": "self.version",
+        "cakephp/collection": "self.version",
+        "cakephp/core": "self.version",
+        "cakephp/datasource": "self.version",
+        "cakephp/database": "self.version",
+        "cakephp/event": "self.version",
+        "cakephp/i18n": "self.version",
+        "cakephp/log": "self.version",
+        "cakephp/orm": "self.version",
+        "cakephp/utility": "self.version",
+        "cakephp/validation": "self.version"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
 		"files": [
 			"src/Core/functions.php",
 			"src/Collection/functions.php",
-			"src/I18n/functions.php"
+			"src/I18n/functions.php",
+            "src/Utility/bootstrap.php"
 		]
 	},
 	"autoload-dev": {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -13,9 +13,14 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use Cake\Routing\Router;
+
 define('TIME_START', microtime(true));
 
 // @deprecated Backward compatibility with 2.x series
 class_alias('Cake\Utility\Text', 'Cake\Utility\String');
 
 require CAKE . 'basics.php';
+
+// Sets the initial router state so future reloads work.
+Router::reload();

--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -1,20 +1,20 @@
 {
-	"name": "cakephp/cache",
-	"description": "Easy to use Caching library with support for multiple caching backends",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\Cache\\": "."
-		}
-	},
-	"require": {
-		"cakephp/core": "dev-master"
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/cache",
+    "description": "Easy to use Caching library with support for multiple caching backends",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\Cache\\": "."
+        }
+    },
+    "require": {
+        "cakephp/core": "dev-master"
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Collection/Iterator/InsertIterator.php
+++ b/src/Collection/Iterator/InsertIterator.php
@@ -98,7 +98,7 @@ class InsertIterator extends Collection
      * Returns the current element in the target collection after inserting
      * the value from the source collection into the specified path.
      *
-     * @return void
+     * @return mixed
      */
     public function current()
     {

--- a/src/Collection/composer.json
+++ b/src/Collection/composer.json
@@ -1,18 +1,18 @@
 {
-	"name": "cakephp/collection",
-	"description": "Work easily with arrays and iterators by having a battery of utility traversal methods",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\Collection\\": "."
-		},
-		"files": ["functions.php"]
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/collection",
+    "description": "Work easily with arrays and iterators by having a battery of utility traversal methods",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\Collection\\": "."
+        },
+        "files": ["functions.php"]
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -175,7 +175,7 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append.
      * @param int $size The number of bytes to overwrite. Defaults to the
      *    length of the last message output.
-     * @return int|bool Returns the number of bytes returned from writing to stdout.
+     * @return void
      */
     public function overwrite($message, $newlines = 1, $size = null)
     {

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -94,7 +94,7 @@ class SecurityComponent extends Component
      * Component startup. All security checking happens here.
      *
      * @param Event $event An Event instance
-     * @return void
+     * @return mixed
      */
     public function startup(Event $event)
     {

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -99,7 +99,7 @@ class ComponentRegistry extends ObjectRegistry
      * @param string $class The classname to create.
      * @param string $alias The alias of the component.
      * @param array $config An array of config to use for the component.
-     * @return Component The constructed component class.
+     * @return \Cake\Controller\Component The constructed component class.
      */
     protected function _create($class, $alias, $config)
     {

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -163,7 +163,8 @@ trait InstanceConfigTrait
     protected function _configWrite($key, $value, $merge = false)
     {
         if (is_string($key) && $value === null) {
-            return $this->_configDelete($key);
+            $this->_configDelete($key);
+            return;
         }
 
         if ($merge) {

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -1,21 +1,21 @@
 {
-	"name": "cakephp/core",
-	"description": "CakePHP Framework Core classes",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"require": {
-		"cakephp/utility": "dev-master"
-	},
-	"autoload": {
-		"psr-4": {
-			"Cake\\Core\\": "."
-		},
-		"files": ["functions.php"]
-	},
-	"minimum-stability": "dev"
+    "name": "cakephp/core",
+    "description": "CakePHP Framework Core classes",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "require": {
+        "cakephp/utility": "dev-master"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cake\\Core\\": "."
+        },
+        "files": ["functions.php"]
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1521,7 +1521,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param callable $callback the function to be executed for each ExpressionInterface
      *   found inside this query.
-     * @return $this
+     * @return void|$this
      */
     public function traverseExpressions(callable $callback)
     {

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -107,7 +107,7 @@ class QueryCompiler
      * Returns a callable object that can be used to compile a SQL string representation
      * of this query.
      *
-     * @param string &$sql initial sql string to append to
+     * @param string $sql initial sql string to append to
      * @param \Cake\Database\Query $query The query that is being compiled
      * @param \Cake\Database\ValueBinder $generator The placeholder and value binder object
      * @return \Closure

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -383,7 +383,7 @@ class SqliteSchema extends BaseSchema
      * Returns whether there is any table in this connection to SQLite containing
      * sequences
      *
-     * @return void
+     * @return bool
      */
     public function hasSequences()
     {

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -1,24 +1,24 @@
 {
-	"name": "cakephp/database",
-	"description": "Flexible and powerful Database abstraction library with a familiar PDO-like API",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "CakePHP Community",
-			"homepage": "http://cakephp.org"
-		}
-	],
-	"require": {
-		"cakephp/core": "dev-master"
-	},
-	"suggest": {
-		"cakephp/log": "Require this if you want to use the built-in query logger",
-		"cakephp/cache": "Require this if you decide to use the schema caching feature"
-	},
-	"autoload": {
-		"psr-4": {
-			"Cake\\Database\\": "."
-		}
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/database",
+    "description": "Flexible and powerful Database abstraction library with a familiar PDO-like API",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "http://cakephp.org"
+        }
+    ],
+    "require": {
+        "cakephp/core": "dev-master"
+    },
+    "suggest": {
+        "cakephp/log": "Require this if you want to use the built-in query logger",
+        "cakephp/cache": "Require this if you decide to use the schema caching feature"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cake\\Database\\": "."
+        }
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -71,7 +71,7 @@ class QueryCacher
      *
      * @param object $query The query the cache read is for.
      * @param \Traversable $results The result set to store.
-     * @return void
+     * @return bool True if the data was successfully cached, false on failure
      */
     public function store($query, Traversable $results)
     {

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -1,24 +1,24 @@
 {
-	"name": "cakephp/datasource",
-	"description": "Provides connection managing and traits for Entities and Queries that can be reused for different datastores",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "CakePHP Community",
-			"homepage": "http://cakephp.org"
-		}
-	],
-	"require": {
-		"cakephp/core": "dev-master"
-	},
-	"suggest": {
-		"cakephp/utility": "Require this if you decide to use EntityTrait",
-		"cakephp/collection": "Require this if you decide to use ResultSetInterface"
-	},
-	"autoload": {
-		"psr-4": {
-			"Cake\\Datasource\\": "."
-		}
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/datasource",
+    "description": "Provides connection managing and traits for Entities and Queries that can be reused for different datastores",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "http://cakephp.org"
+        }
+    ],
+    "require": {
+        "cakephp/core": "dev-master"
+    },
+    "suggest": {
+        "cakephp/utility": "Require this if you decide to use EntityTrait",
+        "cakephp/collection": "Require this if you decide to use ResultSetInterface"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cake\\Datasource\\": "."
+        }
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -199,7 +199,7 @@ abstract class BaseErrorHandler
      *
      * @param string $level The level name of the log.
      * @param array $data Array of error data.
-     * @return void
+     * @return bool
      */
     protected function _logError($level, $data)
     {

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -100,12 +100,14 @@ class EventManager
     public function attach($callable, $eventKey = null, array $options = [])
     {
         if ($eventKey === null) {
-            return $this->on($callable);
+            $this->on($callable);
+            return;
         }
         if ($options) {
-            return $this->on($eventKey, $options, $callable);
+            $this->on($eventKey, $options, $callable);
+            return;
         }
-        return $this->on($eventKey, $callable);
+        $this->on($eventKey, $callable);
     }
 
     /**
@@ -227,9 +229,10 @@ class EventManager
     public function detach($callable, $eventKey = null)
     {
         if ($eventKey === null) {
-            return $this->off($callable);
+            $this->off($callable);
+            return;
         }
-        return $this->off($eventKey, $callable);
+        $this->off($eventKey, $callable);
     }
 
     /**
@@ -267,10 +270,12 @@ class EventManager
     public function off($eventKey, $callable = null)
     {
         if ($eventKey instanceof EventListenerInterface) {
-            return $this->_detachSubscriber($eventKey);
+            $this->_detachSubscriber($eventKey);
+            return;
         }
         if ($callable instanceof EventListenerInterface) {
-            return $this->_detachSubscriber($callable, $eventKey);
+            $this->_detachSubscriber($callable, $eventKey);
+            return;
         }
         if ($callable === null) {
             foreach (array_keys($this->_listeners) as $name) {

--- a/src/Event/composer.json
+++ b/src/Event/composer.json
@@ -1,17 +1,17 @@
 {
-	"name": "cakephp/event",
-	"description": "CakePHP event dispatcher library that helps implementing the observer pattern",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\Event\\": "."
-		}
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/event",
+    "description": "CakePHP event dispatcher library that helps implementing the observer pattern",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\Event\\": "."
+        }
+    },
+    "minimum-stability": "beta"
 }

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -207,7 +207,7 @@ class I18n
      * locale as stored in the `intl.default_locale` PHP setting.
      *
      * @param string|null $locale The name of the locale to set as default.
-     * @return string|null The name of the default locale.
+     * @return string|void The name of the default locale.
      */
     public static function locale($locale = null)
     {

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -122,7 +122,7 @@ class PoFileParser
     /**
      * Saves a translation item to the messages.
      *
-     * @param array &$messages The messages array being collected from the file
+     * @param array $messages The messages array being collected from the file
      * @param array $item The current item being inspected
      * @return void
      */

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -130,7 +130,7 @@ class TranslatorRegistry extends TranslatorLocator
      *
      * @param string $name The name of the translator package to register a loader for
      * @param callable $loader A callable object that should return a Package
-     * @return \Aura\Intl\TranslatorInterface A translator object.
+     * @return void
      */
     public function registerLoader($name, callable $loader)
     {

--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -69,7 +69,7 @@ if (!function_exists('__d')) {
      * @param string $domain Domain.
      * @param string $msg String to translate.
      * @param mixed $args Array with arguments or multiple arguments in function.
-     * @return string Translated string.
+     * @return void|string Translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__d
      */
     function __d($domain, $msg, $args = null)
@@ -94,7 +94,7 @@ if (!function_exists('__dn')) {
      * @param string $plural Plural.
      * @param int $count Count.
      * @param mixed $args Array with arguments or multiple arguments in function.
-     * @return string Plural form of translated string.
+     * @return void|string Plural form of translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dn
      */
     function __dn($domain, $singular, $plural, $count, $args = null)
@@ -121,7 +121,7 @@ if (!function_exists('__x')) {
      * @param string $context Context of the text.
      * @param string $singular Text to translate.
      * @param mixed $args Array with arguments or multiple arguments in function.
-     * @return mixed Translated string.
+     * @return void|string Translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__
      */
     function __x($context, $singular, $args = null)
@@ -148,7 +148,7 @@ if (!function_exists('__xn')) {
      * @param string $plural Plural text.
      * @param int $count Count.
      * @param mixed $args Array with arguments or multiple arguments in function.
-     * @return mixed Plural form of translated string.
+     * @return void|string Plural form of translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__xn
      */
     function __xn($context, $singular, $plural, $count, $args = null)
@@ -176,7 +176,7 @@ if (!function_exists('__dx')) {
      * @param string $context Context of the text.
      * @param string $msg String to translate.
      * @param mixed $args Array with arguments or multiple arguments in function.
-     * @return string Translated string.
+     * @return void|string Translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dx
      */
     function __dx($domain, $context, $msg, $args = null)
@@ -207,7 +207,7 @@ if (!function_exists('__dxn')) {
      * @param string $plural Plural text.
      * @param int $count Count.
      * @param mixed $args Array with arguments or multiple arguments in function.
-     * @return mixed Plural form of translated string.
+     * @return void|string Plural form of translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dxn
      */
     function __dxn($domain, $context, $singular, $plural, $count, $args = null)

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -1,21 +1,21 @@
 {
-	"name": "cakephp/log",
-	"description": "CakePHP logging library with support for multiple different streams",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\Log\\": "."
-		}
-	},
-	"require": {
-		"cakephp/core": "dev-master",
-		"psr/log": "1.0"
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/log",
+    "description": "CakePHP logging library with support for multiple different streams",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\Log\\": "."
+        }
+    },
+    "require": {
+        "cakephp/core": "dev-master",
+        "psr/log": "1.0"
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1995,7 +1995,8 @@ class Email implements JsonSerializable, Serializable
     /**
      * Unserializes the Email object.
      *
-     * @return void.
+     * @param string $data Serialized string.
+     * @return \Cake\Network\Email\Email Configured email instance.
      */
     public function unserialize($data)
     {

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -480,7 +480,7 @@ class Session
     /**
      * Used to write new data to _SESSION, since PHP doesn't like us setting the _SESSION var itself.
      *
-     * @param array &$old Set of old variables => values
+     * @param array $old Set of old variables => values
      * @param array $new New set of variable => value
      * @return void
      */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -653,7 +653,7 @@ class Query extends DatabaseQuery implements JsonSerializable
      * using `contain`
      *
      * @see \Cake\Database\Query::execute()
-     * @return $this
+     * @return void
      */
     protected function _transformQuery()
     {

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -147,11 +147,11 @@ class TableRegistry
      * If no `connection` option is passed the table's defaultConnectionName() method
      * will be called to get the default connection name to use.
      *
-     * @param string $name The alias name you want to get.
+     * @param string $alias The alias name you want to get.
      * @param array $options The options you want to build the table with.
      *   If a table has already been loaded the options will be ignored.
      * @return \Cake\ORM\Table
-     * @throws RuntimeException When you try to configure an alias that already exists.
+     * @throws \RuntimeException When you try to configure an alias that already exists.
      */
     public static function get($alias, array $options = [])
     {

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -1,29 +1,29 @@
 {
-	"name": "cakephp/orm",
-	"description": "CakePHP ORM - Provides a flexible and powerful ORM implementing a data-mapper pattern.",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\ORM\\": "."
-		}
-	},
-	"require": {
-		"cakephp/collection": "dev-master",
-		"cakephp/core": "dev-master",
-		"cakephp/datasource": "dev-master",
-		"cakephp/database": "dev-master",
-		"cakephp/event": "dev-master",
-		"cakephp/utility": "dev-master",
-		"cakephp/validation": "dev-master"
-	},
-	"suggest": {
-		"cakephp/i18n": "dev-master"
-	},
-	"minimum-stability": "beta"
+    "name": "cakephp/orm",
+    "description": "CakePHP ORM - Provides a flexible and powerful ORM implementing a data-mapper pattern.",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\ORM\\": "."
+        }
+    },
+    "require": {
+        "cakephp/collection": "dev-master",
+        "cakephp/core": "dev-master",
+        "cakephp/datasource": "dev-master",
+        "cakephp/database": "dev-master",
+        "cakephp/event": "dev-master",
+        "cakephp/utility": "dev-master",
+        "cakephp/validation": "dev-master"
+    },
+    "suggest": {
+        "cakephp/i18n": "dev-master"
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -242,7 +242,7 @@ class RouteBuilder
      * @param array|callable $options Options to use when generating REST routes, or a callback.
      * @param callable|null $callback An optional callback to be executed in a nested scope. Nested
      *   scopes inherit the existing path and 'id' parameter.
-     * @return array Array of mapped resources
+     * @return void
      */
     public function resources($name, $options = [], $callback = null)
     {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -304,18 +304,22 @@ class Router
             if ($plugin && $prefix) {
                 $path = '/' . implode('/', [$prefix, $pluginUrl]);
                 $params = ['prefix' => $prefix, 'plugin' => $plugin];
-                return static::scope($path, $params, $callback);
+                static::scope($path, $params, $callback);
+                return;
             }
 
             if ($prefix) {
-                return static::prefix($prefix, $callback);
+                static::prefix($prefix, $callback);
+                return;
             }
 
             if ($plugin) {
-                return static::plugin($plugin, $callback);
+                static::plugin($plugin, $callback);
+                return;
             }
 
-            return static::scope('/', $callback);
+            static::scope('/', $callback);
+            return;
         }
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -956,6 +956,3 @@ class Router
         include CONFIG . 'routes.php';
     }
 }
-
-//Save the initial state
-Router::reload();

--- a/src/Shell/CompletionShell.php
+++ b/src/Shell/CompletionShell.php
@@ -41,7 +41,7 @@ class CompletionShell extends Shell
     /**
      * Not called by the autocomplete shell - this is for curious users
      *
-     * @return void
+     * @return int|bool Returns the number of bytes returned from writing to stdout.
      */
     public function main()
     {
@@ -51,7 +51,7 @@ class CompletionShell extends Shell
     /**
      * list commands
      *
-     * @return void
+     * @return void|int|bool Returns the number of bytes returned from writing to stdout.
      */
     public function commands()
     {
@@ -62,7 +62,7 @@ class CompletionShell extends Shell
     /**
      * list options for the named command
      *
-     * @return void
+     * @return void|int|bool Returns the number of bytes returned from writing to stdout.
      */
     public function options()
     {
@@ -78,7 +78,7 @@ class CompletionShell extends Shell
     /**
      * list subcommands for the named command
      *
-     * @return void
+     * @return void|int|bool Returns the number of bytes returned from writing to stdout.
      */
     public function subcommands()
     {
@@ -93,7 +93,7 @@ class CompletionShell extends Shell
     /**
      * Guess autocomplete from the whole argument string
      *
-     * @return void
+     * @return void|int|bool Returns the number of bytes returned from writing to stdout.
      */
     public function fuzzy()
     {
@@ -151,7 +151,7 @@ class CompletionShell extends Shell
      * Emit results as a string, space delimited
      *
      * @param array $options The options to output
-     * @return void
+     * @return void|int|bool Returns the number of bytes returned from writing to stdout.
      */
     protected function _output($options = [])
     {

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -54,7 +54,8 @@ class I18nShell extends Shell
                 $this->out($this->OptionParser->help());
                 break;
             case 'q':
-                return $this->_stop();
+                $this->_stop();
+                return;
             default:
                 $this->out('You have made an invalid selection. Please choose a command to execute by entering E, I, H, or Q.');
         }

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -122,7 +122,8 @@ class ExtractTask extends Shell
             $response = $this->in($message, null, $defaultPath);
             if (strtoupper($response) === 'Q') {
                 $this->err('Extract Aborted');
-                return $this->_stop();
+                $this->_stop();
+                return;
             } elseif (strtoupper($response) === 'D' && count($this->_paths)) {
                 $this->out();
                 return;
@@ -197,7 +198,8 @@ class ExtractTask extends Shell
                 $response = $this->in($message, null, rtrim($this->_paths[0], DS) . DS . 'Locale');
                 if (strtoupper($response) === 'Q') {
                     $this->err('Extract Aborted');
-                    return $this->_stop();
+                    $this->_stop();
+                    return;
                 } elseif ($this->_isPathUsable($response)) {
                     $this->_output = $response . DS;
                     break;
@@ -227,7 +229,8 @@ class ExtractTask extends Shell
         $this->_output = rtrim($this->_output, DS) . DS;
         if (!$this->_isPathUsable($this->_output)) {
             $this->err(sprintf('The output directory %s was not found or writable.', $this->_output));
-            return $this->_stop();
+            $this->_stop();
+            return;
         }
 
         $this->_extract();
@@ -571,7 +574,7 @@ class ExtractTask extends Shell
     /**
      * Get the strings from the position forward
      *
-     * @param int &$position Actual position on tokens array
+     * @param int $position Actual position on tokens array
      * @param int $target Number of strings to extract
      * @return array Strings extracted
      */

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -193,7 +193,7 @@ class TestFixture
      * Get/Set the Cake\Database\Schema\Table instance used by this fixture.
      *
      * @param \Cake\Database\Schema\Table $schema The table to set.
-     * @return \Cake\Database\Schema\Table|null
+     * @return void|\Cake\Database\Schema\Table
      */
     public function schema(Table $schema = null)
     {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -324,7 +324,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      * @param array $expected An array, see above
      * @param string $string An HTML/XHTML/XML string
      * @param bool $fullDebug Whether or not more verbose output should be used.
-     * @return void
+     * @return bool
      */
     public function assertHtml($expected, $string, $fullDebug = false)
     {
@@ -463,7 +463,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      *
      * @param array $assertions Assertions to run.
      * @param string $string The HTML string to check.
-     * @return void
+     * @return string
      */
     protected function _assertAttributes($assertions, $string)
     {

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -486,7 +486,7 @@ class Hash
      * @param array $data Source array from which to extract the data
      * @param array $paths An array containing one or more Hash::extract()-style key paths
      * @param string $format Format string into which values will be inserted, see sprintf()
-     * @return array An array of strings extracted from `$path` and formatted with `$format`
+     * @return void|array An array of strings extracted from `$path` and formatted with `$format`
      * @link http://book.cakephp.org/3.0/en/core-libraries/hash.html#Hash::format
      * @see sprintf()
      * @see Hash::extract()
@@ -719,7 +719,7 @@ class Hash
      * Merge helper function to reduce duplicated code between merge() and expand().
      *
      * @param array $stack The stack of operations to work with.
-     * @param array &$return The return value to operate on.
+     * @param array $return The return value to operate on.
      * @return void
      */
     protected static function _merge($stack, &$return)

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -754,6 +754,3 @@ class Inflector
         return preg_replace(array_keys($map), array_values($map), $string);
     }
 }
-
-// Store the initial state
-Inflector::reset();

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -224,7 +224,7 @@ class Xml
      *
      * @param \DOMDocument $dom Handler to DOMDocument
      * @param \DOMElement $node Handler to DOMElement (child)
-     * @param array &$data Array of data to append to the $node.
+     * @param array $data Array of data to append to the $node.
      * @param string $format Either 'attribute' or 'tags'. This determines where nested keys go.
      * @return void
      * @throws \Cake\Utility\Exception\XmlException
@@ -356,7 +356,7 @@ class Xml
      * Recursive method to toArray
      *
      * @param \SimpleXMLElement $xml SimpleXMLElement object
-     * @param array &$parentData Parent array with data
+     * @param array $parentData Parent array with data
      * @param string $ns Namespace of current child
      * @param array $namespaces List of namespaces in XML
      * @return void

--- a/src/Utility/bootstrap.php
+++ b/src/Utility/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+use Cake\Utility\Inflector;
+
+// Store the initial state
+Inflector::reset();

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -11,7 +11,8 @@
 	"autoload": {
 		"psr-4": {
 			"Cake\\Utility\\": "."
-		}
+		},
+        "files": ["bootstrap.php"]
 	},
 	"minimum-stability": "beta"
 }

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -1,18 +1,18 @@
 {
-	"name": "cakephp/utility",
-	"description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\Utility\\": "."
-		},
+    "name": "cakephp/utility",
+    "description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\Utility\\": "."
+        },
         "files": ["bootstrap.php"]
-	},
-	"minimum-stability": "beta"
+    },
+    "minimum-stability": "beta"
 }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -811,7 +811,7 @@ class Validation
      * an array.
      *
      * @param array $params Parameters sent to validation method
-     * @return void
+     * @return array
      */
     protected static function _defaults($params)
     {

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -1,20 +1,20 @@
 {
-	"name": "cakephp/validation",
-	"description": "CakePHP Validation library",
-	"license": "MIT",
-	"authors": [
-		{
-		"name": "CakePHP Community",
-		"homepage": "http://cakephp.org"
-	}
-	],
-	"autoload": {
-		"psr-4": {
-			"Cake\\Validation\\": "."
-		}
-	},
-	"require": {
-		"cakephp/utility": "dev-master"
-	},
-	"minimum-stability": "dev"
+    "name": "cakephp/validation",
+    "description": "CakePHP Validation library",
+    "license": "MIT",
+    "authors": [
+        {
+        "name": "CakePHP Community",
+        "homepage": "http://cakephp.org"
+    }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Cake\\Validation\\": "."
+        }
+    },
+    "require": {
+        "cakephp/utility": "dev-master"
+    },
+    "minimum-stability": "dev"
 }

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -60,7 +60,7 @@ class FlashHelper extends Helper
      * @param string $key The [Flash.]key you are rendering in the view.
      * @param array $options Additional options to use for the creation of this flash message.
      *    Supports the 'params', and 'element' keys that are used in the helper.
-     * @return string|null Rendered flash message or null if flash key does not exist
+     * @return string|void Rendered flash message or null if flash key does not exist
      *   in session.
      * @throws \UnexpectedValueException If value for flash settings key is not an array.
      */

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -536,7 +536,7 @@ class FormHelper extends Helper
      *    generating the hash, else $this->fields is being used.
      * @param array $secureAttributes will be passed as HTML attributes into the hidden
      *    input elements generated for the Security Component.
-     * @return string A hidden input field with a security hash
+     * @return void|string A hidden input field with a security hash
      */
     public function secure(array $fields = [], array $secureAttributes = [])
     {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -446,7 +446,7 @@ class View
      *
      * @param string|null $view Name of view file to use
      * @param string|null $layout Layout to use.
-     * @return string|null Rendered content or null if content already rendered and returned earlier.
+     * @return string|void Rendered content or null if content already rendered and returned earlier.
      * @throws \Cake\Core\Exception\Exception If there is an error in the view.
      * @triggers View.beforeRender $this, [$viewFileName]
      * @triggers View.afterRender $this, [$viewFileName]

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -66,7 +66,9 @@ class MemcachedEngineTest extends TestCase
         parent::setUp();
         $this->skipIf(!class_exists('Memcached'), 'Memcached is not installed or configured properly.');
 
+        // @codingStandardsIgnoreStart
         $socket = @fsockopen('127.0.0.1', 11211, $errno, $errstr, 1);
+        // @codingStandardsIgnoreEnd
         $this->skipIf(!$socket, 'Memcached is not running.');
         fclose($socket);
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -38,7 +38,9 @@ class RedisEngineTest extends TestCase
         parent::setUp();
         $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
 
+        // @codingStandardsIgnoreStart
         $socket = @fsockopen('127.0.0.1', 6379, $errno, $errstr, 1);
+        // @codingStandardsIgnoreEnd
         $this->skipIf(!$socket, 'Redis is not running.');
         fclose($socket);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,6 @@ use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\I18n;
 use Cake\Log\Log;
-use Cake\Routing\Router;
 
 require_once 'vendor/autoload.php';
 
@@ -117,5 +116,3 @@ Log::config([
 Carbon\Carbon::setTestNow(Carbon\Carbon::now());
 
 ini_set('intl.default_locale', 'en_US');
-
-Router::reload();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\I18n;
 use Cake\Log\Log;
+use Cake\Routing\Router;
 
 require_once 'vendor/autoload.php';
 
@@ -116,3 +117,5 @@ Log::config([
 Carbon\Carbon::setTestNow(Carbon\Carbon::now());
 
 ini_set('intl.default_locale', 'en_US');
+
+Router::reload();


### PR DESCRIPTION
After updating our codesniffer's ruleset to ignore pendantic warnings related to docblocks I have fixed all CS errors. I doubt anyone is going to find the time to resolve those in the near future.

Only the errors reported by `PSR1.Files.SideEffects.FoundWithSymbols` sniff remains. Apart from ignoring the whole file using `@codingStandardsIgnoreFile` I don't know a way of resolving those errors (Using `@codingStandardsIgnoreStart` `@codingStandardsIgnoreEnd` pair doesn't work).
