### PR TITLE
Add `pre-commit` hook for contributors

### DIFF
--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+FILES=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+
+# Determine if a file list is passed
+if [ "$#" -eq 1 ]
+then
+    oIFS=$IFS
+    IFS='
+    '
+    SFILES="$1"
+    IFS=$oIFS
+fi
+SFILES=${SFILES:-$FILES}
+
+if [ "$FILES" != "" ]
+then
+    echo "Running PHPCS"
+    ./vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP $SFILES
+    if [ $? != 0 ]
+    then
+        echo "PHPCS Errors found; commit aborted."
+        exit 1
+    fi
+fi
+exit $?

--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 FILES=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+PROJECT=`php -r "echo dirname(dirname(realpath('$0')));"`
 
 # Determine if a file list is passed
 if [ "$#" -eq 1 ]
@@ -12,7 +13,19 @@ then
 fi
 SFILES=${SFILES:-$FILES}
 
-if [ "$FILES" != "" ]
+echo "Checking PHP Lint..."
+for FILE in $SFILES
+do
+    php -l -d display_errors=0 $PROJECT/$FILE
+    if [ $? != 0 ]
+    then
+        echo "Fix the error before commit."
+        exit 1
+    fi
+    FILES="$FILES $PROJECT/$FILE"
+done
+
+if [ "$SFILES" != "" ]
 then
     echo "Running PHPCS"
     ./vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP $SFILES


### PR DESCRIPTION
Making it easier for our contributors (and ourselves) to run the codesniffer
and avoid having to comment about coding standards in PRs.

UPDATE 1: Worth mentioning that I took this approach from [zumba/swivel](/zumba/swivel/blob/master/contrib/pre-commit). (/cc @jrbasso)

UPDATE 2: If this gets approved, contribution guidelines will need an update and I still haven't touched RST ;) (/cc @antograssiot @bcrowe)
