### PR TITLE
Relax typehints in FixtureManager.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -237,6 +237,7 @@ class Marshaller
      * * associated: Associations listed here will be marshalled as well.
      * * fieldList: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used.
+     * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
      *
      * @param array $data The data to hydrate.
      * @param array $options List of options

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -191,7 +191,7 @@ class FixtureManager
      * @param bool $drop whether drop the fixture if it is already created or not
      * @return void
      */
-    protected function _setupTable(TestFixture $fixture, Connection $db, array $sources, $drop = true)
+    protected function _setupTable($fixture, $db, array $sources, $drop = true)
     {
         if (!empty($fixture->created) && in_array($db->configName(), $fixture->created)) {
             return;


### PR DESCRIPTION
Until we have better interfaces, relying on duck typing will better allow alternatives datasources to provide their own fixture features.

I bumped into this limitation as I was trying to build out fixtures for the elasticsearch plugin.
