### PR TITLE
Allow primary key values to be set when creating records.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1487,7 +1487,7 @@ class Table implements RepositoryInterface, EventListenerInterface
         $id = (array)$this->_newId($primary) + $keys;
         $primary = array_combine($primary, $id);
         $filteredKeys = array_filter($primary, 'strlen');
-        $data = $filteredKeys + $data;
+        $data = $data + $filteredKeys;
 
         if (count($primary) > 1) {
             $schema = $this->schema();

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -100,7 +100,7 @@ class TableUuidTest extends TestCase
 
         $row = $table->find('all')->where(['id' => $id])->first();
         $this->assertNotEmpty($row);
-        $this->assertSame($id, $row->id);
+        $this->assertSame($id, strtolower($row->id));
         $this->assertSame($entity->name, $row->name);
     }
 

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -17,9 +17,11 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Text;
 
 /**
  * Integration tests for Table class with uuid primary keys.
@@ -67,7 +69,7 @@ class TableUuidTest extends TestCase
      */
     public function testSaveNew()
     {
-        $entity = new \Cake\ORM\Entity([
+        $entity = new Entity([
             'name' => 'shiny new',
             'published' => true,
         ]);
@@ -81,6 +83,28 @@ class TableUuidTest extends TestCase
     }
 
     /**
+     * Test saving new records allows manual uuids
+     *
+     * @return void
+     */
+    public function testSaveNewSpecificId()
+    {
+        $id = Text::uuid();
+        $entity = new Entity([
+            'id' => $id,
+            'name' => 'shiny and new',
+            'published' => true,
+        ]);
+        $table = TableRegistry::get('uuiditems');
+        $this->assertSame($entity, $table->save($entity));
+
+        $row = $table->find('all')->where(['id' => $id])->first();
+        $this->assertNotEmpty($row);
+        $this->assertSame($id, $row->id);
+        $this->assertSame($entity->name, $row->name);
+    }
+
+    /**
      * Test saving existing records works
      *
      * @return void
@@ -88,7 +112,7 @@ class TableUuidTest extends TestCase
     public function testSaveUpdate()
     {
         $id = '481fc6d0-b920-43e0-a40d-6d1740cf8569';
-        $entity = new \Cake\ORM\Entity([
+        $entity = new Entity([
             'id' => $id,
             'name' => 'shiny update',
             'published' => true,
@@ -126,10 +150,6 @@ class TableUuidTest extends TestCase
      */
     public function testEmptyUuid()
     {
-        $this->skipIf(
-            !$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
-            'Empty UUIDs only affect SQLServer uniqueidentifier field types'
-        );
         $id = '';
         $table = TableRegistry::get('uuiditems');
         $entity = $table->find('all')


### PR DESCRIPTION
When using UUIDs it is often helpful to allow external systems to define your UUID values. This change lets entity data replace generated values.

Putting this in as a bugfix as I think it is the kind of thing that should have just worked.

Refs #6185
