### PR TITLE
Add the `$idPrefix` config option to FormHelper

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -80,6 +80,7 @@ class FormHelper extends Helper
      * @var array
      */
     protected $_defaultConfig = [
+        'idPrefix' => null,
         'errorClass' => 'form-error',
         'typeMap' => [
             'string' => 'text', 'datetime' => 'datetime', 'boolean' => 'checkbox',
@@ -227,6 +228,7 @@ class FormHelper extends Helper
 
         $this->widgetRegistry($registry, $widgets);
         $this->_addDefaultContextProviders();
+        $this->_idPrefix = $this->config('idPrefix');
     }
 
     /**
@@ -352,7 +354,9 @@ class FormHelper extends Helper
             'idPrefix' => null,
         ];
 
-        $this->_idPrefix = $options['idPrefix'];
+        if (!is_null($options['idPrefix'])) {
+            $this->_idPrefix = $options['idPrefix'];
+        }
         $templater = $this->templater();
 
         if (!empty($options['templates'])) {
@@ -520,7 +524,7 @@ class FormHelper extends Helper
         $templater->pop();
         $this->requestType = null;
         $this->_context = null;
-        $this->_idPrefix = null;
+        $this->_idPrefix = $this->config('idPrefix');
         return $out;
     }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -354,7 +354,7 @@ class FormHelper extends Helper
             'idPrefix' => null,
         ];
 
-        if (!is_null($options['idPrefix'])) {
+        if ($options['idPrefix'] !== null) {
             $this->_idPrefix = $options['idPrefix'];
         }
         $templater = $this->templater();


### PR DESCRIPTION
As it stands, even creating an `AppFormHelper` to define a custom `$_idPrefix` to be used fails because it is always overwritten by the `$options['idPrefix']` (even if that's `NULL`).

This PR fixes that edge case and adds the option to define a custom prefix using the config options, instead of forcing one to overwrite the `FormHelper`.

Closes #6134.

Update: I still need to write tests for this, but first wanted to see what fails as I just made the changes via web :)
