### PR TITLE
Fix Cells not rendering plugin views.

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -162,7 +162,10 @@ abstract class Cell
      */
     public function render($template = null)
     {
-        if ($template !== null && strpos($template, '/') === false) {
+        if ($template !== null &&
+            strpos($template, '/') === false &&
+            strpos($template, '.') === false
+        ) {
             $template = Inflector::underscore($template);
         }
         if ($template === null) {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -126,10 +126,10 @@ abstract class Cell
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request the request to use in the cell
-     * @param \Cake\Network\Response $response the response to use in the cell
-     * @param \Cake\Event\EventManager $eventManager then eventManager to bind events to
-     * @param array $cellOptions cell options to apply
+     * @param \Cake\Network\Request $request The request to use in the cell.
+     * @param \Cake\Network\Response $response The response to use in the cell.
+     * @param \Cake\Event\EventManager $eventManager The eventManager to bind events to.
+     * @param array $cellOptions Cell options to apply.
      */
     public function __construct(
         Request $request = null,
@@ -157,7 +157,7 @@ abstract class Cell
      *
      * @param string|null $template Custom template name to render. If not provided (null), the last
      * value will be used. This value is automatically set by `CellTrait::cell()`.
-     * @return string The rendered cell
+     * @return string The rendered cell.
      * @throws \Cake\View\Exception\MissingCellViewException When a MissingTemplateException is raised during rendering.
      */
     public function render($template = null)

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -174,6 +174,27 @@ class CellTest extends TestCase
     }
 
     /**
+     * Test that a cell can render a plugin view.
+     *
+     * @return void
+     */
+    public function testCellRenderPluginTemplate()
+    {
+        $cell = $this->View->cell('Articles');
+        $this->assertContains(
+            'TestPlugin Articles/display',
+            $cell->render('TestPlugin.display')
+        );
+
+        $cell = $this->View->cell('Articles');
+        $cell->plugin = 'TestPlugin';
+        $this->assertContains(
+            'TestPlugin Articles/display',
+            $cell->render('display')
+        );
+    }
+
+    /**
      * Tests that using plugin's cells works.
      *
      * @return void

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Cell/Articles/display.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Cell/Articles/display.ctp
@@ -1,0 +1,1 @@
+TestPlugin Articles/display


### PR DESCRIPTION
When a `.` is present we can generally assume the user wants to render a plugin view.

Refs #6076
