### PR TITLE
Avoid warnings in extract shell when extracting core messages

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -431,7 +431,7 @@ class ExtractTask extends Shell
                         $details['msgctxt'] = $context;
                     }
                     $this->_addTranslation($domain, $singular, $details);
-                } else {
+                } else if (strpos($this->_file, CAKE_CORE_INCLUDE_PATH) === false) {
                     $this->_markerError($this->_file, $line, $functionName, $count);
                 }
             }

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -431,7 +431,7 @@ class ExtractTask extends Shell
                         $details['msgctxt'] = $context;
                     }
                     $this->_addTranslation($domain, $singular, $details);
-                } else if (strpos($this->_file, CAKE_CORE_INCLUDE_PATH) === false) {
+                } elseif (strpos($this->_file, CAKE_CORE_INCLUDE_PATH) === false) {
                     $this->_markerError($this->_file, $line, $functionName, $count);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/6345
