### PR TITLE
Don't replace array data for custom types.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -51,8 +51,8 @@ class Type
      * @var array
      */
     protected static $_basicTypes = [
-        'string' => ['callback' => 'strval'],
-        'text' => ['callback' => 'strval'],
+        'string' => ['callback' => ['\Cake\Database\Type', 'strval']],
+        'text' => ['callback' => ['\Cake\Database\Type', 'strval']],
         'boolean' => [
             'callback' => ['\Cake\Database\Type', 'boolval'],
             'pdo' => PDO::PARAM_BOOL
@@ -186,10 +186,6 @@ class Type
         if ($value === null) {
             return null;
         }
-        if (is_array($value)) {
-            $value = '';
-        }
-
         if (!empty(self::$_basicTypes[$this->_name])) {
             $typeInfo = self::$_basicTypes[$this->_name];
             if (isset($typeInfo['callback'])) {
@@ -234,6 +230,22 @@ class Type
             return strtolower($value) === 'true' ? true : false;
         }
         return !empty($value);
+    }
+
+    /**
+     * Type converter for string values.
+     *
+     * Will convert values into strings
+     *
+     * @param mixed $value The value to convert to a string.
+     * @return bool
+     */
+    public static function strval($value)
+    {
+        if (is_array($value)) {
+            $value = '';
+        }
+        return strval($value);
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -261,7 +261,7 @@ class TypeTest extends TestCase
         $this->assertFalse($type->toDatabase(0, $driver));
         $this->assertTrue($type->toDatabase('1', $driver));
         $this->assertFalse($type->toDatabase('0', $driver));
-        $this->assertFalse($type->toDatabase([1, 2], $driver));
+        $this->assertTrue($type->toDatabase([1, 2], $driver));
     }
 
     /**
@@ -299,7 +299,7 @@ class TypeTest extends TestCase
         $this->assertFalse($type->toPHP('0', $driver));
         $this->assertFalse($type->toPHP('FALSE', $driver));
         $this->assertFalse($type->toPHP('false', $driver));
-        $this->assertFalse($type->toPHP(['2', '3'], $driver));
+        $this->assertTrue($type->toPHP(['2', '3'], $driver));
     }
 
     /**
@@ -320,7 +320,7 @@ class TypeTest extends TestCase
         $this->assertFalse($type->marshal(0));
         $this->assertFalse($type->marshal(''));
         $this->assertFalse($type->marshal('invalid'));
-        $this->assertFalse($type->marshal(['2', '3']));
+        $this->assertTrue($type->marshal(['2', '3']));
     }
 
 


### PR DESCRIPTION
In the comments attached to cakephp/cakephp@7468434ec14432c38562e0fa882b1c443e389787, a few people mentioned that those changes broke their custom types. This change moves the forced casting of array data into the string/text handling only. The original intention was not to disturb/break custom type objects.

As a side effect of this change boolean handling now better reflects the internal PHP handling of values in that arrays are truthy.

cc @davidyell @robertscherer @dereuromark 
