### PR TITLE
Allow for overwriting all files in shell

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -614,11 +614,15 @@ class Shell
 
         if (is_file($path) && empty($this->params['force']) && $this->interactive) {
             $this->_io->out(sprintf('<warning>File `%s` exists</warning>', $path));
-            $key = $this->_io->askChoice('Do you want to overwrite?', ['y', 'n', 'q'], 'n');
+            $key = $this->_io->askChoice('Do you want to overwrite?', ['y', 'n', 'a', 'q'], 'n');
 
             if (strtolower($key) === 'q') {
                 $this->_io->out('<error>Quitting</error>.', 2);
                 return $this->_stop();
+            }
+            if (strtolower($key) === 'a') {
+                $this->params['force'] = true;
+                $key = 'y';
             }
             if (strtolower($key) !== 'y') {
                 $this->_io->out(sprintf('Skip `%s`', $path), 2);

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -526,6 +526,39 @@ class ShellTest extends TestCase
     }
 
     /**
+     * Test that all files are changed with a 'a' reply.
+     *
+     * @return void
+     */
+    public function testCreateFileOverwriteAll()
+    {
+        $eol = PHP_EOL;
+        $path = TMP . 'shell_test';
+        $files = [
+            $path . DS . 'file1.php' => 'My first content',
+            $path . DS . 'file2.php' => 'My second content',
+            $path . DS . 'file3.php' => 'My third content'
+        ];
+
+        new Folder($path, true);
+
+        $this->io->expects($this->once())
+            ->method('askChoice')
+            ->will($this->returnValue('a'));
+
+        foreach ($files as $file => $content) {
+            touch($file);
+            $this->assertTrue(file_exists($file));
+
+            $contents = "My content";
+            $result = $this->Shell->createFile($file, $contents);
+            $this->assertTrue(file_exists($file));
+            $this->assertTextEquals($contents, file_get_contents($file));
+            $this->assertTrue($result, 'Did create file.');
+        }
+    }
+
+    /**
      * Test that you can't create files that aren't writable.
      *
      * @return void

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -546,11 +546,10 @@ class ShellTest extends TestCase
             ->method('askChoice')
             ->will($this->returnValue('a'));
 
-        foreach ($files as $file => $content) {
+        foreach ($files as $file => $contents) {
             touch($file);
             $this->assertTrue(file_exists($file));
 
-            $contents = "My content";
             $result = $this->Shell->createFile($file, $contents);
             $this->assertTrue(file_exists($file));
             $this->assertTextEquals($contents, file_get_contents($file));


### PR DESCRIPTION
If you are creating multiple files you should be able to overwrite all of them after the first prompt to overwrite.
