### PR TITLE
Improving perfomance when hydrating date or datetime objects.

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -54,6 +54,14 @@ class DateTimeType extends \Cake\Database\Type
     protected $_localeFormat;
 
     /**
+     * An instance of the configured dateTimeClass, used to quickly generate
+     * new instances without calling the constructor.
+     *
+     * @var \DateTime
+     */
+    protected $_datetimeInstance;
+
+    /**
      * {@inheritDoc}
      */
     public function __construct($name = null)
@@ -63,6 +71,8 @@ class DateTimeType extends \Cake\Database\Type
         if (!class_exists(static::$dateTimeClass)) {
             static::$dateTimeClass = 'DateTime';
         }
+
+        $this->_datetimeInstance = new static::$dateTimeClass;
     }
 
     /**
@@ -88,23 +98,27 @@ class DateTimeType extends \Cake\Database\Type
      *
      * @param string $value The value to convert.
      * @param Driver $driver The driver instance to convert with.
-     * @return \Carbon\Carbon
+     * @return \Cake\I18n\Time|DateTime
      */
     public function toPHP($value, Driver $driver)
     {
         if ($value === null) {
             return null;
         }
-        list($value) = explode('.', $value);
-        $class = static::$dateTimeClass;
-        return $class::createFromFormat($this->_format, $value);
+
+        if (strpos($value, '.') !== false) {
+            list($value) = explode('.', $value);
+        }
+
+        $instance = clone $this->_datetimeInstance;
+        return $instance->modify($value);
     }
 
     /**
      * Convert request data into a datetime object.
      *
      * @param mixed $value Request data
-     * @return \Carbon\Carbon
+     * @return \Cake\I18n\Time|DateTime
      */
     public function marshal($value)
     {

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -54,17 +54,6 @@ class DateTypeTest extends TestCase
     }
 
     /**
-     * Tests that passing invalid data will throw an exception
-     *
-     * @expectedException \InvalidArgumentException
-     * @return void
-     */
-    public function testToPHPError()
-    {
-        $this->type->toPHP('2001-01-04 10:11:12', $this->driver);
-    }
-
-    /**
      * Test converting to database format
      *
      * @return void

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -54,17 +54,6 @@ class TimeTypeTest extends TestCase
     }
 
     /**
-     * Tests that passing invalid data will throw an exception
-     *
-     * @expectedException \InvalidArgumentException
-     * @return void
-     */
-    public function testToPHPError()
-    {
-        $this->type->toPHP('2001-01-04 10:11:12', $this->driver);
-    }
-
-    /**
      * Test converting to database format
      *
      * @return void


### PR DESCRIPTION
Carbon's constructor is quite heavy, using the clone keyword reduces
considerably the amount of time needed to hydrate in big number of
Time objects.

This makes the `toPHP` method of the `DateType` and `TimeType` more
forgiving, which is probably a good thing.
