### PR TITLE
Function that just builds and executes the query without returning the result set

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1114,7 +1114,7 @@ class DboSource extends DataSource {
  * @return string The built SQL statement
  */
 	public function getQueryStatement(Model $Model, &$queryData = null, $recursive = null) {
-		$queryData = is_null($queryData) ? array() : $queryData;
+		$queryData = $queryData === null ? array() : $queryData;
 		$queryData = $this->_scrubQueryData($queryData);
 
 		if ($recursive === null && isset($queryData['recursive'])) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1046,62 +1046,7 @@ class DboSource extends DataSource {
 			$Model->recursive = $recursive;
 		}
 
-		if (!empty($queryData['fields'])) {
-			$noAssocFields = true;
-			$queryData['fields'] = $this->fields($Model, null, $queryData['fields']);
-		} else {
-			$noAssocFields = false;
-			$queryData['fields'] = $this->fields($Model);
-		}
-
-		if ($Model->recursive === -1) {
-			// Primary model data only, no joins.
-			$associations = array();
-
-		} else {
-			$associations = $Model->associations();
-
-			if ($Model->recursive === 0) {
-				// Primary model data and its domain.
-				unset($associations[2], $associations[3]);
-			}
-		}
-
-		$originalJoins = $queryData['joins'];
-		$queryData['joins'] = array();
-
-		// Generate hasOne and belongsTo associations inside $queryData
-		$linkedModels = array();
-		foreach ($associations as $type) {
-			if ($type !== 'hasOne' && $type !== 'belongsTo') {
-				continue;
-			}
-
-			foreach ($Model->{$type} as $assoc => $assocData) {
-				$LinkModel = $Model->{$assoc};
-
-				if ($Model->useDbConfig !== $LinkModel->useDbConfig) {
-					continue;
-				}
-
-				if ($noAssocFields) {
-					$assocData['fields'] = false;
-				}
-
-				$external = isset($assocData['external']);
-
-				if ($this->generateAssociationQuery($Model, $LinkModel, $type, $assoc, $assocData, $queryData, $external) === true) {
-					$linkedModels[$type . '/' . $assoc] = true;
-				}
-			}
-		}
-
-		if (!empty($originalJoins)) {
-			$queryData['joins'] = array_merge($queryData['joins'], $originalJoins);
-		}
-
-		// Build SQL statement with the primary model, plus hasOne and belongsTo associations
-		$query = $this->buildAssociationQuery($Model, $queryData);
+		$query = $this->getQueryStatement($Model, $queryData, $recursive);
 
 		$resultSet = $this->fetchAll($query, $Model->cacheQueries);
 		unset($query);
@@ -1119,6 +1064,9 @@ class DboSource extends DataSource {
 			if (isset($queryData['joins'][0]['alias'])) {
 				$joined[$Model->alias] = (array)Hash::extract($queryData['joins'], '{n}.alias');
 			}
+
+			$linkedModels = $queryData['linkedModels'];
+			$associations = $Model->getAssociationsByRecursive();
 
 			foreach ($associations as $type) {
 				foreach ($Model->{$type} as $assoc => $assocData) {
@@ -1154,6 +1102,83 @@ class DboSource extends DataSource {
 		}
 
 		return $resultSet;
+	}
+
+/**
+ * Build SQL statement with the primary model, plus hasOne and belongsTo associations and
+ * and return it in order to use with the query execution methods
+ *
+ * @param Model $Model A Model object that the query is for.
+ * @param array $queryData An array of queryData information containing keys similar to Model::find(), but it is passed by reference.
+ * @param int $recursive Number of levels of association
+ * @return string The built SQL statement
+ */
+	public function getQueryStatement(Model $Model, &$queryData = null, $recursive = null) {
+		$queryData = is_null($queryData) ? array() : $queryData;
+		$queryData = $this->_scrubQueryData($queryData);
+
+		if ($recursive === null && isset($queryData['recursive'])) {
+			$recursive = $queryData['recursive'];
+		}
+
+		if ($recursive !== null) {
+			$modelRecursive = $Model->recursive;
+			$Model->recursive = $recursive;
+		}
+
+		if (!empty($queryData['fields'])) {
+			$noAssocFields = true;
+			$queryData['fields'] = $this->fields($Model, null, $queryData['fields']);
+		} else {
+			$noAssocFields = false;
+			$queryData['fields'] = $this->fields($Model);
+		}
+
+		$originalJoins = $queryData['joins'];
+		$queryData['joins'] = array();
+
+		$associations = $Model->getAssociationsByRecursive();
+
+		// Generate hasOne and belongsTo associations inside $queryData
+		$linkedModels = array();
+		foreach ($associations as $type) {
+			if ($type !== 'hasOne' && $type !== 'belongsTo') {
+				continue;
+			}
+
+			foreach ($Model->{$type} as $assoc => $assocData) {
+				$LinkModel = $Model->{$assoc};
+
+				if ($Model->useDbConfig !== $LinkModel->useDbConfig) {
+					continue;
+				}
+
+				if ($noAssocFields) {
+					$assocData['fields'] = false;
+				}
+
+				$external = isset($assocData['external']);
+
+				if ($this->generateAssociationQuery($Model, $LinkModel, $type, $assoc, $assocData, $queryData, $external) === true) {
+					$linkedModels[$type . '/' . $assoc] = true;
+				}
+			}
+		}
+
+		$queryData['linkedModels'] = $linkedModels;
+
+		if (!empty($originalJoins)) {
+			$queryData['joins'] = array_merge($queryData['joins'], $originalJoins);
+		}
+
+		// Build SQL statement with the primary model, plus hasOne and belongsTo associations
+		$query = $this->buildAssociationQuery($Model, $queryData);
+
+		if ($recursive !== null) {
+			$Model->recursive = $modelRecursive;
+		}
+
+		return $query;
 	}
 
 /**

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1109,7 +1109,7 @@ class DboSource extends DataSource {
  * and return it in order to use with the query execution methods
  *
  * @param Model $Model A Model object that the query is for.
- * @param array $queryData An array of queryData information containing keys similar to Model::find(), but it is passed by reference.
+ * @param array &$queryData An array of queryData information containing keys similar to Model::find(), but it is passed by reference.
  * @param int $recursive Number of levels of association
  * @return string The built SQL statement
  */

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3456,6 +3456,38 @@ class Model extends Object implements CakeEventListener {
 	}
 
 /**
+ * Builds and execute the query. Return DataSource object to retrieve the result explicitly using `fetchResult()`
+ *
+ * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks)
+ * @param int $recursive Number of levels of association
+ * @return mixed DataSource object if query executes with no problem, null on failure
+ */
+	public function runQuery($query = array(), $recursive = null) {
+		$db = clone $this->getDataSource();
+		if (!$db) {
+			return null;
+		}
+
+		$queryData = $this->buildQuery('all', $query);
+		if (is_null($queryData)) {
+			return null;
+		}
+
+		$sql = $db->getQueryStatement($this, $queryData, $recursive);
+		if (!$sql) {
+			return null;
+		}
+
+		if ($result = $db->execute($sql)) {
+			$db->resultSet($result);
+		} else {
+			return null;
+		}
+
+		return $db;
+	}
+
+/**
  * Returns true if all fields pass validation. Will validate hasAndBelongsToMany associations
  * that use the 'with' key as well. Since _saveMulti is incapable of exiting a save operation.
  *

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3359,6 +3359,24 @@ class Model extends Object implements CakeEventListener {
 	}
 
 /**
+ * This gets the association arrays according to the recursive level set
+ * @return array Array of associations or empty array
+ */
+	public function getAssociationsByRecursive() {
+		if ($this->recursive === -1) {
+			// Primary model data only, no joins.
+			return array();
+		}
+
+		$associations = $this->associations();
+		if ($this->recursive === 0) {
+			// Primary model data and its domain.
+			unset($associations[2], $associations[3]);
+		}
+		return $associations;
+	}
+
+/**
  * Returns false if any fields passed match any (by default, all if $or = false) of their matching values.
  *
  * Can be used as a validation method. When used as a validation method, the `$or` parameter

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3459,7 +3459,7 @@ class Model extends Object implements CakeEventListener {
  * Builds and execute the query. Return DataSource object to retrieve the result explicitly using `fetchResult()`
  *
  * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks)
- * @param int $recursive Number of levels of association
+ * @param int|null $recursive Number of levels of association
  * @return mixed DataSource object if query executes with no problem, null on failure
  */
 	public function runQuery($query = array(), $recursive = null) {
@@ -3469,7 +3469,7 @@ class Model extends Object implements CakeEventListener {
 		}
 
 		$queryData = $this->buildQuery('all', $query);
-		if (is_null($queryData)) {
+		if ($queryData === null) {
 			return null;
 		}
 

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -8047,8 +8047,8 @@ class ModelReadTest extends BaseModelTest {
 
 /**
  * test after find callback on related model
- * 
- * @return void 
+ *
+ * @return void
  */
 	public function testRelatedAfterFindCallback() {
 		$this->loadFixtures('Something', 'SomethingElse', 'JoinThing');

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -8288,4 +8288,173 @@ class ModelReadTest extends BaseModelTest {
 		);
 		$this->assertEquals($expected, $results, 'Model related with belongsTo afterFind callback fails');
 	}
+
+/**
+ * test runQuery method
+ *
+ * @return void
+ */
+	public function testRunQuery() {
+		$this->loadFixtures('Article');
+		$Article = new Article();
+		$Article->recursive = -1;
+
+		$query = $Article->runQuery(array(
+			'fields' => array(
+				'user_id',
+				'title',
+				'body',
+				'published'
+			)
+		));
+
+		$results = array();
+		if ($query) {
+			while ($row = $query->fetchResult()) {
+				$results[] = $row;
+			}
+		}
+
+		$expected = array(
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => 3,
+					'title' => 'Second Article',
+					'body' => 'Second Article Body',
+					'published' => 'Y'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'Third Article',
+					'body' => 'Third Article Body',
+					'published' => 'Y'
+				)
+			)
+		);
+		$this->assertEquals($expected, $results);
+
+		$query = $Article->runQuery(array(
+			'fields' => array(
+				'user_id',
+				'title',
+				'body',
+				'published'
+			),
+			'order' => array('user_id', 'title')
+		));
+
+		$results = array();
+		if ($query) {
+			while ($row = $query->fetchResult()) {
+				$results[] = $row;
+			}
+		}
+
+		$expected = array(
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'Third Article',
+					'body' => 'Third Article Body',
+					'published' => 'Y'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => 3,
+					'title' => 'Second Article',
+					'body' => 'Second Article Body',
+					'published' => 'Y'
+				)
+			)
+		);
+		$this->assertEquals($expected, $results);
+
+		$query = $Article->runQuery(array(
+			'fields' => array(
+				'user_id',
+				'title',
+				'body',
+				'published'
+			),
+			'limit' => 1
+		));
+
+		$results = array();
+		if ($query) {
+			while ($row = $query->fetchResult()) {
+				$results[] = $row;
+			}
+		}
+
+		$expected = array(
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y'
+				)
+			)
+		);
+		$this->assertEquals($expected, $results);
+
+		$query = $Article->runQuery(array(
+			'fields' => array(
+				'user_id',
+				'title',
+				'body',
+				'published'
+			),
+			'conditions' => array(
+				'user_id' => 1
+			),
+			'order' => array('user_id', 'title')
+		));
+
+		$results = array();
+		if ($query) {
+			while ($row = $query->fetchResult()) {
+				$results[] = $row;
+			}
+		}
+
+		$expected = array(
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => 1,
+					'title' => 'Third Article',
+					'body' => 'Third Article Body',
+					'published' => 'Y'
+				)
+			)
+		);
+		$this->assertEquals($expected, $results);
+	}
 }


### PR DESCRIPTION
Right now, `find()`, `query()` and `execute()` are returning array of result set. Sometimes, it needs to fetch the query result row by row explicitly to avoid the expensive array processing. So, added a new method `Model->runQuery()` that just builds and executes the query and returns the data source object to fetch the result manually, for example,

```
$db = $MyModel->runQuery();
if ($db) {
  // $db->numRows returns the number of rows fetched
  while ($row = $db->fetchResult()) {
    // do something with $row
  }
}
```

`DboSource->read()` is updated by internally calling a new method `DboSource->getQueryStatement()`.

Refs: #6426 
