### PR TITLE
QueryLogger interpolate

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -71,6 +71,7 @@ class QueryLogger
 
         $keys = [];
         $limit = is_int(key($params)) ? 1 : -1;
+        $params = array_reverse($params);
         foreach ($params as $key => $param) {
             $keys[] = is_string($key) ? "/:$key/" : '/[?]/';
         }


### PR DESCRIPTION
While interpolating the placeholders gets wrongly replaced.

When :c1 gets replaced by his param, every placeholder from :c10 to
:c19 gets replaced with the wrong param too + last number from original
placeholder.

an array_reverse() will prevent this behavior
