### PR TITLE
3.0 fixing belongstomany id joindata

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -108,10 +108,10 @@ class Marshaller
         $primaryKey = $schema->primaryKey();
 
         if (array_intersect($primaryKey, array_keys($data)) == $primaryKey) {
-            $tableName = $this->_table->table();
+            $tableName = $this->_table->alias();
             $record = $this->_table->find('all');
             foreach ($primaryKey as $pkey) {
-                $record->where(["$tableName.$pkey" => $data[$pkey] ]);
+                $record->where(["$tableName.$pkey" => $data[$pkey]]);
             }
 
             $record = $record->first();

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -105,6 +105,18 @@ class Marshaller
         $propertyMap = $this->_buildPropertyMap($options);
 
         $schema = $this->_table->schema();
+        $primaryKey = $schema->primaryKey();
+
+        if ( array_intersect($primaryKey, array_keys($data)) == $primaryKey ) {
+            $record=$this->_table->find('all');
+            foreach ( $primaryKey as $pkey ) {
+                $record->where(["$pkey"=>$data[$pkey] ]);
+            }
+            if ( $record->count() > 0 ) {
+                return $record->first();
+            }
+        }
+
         $entityClass = $this->_table->entityClass();
         $entity = new $entityClass();
         $entity->source($this->_table->registryAlias());
@@ -116,7 +128,6 @@ class Marshaller
         }
 
         $errors = $this->_validate($data, $options, true);
-        $primaryKey = $schema->primaryKey();
         $properties = [];
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -112,8 +112,11 @@ class Marshaller
             foreach ($primaryKey as $pkey) {
                 $record->where(["$pkey" => $data[$pkey] ]);
             }
-            if ($record->count() > 0) {
-                return $record->first();
+
+            $record = $record->first();
+
+            if ($record) {
+                return $record;
             }
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -107,12 +107,12 @@ class Marshaller
         $schema = $this->_table->schema();
         $primaryKey = $schema->primaryKey();
 
-        if ( array_intersect($primaryKey, array_keys($data)) == $primaryKey ) {
-            $record=$this->_table->find('all');
-            foreach ( $primaryKey as $pkey ) {
-                $record->where(["$pkey"=>$data[$pkey] ]);
+        if (array_intersect($primaryKey, array_keys($data)) == $primaryKey) {
+            $record = $this->_table->find('all');
+            foreach ($primaryKey as $pkey) {
+                $record->where(["$pkey" => $data[$pkey] ]);
             }
-            if ( $record->count() > 0 ) {
+            if ($record->count() > 0) {
                 return $record->first();
             }
         }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -108,9 +108,10 @@ class Marshaller
         $primaryKey = $schema->primaryKey();
 
         if (array_intersect($primaryKey, array_keys($data)) == $primaryKey) {
+            $tableName=$this->_table->table();
             $record = $this->_table->find('all');
             foreach ($primaryKey as $pkey) {
-                $record->where(["$pkey" => $data[$pkey] ]);
+                $record->where(["$tableName.$pkey" => $data[$pkey] ]);
             }
 
             $record = $record->first();

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -108,7 +108,7 @@ class Marshaller
         $primaryKey = $schema->primaryKey();
 
         if (array_intersect($primaryKey, array_keys($data)) == $primaryKey) {
-            $tableName=$this->_table->table();
+            $tableName = $this->_table->table();
             $record = $this->_table->find('all');
             foreach ($primaryKey as $pkey) {
                 $record->where(["$tableName.$pkey" => $data[$pkey] ]);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -495,6 +495,52 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test one() with with id and _joinData.
+     *
+     * @return void
+     */
+    public function testOneBelongsToManyJoinDataAssociatedWithIds()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'author_id' => 1,
+            'tags' => [
+                [
+                    'id' => 1,
+                    '_joinData' => [
+                        'active' => 1,
+                        'user' => ['username' => 'MyLux'],
+                    ]
+                ],
+                [
+                    'id' => 2,
+                    '_joinData' => [
+                        'active' => 0,
+                        'user' => ['username' => 'IronFall'],
+                    ]
+                ],
+            ],
+        ];
+        $marshall = new Marshaller($this->articles);
+        $result = $marshall->one($data, ['associated' => ['Tags._joinData.Users']]);
+        $this->assertInstanceOf(
+            'Cake\ORM\Entity',
+            $result->tags[0]
+        );
+        $this->assertInstanceOf(
+            'Cake\ORM\Entity',
+            $result->tags[1]
+        );
+
+        $this->assertEquals(false,$result->tags[0]->isNew() );
+        $this->assertEquals(false,$result->tags[1]->isNew() );
+        $this->assertEquals( TableRegistry::get('tags')->get(1)->tag,$result->tags[0]->tag );
+        $this->assertEquals( TableRegistry::get('tags')->get(2)->tag,$result->tags[1]->tag );
+
+    }
+
+    /**
      * Test one() with deeper associations.
      *
      * @return void

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -533,11 +533,10 @@ class MarshallerTest extends TestCase
             $result->tags[1]
         );
 
-        $this->assertEquals(false,$result->tags[0]->isNew() );
-        $this->assertEquals(false,$result->tags[1]->isNew() );
-        $this->assertEquals( TableRegistry::get('tags')->get(1)->tag,$result->tags[0]->tag );
-        $this->assertEquals( TableRegistry::get('tags')->get(2)->tag,$result->tags[1]->tag );
-
+        $this->assertEquals(false, $result->tags[0]->isNew());
+        $this->assertEquals(false, $result->tags[1]->isNew());
+        $this->assertEquals(TableRegistry::get('tags')->get(1)->tag, $result->tags[0]->tag);
+        $this->assertEquals(TableRegistry::get('tags')->get(2)->tag, $result->tags[1]->tag);
     }
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -522,6 +522,12 @@ class MarshallerTest extends TestCase
                 ],
             ],
         ];
+
+        $articlesTags = TableRegistry::get('ArticlesTags');
+        $Tags = TableRegistry::get('Tags');
+        $t1 = $Tags->find('all')->where(['id' => 1])->first();
+        $t2 = $Tags->find('all')->where(['id' => 2])->first();
+        $articlesTags->belongsTo('Users');
         $marshall = new Marshaller($this->articles);
         $result = $marshall->one($data, ['associated' => ['Tags._joinData.Users']]);
         $this->assertInstanceOf(
@@ -533,10 +539,21 @@ class MarshallerTest extends TestCase
             $result->tags[1]
         );
 
+        $this->assertInstanceOf(
+            'Cake\ORM\Entity',
+            $result->tags[0]->_joinData->user
+        );
+
+        $this->assertInstanceOf(
+            'Cake\ORM\Entity',
+            $result->tags[1]->_joinData->user
+        );
         $this->assertEquals(false, $result->tags[0]->isNew());
         $this->assertEquals(false, $result->tags[1]->isNew());
-        $this->assertEquals(TableRegistry::get('tags')->get(1)->tag, $result->tags[0]->tag);
-        $this->assertEquals(TableRegistry::get('tags')->get(2)->tag, $result->tags[1]->tag);
+        $this->assertEquals($t1->tag, $result->tags[0]->tag);
+        $this->assertEquals($t2->tag, $result->tags[1]->tag);
+        $this->assertEquals($data['tags'][0]['_joinData']['user']['username'], $result->tags[0]->_joinData->user->username);
+        $this->assertEquals($data['tags'][1]['_joinData']['user']['username'], $result->tags[1]->_joinData->user->username);
     }
 
     /**


### PR DESCRIPTION
Added a bugfix. It wasn't possible to create a new entity in the following conditions:

Article->BelongsToMany Tags.

When the article is new, but the tags are already existent. When creating a new entity, while passing id and _joinData for each tag, instead of search for the tag with the defined id, it was adding a new entity (with new=>true) and with the field id filled.

"id" field is not hard coded. It is set to primary key field and it should support multiple keys constituting the primary key.

With this correction, it should look for each tag with the defined id and add the _joinData accordingly and only add a new Tag entity if one with this id is not found in the database.
An example can be found in the test named: testOneBelongsToManyJoinDataAssociatedWithIds
