### PR TITLE
Making EntityTrait::toArray smarter about how it handles input

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -440,13 +440,13 @@ trait EntityTrait
             if (is_array($value)) {
                 $result[$property] = [];
                 foreach ($value as $k => $entity) {
-                    if (method_exists($entity, 'toArray')) {
+                    if ($entity instanceof EntityInterface) {
                         $result[$property][$k] = $entity->toArray();
                     } else {
                         $result[$property][$k] = $entity;
                     }
                 }
-            } elseif (method_exists($value, 'toArray')) {
+            } elseif ($value instanceof EntityInterface) {
                 $result[$property] = $value->toArray();
             } else {
                 $result[$property] = $value;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -437,12 +437,16 @@ trait EntityTrait
         $result = [];
         foreach ($this->visibleProperties() as $property) {
             $value = $this->get($property);
-            if (is_array($value) && isset($value[0]) && $value[0] instanceof EntityInterface) {
+            if (is_array($value)) {
                 $result[$property] = [];
                 foreach ($value as $k => $entity) {
-                    $result[$property][$k] = $entity->toArray();
+                    if (method_exists($entity, 'toArray')) {
+                        $result[$property][$k] = $entity->toArray();
+                    } else {
+                        $result[$property][$k] = $entity;
+                    }
                 }
-            } elseif ($value instanceof EntityInterface) {
+            } elseif (method_exists($value, 'toArray')) {
                 $result[$property] = $value->toArray();
             } else {
                 $result[$property] = $value;

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -807,6 +807,30 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Tests that an entity with entities and other misc types can be properly toArray'd
+     *
+     * @return void
+     */
+    public function testToArrayMixed()
+    {
+        $test = new Entity([
+            'id' => 1,
+            'foo' => [
+                new Entity(['hi' => 'test']),
+                'notentity' => 1
+            ]
+        ]);
+        $expected = [
+            'id' => 1,
+            'foo' => [
+                ['hi' => 'test'],
+                'notentity' => 1
+            ]
+        ];
+        $this->assertEquals($expected, $test->toArray());
+    }
+
+    /**
      * Test that get accessors are called when converting to arrays.
      *
      * @return void


### PR DESCRIPTION
This addresses #6548

`EntityTrait::toArray` used to check the first thing in an array, and if it were an `Entity`, assume everything else in the array was an `Entity`. This change just checks every layer that it has the `toArray` method. I did that instead of seeing if it extends `EntityInterface`, so possibly other classes can be seamlessly toArray'd.
