### PR TITLE
Don't hardcode the primaryKey input Type

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -119,7 +119,8 @@ class FormHelper extends Helper
             'radioWrapper' => '{{label}}',
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
             'submitContainer' => '<div class="submit">{{content}}</div>',
-        ]
+        ],
+        'pkInputType' => 'hidden'
     ];
 
     /**
@@ -1150,7 +1151,7 @@ class FormHelper extends Helper
         $context = $this->_getContext();
 
         if ($context->isPrimaryKey($fieldName)) {
-            return 'hidden';
+            if ($this->_config['pkInputType']) return $this->_config['pkInputType'];
         }
 
         if (substr($fieldName, -3) === '_id') {


### PR DESCRIPTION
I recently programmed a form wich submits data for search purposes.

In my case the primaryKey was one of the field users can filter by.
