### PR TITLE
added sort to prevent from failing PostgreSQL test

### DIFF
--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -229,6 +229,7 @@ class CompositeKeyTest extends TestCase
             'targetTable' => $tags,
             'propertyName' => 'tags',
             'through' => 'SiteArticlesTags',
+            'sort' => 'SiteTags.id',
             'foreignKey' => ['article_id', 'site_id'],
             'targetForeignKey' => ['tag_id', 'site_id']
         ]);

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -229,7 +229,7 @@ class CompositeKeyTest extends TestCase
             'targetTable' => $tags,
             'propertyName' => 'tags',
             'through' => 'SiteArticlesTags',
-            'sort' => 'SiteTags.id',
+            'sort' => ['SiteTags.id' => 'asc'],
             'foreignKey' => ['article_id', 'site_id'],
             'targetForeignKey' => ['tag_id', 'site_id']
         ]);


### PR DESCRIPTION
`Cake\Test\TestCase\ORM\CompositeKeyTest::testBelongsToManyEager` sometimes fails, for example https://travis-ci.org/cakephp/cakephp/jobs/56915123

Adding `sort` to belongsToMany association may resolve it.

From PostgreSQL statement log:

``` sql
-- Before patch:
SELECT SiteArticlesTags.tag_id AS "SiteArticlesTags__tag_id", SiteArticlesTags.site_id AS "SiteArticlesTags__site_id", SiteArticlesTags.article_id AS "SiteArticlesTags__article_id", SiteTags.id AS "SiteTags__id", SiteTags.site_id AS "SiteTags__site_id", SiteTags.name AS "SiteTags__name" FROM site_tags SiteTags INNER JOIN site_articles_tags SiteArticlesTags ON (SiteTags.id = (SiteArticlesTags.tag_id) AND SiteTags.site_id = (SiteArticlesTags.site_id)) INNER JOIN (SELECT (SiteArticles.id), (SiteArticles.site_id) FROM site_articles SiteArticles GROUP BY SiteArticles.id, SiteArticles.site_id ) SiteArticles ON (SiteArticlesTags.article_id, SiteArticlesTags.site_id) = (SiteArticles.id, SiteArticles.site_id)

-- After patch:
SELECT SiteArticlesTags.tag_id AS "SiteArticlesTags__tag_id", SiteArticlesTags.site_id AS "SiteArticlesTags__site_id", SiteArticlesTags.article_id AS "SiteArticlesTags__article_id", SiteTags.id AS "SiteTags__id", SiteTags.site_id AS "SiteTags__site_id", SiteTags.name AS "SiteTags__name" FROM site_tags SiteTags INNER JOIN site_articles_tags SiteArticlesTags ON (SiteTags.id = (SiteArticlesTags.tag_id) AND SiteTags.site_id = (SiteArticlesTags.site_id)) INNER JOIN (SELECT (SiteArticles.id), (SiteArticles.site_id) FROM site_articles SiteArticles GROUP BY SiteArticles.id, SiteArticles.site_id ) SiteArticles ON (SiteArticlesTags.article_id, SiteArticlesTags.site_id) = (SiteArticles.id, SiteArticles.site_id) ORDER BY SiteTags.id
```
