### PR TITLE
Add __debugInfo() to Collection

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -48,4 +48,17 @@ class Collection extends IteratorIterator implements CollectionInterface
 
         parent::__construct($items);
     }
+
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'count' => iterator_count($this),
+        ];
+    }
 }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1163,4 +1163,46 @@ class CollectionTest extends TestCase
 
         $this->assertEquals([1, 2, 3, 1, 2, 3], $collection->toList());
     }
+
+    /**
+     * Tests __debugInfo() or debug() usage
+     *
+     * @return void
+     */
+    public function testDebug()
+    {
+        $items = [1, 2, 3];
+
+        $collection = new Collection($items);
+
+        $result = $collection->__debugInfo();
+        $expected = [
+            'count' => 3,
+        ];
+        $this->assertSame($expected, $result);
+
+        // Calling it again will rewind
+        $result = $collection->__debugInfo();
+        $expected = [
+            'count' => 3,
+        ];
+        $this->assertSame($expected, $result);
+
+        // Make sure it also works with non rewindable iterators
+        $iterator = new NoRewindIterator(new ArrayIterator($items));
+        $collection = new Collection($iterator);
+
+        $result = $collection->__debugInfo();
+        $expected = [
+            'count' => 3,
+        ];
+        $this->assertSame($expected, $result);
+
+        // Calling it again will in this case not rewind
+        $result = $collection->__debugInfo();
+        $expected = [
+            'count' => 0,
+        ];
+        $this->assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
When trying to migrate a 2.x app the last weekend I had the issue that I always had to `debug($collection->count())` to see if there was something in it, the output of debug($collection) itself was always just:

```
object(Cake\Collection\Collection) {
}
```

With the debug info method added, we at least get:

```
object(Cake\Collection\Collection) {
               'count' => (int) 2
}
```
