### PR TITLE
Removed duplicated option on find docblock

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -870,7 +870,6 @@ class Table implements RepositoryInterface, EventListenerInterface
      * - limit
      * - offset
      * - page
-     * - order
      * - group
      * - having
      * - contain


### PR DESCRIPTION
Order is already defined on line 869.
