### PR TITLE
Update requirements to what we actually test.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"source": "https://github.com/cakephp/cakephp"
 	},
 	"require": {
-		"php": ">=5.2.8",
+		"php": ">=5.3.0",
 		"ext-mcrypt": "*"
 	},
 	"require-dev": {


### PR DESCRIPTION
As per [roadmap](https://github.com/cakephp/cakephp/wiki/2.7-Roadmap) and discussed a long time ago, CakePHP 2.7+ [doesn't CI test](https://github.com/cakephp/cakephp/blob/2.7/.travis.yml#L4) or _officially_ support PHP5.2 anymore.
Should we also (composer) require that?
I think that makes sense because without testing we cannot guarantee it anyway.

Even PHP 5.3 is already long EOL, but PHP 5.2 is just super-old and super-outdated.
This way we can at least clean up the code a bit, and remove all those `if (version >= 5.3)` checks.

**Important**: BC still has to be 100% of course - as always between minor versions.
