### PR TITLE
Make Http\Client File uploads safer and better

### DIFF
--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -419,11 +419,15 @@ class Client
         $request->method($method)
             ->url($url)
             ->body($data);
+
         if (isset($options['type'])) {
             $request->header($this->_typeHeaders($options['type']));
         }
         if (isset($options['headers'])) {
             $request->header($options['headers']);
+        }
+        if (is_string($data) && !$request->header('content-type')) {
+            $request->header('Content-Type', 'application/x-www-form-urlencoded');
         }
         $request->cookie($this->_cookies->get($url));
         if (isset($options['cookies'])) {
@@ -459,7 +463,7 @@ class Client
             'xml' => 'application/xml',
         ];
         if (!isset($typeMap[$type])) {
-            throw new Exception('Unknown type alias.');
+            throw new Exception("Unknown type alias '$type'.");
         }
         return [
             'Accept' => $typeMap[$type],

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -192,7 +192,7 @@ class Client
      * @param array $options Additional options for the request.
      * @return \Cake\Network\Http\Response
      */
-    public function get($url, array $data = [], array $options = [])
+    public function get($url, $data = [], array $options = [])
     {
         $options = $this->_mergeOptions($options);
         $body = [];
@@ -369,7 +369,7 @@ class Client
      * Generate a URL based on the scoped client options.
      *
      * @param string $url Either a full URL or just the path.
-     * @param array $query The query data for the URL.
+     * @param string|array $query The query data for the URL.
      * @param array $options The config options stored with Client::config()
      * @return string A complete url with scheme, port, host, path.
      */
@@ -380,7 +380,8 @@ class Client
         }
         if ($query) {
             $q = (strpos($url, '?') === false) ? '?' : '&';
-            $url .= $q . http_build_query($query);
+            $url .= $q;
+            $url .= is_string($query) ? $query : http_build_query($query);
         }
         if (preg_match('#^https?://#', $url)) {
             return $url;

--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -87,6 +87,11 @@ class FormData implements Countable
         } elseif (is_resource($value)) {
             $this->_parts[] = $this->addFile($name, $value);
         } elseif (is_string($value) && strlen($value) && $value[0] === '@') {
+            trigger_error(
+                'Using the @ syntax for file uploads is not safe and is deprecated. ' .
+                'Instead you should use file handles.',
+                E_USER_DEPRECATED
+            );
             $this->_parts[] = $this->addFile($name, $value);
         } else {
             $this->_parts[] = $this->newPart($name, $value);
@@ -124,6 +129,12 @@ class FormData implements Countable
         $contentType = 'application/octet-stream';
         if (is_resource($value)) {
             $content = stream_get_contents($value);
+            if (stream_is_local($value)) {
+                $finfo = new \finfo(FILEINFO_MIME);
+                $metadata = stream_get_meta_data($value);
+                $contentType = $finfo->file($metadata['uri']);
+                $filename = basename($metadata['uri']);
+            }
         } else {
             $finfo = new \finfo(FILEINFO_MIME);
             $value = substr($value, 1);

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -218,6 +218,36 @@ class ClientTest extends TestCase
     }
 
     /**
+     * test get request with string of query data.
+     *
+     * @return void
+     */
+    public function testGetQuerystringString()
+    {
+        $response = new Response();
+
+        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock->expects($this->once())
+            ->method('send')
+            ->with($this->logicalAnd(
+                $this->isInstanceOf('Cake\Network\Http\Request'),
+                $this->attributeEqualTo('_url', 'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3')
+            ))
+            ->will($this->returnValue([$response]));
+
+        $http = new Client([
+            'host' => 'cakephp.org',
+            'adapter' => $mock
+        ]);
+        $data = [
+            'q' => 'hi there',
+            'Category' => ['id' => [2, 3]]
+        ];
+        $result = $http->get('/search', http_build_query($data));
+        $this->assertSame($result, $response);
+    }
+
+    /**
      * Test a GET with a request body. Services like
      * elasticsearch use this feature.
      *

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -431,6 +431,39 @@ class ClientTest extends TestCase
     }
 
     /**
+     * Test that string payloads with no content type have a default content-type set.
+     *
+     * @return void
+     */
+    public function testPostWithStringDataDefaultsToFormEncoding()
+    {
+        $response = new Response();
+        $data = 'some=value&more=data';
+        $headers = [
+            'Connection' => 'close',
+            'User-Agent' => 'CakePHP',
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock->expects($this->any())
+            ->method('send')
+            ->with($this->logicalAnd(
+                $this->attributeEqualTo('_body', $data),
+                $this->attributeEqualTo('_headers', $headers)
+            ))
+            ->will($this->returnValue([$response]));
+
+        $http = new Client([
+            'host' => 'cakephp.org',
+            'adapter' => $mock
+        ]);
+        $http->post('/projects/add', $data);
+        $http->put('/projects/add', $data);
+        $http->delete('/projects/add', $data);
+    }
+
+    /**
      * Test that exceptions are raised on invalid types.
      *
      * @expectedException \Cake\Core\Exception\Exception

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -244,7 +244,7 @@ class ClientTest extends TestCase
             'Category' => ['id' => [2, 3]]
         ];
         $result = $http->get('/search', http_build_query($data));
-        $this->assertSame($result, $response);
+        $this->assertSame($response, $result);
     }
 
     /**

--- a/tests/TestCase/Network/Http/FormDataTest.php
+++ b/tests/TestCase/Network/Http/FormDataTest.php
@@ -137,6 +137,9 @@ class FormDataTest extends TestCase
      */
     public function testAddArrayWithFile()
     {
+        $errorLevel = error_reporting();
+        error_reporting($errorLevel & ~E_USER_DEPRECATED);
+
         $file = CORE_PATH . 'VERSION.txt';
         $contents = file_get_contents($file);
 
@@ -163,6 +166,8 @@ class FormDataTest extends TestCase
             '',
         ];
         $this->assertEquals(implode("\r\n", $expected), $result);
+
+        error_reporting($errorLevel);
     }
 
     /**
@@ -176,7 +181,7 @@ class FormDataTest extends TestCase
         $contents = file_get_contents($file);
 
         $data = new FormData();
-        $data->add('upload', '@' . $file);
+        $data->add('upload', fopen($file, 'r'));
         $boundary = $data->boundary();
         $result = (string)$data;
 
@@ -213,8 +218,8 @@ class FormDataTest extends TestCase
 
         $expected = [
             '--' . $boundary,
-            'Content-Disposition: form-data; name="upload"',
-            'Content-Type: application/octet-stream',
+            'Content-Disposition: form-data; name="upload"; filename="VERSION.txt"',
+            'Content-Type: text/plain; charset=us-ascii',
             '',
             $contents,
             '--' . $boundary . '--',


### PR DESCRIPTION
The @ is not a completely safe way to send files. If a developer passes along user data, that user data can include arbitrary files. This is not desirable, and can go really wrong with URLs.

This also improves content-type and filename detection for local stream resources and request bodies that are strings.

Refs #6540 
