### PR TITLE
3.0 - Autoswitch elements to prefix path

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -964,17 +964,7 @@ class View
         }
         list($plugin, $name) = $this->pluginSplit($name);
 
-        $layoutPaths = ['Layout' . DS . $subDir];
-        if (!empty($this->request->params['prefix'])) {
-            $prefixPath = array_map(
-                'Cake\Utility\Inflector::camelize',
-                explode('/', $this->request->params['prefix'])
-            );
-            array_unshift(
-                $layoutPaths,
-                implode('/', $prefixPath) . DS . $layoutPaths[0]
-            );
-        }
+        $layoutPaths = $this->_getSubPaths('Layout' . DS . $subDir);
 
         foreach ($this->_paths($plugin) as $path) {
             foreach ($layoutPaths as $layoutPath) {
@@ -1000,12 +990,43 @@ class View
         list($plugin, $name) = $this->pluginSplit($name);
 
         $paths = $this->_paths($plugin);
+        $elementPaths = $this->_getSubPaths('Element');
+
         foreach ($paths as $path) {
-            if (file_exists($path . 'Element' . DS . $name . $this->_ext)) {
-                return $path . 'Element' . DS . $name . $this->_ext;
+            foreach ($elementPaths as $elementPath) {
+                if (file_exists($path . $elementPath . DS . $name . $this->_ext)) {
+                    return $path . $elementPath . DS . $name . $this->_ext;
+                }
             }
         }
         return false;
+    }
+
+    /**
+     * Find all sub templates path, based on $basePath
+     * If a prefix is defined in the current request, this method will prepend
+     * the prefixed template path to the $basePath.
+     * This is essentially used to find prefixed template paths for elements
+     * and layouts.
+     *
+     * @param string $basePath Base path on which to get the prefixed one.
+     * @return array Array with all the templates paths.
+     */
+    protected function _getSubPaths($basePath)
+    {
+        $paths = [$basePath];
+        if (!empty($this->request->params['prefix'])) {
+            $prefixPath = array_map(
+                'Cake\Utility\Inflector::camelize',
+                explode('/', $this->request->params['prefix'])
+            );
+            array_unshift(
+                $paths,
+                implode('/', $prefixPath) . DS . $basePath
+            );
+        }
+
+        return $paths;
     }
 
     /**

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -169,4 +169,18 @@ class FlashHelperTest extends TestCase
         $expected = 'flash element from TestTheme';
         $this->assertContains($expected, $result);
     }
+
+    /**
+     * test that when View prefix is set, flash element from that prefix
+     * is used if available.
+     *
+     * @return void
+     */
+    public function testFlashWithPrefix()
+    {
+        $this->View->request->params['prefix'] = 'Admin';
+        $result = $this->Flash->render('flash');
+        $expected = 'flash element from Admin prefix folder';
+        $this->assertContains($expected, $result);
+    }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -817,6 +817,29 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test element method with a prefix
+     *
+     * @return void
+     */
+    public function testPrefixElement()
+    {
+        $this->View->request->params['prefix'] = 'Admin';
+        $result = $this->View->element('prefix_element');
+        $this->assertEquals('this is a prefixed test element', $result);
+
+        $result = $this->View->element('TestPlugin.plugin_element');
+        $this->assertEquals('this is the plugin prefixed element using params[plugin]', $result);
+
+        $this->View->plugin = 'TestPlugin';
+        $result = $this->View->element('test_plugin_element');
+        $this->assertEquals('this is the test set using View::$plugin plugin prefixed element', $result);
+
+        $this->View->request->params['prefix'] = 'FooPrefix/BarPrefix';
+        $result = $this->View->element('prefix_element');
+        $this->assertEquals('this is a nested prefixed test element', $result);
+    }
+
+    /**
      * Test elementInexistent method
      *
      * @expectedException \Cake\View\Exception\MissingElementException
@@ -1715,6 +1738,26 @@ TEXT;
     }
 
     /**
+     * Test extend() in an element and a view.
+     *
+     * @return void
+     */
+    public function testExtendPrefixElement()
+    {
+        $this->View->request->params['prefix'] = 'Admin';
+        $this->View->layout = false;
+        $content = $this->View->render('extend_element');
+        $expected = <<<TEXT
+Parent View.
+View content.
+Parent Element.
+Prefix Element content.
+
+TEXT;
+        $this->assertEquals($expected, $content);
+    }
+
+    /**
      * Extending an element which doesn't exist should throw a missing view exception
      *
      * @return void
@@ -1744,6 +1787,24 @@ TEXT;
         $expected = <<<TEXT
 Parent View.
 this is the test elementThe view
+
+TEXT;
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test extend() preceeded by an element()
+     *
+     * @return void
+     */
+    public function testExtendWithPrefixElementBeforeExtend()
+    {
+        $this->View->request->params['prefix'] = 'Admin';
+        $this->View->layout = false;
+        $result = $this->View->render('extend_with_element');
+        $expected = <<<TEXT
+Parent View.
+this is the test prefix elementThe view
 
 TEXT;
         $this->assertEquals($expected, $result);

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Admin/Element/plugin_element.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Admin/Element/plugin_element.ctp
@@ -1,0 +1,1 @@
+this is the plugin prefixed element using params[plugin]

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Admin/Element/test_plugin_element.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Admin/Element/test_plugin_element.ctp
@@ -1,0 +1,1 @@
+this is the test set using View::$plugin plugin prefixed element

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Element/Flash/plugin_element.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Element/Flash/plugin_element.ctp
@@ -1,1 +1,1 @@
-<?= 'this is the plugin element'; ?>
+this is the plugin element

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Element/plugin_element.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Element/plugin_element.ctp
@@ -1,1 +1,1 @@
-<?= 'this is the plugin element using params[plugin]'; ?>
+this is the plugin element using params[plugin]

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Element/test_plugin_element.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Element/test_plugin_element.ctp
@@ -1,1 +1,1 @@
-<?= 'this is the test set using View::$plugin plugin element'; ?>
+this is the test set using View::$plugin plugin element

--- a/tests/test_app/TestApp/Template/Admin/Element/Flash/default.ctp
+++ b/tests/test_app/TestApp/Template/Admin/Element/Flash/default.ctp
@@ -1,0 +1,1 @@
+flash element from Admin prefix folder

--- a/tests/test_app/TestApp/Template/Admin/Element/extended_element.ctp
+++ b/tests/test_app/TestApp/Template/Admin/Element/extended_element.ctp
@@ -1,0 +1,2 @@
+<?php $this->extend('parent_element'); ?>
+Prefix Element content.

--- a/tests/test_app/TestApp/Template/Admin/Element/prefix_element.ctp
+++ b/tests/test_app/TestApp/Template/Admin/Element/prefix_element.ctp
@@ -1,0 +1,1 @@
+this is a prefixed test element

--- a/tests/test_app/TestApp/Template/Admin/Element/test_element.ctp
+++ b/tests/test_app/TestApp/Template/Admin/Element/test_element.ctp
@@ -1,0 +1,1 @@
+this is the test prefix element

--- a/tests/test_app/TestApp/Template/Element/test_element.ctp
+++ b/tests/test_app/TestApp/Template/Element/test_element.ctp
@@ -1,1 +1,1 @@
-<?= 'this is the test element'; ?>
+this is the test element

--- a/tests/test_app/TestApp/Template/FooPrefix/BarPrefix/Element/prefix_element.ctp
+++ b/tests/test_app/TestApp/Template/FooPrefix/BarPrefix/Element/prefix_element.ctp
@@ -1,0 +1,1 @@
+this is a nested prefixed test element


### PR DESCRIPTION
As per the comments on the original PR, I removed the string echoing in the test elements files (also on the ones that were not part of the changes at first).
This new PR was made to aim at the master branch.

I did most part of the doc, will submit a PR shortly.

---

As Layouts and action view files already switch to a prefix path if available (src/Template/{Prefix}/Layout/my_layout.ctp for instance), elements should too.
This PR implements this behavior.
It should be noted that this also autoswitch Flash elements.

More details on #4320 and #6204
