### PR TITLE
Add underscore support for multi word irregulars.

### DIFF
--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -257,6 +257,31 @@ class InflectorTest extends CakeTestCase {
 	}
 
 /**
+ * testInflectingMultiWordIrregulars
+ *
+ * @return void
+ */
+	public function testInflectingMultiWordIrregulars() {
+		// unset the default rules in order to avoid them possibly matching
+		// the words in case the irregular regex won't match, the tests
+		// should fail in that case
+		Inflector::rules('plural', array(
+			'rules' => array(),
+		));
+		Inflector::rules('singular', array(
+			'rules' => array(),
+		));
+
+		$this->assertEquals(Inflector::singularize('wisdom teeth'), 'wisdom tooth');
+		$this->assertEquals(Inflector::singularize('wisdom-teeth'), 'wisdom-tooth');
+		$this->assertEquals(Inflector::singularize('wisdom_teeth'), 'wisdom_tooth');
+
+		$this->assertEquals(Inflector::pluralize('sweet potato'), 'sweet potatoes');
+		$this->assertEquals(Inflector::pluralize('sweet-potato'), 'sweet-potatoes');
+		$this->assertEquals(Inflector::pluralize('sweet_potato'), 'sweet_potatoes');
+	}
+
+/**
  * testInflectorSlug method
  *
  * @return void

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -386,7 +386,7 @@ class Inflector {
 			self::$_plural['cacheIrregular'] = '(?:' . implode('|', array_keys(self::$_plural['merged']['irregular'])) . ')';
 		}
 
-		if (preg_match('/(.*)\\b(' . self::$_plural['cacheIrregular'] . ')$/i', $word, $regs)) {
+		if (preg_match('/(.*(?:\\b|_))(' . self::$_plural['cacheIrregular'] . ')$/i', $word, $regs)) {
 			self::$_cache['pluralize'][$word] = $regs[1] . substr($regs[2], 0, 1) . substr(self::$_plural['merged']['irregular'][strtolower($regs[2])], 1);
 			return self::$_cache['pluralize'][$word];
 		}
@@ -435,7 +435,7 @@ class Inflector {
 			self::$_singular['cacheIrregular'] = '(?:' . implode('|', array_keys(self::$_singular['merged']['irregular'])) . ')';
 		}
 
-		if (preg_match('/(.*)\\b(' . self::$_singular['cacheIrregular'] . ')$/i', $word, $regs)) {
+		if (preg_match('/(.*(?:\\b|_))(' . self::$_singular['cacheIrregular'] . ')$/i', $word, $regs)) {
 			self::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . substr(self::$_singular['merged']['irregular'][strtolower($regs[2])], 1);
 			return self::$_cache['singularize'][$word];
 		}


### PR DESCRIPTION
Underscore separated words were not catched by the irregular regex,
tests however didn't fail as the default rules matched the tested words
too. The added test should ensure that this won't happen again.

Fixes the gap left by the previous #6538 fix.

Please note that I've choosen to nest the boundary/underscore matching because it seems to be the best compromise with regards to performance.
