### PR TITLE
fixes offset style timezone for datefmt_create

### DIFF
--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -17,6 +17,7 @@ namespace Cake\I18n;
 use Carbon\Carbon;
 use IntlDateFormatter;
 use JsonSerializable;
+use RuntimeException;
 
 /**
  * Extends the built-in DateTime class to provide handy methods and locale-aware
@@ -578,11 +579,16 @@ class Time extends Carbon implements JsonSerializable
         $key = "{$locale}.{$dateFormat}.{$timeFormat}.{$timezone}.{$calendar}.{$pattern}";
 
         if (!isset(static::$_formatters[$key])) {
+            if ($timezone === '+00:00') {
+                $timezone = 'UTC';
+            } elseif ($timezone[0] === '+' || $timezone[0] === '-') {
+                $timezone = 'GMT' . $timezone;
+            }
             static::$_formatters[$key] = datefmt_create(
                 $locale,
                 $dateFormat,
                 $timeFormat,
-                $timezone === '+00:00' ? 'UTC' : $timezone,
+                $timezone,
                 $calendar,
                 $pattern
             );

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -530,6 +530,29 @@ class TimeTest extends TestCase
     }
 
     /**
+     * test formatting dates with offset style timezone
+     *
+     * @return void
+     */
+    public function testI18nFormatWithOffsetTimezone()
+    {
+        $time = new Time('2014-01-01T00:00:00+00');
+        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
+        $this->assertTimeFormat($expected, $result);
+
+        $time = new Time('2014-01-01T00:00:00+09');
+        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
+        $this->assertTimeFormat($expected, $result);
+
+        $time = new Time('2014-01-01T00:00:00-01:30');
+        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
+        $this->assertTimeFormat($expected, $result);
+    }
+
+    /**
      * testListTimezones
      *
      * @return void


### PR DESCRIPTION
`DateTime` class can handle offset style timezone such as `+09:00`.
But the `IntlDateFormatter` does not recognize such timezone.
Therefore, `datefmt_create()` returns null, then `Cake\I18n\Time->i18nFormat()` occures PHP Fatal Error.

How to reproduce:

``` php
$t = Cake\I18n\Time::parse('2014-01-01 00:00:00+09');
echo $t->i18nFormat();
# => PHP Fatal error:  Call to a member function format() on a non-object in (snip)/cakephp/src/I18n/Time.php on line 591
```

This PR fixes timezone like `+09:00` to `GMT+09:00` which is accepted by `IntlDateFormatter`.
After applied, the above example echoes `Wednesday January 1 2014 12:00:00 AM GMT+09:00`

Such date string is returned by PostgreSQL's `TIMESTAMP WITH TIME ZONE` type.

see also http://php.net/manual/en/intldateformatter.create.php
