### PR TITLE
The SessionHandlerInterface requires some methods to return boolean

### DIFF
--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -121,10 +121,7 @@ class DatabaseSession implements SessionHandlerInterface
         $record = compact('data', 'expires');
         $record[$this->_table->primaryKey()] = $id;
         $result = $this->_table->save(new Entity($record));
-        if ($result) {
-            return $result->toArray();
-        }
-        return false;
+        return (bool)$result;
     }
 
     /**
@@ -135,7 +132,7 @@ class DatabaseSession implements SessionHandlerInterface
      */
     public function destroy($id)
     {
-        return $this->_table->delete(new Entity(
+        return (bool)$this->_table->delete(new Entity(
             [$this->_table->primaryKey() => $id],
             ['markNew' => false]
         ));
@@ -149,6 +146,7 @@ class DatabaseSession implements SessionHandlerInterface
      */
     public function gc($maxlifetime)
     {
-        return $this->_table->deleteAll(['expires <' => time() - $maxlifetime]);
+        $this->_table->deleteAll(['expires <' => time() - $maxlifetime]);
+        return true;
     }
 }

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -97,14 +97,9 @@ class DatabaseSessionTest extends TestCase
     public function testWrite()
     {
         $result = $this->storage->write('foo', 'Some value');
-        $expected = [
-            'id' => 'foo',
-            'data' => 'Some value',
-        ];
-        $expires = $result['expires'];
-        unset($result['expires']);
-        $this->assertEquals($expected, $result);
+        $this->assertTrue($result);
 
+        $expires = TableRegistry::get('Sessions')->get('foo')->expires;
         $expected = time() + ini_get('session.gc_maxlifetime');
         $this->assertWithinRange($expected, $expires, 1);
     }


### PR DESCRIPTION
We were returning mixed types on DatabaseSession, which made hhvm super
unhappy. This also future-proofs the class for PHP 7
