### PR TITLE
RFC Email Envelope

### DIFF
--- a/src/Network/Email/Envelope.php
+++ b/src/Network/Email/Envelope.php
@@ -1,0 +1,65 @@
+<?php
+namespace Cake\Network\Email;
+
+use ArrayAccess;
+
+class Envelope implements ArrayAccess
+{
+    protected $_email;
+
+    public function __construct(Email $email = null)
+    {
+        if ($email === null) {
+            $email = new Email();
+        }
+
+        $this->_email = $email;
+    }
+
+    public function __call($method, $args)
+    {
+        $this[$method] = $args;
+        return $this;
+    }
+
+    public function __invoke(Email $email = null)
+    {
+        return $this->send($email);
+    }
+
+    public function send($config = [])
+    {
+        return $this->_email
+            ->profile($this)
+            ->send();
+    }
+
+    public function offsetExists($offset)
+    {
+        return in_array($offset, get_object_vars($this)) ||
+            method_exists($this->_email, $offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        if (!$this->offsetExists($offset)) {
+            throw \Exception();
+        }
+
+        if (isset($this->{$offset})) {
+            return $this->{$offset};
+        }
+
+        return call_user_func([$this->_email, $offset]);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->{$offset} = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->{$offset});
+    }
+}


### PR DESCRIPTION
I was thinking of a good way to be able to make emails re-usable in an application (from shell, controller or model) and isolated/decoupled for easier testing. 

I came up with the following `Cake\Network\Email\Envelope` which could be used like so:

``` php
<?php
namespace App\Email;

use Cake\Event\Event;
use Cake\Event\EventListenerInterface;
use Cake\Network\Email\Envelope;

class WelcomeEnvelope extends Envelope implements EventListenerInterface
{

    public $subject = 'Welcome to %s';
    public $template = 'welcome';

    public function __construct(Email $email = null)
    {
        $this->subject = sprintf($this->subject, Configure::read('App.title'));
        parent::__construct($email);
    }

    public function implementedEvents()
    {
        return ['Model.afterSave' => 'triggeredOnSave'];
    }

    public function triggeredOnSave(Event $event, Entity $entity, array $options)
    {
        if ($entity->isNew()) {
            $this->to($entity->email)->send();
        }
    }
}
```

and then, from anywhere:

``` php
return (new \App\Email\WelcomeEnvelope())->to($recipient)->send();
```

or using an event for example in `App\Model\Table\UsersTable`:

``` php
public function initialize($config = [])
{
  $this->_eventManager->on(new \App\Email\WelcomeEnvelope());
}
```

I quickly showed this to @lorenzo  and @ADmad who seemed to like it thus far and hence me suggesting it here for everyone to comment and help improving it.

PS: Don't mind empty exceptions and their types, etc. For now, I just wanted to get the idea out.

PPS: I only realized now that I had targeted the master branch - will make necessary changes to target next milestone if there is interest.
