### PR TITLE
 DigestAuthenticate documentation argument order for password()

### DIFF
--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -51,7 +51,7 @@ use Cake\Network\Request;
  * DigestAuthenticate requires a special password hash that conforms to RFC2617.
  * You can generate this password using `DigestAuthenticate::password()`
  *
- * `$digestPass = DigestAuthenticate::password($username, env('SERVER_NAME'), $password);`
+ * `$digestPass = DigestAuthenticate::password($username, $password, env('SERVER_NAME'));`
  *
  * If you wish to use digest authentication alongside other authentication methods,
  * it's recommended that you store the digest authentication separately. For


### PR DESCRIPTION
Hi,

I noticed an error in the documentation of DigestAuthenticate class. The two last arguments are reversed.

Hope this helps !
