### PR TITLE
Optimizing Entities accessors by caching the result in another array.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -116,7 +116,7 @@ trait EntityTrait
     protected $_registryAlias;
 
     /**
-     * Holds a list of properties that were mutaded using the get accessor
+     * Holds a list of properties that were mutated using the get accessor
      *
      * @var array
      */

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -116,6 +116,13 @@ trait EntityTrait
     protected $_registryAlias;
 
     /**
+     * Holds a list of properties that were mutaded using the get accessor
+     *
+     * @var array
+     */
+    protected $_mutated = [];
+
+    /**
      * Magic getter to access properties that have been set in this entity
      *
      * @param string $property Name of the property to access
@@ -235,6 +242,7 @@ trait EntityTrait
                 continue;
             }
 
+            unset($this->_mutated[$p]);
             $this->dirty($p, true);
 
             if (!isset($this->_original[$p]) &&
@@ -271,6 +279,10 @@ trait EntityTrait
             throw new InvalidArgumentException('Cannot get an empty property');
         }
 
+        if (array_key_exists($property, $this->_mutated)) {
+            return $this->_mutated[$property];
+        }
+
         $value = null;
         $method = '_get' . Inflector::camelize($property);
 
@@ -280,6 +292,7 @@ trait EntityTrait
 
         if ($this->_methodExists($method)) {
             $result = $this->{$method}($value);
+            $this->_mutated[$property] = $result;
             return $result;
         }
         return $value;

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -227,15 +227,35 @@ class EntityTest extends TestCase
     public function testGetCustomGetters()
     {
         $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
-        $entity->expects($this->exactly(2))->method('_getName')
+        $entity->expects($this->once())->method('_getName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
                 return 'Dr. ' . $name;
             }));
         $entity->set('name', 'Jones');
         $this->assertEquals('Dr. Jones', $entity->get('name'));
         $this->assertEquals('Dr. Jones', $entity->get('name'));
+    }
+
+    /**
+     * Tests get with custom getter
+     *
+     * @return void
+     */
+    public function testGetCustomGettersAfterSet()
+    {
+        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity->expects($this->exactly(2))->method('_getName')
+            ->will($this->returnCallback(function ($name) {
+                return 'Dr. ' . $name;
+            }));
+        $entity->set('name', 'Jones');
+        $this->assertEquals('Dr. Jones', $entity->get('name'));
+        $this->assertEquals('Dr. Jones', $entity->get('name'));
+
+        $entity->set('name', 'Mark');
+        $this->assertEquals('Dr. Mark', $entity->get('name'));
+        $this->assertEquals('Dr. Mark', $entity->get('name'));
     }
 
     /**


### PR DESCRIPTION
This also helps users doing lazy loading of associations so they don't
have to store a flag for whether the association was tried to be loaded
before or not.
