### PR TITLE
Do not warn about i18n functions definitions on extract task

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -448,7 +448,7 @@ class ExtractTask extends AppShell {
 					if ($categoryName !== 'LC_TIME') {
 						$this->_addTranslation($categoryName, $domain, $singular, $details);
 					}
-				} else {
+				} elseif (!is_array($this->_tokens[$count - 1]) || $this->_tokens[$count - 1][0] != T_FUNCTION) {
 					$this->_markerError($this->_file, $line, $functionName, $count);
 				}
 			}


### PR DESCRIPTION
When using extract task with `--extract-core=yes` option, it generates multiple warnings about i18n function usage.

Some warnings (currently 9) are expected, ex. `__($modelName)`:

``` txt
Invalid marker content in CAKE/lib/Cake/View/Helper/FormHelper.php:930
* __(
$modelName)
```

But it shouldn't warn about i18n function declarations (currently 14) in basics.php like `function __($singular, $args = null) {`:

``` txt
Invalid marker content in CAKE/lib/Cake/basics.php:581
* __(
$singular,$args=null)
```
