### PR TITLE
Remove the a tag from disabled pagination elements

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -60,9 +60,9 @@ class PaginatorHelper extends Helper
         'options' => [],
         'templates' => [
             'nextActive' => '<li class="next"><a rel="next" href="{{url}}">{{text}}</a></li>',
-            'nextDisabled' => '<li class="next disabled"><a href="">{{text}}</a></li>',
+            'nextDisabled' => '<li class="next disabled">{{text}}</li>',
             'prevActive' => '<li class="prev"><a rel="prev" href="{{url}}">{{text}}</a></li>',
-            'prevDisabled' => '<li class="prev disabled"><a href="">{{text}}</a></li>',
+            'prevDisabled' => '<li class="prev disabled">{{text}}</li>',
             'counterRange' => '{{start}} - {{end}} of {{count}}',
             'counterPages' => '{{page}} of {{pages}}',
             'first' => '<li class="first"><a href="{{url}}">{{text}}</a></li>',


### PR DESCRIPTION
**Why?**
I think that providing a clickable ui element which essentially 'does nothing' is counter-intuitive.

**Reasons for the change**
- Clicking an empty href will reload the page.
- The `<a>` tag doesn't have a `disabled` attribute.
- Styling can be done on the `<li>`.
- The disabled and active class is on the `<li>` tag.
- In Cake 2 pagination helper, no `<a>` tag was output for disabled links.
