### PR TITLE
Replace rtrim() with basename() in SchemaShell

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -158,7 +158,7 @@ class SchemaShell extends AppShell {
 		}
 
 		if ($snapshot === true) {
-			$fileName = preg_replace('`\.php$`', '', $this->params['file'], 1);
+			$fileName = basename($this->params['file'], '.php');
 			$Folder = new Folder($this->Schema->path);
 			$result = $Folder->read();
 
@@ -285,7 +285,7 @@ class SchemaShell extends AppShell {
 			'connection' => $this->params['connection'],
 		);
 		if (!empty($this->params['snapshot'])) {
-			$fileName = preg_replace('`\.php$`', '', $this->Schema->file, 1);
+			$fileName = basename($this->Schema->file, '.php');
 			$options['file'] = $fileName . '_' . $this->params['snapshot'] . '.php';
 		}
 

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -158,7 +158,7 @@ class SchemaShell extends AppShell {
 		}
 
 		if ($snapshot === true) {
-			$fileName = rtrim($this->params['file'], '.php');
+			$fileName = preg_replace('`\.php$`', '', $this->params['file'], 1);
 			$Folder = new Folder($this->Schema->path);
 			$result = $Folder->read();
 
@@ -285,7 +285,7 @@ class SchemaShell extends AppShell {
 			'connection' => $this->params['connection'],
 		);
 		if (!empty($this->params['snapshot'])) {
-			$fileName = rtrim($this->Schema->file, '.php');
+			$fileName = preg_replace('`\.php$`', '', $this->Schema->file, 1);
 			$options['file'] = $fileName . '_' . $this->params['snapshot'] . '.php';
 		}
 


### PR DESCRIPTION
The second parameter of rtrim is a character mask, not a string to be replaced. It was breaking file names ending in one or more 'p' or 'h' characters.
