### PR TITLE
3.0 Prioritizing cascade delete to assoc. for which cascadeCallbacks is true

### DIFF
--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -14,11 +14,11 @@
  */
 namespace Cake\ORM;
 
+use Cake\Collection\Collection;
 use Cake\ORM\Association;
 use Cake\ORM\AssociationsNormalizerTrait;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
-use Cake\Collection\Collection;
 use InvalidArgumentException;
 
 /**

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -259,7 +259,14 @@ class AssociationCollection
     public function cascadeDelete(Entity $entity, array $options)
     {
         foreach ($this->_items as $assoc) {
-            $assoc->cascadeDelete($entity, $options);
+            if ($assoc->cascadeCallbacks()) {
+                $assoc->cascadeDelete($entity, $options);
+            }
+        }
+        foreach ($this->_items as $assoc) {
+            if (!$assoc->cascadeCallbacks()) {
+                $assoc->cascadeDelete($entity, $options);
+            }
         }
     }
 

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -18,6 +18,7 @@ use Cake\ORM\Association;
 use Cake\ORM\AssociationsNormalizerTrait;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Cake\Collection\Collection;
 use InvalidArgumentException;
 
 /**
@@ -251,6 +252,7 @@ class AssociationCollection
 
     /**
      * Cascade a delete across the various associations.
+     * Cascade first across associations for which cascadeCallbacks is true.
      *
      * @param \Cake\ORM\Entity $entity The entity to delete associations for.
      * @param array $options The options used in the delete operation.
@@ -258,15 +260,16 @@ class AssociationCollection
      */
     public function cascadeDelete(Entity $entity, array $options)
     {
-        foreach ($this->_items as $assoc) {
+        $assocs = new Collection($this->_items);
+        $assocs = $assocs->filter(function ($assoc) use ($entity, $options) {
             if ($assoc->cascadeCallbacks()) {
                 $assoc->cascadeDelete($entity, $options);
+                return false;
             }
-        }
-        foreach ($this->_items as $assoc) {
-            if (!$assoc->cascadeCallbacks()) {
-                $assoc->cascadeDelete($entity, $options);
-            }
+            return true;
+        })->toArray();
+        foreach ($assocs as $assoc) {
+            $assoc->cascadeDelete($entity, $options);
         }
     }
 

--- a/tests/Fixture/GroupsFixture.php
+++ b/tests/Fixture/GroupsFixture.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class GroupsFixture
+ *
+ */
+class GroupsFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'title' => ['type' => 'string'],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['title' => 'foo'],
+        ['title' => 'bar'],
+    ];
+}

--- a/tests/Fixture/GroupsMembersFixture.php
+++ b/tests/Fixture/GroupsMembersFixture.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class GroupsMembersFixture
+ *
+ */
+class GroupsMembersFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'group_id' => ['type' => 'integer'],
+        'member_id' => ['type' => 'integer'],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['group_id' => 1, 'member_id' => 1],
+        ['group_id' => 2, 'member_id' => 1],
+    ];
+}

--- a/tests/Fixture/MembersFixture.php
+++ b/tests/Fixture/MembersFixture.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class MembersFixture
+ *
+ */
+class MembersFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'group_count' => ['type' => 'integer'],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['group_count' => 2],
+    ];
+}

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -56,6 +56,9 @@ class TableTest extends TestCase
         'core.tags',
         'core.articles_tags',
         'core.site_articles',
+        'core.members',
+        'core.groups',
+        'core.groups_members',
     ];
 
     /**
@@ -2463,6 +2466,20 @@ class TableTest extends TestCase
         $junction = $table->association('tags')->junction();
         $query = $junction->find('all')->where(['article_id' => 1]);
         $this->assertNull($query->all()->first(), 'Should not find any rows.');
+    }
+
+    public function testDeleteAssociationsCascadingCallbacksOrder()
+    {
+        $Members = TableRegistry::get('Members');
+
+        $member = $Members->get(1);
+        $this->assertEquals(2, $member->group_count);
+
+        $group = $Members->Groups->get(1);
+        $Members->Groups->delete($group);
+
+        $member = $Members->get(1);
+        $this->assertEquals(1, $member->group_count);
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/GroupsMembersTable.php
+++ b/tests/test_app/TestApp/Model/Table/GroupsMembersTable.php
@@ -27,5 +27,4 @@ class GroupsMembersTable extends Table
 
         $this->addBehavior('CounterCache', ['Members' => ['group_count']]);
     }
-
 }

--- a/tests/test_app/TestApp/Model/Table/GroupsMembersTable.php
+++ b/tests/test_app/TestApp/Model/Table/GroupsMembersTable.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Article table class
+ *
+ */
+class GroupsMembersTable extends Table
+{
+
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Members');
+
+        $this->addBehavior('CounterCache', ['Members' => ['group_count']]);
+    }
+
+}

--- a/tests/test_app/TestApp/Model/Table/GroupsTable.php
+++ b/tests/test_app/TestApp/Model/Table/GroupsTable.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Article table class
+ *
+ */
+class GroupsTable extends Table
+{
+
+    public function initialize(array $config)
+    {
+        $this->belongsToMany('Members');
+
+        $this->hasMany('GroupsMembers', [
+            'dependent' => true,
+            'cascadeCallbacks' => true
+        ]);
+    }
+
+}

--- a/tests/test_app/TestApp/Model/Table/GroupsTable.php
+++ b/tests/test_app/TestApp/Model/Table/GroupsTable.php
@@ -30,5 +30,4 @@ class GroupsTable extends Table
             'cascadeCallbacks' => true
         ]);
     }
-
 }

--- a/tests/test_app/TestApp/Model/Table/MembersTable.php
+++ b/tests/test_app/TestApp/Model/Table/MembersTable.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * Article table class
+ *
+ */
+class MembersTable extends Table
+{
+
+    public function initialize(array $config)
+    {
+        $this->belongsToMany('Groups');
+    }
+
+}

--- a/tests/test_app/TestApp/Model/Table/MembersTable.php
+++ b/tests/test_app/TestApp/Model/Table/MembersTable.php
@@ -25,5 +25,4 @@ class MembersTable extends Table
     {
         $this->belongsToMany('Groups');
     }
-
 }


### PR DESCRIPTION
To fully understand this pull request, here is the bug i'm trying to fix:
## Setup

Let's say that:
- Users belongsToMany Groups through GroupMemberships
- GroupMemberships table contains a field named `leading` set to true or false whether its user is the leader of its group or not. 
- Users table contains a field named `leading_groups_count`. 

Tables are setup like this:

```
// GroupMemberships.php
$this->belongsTo('Users');
$this->addBehavior('CounterCache', ['Users' => [
    'leading_groups_count' => [
        'conditions' => [
            'leading' => true,
        ]
    ]
]);

// GroupsTable.php
$this->belongsToMany('Users', ['through' => 'GroupMemberships']));
$this->hasMany('GroupMemberships', [
    'dependent' => true,
    'cascadeCallbacks' => true
]);
```
## The problem

When a group is deleted, I'm expecting the related GroupMemberships rows to be deleted one by one (and not through deleteAll()) as I set cascadeCallbacks to true.
But it's not happening this way. GroupMemberships rows are being bulk deleted. As a result, the counterCache behavior is not called, and the `leading_groups_count` field in Users table is not updated.
## Solution proposed

I found that if I defined the HasMany association before the belongsToMany one in GroupsTable, the problem was solved. However, I don't like the fact that the app behavior depends on the order where associations are being defined (it doesn't look right).

So what I did was modifying AssociationCollection::cascadeDelete() to make sure that associations for which cascadeCallbacks is true are handled first.
