### PR TITLE
Assigning request and response by reference in Components.

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -110,7 +110,7 @@ class Component implements EventListenerInterface
         $this->_registry = $registry;
         $controller = $registry->getController();
         if ($controller) {
-            $this->request = $controller->request;
+            $this->request =& $controller->request;
         }
 
         $this->config($config);

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -242,8 +242,7 @@ class AuthComponent extends Component
     {
         $controller = $this->_registry->getController();
         $this->eventManager($controller->eventManager());
-        $this->request = $controller->request;
-        $this->response = $controller->response;
+        $this->response =& $controller->response;
         $this->session = $controller->request->session();
     }
 

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -107,13 +107,6 @@ class CookieComponent extends Component
     protected $_response = null;
 
     /**
-     * The request from the controller.
-     *
-     * @var \Cake\Network\Request
-     */
-    protected $_request;
-
-    /**
      * Valid cipher names for encrypted cookies.
      *
      * @var array
@@ -133,20 +126,18 @@ class CookieComponent extends Component
         }
 
         $controller = $this->_registry->getController();
-        if ($controller && isset($controller->request)) {
-            $this->_request = $controller->request;
-        } else {
-            $this->_request = Request::createFromGlobals();
+
+        if ($controller !== null) {
+            $this->_response =& $controller->response;
+        }
+
+        if ($controller === null) {
+            $this->request = Request::createFromGlobals();
+            $this->_response = new Response();
         }
 
         if (empty($this->_config['path'])) {
-            $this->config('path', $this->_request->webroot);
-        }
-
-        if ($controller && isset($controller->response)) {
-            $this->_response = $controller->response;
-        } else {
-            $this->_response = new Response();
+            $this->config('path', $this->request->webroot);
         }
     }
 
@@ -261,10 +252,10 @@ class CookieComponent extends Component
         if (isset($this->_loaded[$first])) {
             return;
         }
-        if (!isset($this->_request->cookies[$first])) {
+        if (!isset($this->request->cookies[$first])) {
             return;
         }
-        $cookie = $this->_request->cookies[$first];
+        $cookie = $this->request->cookies[$first];
         $config = $this->configKey($first);
         $this->_loaded[$first] = true;
         $this->_values[$first] = $this->_decrypt($cookie, $config['encryption']);

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -47,13 +47,6 @@ class RequestHandlerComponent extends Component
     public $enabled = true;
 
     /**
-     * Holds the reference to Controller::$request
-     *
-     * @var \Cake\Network\Request
-     */
-    public $request;
-
-    /**
      * Holds the reference to Controller::$response
      *
      * @var \Cake\Network\Response
@@ -152,18 +145,7 @@ class RequestHandlerComponent extends Component
     public function initialize(array $config)
     {
         $controller = $this->_registry->getController();
-        $request = $this->request = $controller->request;
-        $this->response = $controller->response;
-
-        if (isset($request->params['_ext'])) {
-            $this->ext = $request->params['_ext'];
-        }
-        if (empty($this->ext) || in_array($this->ext, ['html', 'htm'])) {
-            $this->_setExtension($request, $this->response);
-        }
-        if (empty($this->ext) && $request->is('ajax')) {
-            $this->ext = 'ajax';
-        }
+        $this->response =& $controller->response;
 
         if ($this->_config['viewClassMap']) {
             $this->viewClassMap($this->_config['viewClassMap']);
@@ -232,7 +214,19 @@ class RequestHandlerComponent extends Component
     public function startup(Event $event)
     {
         $controller = $event->subject();
-        $controller->request->params['isAjax'] = $this->request->is('ajax');
+        $request = $controller->request;
+
+        if (isset($request->params['_ext'])) {
+            $this->ext = $request->params['_ext'];
+        }
+        if (empty($this->ext) || in_array($this->ext, ['html', 'htm'])) {
+            $this->_setExtension($request, $this->response);
+        }
+        if (empty($this->ext) && $request->is('ajax')) {
+            $this->ext = 'ajax';
+        }
+
+        $request->params['isAjax'] = $this->request->is('ajax');
         $isRecognized = (
             !in_array($this->ext, ['html', 'htm']) &&
             $this->response->getMimeType($this->ext)
@@ -247,7 +241,7 @@ class RequestHandlerComponent extends Component
         foreach ($this->_inputTypeMap as $type => $handler) {
             if ($this->requestedWith($type)) {
                 $input = call_user_func_array([$controller->request, 'input'], $handler);
-                $controller->request->data = $input;
+                $request->data = $input;
             }
         }
     }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -99,7 +99,6 @@ class SecurityComponent extends Component
     public function startup(Event $event)
     {
         $controller = $event->subject();
-        $this->request = $controller->request;
         $this->session = $this->request->session();
         $this->_action = $this->request->params['action'];
         $this->_secureRequired($controller);

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -118,7 +118,7 @@ class RequestHandlerComponentTest extends TestCase
     {
         $this->assertNull($this->RequestHandler->ext);
         $this->Controller->request->params['_ext'] = 'rss';
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('rss', $this->RequestHandler->ext);
     }
 
@@ -133,7 +133,7 @@ class RequestHandlerComponentTest extends TestCase
         Router::extensions('json', false);
 
         $this->RequestHandler->ext = null;
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('json', $this->RequestHandler->ext);
     }
 
@@ -149,7 +149,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->ext = null;
         Router::extensions('json', false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('json', $this->RequestHandler->ext);
     }
 
@@ -163,7 +163,7 @@ class RequestHandlerComponentTest extends TestCase
         Router::extensions('csv', false);
         $this->request->env('HTTP_ACCEPT', 'text/plain, */*; q=0.01');
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
     }
 
@@ -179,7 +179,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->ext = null;
         Router::extensions(['rss', 'json'], false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('json', $this->RequestHandler->ext);
     }
 
@@ -194,7 +194,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->assertNull($this->RequestHandler->ext);
         Router::extensions('json', false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
     }
 
@@ -215,13 +215,13 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->ext = null;
         Router::extensions(['xml', 'json'], false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('xml', $this->RequestHandler->ext);
 
         $this->RequestHandler->ext = null;
         Router::extensions(['json', 'xml'], false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('json', $this->RequestHandler->ext);
     }
 
@@ -239,7 +239,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->ext = null;
         Router::extensions(['xml', 'json'], false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertEquals('json', $this->RequestHandler->ext);
     }
 
@@ -257,7 +257,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->ext = null;
         Router::extensions(['html', 'xml'], false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
     }
 
@@ -271,7 +271,7 @@ class RequestHandlerComponentTest extends TestCase
         $_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;image/png,image/jpeg,image/*;q=0.9,*/*;q=0.8';
         Router::extensions(['xml', 'json'], false);
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
     }
 
@@ -291,7 +291,7 @@ class RequestHandlerComponentTest extends TestCase
             ->method('accepts')
             ->will($this->returnValue(['application/json']));
 
-        $this->RequestHandler->initialize([]);
+        $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
 
         call_user_func_array(['Cake\Routing\Router', 'extensions'], [$extensions, false]);
@@ -484,14 +484,14 @@ class RequestHandlerComponentTest extends TestCase
         if (!function_exists('str_getcsv')) {
             $this->markTestSkipped('Need "str_getcsv" for this test.');
         }
-        $event = new Event('Controller.startup', $this->Controller);
         $this->Controller->request = $this->getMock('Cake\Network\Request', ['_readInput']);
         $this->Controller->request->expects($this->once())
             ->method('_readInput')
             ->will($this->returnValue('"A","csv","string"'));
         $this->RequestHandler->addInputType('csv', ['str_getcsv']);
-        $this->request->env('REQUEST_METHOD', 'POST');
-        $this->request->env('CONTENT_TYPE', 'text/csv');
+        $this->Controller->request->env('REQUEST_METHOD', 'POST');
+        $this->Controller->request->env('CONTENT_TYPE', 'text/csv');
+        $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->startup($event);
         $expected = [
             'A', 'csv', 'string'


### PR DESCRIPTION
Changing the instances in the controller class meant that all components
went of of sync with what the controller is doing.

In the future we should avoid having public properties and also try
to use parameters out of the event payload instead of relying on
the object state.
