### PR TITLE
Collection and Query isEmpty()

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -830,4 +830,21 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * @return \Cake\Collection\CollectionInterface
      */
     public function through(callable $handler);
+
+    /**
+     * Returns whether or not there are elements in this collection
+     *
+     * ### Example:
+     *
+     * ```
+     * $items [1, 2, 3];
+     * (new Collection($items))->isEmpty(); // false
+     * ```
+     * ```
+     * (new Collection([]))->isEmpty(); // true
+     * ```
+     *
+     * @return bool
+     */
+    public function isEmpty();
 }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -532,6 +532,15 @@ trait CollectionTrait
     }
 
     /**
+     * {@inheritDoc}
+     *
+     */
+    public function isEmpty()
+    {
+        return iterator_count($this->take(1)) === 0;
+    }
+
+    /**
      * Returns the closest nested iterator that can be safely traversed without
      * losing any possible transformations.
      *

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1226,4 +1226,23 @@ class CollectionTest extends TestCase
         ];
         $this->assertSame($expected, $result);
     }
+
+    /**
+     * Tests the isEmpty() method
+     *
+     * @return void
+     */
+    public function testIsEmpty()
+    {
+        $collection = new Collection([1, 2, 3]);
+        $this->assertFalse($collection->isEmpty());
+
+        $collection = $collection->map(function () {
+            return null;
+        });
+        $this->assertFalse($collection->isEmpty());
+
+        $collection = $collection->filter();
+        $this->assertTrue($collection->isEmpty());
+    }
 }

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -413,14 +413,6 @@ class StaticConfigTraitTest extends TestCase
      */
     public function testParseDsnPathSetting()
     {
-        $dsn = 'file:///';
-        $expected = [
-            'className' => 'Cake\Log\Engine\FileLog',
-            'path' => '/',
-            'scheme' => 'file',
-        ];
-        $this->assertEquals($expected, TestLogStaticConfig::parseDsn($dsn));
-
         $dsn = 'file:///?path=/tmp/persistent/';
         $expected = [
             'className' => 'Cake\Log\Engine\FileLog',

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2630,4 +2630,16 @@ class QueryTest extends TestCase
         $this->assertCount(2, $result->tags);
         $this->assertEquals(2, $result->_matchingData['tags']->id);
     }
+
+    /**
+     * Tests that isEmpty() can be called on a query
+     *
+     * @return void
+     */
+    public function testIsEmpty()
+    {
+        $table = TableRegistry::get('articles');
+        $this->assertFalse($table->find()->isEmpty());
+        $this->assertTrue($table->find()->where(['id' => -1])->isEmpty());
+    }
 }


### PR DESCRIPTION
One of the most common questions for cake 3 is how to determine if the query has any results, the same question is also often asked in stackoverflow for collection objects. That made me realize we needed a method for checking collection emptiness in a non-hacky way.
