### PR TITLE
Fixed documentation for deprecated feature (Building XML from a remote U...

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -49,10 +49,14 @@ class Xml
      * $xml = Xml::build('/path/to/an/xml/file.xml');
      * ```
      *
-     * Building from a remote URL:
+     * Building XML from a remote URL:
      *
      * ```
-     * $xml = Xml::build('http://example.com/example.xml');
+     * use Cake\Network\Http\Client;
+     *
+     * $http = new Client();
+     * $response = $http->get('http://example.com/example.xml');
+     * $xml = Xml::build($response->body());
      * ```
      *
      * Building from an array:


### PR DESCRIPTION
As discussed here https://github.com/cakephp/cakephp/issues/6229, the support for remote files was removed for security reasons. 
I changed the comments for the API (http://api.cakephp.org/3.0/class-Cake.Utility.Xml.html) to use the Http Client class that comes bundled with CakePHP.
