### PR TITLE
Add the {*} matcher to Hash::extract()

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -837,6 +837,28 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Test wildcard matcher
+ *
+ * @return void
+ */
+	public function testExtractWildcard() {
+		$data = array(
+			'02000009C5560001' => array('name' => 'Mr. Alphanumeric'),
+			'2300000918020101' => array('name' => 'Mr. Numeric'),
+			'390000096AB30001' => array('name' => 'Mrs. Alphanumeric'),
+			'stuff' => array('name' => 'Ms. Word'),
+		);
+		$result = Hash::extract($data, '{*}.name');
+		$expected = array(
+			'Mr. Alphanumeric',
+			'Mr. Numeric',
+			'Mrs. Alphanumeric',
+			'Ms. Word',
+		);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Test the attribute presense selector.
  *
  * @return void

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -847,6 +847,8 @@ class HashTest extends CakeTestCase {
 			'2300000918020101' => array('name' => 'Mr. Numeric'),
 			'390000096AB30001' => array('name' => 'Mrs. Alphanumeric'),
 			'stuff' => array('name' => 'Ms. Word'),
+			123 => array('name' => 'Mr. Number'),
+			true => array('name' => 'Ms. Bool'),
 		);
 		$result = Hash::extract($data, '{*}.name');
 		$expected = array(
@@ -854,6 +856,8 @@ class HashTest extends CakeTestCase {
 			'Mr. Numeric',
 			'Mrs. Alphanumeric',
 			'Ms. Word',
+			'Mr. Number',
+			'Ms. Bool',
 		);
 		$this->assertEquals($expected, $result);
 	}

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -76,6 +76,7 @@ class Hash {
  *
  * - `{n}` Matches any numeric key, or integer.
  * - `{s}` Matches any string key.
+ * - `{*}` Matches any value.
  * - `Foo` Matches any key with the exact same value.
  *
  * There are a number of attribute operators:
@@ -171,16 +172,16 @@ class Hash {
  * @return bool
  */
 	protected static function _matchToken($key, $token) {
-		if ($token === '{n}') {
-			return is_numeric($key);
+		switch ($token) {
+			case '{n}':
+				return is_numeric($key);
+			case '{s}':
+				return is_string($key);
+			case '{*}':
+				return true;
+			default:
+				return is_numeric($token) ? ($key == $token) : $key === $token;
 		}
-		if ($token === '{s}') {
-			return is_string($key);
-		}
-		if (is_numeric($token)) {
-			return ($key == $token);
-		}
-		return ($key === $token);
 	}
 
 /**


### PR DESCRIPTION
This matcher will match anything and is useful when you just want to traverse through data and you're not too picky.

I've also refactored the conditions to use a case as it is slightly more readable and uses fewer lines of code.

If people are happy with this, I'll forward port the changes to 3.x as well.

Refs #6447
