### PR TITLE
Fix timing side channel in HMAC comparison

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -248,8 +248,8 @@ class Security
         if (function_exists('hash_equals')) {
             return hash_equals($hmac, $compare);
         }
-        $hashLength = mb_strlen($hmac, '8bit');
-        $compareLength = mb_strlen($compare, '8bit');
+        $hashLength = strlen($hmac);
+        $compareLength = strlen($compare);
         if ($hashLength !== $compareLength) {
             return false;
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -26,6 +26,9 @@ class Text
     /**
      * Generate a random UUID version 4
      *
+     * Warning: This method should not be used as a random seed for any cryptographic operations.
+     * Instead you should use the ssl or mcrypt extensions.
+     *
      * @see http://www.ietf.org/rfc/rfc4122.txt
      * @return string RFC 4122 UUID
      * @copyright Matt Farina MIT License https://github.com/lootils/uuid/blob/master/LICENSE

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -27,7 +27,7 @@ class Text
      * Generate a random UUID version 4
      *
      * Warning: This method should not be used as a random seed for any cryptographic operations.
-     * Instead you should use the ssl or mcrypt extensions.
+     * Instead you should use the openssl or mcrypt extensions.
      *
      * @see http://www.ietf.org/rfc/rfc4122.txt
      * @return string RFC 4122 UUID


### PR DESCRIPTION
Based on the feedback in #6139 this implements a more time safe comparison for HMACs and recommends not using `Text::uuid()` for crypto use cases.
