### PR TITLE
Backport _xmlOptions

### DIFF
--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -96,7 +96,6 @@ class XmlViewTest extends CakeTestCase {
 		$this->assertFalse(isset($View->Html), 'No helper loaded.');
 	}
 
-
 /**
  * Test that rendering with _serialize respects XML options.
  *
@@ -167,7 +166,7 @@ class XmlViewTest extends CakeTestCase {
 		$this->assertSame($expected, $result);
 	}
 
-	/**
+/**
  * Test render with an array in _serialize
  *
  * @return void

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -96,7 +96,78 @@ class XmlViewTest extends CakeTestCase {
 		$this->assertFalse(isset($View->Html), 'No helper loaded.');
 	}
 
+
 /**
+ * Test that rendering with _serialize respects XML options.
+ *
+ * @return void
+ */
+	public function testRenderSerializeWithOptions() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$data = [
+			'_serialize' => ['tags'],
+			'_xmlOptions' => ['format' => 'attributes'],
+			'tags' => [
+				'tag' => [
+					[
+						'id' => '1',
+						'name' => 'defect'
+					],
+					[
+						'id' => '2',
+						'name' => 'enhancement'
+					]
+				]
+			]
+		];
+		$Controller->set($data);
+		$Controller->viewClass = 'Xml';
+		$View = new XmlView($Controller);
+		$result = $View->render();
+
+		$expected = Xml::build(['response' => ['tags' => $data['tags']]], $data['_xmlOptions'])->asXML();
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * Test that rendering with _serialize can work with string setting.
+ *
+ * @return void
+ */
+	public function testRenderSerializeWithString() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$data = [
+			'_serialize' => 'tags',
+			'_xmlOptions' => ['format' => 'attributes'],
+			'tags' => [
+				'tags' => [
+					'tag' => [
+						[
+							'id' => '1',
+							'name' => 'defect'
+						],
+						[
+							'id' => '2',
+							'name' => 'enhancement'
+						]
+					]
+				]
+			]
+		];
+		$Controller->set($data);
+		$Controller->viewClass = 'Xml';
+		$View = new XmlView($Controller);
+		$result = $View->render();
+
+		$expected = Xml::build($data['tags'], $data['_xmlOptions'])->asXML();
+		$this->assertSame($expected, $result);
+	}
+
+	/**
  * Test render with an array in _serialize
  *
  * @return void

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -106,28 +106,28 @@ class XmlViewTest extends CakeTestCase {
 		$Request = new CakeRequest();
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
-		$data = [
-			'_serialize' => ['tags'],
-			'_xmlOptions' => ['format' => 'attributes'],
-			'tags' => [
-				'tag' => [
-					[
+		$data = array(
+			'_serialize' => array('tags'),
+			'_xmlOptions' => array('format' => 'attributes'),
+			'tags' => array(
+				'tag' => array(
+					array(
 						'id' => '1',
 						'name' => 'defect'
-					],
-					[
+					),
+					array(
 						'id' => '2',
 						'name' => 'enhancement'
-					]
-				]
-			]
-		];
+					)
+				)
+			)
+		);
 		$Controller->set($data);
 		$Controller->viewClass = 'Xml';
 		$View = new XmlView($Controller);
 		$result = $View->render();
 
-		$expected = Xml::build(['response' => ['tags' => $data['tags']]], $data['_xmlOptions'])->asXML();
+		$expected = Xml::build(array('response' => array('tags' => $data['tags'])), $data['_xmlOptions'])->asXML();
 		$this->assertSame($expected, $result);
 	}
 
@@ -140,24 +140,24 @@ class XmlViewTest extends CakeTestCase {
 		$Request = new CakeRequest();
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
-		$data = [
+		$data = array(
 			'_serialize' => 'tags',
-			'_xmlOptions' => ['format' => 'attributes'],
-			'tags' => [
-				'tags' => [
-					'tag' => [
-						[
+			'_xmlOptions' => array('format' => 'attributes'),
+			'tags' => array(
+				'tags' => array(
+					'tag' => array(
+						array(
 							'id' => '1',
 							'name' => 'defect'
-						],
-						[
+						),
+						array(
 							'id' => '2',
 							'name' => 'enhancement'
-						]
-					]
-				]
-			]
-		];
+						)
+					)
+				)
+			)
+		);
 		$Controller->set($data);
 		$Controller->viewClass = 'Xml';
 		$View = new XmlView($Controller);

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -156,7 +156,7 @@ class Xml {
  *
  * ### Options
  *
- * - `format` If create childs ('tags') or attributes ('attribute').
+ * - `format` If create childs ('tags') or attributes ('attributes').
  * - `pretty` Returns formatted Xml when set to `true`. Defaults to `false`
  * - `version` Version of XML document. Default is 1.0.
  * - `encoding` Encoding of XML document. If null remove from XML header. Default is the some of application.
@@ -180,7 +180,7 @@ class Xml {
  *
  * `<root><tag><id>1</id><value>defect</value>description</tag></root>`
  *
- * And calling `Xml::fromArray($value, 'attribute');` Will generate:
+ * And calling `Xml::fromArray($value, 'attributes');` Will generate:
  *
  * `<root><tag id="1" value="defect">description</tag></root>`
  *
@@ -229,7 +229,7 @@ class Xml {
  * @param DOMDocument $dom Handler to DOMDocument
  * @param DOMElement $node Handler to DOMElement (child)
  * @param array &$data Array of data to append to the $node.
- * @param string $format Either 'attribute' or 'tags'. This determines where nested keys go.
+ * @param string $format Either 'attributes' or 'tags'. This determines where nested keys go.
  * @return void
  * @throws XmlException
  */

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -109,6 +109,10 @@ class XmlView extends View {
 /**
  * Serialize view vars.
  *
+ * ### Special parameters
+ * `_xmlOptions` You can set an array of custom options for Xml::fromArray() this way, e.g.
+ *   'format' as 'attributes' instead of 'tags'.
+ *
  * @param array $serialize The viewVars that need to be serialized.
  * @return string The serialized data
  */
@@ -131,6 +135,9 @@ class XmlView extends View {
 		}
 
 		$options = array();
+		if (isset($this->viewVars['_xmlOptions'])) {
+			$options = $this->viewVars['_xmlOptions'];
+		}
 		if (Configure::read('debug')) {
 			$options['pretty'] = true;
 		}


### PR DESCRIPTION
Backport of https://github.com/cakephp/cakephp/pull/6452

Also fixed documentation here to plural attributes, as the code uses

``` php
$xmlResponse = Xml::fromArray($xml, array('pretty' => true, 'format' => 'attributes'));
```
