### PR TITLE
3.0 Fix SelectBoxWidget with complex options and the val option

### DIFF
--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -241,6 +241,7 @@ class SelectBoxWidget implements WidgetInterface
             ];
             if (is_array($val) && isset($optAttrs['text'], $optAttrs['value'])) {
                 $optAttrs = $val;
+                $key = $optAttrs['value'];
             }
             if ($this->_isSelected($key, $selected)) {
                 $optAttrs['selected'] = true;

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -211,6 +211,37 @@ class SelectBoxWidgetTest extends TestCase
     }
 
     /**
+     * test complex option rendering with a selected value
+     *
+     * @return void
+     */
+    public function testRenderComplexSelected()
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'id' => 'BirdName',
+            'name' => 'Birds[name]',
+            'val' => 'a',
+            'options' => [
+                ['value' => 'a', 'text' => 'Albatross'],
+                ['value' => 'b', 'text' => 'Budgie', 'data-foo' => 'bar'],
+            ]
+        ];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
+            ['option' => ['value' => 'a', 'selected' => 'selected']],
+            'Albatross',
+            '/option',
+            ['option' => ['value' => 'b', 'data-foo' => 'bar']],
+            'Budgie',
+            '/option',
+            '/select'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * test rendering a multi select
      *
      * @return void
@@ -568,6 +599,37 @@ class SelectBoxWidgetTest extends TestCase
             '/option',
             ['option' => ['value' => 'c', 'disabled' => 'disabled']],
             'Canary',
+            '/option',
+            '/select'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * test complex option rendering with a disabled element
+     *
+     * @return void
+     */
+    public function testRenderComplexDisabled()
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'disabled' => ['b'],
+            'id' => 'BirdName',
+            'name' => 'Birds[name]',
+            'options' => [
+                ['value' => 'a', 'text' => 'Albatross'],
+                ['value' => 'b', 'text' => 'Budgie', 'data-foo' => 'bar'],
+            ]
+        ];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
+            ['option' => ['value' => 'a']],
+            'Albatross',
+            '/option',
+            ['option' => ['value' => 'b', 'data-foo' => 'bar', 'disabled' => 'disabled']],
+            'Budgie',
             '/option',
             '/select'
         ];


### PR DESCRIPTION
`SelectBoxWidget` renders no selected option element when both complex options and the `val` option passed.

View code:

``` php
echo $this->Form->select('lang', [
    ['value' => 'pl', 'text' => 'Perl', 'class' => 'perl'],
    ['value' => 'php', 'text' => 'PHP', 'class' => 'php'],
], ['val' => 'php']);
```

Expected:

``` html
<select name="lang">
    <option value="pl" class="perl">Perl</option>
    <option value="php" class="php" selected="selected">PHP</option>
</select>
```

Actual:

``` html
<select name="lang">
    <option value="pl" class="perl">Perl</option>
    <option value="php" class="php">PHP</option>
</select>
```

The `disabled` option has same issue.
