### PR TITLE
Add __debugInfo() methods to more objects.

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -188,4 +188,19 @@ class Form
     {
         return true;
     }
+
+    /**
+     * Get the printable version of a Form instance.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        $special = [
+            '_schema' => $this->schema()->__debugInfo(),
+            '_errors' => $this->errors(),
+            '_validator' => $this->validator()->__debugInfo()
+        ];
+        return $special + get_object_vars($this);
+    }
 }

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -121,4 +121,16 @@ class Schema
         }
         return $field['type'];
     }
+
+    /**
+     * Get the printable version of this object
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            '_fields' => $this->_fields
+        ];
+    }
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -580,4 +580,28 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
         return $errors;
     }
+
+    /**
+     * Get the printable version of this object.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        $fields = [];
+        foreach ($this->_fields as $name => $fieldSet) {
+            $fields[$name] = [
+                'isPresenceRequired' => $fieldSet->isPresenceRequired(),
+                'isEmptyAllowed' => $fieldSet->isEmptyAllowed(),
+                'rules' => array_keys($fieldSet->rules()),
+            ];
+        }
+        return [
+            '_presenceMessages' => $this->_presenceMessages,
+            '_allowEmptyMessages' => $this->_allowEmptyMessages,
+            '_useI18n' => $this->_useI18n,
+            '_providers' => array_keys($this->_providers),
+            '_fields' => $fields
+        ];
+    }
 }

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -154,4 +154,18 @@ class FormTest extends TestCase
 
         $this->assertTrue($form->execute($data));
     }
+
+    /**
+     * test __debugInfo
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $form = new Form();
+        $result = $form->__debugInfo();
+        $this->assertArrayHasKey('_schema', $result);
+        $this->assertArrayHasKey('_errors', $result);
+        $this->assertArrayHasKey('_validator', $result);
+    }
 }

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -116,4 +116,28 @@ class SchemaTest extends TestCase
         $this->assertEquals('decimal', $schema->fieldType('numbery'));
         $this->assertNull($schema->fieldType('nope'));
     }
+
+    /**
+     * test __debugInfo
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $schema = new Schema();
+
+        $schema->addField('name', 'string')
+            ->addField('numbery', [
+                'type' => 'decimal',
+                'required' => true
+            ]);
+        $result = $schema->__debugInfo();
+        $expected = [
+            '_fields' => [
+                'name' => ['type' => 'string', 'length' => null, 'precision' => null],
+                'numbery' => ['type' => 'decimal', 'length' => null, 'precision' => null],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -769,4 +769,44 @@ class ValidatorTest extends TestCase
         ];
         $this->assertNotEmpty($validator->errors($data), 'Validation should fail.');
     }
+
+    /**
+     * Test debugInfo helper method.
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $validator = new Validator();
+        $validator->provider('test', $this);
+        $validator->add('title', 'not-empty', ['rule' => 'notEmpty']);
+        $validator->requirePresence('body');
+        $validator->allowEmpty('published');
+
+        $result = $validator->__debugInfo();
+        $expected = [
+            '_providers' => ['test'],
+            '_fields' => [
+                'title' => [
+                    'isPresenceRequired' => false,
+                    'isEmptyAllowed' => false,
+                    'rules' => ['not-empty'],
+                ],
+                'body' => [
+                    'isPresenceRequired' => true,
+                    'isEmptyAllowed' => false,
+                    'rules' => [],
+                ],
+                'published' => [
+                    'isPresenceRequired' => false,
+                    'isEmptyAllowed' => true,
+                    'rules' => [],
+                ],
+            ],
+            '_presenceMessages' => [],
+            '_allowEmptyMessages' => [],
+            '_useI18n' => true,
+        ];
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
Many of these objects can contain Closures, and I'd like to improve how they are printed in DebugKit. This feels like the best way to improve developer experience around these objects without making the solution too specific to DebugKit.

Refs cakephp/cakephp#6504
