### PR TITLE
Add and use Table::aliasField() where it makes sense.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -199,12 +199,11 @@ class TranslateBehavior extends Behavior
 
         $conditions = function ($field, $locale, $query, $select) {
             return function ($q) use ($field, $locale, $query, $select) {
-                $q->where([$q->repository()->alias() . '.locale' => $locale]);
-                $alias = $this->_table->alias();
+                $q->where([$q->repository()->aliasField('locale') => $locale]);
 
                 if ($query->autoFields() ||
                     in_array($field, $select, true) ||
-                    in_array("$alias.$field", $select, true)
+                    in_array($this->_table->aliasField($field), $select, true)
                 ) {
                     $q->select(['id', 'content']);
                 }

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -347,10 +347,9 @@ class TreeBehavior extends Behavior
         }
 
         $config = $this->config();
-        $alias = $this->_table->alias();
         list($left, $right) = array_map(
-            function ($field) use ($alias) {
-                return "$alias.$field";
+            function ($field) {
+                return $this->_table->aliasField($field);
             },
             [$config['left'], $config['right']]
         );
@@ -375,8 +374,7 @@ class TreeBehavior extends Behavior
     public function childCount(Entity $node, $direct = false)
     {
         $config = $this->config();
-        $alias = $this->_table->alias();
-        $parent = $alias . '.' . $config['parent'];
+        $parent = $this->_table->aliasField($config['parent']);
 
         if ($direct) {
             return $this->_scope($this->_table->find())
@@ -407,11 +405,10 @@ class TreeBehavior extends Behavior
     public function findChildren(Query $query, array $options)
     {
         $config = $this->config();
-        $alias = $this->_table->alias();
         $options += ['for' => null, 'direct' => false];
         list($parent, $left, $right) = array_map(
-            function ($field) use ($alias) {
-                return "$alias.$field";
+            function ($field) {
+                return $this->_table->aliasField($field);
             },
             [$config['parent'], $config['left'], $config['right']]
         );
@@ -458,7 +455,10 @@ class TreeBehavior extends Behavior
     public function findTreeList(Query $query, array $options)
     {
         return $this->_scope($query)
-            ->find('threaded', ['parentField' => $this->config()['parent'], 'order' => [$this->config()['left'] => 'ASC']])
+            ->find('threaded', [
+                'parentField' => $this->config('parent'),
+                'order' => [$this->config('left') => 'ASC']
+            ])
             ->formatResults(function ($results) use ($options) {
                 $options += [
                     'keyPath' => $this->_getPrimaryKey(),

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -359,6 +359,17 @@ class Table implements RepositoryInterface, EventListenerInterface
     }
 
     /**
+     * Alias a field with the table's current alias.
+     *
+     * @param string $field The field to alias.
+     * @return string The field prefixed with the table alias.
+     */
+    public function aliasField($field)
+    {
+        return $this->alias() . '.' . $field;
+    }
+
+    /**
      * Returns the table registry key used to create this table instance
      *
      * @param string|null $registryAlias the key used to access this object

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -162,6 +162,17 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test that aliasField() works.
+     *
+     * @return void
+     */
+    public function testAliasField()
+    {
+        $table = new Table(['alias' => 'Users']);
+        $this->assertEquals('Users.id', $table->aliasField('id'));
+    }
+
+    /**
      * Tests connection method
      *
      * @return void


### PR DESCRIPTION
Adding this method came up in #6086 and it was simple enough to implement. Split out from #6099 as that pull request had some contentious issues.
