### PR TITLE
Make the 2.x way possible again to auto-find the fields on find(list)

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -956,11 +956,30 @@ class Table implements RepositoryInterface, EventListenerInterface
      */
     public function findList(Query $query, array $options)
     {
-        $options += [
+        $defaults = [
             'keyField' => $this->primaryKey(),
             'valueField' => $this->displayField(),
             'groupField' => null
         ];
+
+        if ($query->clause('select') && count($query->clause('select')) <= 3) {
+            $select = (array)$query->clause('select');
+            foreach (array_keys($defaults) as $fieldName) {
+                $part = array_splice($select, 0, 1);
+                if (empty($part)) {
+                    break;
+                }
+                list($key, $value) = each($part);
+
+                if (is_numeric($key)) {
+                    $defaults[$fieldName] = $value;
+                } else {
+                    $defaults[$fieldName] = $key;
+                }
+            }
+        }
+
+        $options += $defaults;
 
         if (isset($options['idField'])) {
             $options['keyField'] = $options['idField'];


### PR DESCRIPTION
In the 2.x docs:

``` php
    $justusernames = $this->Article->User->find('list', array(
        'fields' => array('User.username')
    ));
    $usernameMap = $this->Article->User->find('list', array(
        'fields' => array('User.username', 'User.first_name')
    ));
    $usernameGroups = $this->Article->User->find('list', array(
        'fields' => array('User.username', 'User.first_name', 'User.group')
    ));
```

This wasn't possible in 3.x so far anymore. Also see https://github.com/cakephp/cakephp/issues/6291

This patch would enable it again for "fields" with <= 3 fields defined.
The original patch was for `2-3`, but the case `1` would also be possible by duplicating the single field given (not included yet).
Also no tests added yet.

I want to first discuss if we want the 2.x behavior back or if we stick with the more explicit forcing of keyField, valueField and groupField.
If so, I can rebase it towards 3.1 then as enhancement.
