### PR TITLE
3.0 Multiple Flash messages

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -137,6 +137,7 @@ class FlashComponent extends Component
      *   expected for the $options value of the FlashComponent::set() method
      *   - `message` The message to overwrite
      *   - `params` An array of variables to make available when using an element
+     * @param string $key The flash key where the message is stored
      * @return void
      */
     public function edit($index, $message, $key = 'flash')

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -45,7 +45,7 @@ class FlashComponent extends Component
         'element' => 'default',
         'params' => [],
         'reset' => false,
-        'stackLimit' => 50
+        'limit' => 50
     ];
 
     /**
@@ -110,7 +110,7 @@ class FlashComponent extends Component
             $index++;
         }
 
-        if ($index >= $this->config('stackLimit')) {
+        if ($index >= $this->config('limit')) {
             array_shift($messages);
             $this->_session->write($sessionKey, $messages);
             $index--;

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -65,6 +65,11 @@ class FlashComponent extends Component
      *
      * In your controller: $this->Flash->set('This has been saved');
      *
+     * All messages will be added in a stack, meaning that if you call this method
+     * twice, two messages will be registered and rendered with the FlashHelper.
+     * If you want to reset a message, you can use the `reset` option and set it to
+     * true.
+     *
      * ### Options:
      *
      * - `key` The key to set under the session's Flash key
@@ -155,9 +160,7 @@ class FlashComponent extends Component
     }
 
     /**
-     * Delete a message from the session
-     * If there are no remaining messages (in case of a stack), the stack
-     * array is nulled
+     * Delete a message from the stack
      *
      * @param string $key The flash key where the message is stored
      * @param null|string $index The index of the message to delete
@@ -185,10 +188,10 @@ class FlashComponent extends Component
     }
 
     /**
-     * Delete all messages from a special type
+     * Delete all messages of a specific type
      *
-     * @param string $type The type of message to clear
-     * @param string $key The flash key where the message is stored
+     * @param string $type The type of messages to clear
+     * @param string $key The flash key where the messages are stored
      * @return void
      */
     public function clear($type, $key = '')
@@ -225,7 +228,7 @@ class FlashComponent extends Component
 
     /**
      * Get the correct and full element path for the given $optElement
-     * $optElement is supposed to be of the same type as the one given to the
+     * $optElement is supposed to be of the same format as the one given to the
      * FlashComponent::set() method
      *
      * @param string $optElement Element path to resolve

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -142,7 +142,7 @@ class FlashComponent extends Component
     public function edit($index, $message, $key = 'flash')
     {
         $sessionKey = 'Flash.' . $key . '.' . $index;
-        if ($this->_session->check($sessionKey) === false) {
+        if (!$this->_session->check($sessionKey)) {
             return;
         }
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -17,6 +17,7 @@ namespace Cake\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Network\Exception\InternalErrorException;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
 /**
@@ -42,7 +43,9 @@ class FlashComponent extends Component
     protected $_defaultConfig = [
         'key' => 'flash',
         'element' => 'default',
-        'params' => []
+        'params' => [],
+        'reset' => false,
+        'stackLimit' => 50
     ];
 
     /**
@@ -67,12 +70,14 @@ class FlashComponent extends Component
      * - `key` The key to set under the session's Flash key
      * - `element` The element used to render the flash message. Default to 'default'.
      * - `params` An array of variables to make available when using an element
+     * - `reset` A bool. If true, this will destroy the current stack and start a
+     *  new one with $message
      *
      * @param string|\Exception $message Message to be flashed. If an instance
      *   of \Exception the exception message will be used and code will be set
      *   in params.
      * @param array $options An array of options
-     * @return void
+     * @return int The last inserted index to the stack
      */
     public function set($message, array $options = [])
     {
@@ -83,20 +88,160 @@ class FlashComponent extends Component
             $message = $message->getMessage();
         }
 
-        list($plugin, $element) = pluginSplit($options['element']);
+        $options['element'] = $this->_getElement($options['element']);
 
-        if ($plugin) {
-            $options['element'] = $plugin . '.Flash/' . $element;
-        } else {
-            $options['element'] = 'Flash/' . $element;
+        $sessionKey = 'Flash.' . $options['key'];
+        $messages = [];
+        $index = 0;
+
+        if ($options['reset'] === false) {
+            $messages = $this->_session->read($sessionKey);
         }
 
-        $this->_session->write('Flash.' . $options['key'], [
+        if (!empty($messages)) {
+            end($messages);
+            $index = key($messages);
+            reset($messages);
+            $index++;
+        }
+
+        if ($index >= $this->config('stackLimit')) {
+            array_shift($messages);
+            $this->_session->write($sessionKey, $messages);
+            $index--;
+        }
+
+        $sessionKey .= '.' . $index;
+        $this->_session->write($sessionKey, [
             'message' => $message,
             'key' => $options['key'],
             'element' => $options['element'],
             'params' => $options['params']
         ]);
+
+        return $index;
+    }
+
+    /**
+     * Edit a message of the messages stack
+     *
+     * @param int $index The index of the message to edit
+     * @param string|array $message Message as a string to overwrite or an array of params
+     *   Available keys are :
+     *   - `element` The element used to render the flash message. The format is the same as
+     *   expected for the $options value of the FlashComponent::set() method
+     *   - `message` The message to overwrite
+     *   - `params` An array of variables to make available when using an element
+     * @return void
+     */
+    public function edit($index, $message, $key = 'flash')
+    {
+        $sessionKey = 'Flash.' . $key . '.' . $index;
+        if ($this->_session->check($sessionKey) === false) {
+            return;
+        }
+
+        $session = $this->_session->read($sessionKey);
+        if (is_string($message)) {
+            $session['message'] = $message;
+        } elseif (is_array($message)) {
+            if (!empty($message['element'])) {
+                $message['element'] = $this->_getElement($message['element']);
+            }
+            $session = Hash::merge($session, $message);
+        }
+
+        $this->_session->write($sessionKey, $session);
+    }
+
+    /**
+     * Delete a message from the session
+     * If there are no remaining messages (in case of a stack), the stack
+     * array is nulled
+     *
+     * @param string $key The flash key where the message is stored
+     * @param null|string $index The index of the message to delete
+     * @return void
+     */
+    public function delete($key = '', $index = null)
+    {
+        if (empty($key)) {
+            $key = $this->config('key');
+        }
+
+        $sessionKey = $noIndexKey = 'Flash.' . $key;
+        if ($index !== null) {
+            $sessionKey .= '.' . $index;
+        }
+
+        if ($this->_session->check($sessionKey)) {
+            $this->_session->delete($sessionKey);
+        }
+
+        $remaining = $this->_session->read($noIndexKey);
+        if (is_array($remaining) && empty($remaining)) {
+            $this->_session->delete($noIndexKey);
+        }
+    }
+
+    /**
+     * Delete all messages from a special type
+     *
+     * @param string $type The type of message to clear
+     * @param string $key The flash key where the message is stored
+     * @return void
+     */
+    public function clear($type, $key = '')
+    {
+        if (empty($key)) {
+            $key = $this->config('key');
+        }
+
+        $messages = $this->_session->read('Flash.' . $key);
+        if (!is_numeric(key($messages)) && $this->_hasType($messages, $type)) {
+            $this->delete($key);
+        } else {
+            foreach ($messages as $index => $message) {
+                if ($this->_hasType($message, $type)) {
+                    $this->delete($key, $index);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if the given $message is of type $type
+     *
+     * @param array $message Flash message array to test the type of
+     * @param string $type Type of message to test against
+     * @return bool
+     */
+    protected function _hasType(array $message, $type)
+    {
+        $elementParts = explode('/', $message['element']);
+        $messageType = end($elementParts);
+        return $messageType === $type;
+    }
+
+    /**
+     * Get the correct and full element path for the given $optElement
+     * $optElement is supposed to be of the same type as the one given to the
+     * FlashComponent::set() method
+     *
+     * @param string $optElement Element path to resolve
+     * @return string
+     */
+    protected function _getElement($optElement)
+    {
+        list($plugin, $element) = pluginSplit($optElement);
+
+        if ($plugin) {
+            $optElement = $plugin . '.Flash/' . $element;
+        } else {
+            $optElement = 'Flash/' . $element;
+        }
+
+        return $optElement;
     }
 
     /**
@@ -115,7 +260,8 @@ class FlashComponent extends Component
      *
      * @param string $name Element name to use.
      * @param array $args Parameters to pass when calling `FlashComponent::set()`.
-     * @return void
+     * @return null|int If stacking is disabled, will return null. Otherwise, it will return the
+     * last inserted index to the stack
      * @throws \Cake\Network\Exception\InternalErrorException If missing the flash message.
      */
     public function __call($name, $args)
@@ -136,6 +282,6 @@ class FlashComponent extends Component
             $options += (array)$args[1];
         }
 
-        $this->set($args[0], $options);
+        return $this->set($args[0], $options);
     }
 }

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -26,7 +26,16 @@ class FlashHelper extends Helper
 {
 
     /**
-     * Used to render the message set in FlashComponent::set()
+     * Default config for the helper.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'stackElement' => false
+    ];
+
+    /**
+     * Used to render the message (or the stack of messages) set in FlashComponent::set()
      *
      * In your view: $this->Flash->render('somekey');
      * Will default to flash if no param is passed
@@ -57,6 +66,9 @@ class FlashHelper extends Helper
      * ]);
      * ```
      *
+     * If the $key contains a stack of messages, each messages will be rendered with
+     * their own parameters and returned as one string.
+     *
      * @param string $key The [Flash.]key you are rendering in the view.
      * @param array $options Additional options to use for the creation of this flash message.
      *    Supports the 'params', and 'element' keys that are used in the helper.
@@ -77,9 +89,44 @@ class FlashHelper extends Helper
                 $key
             ));
         }
-        $flash = $options + $flash;
-        $this->request->session()->delete("Flash.$key");
 
+        $this->request->session()->delete("Flash.$key");
+        return $this->_renderStack($flash, $options);
+    }
+
+    /**
+     * Renders the given stack of messages
+     *
+     * @param array $messages Messages to render
+     * @param array $options Additional options to use for the creation of this flash message.
+     *    Supports the 'params', and 'element' keys that are used in the helper.
+     * @return string The full stack rendered as a string
+     */
+    protected function _renderStack(array $messages, array $options = [])
+    {
+        $out = '';
+        foreach ($messages as $message) {
+            $message = $options + $message;
+            $out .= $this->_render($message);
+        }
+
+        $stackElement = $this->config('stackElement');
+        if (!empty($stackElement)) {
+            $out = $this->_View->element($this->config('stackElement'), ['messages' => $out]);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Renders a single message by calling its element
+     *
+     * @param array $flash Flash message parameter
+     * @return string|void Rendered flash message or null if flash key does not exist
+     *   in session.
+     */
+    protected function _render(array $flash)
+    {
         return $this->_View->element($flash['element'], $flash);
     }
 

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -35,7 +35,7 @@ class FlashHelper extends Helper
     ];
 
     /**
-     * Used to render the message (or the stack of messages) set in FlashComponent::set()
+     * Used to render the messages stack set in FlashComponent::set()
      *
      * In your view: $this->Flash->render('somekey');
      * Will default to flash if no param is passed

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -308,7 +308,7 @@ class FlashComponentTest extends TestCase
     {
         $this->assertNull($this->Session->read('Flash.flash'));
 
-        $this->Flash->config('stackLimit', 2);
+        $this->Flash->config('limit', 2);
 
         $this->Flash->set('This is a test message');
         $this->Flash->set('This is another test message');

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -67,16 +67,18 @@ class FlashComponentTest extends TestCase
 
         $this->Flash->set('This is a test message');
         $expected = [
-            'message' => 'This is a test message',
-            'key' => 'flash',
-            'element' => 'Flash/default',
-            'params' => []
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);
 
         $this->Flash->set('This is a test message', ['element' => 'test', 'params' => ['foo' => 'bar']]);
-        $expected = [
+        $expected[] = [
             'message' => 'This is a test message',
             'key' => 'flash',
             'element' => 'Flash/test',
@@ -86,7 +88,7 @@ class FlashComponentTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $this->Flash->set('This is a test message', ['element' => 'MyPlugin.alert']);
-        $expected = [
+        $expected[] = [
             'message' => 'This is a test message',
             'key' => 'flash',
             'element' => 'MyPlugin.Flash/alert',
@@ -97,12 +99,138 @@ class FlashComponentTest extends TestCase
 
         $this->Flash->set('This is a test message', ['key' => 'foobar']);
         $expected = [
-            'message' => 'This is a test message',
-            'key' => 'foobar',
-            'element' => 'Flash/default',
-            'params' => []
+            [
+                'message' => 'This is a test message',
+                'key' => 'foobar',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
         ];
         $result = $this->Session->read('Flash.foobar');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test a set() call with the reset flag to true
+     *
+     * @return void
+     * @covers \Cake\Controller\Component\FlashComponent::set
+     */
+    public function testSetWithReset()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set('This is a test message');
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set('This is another test message', ['reset' => true]);
+        $expected = [
+            [
+                'message' => 'This is another test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testEdit()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $firstIndex = $this->Flash->set('This is a test message', ['key' => 'mykey', 'params' => ['title' => 'A title', 'subtitle' => 'A subtitle']]);
+        $secondIndex = $this->Flash->set('This is another test message', ['key' => 'mykey']);
+        $thirdIndex = $this->Flash->set('This is a third test message', ['key' => 'mykey']);
+
+        $this->Flash->edit($secondIndex, 'Edited', 'mykey');
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => ['title' => 'A title', 'subtitle' => 'A subtitle']
+            ],
+            [
+                'message' => 'Edited',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ],
+            [
+                'message' => 'This is a third test message',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.mykey');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->edit($firstIndex, ['message' => 'Edited'], 'mykey');
+        $expected = [
+            [
+                'message' => 'Edited',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => ['title' => 'A title', 'subtitle' => 'A subtitle']
+            ],
+            [
+                'message' => 'Edited',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ],
+            [
+                'message' => 'This is a third test message',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.mykey');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->edit(
+            $firstIndex,
+            [
+                'message' => 'Edited',
+                'element' => 'edited',
+                'params' => ['title' => 'Some title']
+            ],
+            'mykey'
+        );
+        $expected = [
+            [
+                'message' => 'Edited',
+                'key' => 'mykey',
+                'element' => 'Flash/edited',
+                'params' => ['title' => 'Some title', 'subtitle' => 'A subtitle']
+            ],
+            [
+                'message' => 'Edited',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ],
+            [
+                'message' => 'This is a third test message',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.mykey');
         $this->assertEquals($expected, $result);
     }
 
@@ -118,10 +246,12 @@ class FlashComponentTest extends TestCase
 
         $this->Flash->set(new \Exception('This is a test message', 404));
         $expected = [
-            'message' => 'This is a test message',
-            'key' => 'flash',
-            'element' => 'Flash/default',
-            'params' => ['code' => 404]
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => ['code' => 404]
+            ]
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);
@@ -139,13 +269,211 @@ class FlashComponentTest extends TestCase
         $this->Controller->loadComponent('Flash', ['element' => 'test']);
         $this->Controller->Flash->set('This is a test message');
         $expected = [
-            'message' => 'This is a test message',
-            'key' => 'flash',
-            'element' => 'Flash/test',
-            'params' => []
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/test',
+                'params' => []
+            ]
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests that set() can stack messages
+     *
+     * @return void
+     */
+    public function testSetReturnIndex()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->config('stacking.enabled', true);
+
+        $firstIndex = $this->Flash->set('This is a test message');
+        $secondIndex = $this->Flash->set('This is another test message');
+
+        $this->assertEquals($firstIndex, 0);
+        $this->assertEquals($secondIndex, 1);
+    }
+
+    /**
+     * Tests that set() can stack messages after a first message
+     * has already been set
+     *
+     * @return void
+     */
+    public function testSetWithLimit()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->config('stackLimit', 2);
+
+        $this->Flash->set('This is a test message');
+        $this->Flash->set('This is another test message');
+        $this->assertEquals(2, count($this->Session->read('Flash.flash')));
+
+        $this->Flash->set('This is a third test message');
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals(2, count($result));
+        $expected = [
+            [
+                'message' => 'This is another test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ],
+            [
+                'message' => 'This is a third test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests that delete() can remove the flash message
+     *
+     * @return void
+     */
+    public function testDelete()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+        $this->Flash->set('This is a test message');
+        $this->Flash->delete();
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set('This is a test message');
+        $this->Flash->set('This is a test message', ['key' => 'mykey']);
+        $this->Flash->delete();
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'mykey',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $this->assertEquals($expected, $this->Session->read('Flash.mykey'));
+        $this->Flash->delete('mykey');
+
+        $this->Flash->set('This is a test message');
+        $secondIndex = $this->Flash->set('This is another test message');
+        $this->Flash->set('This is a third test message');
+
+        $this->Flash->delete('', $secondIndex);
+        $expected = [
+            0 => [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ],
+            2 => [
+                'message' => 'This is a third test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals(2, count($result));
+        $this->assertEquals($expected, $result);
+
+        $newThirdIndex = $this->Flash->set('This is the new third test message');
+        $expected[3] = [
+            'message' => 'This is the new third test message',
+            'key' => 'flash',
+            'element' => 'Flash/default',
+            'params' => []
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals(3, $newThirdIndex);
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->delete();
+        $result = $this->Session->read('Flash.flash');
+        $this->assertNull($result);
+    }
+
+    /**
+     * Tests that clear() can remove all of the flash messages
+     * of the same type when flash are set with a magic call
+     *
+     * @return void
+     */
+    public function testClear()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+        $this->Flash->set('This is a test message');
+        $this->Flash->clear('default');
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set('This is a test message', ['element' => 'test']);
+        $this->Flash->set('This is another test message', ['element' => 'success']);
+        $this->Flash->set('This is a third test message', ['element' => 'success']);
+        $this->Flash->set('This is a test message with another key', ['element' => 'success', 'key' => 'mykey']);
+        $this->Flash->set('This is second test message with another key', ['element' => 'success', 'key' => 'mykey']);
+        $this->Flash->clear('success');
+
+        $expected = [
+            0 => [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/test',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $expected = [
+            0 => [
+                'message' => 'This is a test message with another key',
+                'key' => 'mykey',
+                'element' => 'Flash/success',
+                'params' => []
+            ],
+            1 => [
+                'message' => 'This is second test message with another key',
+                'key' => 'mykey',
+                'element' => 'Flash/success',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.mykey');
+        $this->assertEquals($expected, $result);
+        $this->Flash->clear('success', 'mykey');
+        $this->assertNull($this->Session->read('Flash.mykey'));
+    }
+
+    /**
+     * Tests that delete() can remove flash messages from a stack
+     *
+     * @return void
+     */
+    public function testDeleteAll()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $firstIndex = $this->Flash->set('This is a test message');
+        $secondIndex = $this->Flash->set('This is another test message');
+        $thirdIndex = $this->Flash->set('This is a third test message');
+
+        $this->Flash->delete('', $firstIndex);
+        $this->Flash->delete('', $secondIndex);
+
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals(1, count($result));
+
+        $this->Flash->delete('', $thirdIndex);
+        $result = $this->Session->read('Flash.flash');
+        $this->assertNull($result);
     }
 
     /**
@@ -160,17 +488,19 @@ class FlashComponentTest extends TestCase
 
         $this->Flash->success('It worked');
         $expected = [
-            'message' => 'It worked',
-            'key' => 'flash',
-            'element' => 'Flash/success',
-            'params' => []
+            [
+                'message' => 'It worked',
+                'key' => 'flash',
+                'element' => 'Flash/success',
+                'params' => []
+            ]
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);
 
         $this->Flash->error('It did not work', ['element' => 'error_thing']);
 
-        $expected = [
+        $expected[] = [
             'message' => 'It did not work',
             'key' => 'flash',
             'element' => 'Flash/error',
@@ -181,11 +511,153 @@ class FlashComponentTest extends TestCase
         
         $this->Flash->success('It worked', ['plugin' => 'MyPlugin']);
 
-        $expected = [
+        $expected[] = [
             'message' => 'It worked',
             'key' => 'flash',
             'element' => 'MyPlugin.Flash/success',
             'params' => []
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test a set() call with the reset flag to true
+     *
+     * @return void
+     * @covers \Cake\Controller\Component\FlashComponent::set
+     */
+    public function testCallWithReset()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->success('It worked');
+        $expected = [
+            [
+                'message' => 'It worked',
+                'key' => 'flash',
+                'element' => 'Flash/success',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->success('It worked too', ['reset' => true]);
+        $expected = [
+            [
+                'message' => 'It worked too',
+                'key' => 'flash',
+                'element' => 'Flash/success',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test magic call method with stacking enabled.
+     *
+     * @covers \Cake\Controller\Component\FlashComponent::__call
+     * @return void
+     */
+    public function testCallReturnIndex()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $firstIndex = $this->Flash->success('It worked');
+        $secondIndex = $this->Flash->error('It did not work');
+        $thirdIndex = $this->Flash->warning('Something unexpected occurred', ['plugin' => 'MyPlugin']);
+
+        $this->assertEquals($firstIndex, 0);
+        $this->assertEquals($secondIndex, 1);
+        $this->assertEquals($thirdIndex, 2);
+    }
+
+    /**
+     * Tests that delete() removes messages from a stack if stacking
+     * is enabled and when messages are set with the magic call
+     *
+     * @return void
+     */
+    public function testDeleteWithCall()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+        $this->Flash->success('This is a test message');
+        $this->Flash->delete();
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $firstIndex = $this->Flash->success('It worked');
+        $secondIndex = $this->Flash->error('It did not work');
+        $thirdIndex = $this->Flash->warning('Something unexpected occurred', ['plugin' => 'MyPlugin']);
+
+        $this->Flash->delete('', $secondIndex);
+        $result = $this->Session->read('Flash.flash');
+        $expected = [
+            0 => [
+                'message' => 'It worked',
+                'key' => 'flash',
+                'element' => 'Flash/success',
+                'params' => []
+            ],
+            2 => [
+                'message' => 'Something unexpected occurred',
+                'key' => 'flash',
+                'element' => 'MyPlugin.Flash/warning',
+                'params' => []
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals(2, count($result));
+        $this->assertEquals($expected, $result);
+
+        $newThirdIndex = $this->Flash->warning('Something unexpected occurred', ['plugin' => 'MyPlugin']);
+        $expected[3] = [
+            'message' => 'Something unexpected occurred',
+            'key' => 'flash',
+            'element' => 'MyPlugin.Flash/warning',
+            'params' => []
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals(3, $newThirdIndex);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests that clear() can remove all of the flash messages
+     * of the same type when flash are set with a magic call
+     *
+     * @return void
+     */
+    public function testClearWithCall()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+        $this->Flash->success('This is a test message');
+        $this->Flash->clear('success');
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->config('stacking', ['enabled' => true]);
+        $this->Flash->success('It worked');
+        $this->Flash->success('It worked too');
+        $this->Flash->error('It did not work');
+        $this->Flash->success('That worked as well');
+        $this->Flash->warning('Something unexpected occurred', ['plugin' => 'MyPlugin']);
+        $this->Flash->clear('success');
+
+        $expected = [
+            2 => [
+                'message' => 'It did not work',
+                'key' => 'flash',
+                'element' => 'Flash/error',
+                'params' => []
+            ],
+            4 => [
+                'message' => 'Something unexpected occurred',
+                'key' => 'flash',
+                'element' => 'MyPlugin.Flash/warning',
+                'params' => []
+            ]
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -118,7 +118,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     {
         $this->post('/posts/index');
 
-        $this->assertSession('An error message', 'Flash.flash.message');
+        $this->assertSession('An error message', 'Flash.flash.0.message');
         $this->assertCookie(1, 'remember_me');
     }
 

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -46,25 +46,54 @@ class FlashHelperTest extends TestCase
         $session->write([
             'Flash' => [
                 'flash' => [
-                    'key' => 'flash',
-                    'message' => 'This is a calling',
-                    'element' => 'Flash/default',
-                    'params' => []
+                    [
+                        'key' => 'flash',
+                        'message' => 'This is a calling',
+                        'element' => 'Flash/default',
+                        'params' => []
+                    ]
                 ],
                 'notification' => [
-                    'key' => 'notification',
-                    'message' => 'This is a test of the emergency broadcasting system',
-                    'element' => 'flash_helper',
-                    'params' => [
-                        'title' => 'Notice!',
-                        'name' => 'Alert!'
+                    [
+                        'key' => 'notification',
+                        'message' => 'This is a test of the emergency broadcasting system',
+                        'element' => 'flash_helper',
+                        'params' => [
+                            'title' => 'Notice!',
+                            'name' => 'Alert!'
+                        ]
                     ]
                 ],
                 'classy' => [
-                    'key' => 'classy',
-                    'message' => 'Recorded',
-                    'element' => 'flash_classy',
-                    'params' => []
+                    [
+                        'key' => 'classy',
+                        'message' => 'Recorded',
+                        'element' => 'flash_classy',
+                        'params' => []
+                    ]
+                ],
+                'stack' => [
+                    [
+                        'key' => 'flash',
+                        'message' => 'This is a calling',
+                        'element' => 'Flash/default',
+                        'params' => []
+                    ],
+                    [
+                        'key' => 'notification',
+                        'message' => 'This is a test of the emergency broadcasting system',
+                        'element' => 'flash_helper',
+                        'params' => [
+                            'title' => 'Notice!',
+                            'name' => 'Alert!'
+                        ]
+                    ],
+                    [
+                        'key' => 'classy',
+                        'message' => 'Recorded',
+                        'element' => 'flash_classy',
+                        'params' => []
+                    ]
                 ]
             ]
         ]);
@@ -168,5 +197,53 @@ class FlashHelperTest extends TestCase
         $result = $this->Flash->render('flash');
         $expected = 'flash element from TestTheme';
         $this->assertContains($expected, $result);
+    }
+
+    /**
+     * Test that when rendering a stack, messages are displayed in their
+     * respective element, in the order they were added in the stack
+     *
+     * @return void
+     */
+    public function testFlashWithStack()
+    {
+        $result = $this->Flash->render('stack');
+        $expected = [
+            ['div' => ['class' => 'message']], 'This is a calling', '/div',
+            ['div' => ['id' => 'notificationLayout']],
+            '<h1', 'Alert!', '/h1',
+            '<h3', 'Notice!', '/h3',
+            '<p', 'This is a test of the emergency broadcasting system', '/p',
+            '/div',
+            ['div' => ['id' => 'classy-message']], 'Recorded', '/div'
+        ];
+        $this->assertHtml($expected, $result);
+        $this->assertNull($this->View->request->session()->read('Flash.stack'));
+    }
+
+    /**
+     * Test that when rendering a stack, messages are displayed in their
+     * respective element, in the order they were added in the stack, inside
+     * the stackElement defined
+     *
+     * @return void
+     */
+    public function testFlashWithStackAndStackTemplate()
+    {
+        $this->Flash->config(['stackElement' => 'flash_stack']);
+        $result = $this->Flash->render('stack');
+        $expected = [
+            ['div' => ['class' => 'flash-stack']],
+            ['div' => ['class' => 'message']], 'This is a calling', '/div',
+            ['div' => ['id' => 'notificationLayout']],
+            '<h1', 'Alert!', '/h1',
+            '<h3', 'Notice!', '/h3',
+            '<p', 'This is a test of the emergency broadcasting system', '/p',
+            '/div',
+            ['div' => ['id' => 'classy-message']], 'Recorded', '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+        $this->assertNull($this->View->request->session()->read('Flash.stack'));
     }
 }

--- a/tests/test_app/TestApp/Template/Element/flash_stack.ctp
+++ b/tests/test_app/TestApp/Template/Element/flash_stack.ctp
@@ -1,0 +1,1 @@
+<div class="flash-stack"><?= $messages; ?></div>


### PR DESCRIPTION
Add the ability to the FlashComponent and FlashHelper to set and render multiple flash messages.
I also implementend the ability to enable the stacking at a late state (see the tests).
The FlashComponent also got 2 new method : `delete()` and `clear()`. 

`delete()` allows the deletion of flash messages based on index if the stacking ability is enabled and the message if not
`clear()` allows the deleting of messages based on their types. About this method, I went with the current implementation. I'm not really sure if it's the best, performance wise. Another approach would be to keep a map of indexes to quickly get them and delete them. I'm open to suggestion on this.

The `set()` and `__call()` method now returns the index of the inserted message, or null if stacking is disabled.

To enable the stacking, I did not create a specific method, the call to `config()` being straightforward enough in my opinion. But I'm not against having a `enableStacking()` method.

It is also possible to have the stack of messages rendered in a specific element, that can be setup in the FlashHelper configuration.

More details on #4619
