### PR TITLE
QueryLogger bug with same named placeholder used multiple times

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -70,10 +70,11 @@ class QueryLogger
         }, $query->params);
 
         $keys = [];
+        $limit = is_int(key($params)) ? 1 : -1;
         foreach ($params as $key => $param) {
             $keys[] = is_string($key) ? "/:$key/" : '/[?]/';
         }
 
-        return preg_replace($keys, $params, $query->query, 1);
+        return preg_replace($keys, $params, $query->query, $limit);
     }
 }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -85,6 +85,24 @@ class QueryLoggerTest extends TestCase
     }
 
     /**
+     * Tests that repeated placeholders are correctly replaced
+     *
+     * @return void
+     */
+    public function testStringInterpolation3()
+    {
+        $logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
+        $query = new LoggedQuery;
+        $query->query = 'SELECT a FROM b where a = :p1 AND b = :p1 AND c = :p2 AND d = :p2';
+        $query->params = ['p1' => 'string', 'p2' => 3];
+
+        $logger->expects($this->once())->method('_log')->with($query);
+        $logger->log($query);
+        $expected = "SELECT a FROM b where a = 'string' AND b = 'string' AND c = 3 AND d = 3";
+        $this->assertEquals($expected, (string)$query);
+    }
+
+    /**
      * Tests that the logged query object is passed to the built-in logger using
      * the correct scope
      *


### PR DESCRIPTION
If you use the same placeholder multiple times within the same query, the QueryLogger logs an invalid query, since only the first placeholder appearance gets replaced by the desired value.

Based on the fact that

> You cannot use both named and question mark parameter markers within the same SQL statement
> - http://php.net/pdo.prepare

I check for a numeric or string key in the params array to set the limit count of the regexp
