### PR TITLE
Fix #6097

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -107,23 +107,22 @@ class Marshaller
         $schema = $this->_table->schema();
         $primaryKey = $schema->primaryKey();
 
+        $entity = null;
         if (array_intersect($primaryKey, array_keys($data)) == $primaryKey) {
             $tableName = $this->_table->alias();
-            $record = $this->_table->find('all');
+            $query = $this->_table->find('all');
             foreach ($primaryKey as $pkey) {
-                $record->where(["$tableName.$pkey" => $data[$pkey]]);
+                $query->where(["$tableName.$pkey" => $data[$pkey]]);
             }
-
-            $record = $record->first();
-
-            if ($record) {
-                return $record;
-            }
+            $entity = $query->first();
         }
 
-        $entityClass = $this->_table->entityClass();
-        $entity = new $entityClass();
-        $entity->source($this->_table->registryAlias());
+        if (!isset($entity)) {
+            $entityClass = $this->_table->entityClass();
+            $entity = new $entityClass();
+            $entity->source($this->_table->registryAlias());
+        }
+
 
         if (isset($options['accessibleFields'])) {
             foreach ((array)$options['accessibleFields'] as $key => $value) {


### PR DESCRIPTION
Fix #6097 by allowing newEntity() to operate on existing entities when request data contains a matching primary key. While its somewhat questionable that the marshaller is doing queries for 'new' entity creation, we have to accept that people will create and update/join entities at the same time.

I've also implemented `Table::aliasField()` as discussed in #6086
