### PR TITLE
Implement nested field validators.

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -200,6 +200,16 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
+     * Get the list of providers in this validator.
+     *
+     * @return array
+     */
+    public function providers()
+    {
+        return array_keys($this->_providers);
+    }
+
+    /**
      * Returns whether a rule set is defined for a field or not
      *
      * @param string $field name of the field to check
@@ -319,6 +329,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * This method assumes that the sub-document has a 1:1 relationship with the parent.
      *
+     * The providers of the parent validator will be synced into the nested validator, when
+     * errors are checked. This ensures that any validation rule providers connected
+     * in the parent will have the same values in the nested validator when rules are evaluated.
+     *
      * @param string $field The root field for the nested validator.
      * @param \Cake\Validation\Validator $validator The nested validator.
      * @return $this
@@ -329,6 +343,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $field->add(static::NESTED, ['rule' => function ($value, $context) use ($validator) {
             if (!is_array($value)) {
                 return false;
+            }
+            foreach ($this->providers() as $provider) {
+                $validator->provider($provider, $this->provider($provider));
             }
             $errors = $validator->errors($value);
             return empty($errors) ? true : $errors;
@@ -345,6 +362,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * This method assumes that the sub-document has a 1:N relationship with the parent.
      *
+     * The providers of the parent validator will be synced into the nested validator, when
+     * errors are checked. This ensures that any validation rule providers connected
+     * in the parent will have the same values in the nested validator when rules are evaluated.
+     *
      * @param string $field The root field for the nested validator.
      * @param \Cake\Validation\Validator $validator The nested validator.
      * @return $this
@@ -355,6 +376,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $field->add(static::NESTED, ['rule' => function ($value, $context) use ($validator) {
             if (!is_array($value)) {
                 return false;
+            }
+            foreach ($this->providers() as $provider) {
+                $validator->provider($provider, $this->provider($provider));
             }
             $errors = [];
             foreach ($value as $i => $row) {

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -62,6 +62,27 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Testing addNested connects providers
+     *
+     * @return void
+     */
+    public function testAddNestedSingleProviders()
+    {
+        $validator = new Validator();
+        $validator->provider('test', $this);
+
+        $inner = new Validator();
+        $inner->add('username', 'not-blank', ['rule' => function () use ($inner, $validator) {
+            $this->assertSame($validator->providers(), $inner->providers(), 'Providers should match');
+            return false;
+        }]);
+        $validator->addNested('user', $inner);
+
+        $result = $validator->errors(['user' => ['username' => 'example']]);
+        $this->assertNotEmpty($result, 'Validation should fail');
+    }
+
+    /**
      * Testing addNestedMany field rules
      *
      * @return void
@@ -74,6 +95,27 @@ class ValidatorTest extends TestCase
         $this->assertSame($validator, $validator->addNestedMany('comments', $inner));
 
         $this->assertCount(1, $validator->field('comments'));
+    }
+
+    /**
+     * Testing addNestedMany connects providers
+     *
+     * @return void
+     */
+    public function testAddNestedManyProviders()
+    {
+        $validator = new Validator();
+        $validator->provider('test', $this);
+
+        $inner = new Validator();
+        $inner->add('comment', 'not-blank', ['rule' => function () use ($inner, $validator) {
+            $this->assertSame($validator->providers(), $inner->providers(), 'Providers should match');
+            return false;
+        }]);
+        $validator->addNestedMany('comments', $inner);
+
+        $result = $validator->errors(['comments' => [['comment' => 'example']]]);
+        $this->assertNotEmpty($result, 'Validation should fail');
     }
 
     /**


### PR DESCRIPTION
This adds support for nested field validators. To better support model-less forms and the elasticsearch ODM, we will need to validate nested fields. This set of changes is the smallest change I could make that implements the basic requirements.

Refs #6496
