### PR TITLE
Update ShellTest::testDispatchShell

### DIFF
--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -912,7 +912,6 @@ class ShellTest extends TestCase
         $expected = <<<TEXT
 <info>Welcome to CakePHP Console</info>
 I am a test task, I dispatch another Shell
-<info>Welcome to CakePHP Console</info>
 I am a dispatched Shell
 
 TEXT;


### PR DESCRIPTION
#6292 was merged too early, without having the `Shell::dispatchShell()` test added on #6325 updated (after the master -> 3.1 merge).

This leads the `ShellTest::testDispatchShell()` test to fail (it outputs the welcome message twice, however, with #6292, the welcome message is supposed to be displayed only once)

This is a fix correcting the 3.1 build.

Failed build before this change (I cancelled it after the first failures) : https://travis-ci.org/HavokInspiration/cakephp/builds/59380179
Build after this change : https://travis-ci.org/HavokInspiration/cakephp/builds/59380449
(test failing test seems unrelated)
