### PR TITLE
Use mbstring functions around crypto code

### DIFF
--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -77,9 +77,9 @@ class OpenSsl
         $method = 'AES-256-CBC';
         $ivSize = openssl_cipher_iv_length($method);
 
-        $iv = substr($cipher, 0, $ivSize);
+        $iv = mb_substr($cipher, 0, $ivSize, '8bit');
 
-        $cipher = substr($cipher, $ivSize);
+        $cipher = mb_substr($cipher, $ivSize, null, '8bit');
         return openssl_decrypt($cipher, $method, $key, true, $iv);
     }
 }

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -146,7 +146,7 @@ class Security
         if (empty($operation) || !in_array($operation, ['encrypt', 'decrypt'])) {
             throw new InvalidArgumentException('You must specify the operation for Security::rijndael(), either encrypt or decrypt');
         }
-        if (strlen($key) < 32) {
+        if (mb_strlen($key, '8bit') < 32) {
             throw new InvalidArgumentException('You must use a key larger than 32 bytes for Security::rijndael()');
         }
         $crypto = static::engine();
@@ -174,7 +174,7 @@ class Security
             $hmacSalt = static::$_salt;
         }
         // Generate the encryption and hmac key.
-        $key = substr(hash('sha256', $key . $hmacSalt), 0, 32);
+        $key = mb_substr(hash('sha256', $key . $hmacSalt), 0, 32, '8bit');
 
         $crypto = static::engine();
         $ciphertext = $crypto->encrypt($plain, $key);
@@ -192,7 +192,7 @@ class Security
      */
     protected static function _checkKey($key, $method)
     {
-        if (strlen($key) < 32) {
+        if (mb_strlen($key, '8bit') < 32) {
             throw new InvalidArgumentException(
                 sprintf('Invalid key for %s, key must be at least 256 bits (32 bytes) long.', $method)
             );
@@ -219,12 +219,12 @@ class Security
         }
 
         // Generate the encryption and hmac key.
-        $key = substr(hash('sha256', $key . $hmacSalt), 0, 32);
+        $key = mb_substr(hash('sha256', $key . $hmacSalt), 0, 32, '8bit');
 
         // Split out hmac for comparison
         $macSize = 64;
-        $hmac = substr($cipher, 0, $macSize);
-        $cipher = substr($cipher, $macSize);
+        $hmac = mb_substr($cipher, 0, $macSize, '8bit');
+        $cipher = mb_substr($cipher, $macSize, null, '8bit');
 
         $compareHmac = hash_hmac('sha256', $cipher, $key);
         if (!static::_constantEquals($hmac, $compareHmac)) {

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -248,8 +248,8 @@ class Security
         if (function_exists('hash_equals')) {
             return hash_equals($hmac, $compare);
         }
-        $hashLength = strlen($hmac);
-        $compareLength = strlen($compare);
+        $hashLength = mb_strlen($hmac, '8bit');
+        $compareLength = mb_strlen($compare, '8bit');
         if ($hashLength !== $compareLength) {
             return false;
         }


### PR DESCRIPTION
Related to #6139. The str\* functions can be overloaded with mulitbyte variants that will do the wrong thing in this context. We should play it safe and use mbstring functions instead.
