### PR TITLE
Accomodate older versions of SQLite.

### DIFF
--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -207,12 +207,14 @@ class SqliteSchema extends BaseSchema
      */
     public function convertForeignKeyDescription(Table $table, $row)
     {
+        $update = isset($row['on_update']) ? $row['on_update'] : '';
+        $delete = isset($row['on_delete']) ? $row['on_delete'] : '';
         $data = [
             'type' => Table::CONSTRAINT_FOREIGN,
             'columns' => [$row['from']],
             'references' => [$row['table'], $row['to']],
-            'update' => $this->_convertOnClause($row['on_update']),
-            'delete' => $this->_convertOnClause($row['on_delete']),
+            'update' => $this->_convertOnClause($update),
+            'delete' => $this->_convertOnClause($delete),
         ];
         $name = $row['from'] . '_fk';
         $table->addConstraint($name, $data);


### PR DESCRIPTION
SQLite prior to 3.6 does not support reflecting foreign key update/delete properties. Conditionally parsing them is better than notice errors.

Refs #6230
