### PR TITLE
Make content type header available in integration tests

### DIFF
--- a/src/TestSuite/Stub/Response.php
+++ b/src/TestSuite/Stub/Response.php
@@ -28,5 +28,9 @@ class Response extends Base
      */
     public function send()
     {
+        if (isset($this->_headers['Location']) && $this->_status === 200) {
+            $this->statusCode(302);
+        }
+        $this->_setContentType();
     }
 }

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -283,6 +283,19 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test that type() in an action sets the content-type header.
+     *
+     * @return void
+     */
+    public function testContentTypeInAction()
+    {
+        $this->get('/tests_apps/set_type');
+        $this->assertHeader('Content-Type', 'application/json; charset=UTF-8');
+        $this->assertContentType('json');
+        $this->assertContentType('application/json');
+    }
+
+    /**
      * Test the content assertion.
      *
      * @return void

--- a/tests/test_app/TestApp/Controller/TestsAppsController.php
+++ b/tests/test_app/TestApp/Controller/TestsAppsController.php
@@ -55,4 +55,10 @@ class TestsAppsController extends AppController
     {
         return $this->redirect('http://cakephp.org', 301);
     }
+
+    public function set_type()
+    {
+        $this->response->type('json');
+        return $this->response;
+    }
 }


### PR DESCRIPTION
Make the content-type header correct in IntegrationTestCase methods. While this is a tiny bit of duplicate code it is less invasive than other solutions I had come up with.

Refs #6340
