### PR TITLE
3.0 Make sure $object implement EventListenerInterface in ObjectRegistry

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Core;
 
+use Cake\Event\EventListenerInterface;
 use RuntimeException;
 
 /**
@@ -277,7 +278,7 @@ abstract class ObjectRegistry
     {
         list(, $name) = pluginSplit($objectName);
         $this->unload($objectName);
-        if (isset($this->_eventManager)) {
+        if (isset($this->_eventManager) && $object instanceof EventListenerInterface) {
             $this->eventManager()->attach($object);
         }
         $this->_loaded[$name] = $object;
@@ -297,7 +298,7 @@ abstract class ObjectRegistry
             return;
         }
         $object = $this->_loaded[$objectName];
-        if (isset($this->_eventManager)) {
+        if (isset($this->_eventManager) && $object instanceof EventListenerInterface) {
             $this->eventManager()->off($object);
         }
         unset($this->_loaded[$objectName]);

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -279,7 +279,7 @@ abstract class ObjectRegistry
         list(, $name) = pluginSplit($objectName);
         $this->unload($objectName);
         if (isset($this->_eventManager) && $object instanceof EventListenerInterface) {
-            $this->eventManager()->attach($object);
+            $this->eventManager()->on($object);
         }
         $this->_loaded[$name] = $object;
     }


### PR DESCRIPTION
`InvalidArgumentException` was triggered while trying to set or unload objects, which weren't event listeners.
