### PR TITLE
Improved __debugInfo for Entity and Query

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1696,6 +1696,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function __debugInfo()
     {
         return [
+            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $this->sql(),
             'params' => $this->valueBinder()->bindings(),
             'defaultTypes' => $this->defaultTypes(),

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -885,15 +885,14 @@ trait EntityTrait
      */
     public function __debugInfo()
     {
-        return [
-            'new' => $this->isNew(),
-            'accessible' => array_filter($this->_accessible),
-            'properties' => $this->_properties,
-            'dirty' => $this->_dirty,
-            'original' => $this->_original,
-            'virtual' => $this->_virtual,
-            'errors' => $this->_errors,
-            'repository' => $this->_registryAlias
+        return $this->_properties + [
+            '[new]' => $this->isNew(),
+            '[accessible]' => array_filter($this->_accessible),
+            '[dirty]' => $this->_dirty,
+            '[original]' => $this->_original,
+            '[virtual]' => $this->_virtual,
+            '[errors]' => $this->_errors,
+            '[repository]' => $this->_registryAlias
         ];
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2949,6 +2949,7 @@ class QueryTest extends TestCase
             ->where(['id' => '1']);
 
         $expected = [
+            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $query->sql(),
             'params' => [
                 ':c0' => ['value' => '1', 'type' => 'integer', 'placeholder' => 'c0']
@@ -2962,6 +2963,7 @@ class QueryTest extends TestCase
 
         $query->execute();
         $expected = [
+            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $query->sql(),
             'params' => [
                 ':c0' => ['value' => '1', 'type' => 'integer', 'placeholder' => 'c0']

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1163,6 +1163,7 @@ class EntityTest extends TestCase
     public function testDebugInfo()
     {
         $entity = new Entity(['foo' => 'bar'], ['markClean' => true]);
+        $entity->somethingElse = 'value';
         $entity->accessible('name', true);
         $entity->virtualProperties(['baz']);
         $entity->dirty('foo', true);
@@ -1170,14 +1171,15 @@ class EntityTest extends TestCase
         $entity->source('foos');
         $result = $entity->__debugInfo();
         $expected = [
-            'new' => true,
-            'accessible' => ['*' => true, 'name' => true],
-            'properties' => ['foo' => 'bar'],
-            'dirty' => ['foo' => true],
-            'original' => [],
-            'virtual' => ['baz'],
-            'errors' => ['foo' => ['An error']],
-            'repository' => 'foos'
+            'foo' => 'bar',
+            'somethingElse' => 'value',
+            '[new]' => true,
+            '[accessible]' => ['*' => true, 'name' => true],
+            '[dirty]' => ['somethingElse' => true, 'foo' => true],
+            '[original]' => [],
+            '[virtual]' => ['baz'],
+            '[errors]' => ['foo' => ['An error']],
+            '[repository]' => 'foos'
         ];
         $this->assertSame($expected, $result);
     }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2177,6 +2177,7 @@ class QueryTest extends TestCase
             });
 
         $expected = [
+            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $query->sql(),
             'params' => $query->valueBinder()->bindings(),
             'defaultTypes' => [


### PR DESCRIPTION
After helping some people in IRC I realized that the way we presented properties for entities in `__debugInfo` was misleading. A lot of people thought they had to do `$entity->properties->name`. This change will put all properties in the debug info without any nesting, and wrap non-properties using `[]`.

For queries, added a help text that will appear at the top. The text will hint the users to execute the query to see its contents.
