### PR TITLE
use short array syntax

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2365,7 +2365,7 @@ class FormHelper extends Helper
                 $options['disabled'] === 'disabled' ||
                 (is_array($options['disabled']) &&
                     !empty($options['options']) &&
-                    array_diff($options['options'], $options['disabled']) === array()
+                    array_diff($options['options'], $options['disabled']) === []
                 )
             );
         }

--- a/src/basics.php
+++ b/src/basics.php
@@ -131,14 +131,14 @@ if (!function_exists('json_last_error_msg')) {
      */
     function json_last_error_msg()
     {
-        static $errors = array(
+        static $errors = [
             JSON_ERROR_NONE => '',
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
             JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
             JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
             JSON_ERROR_SYNTAX => 'Syntax error',
             JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
-        );
+        ];
         $error = json_last_error();
         return array_key_exists($error, $errors) ? $errors[$error] : "Unknown error ({$error})";
     }

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -454,7 +454,7 @@ class MemcachedEngineTest extends TestCase
     {
         $Memcached = new TestMemcachedEngine();
         $result = $Memcached->parseServerString('udomain.net:13211');
-        $this->assertEquals(array('udomain.net', '13211'), $result);
+        $this->assertEquals(['udomain.net', '13211'], $result);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -158,19 +158,19 @@ class DebuggerTest extends TestCase
      */
     public function testAddFormat()
     {
-        Debugger::addFormat('js', array(
+        Debugger::addFormat('js', [
             'traceLine' => '{:reference} - <a href="txmt://open?url=file://{:file}' .
                 '&line={:line}">{:path}</a>, line {:line}'
-        ));
+        ]);
         Debugger::outputAs('js');
 
         $result = Debugger::trace();
         $this->assertRegExp('/' . preg_quote('txmt://open?url=file://', '/') . '(\/|[A-Z]:\\\\)' . '/', $result);
 
-        Debugger::addFormat('xml', array(
+        Debugger::addFormat('xml', [
             'error' => '<error><code>{:code}</code><file>{:file}</file><line>{:line}</line>' .
                 '{:description}</error>',
-        ));
+        ]);
         Debugger::outputAs('xml');
 
         ob_start();
@@ -184,14 +184,14 @@ class DebuggerTest extends TestCase
         ]);
         $result = ob_get_clean();
 
-        $expected = array(
+        $expected = [
             '<error',
             '<code', '8', '/code',
             '<file', 'preg:/[^<]+/', '/file',
             '<line', '' . ((int)__LINE__ - 9), '/line',
             'preg:/Undefined variable:\s+foo/',
             '/error'
-        );
+        ];
         $this->assertHtml($expected, $result, true);
     }
 
@@ -202,7 +202,7 @@ class DebuggerTest extends TestCase
      */
     public function testAddFormatCallback()
     {
-        Debugger::addFormat('callback', array('callback' => array($this, 'customFormat')));
+        Debugger::addFormat('callback', ['callback' => [$this, 'customFormat']]);
         Debugger::outputAs('callback');
 
         ob_start();


### PR DESCRIPTION
I tried the new "Generic.Arrays.DisallowLongArraySyntax" rule form  phpcs and it shows up these guys.
After next phpcs release, we could add this rule to the cakephp-codesniffer as stated before by @Admad without new warnings
