### PR TITLE
Fetch widget's secure fields after rendering widget.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2519,17 +2519,22 @@ class FormHelper extends Helper
      */
     public function widget($name, array $data = [])
     {
+        $secure = null;
+        if (isset($data['secure'])) {
+            $secure = $data['secure'];
+            unset($data['secure']);
+        }
+
         $widget = $this->_registry->get($name);
-        if (isset($data['secure'], $data['name']) &&
-            $data['secure'] !== self::SECURE_SKIP
-        ) {
+        $out = $widget->render($data, $this->context());
+
+        if (isset($data['name']) && $secure !== null && $secure !== self::SECURE_SKIP) {
             foreach ($widget->secureFields($data) as $field) {
-                $this->_secure($data['secure'], $this->_secureFieldName($field));
+                $this->_secure($secure, $this->_secureFieldName($field));
             }
         }
-        unset($data['secure']);
 
-        return $widget->render($data, $this->context());
+        return $out;
     }
 
     /**

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -59,6 +59,13 @@ class DateTimeWidget implements WidgetInterface
     protected $_templates;
 
     /**
+     * List of fields to be secured populated after call to render().
+     *
+     * @var array
+     */
+    protected $_secureFields = [];
+
+    /**
      * Constructor
      *
      * @param \Cake\View\StringTemplate $templates Templates list.
@@ -136,6 +143,7 @@ class DateTimeWidget implements WidgetInterface
             'second' => [],
             'meridian' => null,
         ];
+        $this->_secureFields = [];
 
         $selected = $this->_deconstructDate($data['val'], $data);
 
@@ -171,6 +179,7 @@ class DateTimeWidget implements WidgetInterface
                 $data[$select]['disabled'] = $data['disabled'];
             }
             $templateOptions[$select] = $this->{$method}($data[$select], $context);
+            $this->_secureFields[] = $data['name'] . '[' . $select . ']';
             unset($data[$select]);
         }
         unset($data['name'], $data['empty'], $data['disabled'], $data['val']);
@@ -569,16 +578,6 @@ class DateTimeWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
-        $fields = [];
-        $hourFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
-        foreach ($this->_selects as $type) {
-            if ($type === 'meridian' && ($hourFormat === null || $hourFormat === 24)) {
-                continue;
-            }
-            if (!isset($data[$type]) || $data[$type] !== false) {
-                $fields[] = $data['name'] . '[' . $type . ']';
-            }
-        }
-        return $fields;
+        return $this->_secureFields;
     }
 }

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -1047,6 +1047,7 @@ class DateTimeWidgetTest extends TestCase
         $data = [
             'name' => 'date',
         ];
+        $this->DateTime->render($data, $this->context);
         $result = $this->DateTime->secureFields($data);
         $expected = [
             'date[year]', 'date[month]', 'date[day]',
@@ -1058,6 +1059,7 @@ class DateTimeWidgetTest extends TestCase
             'name' => 'date',
             'hour' => ['format' => 24]
         ];
+        $this->DateTime->render($data, $this->context);
         $result = $this->DateTime->secureFields($data);
         $this->assertEquals($expected, $result, 'No meridian on 24hr input');
 
@@ -1073,6 +1075,7 @@ class DateTimeWidgetTest extends TestCase
             'minute' => false,
             'second' => false,
         ];
+        $this->DateTime->render($data, $this->context);
         $result = $this->DateTime->secureFields($data);
         $expected = [
             'date[hour]', 'date[meridian]'


### PR DESCRIPTION
I believe this is what @efanzini was trying to achieve in #6353.

This simplies things for widgets which contain multiple inputs and
the inputs that will get rendered depends on data. It avoids having
to scan the data twice, once for rendering and once of deciding
secure fields.

This change though makes the `$data` param of `secureFields()` redundant.
Should we update all widgets in similar way and drop the `$data` param in 3.1?
