### PR TITLE
Implement assertRedirectContains()

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -480,7 +480,7 @@ abstract class IntegrationTestCase extends TestCase
      * @param string $message The failure message that will be appended to the generated message.
      * @return void
      */
-    public function assertRedirectContains($url = null, $message = '')
+    public function assertRedirectContains($url, $message = '')
     {
         if (!$this->_response) {
             $this->fail('No response set, cannot assert location header. ' . $message);

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -474,6 +474,25 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Asserts that the Location header contains a substring
+     *
+     * @param string $url The URL you expected the client to go to.
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertRedirectContains($url = null, $message = '')
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert location header. ' . $message);
+        }
+        $result = $this->_response->header();
+        if (empty($result['Location'])) {
+            $this->fail('No location header set. ' . $message);
+        }
+        $this->assertContains($url, $result['Location'], $message);
+    }
+
+    /**
      * Asserts that the Location header is not set.
      *
      * @param string $message The failure message that will be appended to the generated message.

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -243,6 +243,19 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test the location header assertion string contains
+     *
+     * @return void
+     */
+    public function testAssertRedirectContains()
+    {
+        $this->_response = new Response();
+        $this->_response->header('Location', 'http://localhost/tasks/index');
+
+        $this->assertRedirectContains('/tasks/index');
+    }
+
+    /**
      * Test the header assertion.
      *
      * @return void


### PR DESCRIPTION
Being able to assert substrings of redirect URLs can be helpful when generating URLs to external services.

Refs #6114
