### PR TITLE
Fixes #6369

### DIFF
--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -102,7 +102,11 @@ class DatabaseSession implements SessionHandlerInterface
             return false;
         }
 
-        return $result['data'];
+        if (is_string($result['data'])) {
+            return $result['data'];
+        }
+
+        return stream_get_contents($result['data']);
     }
 
     /**

--- a/tests/Fixture/SessionsFixture.php
+++ b/tests/Fixture/SessionsFixture.php
@@ -30,7 +30,7 @@ class SessionsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'string', 'length' => 128],
-        'data' => ['type' => 'text', 'null' => true],
+        'data' => ['type' => 'binary', 'null' => true],
         'expires' => ['type' => 'integer', 'length' => 11, 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -175,6 +175,6 @@ class DatabaseSessionTest extends TestCase
         $entity->value = 'something';
         $result = $this->storage->write('key', serialize($entity));
         $data = TableRegistry::get('Sessions')->get('key')->data;
-        $this->assertEquals(serialize($entity), $data);
+        $this->assertEquals(serialize($entity), stream_get_contents($data));
     }
 }

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Network\Session;
 use Cake\Network\Session\DatabaseSession;
+use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -161,5 +162,19 @@ class DatabaseSessionTest extends TestCase
         sleep(1);
         $storage->gc(0);
         $this->assertFalse($storage->read('foo'));
+    }
+
+    /**
+     * Tests serializing an entity
+     *
+     * @return void
+     */
+    public function testSerializeEntity()
+    {
+        $entity = new Entity();
+        $entity->value = 'something';
+        $result = $this->storage->write('key', serialize($entity));
+        $data = TableRegistry::get('Sessions')->get('key')->data;
+        $this->assertEquals(serialize($entity), $data);
     }
 }


### PR DESCRIPTION
This fixes an issue with postgres data saving. `serialize` returns a binary string, it needs to be saved as binary. I will make changes in the app template to reflect this changes
