### PR TITLE
Faster hydration

### DIFF
--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "cakephp/core": "dev-master"
+        "cakephp/core": "~3.0"
     },
     "minimum-stability": "beta"
 }

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -56,6 +56,19 @@ class Entity implements EntityInterface
         ];
         $this->_className = get_class($this);
 
+        if (!empty($options['source'])) {
+            $this->source($options['source']);
+        }
+
+        if ($options['markNew'] !== null) {
+            $this->isNew($options['markNew']);
+        }
+
+        if (!empty($properties) && $options['markClean'] && !$options['useSetters']) {
+            $this->_properties = $properties;
+            return;
+        }
+
         if (!empty($properties)) {
             $this->set($properties, [
                 'setter' => $options['useSetters'],
@@ -65,14 +78,6 @@ class Entity implements EntityInterface
 
         if ($options['markClean']) {
             $this->clean();
-        }
-
-        if ($options['markNew'] !== null) {
-            $this->isNew($options['markNew']);
-        }
-
-        if (!empty($options['source'])) {
-            $this->source($options['source']);
         }
     }
 }

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -91,7 +91,7 @@ class DateTimeWidget implements WidgetInterface
      * - `minute` - Array of options for the minute select box.
      * - `second` - Set to true to enable the seconds input. Defaults to false.
      * - `meridian` - Set to true to enable the meridian input. Defaults to false.
-     *   The meridian will be enabled automatically if you chose a 12 hour format.
+     *   The meridian will be enabled automatically if you choose a 12 hour format.
      *
      * The `year` option accepts the `start` and `end` options. These let you control
      * the year range that is generated. It defaults to +-5 years from today.

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -241,6 +241,7 @@ class SelectBoxWidget implements WidgetInterface
             ];
             if (is_array($val) && isset($optAttrs['text'], $optAttrs['value'])) {
                 $optAttrs = $val;
+                $key = $optAttrs['value'];
             }
             if ($this->_isSelected($key, $selected)) {
                 $optAttrs['selected'] = true;

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -211,6 +211,37 @@ class SelectBoxWidgetTest extends TestCase
     }
 
     /**
+     * test complex option rendering with a selected value
+     *
+     * @return void
+     */
+    public function testRenderComplexSelected()
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'id' => 'BirdName',
+            'name' => 'Birds[name]',
+            'val' => 'a',
+            'options' => [
+                ['value' => 'a', 'text' => 'Albatross'],
+                ['value' => 'b', 'text' => 'Budgie', 'data-foo' => 'bar'],
+            ]
+        ];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
+            ['option' => ['value' => 'a', 'selected' => 'selected']],
+            'Albatross',
+            '/option',
+            ['option' => ['value' => 'b', 'data-foo' => 'bar']],
+            'Budgie',
+            '/option',
+            '/select'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * test rendering a multi select
      *
      * @return void
@@ -568,6 +599,37 @@ class SelectBoxWidgetTest extends TestCase
             '/option',
             ['option' => ['value' => 'c', 'disabled' => 'disabled']],
             'Canary',
+            '/option',
+            '/select'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * test complex option rendering with a disabled element
+     *
+     * @return void
+     */
+    public function testRenderComplexDisabled()
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'disabled' => ['b'],
+            'id' => 'BirdName',
+            'name' => 'Birds[name]',
+            'options' => [
+                ['value' => 'a', 'text' => 'Albatross'],
+                ['value' => 'b', 'text' => 'Budgie', 'data-foo' => 'bar'],
+            ]
+        ];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
+            ['option' => ['value' => 'a']],
+            'Albatross',
+            '/option',
+            ['option' => ['value' => 'b', 'data-foo' => 'bar', 'disabled' => 'disabled']],
+            'Budgie',
             '/option',
             '/select'
         ];


### PR DESCRIPTION
Optimizing the Entity constructor by not looping over properties.

In the case of hydrating an entity for the first time, there is no
actual need for calling the genering set() method. This change makes
hydrating entities twice as fast.

Also merging the PR's from the 3.0 branch that are not in master
