### PR TITLE
WIP - Hash get with non string path

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -240,6 +240,25 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Test testGetNonStringPath()
+ *
+ * @return void
+ */
+	public function testGetNonStringPath() {
+		$result = Hash::get(array(1.1 => 'one.one'), 1.1);
+		$this->assertEquals('one.one', $result);
+
+		$result = Hash::get(array('1' => array('1' => 'one.one')), 1.1);
+		$this->assertNull($result);
+
+		$result = Hash::get(array(true => 'true'), true);
+		$this->assertEquals('true', $result);
+
+		$result = Hash::get(array('one' => 'two'), null, '-');
+		$this->assertEquals('-', $result);
+	}
+
+/**
  * Test dimensions.
  *
  * @return void

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -240,20 +240,11 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
- * Test testGetNonStringPath()
+ * Test testGetNullPath()
  *
  * @return void
  */
-	public function testGetNonStringPath() {
-		$result = Hash::get(array(1.1 => 'one.one'), 1.1);
-		$this->assertEquals('one.one', $result);
-
-		$result = Hash::get(array('1' => array('1' => 'one.one')), 1.1);
-		$this->assertNull($result);
-
-		$result = Hash::get(array(true => 'true'), true);
-		$this->assertEquals('true', $result);
-
+	public function testGetNullPath() {
 		$result = Hash::get(array('one' => 'two'), null, '-');
 		$this->assertEquals('-', $result);
 	}


### PR DESCRIPTION
Shouldn't Hash::get support other types for path?

Before 2.6 it did support null as path, now it throws a InvalidArgumentException for null value and booleans.
