### PR TITLE
Master fix marshal

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -140,7 +140,7 @@ class DateTimeType extends Type
                 $date = new $class($value);
                 $compare = true;
             }
-            if ($compare && $date && $date->format($this->_format) !== $value) {
+            if ($compare && $date && (string)$date !== $value) {
                 return $value;
             }
             if ($date) {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -129,7 +129,7 @@ class DateTimeType extends Type
 
         $class = static::$dateTimeClass;
         try {
-            $compare = $date = false;
+            $date = false;
             if ($value === '' || $value === null || $value === false || $value === true) {
                 return null;
             } elseif (is_numeric($value)) {
@@ -138,10 +138,6 @@ class DateTimeType extends Type
                 return $this->_parseValue($value);
             } elseif (is_string($value)) {
                 $date = new $class($value);
-                $compare = true;
-            }
-            if ($compare && $date && (string)$date !== $value) {
-                return $value;
             }
             if ($date) {
                 return $date;


### PR DESCRIPTION
The `$date->format($this->_format) !== $value` is flawed and breaks with Forms that use type=>text instead of dropdowns for date(time) fields.
On form generation the date gets transformed into a localized value (auto to string conversion) and upon save the check compares it to the _format value, which does not match, resulting in destroyed data.

This relaxes and fixes it. But it breaks other tests. Solutions?
I also first tried `(string)$date !== $value` which would make more sense than the current check as it is the equivalent of the view conversion.
