### PR TITLE
Don't let the actual status code bleed through.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -300,6 +300,7 @@ class RequestHandlerComponent extends Component
                 'REQUEST_METHOD' => 'GET'
             ]
         ]));
+        $response->statusCode(200);
         $response->send();
         $response->stop();
     }

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -31,7 +31,7 @@ use Cake\Utility\Xml;
  * Request object for handling alternative HTTP requests
  *
  * Alternative HTTP requests can come from wireless units like mobile phones, palmtop computers,
- * and the like. These units have no use for Ajax requests, and this Component can tell how Cake
+ * and the like. These units have no use for AJAX requests, and this Component can tell how Cake
  * should respond to the different needs of a handheld computer and a desktop machine.
  *
  * @link http://book.cakephp.org/3.0/en/controllers/components/request-handling.html
@@ -142,7 +142,7 @@ class RequestHandlerComponent extends Component
      * Checks to see if a specific content type has been requested and sets RequestHandler::$ext
      * accordingly. Checks the following in order: 1. The '_ext' value parsed by the Router. 2. A specific
      * AJAX type request indicated by the presence of a header. 3. The Accept header. With the exception
-     * of an ajax request indicated using the second header based method above, the type must have
+     * of an AJAX request indicated using the second header based method above, the type must have
      * been configured in {@link Cake\Routing\Router}.
      *
      * @param array $config The config data.
@@ -273,12 +273,12 @@ class RequestHandlerComponent extends Component
     }
 
     /**
-     * Handles (fakes) redirects for Ajax requests using requestAction()
+     * Handles (fakes) redirects for AJAX requests using requestAction()
      *
      * @param Event $event The Controller.beforeRedirect event.
      * @param string|array $url A string or array containing the redirect location
      * @param \Cake\Network\Response $response The response object.
-     * @return void
+     * @return void|\Cake\Network\Response The response object if the redirect is caught.
      */
     public function beforeRedirect(Event $event, $url, Response $response)
     {
@@ -301,8 +301,7 @@ class RequestHandlerComponent extends Component
             ]
         ]));
         $response->statusCode(200);
-        $response->send();
-        $response->stop();
+        return $response;
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -834,10 +834,10 @@ class RequestHandlerComponentTest extends TestCase
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $this->Controller->response->statusCode(302);
         $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
         $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
         $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->response->statusCode(302);
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -810,16 +810,13 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
-        $this->Controller->response->expects($this->once())->method('stop');
 
-        ob_start();
-        $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->Controller->RequestHandler->beforeRedirect(
             $event,
-            ['controller' => 'request_handler_test', 'action' => 'destination'],
+            ['controller' => 'RequestHandlerTest', 'action' => 'destination'],
             $this->Controller->response
         );
-        $result = ob_get_clean();
-        $this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
+        $this->assertRegExp('/posts index/', $response->body(), 'RequestAction redirect failed.');
     }
 
     /**
@@ -841,17 +838,14 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
-        $this->Controller->response->expects($this->once())->method('stop');
 
-        ob_start();
-        $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->Controller->RequestHandler->beforeRedirect(
             $event,
-            ['controller' => 'request_handler_test', 'action' => 'destination'],
+            ['controller' => 'RequestHandlerTest', 'action' => 'destination'],
             $this->Controller->response
         );
-        $result = ob_get_clean();
-        $this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
-        $this->assertSame(200, $this->Controller->response->statusCode());
+        $this->assertRegExp('/posts index/', $response->body(), 'RequestAction redirect failed.');
+        $this->assertSame(200, $response->statusCode());
     }
 
     /**
@@ -873,17 +867,14 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
-        $this->Controller->response->expects($this->once())->method('stop');
 
-        ob_start();
-        $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->Controller->RequestHandler->beforeRedirect(
             $event,
-            ['controller' => 'request_handler_test', 'action' => 'ajax2_layout'],
+            ['controller' => 'RequestHandlerTest', 'action' => 'ajax2_layout'],
             $this->Controller->response
         );
-        $result = ob_get_clean();
-        $this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
-        $this->assertRegExp('/Ajax!/', $result, 'Layout was not rendered.');
+        $this->assertRegExp('/posts index/', $response->body(), 'RequestAction redirect failed.');
+        $this->assertRegExp('/Ajax!/', $response->body(), 'Layout was not rendered.');
     }
 
     /**
@@ -912,9 +903,9 @@ class RequestHandlerComponentTest extends TestCase
         $RequestHandler->response = $this->Controller->response;
 
         ob_start();
-        $RequestHandler->beforeRedirect(
+        $response = $RequestHandler->beforeRedirect(
             $event,
-            ['controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second'],
+            ['controller' => 'RequestHandlerTest', 'action' => 'param_method', 'first', 'second'],
             $this->Controller->response
         );
         $result = ob_get_clean();

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -903,7 +903,7 @@ class RequestHandlerComponentTest extends TestCase
         $RequestHandler->response = $this->Controller->response;
 
         ob_start();
-        $response = $RequestHandler->beforeRedirect(
+        $RequestHandler->beforeRedirect(
             $event,
             ['controller' => 'RequestHandlerTest', 'action' => 'param_method', 'first', 'second'],
             $this->Controller->response


### PR DESCRIPTION
Code with jQuery success() as http://sandbox3.dereuromark.de/sandbox/ajax-examples/redirecting used to work.
The changes in the beforeRedirect() AJAX catching broke that as the status code bleed-through makes jQuery not workable anymore. It jumps to error() callback instead - and the response data is not accessible anymore.
