### PR TITLE
Skip non-entity entries in BelongsToMany associations

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -804,6 +804,9 @@ class BelongsToMany extends Association
         $primary = (array)$target->primaryKey();
         $jointProperty = $this->_junctionProperty;
         foreach ($targetEntities as $k => $entity) {
+            if (!($entity instanceof EntityInterface)) {
+                continue;
+            }
             $key = array_values($entity->extract($primary));
             foreach ($present as $i => $data) {
                 if ($key === $data && !$entity->get($jointProperty)) {
@@ -873,6 +876,9 @@ class BelongsToMany extends Association
         $missing = [];
 
         foreach ($targetEntities as $entity) {
+            if (!($entity instanceof EntityInterface)) {
+                continue;
+            }
             $joint = $entity->get($jointProperty);
 
             if (!$joint || !($joint instanceof EntityInterface)) {

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -912,7 +912,7 @@ class BelongsToManyTest extends TestCase
      *
      * @return void
      */
-    public function testSaveAssociatedOnlyEntities()
+    public function testSaveAssociatedOnlyEntitiesAppend()
     {
         $connection = ConnectionManager::get('test');
         $mock = $this->getMock(

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3171,6 +3171,22 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test that belongsToMany ignores non-entity data.
+     *
+     * @return void
+     */
+    public function testSaveBelongsToManyIgnoreNonEntityData()
+    {
+        $articles = TableRegistry::get('Articles');
+        $article = $articles->get(1, ['contain' => ['Tags']]);
+        $article->tags = [
+            '_ids' => [2, 1]
+        ];
+        $result = $articles->save($article);
+        $this->assertSame($result, $article);
+    }
+
+    /**
      * Tests that saving a persisted and clean entity will is a no-op
      *
      * @group save


### PR DESCRIPTION
When saving entities with accessible belongs to many association properties that were not marshalled, fatal errors would be encountered. Skipping the obviously bad data is a resonable course of action as the ORM should not marshall it, as it was either explicitly or implicitly not marshalled.

Refs #6301
