### PR TITLE
Time::jsonSerialize() change "format(static::ISO8601)" by __toString()

### DIFF
--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -799,7 +799,7 @@ class Time extends Carbon implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        return $this->format(static::ISO8601);
+        return $this->__toString();
     }
 
     /**


### PR DESCRIPTION
The function Time::jsonSerialize() should not have the format hard coded.
It should use the function '__toString()' instead of 'format(static::ISO8601)'.
So you can config how the Time fields would be formatted in JSON.
Thanks a lot.
