### PR TITLE
3.1 - Add more tests to dispatchShell

### DIFF
--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -690,6 +690,78 @@ class ShellTest extends TestCase
     }
 
     /**
+     * test calling a shell that dispatch another one
+     *
+     * @return void
+     */
+    public function testDispatchShell()
+    {
+        $Shell = new TestingDispatchShell();
+        ob_start();
+        $Shell->runCommand(['test_task'], true);
+        $result = ob_get_clean();
+
+        $expected = <<<TEXT
+<info>Welcome to CakePHP Console</info>
+I am a test task, I dispatch another Shell
+I am a dispatched Shell
+
+TEXT;
+        $this->assertEquals($expected, $result);
+
+        ob_start();
+        $Shell->runCommand(['test_task_dispatch_array'], true);
+        $result = ob_get_clean();
+        $this->assertEquals($expected, $result);
+
+        ob_start();
+        $Shell->runCommand(['test_task_dispatch_command_string'], true);
+        $result = ob_get_clean();
+        $this->assertEquals($expected, $result);
+
+        ob_start();
+        $Shell->runCommand(['test_task_dispatch_command_array'], true);
+        $result = ob_get_clean();
+        $this->assertEquals($expected, $result);
+
+        $expected = <<<TEXT
+<info>Welcome to CakePHP Console</info>
+I am a test task, I dispatch another Shell
+I am a dispatched Shell. My param `foo` has the value `bar`
+
+TEXT;
+
+        ob_start();
+        $Shell->runCommand(['test_task_dispatch_with_param'], true);
+        $result = ob_get_clean();
+        $this->assertEquals($expected, $result);
+
+        $expected = <<<TEXT
+<info>Welcome to CakePHP Console</info>
+I am a test task, I dispatch another Shell
+I am a dispatched Shell. My param `foo` has the value `bar`
+My param `fooz` has the value `baz`
+
+TEXT;
+        ob_start();
+        $Shell->runCommand(['test_task_dispatch_with_multiple_params'], true);
+        $result = ob_get_clean();
+        $this->assertEquals($expected, $result);
+
+        $expected = <<<TEXT
+<info>Welcome to CakePHP Console</info>
+I am a test task, I dispatch another Shell
+<info>Welcome to CakePHP Console</info>
+I am a dispatched Shell
+
+TEXT;
+        ob_start();
+        $Shell->runCommand(['test_task_dispatch_with_requested_off'], true);
+        $result = ob_get_clean();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test that runCommand() doesn't call public methods when the second arg is false.
      *
      * @return void
@@ -895,27 +967,6 @@ class ShellTest extends TestCase
 
         $shell->Slice = $task;
         $shell->runCommand(['slice', 'one']);
-    }
-
-    /**
-     * test calling a shell that dispatch another one
-     *
-     * @return void
-     */
-    public function testDispatchShell()
-    {
-        $Shell = new TestingDispatchShell();
-        ob_start();
-        $Shell->runCommand(['test_task'], true);
-        $result = ob_get_clean();
-
-        $expected = <<<TEXT
-<info>Welcome to CakePHP Console</info>
-I am a test task, I dispatch another Shell
-I am a dispatched Shell
-
-TEXT;
-        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -80,7 +80,7 @@ class TestingDispatchShell extends Shell
         $this->out('I am a test task, I dispatch another Shell');
         Configure::write('App.namespace', 'TestApp');
         $this->dispatchShell([
-            'command' => ['testing_dispatch dispatch_test_task_params'],
+            'command' => 'testing_dispatch dispatch_test_task_params',
             'extra' => [
                 'foo' => 'bar',
                 'fooz' => 'baz'

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -39,11 +39,80 @@ class TestingDispatchShell extends Shell
     {
         $this->out('I am a test task, I dispatch another Shell');
         Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell('testing_dispatch dispatch_test_task');
+    }
+
+    public function testTaskDispatchArray()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
         $this->dispatchShell('testing_dispatch', 'dispatch_test_task');
+    }
+
+    public function testTaskDispatchCommandString()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell(['command' => 'testing_dispatch dispatch_test_task']);
+    }
+
+    public function testTaskDispatchCommandArray()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell(['command' => ['testing_dispatch', 'dispatch_test_task']]);
+    }
+
+    public function testTaskDispatchWithParam()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell([
+            'command' => ['testing_dispatch', 'dispatch_test_task_param'],
+            'extra' => [
+                'foo' => 'bar'
+            ]
+        ]);
+    }
+
+    public function testTaskDispatchWithMultipleParams()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell([
+            'command' => ['testing_dispatch dispatch_test_task_params'],
+            'extra' => [
+                'foo' => 'bar',
+                'fooz' => 'baz'
+            ]
+        ]);
+    }
+
+    public function testTaskDispatchWithRequestedOff()
+    {
+        $this->out('I am a test task, I dispatch another Shell');
+        Configure::write('App.namespace', 'TestApp');
+        $this->dispatchShell([
+            'command' => ['testing_dispatch', 'dispatch_test_task'],
+            'extra' => [
+                'requested' => false
+            ]
+        ]);
     }
 
     public function dispatchTestTask()
     {
         $this->out('I am a dispatched Shell');
+    }
+
+    public function dispatchTestTaskParam()
+    {
+        $this->out('I am a dispatched Shell. My param `foo` has the value `' . $this->param('foo') . '`');
+    }
+
+    public function dispatchTestTaskParams()
+    {
+        $this->out('I am a dispatched Shell. My param `foo` has the value `' . $this->param('foo') . '`');
+        $this->out('My param `fooz` has the value `' . $this->param('fooz') . '`');
     }
 }


### PR DESCRIPTION
Follow up to #6292 and #6383.

This adds more tests to the `Shell::dispatchShell()` functionality.
These tests dispatch a shell in every possible way (I'll document them in the docs) and tests the output as well as the param merge (passed with `extra`)
