### PR TITLE
Add support for placeholders in validation message

### DIFF
--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -150,7 +150,7 @@ class ValidationRule
         }
     
         if (class_exists('Cake\Utility\Text', false)) {
-            return String::insert($this->_message, $data);
+            return Text::insert($this->_message, $data);
         }
 
         return $this->_message;

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -18,6 +18,7 @@
  */
 namespace Cake\Validation;
 
+use Cake\Utility\Text;
 use InvalidArgumentException;
 
 /**
@@ -140,10 +141,19 @@ class ValidationRule
             $result = $callable($value, $context);
         }
 
-        if ($result === false) {
-            return $this->_message ?: false;
+        if ($result !== false) {
+            return $result;
         }
-        return $result;
+
+        if (!$this->_message) {
+            return false;
+        }
+    
+        if (class_exists('Cake\Utility\Text', false)) {
+            return String::insert($this->_message, $data);
+        }
+
+        return $this->_message;
     }
 
     /**

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -150,7 +150,7 @@ class ValidationRule
         }
     
         if (class_exists('Cake\Utility\Text', false)) {
-            return Text::insert($this->_message, $data);
+            return Text::insert($this->_message, $context['data']);
         }
 
         return $this->_message;


### PR DESCRIPTION
Something like this would now be possible:

```
$validator->add('picture', 'file', [
    'rule' => ['mimeType', ['image/jpeg', 'image/png']],
    'message' => 'Wrong mime type. (Got :mimeType)',
]);
```
