### PR TITLE
Fix csrf error with forms generated through requestAction()

### DIFF
--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -108,6 +108,9 @@ trait RequestActionTrait
             unset($extra[$index]);
         }
         $extra += ['autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1];
+        if(isset($this->request->params['_csrfToken'])) {
+            $extra += ['_csrfToken' => $this->request->params['_csrfToken']];
+        }
 
         $baseUrl = Configure::read('App.fullBaseUrl');
         if (is_string($url) && strpos($url, $baseUrl) === 0) {

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -108,7 +108,7 @@ trait RequestActionTrait
             unset($extra[$index]);
         }
         $extra += ['autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1];
-        if(isset($this->request->params['_csrfToken'])) {
+        if (isset($this->request->params['_csrfToken'])) {
             $extra += ['_csrfToken' => $this->request->params['_csrfToken']];
         }
 


### PR DESCRIPTION
When a form is generated by a view whose controller's action was requested by an other controller, then the form submission will be blackholed (hope this makes sense, not easy to describe...).
This PR fixes this issue.
