### PR TITLE
Use peer_name instead of deprecated CN_match

### DIFF
--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -234,7 +234,7 @@ class Stream
         if (!empty($options['ssl_verify_host'])) {
             $url = $request->url();
             $host = parse_url($url, PHP_URL_HOST);
-            $this->_sslContextOptions['CN_match'] = $host;
+            $this->_sslContextOptions['peer_name'] = $host;
         }
         foreach ($sslOptions as $key) {
             if (isset($options[$key])) {

--- a/tests/TestCase/Network/Http/Adapter/StreamTest.php
+++ b/tests/TestCase/Network/Http/Adapter/StreamTest.php
@@ -163,7 +163,7 @@ class StreamTest extends TestCase
         $this->stream->send($request, $options);
         $result = $this->stream->contextOptions();
         $expected = [
-            'CN_match' => 'localhost.com',
+            'peer_name' => 'localhost.com',
             'verify_peer' => true,
             'verify_depth' => 9000,
             'allow_self_signed' => false,


### PR DESCRIPTION
`CN_match` was deprecated in PHP 5.6 in favour for `peer_name`
