### PR TITLE
Added webroot check on $path

### DIFF
--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -332,7 +332,11 @@ class Helper extends Object {
 		if (isset($plugin)) {
 			$path = Inflector::underscore($plugin) . '/' . $path;
 		}
-		$path = $this->_encodeUrl($this->assetTimestamp($this->webroot($path)));
+		if(strpos($path, $this->webroot) !== 0){
+	        	$path = $this->_encodeUrl($this->assetTimestamp($this->webroot($path)));
+		} else {
+			$path = $this->_encodeUrl($this->assetTimestamp($path));
+		}
 
 		if (!empty($options['fullBase'])) {
 			$path = rtrim(Router::fullBaseUrl(), '/') . '/' . ltrim($path, '/');


### PR DESCRIPTION
When working with the framework within sub-folders if the webroot is already passed as part of the url, then the webroot should not be added again to the encodedUrl.

http://example.com/mysite/
$this->Html->css('/mysite/style.css');
used to create a path of:
/mysite/mysite/style.css
Checking for existing webroot creates the path of:
/mysite/style.css
