### PR TITLE
Implementing Collection::through()

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -825,7 +825,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * });
      * ```
      *
-     * @param callable $transformer A callable function that will receive
+     * @param callable $handler A callable function that will receive
      * this collection as first argument.
      * @return \Cake\Collection\CollectionInterface
      */

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -768,7 +768,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * $comments = (new Collection($comments))->stopWhen(['is_approved' => false]);
      * ```
      *
-     * @param callable|array $condition the method that will receive each of the elements and
+     * @param callable $condition the method that will receive each of the elements and
      * returns false when the iteration should be stopped.
      * If an array, it will be interpreted as a key-value list of conditions where
      * the key is a property path as accepted by `Collection::extract`,
@@ -806,9 +806,28 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * });
      * ```
      *
-     * @param callable|array $transformer A callable function that will receive each of
+     * @param callable $transformer A callable function that will receive each of
      * the items in the collection and should return an array or Traversable object
      * @return \Cake\Collection\CollectionInterface
      */
     public function unfold(callable $transformer = null);
+
+    /**
+     * Passes this collection through a callable as its first argument.
+     * This is useful for decorating the full collection with another object.
+     *
+     * ### Example:
+     *
+     * ```
+     * $items [1, 2, 3];
+     * $decorated = (new Collection($items))->through(function ($collection) {
+     *      return new MyCustomCollection($collection);
+     * });
+     * ```
+     *
+     * @param callable $transformer A callable function that will receive
+     * this collection as first argument.
+     * @return \Cake\Collection\CollectionInterface
+     */
+    public function through(callable $handler);
 }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -522,6 +522,15 @@ trait CollectionTrait
     }
 
     /**
+     * {@inheritDoc}
+     *
+     */
+    public function through(callable $handler) {
+        $result = $handler($this);
+        return $result instanceof CollectionInterface ? $result: new Collection($result);
+    }
+
+    /**
      * Returns the closest nested iterator that can be safely traversed without
      * losing any possible transformations.
      *

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -525,7 +525,8 @@ trait CollectionTrait
      * {@inheritDoc}
      *
      */
-    public function through(callable $handler) {
+    public function through(callable $handler) 
+    {
         $result = $handler($this);
         return $result instanceof CollectionInterface ? $result: new Collection($result);
     }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -525,7 +525,7 @@ trait CollectionTrait
      * {@inheritDoc}
      *
      */
-    public function through(callable $handler) 
+    public function through(callable $handler)
     {
         $result = $handler($this);
         return $result instanceof CollectionInterface ? $result: new Collection($result);

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1132,4 +1132,35 @@ class CollectionTest extends TestCase
         $expected = [1, 2, 2, 3, 4, 3, 4, 5, 6];
         $this->assertEquals($expected, $collection->toArray(false));
     }
+
+    /**
+     * Tests the through() method
+     *
+     * @return void
+     */
+    public function testThrough()
+    {
+        $items = [1, 2, 3];
+        $collection = (new Collection($items))->through(function ($collection) {
+            return $collection->append($collection->toList());
+        });
+
+        $this->assertEquals([1, 2, 3, 1, 2, 3], $collection->toList());
+    }
+
+    /**
+     * Tests the through method when it returns an array
+     *
+     * @return void
+     */
+    public function testThroughReturnArray()
+    {
+        $items = [1, 2, 3];
+        $collection = (new Collection($items))->through(function ($collection) {
+            $list = $collection->toList();
+            return array_merge($list, $list);
+        });
+
+        $this->assertEquals([1, 2, 3, 1, 2, 3], $collection->toList());
+    }
 }


### PR DESCRIPTION
Another pattern that it seems to be repeating is the need to abstract some collection chains into another callable or class. Imagine the following chain:

``` php
$collection->map(...)->filter(...)->unfold(...)->each(...)
```

The logic before the `each()` is potentially reusable, but only when the combination of the map, filter and unfold calls are called in that order. The `through` function allows the developer to extract the logic out of the chain. For example:

``` php
$collection
   ->through(function ($collection) {
        return $collection->map(...)->filter(...)->unfold(...);
   })
   ->each(...)
```

This can later be extracted even further to its own class:

``` php
class CustomLogic {

    public function __invoke($collection) {
        return $collection->map(...)->filter(...)->unfold(...);
    }
}

$collection->through(new CustomLogic)->each(...)
```

This is actually the same technique we use for `Query::formatResults()` but applied directly to collections.
