### PR TITLE
Preventing PHP to segfault on PHP 7

### DIFF
--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -598,7 +598,7 @@ class RssHelperTest extends TestCase
         $tmpFile = WWW_ROOT . 'tests/cakephp.file.test.tmp';
         $File = new File($tmpFile, true);
 
-        $this->assertTrue($File->write('123'), 'Could not write to ' . $tmpFile);
+        $this->assertTrue($File->write('1234'), 'Could not write to ' . $tmpFile);
 
         clearstatcache();
 


### PR DESCRIPTION
PHP 7 issue [#69329](https://bugs.php.net/bug.php?id=69329) causes the `mime_content_type` function to fail in files smaller than 3 bytes. This change just increase the file on cake to avoid the error. The content of this file is not checked on the tests, just the mime content type.
