### PR TITLE
Rename Validation::notEmpty() to Validation::notBlank().

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -130,9 +130,11 @@ class Validation
      *
      * @param string|array $check Value to check
      * @return bool Success
+     * @deprecated 3.0.2
      */
     public static function blank($check)
     {
+        trigger_error('Validation::blank() is deprecated.');
         if (is_array($check)) {
             extract(static::_defaults($check));
         }
@@ -783,9 +785,14 @@ class Validation
      * @param string $method class method name for validation to run
      * @param array|null $args arguments to send to method
      * @return mixed user-defined class class method returns
+     * @deprecated 3.0.2 You can just set a callable for `rule` key when adding validators.
      */
     public static function userDefined($check, $object, $method, $args = null)
     {
+        trigger_error(
+            'Validation::userDefined() is deprecated. Just set a callable for `rule` key when adding validators instead.',
+            E_USER_DEPRECATED
+        );
         return call_user_func_array([$object, $method], [$check, $args]);
     }
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -46,6 +46,20 @@ class Validation
     public static $errors = [];
 
     /**
+     * Backwards compatibility wrapper for Validation::notBlank().
+     *
+     * @param string|array $check Value to check.
+     * @return bool Success.
+     * @deprecated 3.0.2 Use Validation::notBlank() instead.
+     * @see Validation::notBlank()
+     */
+    public function notEmpty($check)
+    {
+        trigger_error('Validation::notEmpty() is deprecated. Use Validation::notBlank() instead.', E_USER_DEPRECATED);
+        return static::notBlank($check);
+    }
+
+    /**
      * Checks that a string contains something other than whitespace
      *
      * Returns true if string contains something other than whitespace
@@ -53,14 +67,10 @@ class Validation
      * $check can be passed as an array:
      * ['check' => 'valueToCheck'];
      *
-     * It is recommended to *not* use this method, and instead use Validator::allowEmpty()
-     * & Validator::notEmpty() instead. This method is only provided for
-     * backwards compatibility.
-     *
      * @param string|array $check Value to check
      * @return bool Success
      */
-    public static function notEmpty($check)
+    public static function notBlank($check)
     {
         if (is_array($check)) {
             extract(static::_defaults($check));

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -80,15 +80,15 @@ class ValidationTest extends TestCase
      */
     public function testNotEmpty()
     {
-        $this->assertTrue(Validation::notEmpty('abcdefg'));
-        $this->assertTrue(Validation::notEmpty('fasdf '));
-        $this->assertTrue(Validation::notEmpty('fooo' . chr(243) . 'blabla'));
-        $this->assertTrue(Validation::notEmpty('abçďĕʑʘπй'));
-        $this->assertTrue(Validation::notEmpty('José'));
-        $this->assertTrue(Validation::notEmpty('é'));
-        $this->assertTrue(Validation::notEmpty('π'));
-        $this->assertFalse(Validation::notEmpty("\t "));
-        $this->assertFalse(Validation::notEmpty(""));
+        $this->assertTrue(Validation::notBlank('abcdefg'));
+        $this->assertTrue(Validation::notBlank('fasdf '));
+        $this->assertTrue(Validation::notBlank('fooo' . chr(243) . 'blabla'));
+        $this->assertTrue(Validation::notBlank('abçďĕʑʘπй'));
+        $this->assertTrue(Validation::notBlank('José'));
+        $this->assertTrue(Validation::notBlank('é'));
+        $this->assertTrue(Validation::notBlank('π'));
+        $this->assertFalse(Validation::notBlank("\t "));
+        $this->assertFalse(Validation::notBlank(""));
     }
 
     /**
@@ -99,14 +99,14 @@ class ValidationTest extends TestCase
     public function testNotEmptyISO88591AppEncoding()
     {
         Configure::write('App.encoding', 'ISO-8859-1');
-        $this->assertTrue(Validation::notEmpty('abcdefg'));
-        $this->assertTrue(Validation::notEmpty('fasdf '));
-        $this->assertTrue(Validation::notEmpty('fooo' . chr(243) . 'blabla'));
-        $this->assertTrue(Validation::notEmpty('abçďĕʑʘπй'));
-        $this->assertTrue(Validation::notEmpty('José'));
-        $this->assertTrue(Validation::notEmpty(utf8_decode('José')));
-        $this->assertFalse(Validation::notEmpty("\t "));
-        $this->assertFalse(Validation::notEmpty(""));
+        $this->assertTrue(Validation::notBlank('abcdefg'));
+        $this->assertTrue(Validation::notBlank('fasdf '));
+        $this->assertTrue(Validation::notBlank('fooo' . chr(243) . 'blabla'));
+        $this->assertTrue(Validation::notBlank('abçďĕʑʘπй'));
+        $this->assertTrue(Validation::notBlank('José'));
+        $this->assertTrue(Validation::notBlank(utf8_decode('José')));
+        $this->assertFalse(Validation::notBlank("\t "));
+        $this->assertFalse(Validation::notBlank(""));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -23,25 +23,6 @@ use Cake\Validation\Validation;
 use Locale;
 
 /**
- * CustomValidator class
- *
- */
-class CustomValidator
-{
-
-    /**
-     * Makes sure that a given $email address is valid and unique
-     *
-     * @param string $check
-     * @return bool
-     */
-    public static function customValidate($check)
-    {
-        return (bool)preg_match('/^[0-9]{3}$/', $check);
-    }
-}
-
-/**
  * Test Case for Validation Class
  *
  */
@@ -169,38 +150,6 @@ class ValidationTest extends TestCase
 
         $this->assertFalse(Validation::lengthBetween('abcdefg', 1, 6));
         $this->assertFalse(Validation::lengthBetween('ÆΔΩЖÇ', 1, 3));
-    }
-
-    /**
-     * testBlank method
-     *
-     * @return void
-     */
-    public function testBlank()
-    {
-        $this->assertTrue(Validation::blank(''));
-        $this->assertTrue(Validation::blank(' '));
-        $this->assertTrue(Validation::blank("\n"));
-        $this->assertTrue(Validation::blank("\t"));
-        $this->assertTrue(Validation::blank("\r"));
-        $this->assertFalse(Validation::blank('    Blank'));
-        $this->assertFalse(Validation::blank('Blank'));
-    }
-
-    /**
-     * testBlankAsArray method
-     *
-     * @return void
-     */
-    public function testBlankAsArray()
-    {
-        $this->assertTrue(Validation::blank(['check' => '']));
-        $this->assertTrue(Validation::blank(['check' => ' ']));
-        $this->assertTrue(Validation::blank(['check' => "\n"]));
-        $this->assertTrue(Validation::blank(['check' => "\t"]));
-        $this->assertTrue(Validation::blank(['check' => "\r"]));
-        $this->assertFalse(Validation::blank(['check' => '    Blank']));
-        $this->assertFalse(Validation::blank(['check' => 'Blank']));
     }
 
     /**
@@ -2263,19 +2212,6 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::naturalNumber(49));
         $this->assertTrue(Validation::naturalNumber('0', true));
         $this->assertTrue(Validation::naturalNumber(0, true));
-    }
-
-    /**
-     * testUserDefined method
-     *
-     * @return void
-     */
-    public function testUserDefined()
-    {
-        $validator = new CustomValidator;
-        $this->assertFalse(Validation::userDefined('33', $validator, 'customValidate'));
-        $this->assertFalse(Validation::userDefined('3333', $validator, 'customValidate'));
-        $this->assertTrue(Validation::userDefined('333', $validator, 'customValidate'));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -513,7 +513,7 @@ class ValidatorTest extends TestCase
         $validator = new Validator;
         $validator
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
-            ->add('email', 'notEmpty', ['rule' => 'notEmpty'])
+            ->add('email', 'notBlank', ['rule' => 'notBlank'])
             ->add('email', 'email', ['rule' => 'email', 'message' => 'Y u no write email?']);
         $errors = $validator->errors(['email' => 'not an email!']);
         $expected = [


### PR DESCRIPTION
This avoids confusion for new users with Validator::notEmpty().

Refs #6284, #5856.
