### PR TITLE
$conditions made optional for Table::updateAll()

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -76,7 +76,7 @@ interface RepositoryInterface
      *
      * @param array $fields A hash of field => new value.
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
-     * can take.
+     * can take. If no condition is passed, update all records.
      * @return int Count Returns the affected rows.
      */
     public function updateAll($fields, $conditions);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1149,7 +1149,7 @@ class Table implements RepositoryInterface, EventListenerInterface
     /**
      * {@inheritDoc}
      */
-    public function updateAll($fields, $conditions)
+    public function updateAll($fields, $conditions = [])
     {
         $query = $this->query();
         $query->update()

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -838,6 +838,18 @@ class TableTest extends TestCase
         $expected = array_fill(0, 3, $fields);
         $expected[] = ['username' => 'garrett'];
         $this->assertEquals($expected, $result);
+
+        $fields = ['username' => 'pierre'];
+        $count = $table->find()->count();
+        $result = $table->updateAll($fields);
+        $this->assertSame($count, $result);
+
+        $result = $table->find('all')
+            ->select(['username'])
+            ->hydrate(false)
+            ->toArray();
+        $expected = array_fill(0, $count, $fields);
+        $this->assertEquals($expected, $result);
     }
 
     /**


### PR DESCRIPTION
To update all records of a table, one has to write `$table->updateAll(['field' => 'newValue'], []);`.
I just made it possible to write `$table->updateAll(['field' => 'newValue']);` instead.
