### PR TITLE
Fix for the request building in the integration test case

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -21,6 +21,7 @@ use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\Stub\Response;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * A test case class intended to make integration tests of
@@ -355,7 +356,7 @@ abstract class IntegrationTestCase extends TestCase
         }
         $env['REQUEST_METHOD'] = $method;
         $props['environment'] = $env;
-        $props += $this->_request;
+        $props = Hash::merge($props, $this->_request);
         return new Request($props);
     }
 

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -54,7 +54,11 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->configRequest([
             'headers' => ['X-CSRF-Token' => 'abc123'],
             'base' => '',
-            'webroot' => '/'
+            'webroot' => '/',
+            'environment' => [
+                'PHP_AUTH_USER' => 'foo',
+                'PHP_AUTH_PW' => 'bar'
+            ]
         ]);
         $this->cookie('split_token', 'def345');
         $this->session(['User' => ['id' => 1, 'username' => 'mark']]);
@@ -64,6 +68,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertEquals('tasks/add', $request->url);
         $this->assertEquals(['split_token' => 'def345'], $request->cookies);
         $this->assertEquals(['id' => '1', 'username' => 'mark'], $request->session()->read('User'));
+        $this->assertEquals('foo', $request->env('PHP_AUTH_USER'));
+        $this->assertEquals('bar', $request->env('PHP_AUTH_PW'));
     }
 
     /**


### PR DESCRIPTION
This fix uses Hash::merge instead of += to merge the properties of the mocked Request. This allows a developer to add environment variables for the mocked request. Allowing to test Basic Auth logic.

Related ticket: https://github.com/cakephp/cakephp/issues/6340#issuecomment-93645680
