### PR TITLE
postLink in FormHelper htmlspecialchars action url

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1649,7 +1649,7 @@ class FormHelper extends Helper
 
         $formName = str_replace('.', '', uniqid('post_', true));
         $formOptions = [
-            'action' => $this->Url->build($url),
+            'action' => Router::url($url),
             'name' => $formName,
             'style' => 'display:none;',
             'method' => 'post',


### PR DESCRIPTION
After using the postLink function in the FormHelper, I found out that `$this->Url->build($url)` htmlspecialchars `&` characters variables to `&amp;`, which isn't working in the action attribute of a form (and it's being blackholed too by the SecurityComponent).

My URL in the action attribute is:
`http://localhost/admin/acl/Actions/generate?permissions=1&amp;sync=1`

But that is being blackholed too, it works when I use:
`http://localhost/admin/acl/Actions/generate?permissions=1&sync=1`
