### PR TITLE
Allow cookies to contain square brackets

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -219,8 +219,12 @@ class CookieComponent extends Component
         foreach ($key as $name => $value) {
             $this->_load($name);
 
-            $this->_values = Hash::insert($this->_values, $name, $value);
             $parts = explode('.', $name);
+            if (count($parts) > 1) {
+                $this->_values = Hash::insert($this->_values, $name, $value);
+            } else {
+                $this->_values[$name] = $value;
+            }
             $keys[] = $parts[0];
         }
 

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -215,9 +215,13 @@ class CookieComponentTest extends TestCase
     public function testWriteSimple()
     {
         $this->Cookie->write('Testing', 'value');
-        $result = $this->Cookie->read('Testing');
+        $this->Cookie->write('Some[brackets]', 'yummy');
 
+        $result = $this->Cookie->read('Testing');
         $this->assertEquals('value', $result);
+
+        $result = $this->Cookie->read('Some[brackets]');
+        $this->assertEquals('yummy', $result);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -238,7 +238,7 @@ class CookieComponentTest extends TestCase
      *
      * @return void
      */
-    public function testWriteThanRead()
+    public function testWriteThenRead()
     {
         $this->request->cookies = [
             'User' => ['name' => 'mark']
@@ -419,8 +419,8 @@ class CookieComponentTest extends TestCase
      */
     public function testWriteMixedArray()
     {
-        $this->Cookie->write('User', ['name' => 'mark'], false);
-        $this->Cookie->write('User.email', 'mark@example.com', false);
+        $this->Cookie->write('User', ['name' => 'mark']);
+        $this->Cookie->write('User.email', 'mark@example.com');
         $expected = [
             'name' => 'User',
             'value' => '{"name":"mark","email":"mark@example.com"}',
@@ -434,8 +434,8 @@ class CookieComponentTest extends TestCase
 
         $this->assertEquals($expected, $result);
 
-        $this->Cookie->write('User.email', 'mark@example.com', false);
-        $this->Cookie->write('User', ['name' => 'mark'], false);
+        $this->Cookie->write('User.email', 'mark@example.com');
+        $this->Cookie->write('User', ['name' => 'mark']);
         $expected = [
             'name' => 'User',
             'value' => '{"name":"mark"}',


### PR DESCRIPTION
Allow square brackets in cookie names. This allows 3.x cookies to be more compatible with 2.x data.

Refs #6172
