### PR TITLE
Fix integer/float fields causing blackhole requests.

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -310,6 +310,8 @@ class SecurityComponent extends Component
             if (preg_match('/(\.\d){1,10}$/', $key)) {
                 $multi[$i] = preg_replace('/(\.\d+){1,10}$/', '', $key);
                 unset($fieldList[$i]);
+            } else {
+                $fieldList[$i] = (string)$key;
             }
         }
         if (!empty($multi)) {

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -503,6 +503,26 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * Tests validation of integer field names.
+     *
+     * @return void
+     */
+    public function testValidateIntFieldName()
+    {
+        $event = new Event('Controller.startup', $this->Controller);
+        $this->Controller->Security->startup($event);
+
+        $fields = '4a221010dd7a23f7166cb10c38bc21d81341c387%3A';
+        $unlocked = '';
+
+        $this->Controller->request->data = [
+            1 => 'value,',
+            '_Token' => compact('fields', 'unlocked')
+        ];
+        $this->assertTrue($this->Controller->Security->validatePost($this->Controller));
+    }
+
+    /**
      * testValidatePostNoModel method
      *
      * @return void


### PR DESCRIPTION
Cast integer/float field names to match the stringy values used in FormHelper.

Refs #6343
