### PR TITLE
Fix many placeholders in query logger

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -71,6 +71,7 @@ class QueryLogger
 
         $keys = [];
         $limit = is_int(key($params)) ? 1 : -1;
+        $params = array_reverse($params);
         foreach ($params as $key => $param) {
             $keys[] = is_string($key) ? "/:$key\b/" : '/[?]/';
         }


### PR DESCRIPTION
Having more than 10 placeholders would wrongly assign the values.

For example :c1 = 55 would overwrite :c10 placeholder to "550". Reversing the order of params will assign longer placeholders first.

Note: Postgres does not have 1/0 values for booleans but true/false. Could this be somehow fixed? There is probably no way to get the query connection and chceck if the driver is postgres.
