### PR TITLE
Call $widget->render() before $widget->secureFields()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2518,6 +2518,12 @@ class FormHelper extends Helper
     public function widget($name, array $data = [])
     {
         $widget = $this->_registry->get($name);
+        
+        $widgetData = $data;
+        unset($widgetData['secure']);
+        
+        $return = $widget->render($data, $this->context());
+        
         if (isset($data['secure'], $data['name']) &&
             $data['secure'] !== self::SECURE_SKIP
         ) {
@@ -2525,9 +2531,8 @@ class FormHelper extends Helper
                 $this->_secure($data['secure'], $this->_secureFieldName($field));
             }
         }
-        unset($data['secure']);
 
-        return $widget->render($data, $this->context());
+        return $return;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2522,7 +2522,7 @@ class FormHelper extends Helper
         $widgetData = $data;
         unset($widgetData['secure']);
         
-        $return = $widget->render($data, $this->context());
+        $return = $widget->render($widgetData, $this->context());
         
         if (isset($data['secure'], $data['name']) &&
             $data['secure'] !== self::SECURE_SKIP

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -57,6 +57,13 @@ class DateTimeWidget implements WidgetInterface
      * @var \Cake\View\StringTemplate
      */
     protected $_templates;
+    
+    /**
+     * The list of inputs this widget has generated
+     * 
+     * @var array
+     */
+    protected $_secureFields = [];
 
     /**
      * Constructor
@@ -309,6 +316,7 @@ class DateTimeWidget implements WidgetInterface
             $options['options'] = array_reverse($options['options'], true);
         }
         unset($options['start'], $options['end'], $options['order']);
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -340,6 +348,7 @@ class DateTimeWidget implements WidgetInterface
         }
 
         unset($options['leadingZeroKey'], $options['leadingZeroValue'], $options['names']);
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -361,6 +370,7 @@ class DateTimeWidget implements WidgetInterface
         $options['options'] = $this->_generateNumbers(1, 31, $options);
 
         unset($options['names'], $options['leadingZeroKey'], $options['leadingZeroValue']);
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -413,6 +423,7 @@ class DateTimeWidget implements WidgetInterface
             $options['format'], $options['leadingZeroKey'],
             $options['leadingZeroValue']
         );
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -444,6 +455,7 @@ class DateTimeWidget implements WidgetInterface
             $options['interval'],
             $options['round']
         );
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -465,6 +477,7 @@ class DateTimeWidget implements WidgetInterface
         ];
 
         unset($options['leadingZeroKey'], $options['leadingZeroValue']);
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -482,6 +495,7 @@ class DateTimeWidget implements WidgetInterface
             'val' => null,
             'options' => ['am' => 'am', 'pm' => 'pm']
         ];
+        $this->_secureFields[] = $options['name'];
         return $this->_select->render($options, $context);
     }
 
@@ -569,16 +583,6 @@ class DateTimeWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        $fields = [];
-        $hourFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
-        foreach ($this->_selects as $type) {
-            if ($type === 'meridian' && ($hourFormat === null || $hourFormat === 24)) {
-                continue;
-            }
-            if (!isset($data[$type]) || $data[$type] !== false) {
-                $fields[] = $data['name'] . '[' . $type . ']';
-            }
-        }
-        return $fields;
+        return $this->_secureFields;
     }
 }

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -143,6 +143,8 @@ class DateTimeWidget implements WidgetInterface
             'second' => [],
             'meridian' => null,
         ];
+        
+        $this->_secureFields = [];
 
         $selected = $this->_deconstructDate($data['val'], $data);
 


### PR DESCRIPTION
Recently i made a widget wich outputs many input fields.

having secureFields() called after render() has simplified my code, i don't have to generate the same input list 2 times

sorry for bad english
