### PR TITLE
Don't include views in table list.

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -29,10 +29,11 @@ class SqlserverSchema extends BaseSchema
      */
     public function listTablesSql($config)
     {
-        $sql = 'SELECT TABLE_NAME
+        $sql = "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = ?
-            ORDER BY TABLE_NAME';
+            AND TABLE_TYPE = 'BASE TABLE'
+            ORDER BY TABLE_NAME";
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
         return [$sql, [$schema]];
     }


### PR DESCRIPTION
When using SQLServer we should only include 'BASE TABLE' types in the list of tables. This prevents errors where bake and other schema tooling tries to interact with views and fails.

Refs cakephp/bake#60
