### PR TITLE
Don't assume that queries always contain fields

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -586,7 +586,9 @@ class ResultSet implements ResultSetInterface
         }
 
         $options['source'] = $this->_defaultTable->registryAlias();
-        $results = $results[$defaultAlias];
+        if (isset($results[$defaultAlias])) {
+            $results = $results[$defaultAlias];
+        }
         if ($this->_hydrate && !($results instanceof Entity)) {
             $results = new $this->_entityClass($results, $options);
         }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2041,6 +2041,26 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test finding fields on the non-default table that
+     * have the same name as the primary table.
+     *
+     * @return void
+     */
+    public function testContainSelectedFields()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsTo('Authors');
+
+        $query = $table->find()
+            ->contain(['Authors'])
+            ->order(['Authors.id' => 'asc'])
+            ->select(['Authors.id']);
+        $results = $query->extract('Authors.id')->toList();
+        $expected = [1, 1, 3];
+        $this->assertEquals($expected, $results);
+    }
+
+    /**
      * Tests that it is possible to attach more association when using a query
      * builder for other associations
      *


### PR DESCRIPTION
Not all queries will have fields from the original table. In the cases they do not, there shouldn't be any notice errors.

Refs #6326
