### PR TITLE
Postgres' money type should be handled as a string

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -103,7 +103,11 @@ class PostgresSchema extends BaseSchema
         if ($col === 'char' || $col === 'character') {
             return ['type' => 'string', 'fixed' => true, 'length' => $length];
         }
-        if (strpos($col, 'char') !== false) {
+        // money is 'string' as it includes arbitrary text content
+        // before the number value.
+        if (strpos($col, 'char') !== false ||
+            strpos($col, 'money') !== false
+        ) {
             return ['type' => 'string', 'length' => $length];
         }
         if (strpos($col, 'text') !== false) {
@@ -116,7 +120,6 @@ class PostgresSchema extends BaseSchema
             return ['type' => 'float', 'length' => null];
         }
         if (strpos($col, 'numeric') !== false ||
-            strpos($col, 'money') !== false ||
             strpos($col, 'decimal') !== false
         ) {
             return ['type' => 'decimal', 'length' => null];

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -138,10 +138,6 @@ SQL;
                 'DECIMAL(10,2)',
                 ['type' => 'decimal', 'length' => null]
             ],
-            [
-                'MONEY',
-                ['type' => 'decimal', 'length' => null]
-            ],
             // String
             [
                 'VARCHAR',
@@ -166,6 +162,10 @@ SQL;
             [
                 'CHARACTER(10)',
                 ['type' => 'string', 'fixed' => true, 'length' => 10]
+            ],
+            [
+                'MONEY',
+                ['type' => 'string', 'length' => null]
             ],
             // UUID
             [

--- a/tests/test_app/TestApp/Controller/TestsAppsController.php
+++ b/tests/test_app/TestApp/Controller/TestsAppsController.php
@@ -23,9 +23,6 @@ namespace TestApp\Controller;
 
 class TestsAppsController extends AppController
 {
-
-    public $uses = [];
-
     public $components = ['RequestHandler'];
 
     public function index()


### PR DESCRIPTION
The money type contains effectively arbitrary string content before the numbers. Treating this data as a float results in 0.0 for all amounts which is annoying. By handling this type as a string we can give the developer the data they would see in pgadmin.
