### PR TITLE
Avoid selecting all fields if possible when using find('list').

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -968,6 +968,14 @@ class Table implements RepositoryInterface, EventListenerInterface
             trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_WARNING);
         }
 
+        if (!$query->clause('select')) {
+            $fields = array_merge((array)$options['keyField'], (array)$options['valueField']);
+            $columns = $this->schema()->columns();
+            if (count($fields) === count(array_intersect($fields, $columns))) {
+                $query->select($fields);
+            }
+        }
+
         $options = $this->_setFieldMatchers(
             $options,
             ['keyField', 'valueField', 'groupField']

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -968,7 +968,11 @@ class Table implements RepositoryInterface, EventListenerInterface
             trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_WARNING);
         }
 
-        if (!$query->clause('select')) {
+        if (!$query->clause('select') &&
+            !is_object($options['keyField']) &&
+            !is_object($options['valueField']) &&
+            !is_object($options['groupField'])
+        ) {
             $fields = array_merge(
                 (array)$options['keyField'],
                 (array)$options['valueField'],

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -969,7 +969,11 @@ class Table implements RepositoryInterface, EventListenerInterface
         }
 
         if (!$query->clause('select')) {
-            $fields = array_merge((array)$options['keyField'], (array)$options['valueField']);
+            $fields = array_merge(
+                (array)$options['keyField'],
+                (array)$options['valueField'],
+                (array)$options['groupField']
+            );
             $columns = $this->schema()->columns();
             if (count($fields) === count(array_intersect($fields, $columns))) {
                 $query->select($fields);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1265,7 +1265,7 @@ class TableTest extends TestCase
         $articles->belongsTo('Authors');
         $query = $articles->find('list', ['valueField' => 'author.name'])
             ->contain(['Authors'])
-            ->order('Articles.id');
+            ->order('articles.id');
         $this->assertEmpty($query->clause('select'));
 
         $expected = [

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1251,6 +1251,32 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test find('list') with value field from associated table
+     *
+     * @return void
+     */
+    public function testFindListWithAssociatedTable()
+    {
+        $articles = new Table([
+            'table' => 'articles',
+            'connection' => $this->connection,
+        ]);
+
+        $articles->belongsTo('Authors');
+        $query = $articles->find('list', ['valueField' => 'author.name'])
+            ->contain(['Authors'])
+            ->order('Articles.id');
+        $this->assertEmpty($query->clause('select'));
+
+        $expected = [
+            1 => 'mariano',
+            2 => 'larry',
+            3 => 'mariano',
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    /**
      * Test the default entityClass.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1197,18 +1197,20 @@ class TableTest extends TestCase
         $expected = ['id', 'username'];
         $this->assertSame($expected, $query->clause('select'));
 
-        $select = ['odd' => new QueryExpression('id % 2')];
-        $query = $table->find('list', ['groupField' => 'odd'])
-            ->select($select)
-            ->order('id');
-        $expected = array_merge(['id', 'username'], $select);
-        $this->assertSame($expected, $query->clause('select'));
-
         $expected = ['odd' => new QueryExpression('id % 2'), 'id', 'username'];
         $query = $table->find('list', [
             'fields' => $expected,
             'groupField' => 'odd',
         ]);
+        $this->assertSame($expected, $query->clause('select'));
+
+        $articles = new Table([
+            'table' => 'articles',
+            'connection' => $this->connection,
+        ]);
+
+        $query = $articles->find('list', ['groupField' => 'author_id']);
+        $expected = ['id', 'title', 'author_id'];
         $this->assertSame($expected, $query->clause('select'));
     }
 
@@ -1229,7 +1231,6 @@ class TableTest extends TestCase
         $query = $table
             ->find('list')
             ->order('id');
-
         $this->assertEmpty($query->clause('select'));
 
         $expected = [
@@ -1239,6 +1240,9 @@ class TableTest extends TestCase
             4 => 'bonus'
         ];
         $this->assertSame($expected, $query->toArray());
+
+        $query = $table->find('list', ['groupField' => 'odd']);
+        $this->assertEmpty($query->clause('select'));
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1197,6 +1197,11 @@ class TableTest extends TestCase
         $expected = ['id', 'username'];
         $this->assertSame($expected, $query->clause('select'));
 
+        $query = $table->find('list', ['valueField' => function ($row) {
+            return $row->username;
+        }]);
+        $this->assertEmpty($query->clause('select'));
+
         $expected = ['odd' => new QueryExpression('id % 2'), 'id', 'username'];
         $query = $table->find('list', [
             'fields' => $expected,

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1217,6 +1217,18 @@ class TableTest extends TestCase
         $query = $articles->find('list', ['groupField' => 'author_id']);
         $expected = ['id', 'title', 'author_id'];
         $this->assertSame($expected, $query->clause('select'));
+
+        $query = $articles->find('list', ['valueField' => ['author_id', 'title']])
+            ->order('id');
+        $expected = ['id', 'author_id', 'title'];
+        $this->assertSame($expected, $query->clause('select'));
+
+        $expected = [
+            1 => '1;First Article',
+            2 => '3;Second Article',
+            3 => '1;Third Article',
+        ];
+        $this->assertSame($expected, $query->toArray());
     }
 
     /**


### PR DESCRIPTION
Closes #6186.
