### PR TITLE
3.1 - Console colors

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -138,10 +138,10 @@ class ConsoleOutput
      * @var array
      */
     protected static $_styles = [
-        'emergency' => ['text' => 'red', 'underline' => true],
-        'alert' => ['text' => 'red', 'underline' => true],
-        'critical' => ['text' => 'red', 'underline' => true],
-        'error' => ['text' => 'red', 'underline' => true],
+        'emergency' => ['text' => 'red'],
+        'alert' => ['text' => 'red'],
+        'critical' => ['text' => 'red'],
+        'error' => ['text' => 'red'],
         'warning' => ['text' => 'yellow'],
         'info' => ['text' => 'cyan'],
         'debug' => ['text' => 'yellow'],

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -94,7 +94,7 @@ class ConsoleOutput
      */
     protected static $_foregroundColors = [
         'black' => 30,
-        'red' => 31,
+        'red' => 91,
         'green' => 32,
         'yellow' => 33,
         'blue' => 34,

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -143,7 +143,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingSimple()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[31mError:\033[0m Something bad");
+            ->with("\033[91mError:\033[0m Something bad");
 
         $this->output->write('<error>Error:</error> Something bad', false);
     }
@@ -202,7 +202,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingMultipleStylesName()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
+            ->with("\033[91mBad\033[0m \033[33mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', false);
     }
@@ -215,7 +215,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingMultipleSameTags()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
+            ->with("\033[91mBad\033[0m \033[91mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <error>Warning</error> Regular', false);
     }

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -109,7 +109,7 @@ class ConsoleOutputTest extends TestCase
     public function testStylesGet()
     {
         $result = $this->output->styles('error');
-        $expected = ['text' => 'red', 'underline' => true];
+        $expected = ['text' => 'red'];
         $this->assertEquals($expected, $result);
 
         $this->assertNull($this->output->styles('made_up_goop'));
@@ -143,7 +143,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingSimple()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[31;4mError:\033[0m Something bad");
+            ->with("\033[31mError:\033[0m Something bad");
 
         $this->output->write('<error>Error:</error> Something bad', false);
     }
@@ -202,7 +202,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingMultipleStylesName()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[31;4mBad\033[0m \033[33mWarning\033[0m Regular");
+            ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', false);
     }
@@ -215,7 +215,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingMultipleSameTags()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[31;4mBad\033[0m \033[31;4mWarning\033[0m Regular");
+            ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <error>Warning</error> Regular', false);
     }


### PR DESCRIPTION
- Remove underline from all error levels since it's annoying
- Change default red to high intensity version.  The current red is unreadable for those with dark background. The high intensity looks better and still readable with bright background.
