### PR TITLE
Cast arrays into scalar values safely.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -186,6 +186,9 @@ class Type
         if ($value === null) {
             return null;
         }
+        if (is_array($value)) {
+            $value = '';
+        }
 
         if (!empty(self::$_basicTypes[$this->_name])) {
             $typeInfo = self::$_basicTypes[$this->_name];

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -52,6 +52,9 @@ class FloatType extends \Cake\Database\Type
         if ($value === null || $value === '') {
             return null;
         }
+        if (is_array($value)) {
+            return 1;
+        }
         return floatval($value);
     }
 
@@ -67,6 +70,9 @@ class FloatType extends \Cake\Database\Type
     {
         if ($value === null) {
             return null;
+        }
+        if (is_array($value)) {
+            return 1;
         }
         return floatval($value);
     }
@@ -98,6 +104,9 @@ class FloatType extends \Cake\Database\Type
             return (float)$value;
         } elseif (is_string($value) && $this->_useLocaleParser) {
             return $this->_parseValue($value);
+        }
+        if (is_array($value)) {
+            return 1;
         }
 
         return $value;

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -37,6 +37,9 @@ class IntegerType extends \Cake\Database\Type
         if ($value === null || $value === '') {
             return null;
         }
+        if (is_array($value)) {
+            return 1;
+        }
         return (int)$value;
     }
 
@@ -52,6 +55,9 @@ class IntegerType extends \Cake\Database\Type
     {
         if ($value === null) {
             return null;
+        }
+        if (is_array($value)) {
+            return 1;
         }
         return (int)$value;
     }
@@ -84,6 +90,9 @@ class IntegerType extends \Cake\Database\Type
         }
         if (ctype_digit($value)) {
             return (int)$value;
+        }
+        if (is_array($value)) {
+            return 1;
         }
         return $value;
     }

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -69,6 +69,9 @@ class FloatTypeTest extends TestCase
 
         $result = $this->type->toPHP('2 bears', $this->driver);
         $this->assertSame(2.0, $result);
+
+        $result = $this->type->toPHP(['3', '4'], $this->driver);
+        $this->assertSame(1, $result);
     }
 
     /**
@@ -86,6 +89,9 @@ class FloatTypeTest extends TestCase
 
         $result = $this->type->toDatabase('2.51', $this->driver);
         $this->assertSame(2.51, $result);
+
+        $result = $this->type->toDatabase(['3', '4'], $this->driver);
+        $this->assertSame(1, $result);
     }
 
     /**
@@ -106,6 +112,9 @@ class FloatTypeTest extends TestCase
 
         $result = $this->type->marshal('3.5 bears', $this->driver);
         $this->assertSame('3.5 bears', $result);
+
+        $result = $this->type->marshal(['3', '4'], $this->driver);
+        $this->assertSame(1, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -54,6 +54,9 @@ class IntegerTypeTest extends TestCase
 
         $result = $this->type->toPHP('2 bears', $this->driver);
         $this->assertSame(2, $result);
+
+        $result = $this->type->toPHP(['3', '4'], $this->driver);
+        $this->assertSame(1, $result);
     }
 
     /**
@@ -71,6 +74,9 @@ class IntegerTypeTest extends TestCase
 
         $result = $this->type->toDatabase('2', $this->driver);
         $this->assertSame(2, $result);
+
+        $result = $this->type->toDatabase(['3', '4'], $this->driver);
+        $this->assertSame(1, $result);
     }
 
     /**
@@ -100,6 +106,9 @@ class IntegerTypeTest extends TestCase
 
         $result = $this->type->marshal('2 monkeys', $this->driver);
         $this->assertSame('2 monkeys', $result);
+
+        $result = $this->type->marshal(['3', '4'], $this->driver);
+        $this->assertSame(1, $result);
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -84,8 +84,6 @@ class TypeTest extends TestCase
     public function basicTypesProvider()
     {
         return [
-            ['float'],
-            ['integer'],
             ['string'],
             ['text'],
             ['boolean']
@@ -158,63 +156,6 @@ class TypeTest extends TestCase
     }
 
     /**
-     * Tests floats from database are converted correctly to PHP
-     *
-     * @return void
-     */
-    public function testFloatToPHP()
-    {
-        $type = Type::build('float');
-        $float = '3.14159';
-        $driver = $this->getMock('\Cake\Database\Driver');
-        $this->assertEquals(3.14159, $type->toPHP($float, $driver));
-        $this->assertEquals(3.14159, $type->toPHP(3.14159, $driver));
-        $this->assertEquals(3.00, $type->toPHP(3, $driver));
-    }
-
-    /**
-     * Tests floats from PHP are converted correctly to statement value
-     *
-     * @return void
-     */
-
-    public function testFloatToStatement()
-    {
-        $type = Type::build('float');
-        $float = '3.14159';
-        $driver = $this->getMock('\Cake\Database\Driver');
-        $this->assertEquals(PDO::PARAM_STR, $type->toStatement($float, $driver));
-    }
-
-    /**
-     * Tests integers from database are converted correctly to PHP
-     *
-     * @return void
-     */
-    public function testIntegerToPHP()
-    {
-        $type = Type::build('integer');
-        $integer = '3';
-        $driver = $this->getMock('\Cake\Database\Driver');
-        $this->assertEquals(3, $type->toPHP($integer, $driver));
-        $this->assertEquals(3, $type->toPHP(3, $driver));
-        $this->assertEquals(3, $type->toPHP(3.57, $driver));
-    }
-
-    /**
-     * Tests integers from PHP are converted correctly to statement value
-     *
-     * @return void
-     */
-    public function testIntegerToStatement()
-    {
-        $type = Type::build('integer');
-        $integer = '3';
-        $driver = $this->getMock('\Cake\Database\Driver');
-        $this->assertEquals(PDO::PARAM_INT, $type->toStatement($integer, $driver));
-    }
-
-    /**
      * Tests bigintegers from database are converted correctly to PHP
      *
      * @return void
@@ -259,6 +200,7 @@ class TypeTest extends TestCase
         $this->assertEquals('foo', $type->toPHP($string, $driver));
         $this->assertEquals('3', $type->toPHP(3, $driver));
         $this->assertEquals('3.14159', $type->toPHP(3.14159, $driver));
+        $this->assertEquals('', $type->toPHP([3, 'elf'], $driver));
     }
 
     /**
@@ -287,6 +229,7 @@ class TypeTest extends TestCase
         $this->assertEquals('foo', $type->toPHP($string, $driver));
         $this->assertEquals('3', $type->toPHP(3, $driver));
         $this->assertEquals('3.14159', $type->toPHP(3.14159, $driver));
+        $this->assertEquals('', $type->toPHP([2, 3], $driver));
     }
 
     /**
@@ -311,22 +254,14 @@ class TypeTest extends TestCase
     {
         $type = Type::build('boolean');
         $driver = $this->getMock('\Cake\Database\Driver');
+
         $this->assertTrue($type->toDatabase(true, $driver));
-
-        $driver = $this->getMock('\Cake\Database\Driver');
         $this->assertFalse($type->toDatabase(false, $driver));
-
-        $driver = $this->getMock('\Cake\Database\Driver');
         $this->assertTrue($type->toDatabase(1, $driver));
-
-        $driver = $this->getMock('\Cake\Database\Driver');
         $this->assertFalse($type->toDatabase(0, $driver));
-
-        $driver = $this->getMock('\Cake\Database\Driver');
         $this->assertTrue($type->toDatabase('1', $driver));
-
-        $driver = $this->getMock('\Cake\Database\Driver');
         $this->assertFalse($type->toDatabase('0', $driver));
+        $this->assertFalse($type->toDatabase([1, 2], $driver));
     }
 
     /**
@@ -338,9 +273,8 @@ class TypeTest extends TestCase
     {
         $type = Type::build('boolean');
         $driver = $this->getMock('\Cake\Database\Driver');
-        $this->assertEquals(PDO::PARAM_BOOL, $type->toStatement(true, $driver));
 
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $this->assertEquals(PDO::PARAM_BOOL, $type->toStatement(true, $driver));
         $this->assertEquals(PDO::PARAM_BOOL, $type->toStatement(false, $driver));
     }
 
@@ -365,6 +299,7 @@ class TypeTest extends TestCase
         $this->assertFalse($type->toPHP('0', $driver));
         $this->assertFalse($type->toPHP('FALSE', $driver));
         $this->assertFalse($type->toPHP('false', $driver));
+        $this->assertFalse($type->toPHP(['2', '3'], $driver));
     }
 
     /**
@@ -385,6 +320,7 @@ class TypeTest extends TestCase
         $this->assertFalse($type->marshal(0));
         $this->assertFalse($type->marshal(''));
         $this->assertFalse($type->marshal('invalid'));
+        $this->assertFalse($type->marshal(['2', '3']));
     }
 
 
@@ -429,6 +365,7 @@ class TypeTest extends TestCase
         $this->assertSame(3.14159, $type->toPHP('3.14159', $driver));
         $this->assertSame(3.14159, $type->toPHP(3.14159, $driver));
         $this->assertSame(3.0, $type->toPHP(3, $driver));
+        $this->assertSame(1, $type->toPHP(['3', '4'], $driver));
     }
 
     /**


### PR DESCRIPTION
strval and intval throw errors when they receive arrays. Convert string/bool values into ''/false. Integers and floats cast into 1 as that's what PHP would normally do.

Refs #6083
