### PR TITLE
Closes Issue 6240 for CakePHP 2.6 branch

### DIFF
--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -177,6 +177,7 @@ class InflectorTest extends CakeTestCase {
 		$this->assertEquals(Inflector::singularize('body_curves'), 'body_curve');
 		$this->assertEquals(Inflector::singularize('metadata'), 'metadata');
 		$this->assertEquals(Inflector::singularize('files_metadata'), 'files_metadata');
+		$this->assertEquals(Inflector::singularize('sieves'), 'sieve');
 		$this->assertEquals(Inflector::singularize(''), '');
 	}
 
@@ -248,6 +249,7 @@ class InflectorTest extends CakeTestCase {
 		$this->assertEquals(Inflector::pluralize('metadata'), 'metadata');
 		$this->assertEquals(Inflector::pluralize('files_metadata'), 'files_metadata');
 		$this->assertEquals(Inflector::pluralize('stadia'), 'stadia');
+		$this->assertEquals(Inflector::pluralize('sieve'), 'sieves');
 		$this->assertEquals(Inflector::pluralize(''), '');
 	}
 

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -107,7 +107,8 @@ class Inflector {
 			'hero' => 'heroes',
 			'tooth' => 'teeth',
 			'goose' => 'geese',
-			'foot' => 'feet'
+			'foot' => 'feet',
+			'sieve' => 'sieves'
 		)
 	);
 


### PR DESCRIPTION
Corrects `sieves` singularization in the Inflector class.
