### PR TITLE
[Network][Http] Migration from 2.x to 3.x

### DIFF
--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -66,6 +66,7 @@ class Stream
     {
         $this->_stream = null;
         $this->_context = [];
+        $this->_contextOptions = [];
         $this->_connectionErrors = [];
 
         $this->_buildContext($request, $options);

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -255,6 +255,36 @@ class Client
     }
 
     /**
+     * Do an OPTIONS request.
+     *
+     * @param string $url The url or path you want to request.
+     * @param mixed $data The request data you want to send.
+     * @param array $options Additional options for the request.
+     * @return \Cake\Network\Http\Response
+     */
+    public function options($url, $data = [], array $options = [])
+    {
+        $options = $this->_mergeOptions($options);
+        $url = $this->buildUrl($url, [], $options);
+        return $this->_doRequest(Request::METHOD_OPTIONS, $url, $data, $options);
+    }
+
+    /**
+     * Do a TRACE request.
+     *
+     * @param string $url The url or path you want to request.
+     * @param mixed $data The request data you want to send.
+     * @param array $options Additional options for the request.
+     * @return \Cake\Network\Http\Response
+     */
+    public function trace($url, $data = [], array $options = [])
+    {
+        $options = $this->_mergeOptions($options);
+        $url = $this->buildUrl($url, [], $options);
+        return $this->_doRequest(Request::METHOD_TRACE, $url, $data, $options);
+    }
+
+    /**
      * Do a DELETE request.
      *
      * @param string $url The url or path you want to request.

--- a/src/Network/Http/Message.php
+++ b/src/Network/Http/Message.php
@@ -107,6 +107,20 @@ class Message
     const METHOD_PATCH = 'PATCH';
 
     /**
+     * HTTP OPTIONS method
+     *
+     * @var string
+     */
+    const METHOD_OPTIONS = 'OPTIONS';
+
+    /**
+     * HTTP TRACE method
+     *
+     * @var string
+     */
+    const METHOD_TRACE = 'TRACE';
+
+    /**
      * HTTP HEAD method
      *
      * @var string

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -173,4 +173,21 @@ class Request extends Message
         }
         return $this;
     }
+
+    /**
+     * Get/Set http version.
+     *
+     * @param string|null $version The http version.
+     *
+     * @return $this|string Either $this or the http version.
+     */
+    public function version($version = null)
+    {
+        if ($version === null) {
+            return parent::version();
+        }
+
+        $this->_version = $version;
+        return $this;
+    }
 }

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -319,6 +319,8 @@ class ClientTest extends TestCase
             [Request::METHOD_PUT],
             [Request::METHOD_DELETE],
             [Request::METHOD_PATCH],
+            [Request::METHOD_OPTIONS],
+            [Request::METHOD_TRACE],
         ];
     }
     /**

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -119,4 +119,18 @@ class RequestTest extends TestCase
         $result = $request->cookie('session');
         $this->assertEquals('123456', $result);
     }
+
+    /**
+     * test version method.
+     *
+     * @return void
+     */
+    public function testVersion()
+    {
+        $request = new Request();
+        $result = $request->version('1.0');
+        $this->assertSame($request, $request, 'Should return self');
+
+        $this->assertSame('1.0', $request->version());
+    }
 }


### PR DESCRIPTION
Hey!

i'm currently migrating my library (egeloen/ivory-http-adapter#103) from CakePHP 2.x to 3.x, I discover some missing features and one bug.
- My first commit adds support for OPTIONS/TRACE verb. 
- The second commit allows to set an http version on the request (I have checked and the stream uses the one comming from the request, so, IMO we should be able to set it).
- The third commit fixes an issue about the stream adapter. Given you reuse the same adapter for multiple requests, the context options were not resetted and so, it results some strange behavior when for example, you firstly send a request with data and then, send an other request without data. Before this fix, the context still wrap the previous one.
