### PR TITLE
XmlView should also have options just as JsonView has. 

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -160,7 +160,7 @@ class Xml
      *
      * ### Options
      *
-     * - `format` If create childs ('tags') or attributes ('attribute').
+     * - `format` If create childs ('tags') or attributes ('attributes').
      * - `pretty` Returns formatted Xml when set to `true`. Defaults to `false`
      * - `version` Version of XML document. Default is 1.0.
      * - `encoding` Encoding of XML document. If null remove from XML header. Default is the some of application.
@@ -184,7 +184,7 @@ class Xml
      *
      * `<root><tag><id>1</id><value>defect</value>description</tag></root>`
      *
-     * And calling `Xml::fromArray($value, 'attribute');` Will generate:
+     * And calling `Xml::fromArray($value, 'attributes');` Will generate:
      *
      * `<root><tag id="1" value="defect">description</tag></root>`
      *
@@ -237,7 +237,7 @@ class Xml
      * @param \DOMDocument $dom Handler to DOMDocument
      * @param \DOMElement $node Handler to DOMElement (child)
      * @param array $data Array of data to append to the $node.
-     * @param string $format Either 'attribute' or 'tags'. This determines where nested keys go.
+     * @param string $format Either 'attributes' or 'tags'. This determines where nested keys go.
      * @return void
      * @throws \Cake\Utility\Exception\XmlException
      */

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -147,6 +147,10 @@ class JsonView extends View
     /**
      * Serialize view vars
      *
+     * ### Special parameters
+     * `_jsonOptions` You can set custom options for json_encode() this way,
+     *   e.g. `JSON_HEX_TAG | JSON_HEX_APOS`.
+     *
      * @param array|string $serialize The name(s) of the view variable(s) that need(s) to be serialized
      * @return string The serialized data
      */

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -131,6 +131,10 @@ class XmlView extends View
     /**
      * Serialize view vars.
      *
+     * ### Special parameters
+     * `_xmlOptions` You can set an array of custom options for Xml::fromArray() this way, e.g.
+     *   'format' as 'attributes' instead of 'tags'.
+     *
      * @param array|string $serialize The name(s) of the view variable(s) that need(s) to be serialized
      * @return string The serialized data
      */
@@ -154,6 +158,9 @@ class XmlView extends View
         }
 
         $options = [];
+        if (isset($this->viewVars['_xmlOptions'])) {
+            $options = $this->viewVars['_xmlOptions'];
+        }
         if (Configure::read('debug')) {
             $options['pretty'] = true;
         }

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -108,6 +108,78 @@ class XmlViewTest extends TestCase
     }
 
     /**
+     * Test that rendering with _serialize respects XML options.
+     *
+     * @return void
+     */
+    public function testRenderSerializeWithOptions()
+    {
+        $Request = new Request();
+        $Response = new Response();
+        $Controller = new Controller($Request, $Response);
+        $data = [
+            '_serialize' => ['tags'],
+            '_xmlOptions' => ['format' => 'attributes'],
+            'tags' => [
+                    'tag' => [
+                        [
+                            'id' => '1',
+                            'name' => 'defect'
+                        ],
+                        [
+                            'id' => '2',
+                            'name' => 'enhancement'
+                        ]
+                    ]
+            ]
+        ];
+        $Controller->set($data);
+        $Controller->viewClass = 'Xml';
+        $View = $Controller->createView();
+        $result = $View->render();
+
+        $expected = Xml::build(['response' => ['tags' => $data['tags']]], $data['_xmlOptions'])->asXML();
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test that rendering with _serialize can work with string setting.
+     *
+     * @return void
+     */
+    public function testRenderSerializeWithString()
+    {
+        $Request = new Request();
+        $Response = new Response();
+        $Controller = new Controller($Request, $Response);
+        $data = [
+            '_serialize' => 'tags',
+            '_xmlOptions' => ['format' => 'attributes'],
+            'tags' => [
+                'tags' => [
+                    'tag' => [
+                        [
+                            'id' => '1',
+                            'name' => 'defect'
+                        ],
+                        [
+                            'id' => '2',
+                            'name' => 'enhancement'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $Controller->set($data);
+        $Controller->viewClass = 'Xml';
+        $View = $Controller->createView();
+        $result = $View->render();
+
+        $expected = Xml::build($data['tags'], $data['_xmlOptions'])->asXML();
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * Test render with an array in _serialize
      *
      * @return void


### PR DESCRIPTION
These were missing in the XmlView class so far, but needed, if output should be attributes instead of default tags.

Also fixed documentation (plural "attributes).
