### PR TITLE
Nested prefix cascade elements path

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1005,7 +1005,8 @@ class View
     /**
      * Find all sub templates path, based on $basePath
      * If a prefix is defined in the current request, this method will prepend
-     * the prefixed template path to the $basePath.
+     * the prefixed template path to the $basePath, cascading up in case the prefix
+     * is nested.
      * This is essentially used to find prefixed template paths for elements
      * and layouts.
      *
@@ -1016,14 +1017,16 @@ class View
     {
         $paths = [$basePath];
         if (!empty($this->request->params['prefix'])) {
-            $prefixPath = array_map(
-                'Cake\Utility\Inflector::camelize',
-                explode('/', $this->request->params['prefix'])
-            );
-            array_unshift(
-                $paths,
-                implode('/', $prefixPath) . DS . $basePath
-            );
+            $prefixPath = explode('/', $this->request->params['prefix']);
+            $path = '';
+            foreach ($prefixPath as $prefixPart) {
+                $path .= Inflector::camelize($prefixPart) . DS;
+
+                array_unshift(
+                    $paths,
+                    $path . $basePath
+                );
+            }
         }
 
         return $paths;

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -681,6 +681,12 @@ class ViewTest extends TestCase
         $result = $View->getLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
+        $View->request->params['prefix'] = 'foo_prefix/bar_prefix';
+        $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
+            'FooPrefix' . DS . 'Layout' . DS . 'nested_prefix_cascade.ctp';
+        $result = $View->getLayoutFileName('nested_prefix_cascade');
+        $this->assertPathEquals($expected, $result);
+
         // Fallback to app's layout
         $View->request->params['prefix'] = 'Admin';
         $expected = TEST_APP . 'TestApp' . DS . 'Template' . DS .
@@ -837,6 +843,10 @@ class ViewTest extends TestCase
         $this->View->request->params['prefix'] = 'FooPrefix/BarPrefix';
         $result = $this->View->element('prefix_element');
         $this->assertEquals('this is a nested prefixed test element', $result);
+
+        $this->View->request->params['prefix'] = 'FooPrefix/BarPrefix';
+        $result = $this->View->element('prefix_element_in_parent');
+        $this->assertEquals('this is a nested prefixed test element in first level element', $result);
     }
 
     /**

--- a/tests/test_app/TestApp/Template/FooPrefix/Element/prefix_element_in_parent.ctp
+++ b/tests/test_app/TestApp/Template/FooPrefix/Element/prefix_element_in_parent.ctp
@@ -1,0 +1,1 @@
+this is a nested prefixed test element in first level element


### PR DESCRIPTION
In case of a nested prefixed namespace, the elements and layouts path resolution should cascade the prefix structure up.

More details on #6293 
