### PR TITLE
Remove unused method

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -48,16 +48,6 @@ class Security
     protected static $_instance;
 
     /**
-     * Generate authorization hash.
-     *
-     * @return string Hash
-     */
-    public static function generateAuthKey()
-    {
-        return Security::hash(Text::uuid());
-    }
-
-    /**
      * Create a hash from string using given method.
      *
      * @param string $string String to hash

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -27,16 +27,6 @@ class SecurityTest extends TestCase
 {
 
     /**
-     * testGenerateAuthkey method
-     *
-     * @return void
-     */
-    public function testGenerateAuthkey()
-    {
-        $this->assertEquals(strlen(Security::generateAuthKey()), 40);
-    }
-
-    /**
      * testHash method
      *
      * @return void


### PR DESCRIPTION
This used to be used for generating `Security.salt` and `Security.cipherSeed`, but the method is unused in 3.x
