### PR TITLE
Added cleanSavaData method - Suggested improvement

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -379,9 +379,7 @@ class TranslateBehavior extends ModelBehavior {
 		$fields = array_merge($this->settings[$Model->alias], $this->runtime[$Model->alias]['fields']);
 		if ($locale !== Configure::read('Config.language')) {
 			foreach ($fields as $field) {
-				if (isset($Model->data[$Model->alias][$field])) {
-					unset($Model->data[$Model->alias][$field]);
-				}
+				unset($Model->data[$Model->alias][$field]);
 			}
 		}
 	}

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -368,6 +368,8 @@ class TranslateBehavior extends ModelBehavior {
  * Prevents Model data from being saved if not in the 'base' language
  * as defined by Config.language 
  *
+ * @param Model $Model Model using this behavior.
+ * @return void
  */
 	protected function _cleanSaveData(Model $Model) {
 		$locale = $this->_getLocale($Model);
@@ -375,7 +377,7 @@ class TranslateBehavior extends ModelBehavior {
 			return true;
 		}
 		$fields = array_merge($this->settings[$Model->alias], $this->runtime[$Model->alias]['fields']);
-		if ($locale != Configure::read('Config.language')) {
+		if ($locale !== Configure::read('Config.language')) {
 			foreach ($fields as $field) {
 				if (isset($Model->data[$Model->alias][$field])) {
 					unset($Model->data[$Model->alias][$field]);

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -334,6 +334,7 @@ class TranslateBehavior extends ModelBehavior {
 	public function beforeValidate(Model $Model, $options = array()) {
 		unset($this->runtime[$Model->alias]['beforeSave']);
 		$this->_setRuntimeData($Model);
+		$this->_cleanSaveData($Model);
 		return true;
 	}
 
@@ -353,10 +354,34 @@ class TranslateBehavior extends ModelBehavior {
 			unset($this->runtime[$Model->alias]['beforeSave']);
 		}
 		if (isset($this->runtime[$Model->alias]['beforeSave'])) {
+			$this->_cleanSaveData($Model);
 			return true;
 		}
 		$this->_setRuntimeData($Model);
+		$this->_cleanSaveData($Model);
 		return true;
+	}
+	
+/**
+ * Clean save data
+ *
+ * Prevents Model data from being saved if not in the 'base' language
+ * as defined by Config.language 
+ *
+ */
+	protected function _cleanSaveData(Model $Model) {
+		$locale = $this->_getLocale($Model);
+		if (empty($locale)) {
+			return true;
+		}
+		$fields = array_merge($this->settings[$Model->alias], $this->runtime[$Model->alias]['fields']);
+		if ($locale != Configure::read('Config.language')) {
+			foreach ($fields as $field) {
+				if (isset($Model->data[$Model->alias][$field])) {
+					unset($Model->data[$Model->alias][$field]);
+				}
+			}
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -38,7 +38,7 @@ class TranslateBehaviorTest extends CakeTestCase {
  * @var array
  */
 	public $fixtures = array(
-		'core.translated_item', 'core.translate', 'core.translate_table',
+		'core.translated_item', 'core.translated_item_title', 'core.translate_title', 'core.translate', 'core.translate_table',
 		'core.translated_article', 'core.translate_article', 'core.user', 'core.comment', 'core.tag', 'core.articles_tag',
 		'core.translate_with_prefix'
 	);
@@ -886,6 +886,42 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$expected = array('TranslatedItem' => array_merge($oldData, $newData, array('locale' => 'spa')));
 		$this->assertEquals($expected, $result);
 	}
+
+/**
+ * testUpdateLang method
+ *
+ * @return void
+ */
+  public function testUpdateTitle() {
+    $this->loadFixtures('TranslateTitle', 'TranslatedItemTitle');
+
+    $TestModel = new TranslatedItemTitle();
+    $TestModel->id = 1;
+    $TestModel->locale = 'deu';
+    $data = $TestModel->read(null, $TestModel->id);
+    $newData = array_merge($data, array('TranslatedItemTitle' => array('title' => 'De Titel #1')));
+    $savedData = $TestModel->save($newData);
+    $expectedSave = array(
+      'TranslatedItemTitle' => array(
+        'id' => '1',
+        'translated_article_id' => '1',
+        'slug' => 'first_translated',
+        'locale' => 'deu'
+      )
+    );
+    $TestModel->Behaviors->unload('Translate');
+    $result = $TestModel->read(null, $TestModel->id);
+    $expected = array(
+      'TranslatedItemTitle' => array(
+        'id' => '1',
+        'translated_article_id' => '1',
+        'slug' => 'first_translated',
+        'title' => 'Title #1'
+      )
+    );
+    $this->assertEquals($expectedSave, $savedData);
+    $this->assertEquals($expected, $result);
+  }
 
 /**
  * testMultipleCreate method

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -3189,6 +3189,43 @@ class TranslatedItem2 extends CakeTestModel {
 }
 
 /**
+ * TranslatedItemTitle class.
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class TranslatedItemTitle extends CakeTestModel {
+
+/**
+ * name property
+ *
+ * @var string
+ */
+  public $name = 'TranslatedItemTitle';
+
+/**
+ * cacheQueries property
+ *
+ * @var bool
+ */
+  public $cacheQueries = false;
+
+/**
+ * actsAs property
+ *
+ * @var array
+ */
+  public $actsAs = array('Translate' => array('content', 'title'));
+
+/**
+ * translateModel property
+ *
+ * @var string
+ */
+  public $translateModel = 'TranslateTestModel';
+
+}
+
+/**
  * TranslatedItemWithTable class.
  *
  * @package       Cake.Test.Case.Model

--- a/lib/Cake/Test/Fixture/TranslateTitleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateTitleFixture.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 1.2.0.5669
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class TranslateTitleFixture
+ *
+ * @package       Cake.Test.Fixture
+ */
+class TranslateTitleFixture extends CakeTestFixture {
+
+/**
+ * table property
+ *
+ * @var string
+ */
+	public $table = 'i18n';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'locale' => array('type' => 'string', 'length' => 6, 'null' => false),
+		'model' => array('type' => 'string', 'null' => false),
+		'foreign_key' => array('type' => 'integer', 'null' => false),
+		'field' => array('type' => 'string', 'null' => false),
+		'content' => array('type' => 'text')
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('locale' => 'eng', 'model' => 'TranslatedItemTitle', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Title #1'),
+		array('locale' => 'eng', 'model' => 'TranslatedItemTitle', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Content #1'),
+		array('locale' => 'deu', 'model' => 'TranslatedItemTitle', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Titel #1'),
+		array('locale' => 'deu', 'model' => 'TranslatedItemTitle', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Inhalt #1'),
+	);
+}

--- a/lib/Cake/Test/Fixture/TranslatedItemTitleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslatedItemTitleFixture.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 1.2.0.5669
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class TranslatedItemTitleFixture
+ *
+ * @package       Cake.Test.Fixture
+ */
+class TranslatedItemTitleFixture extends CakeTestFixture {
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'translated_article_id' => array('type' => 'integer'),
+		'slug' => array('type' => 'string', 'null' => false),
+		'title' => array('type' => 'string', 'null' => false)
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('translated_article_id' => 1, 'slug' => 'first_translated', 'title' => 'Title #1'),
+	);
+}


### PR DESCRIPTION
The book makes a small mention of the DB schema:
`When defining fields for TranslateBehavior to translate, be sure to omit those fields from the translated model’s schema. If you leave the fields in, there can be issues when retrieving data with fallback locales.`

The issue is that if the model's schema has those fields, it will try to update them for whatever current language is selected. The above patch allows for only the 'default' language, as defined by `Config.language`, to be saved back into the model. If another language is selected at the time of the save, then the model's schema will not be updated with the data. Only the translate table data will be.
