### PR TITLE
[Network][Http] Fix ssl options

### DIFF
--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -35,11 +35,18 @@ class Stream
     protected $_context;
 
     /**
-     * Array of options/content for the stream context.
+     * Array of options/content for the http stream context.
      *
      * @var array
      */
     protected $_contextOptions;
+
+    /**
+     * Array of options/content for the ssl stream context.
+     *
+     * @var array
+     */
+    protected $_sslContextOptions;
 
     /**
      * The stream resource.
@@ -67,6 +74,7 @@ class Stream
         $this->_stream = null;
         $this->_context = [];
         $this->_contextOptions = [];
+        $this->_sslContextOptions = [];
         $this->_connectionErrors = [];
 
         $this->_buildContext($request, $options);
@@ -119,9 +127,7 @@ class Stream
         if ($scheme === 'https') {
             $this->_buildSslContext($request, $options);
         }
-        $this->_context = stream_context_create([
-            'http' => $this->_contextOptions
-        ]);
+        $this->_context = stream_context_create($this->contextOptions());
     }
 
     /**
@@ -225,12 +231,12 @@ class Stream
         if (!empty($options['ssl_verify_host'])) {
             $url = $request->url();
             $host = parse_url($url, PHP_URL_HOST);
-            $this->_contextOptions['CN_match'] = $host;
+            $this->_sslContextOptions['CN_match'] = $host;
         }
         foreach ($sslOptions as $key) {
             if (isset($options[$key])) {
                 $name = substr($key, 4);
-                $this->_contextOptions[$name] = $options[$key];
+                $this->_sslContextOptions[$name] = $options[$key];
             }
         }
     }
@@ -303,6 +309,9 @@ class Stream
      */
     public function contextOptions()
     {
-        return $this->_contextOptions;
+        return [
+            'http' => $this->_contextOptions,
+            'ssl'  => $this->_sslContextOptions,
+        ];
     }
 }

--- a/tests/TestCase/Network/Http/Adapter/StreamTest.php
+++ b/tests/TestCase/Network/Http/Adapter/StreamTest.php
@@ -84,9 +84,9 @@ class StreamTest extends TestCase
             'Content-Type: application/json',
             'Cookie: testing=value; utm_src=awesome',
         ];
-        $this->assertEquals(implode("\r\n", $expected), $result['header']);
-        $this->assertEquals($options['redirect'], $result['max_redirects']);
-        $this->assertTrue($result['ignore_errors']);
+        $this->assertEquals(implode("\r\n", $expected), $result['http']['header']);
+        $this->assertEquals($options['redirect'], $result['http']['max_redirects']);
+        $this->assertTrue($result['http']['ignore_errors']);
     }
 
     /**
@@ -114,8 +114,8 @@ class StreamTest extends TestCase
             'User-Agent: CakePHP',
             'Content-Type: application/json',
         ];
-        $this->assertEquals(implode("\r\n", $expected), $result['header']);
-        $this->assertEquals($content, $result['content']);
+        $this->assertEquals(implode("\r\n", $expected), $result['http']['header']);
+        $this->assertEquals($content, $result['http']['content']);
     }
 
     /**
@@ -139,9 +139,9 @@ class StreamTest extends TestCase
             'User-Agent: CakePHP',
             'Content-Type: multipart/form-data; boundary="',
         ];
-        $this->assertStringStartsWith(implode("\r\n", $expected), $result['header']);
-        $this->assertContains('Content-Disposition: form-data; name="a"', $result['content']);
-        $this->assertContains('my value', $result['content']);
+        $this->assertStringStartsWith(implode("\r\n", $expected), $result['http']['header']);
+        $this->assertContains('Content-Disposition: form-data; name="a"', $result['http']['content']);
+        $this->assertContains('my value', $result['http']['content']);
     }
 
     /**
@@ -169,7 +169,7 @@ class StreamTest extends TestCase
             'allow_self_signed' => false,
         ];
         foreach ($expected as $k => $v) {
-            $this->assertEquals($v, $result[$k]);
+            $this->assertEquals($v, $result['ssl'][$k]);
         }
     }
 


### PR DESCRIPTION
Hey!

After #6370, I'm on my way to implement egeloen/ivory-http-adapter#62 which basically implement support for ssl verification. Unfortunatelly, on the 2.x version everything is wroking fine but for the 3.x the test does not pass. The issue is the ssl option is merged in the context option which is http one but the ssl option should be put into its own node (namely `ssl`) to the `stream_context_create`.

In order to implement it in a BC way, I have introduce a new property to the stream which deals with these options. Additionally, I have targeted it to the master branch as it is a little fix but if you disagree I can retarget it to the 3.1 branch.
