### PR TITLE
Fix maxDimensions() for empty/1 dimensional arrays.

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -275,6 +275,14 @@ class HashTest extends CakeTestCase {
  * @return void
  */
 	public function testMaxDimensions() {
+		$data = array();
+		$result = Hash::maxDimensions($data);
+		$this->assertEquals(0, $result);
+
+		$data = array('a', 'b');
+		$result = Hash::maxDimensions($data);
+		$this->assertEquals(1, $result);
+
 		$data = array('1' => '1.1', '2', '3' => array('3.1' => '3.1.1'));
 		$result = Hash::maxDimensions($data);
 		$this->assertEquals($result, 2);

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -763,10 +763,14 @@ class Hash {
 		$depth = array();
 		if (is_array($data) && reset($data) !== false) {
 			foreach ($data as $value) {
-				$depth[] = self::dimensions((array)$value) + 1;
+				if (is_array($value)) {
+					$depth[] = self::dimensions($value) + 1;
+				} else {
+					$depth[] = 1;
+				}
 			}
 		}
-		return max($depth);
+		return empty($depth) ? 0 : max($depth);
 	}
 
 /**


### PR DESCRIPTION
maxDimensions() should not emit warnings or mis-calculate an array's dimensions.

Fixes #6224
