### PR TITLE
Add Type::set()

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -109,7 +109,7 @@ class Type
      * Returns a Type object capable of converting a type identified by $name
      *
      * @param string $name The type identifier you want to set.
-     * @param \Cake\Databse\Type $type The type instance you want to set.
+     * @param \Cake\Databse\Type $instance The type instance you want to set.
      * @return void
      */
     public static function set($name, Type $instance)

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -106,6 +106,18 @@ class Type
     }
 
     /**
+     * Returns a Type object capable of converting a type identified by $name
+     *
+     * @param string $name The type identifier you want to set.
+     * @param \Cake\Databse\Type $type The type instance you want to set.
+     * @return void
+     */
+    public static function set($name, Type $instance)
+    {
+        static::$_builtTypes[$name] = $instance;
+    }
+
+    /**
      * Registers a new type identifier and maps it to a fully namespaced classname,
      * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -380,4 +380,16 @@ class TypeTest extends TestCase
         $driver = $this->getMock('\Cake\Database\Driver');
         $this->assertEquals(PDO::PARAM_STR, $type->toStatement($string, $driver));
     }
+
+    /**
+     * Test setting instances into the factory/registry.
+     *
+     * @return void
+     */
+    public function testSet()
+    {
+        $instance = $this->getMock('Cake\Database\Type');
+        Type::set('random', $instance);
+        $this->assertSame($instance, Type::build('random'));
+    }
 }


### PR DESCRIPTION
This method allows userland code to inject constructed instances into the Type registry allowing userland instances to be used later via build().

Refs #6474
