### PR TITLE
Renew the session even the session id is '0'.

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -721,7 +721,7 @@ class CakeSession {
  * @return void
  */
 	public static function renew() {
-		if (!session_id()) {
+		if (session_id() === '') {
 			return;
 		}
 		if (isset($_COOKIE[session_name()])) {


### PR DESCRIPTION
This fixes AuthComponent not being able to log a user in when they inadvertently change their session id to 0.

Refs #6053
