### PR TITLE
Bubble up exception if it is clearly to be not swallowed away.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -456,7 +456,7 @@ abstract class IntegrationTestCase extends TestCase
         $status = $this->_response->statusCode();
 
         if ($this->_exception && ($status < $min || $status > $max)) {
-            throw $this->_exception;
+            $this->fail($this->_exception);
         }
 
         $this->assertGreaterThanOrEqual($min, $status, $message);

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -51,6 +51,13 @@ abstract class IntegrationTestCase extends TestCase
     protected $_response;
 
     /**
+     * The exception being thrown if the case.
+     *
+     * @var \Cake\Core\Exception\Exception
+     */
+    protected $_exception;
+
+    /**
      * Session data to use in the next request.
      *
      * @var array
@@ -115,6 +122,7 @@ abstract class IntegrationTestCase extends TestCase
         $this->_session = [];
         $this->_cookie = [];
         $this->_response = null;
+        $this->_exception = null;
         $this->_controller = null;
         $this->_viewName = null;
         $this->_layoutName = null;
@@ -280,6 +288,7 @@ abstract class IntegrationTestCase extends TestCase
         } catch (\PHPUnit_Exception $e) {
             throw $e;
         } catch (\Exception $e) {
+            $this->_exception = $e;
             $this->_handleError($e);
         }
     }
@@ -445,6 +454,11 @@ abstract class IntegrationTestCase extends TestCase
             $this->fail('No response set, cannot assert status code.');
         }
         $status = $this->_response->statusCode();
+
+        if ($this->_exception && ($status < $min || $status > $max)) {
+            throw $this->_exception;
+        }
+
         $this->assertGreaterThanOrEqual($min, $status, $message);
         $this->assertLessThanOrEqual($max, $status, $message);
     }


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/6422

Before:

```
1) App\Test\TestCase\Controller\AccountControllerTest::testEdit
Status code is not 200 but 500
Failed asserting that 500 is equal to 200 or is less than 200.
```

:-1: 

Now it properly shows whats wrong:

```
1) App\Test\TestCase\Controller\AccountControllerTest::testEdit
RuntimeException: The "Passwordable" alias has already been loaded with the foll
owing config: array (
  'field' => 'password',
  'confirm' => true,
  'require' => true,
) which differs from array (
  'require' => false,
)

...\app\vendor\cakephp\cakephp\src\Core\ObjectRegistry.php:138
...\app\vendor\cakephp\cakephp\src\Core\ObjectRegistry.php:74
...\app\vendor\cakephp\cakephp\src\ORM\Table.php:600
...\app\src\Controller\AccountController.php:181
...\app\vendor\cakephp\cakephp\src\Controller\Controller.php:41
0
...\app\vendor\cakephp\cakephp\src\Routing\Dispatcher.php:114
...\app\vendor\cakephp\cakephp\src\Routing\Dispatcher.php:87
...\app\vendor\cakephp\cakephp\src\TestSuite\IntegrationTestCas
e.php:285
...\app\vendor\cakephp\cakephp\src\TestSuite\IntegrationTestCas
e.php:197
...\app\tests\TestCase\Controller\AccountControllerTest.php:244
```

:+1: 
