### PR TITLE
Add branch alias "3.0.x-dev" for master branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,10 @@
         "cakephp/orm": "self.version",
         "cakephp/utility": "self.version",
         "cakephp/validation": "self.version"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows one to use the master branch for app and avoid
version conflicts due to plugins using "~3.0" version.
