### PR TITLE
Fix for query parameters in integration test

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -350,11 +350,13 @@ abstract class IntegrationTestCase extends TestCase
         $session = Session::create($sessionConfig);
         $session->write($this->_session);
 
+        list ($url, $query) = $this->_url($url);
         $props = [
-            'url' => Router::url($url),
+            'url' => $url,
             'post' => $data,
             'cookies' => $this->_cookie,
             'session' => $session,
+            'query' => $query
         ];
         $env = [];
         if (isset($this->_request['headers'])) {
@@ -367,6 +369,25 @@ abstract class IntegrationTestCase extends TestCase
         $props['environment'] = $env;
         $props = Hash::merge($props, $this->_request);
         return new Request($props);
+    }
+
+    /**
+     * Creates a valid request url and parameter array more like Request::_url()
+     *
+     * @param string|array $url The URL
+     * @return array Qualified URL and the query parameters
+     */
+    protected function _url($url)
+    {
+        $url = Router::url($url);
+        $query = [];
+
+        if (strpos($url, '?') !== false) {
+            list($url, $parameters) = explode('?', $url, 2);
+            parse_str($parameters, $query);
+        }
+
+        return [$url, $query];
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -73,6 +73,18 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test building a request, with query parameters
+     *
+     * @return void
+     */
+    public function testRequestBuildingQueryParameters()
+    {
+        $request = $this->_buildRequest('/tasks/view?archived=yes', 'GET', []);
+
+        $this->assertEquals('/tasks/view?archived=yes', $request->here());
+        $this->assertEquals('yes', $request->query('archived'));
+    }
+    /**
      * Test sending get requests.
      *
      * @return void

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -84,6 +84,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertEquals('/tasks/view?archived=yes', $request->here());
         $this->assertEquals('yes', $request->query('archived'));
     }
+
     /**
      * Test sending get requests.
      *


### PR DESCRIPTION
Hi,

Currently the `php $request->here()` method returns `/tasks/view?archived=yes?archived=yes` in the IntegrationTestCase and the query parameters array is not set, when testing a `GET`.
