### PR TITLE
Allow generating widgets without name.

### DIFF
--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -85,6 +85,10 @@ class BasicWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        return [$data['name']];
+        if ($data['name']) {
+            return [$data['name']];
+        }
+
+        return [];
     }
 }

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -104,6 +104,10 @@ class CheckboxWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        return [$data['name']];
+        if ($data['name']) {
+            return [$data['name']];
+        }
+
+        return [];
     }
 }

--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -74,6 +74,10 @@ class FileWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
+        if (!$data['name']) {
+            return [];
+        }
+
         $fields = [];
         foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $suffix) {
             $fields[] = $data['name'] . '[' . $suffix . ']';

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -237,6 +237,10 @@ class RadioWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        return [$data['name']];
+        if ($data['name']) {
+            return [$data['name']];
+        }
+
+        return [];
     }
 }

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -129,9 +129,6 @@ class SelectBoxWidget implements WidgetInterface
             'val' => null,
         ];
 
-        if (empty($data['name'])) {
-            throw new \RuntimeException('Cannot make inputs with empty name attributes.');
-        }
         $options = $this->_renderContent($data);
         $name = $data['name'];
         unset($data['name'], $data['options'], $data['empty'], $data['val'], $data['escape']);
@@ -300,6 +297,10 @@ class SelectBoxWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        return [$data['name']];
+        if ($data['name']) {
+            return [$data['name']];
+        }
+
+        return [];
     }
 }

--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -74,6 +74,10 @@ class TextareaWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        return [$data['name']];
+        if ($data['name']) {
+            return [$data['name']];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
If widget name is empty preclude it from secure fields list.

I am making a custom widget which consists of a basic text input and select input. Only the basic input needs to be actually POSTed and the select is only for display purpose required by jquery plugin. Without this change i am unable to keep "name" attribute of the select tag empty to prevent it from being POSTed.

I also ensured for all widgets which can have empty name that `secureFields()` should return empty array.

TL;DR;  Inputs without names are valid and should not cause request to be blackholed on form post.
