### PR TITLE
Fix errors when testing controllers that use file()

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -301,6 +301,18 @@ class ControllerTestCaseTest extends CakeTestCase {
 	}
 
 /**
+ * Test that file responses don't trigger errors.
+ *
+ * @return void
+ */
+	public function testActionWithFile() {
+		$Controller = $this->Case->generate('TestsApps');
+		$this->Case->testAction('/tests_apps/file');
+		$this->assertArrayHasKey('Content-Disposition', $Controller->response->header());
+		$this->assertArrayHasKey('Content-Length', $Controller->response->header());
+	}
+
+/**
  * Make sure testAction() can hit plugin controllers.
  *
  * @return void

--- a/lib/Cake/Test/test_app/Controller/TestsAppsController.php
+++ b/lib/Cake/Test/test_app/Controller/TestsAppsController.php
@@ -44,6 +44,10 @@ class TestsAppsController extends AppController {
 		$this->render('index');
 	}
 
+	public function file() {
+		$this->response->file(__FILE__);
+	}
+
 	public function redirect_to() {
 		return $this->redirect('http://cakephp.org');
 	}

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -271,7 +271,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 			$params['requested'] = 1;
 		}
 		$Dispatch->testController = $this->controller;
-		$Dispatch->response = $this->getMock('CakeResponse', array('send'));
+		$Dispatch->response = $this->getMock('CakeResponse', array('send', '_clearBuffer'));
 		$this->result = $Dispatch->dispatch($request, $Dispatch->response, $params);
 		$this->controller = $Dispatch->testController;
 		$this->vars = $this->controller->viewVars;


### PR DESCRIPTION
Fix errors related to ob_end_clean() closing PHPUnit's output buffer when testing controller methods that use response->file().
