### PR TITLE
3.x - Folder::copy can now copy non-recursively

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -725,7 +725,7 @@ class Folder
                         $this->delete($to);
                     }
 
-                    if(is_dir($from) && $options['recursive'] === false) {
+                    if (is_dir($from) && $options['recursive'] === false) {
                         continue;
                     }
 

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -661,6 +661,7 @@ class Folder
      * - `mode` The mode to copy the files/directories with as integer, e.g. 0775.
      * - `skip` Files/directories to skip.
      * - `scheme` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
+     * - `recursive` Whether to copy recursively or not (default: true - recursive)
      *
      * @param array|string $options Either an array of options (see above) or a string of the destination directory.
      * @return bool Success.
@@ -680,7 +681,8 @@ class Folder
             'from' => $this->path,
             'mode' => $this->mode,
             'skip' => [],
-            'scheme' => Folder::MERGE
+            'scheme' => Folder::MERGE,
+            'recursive' => true
         ];
 
         $fromDir = $options['from'];
@@ -723,6 +725,10 @@ class Folder
                         $this->delete($to);
                     }
 
+                    if(is_dir($from) && $options['recursive'] === false) {
+                        continue;
+                    }
+
                     if (is_dir($from) && !file_exists($to)) {
                         $old = umask(0);
                         if (mkdir($to, $mode, true)) {
@@ -763,6 +769,7 @@ class Folder
      * - `chmod` The mode to copy the files/directories with.
      * - `skip` Files/directories to skip.
      * - `scheme` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
+     * - `recursive` Whether to copy recursively or not (default: true - recursive)
      *
      * @param array|string $options (to, from, chmod, skip, scheme)
      * @return bool Success
@@ -774,7 +781,7 @@ class Folder
             $to = $options;
             $options = (array)$options;
         }
-        $options += ['to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => []];
+        $options += ['to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => [], 'recursive' => true];
 
         if ($this->copy($options)) {
             if ($this->delete($options['from'])) {

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1045,6 +1045,7 @@ class FolderTest extends TestCase
         $result = $Folder->copy(['to' => $folderThree, 'recursive' => false]);
 
         $this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
+        $this->assertFalse(is_dir($folderThree . DS . 'folderA'));
         $this->assertFalse(file_exists($folderThree . DS . 'folderA' . DS . 'fileA.php'));
     }
 
@@ -1233,5 +1234,17 @@ class FolderTest extends TestCase
 
         $Folder = new Folder($path);
         $Folder->delete();
+    }
+    
+    public function testMoveWithoutRecursive()
+    {
+        extract($this->_setupFilesystem());
+
+        $Folder = new Folder($folderOne);
+        $result = $Folder->move(['to' => $folderTwo, 'recursive' => false]);
+        $this->assertTrue($result);
+        $this->assertTrue(file_exists($folderTwo . '/file1.php'));
+        $this->assertFalse(is_dir($folderTwo . '/folderA'));
+        $this->assertFalse(file_exists($folderTwo . '/folderA/fileA.php'));
     }
 }

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1031,6 +1031,24 @@ class FolderTest extends TestCase
     }
 
     /**
+     * testCopyWithoutResursive
+     *
+     * Verify that only the files exist in the target directory.
+     *
+     * @return void
+     */
+    public function testCopyWithoutRecursive()
+    {
+        extract($this->_setupFilesystem());
+
+        $Folder = new Folder($folderOne);
+        $result = $Folder->copy(['to' => $folderThree, 'recursive' => false]);
+
+        $this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
+        $this->assertFalse(file_exists($folderThree . DS . 'folderA' . DS . 'fileA.php'));
+    }
+
+    /**
      * Setup filesystem for copy tests
      * $path: folder_test/
      * - folder1/file1.php


### PR DESCRIPTION
I reported (Issue #6505) that I would like to have the option to turn off recursive copy/move for the Folder::copy() and Folder::move() methods. This in implemented and tested in this pull request.

I guess a change in the cookbook/documentation would be needed as well. If you can tell me where I have to make those changes I will create a second pull request for that.
