### PR TITLE
Fix missing SET NAMES in MySQL

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -62,6 +62,9 @@ class Mysql extends \Cake\Database\Driver
         if (!empty($config['timezone'])) {
             $config['init'][] = sprintf("SET time_zone = '%s'", $config['timezone']);
         }
+        if (!empty($config['encoding'])) {
+            $config['init'][] = sprintf("SET NAMES %s", $config['encoding']);
+        }
 
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -89,8 +89,9 @@ class Mysql extends \Cake\Database\Driver
         $this->_connect($dsn, $config);
 
         if (!empty($config['init'])) {
+            $connection = $this->connection();
             foreach ((array)$config['init'] as $command) {
-                $this->connection()->exec($command);
+                $connection->exec($command);
             }
         }
         return true;


### PR DESCRIPTION
Fix the missing SET NAMES call for the MySQL driver, and unskip the tests.

Refs #6332
