### PR TITLE
PHP 7 test fixes

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -18,7 +18,9 @@ use Cake\Routing\Router;
 define('TIME_START', microtime(true));
 
 // @deprecated Backward compatibility with 2.x series
-class_alias('Cake\Utility\Text', 'Cake\Utility\String');
+if (PHP_VERSION_ID < 70000) {
+    class_alias('Cake\Utility\Text', 'Cake\Utility\String');
+}
 
 require CAKE . 'basics.php';
 

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -46,12 +46,28 @@ class ControllerAuthorizeTest extends TestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_Error
      * @return void
      */
     public function testControllerTypeError()
     {
-        $this->auth->controller(new \StdClass());
+        $this->skipIf(PHP_VERSION_ID >= 70000);
+
+        $this->setExpectedException('PHPUnit_Framework_Error');
+        $this->auth->controller(new \stdClass());
+    }
+
+    /**
+     * @return void
+     */
+    public function testControllerTypeErrorPhp7()
+    {
+        $this->skipIf(PHP_VERSION_ID < 70000);
+
+        try {
+            $this->auth->controller(new \stdClass());
+        } catch (\BaseException $e) {
+            $this->assertTrue(true);
+        }
     }
 
     /**

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -52,7 +52,8 @@ class ControllerAuthorizeTest extends TestCase
     {
         $this->skipIf(PHP_VERSION_ID >= 70000);
 
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        $message = '/^Argument 1 passed to Cake\\\Auth\\\ControllerAuthorize::controller\(\) must be an instance of Cake\\\Controller\\\Controller, instance of stdClass given.*/';
+        $this->setExpectedExceptionRegExp('PHPUnit_Framework_Error', $message);
         $this->auth->controller(new \stdClass());
     }
 
@@ -65,8 +66,10 @@ class ControllerAuthorizeTest extends TestCase
 
         try {
             $this->auth->controller(new \stdClass());
+            $this->fail();
         } catch (\BaseException $e) {
-            $this->assertTrue(true);
+            $expectedMessage = 'Argument 1 passed to Cake\Auth\ControllerAuthorize::controller() must be an instance of Cake\Controller\Controller, instance of stdClass given';
+            $this->assertContains($expectedMessage, $e->getMessage());
         }
     }
 

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -469,7 +469,8 @@ class ConfigureTest extends TestCase
     {
         $this->skipIf(PHP_VERSION_ID >= 70000);
 
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        $message = '/^Argument 2 passed to Cake\\\Core\\\Configure::config\(\) must implement interface Cake\\\Core\\\Configure\\\ConfigEngineInterface, instance of stdClass given.*/';
+        $this->setExpectedExceptionRegExp('PHPUnit_Framework_Error', $message);
         Configure::config('test', new \stdClass());
     }
 
@@ -484,8 +485,10 @@ class ConfigureTest extends TestCase
 
         try {
             Configure::config('test', new \stdClass());
+            $this->fail();
         } catch (\BaseException $e) {
-            $this->assertTrue(true);
+            $expectedMessage = 'Argument 2 passed to Cake\Core\Configure::config() must implement interface Cake\Core\Configure\ConfigEngineInterface, instance of stdClass given';
+            $this->assertContains($expectedMessage, $e->getMessage());
         }
     }
 

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -463,13 +463,30 @@ class ConfigureTest extends TestCase
     /**
      * test engine() throwing exceptions on missing interface.
      *
-     * @expectedException \PHPUnit_Framework_Error
      * @return void
      */
     public function testEngineExceptionOnIncorrectClass()
     {
-        $engine = new \StdClass();
-        Configure::config('test', $engine);
+        $this->skipIf(PHP_VERSION_ID >= 70000);
+
+        $this->setExpectedException('PHPUnit_Framework_Error');
+        Configure::config('test', new \stdClass());
+    }
+
+    /**
+     * test engine() throwing exceptions on missing interface (PHP 7)
+     *
+     * @return void
+     */
+    public function testEngineExceptionOnIncorrectClassPhp7()
+    {
+        $this->skipIf(PHP_VERSION_ID < 70000);
+
+        try {
+            Configure::config('test', new \stdClass());
+        } catch (\BaseException $e) {
+            $this->assertTrue(true);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed test cases for checking typehint on classes and ignoring class alias on PHP 7 (string can't be a class name anymore in PHP 7).

I'm getting segfault on the `tests/TestCase/View/Helper/RssHelperTest.php`, but I will review it separately of these code changes. It is probably a PHP issue.
