### PR TITLE
Don't marshall non-array data.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -531,6 +531,9 @@ class Marshaller
         }
 
         foreach ((new Collection($indexed))->append($new) as $value) {
+            if (!is_array($value)) {
+                continue;
+            }
             $output[] = $this->one($value, $options);
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -248,6 +248,9 @@ class Marshaller
     {
         $output = [];
         foreach ($data as $record) {
+            if (!is_array($record)) {
+                continue;
+            }
             $output[] = $this->one($record, $options);
         }
         return $output;

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -716,6 +716,24 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test many() with some invalid data
+     *
+     * @return void
+     */
+    public function testManyInvalidData()
+    {
+        $data = [
+            ['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
+            ['id' => 1, 'comment' => 'Changed 1', 'user_id' => 1],
+            '_csrfToken' => 'abc123',
+        ];
+        $marshall = new Marshaller($this->comments);
+        $result = $marshall->many($data);
+
+        $this->assertCount(2, $result);
+    }
+
+    /**
      * test many() with nested associations.
      *
      * @return void

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1513,6 +1513,32 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test mergeMany() with some invalid data
+     *
+     * @return void
+     */
+    public function testMergeManyInvalidData()
+    {
+        $entities = [
+            new OpenEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2]),
+            new OpenEntity(['id' => 2, 'comment' => 'Second post', 'user_id' => 2])
+        ];
+        $entities[0]->clean();
+        $entities[1]->clean();
+
+        $data = [
+            ['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
+            ['id' => 1, 'comment' => 'Changed 1', 'user_id' => 1],
+            '_csrfToken' => 'abc123',
+        ];
+        $marshall = new Marshaller($this->comments);
+        $result = $marshall->mergeMany($entities, $data);
+
+        $this->assertSame($entities[0], $result[0]);
+        $this->assertSame($entities[1], $result[1]);
+    }
+
+    /**
      * Tests that only records found in the data array are returned, those that cannot
      * be matched are discarded
      *


### PR DESCRIPTION
Non array data will never turn into entities, so we can skip it.

Refs #6271
