### PR TITLE
Add a test for the Shell::dispatchShell method

### DIFF
--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -23,6 +23,7 @@ use Cake\Filesystem\Folder;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use TestApp\Shell\TestingDispatchShell;
 
 /**
  * Class for testing merging vars
@@ -821,6 +822,32 @@ class ShellTest extends TestCase
 
         $shell->Slice = $task;
         $shell->runCommand(['slice', 'one']);
+    }
+
+    /**
+     * test calling a shell that dispatch another one
+     *
+     * @return void
+     */
+    public function testDispatchShell()
+    {
+        $this->skipIf(!touch(TEST_APP . 'shell.log'), 'Can\'t write shell test log file');
+        $Shell = new TestingDispatchShell();
+        $Shell->runCommand(['test_task'], true);
+
+        $result = file_get_contents(TEST_APP . 'shell.log');
+        $expected = <<<TEXT
+<info>Welcome to CakePHP v3.0.1 Console</info>
+I am a test task, I dispatch another Shell
+<info>Welcome to CakePHP v3.0.1 Console</info>
+I am a dispatched Shell
+
+TEXT;
+        $this->assertEquals($expected, $result);
+
+        //@codingStandardsIgnoreStart
+        @unlink(TEST_APP . 'shell.log');
+        //@codingStandardsIgnoreEnd
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -831,11 +831,11 @@ class ShellTest extends TestCase
      */
     public function testDispatchShell()
     {
-        $this->skipIf(!touch(TEST_APP . 'shell.log'), 'Can\'t write shell test log file');
         $Shell = new TestingDispatchShell();
+        ob_start();
         $Shell->runCommand(['test_task'], true);
+        $result = ob_get_clean();
 
-        $result = file_get_contents(TEST_APP . 'shell.log');
         $expected = <<<TEXT
 <info>Welcome to CakePHP v3.0.1 Console</info>
 I am a test task, I dispatch another Shell
@@ -844,10 +844,6 @@ I am a dispatched Shell
 
 TEXT;
         $this->assertEquals($expected, $result);
-
-        //@codingStandardsIgnoreStart
-        @unlink(TEST_APP . 'shell.log');
-        //@codingStandardsIgnoreEnd
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -837,9 +837,9 @@ class ShellTest extends TestCase
         $result = ob_get_clean();
 
         $expected = <<<TEXT
-<info>Welcome to CakePHP v3.0.1 Console</info>
+<info>Welcome to CakePHP Console</info>
 I am a test task, I dispatch another Shell
-<info>Welcome to CakePHP v3.0.1 Console</info>
+<info>Welcome to CakePHP Console</info>
 I am a dispatched Shell
 
 TEXT;

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -120,7 +120,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = "TestPlugin.example TestPlugin.sample " .
-            "TestPluginTwo.example TestPluginTwo.welcome i18n orm_cache plugin server sample\n";
+            "TestPluginTwo.example TestPluginTwo.welcome i18n orm_cache plugin server sample testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
 

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Testing Dispatch Shell Shell file
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Shell;
+
+use Cake\Console\Shell;
+use Cake\Core\Configure;
+
+/**
+ * Class for testing dispatchShell functionality
+ */
+class TestingDispatchShell extends Shell
+{
+
+    public $outPath = '';
+
+    protected function _welcome()
+    {
+        $this->out(sprintf('<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version()));
+    }
+
+    public function out($message = null, $newlines = 1, $level = Shell::NORMAL)
+    {
+        file_put_contents(TEST_APP . 'shell.log', $message . "\n", FILE_APPEND);
+    }
+
+    public function testTask()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell('testing_dispatch', 'dispatch_test_task');
+    }
+
+    public function dispatchTestTask()
+    {
+        $this->out('I am a dispatched Shell');
+    }
+}

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -25,8 +25,6 @@ use Cake\Core\Configure;
 class TestingDispatchShell extends Shell
 {
 
-    public $outPath = '';
-
     protected function _welcome()
     {
         $this->out(sprintf('<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version()));
@@ -34,7 +32,7 @@ class TestingDispatchShell extends Shell
 
     public function out($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
-        file_put_contents(TEST_APP . 'shell.log', $message . "\n", FILE_APPEND);
+        echo $message . "\n";
     }
 
     public function testTask()

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -27,7 +27,7 @@ class TestingDispatchShell extends Shell
 
     protected function _welcome()
     {
-        $this->out(sprintf('<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version()));
+        $this->out('<info>Welcome to CakePHP Console</info>');
     }
 
     public function out($message = null, $newlines = 1, $level = Shell::NORMAL)


### PR DESCRIPTION
As discussed in #6292, the method `Shell::dispatchShell()` currently does not have tests.
This PR aims to correct that.

I target master because I figured that the sooner the better.
If this is accepted, I'll wait for the next 3.0 -> 3.1 merge and rebase #6292 to add more tests since it modifies how `Shell::dispatchShell()` works.
