### PR TITLE
Make extractOriginal() consistent with getOriginal().

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -528,7 +528,7 @@ trait EntityTrait
      * Returns an array with the requested original properties
      * stored in this entity, indexed by property name.
      *
-     * Properties that have are unchanged changed will be included in the
+     * Properties that are unchanged from their original value will be included in the
      * return of this method.
      *
      * @param array $properties List of properties to be returned
@@ -551,7 +551,7 @@ trait EntityTrait
      * stored in this entity, indexed by property name.
      *
      * This method will only return properties that have been modified since
-     * the entity was built unchanged properties will be omitted.
+     * the entity was built. Unchanged properties will be omitted.
      *
      * @param array $properties List of properties to be returned
      * @return array

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -528,7 +528,7 @@ trait EntityTrait
      * Returns an array with the requested original properties
      * stored in this entity, indexed by property name.
      *
-     * Properties that have not changed will be included in the
+     * Properties that have are unchanged changed will be included in the
      * return of this method.
      *
      * @param array $properties List of properties to be returned
@@ -550,13 +550,13 @@ trait EntityTrait
      * Returns an array with only the original properties
      * stored in this entity, indexed by property name.
      *
-     * This method will only return properties that have been modified.
-     * Unchanged properties will be omited.
+     * This method will only return properties that have been modified since
+     * the entity was built unchanged properties will be omitted.
      *
      * @param array $properties List of properties to be returned
      * @return array
      */
-    public function extractOriginalDirty(array $properties)
+    public function extractOriginalChanged(array $properties)
     {
         $result = [];
         foreach ($properties as $property) {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -526,12 +526,37 @@ trait EntityTrait
 
     /**
      * Returns an array with the requested original properties
-     * stored in this entity, indexed by property name
+     * stored in this entity, indexed by property name.
+     *
+     * Properties that have not changed will be included in the
+     * return of this method.
      *
      * @param array $properties List of properties to be returned
      * @return array
      */
     public function extractOriginal(array $properties)
+    {
+        $result = [];
+        foreach ($properties as $property) {
+            $original = $this->getOriginal($property);
+            if ($original !== null) {
+                $result[$property] = $original;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Returns an array with only the original properties
+     * stored in this entity, indexed by property name.
+     *
+     * This method will only return properties that have been modified.
+     * Unchanged properties will be omited.
+     *
+     * @param array $properties List of properties to be returned
+     * @return array
+     */
+    public function extractOriginalDirty(array $properties)
     {
         $result = [];
         foreach ($properties as $property) {

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -138,7 +138,7 @@ class CounterCacheBehavior extends Behavior
         $countConditions = $entity->extract($foreignKeys);
         $updateConditions = array_combine($primaryKeys, $countConditions);
 
-        $countOriginalConditions = $entity->extractOriginal($foreignKeys);
+        $countOriginalConditions = $entity->extractOriginalDirty($foreignKeys);
         if ($countOriginalConditions !== []) {
             $updateOriginalConditions = array_combine($primaryKeys, $countOriginalConditions);
         }

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -138,7 +138,7 @@ class CounterCacheBehavior extends Behavior
         $countConditions = $entity->extract($foreignKeys);
         $updateConditions = array_combine($primaryKeys, $countConditions);
 
-        $countOriginalConditions = $entity->extractOriginalDirty($foreignKeys);
+        $countOriginalConditions = $entity->extractOriginalChanged($foreignKeys);
         if ($countOriginalConditions !== []) {
             $updateOriginalConditions = array_combine($primaryKeys, $countOriginalConditions);
         }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -92,7 +92,7 @@ class EntityTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
 
-        $result = $entity->extractOriginalDirty(['id', 'title', 'body']);
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body']);
         $expected = [
             'body' => 'no',
         ];

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -72,6 +72,34 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Test extractOriginal()
+     *
+     * @return void
+     */
+    public function testExtractOriginal()
+    {
+        $entity = new Entity([
+            'id' => 1,
+            'title' => 'original',
+            'body' => 'no'
+        ], ['markNew' => true]);
+        $entity->set('body', 'updated body');
+        $result = $entity->extractOriginal(['id', 'title', 'body']);
+        $expected = [
+            'id' => 1,
+            'title' => 'original',
+            'body' => 'no'
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = $entity->extractOriginalDirty(['id', 'title', 'body']);
+        $expected = [
+            'body' => 'no',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Tests setting a single property using a setter function
      *
      * @return void


### PR DESCRIPTION
Make the two methods consistent. Introduce a new method for getting the original value of properties that have been modified.

I'm not very happy with the new method name, and would like suggestions if people can think of a better/clearer name.

Refs #6467
