### PR TITLE
Allow BC for nullish DB values as strings.

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -103,7 +103,7 @@ class DateTimeType extends Type
      */
     public function toPHP($value, Driver $driver)
     {
-        if ($value === null) {
+        if ($value === null || (int)$value === 0) {
             return null;
         }
 

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -65,6 +65,7 @@ class DateTimeTypeTest extends TestCase
     public function testToPHP()
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
+        $this->assertNull($this->type->toPHP('0000-00-00 00:00:00', $this->driver));
 
         $result = $this->type->toPHP('2001-01-04 12:13:14', $this->driver);
         $this->assertInstanceOf('Cake\I18n\Time', $result);

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -45,6 +45,7 @@ class DateTypeTest extends TestCase
     public function testToPHP()
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
+        $this->assertNull($this->type->toPHP('0000-00-00', $this->driver));
 
         $result = $this->type->toPHP('2001-01-04', $this->driver);
         $this->assertInstanceOf('DateTime', $result);


### PR DESCRIPTION
When working with legacy apps/DBs, there often is the (valid in MySQL) string value `0000-00-00 ...` used for NULL. That currently breaks terribly, as it is converted to a negative value in Carbon:

```
object(Cake\I18n\Time) {
    'time' => '-0001-11-30T00:00:00+0000',
    'timezone' => 'UTC',
    'fixedNowTime' => false
}
```

making "empty" comparisons difficult.

And then on top throws errors like

```
IntlDateFormatter::format(): datefmt_format: error calling ::getTimeStamp() on the object [CORE\src\I18n\Time.php, line 597]
```

This is an easy fix here for BC and doesn't hurt IMO.

PS: "MySQL permits you to store a “zero” value of '0000-00-00' as a “dummy date.” This is in some cases more convenient than using NULL values, and uses less data and index space" https://dev.mysql.com/doc/refman/5.0/en/date-and-time-types.html Even though people really should be using NULL here as default value :)
