### PR TITLE
Widgets securefields 2

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2519,17 +2519,19 @@ class FormHelper extends Helper
      */
     public function widget($name, array $data = [])
     {
+        $secure = null;
+        if (isset($data['secure'])) {
+            $secure = $data['secure'];
+            unset($data['secure']);
+        }
         $widget = $this->_registry->get($name);
-        if (isset($data['secure'], $data['name']) &&
-            $data['secure'] !== self::SECURE_SKIP
-        ) {
+        $out = $widget->render($data, $this->context());
+        if (isset($data['name']) && $secure !== null && $secure !== self::SECURE_SKIP) {
             foreach ($widget->secureFields($data) as $field) {
-                $this->_secure($data['secure'], $this->_secureFieldName($field));
+                $this->_secure($secure, $this->_secureFieldName($field));
             }
         }
-        unset($data['secure']);
-
-        return $widget->render($data, $this->context());
+        return $out;
     }
 
     /**

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -159,10 +159,10 @@ class DateTimeWidget implements WidgetInterface
     }
 
     /**
-     * Normalize data
+     * Normalize data.
      *
-     * @param $data Data to normalize.
-     * @return array
+     * @param array $data Data to normalize.
+     * @return array Normalized data.
      */
     protected function _normalizeData($data)
     {

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -123,29 +123,9 @@ class DateTimeWidget implements WidgetInterface
      */
     public function render(array $data, ContextInterface $context)
     {
-        $data += [
-            'name' => '',
-            'empty' => false,
-            'disabled' => null,
-            'val' => null,
-            'year' => [],
-            'month' => [],
-            'day' => [],
-            'hour' => [],
-            'minute' => [],
-            'second' => [],
-            'meridian' => null,
-        ];
+        $data = $this->_normalizeData($data);
 
         $selected = $this->_deconstructDate($data['val'], $data);
-
-        $timeFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
-        if ($timeFormat === 12 && !isset($data['meridian'])) {
-            $data['meridian'] = [];
-        }
-        if ($timeFormat === 24) {
-            $data['meridian'] = false;
-        }
 
         $templateOptions = [];
         foreach ($this->_selects as $select) {
@@ -176,6 +156,39 @@ class DateTimeWidget implements WidgetInterface
         unset($data['name'], $data['empty'], $data['disabled'], $data['val']);
         $templateOptions['attrs'] = $this->_templates->formatAttributes($data);
         return $this->_templates->format('dateWidget', $templateOptions);
+    }
+
+    /**
+     * Normalize data
+     *
+     * @param $data Data to normalize.
+     * @return array
+     */
+    protected function _normalizeData($data)
+    {
+        $data += [
+            'name' => '',
+            'empty' => false,
+            'disabled' => null,
+            'val' => null,
+            'year' => [],
+            'month' => [],
+            'day' => [],
+            'hour' => [],
+            'minute' => [],
+            'second' => [],
+            'meridian' => null,
+        ];
+
+        $timeFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
+        if ($timeFormat === 12 && !isset($data['meridian'])) {
+            $data['meridian'] = [];
+        }
+        if ($timeFormat === 24) {
+            $data['meridian'] = false;
+        }
+
+        return $data;
     }
 
     /**
@@ -569,15 +582,15 @@ class DateTimeWidget implements WidgetInterface
      */
     public function secureFields(array $data)
     {
+        $data = $this->_normalizeData($data);
+
         $fields = [];
-        $hourFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
-        foreach ($this->_selects as $type) {
-            if ($type === 'meridian' && ($hourFormat === null || $hourFormat === 24)) {
+        foreach ($this->_selects as $select) {
+            if ($data[$select] === false || $data[$select] === null) {
                 continue;
             }
-            if (!isset($data[$type]) || $data[$type] !== false) {
-                $fields[] = $data['name'] . '[' . $type . ']';
-            }
+
+            $fields[] = $data['name'] . '[' . $select . ']';
         }
         return $fields;
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -263,6 +263,35 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Test that secureFields() of widget is called after calling render(),
+     * not before.
+     *
+     * @return void
+     */
+    public function testOrderForRenderingWidgetAndFetchingSecureFields()
+    {
+        $data = [
+            'val' => 1,
+            'name' => 'test'
+        ];
+        $mock = $this->getMock('Cake\View\Widget\WidgetInterface');
+        $this->assertNull($this->Form->addWidget('test', $mock));
+
+        $mock->expects($this->at(0))
+            ->method('render')
+            ->with($data)
+            ->will($this->returnValue('HTML'));
+
+        $mock->expects($this->at(1))
+            ->method('secureFields')
+            ->with($data)
+            ->will($this->returnValue(['test']));
+
+        $result = $this->Form->widget('test', $data + ['secure' => true]);
+        $this->assertEquals('HTML', $result);
+    }
+
+    /**
      * Test that empty string is not added to secure fields list when
      * rendering input widget without name.
      *


### PR DESCRIPTION
Alternate to #6371 as per [comment](https://github.com/cakephp/cakephp/pull/6371#issuecomment-94371095).

The order of calls to render() and secureFields() is swapped to allow flexibility to devs to populate secure fields list based on rendering process.

DateTimeWidget::render() and DateTimeWidget::secureFields() stay independent. I just pulled the normalization code into a separate method.

Refs  #6353.
