### PR TITLE
Fix input submit via magic input method.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1012,6 +1012,7 @@ class FormHelper extends Helper
 
         $label = $options['label'];
         unset($options['label']);
+
         $nestedInput = false;
         if ($options['type'] === 'checkbox') {
             $nestedInput = true;
@@ -1023,7 +1024,7 @@ class FormHelper extends Helper
         }
 
         $input = $this->_getInput($fieldName, $options);
-        if ($options['type'] === 'hidden') {
+        if ($options['type'] === 'hidden' || $options['type'] === 'submit') {
             if ($newTemplates) {
                 $templater->pop();
             }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3121,6 +3121,24 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testFormInputSubmit method
+     *
+     * test correct results for form::input() and type submit.
+     *
+     * @return void
+     */
+    public function testFormInputSubmit()
+    {
+        $result = $this->Form->input('Test Submit', ['type' => 'submit', 'class' => 'foobar']);
+        $expected = [
+            'div' => ['class' => 'submit'],
+            'input' => ['type' => 'submit', 'class' => 'foobar', 'id' => 'test-submit', 'value' => 'Test Submit'],
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * testFormInputs method
      *
      * test correct results from form::inputs().


### PR DESCRIPTION
`$this->Form->input('Test Submit', ['type' => 'submit'])` outputs a label and a second div wrapper:

``` html
<div class="submit">
    <label for="test-submit">Test Submit</label>
    <div class="submit">
        <input type="submit" class="foobar" id="test-submit" value="Test Submit">
    </div>
</div>
```

We can default the label to false here by returning early as for hidden input.
