### PR TITLE
Fix notice errors in pagination link generation.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -1260,6 +1260,14 @@ class PaginatorHelperTest extends CakeTestCase {
 				'paramType' => 'named'
 			)
 		);
+		$result = $this->Paginator->sort('title', 'Title', array('model' => 'Client'));
+		$expected = array(
+			'a' => array('href' => '/index/sort:title/direction:asc'),
+			'Title',
+			'/a'
+		);
+		$this->assertTags($result, $expected);
+
 		$result = $this->Paginator->next('Next', array('model' => 'Client'));
 		$expected = array(
 			'span' => array('class' => 'next'),
@@ -1273,6 +1281,39 @@ class PaginatorHelperTest extends CakeTestCase {
 		$result = $this->Paginator->next('Next', array('model' => 'Server'), 'No Next', array('model' => 'Server'));
 		$expected = array(
 			'span' => array('class' => 'next'), 'No Next', '/span'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test creating paging links for missing models.
+ *
+ * @return void
+ */
+	public function testPagingLinksMissingModel() {
+		$result = $this->Paginator->sort('title', 'Title', array('model' => 'Missing'));
+		$expected = array(
+			'a' => array('href' => '/index/sort:title/direction:asc'),
+			'Title',
+			'/a'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->next('Next', array('model' => 'Missing'));
+		$expected = array(
+			'span' => array('class' => 'next'),
+			'a' => array('href' => '/index/page:2', 'rel' => 'next'),
+			'Next',
+			'/a',
+			'/span'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->prev('Prev', array('model' => 'Missing'));
+		$expected = array(
+			'span' => array('class' => 'prev'),
+			'Prev',
+			'/span'
 		);
 		$this->assertTags($result, $expected);
 	}

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -120,7 +120,7 @@ class PaginatorHelper extends AppHelper {
  * Gets the current paging parameters from the resultset for the given model
  *
  * @param string $model Optional model name. Uses the default if none is specified.
- * @return array|null The array of paging parameters for the paginated resultset.
+ * @return array The array of paging parameters for the paginated resultset.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::params
  */
 	public function params($model = null) {
@@ -128,7 +128,14 @@ class PaginatorHelper extends AppHelper {
 			$model = $this->defaultModel();
 		}
 		if (!isset($this->request->params['paging']) || empty($this->request->params['paging'][$model])) {
-			return null;
+			return array(
+				'prevPage' => false,
+				'nextPage' => true,
+				'paramType' => 'named',
+				'pageCount' => 1,
+				'options' => array(),
+				'page' => 1
+			);
 		}
 		return $this->request->params['paging'][$model];
 	}


### PR DESCRIPTION
No errors should be emitted when creating links for models that were not paginated.

Refs #6090
