### PR TITLE
3.0 remove @see causing new apigen build to fail

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -108,7 +108,6 @@ if (!function_exists('stackTrace')) {
      *
      * @param array $options Format for outputting stack trace
      * @return mixed Formatted stack trace
-     * @see Debugger::trace()
      */
     function stackTrace(array $options = [])
     {


### PR DESCRIPTION
This line is causing issue with apigen v4.x generation and I didn't find any other solution.
I don't think we will miss it really...
