### PR TITLE
Support form groups templates by type

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1053,7 +1053,10 @@ class FormHelper extends Helper
      */
     protected function _groupTemplate($options)
     {
-        $groupTemplate = $options['options']['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
+        $groupTemplate = $options['options']['type'] . 'FormGroup';
+        if (!$this->templater()->get($groupTemplate)) {
+            $groupTemplate = 'formGroup';
+        }
         return $this->templater()->format($groupTemplate, [
             'input' => $options['input'],
             'label' => $options['label'],

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6968,6 +6968,26 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Test that *Container templates are used by input.
+     *
+     * @return void
+     */
+    public function testFormGroupTemplates()
+    {
+        $this->Form->templates([
+            'radioFormGroup' => '<div class="radio">{{label}}{{input}}</div>',
+        ]);
+
+        $this->Form->create($this->article);
+
+        $result = $this->Form->input('accept', [
+            'type' => 'radio',
+            'options' => ['Y', 'N']
+        ]);
+        $this->assertContains('<div class="radio">', $result);
+    }
+
+    /**
      * Test resetting templates.
      *
      * @return void


### PR DESCRIPTION
I noticed that `inputContainer` can be customized in templates to use a container based on the input type but that was not the case for `formGroup`.  Only `checkboxFormGroup` was supported.

This adds support for all types of `formGroups`, making it similar to `inputContainer` and most importantly, allowing for more fine-grained control using templates.

UPDATE: I am suggesting it for 3.0.x for same reasons outlined [here](https://github.com/cakephp/cakephp/pull/6210#issuecomment-87937338).
