### PR TITLE
Cache: Use extension_loaded() instead of *_exists()

### DIFF
--- a/src/Cache/Engine/ApcEngine.php
+++ b/src/Cache/Engine/ApcEngine.php
@@ -42,8 +42,12 @@ class ApcEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
+        if (!extension_loaded('apc')) {
+            return false;
+        }
+
         parent::init($config);
-        return function_exists('apc_dec');
+        return true;
     }
 
     /**

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -101,7 +101,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
-        if (!class_exists('Memcached')) {
+        if (!extension_loaded('memcached')) {
             return false;
         }
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -76,11 +76,11 @@ class RedisEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
-        if (!class_exists('Redis')) {
+        if (!extension_loaded('redis')) {
             return false;
         }
-        parent::init($config);
 
+        parent::init($config);
         return $this->_connect();
     }
 

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -42,8 +42,12 @@ class WincacheEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
+        if (!extension_loaded('wincache')) {
+            return false;
+        }
+
         parent::init($config);
-        return function_exists('wincache_ucache_info');
+        return true;
     }
 
     /**

--- a/src/Cache/Engine/XcacheEngine.php
+++ b/src/Cache/Engine/XcacheEngine.php
@@ -58,11 +58,12 @@ class XcacheEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
-        if (php_sapi_name() !== 'cli') {
-            parent::init($config);
-            return function_exists('xcache_info');
+        if (!extension_loaded('xcache') || php_sapi_name() === 'cli') {
+            return false;
         }
-        return false;
+
+        parent::init($config);
+        return true;
     }
 
     /**


### PR DESCRIPTION
1. extension_loaded() is slightly faster than function|class_exists()
2. Standardize the code block, don't do parent::init() before
   extension_loaded() check.
