### PR TITLE
Between is not a valid rule in the core

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -278,7 +278,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *          ->add('user_id', 'valid', ['rule' => 'numeric', 'message' => 'Invalid User'])
      *
      *      $validator->add('password', [
-     *          'size' => ['rule' => ['between', 8, 20]],
+     *          'size' => ['rule' => ['lengthBetween', 8, 20]],
      *          'hasSpecialCharacter' => ['rule' => 'validateSpecialchar', 'message' => 'not valid']
      *      ]);
      * ```


### PR DESCRIPTION
Using a rule that is valid in the core to not confuse people.
