### PR TITLE
3.1 - Reduce the number of static TableRegistry calls and use table locators instead.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -21,6 +21,7 @@ use Cake\Core\Plugin;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Filesystem\File;
 use Cake\Log\LogTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
 use Cake\Utility\Text;
@@ -33,6 +34,7 @@ use Cake\Utility\Text;
 class Shell
 {
 
+    use LocatorAwareTrait;
     use LogTrait;
     use MergeVariablesTrait;
     use ModelAwareTrait;
@@ -158,7 +160,7 @@ class Shell
         }
         $this->_io = $io ?: new ConsoleIo();
 
-        $this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
+        $this->modelFactory('Table', [$this->tableLocator(), 'get']);
         $this->Tasks = new TaskRegistry($this);
 
         $this->_io->setLoggers(true);

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -160,7 +160,8 @@ class Shell
         }
         $this->_io = $io ?: new ConsoleIo();
 
-        $this->modelFactory('Table', [$this->tableLocator(), 'get']);
+        $locator = $this->tableLocator() ? : 'Cake\ORM\TableRegistry';
+        $this->modelFactory('Table', [$locator, 'get']);
         $this->Tasks = new TaskRegistry($this);
 
         $this->_io->setLoggers(true);

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -22,6 +22,7 @@ use Cake\Event\EventManagerTrait;
 use Cake\Log\LogTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\MergeVariablesTrait;
@@ -84,6 +85,7 @@ class Controller implements EventListenerInterface
 {
 
     use EventManagerTrait;
+    use LocatorAwareTrait;
     use LogTrait;
     use MergeVariablesTrait;
     use ModelAwareTrait;
@@ -270,7 +272,7 @@ class Controller implements EventListenerInterface
             $this->eventManager($eventManager);
         }
 
-        $this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
+        $this->modelFactory('Table', [$this->locator(), 'get']);
         $modelClass = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
         $this->_setModelClass($modelClass);
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -272,7 +272,7 @@ class Controller implements EventListenerInterface
             $this->eventManager($eventManager);
         }
 
-        $this->modelFactory('Table', [$this->locator(), 'get']);
+        $this->modelFactory('Table', [$this->tableLocator(), 'get']);
         $modelClass = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
         $this->_setModelClass($modelClass);
 

--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -51,11 +51,13 @@ class DatabaseSession implements SessionHandlerInterface
      */
     public function __construct(array $config = [])
     {
+        $tableLocator = isset($config['tableLocator']) ? $config['tableLocator'] : TableRegistry::locator();
+
         if (empty($config['model'])) {
-            $config = TableRegistry::exists('Sessions') ? [] : ['table' => 'sessions'];
-            $this->_table = TableRegistry::get('Sessions', $config);
+            $config = $tableLocator->exists('Sessions') ? [] : ['table' => 'sessions'];
+            $this->_table = $tableLocator->get('Sessions', $config);
         } else {
-            $this->_table = TableRegistry::get($config['model']);
+            $this->_table = $tableLocator->get($config['model']);
         }
 
         $this->_timeout = ini_get('session.gc_maxlifetime');

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -293,11 +293,13 @@ abstract class Association
             $registryAlias = $this->_name;
         }
 
+        $tableLocator = $this->tableLocator();
+
         $config = [];
-        if (!$this->tableLocator()->exists($registryAlias)) {
+        if (!$tableLocator->exists($registryAlias)) {
             $config = ['className' => $this->_className];
         }
-        $this->_targetTable = $this->tableLocator()->get($registryAlias, $config);
+        $this->_targetTable = $tableLocator->get($registryAlias, $config);
 
         return $this->_targetTable;
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -18,6 +18,7 @@ use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetDecorator;
+use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -145,6 +146,13 @@ abstract class Association
     protected $_targetTable;
 
     /**
+     * Table locator instance
+     *
+     * @var \Cake\ORM\Locator\LocatorInterface
+     */
+    protected $_locator;
+
+    /**
      * The type of join to be used when adding the association to a query
      *
      * @var string
@@ -198,6 +206,7 @@ abstract class Association
             'finder',
             'foreignKey',
             'joinType',
+            'locator',
             'propertyName',
             'sourceTable',
             'targetTable'
@@ -214,6 +223,10 @@ abstract class Association
 
         list(, $name) = pluginSplit($alias);
         $this->_name = $name;
+
+        if (!$this->_locator) {
+            $this->_locator =& TableRegistry::locator();
+        }
 
         $this->_options($options);
 
@@ -292,10 +305,10 @@ abstract class Association
         }
 
         $config = [];
-        if (!TableRegistry::exists($registryAlias)) {
+        if (!$this->_locator->exists($registryAlias)) {
             $config = ['className' => $this->_className];
         }
-        $this->_targetTable = TableRegistry::get($registryAlias, $config);
+        $this->_targetTable = $this->_locator->get($registryAlias, $config);
 
         return $this->_targetTable;
     }
@@ -434,6 +447,21 @@ abstract class Association
             $this->_finder = $finder;
         }
         return $this->_finder;
+    }
+
+    /**
+     * Sets the table locator for this association.
+     * If no parameters are passed, it will return the currently used locator.
+     *
+     * @param LocatorInterface|null $locator LocatorInterface instance.
+     * @return LocatorInterface
+     */
+    public function locator(LocatorInterface $locator = null)
+    {
+        if ($locator !== null) {
+            $this->_locator = $locator;
+        }
+        return $this->_locator;
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -200,7 +200,7 @@ abstract class Association
             'finder',
             'foreignKey',
             'joinType',
-            'locator',
+            'tableLocator',
             'propertyName',
             'sourceTable',
             'targetTable'
@@ -295,10 +295,10 @@ abstract class Association
         }
 
         $config = [];
-        if (!$this->locator()->exists($registryAlias)) {
+        if (!$this->tableLocator()->exists($registryAlias)) {
             $config = ['className' => $this->_className];
         }
-        $this->_targetTable = $this->locator()->get($registryAlias, $config);
+        $this->_targetTable = $this->tableLocator()->get($registryAlias, $config);
 
         return $this->_targetTable;
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -21,7 +21,6 @@ use Cake\Datasource\ResultSetDecorator;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use RuntimeException;

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -18,7 +18,7 @@ use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetDecorator;
-use Cake\ORM\Locator\LocatorInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -35,6 +35,7 @@ abstract class Association
 {
 
     use ConventionsTrait;
+    use LocatorAwareTrait;
 
     /**
      * Strategy name to use joins for fetching associated records
@@ -146,13 +147,6 @@ abstract class Association
     protected $_targetTable;
 
     /**
-     * Table locator instance
-     *
-     * @var \Cake\ORM\Locator\LocatorInterface
-     */
-    protected $_locator;
-
-    /**
      * The type of join to be used when adding the association to a query
      *
      * @var string
@@ -223,10 +217,6 @@ abstract class Association
 
         list(, $name) = pluginSplit($alias);
         $this->_name = $name;
-
-        if (!$this->_locator) {
-            $this->_locator =& TableRegistry::locator();
-        }
 
         $this->_options($options);
 
@@ -305,10 +295,10 @@ abstract class Association
         }
 
         $config = [];
-        if (!$this->_locator->exists($registryAlias)) {
+        if (!$this->locator()->exists($registryAlias)) {
             $config = ['className' => $this->_className];
         }
-        $this->_targetTable = $this->_locator->get($registryAlias, $config);
+        $this->_targetTable = $this->locator()->get($registryAlias, $config);
 
         return $this->_targetTable;
     }
@@ -447,21 +437,6 @@ abstract class Association
             $this->_finder = $finder;
         }
         return $this->_finder;
-    }
-
-    /**
-     * Sets the table locator for this association.
-     * If no parameters are passed, it will return the currently used locator.
-     *
-     * @param LocatorInterface|null $locator LocatorInterface instance.
-     * @return LocatorInterface
-     */
-    public function locator(LocatorInterface $locator = null)
-    {
-        if ($locator !== null) {
-            $this->_locator = $locator;
-        }
-        return $this->_locator;
     }
 
     /**

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -18,7 +18,6 @@ use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use RuntimeException;
@@ -177,15 +176,15 @@ class BelongsToMany extends Association
                 $tableAlias = Inflector::camelize($tableName);
 
                 $config = [];
-                if (!TableRegistry::exists($tableAlias)) {
+                if (!$this->_locator->exists($tableAlias)) {
                     $config = ['table' => $tableName];
                 }
-                $table = TableRegistry::get($tableAlias, $config);
+                $table = $this->_locator->get($tableAlias, $config);
             }
         }
 
         if (is_string($table)) {
-            $table = TableRegistry::get($table);
+            $table = $this->_locator->get($table);
         }
         $junctionAlias = $table->alias();
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -176,15 +176,15 @@ class BelongsToMany extends Association
                 $tableAlias = Inflector::camelize($tableName);
 
                 $config = [];
-                if (!$this->locator()->exists($tableAlias)) {
+                if (!$this->tableLocator()->exists($tableAlias)) {
                     $config = ['table' => $tableName];
                 }
-                $table = $this->locator()->get($tableAlias, $config);
+                $table = $this->tableLocator()->get($tableAlias, $config);
             }
         }
 
         if (is_string($table)) {
-            $table = $this->locator()->get($table);
+            $table = $this->tableLocator()->get($table);
         }
         $junctionAlias = $table->alias();
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -176,15 +176,15 @@ class BelongsToMany extends Association
                 $tableAlias = Inflector::camelize($tableName);
 
                 $config = [];
-                if (!$this->_locator->exists($tableAlias)) {
+                if (!$this->locator()->exists($tableAlias)) {
                     $config = ['table' => $tableName];
                 }
-                $table = $this->_locator->get($tableAlias, $config);
+                $table = $this->locator()->get($tableAlias, $config);
             }
         }
 
         if (is_string($table)) {
-            $table = $this->_locator->get($table);
+            $table = $this->locator()->get($table);
         }
         $junctionAlias = $table->alias();
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -163,6 +163,7 @@ class BelongsToMany extends Association
         $source = $this->source();
         $sAlias = $source->alias();
         $tAlias = $target->alias();
+        $tableLocator = $this->tableLocator();
 
         if ($table === null) {
             if (!empty($this->_junctionTable)) {
@@ -176,15 +177,15 @@ class BelongsToMany extends Association
                 $tableAlias = Inflector::camelize($tableName);
 
                 $config = [];
-                if (!$this->tableLocator()->exists($tableAlias)) {
+                if (!$tableLocator->exists($tableAlias)) {
                     $config = ['table' => $tableName];
                 }
-                $table = $this->tableLocator()->get($tableAlias, $config);
+                $table = $tableLocator->get($tableAlias, $config);
             }
         }
 
         if (is_string($table)) {
-            $table = $this->tableLocator()->get($table);
+            $table = $tableLocator->get($table);
         }
         $junctionAlias = $table->alias();
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -141,18 +141,19 @@ class TranslateBehavior extends Behavior
         $targetAlias = $this->_translationTable->alias();
         $alias = $this->_table->alias();
         $filter = $this->_config['onlyTranslated'];
+        $tableLocator = $this->tableLocator();
 
         foreach ($fields as $field) {
             $name = $alias . '_' . $field . '_translation';
 
-            if (!$this->tableLocator()->exists($name)) {
-                $fieldTable = $this->tableLocator()->get($name, [
+            if (!$tableLocator->exists($name)) {
+                $fieldTable = $tableLocator->get($name, [
                     'className' => $table,
                     'alias' => $name,
                     'table' => $this->_translationTable->table()
                 ]);
             } else {
-                $fieldTable = $this->tableLocator()->get($name);
+                $fieldTable = $tableLocator->get($name);
             }
 
             $conditions = [

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -81,7 +81,7 @@ class TranslateBehavior extends Behavior
         'allowEmptyTranslations' => true,
         'onlyTranslated' => false,
         'strategy' => 'subquery',
-        'locator' => null
+        'tableLocator' => null
     ];
 
     /**
@@ -97,8 +97,8 @@ class TranslateBehavior extends Behavior
             'referenceName' => $this->_referenceName($table)
         ];
 
-        if (isset($config['locator'])) {
-            $this->_locator = $config['locator'];
+        if (isset($config['tableLocator'])) {
+            $this->_tableLocator = $config['tableLocator'];
         }
 
         parent::__construct($table, $config);
@@ -112,7 +112,7 @@ class TranslateBehavior extends Behavior
      */
     public function initialize(array $config)
     {
-        $this->_translationTable = $this->locator()->get($this->_config['translationTable']);
+        $this->_translationTable = $this->tableLocator()->get($this->_config['translationTable']);
 
         $this->setupFieldAssociations(
             $this->_config['fields'],
@@ -145,14 +145,14 @@ class TranslateBehavior extends Behavior
         foreach ($fields as $field) {
             $name = $alias . '_' . $field . '_translation';
 
-            if (!$this->locator()->exists($name)) {
-                $fieldTable = $this->locator()->get($name, [
+            if (!$this->tableLocator()->exists($name)) {
+                $fieldTable = $this->tableLocator()->get($name, [
                     'className' => $table,
                     'alias' => $name,
                     'table' => $this->_translationTable->table()
                 ]);
             } else {
-                $fieldTable = $this->locator()->get($name);
+                $fieldTable = $this->tableLocator()->get($name);
             }
 
             $conditions = [

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -43,7 +43,8 @@ trait LocatorAwareTrait
             $this->_locator = $locator;
         }
         if (!$this->_locator) {
-            $this->_locator = TableRegistry::locator();
+            $locator = TableRegistry::locator();
+            $this->_locator =& $locator;
         }
         return $this->_locator;
     }

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\ORM\Locator;
 
-use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\TableRegistry;
 
 /**

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\Locator;
+
+use Cake\ORM\Locator\LocatorInterface;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Contains method for setting and accessing LocatorInterface instance
+ */
+trait LocatorAwareTrait
+{
+
+    /**
+     * Table locator instance
+     *
+     * @var \Cake\ORM\Locator\LocatorInterface
+     */
+    protected $_locator;
+
+    /**
+     * Sets the table locator.
+     * If no parameters are passed, it will return the currently used locator.
+     *
+     * @param LocatorInterface|null $locator LocatorInterface instance.
+     * @return LocatorInterface
+     */
+    public function locator(LocatorInterface $locator = null)
+    {
+        if ($locator !== null) {
+            $this->_locator = $locator;
+        }
+        if (!$this->_locator) {
+            $this->_locator = TableRegistry::locator();
+        }
+        return $this->_locator;
+    }
+}

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -34,8 +34,8 @@ trait LocatorAwareTrait
      * Sets the table locator.
      * If no parameters are passed, it will return the currently used locator.
      *
-     * @param LocatorInterface|null $locator LocatorInterface instance.
-     * @return LocatorInterface
+     * @param \Cake\ORM\Locator\LocatorInterface|null $locator LocatorInterface instance.
+     * @return \Cake\ORM\Locator\LocatorInterface
      */
     public function locator(LocatorInterface $locator = null)
     {

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -43,8 +43,7 @@ trait LocatorAwareTrait
             $this->_locator = $locator;
         }
         if (!$this->_locator) {
-            $locator = TableRegistry::locator();
-            $this->_locator =& $locator;
+            $this->_locator = TableRegistry::locator();
         }
         return $this->_locator;
     }

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -27,23 +27,23 @@ trait LocatorAwareTrait
      *
      * @var \Cake\ORM\Locator\LocatorInterface
      */
-    protected $_locator;
+    protected $_tableLocator;
 
     /**
      * Sets the table locator.
      * If no parameters are passed, it will return the currently used locator.
      *
-     * @param \Cake\ORM\Locator\LocatorInterface|null $locator LocatorInterface instance.
+     * @param \Cake\ORM\Locator\LocatorInterface|null $tableLocator LocatorInterface instance.
      * @return \Cake\ORM\Locator\LocatorInterface
      */
-    public function locator(LocatorInterface $locator = null)
+    public function tableLocator(LocatorInterface $tableLocator = null)
     {
-        if ($locator !== null) {
-            $this->_locator = $locator;
+        if ($tableLocator !== null) {
+            $this->_tableLocator = $tableLocator;
         }
-        if (!$this->_locator) {
-            $this->_locator = TableRegistry::locator();
+        if (!$this->_tableLocator) {
+            $this->_tableLocator = TableRegistry::locator();
         }
-        return $this->_locator;
+        return $this->_tableLocator;
     }
 }

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -142,7 +142,7 @@ abstract class Cell
         $this->eventManager($eventManager);
         $this->request = $request;
         $this->response = $response;
-        $this->modelFactory('Table', [$this->locator(), 'get']);
+        $this->modelFactory('Table', [$this->tableLocator(), 'get']);
 
         foreach ($this->_validCellOptions as $var) {
             if (isset($cellOptions[$var])) {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -19,6 +19,7 @@ use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 use Cake\View\Exception\MissingCellViewException;
 use Cake\View\Exception\MissingTemplateException;
@@ -32,6 +33,7 @@ abstract class Cell
 {
 
     use EventManagerTrait;
+    use LocatorAwareTrait;
     use ModelAwareTrait;
     use ViewVarsTrait;
 
@@ -140,7 +142,7 @@ abstract class Cell
         $this->eventManager($eventManager);
         $this->request = $request;
         $this->response = $response;
-        $this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
+        $this->modelFactory('Table', [$this->locator(), 'get']);
 
         foreach ($this->_validCellOptions as $var) {
             if (isset($cellOptions[$var])) {

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -337,13 +337,13 @@ class AssociationTest extends TestCase
         $locator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
         $config = [
             'className' => '\Cake\Test\TestCase\ORM\TestTable',
-            'locator' => $locator
+            'tableLocator' => $locator
         ];
         $assoc = $this->getMock(
             '\Cake\ORM\Association',
             ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
             ['Foo', $config]
         );
-        $this->assertEquals($locator, $assoc->locator());
+        $this->assertEquals($locator, $assoc->tableLocator());
     }
 }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -328,21 +328,6 @@ class AssociationTest extends TestCase
     }
 
     /**
-     * Tests locator method
-     *
-     * @return void
-     */
-    public function testLocator()
-    {
-        $locator = $this->association->locator();
-        $this->assertSame(TableRegistry::locator(), $locator);
-
-        $newLocator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
-        $associationLocator = $this->association->locator($newLocator);
-        $this->assertSame($newLocator, $associationLocator);
-    }
-    
-    /**
      * Tests that `locator` is a valid option for the association constructor
      *
      * @return void

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -326,4 +326,39 @@ class AssociationTest extends TestCase
             $this->association->find()->getOptions()
         );
     }
+
+    /**
+     * Tests locator method
+     *
+     * @return void
+     */
+    public function testLocator()
+    {
+        $locator = $this->association->locator();
+        $this->assertSame(TableRegistry::locator(), $locator);
+
+        $newLocator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
+        $associationLocator = $this->association->locator($newLocator);
+        $this->assertSame($newLocator, $associationLocator);
+    }
+    
+    /**
+     * Tests that `locator` is a valid option for the association constructor
+     *
+     * @return void
+     */
+    public function testLocatorInConstructor()
+    {
+        $locator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
+        $config = [
+            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'locator' => $locator
+        ];
+        $assoc = $this->getMock(
+            '\Cake\ORM\Association',
+            ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
+            ['Foo', $config]
+        );
+        $this->assertEquals($locator, $assoc->locator());
+    }
 }

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\ORM\Locator;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * LocatorAwareTrait test case
+ *
+ */
+class LocatorAwareTraitTest extends TestCase
+{
+
+    /**
+     * setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->subject = $this->getObjectForTrait('Cake\ORM\Locator\LocatorAwareTrait');
+    }
+
+    /**
+     * Tests locator method
+     *
+     * @return void
+     */
+    public function testLocator()
+    {
+        $locator = $this->subject->locator();
+        $this->assertSame(TableRegistry::locator(), $locator);
+
+        $newLocator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
+        $subjectLocator = $this->subject->locator($newLocator);
+        $this->assertSame($newLocator, $subjectLocator);
+    }
+}

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -37,17 +37,17 @@ class LocatorAwareTraitTest extends TestCase
     }
 
     /**
-     * Tests locator method
+     * Tests tableLocator method
      *
      * @return void
      */
-    public function testLocator()
+    public function testTableLocator()
     {
-        $locator = $this->subject->locator();
-        $this->assertSame(TableRegistry::locator(), $locator);
+        $tableLocator = $this->subject->tableLocator();
+        $this->assertSame(TableRegistry::locator(), $tableLocator);
 
         $newLocator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
-        $subjectLocator = $this->subject->locator($newLocator);
+        $subjectLocator = $this->subject->tableLocator($newLocator);
         $this->assertSame($newLocator, $subjectLocator);
     }
 }


### PR DESCRIPTION
I've finally found some free time to do this...

This follows PR #6244.
I've replaced some of the most commonly used calls to `TableRegistry` with calls to the table locator instance.

I've added LocatorAwareTrait which holds `LocatorInterface` instance and its accessor/mutator. ~~Also it falls back to `TableRegistry::locator()` _reference_ so if a locator hasn't been explicitly set, a trait's instance would follow changes made to the `TableRegistry`'s instance.~~ (Nah, I have no idea why I thought it could work that way).

So now classes which use this trait include `Association` and `TranslateBehavior` for locating nessesary models. Also I've injected `modelFactory()` in `Cell` and `Controller` as this generated a lot of calls to `TableRegistry`.

PS. There was a [suggestion](https://github.com/cakephp/cakephp/pull/6244#issuecomment-88899700) to pass locators to associations from a Table, but I think table shouldn't inject dependencies into its associations.~~, because by default locator should be replacable, and there's a way to do it from `TableRegistry`. So if there's a need we can pass some locator in association options, but by default it should fall back to TableRegistry's instance.~~

PS2. Now I'm wondering if I it would be reasonable just to do this in `LocatorAwareTrait`:

``` php
if (!$this->_locator) {
    return TableRegistry::locator();
}
```
