### PR TITLE
3.1 - Shell "requested" param

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -211,7 +211,7 @@ class Shell
      */
     public function startup()
     {
-        if (!(bool)$this->param('requested')) {
+        if (!$this->param('requested')) {
             $this->_welcome();
         }
     }
@@ -300,22 +300,29 @@ class Shell
      *
      * `return $this->dispatchShell('schema', 'create', 'i18n', '--dry');`
      *
+     * With an array having two key / value pairs:
+     *  - `command` can accept either a string or an array. Represents the command to dispatch
+     *  - `extra` can accept an array of extra parameters to pass on to the dispatcher. This
+     *  parameters will be available in the `param` property of the called `Shell`
+     *
+     * `return $this->dispatchShell([
+     *      'command' => 'schema create DbAcl',
+     *      'extra' => ['param' => 'value']
+     * ]);`
+     *
+     * or
+     *
+     * `return $this->dispatchShell([
+     *      'command' => ['schema', 'create', 'DbAcl'],
+     *      'extra' => ['param' => 'value']
+     * ]);`
+     *
      * @return mixed The return of the other shell.
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#invoking-other-shells-from-your-shell
      */
     public function dispatchShell()
     {
-        $args = func_get_args();
-        $extra = [];
-        if (is_array($args[0]) && isset($args[0]['command'])) {
-            if (!empty($args[0]['extra'])) {
-                $extra = $args[0]['extra'];
-            }
-
-            $args = explode(' ', $args[0]['command']);
-        } elseif (is_string($args[0]) && count($args) === 1) {
-            $args = explode(' ', $args[0]);
-        }
+        list($args, $extra) = $this->parseDispatchArguments(func_get_args());
 
         if (!isset($extra['requested'])) {
             $extra['requested'] = true;
@@ -323,6 +330,39 @@ class Shell
 
         $dispatcher = new ShellDispatcher($args, false);
         return $dispatcher->dispatch($extra);
+    }
+
+    /**
+     * Parses the arguments for the dispatchShell() method.
+     *
+     * @param array $args Arguments fetch from the dispatchShell() method with
+     * func_get_args()
+     * @return array First value has to be an array of the command arguments.
+     * Second value has to be an array of extra parameter to pass on to the dispatcher
+     */
+    public function parseDispatchArguments($args)
+    {
+        $extra = [];
+
+        if (is_string($args[0]) && count($args) === 1) {
+            $args = explode(' ', $args[0]);
+            return [$args, $extra];
+        }
+
+        if (is_array($args[0]) && !empty($args[0]['command'])) {
+            $command = $args[0]['command'];
+            if (is_string($command)) {
+                $command = explode(' ', $command);
+            }
+
+            if (!empty($args[0]['extra'])) {
+                $extra = $args[0]['extra'];
+            }
+
+            return [$command, $extra];
+        }
+
+        return [$args, $extra];
     }
 
     /**

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -114,12 +114,13 @@ class ShellDispatcher
      * Run the dispatcher
      *
      * @param array $argv The argv from PHP
+     * @param array $extra Extra parameters
      * @return int The exit code of the shell process.
      */
-    public static function run($argv)
+    public static function run($argv, $extra = [])
     {
         $dispatcher = new ShellDispatcher($argv);
-        return $dispatcher->dispatch();
+        return $dispatcher->dispatch($extra);
     }
 
     /**
@@ -164,11 +165,15 @@ class ShellDispatcher
      * Converts a shell command result into an exit code. Null/True
      * are treated as success. All other return values are an error.
      *
+     * @param array $extra Extra parameters that you can manually pass to the Shell
+     * to be dispatched.
+     * Built-in extra parameter is :
+     * - `requested` : if used, will prevent the Shell welcome message to be displayed
      * @return int The cli command exit code. 0 is success.
      */
-    public function dispatch()
+    public function dispatch($extra = [])
     {
-        $result = $this->_dispatch();
+        $result = $this->_dispatch($extra);
         if ($result === null || $result === true) {
             return 0;
         }
@@ -178,10 +183,14 @@ class ShellDispatcher
     /**
      * Dispatch a request.
      *
+     * @param array $extra Extra parameters that you can manually pass to the Shell
+     * to be dispatched.
+     * Built-in extra parameter is :
+     * - `requested` : if used, will prevent the Shell welcome message to be displayed
      * @return bool
      * @throws \Cake\Console\Exception\MissingShellMethodException
      */
-    protected function _dispatch()
+    protected function _dispatch($extra = [])
     {
         $shell = $this->shiftArgs();
 
@@ -197,7 +206,7 @@ class ShellDispatcher
         $Shell = $this->findShell($shell);
 
         $Shell->initialize();
-        return $Shell->runCommand($this->args, true);
+        return $Shell->runCommand($this->args, true, $extra);
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -616,6 +616,33 @@ class ShellTest extends TestCase
     }
 
     /**
+     * test that a command called with an extra parameter passed merges the extra parameters
+     * to the shell's one
+     * Also tests that if an extra `requested` parameter prevents the welcome message from
+     * being displayed
+     *
+     * @return void
+     */
+    public function testRunCommandWithExtra()
+    {
+        $Parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
+        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $Shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'slice', '_welcome', 'param'], [$io]);
+        $Parser->addSubCommand('slice');
+        $Shell->expects($this->once())
+            ->method('getOptionParser')
+            ->will($this->returnValue($Parser));
+        $Shell->expects($this->once())
+            ->method('slice')
+            ->with('cakes');
+        $Shell->expects($this->never())->method('_welcome');
+        $Shell->expects($this->once())->method('param')
+            ->with('requested')
+            ->will($this->returnValue(true));
+        $Shell->runCommand(['slice', 'cakes'], false, ['requested' => true]);
+    }
+
+    /**
      * Test that runCommand() doesn't call public methods when the second arg is false.
      *
      * @return void

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -643,6 +643,52 @@ class ShellTest extends TestCase
     }
 
     /**
+     * Test the dispatchShell() arguments parser
+     *
+     * @return void
+     */
+    public function testDispatchShellArgsParser()
+    {
+        $Shell = new Shell();
+
+        $expected = [['schema', 'create', 'DbAcl'], []];
+        // Shell::dispatchShell('schema create DbAcl');
+        $result = $Shell->parseDispatchArguments(['schema create DbAcl']);
+        $this->assertEquals($expected, $result);
+
+        // Shell::dispatchShell('schema', 'create', 'DbAcl');
+        $result = $Shell->parseDispatchArguments(['schema', 'create', 'DbAcl']);
+        $this->assertEquals($expected, $result);
+
+        // Shell::dispatchShell(['command' => 'schema create DbAcl']);
+        $result = $Shell->parseDispatchArguments([[
+            'command' => 'schema create DbAcl'
+        ]]);
+        $this->assertEquals($expected, $result);
+
+        // Shell::dispatchShell(['command' => ['schema', 'create', 'DbAcl']]);
+        $result = $Shell->parseDispatchArguments([[
+            'command' => ['schema', 'create', 'DbAcl']
+        ]]);
+        $this->assertEquals($expected, $result);
+
+        $expected[1] = ['param' => 'value'];
+        // Shell::dispatchShell(['command' => 'schema create DbAcl', 'extra' => ['param' => 'value']]);
+        $result = $Shell->parseDispatchArguments([[
+            'command' => 'schema create DbAcl',
+            'extra' => ['param' => 'value']
+        ]]);
+        $this->assertEquals($expected, $result);
+
+        // Shell::dispatchShell(['command' => ['schema', 'create', 'DbAcl'], 'extra' => ['param' => 'value']]);
+        $result = $Shell->parseDispatchArguments([[
+            'command' => ['schema', 'create', 'DbAcl'],
+            'extra' => ['param' => 'value']
+        ]]);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test that runCommand() doesn't call public methods when the second arg is false.
      *
      * @return void


### PR DESCRIPTION
Dispatching a Shell within another shell (with `Shell::dispatchShell()`) makes the welcome message called twice :

```
Welcome to CakePHP v3.0.0 Console
---------------------------------------------------------------
App : src
Path: /home/yves/PhpStormProjects/cakephp-app/src/
---------------------------------------------------------------

First Shell output
Need to dispatch another shell inside this one

Welcome to CakePHP v3.0.0 Console
---------------------------------------------------------------
App : src
Path: /home/yves/PhpStormProjects/cakephp-app/src/
---------------------------------------------------------------

Second shell output
```

This PR adds a new parameter called "requested" that will prevent the welcome message to be displayed.
By extension, this parameter could be used in userland to detect if the Shell was called with the dispatchMethod.
Additionally, any call to dispatchShell() will append this parameter to the list of parameters.

More details on #6272.
