### PR TITLE
Fix blob reading in SQLServer

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -39,7 +39,8 @@ class Sqlserver extends \Cake\Database\Driver
         'username' => '',
         'password' => '',
         'database' => 'cake',
-        'encoding' => PDO::SQLSRV_ENCODING_UTF8,
+        // PDO::SQLSRV_ENCODING_UTF8
+        'encoding' => 65001,
         'flags' => [],
         'init' => [],
         'settings' => [],

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -55,6 +55,9 @@ class BinaryType extends Type
         if ($value === null) {
             return null;
         }
+        if (is_string($value) && preg_match('/^[a-zA-Z0-9]+$/', $value)) {
+            $value = pack('H*', $value);
+        }
         if (is_string($value)) {
             return fopen('data:text/plain;base64,' . base64_encode($value), 'rb');
         }

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -16,6 +16,7 @@ namespace Cake\Database\Type;
 
 use Cake\Core\Exception\Exception;
 use Cake\Database\Driver;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Type;
 use PDO;
 
@@ -55,7 +56,7 @@ class BinaryType extends Type
         if ($value === null) {
             return null;
         }
-        if (is_string($value) && preg_match('/^[a-zA-Z0-9]+$/', $value)) {
+        if (is_string($value) && $driver instanceof Sqlserver) {
             $value = pack('H*', $value);
         }
         if (is_string($value)) {

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -46,10 +46,6 @@ class BinaryTypeTest extends TestCase
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
-        $result = $this->type->toPHP('536F6D652076616C7565', $this->driver);
-        $this->assertInternalType('resource', $result);
-        $this->assertSame('Some value', stream_get_contents($result));
-
         $result = $this->type->toPHP('some data', $this->driver);
         $this->assertInternalType('resource', $result);
 
@@ -57,6 +53,20 @@ class BinaryTypeTest extends TestCase
         $result = $this->type->toPHP($fh, $this->driver);
         $this->assertSame($fh, $result);
         fclose($fh);
+    }
+
+    /**
+     * SQLServer returns binary fields as hexidecimal
+     * Ensure decoding happens for SQLServer drivers
+     *
+     * @return void
+     */
+    public function testToPHPSqlserver()
+    {
+        $driver = $this->getMock('Cake\Database\Driver\Sqlserver', [], [], '', false);
+        $result = $this->type->toPHP('536F6D652076616C7565', $driver);
+        $this->assertInternalType('resource', $result);
+        $this->assertSame('Some value', stream_get_contents($result));
     }
 
     /**

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -46,6 +46,10 @@ class BinaryTypeTest extends TestCase
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
+        $result = $this->type->toPHP('536F6D652076616C7565', $this->driver);
+        $this->assertInternalType('resource', $result);
+        $this->assertSame('Some value', stream_get_contents($result));
+
         $result = $this->type->toPHP('some data', $this->driver);
         $this->assertInternalType('resource', $result);
 


### PR DESCRIPTION
VARBINARY fields in SQLServer come back as hexadecimal encoded strings. In order for these to be useful, they need to be converted into resources like other blobby things.

This should fix that AppVeyor builds as well.
