### PR TITLE
String return values from rules should trigger errors.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ chance of keeping on top of things.
 ## Submitting Changes
 
 * Push your changes to a topic branch in your fork of the repository.
-* Submit a pull request to the repository in the cakephp organization, with the
+* Submit a pull request to the repository in the CakePHP organization, with the
   correct target branch.
 
 ## Test cases and codesniffer
@@ -61,7 +61,7 @@ driver settings as required to run tests for particular database.
 
 You can also register on [Travis CI](https://travis-ci.org/) and from your
 [profile](https://travis-ci.org/profile) page enable the service hook for your
-cakephp fork on github for automated test builds.
+CakePHP fork on GitHub for automated test builds.
 
 To run the sniffs for CakePHP coding standards:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ To run the sniffs for CakePHP coding standards:
     phpcs -p --extensions=php --standard=CakePHP ./src
 
 Check the [cakephp-codesniffer](https://github.com/cakephp/cakephp-codesniffer)
-repository to setup the CakePHP standard. The [README](https://github.com/cakephp/cakephp-codesniffer/blob/master/README.mdown) contains installation info
+repository to setup the CakePHP standard. The [README](https://github.com/cakephp/cakephp-codesniffer/blob/master/README.md) contains installation info
 for the sniff and phpcs.
 
 # Additional Resources

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ composer require cakephp/cakephp:"~3.0"
 
 Assuming you have PHPUnit installed system wide using one of the methods stated
 [here](http://phpunit.de/manual/current/en/installation.html), you can run the
-tests for cakephp by doing the following:
+tests for CakePHP by doing the following:
 
 1. Copy `phpunit.xml.dist` to `phpunit.xml`.
 2. Add the relevant database credentials to your `phpunit.xml` if you want to run tests against

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -527,6 +527,11 @@ class ResultSet implements ResultSetInterface
 
         foreach ($this->_containMap as $assoc) {
             $alias = $assoc['nestKey'];
+
+            if ($assoc['canBeJoined'] && empty($this->_map[$alias])) {
+                continue;
+            }
+
             $instance = $assoc['instance'];
 
             if (!$assoc['canBeJoined'] && !isset($row[$alias])) {

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -376,19 +376,24 @@ class RulesChecker
 
         return function ($entity, $scope) use ($rule, $name, $options) {
             $pass = $rule($entity, $options + $scope);
-
-            if ($pass || empty($options['errorField'])) {
-                return $pass;
+            if ($pass === true || empty($options['errorField'])) {
+                return $pass === true;
             }
 
-            $message = isset($options['message']) ? $options['message'] : 'invalid';
+            $message = 'invalid';
+            if (isset($options['message'])) {
+                $message = $options['message'];
+            }
+            if (is_string($pass)) {
+                $message = $pass;
+            }
             if ($name) {
                 $message = [$name => $message];
             } else {
-                $message = (array)$message;
+                $message = [$message];
             }
             $entity->errors($options['errorField'], $message);
-            return $pass;
+            return $pass === true;
         };
     }
 }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -463,7 +463,7 @@ class Inflector
      *
      * ```
      * Inflector::rules('plural', ['/^(inflect)or$/i' => '\1ables']);
-     * Inflector::rules('irregular' => ['red' => 'redlings']);
+     * Inflector::rules('irregular', ['red' => 'redlings']);
      * Inflector::rules('uninflected', ['dontinflectme']);
      * Inflector::rules('transliteration', ['/å/' => 'aa']);
      * ```

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -798,4 +798,24 @@ class QueryRegressionTest extends TestCase
             ->toArray();
         $this->assertNotEmpty($result[0]->article);
     }
+
+    /**
+     * Tests that using contain but selecting no fields from the association
+     * does not trigger any errors and fetches the right results.
+     *
+     * @see https://github.com/cakephp/cakephp/issues/6214
+     * @return void
+     */
+    public function testContainWithNoFields()
+    {
+        $table = TableRegistry::get('Comments');
+        $table->belongsTo('Users');
+        $results = $table->find()
+            ->select(['Comments.id', 'Comments.user_id'])
+            ->contain(['Users'])
+            ->where(['Users.id' => 1])
+            ->combine('id', 'user_id');
+
+        $this->assertEquals([3 => 1, 4 => 1, 5 => 1], $results->toArray());
+    }
 }

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -716,6 +716,50 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
+     * Test adding rules that return error string
+     *
+     * @group save
+     * @return void
+     */
+    public function testCustomErrorMessageFromRule()
+    {
+        $entity = new Entity([
+            'name' => 'larry'
+        ]);
+
+        $table = TableRegistry::get('Authors');
+        $rules = $table->rulesChecker();
+        $rules->add(function () {
+            return 'So much nope';
+        }, ['errorField' => 'name']);
+
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['So much nope'], $entity->errors('name'));
+    }
+
+    /**
+     * Test adding rules with no errorField do not accept strings
+     *
+     * @group save
+     * @return void
+     */
+    public function testCustomErrorMessageFromRuleNoErrorField()
+    {
+        $entity = new Entity([
+            'name' => 'larry'
+        ]);
+
+        $table = TableRegistry::get('Authors');
+        $rules = $table->rulesChecker();
+        $rules->add(function () {
+            return 'So much nope';
+        });
+
+        $this->assertFalse($table->save($entity));
+        $this->assertEmpty($entity->errors());
+    }
+
+    /**
      * Tests that using existsIn for a hasMany association will not be called
      * as the foreign key for the association was automatically validated already.
      *


### PR DESCRIPTION
This makes rules and validation more consistent. Returning a string from a rule always triggers a validation failure, but only when the errorField is defined does an error message get populated.

Refs #6181
