### PR TITLE
Making Collection an IteratorAggregate

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -30,6 +30,11 @@ class Collection implements IteratorAggregate, CollectionInterface
 
     use CollectionTrait;
 
+    /**
+     * Holds the reference to the wrapped iterator
+     *
+     * @var \Iterator
+     */
     protected $_innerIterator;
 
     /**
@@ -52,6 +57,11 @@ class Collection implements IteratorAggregate, CollectionInterface
         $this->_innerIterator = $items;
     }
 
+    /**
+     * Returns the iterator wrapped by this class
+     *
+     * @return \Iterator
+     */
     public function getIterator()
     {
         $iterator = $this->_innerIterator;

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -18,16 +18,19 @@ use ArrayIterator;
 use Cake\Collection\CollectionInterface;
 use Cake\Collection\CollectionTrait;
 use InvalidArgumentException;
+use IteratorAggregate;
 use IteratorIterator;
 
 /**
  * A collection is an immutable list of elements with a handful of functions to
  * iterate, group, transform and extract information from it.
  */
-class Collection extends IteratorIterator implements CollectionInterface
+class Collection implements IteratorAggregate, CollectionInterface
 {
 
     use CollectionTrait;
+
+    protected $_innerIterator;
 
     /**
      * Constructor. You can provide an array or any traversable object
@@ -46,7 +49,16 @@ class Collection extends IteratorIterator implements CollectionInterface
             throw new InvalidArgumentException($msg);
         }
 
-        parent::__construct($items);
+        $this->_innerIterator = $items;
+    }
+
+    public function getIterator()
+    {
+        $iterator = $this->_innerIterator;
+        while ($iterator instanceof IteratorAggregate) {
+            $iterator = $iterator->getIterator();
+        }
+        return $iterator;
     }
 
     /**

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Collection;
 
-use Iterator;
 use JsonSerializable;
+use Traversable;
 
 /**
  * Describes the methods a Collection should implement. A collection is an immutable
@@ -23,7 +23,7 @@ use JsonSerializable;
  * generating other collections.
  *
  */
-interface CollectionInterface extends Iterator, JsonSerializable
+interface CollectionInterface extends JsonSerializable, Traversable
 {
 
     /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -29,6 +29,8 @@ use Cake\Collection\Iterator\StoppableIterator;
 use Cake\Collection\Iterator\TreeIterator;
 use Cake\Collection\Iterator\UnfoldIterator;
 use Iterator;
+use IteratorAggregate;
+use IteratorIterator;
 use LimitIterator;
 use RecursiveIteratorIterator;
 
@@ -269,7 +271,11 @@ trait CollectionTrait
      */
     public function sample($size = 10)
     {
-        return new Collection(new LimitIterator($this->shuffle(), 0, $size));
+        return new Collection(new LimitIterator(
+            $this->shuffle()->getIterator(),
+            0,
+            $size
+        ));
     }
 
     /**
@@ -316,10 +322,12 @@ trait CollectionTrait
      */
     public function append($items)
     {
-        $items = $items instanceof Iterator ? $items : new Collection($items);
+        $items = $items instanceof Iterator ?
+            $items :
+            (new Collection($items))->getIterator();
         $list = new AppendIterator;
-        $list->append($this);
-        $list->append($items->_unwrap());
+        $list->append($this->_unwrap());
+        $list->append($items);
         return new Collection($list);
     }
 
@@ -540,8 +548,8 @@ trait CollectionTrait
     protected function _unwrap()
     {
         $iterator = $this;
-        while (get_class($iterator) === 'Cake\Collection\Collection') {
-            $iterator = $iterator->getInnerIterator();
+        while ($iterator instanceof IteratorAggregate) {
+            $iterator = $iterator->getIterator();
         }
         return $iterator;
     }

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -15,6 +15,9 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 use Countable;
 use SplDoublyLinkedList;
 
@@ -22,8 +25,10 @@ use SplDoublyLinkedList;
  * Creates an iterator from another iterator that will keep the results of the inner
  * iterator in memory, so that results don't have to be re-calculated.
  */
-class BufferedIterator extends Collection implements Countable
+class BufferedIterator extends IteratorIterator implements CollectionInterface, Countable
 {
+
+    use CollectionTrait;
 
     /**
      * The in-memory cache containing results from previous iterators
@@ -77,7 +82,7 @@ class BufferedIterator extends Collection implements Countable
     public function __construct($items)
     {
         $this->_buffer = new SplDoublyLinkedList;
-        parent::__construct($items);
+        parent::__construct(new Collection($items));
     }
 
     /**

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -17,8 +17,8 @@ namespace Cake\Collection\Iterator;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Collection\CollectionTrait;
-use IteratorIterator;
 use Countable;
+use IteratorIterator;
 use SplDoublyLinkedList;
 
 /**

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -15,13 +15,18 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 
 /**
  * Creates an iterator from another iterator that extract the requested column
  * or property based on a path
  */
-class ExtractIterator extends Collection
+class ExtractIterator extends IteratorIterator implements CollectionInterface
 {
+
+    use CollectionTrait;
 
     /**
      * A callable responsible for extracting a single value for each
@@ -54,7 +59,7 @@ class ExtractIterator extends Collection
     public function __construct($items, $path)
     {
         $this->_extractor = $this->_propertyExtractor($path);
-        parent::__construct($items);
+        parent::__construct(new Collection($items));
     }
 
     /**

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -27,6 +27,11 @@ use IteratorIterator;
 class FilterIterator extends Collection
 {
 
+    /**
+     * The callback function to use for filtering.
+     *
+     * @var callable
+     */
     protected $_callback;
 
     /**
@@ -46,6 +51,11 @@ class FilterIterator extends Collection
         parent::__construct($items);
     }
 
+    /**
+     * Returns the iterator wrapped by this class
+     *
+     * @return \Iterator
+     */
     public function getIterator()
     {
         $it = parent::getIterator();

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -17,6 +17,7 @@ namespace Cake\Collection\Iterator;
 use Cake\Collection\Collection;
 use CallbackFilterIterator;
 use Iterator;
+use IteratorIterator;
 
 /**
  * Creates a filtered iterator from another iterator. The filtering is done by
@@ -25,6 +26,8 @@ use Iterator;
  */
 class FilterIterator extends Collection
 {
+
+    protected $_callback;
 
     /**
      * Creates a filtered iterator using the callback to determine which items are
@@ -37,9 +40,18 @@ class FilterIterator extends Collection
      * @param Iterator $items The items to be filtered.
      * @param callable $callback Callback.
      */
-    public function __construct(Iterator $items, callable $callback)
+    public function __construct($items, callable $callback)
     {
-        $wrapper = new CallbackFilterIterator($items, $callback);
-        parent::__construct($wrapper);
+        $this->_callback = $callback;
+        parent::__construct($items);
+    }
+
+    public function getIterator()
+    {
+        $it = parent::getIterator();
+        if (!$it instanceof Iterator) {
+            $it = new IteratorIterator($it);
+        }
+        return new CallbackFilterIterator($it, $this->_callback);
     }
 }

--- a/src/Collection/Iterator/InsertIterator.php
+++ b/src/Collection/Iterator/InsertIterator.php
@@ -15,6 +15,9 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 
 /**
  * This iterator will insert values into a property of each of the records returned.
@@ -22,8 +25,10 @@ use Cake\Collection\Collection;
  * when you have two separate collections and want to merge them together by placing
  * each of the values from one collection into a property inside the other collection.
  */
-class InsertIterator extends Collection
+class InsertIterator extends IteratorIterator implements CollectionInterface
 {
+
+    use CollectionTrait;
 
     /**
      * The collection from which to extract the values to be inserted
@@ -67,7 +72,7 @@ class InsertIterator extends Collection
      */
     public function __construct($into, $path, $values)
     {
-        parent::__construct($into);
+        parent::__construct(new Collection($into));
 
         if (!($values instanceof Collection)) {
             $values = new Collection($values);
@@ -77,7 +82,7 @@ class InsertIterator extends Collection
         $target = array_pop($path);
         $this->_path = $path;
         $this->_target = $target;
-        $this->_values = $values;
+        $this->_values = $values->getIterator();
     }
 
     /**

--- a/src/Collection/Iterator/NestIterator.php
+++ b/src/Collection/Iterator/NestIterator.php
@@ -15,6 +15,9 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 use RecursiveIterator;
 
 /**
@@ -22,8 +25,10 @@ use RecursiveIterator;
  * check or retrieve them
  *
  */
-class NestIterator extends Collection implements RecursiveIterator
+class NestIterator extends IteratorIterator implements CollectionInterface, RecursiveIterator
 {
+
+    use CollectionTrait;
 
     /**
      * The name of the property that contains the nested items for each element
@@ -41,7 +46,7 @@ class NestIterator extends Collection implements RecursiveIterator
      */
     public function __construct($items, $nestKey)
     {
-        parent::__construct($items);
+        parent::__construct(new Collection($items));
         $this->_nestKey = $nestKey;
     }
 

--- a/src/Collection/Iterator/NoChildrenIterator.php
+++ b/src/Collection/Iterator/NoChildrenIterator.php
@@ -15,14 +15,24 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 use RecursiveIterator;
 
 /**
  * An iterator that can be used as argument for other iterators that require
  * a RecursiveIterator, but that will always report as having no nested items.
  */
-class NoChildrenIterator extends Collection implements RecursiveIterator
+class NoChildrenIterator extends IteratorIterator implements CollectionInterface, RecursiveIterator
 {
+
+    use CollectionTrait;
+
+    public function __construct($items)
+    {
+        parent::__construct(new Collection($items));
+    }
 
     /**
      * Returns false as there are no children iterators in this collection

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -15,13 +15,18 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 
 /**
  * Creates an iterator from another iterator that will modify each of the values
  * by converting them using a callback function.
  */
-class ReplaceIterator extends Collection
+class ReplaceIterator extends IteratorIterator implements CollectionInterface
 {
+
+    use CollectionTrait;
 
     /**
      * The callback function to be used to modify each of the values
@@ -51,7 +56,7 @@ class ReplaceIterator extends Collection
     public function __construct($items, callable $callback)
     {
         $this->_callback = $callback;
-        parent::__construct($items);
+        parent::__construct(new Collection($items));
         $this->_innerIterator = $this->getInnerIterator();
     }
 

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -41,10 +41,25 @@ use Cake\Collection\CollectionInterface;
 class SortIterator extends Collection
 {
 
+    /**
+     * The callback function to use for extracting the sortable property.
+     *
+     * @var callable
+     */
     protected $_callback;
 
+    /**
+     * The sorting direction
+     *
+     * @var integer
+     */
     protected $_dir;
 
+    /**
+     * The sorting type
+     *
+     * @var integer
+     */
     protected $_type;
 
     /**
@@ -72,6 +87,11 @@ class SortIterator extends Collection
         $this->_type = $type;
     }
 
+    /**
+     * Returns the iterator wrapped by this class
+     *
+     * @return \Iterator
+     */
     public function getIterator()
     {
         $items = iterator_to_array(parent::getIterator(), false);

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 
@@ -40,6 +41,12 @@ use Cake\Collection\CollectionInterface;
 class SortIterator extends Collection
 {
 
+    protected $_callback;
+
+    protected $_dir;
+
+    protected $_type;
+
     /**
      * Wraps this iterator around the passed items so when iterated they are returned
      * in order.
@@ -59,22 +66,29 @@ class SortIterator extends Collection
      */
     public function __construct($items, $callback, $dir = SORT_DESC, $type = SORT_NUMERIC)
     {
-        if (is_array($items)) {
-            $items = new Collection($items);
-        }
+        parent::__construct($items);
+        $this->_callback = $callback;
+        $this->_dir = $dir;
+        $this->_type = $type;
+    }
 
-        $items = iterator_to_array($items, false);
-        $callback = $this->_propertyExtractor($callback);
+    public function getIterator()
+    {
+        $items = iterator_to_array(parent::getIterator(), false);
+        $callback = $this->_propertyExtractor($this->_callback);
         $results = [];
         foreach ($items as $key => $value) {
             $results[$key] = $callback($value);
         }
 
-        $dir === SORT_DESC ? arsort($results, $type) : asort($results, $type);
+        $this->_dir === SORT_DESC ?
+            arsort($results, $this->_type) :
+            asort($results, $this->_type);
 
         foreach (array_keys($results) as $key) {
             $results[$key] = $items[$key];
         }
-        parent::__construct($results);
+
+        return new ArrayIterator($results);
     }
 }

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -15,6 +15,9 @@
 namespace Cake\Collection\Iterator;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
+use Cake\Collection\CollectionTrait;
+use IteratorIterator;
 
 /**
  * Creates an iterator from another iterator that will verify a condition on each
@@ -24,8 +27,10 @@ use Cake\Collection\Collection;
  * @internal
  * @see Collection::stopWhen()
  */
-class StoppableIterator extends Collection
+class StoppableIterator extends IteratorIterator implements CollectionInterface
 {
+
+    use CollectionTrait;
 
     /**
      * The condition to evaluate for each item of the collection
@@ -56,7 +61,7 @@ class StoppableIterator extends Collection
     public function __construct($items, callable $condition)
     {
         $this->_condition = $condition;
-        parent::__construct($items);
+        parent::__construct(new Collection($items));
         $this->_innnerIterator = $this->getInnerIterator();
     }
 

--- a/src/Collection/functions.php
+++ b/src/Collection/functions.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         2.0.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 use Cake\Collection\Collection;

--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -16,6 +16,7 @@ namespace Cake\Datasource;
 
 use Cake\Collection\Collection;
 use Cake\Datasource\ResultSetInterface;
+use Countable;
 
 /**
  * Generic ResultSet decorator. This will make any traversable object appear to
@@ -37,11 +38,12 @@ class ResultSetDecorator extends Collection implements ResultSetInterface
      */
     public function count()
     {
-        if ($this->getInnerIterator() instanceof \Countable) {
-            return $this->getInnerIterator()->count();
+        $iterator = $this->getIterator();
+        if ($iterator instanceof Countable) {
+            return $iterator->count();
         }
 
-        return count($this->toArray());
+        return iterator_count($this);
     }
 
     /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -19,6 +19,7 @@ use Cake\Collection\CollectionTrait;
 use Cake\Database\Exception;
 use Cake\Database\Type;
 use Cake\Datasource\ResultSetInterface;
+use Iterator;
 use SplFixedArray;
 
 /**
@@ -28,7 +29,7 @@ use SplFixedArray;
  * queries required for eager loading external associations.
  *
  */
-class ResultSet implements ResultSetInterface
+class ResultSet implements Iterator, ResultSetInterface
 {
 
     use CollectionTrait;

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -118,7 +118,7 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $result = $collection->reject(function ($v, $k, $items) use ($collection) {
-            $this->assertSame($collection->getInnerIterator(), $items);
+            $this->assertSame($collection->getIterator(), $items);
             return $v > 2;
         });
         $this->assertEquals(['a' => 1, 'b' => 2], iterator_to_array($result));
@@ -244,7 +244,7 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $map = $collection->map(function ($v, $k, $it) use ($collection) {
-            $this->assertSame($collection->getInnerIterator(), $it);
+            $this->assertSame($collection->getIterator(), $it);
             return $v * $v;
         });
         $this->assertInstanceOf('Cake\Collection\Iterator\ReplaceIterator', $map);


### PR DESCRIPTION
This _could_ be considered a braking change, although from the outside it keeps exactly the same API as before.

I have changed the Collection class to be an `IteratorAggregate` instead of an `IteratorIterator`, this is needed to support the `Serializable` interface in the class as it is impossible to serialize an `IteratorIterator`... thanks, PHP :+1:

One problem I see is people calling $collection->getInnerIterator() directly, which would be extremely weird as not all return values of the collection methods are `IteratorIterator`.

Another problem is people passing the collection object to any of the SPL iterator objects as an argument (http://php.net/manual/en/spl.iterators.php) as they only take an instance of `Iterator` instead of anything traversable... thanks again, PHP :100: Same argument as before: the promise was that methods would return `CollectionInterface` as something traversable.

Moreover, there is little value in wrapping the collection in an SPL iterator since most of the functionality provided in them is already built-in.

If you think this is too big of a change, we could just drop the idea of serializing collections.
