### PR TITLE
Deprecate notEmpty in favor of notBlank.

### DIFF
--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -383,6 +383,8 @@ class ModelTask extends BakeTask {
 		if (class_exists('Validation')) {
 			$options = get_class_methods('Validation');
 		}
+		$deprecatedOptions = array('notEmpty');
+		$options = array_diff($options, $deprecatedOptions);
 		sort($options);
 		$default = 1;
 		foreach ($options as $option) {

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -443,9 +443,9 @@ class ModelTask extends BakeTask {
 				} elseif ($metaData['type'] === 'string' && $metaData['length'] == 36) {
 					$guess = $methods['uuid'];
 				} elseif ($metaData['type'] === 'string') {
-					$guess = $methods['notEmpty'];
+					$guess = $methods['notBlank'];
 				} elseif ($metaData['type'] === 'text') {
-					$guess = $methods['notEmpty'];
+					$guess = $methods['notBlank'];
 				} elseif ($metaData['type'] === 'integer') {
 					$guess = $methods['numeric'];
 				} elseif ($metaData['type'] === 'float') {

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -134,7 +134,7 @@ class Model extends Object implements CakeEventListener {
  *
  * ```
  * public $validate = array(
- *     'name' => 'notEmpty'
+ *     'name' => 'notBlank'
  * );
  * ```
  *

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -537,7 +537,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  *
  * ```
  *		$validator
- *			->add('title', 'required', array('rule' => 'notEmpty', 'required' => true))
+ *			->add('title', 'required', array('rule' => 'notBlank', 'required' => true))
  *			->add('user_id', 'valid', array('rule' => 'numeric', 'message' => 'Invalid User'))
  *
  *		$validator->add('password', array(

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -185,7 +185,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *
  * ```
  *		$set
- *			->setRule('required', array('rule' => 'notEmpty', 'required' => true))
+ *			->setRule('required', array('rule' => 'notBlank', 'required' => true))
  *			->setRule('between', array('rule' => array('lengthBetween', 4, 10))
  * ```
  *
@@ -227,7 +227,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *
  * ```
  *		$set->setRules(array(
- *			'required' => array('rule' => 'notEmpty', 'required' => true),
+ *			'required' => array('rule' => 'notBlank', 'required' => true),
  *			'inRange' => array('rule' => array('between', 4, 10)
  * 		));
  * ```

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -268,7 +268,7 @@ class ModelTaskTest extends CakeTestCase {
  */
 	public function testInitValidations() {
 		$result = $this->Task->initValidations();
-		$this->assertTrue(in_array('notEmpty', $result));
+		$this->assertTrue(in_array('notBlank', $result));
 	}
 
 /**
@@ -282,7 +282,7 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->initValidations();
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notEmpty' => 'notEmpty');
+		$expected = array('notBlank' => 'notBlank');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'date', 'length' => 10, 'null' => false));
@@ -318,7 +318,7 @@ class ModelTaskTest extends CakeTestCase {
 			->will($this->onConsecutiveCalls('25', 'y', '19', 'n'));
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notEmpty' => 'notEmpty', 'maxLength' => 'maxLength');
+		$expected = array('notBlank' => 'notBlank', 'maxLength' => 'maxLength');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -339,7 +339,7 @@ class ModelTaskTest extends CakeTestCase {
 			->with($this->stringContains('make a valid'));
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notEmpty' => 'notEmpty');
+		$expected = array('notBlank' => 'notBlank');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -371,7 +371,7 @@ class ModelTaskTest extends CakeTestCase {
 			->will($this->onConsecutiveCalls('25', 'y', 's'));
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notEmpty' => 'notEmpty', '_skipFields' => true);
+		$expected = array('notBlank' => 'notBlank', '_skipFields' => true);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -387,7 +387,7 @@ class ModelTaskTest extends CakeTestCase {
 			->will($this->onConsecutiveCalls('25', 's'));
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notEmpty' => 'notEmpty', '_skipFields' => true);
+		$expected = array('notBlank' => 'notBlank', '_skipFields' => true);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -444,7 +444,7 @@ class ModelTaskTest extends CakeTestCase {
 		$result = $this->Task->doValidation($Model);
 		$expected = array(
 			'name' => array(
-				'notEmpty' => 'notEmpty'
+				'notBlank' => 'notBlank'
 			),
 			'email' => array(
 				'email' => 'email',
@@ -502,7 +502,7 @@ class ModelTaskTest extends CakeTestCase {
 		$result = $this->Task->doValidation($Model);
 		$expected = array(
 			'name' => array(
-				'notEmpty' => 'notEmpty'
+				'notBlank' => 'notBlank'
 			),
 			'email' => array(
 				'email' => 'email',
@@ -838,7 +838,7 @@ class ModelTaskTest extends CakeTestCase {
 	public function testBakeValidation() {
 		$validate = array(
 			'name' => array(
-				'notempty' => 'notEmpty'
+				'notBlank' => 'notBlank'
 			),
 			'email' => array(
 				'email' => 'email',
@@ -855,8 +855,8 @@ class ModelTaskTest extends CakeTestCase {
 		$this->assertRegExp('/\$validate \= array\(/', $result);
 		$expected = <<< STRINGEND
 array(
-			'notempty' => array(
-				'rule' => array('notEmpty'),
+			'notBlank' => array(
+				'rule' => array('notBlank'),
 				//'message' => 'Your custom message here',
 				//'allowEmpty' => false,
 				//'required' => false,

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -1106,7 +1106,7 @@ class ControllerTest extends CakeTestCase {
 		$TestController = new TestController();
 
 		$Post = new ControllerPost();
-		$Post->validate = array('title' => 'notEmpty');
+		$Post->validate = array('title' => 'notBlank');
 		$Post->set('title', '');
 		$result = $TestController->validateErrors($Post);
 

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -942,7 +942,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 
 		$TestModel = new TranslatedItem();
 		$TestModel->locale = 'eng';
-		$TestModel->validate['title'] = 'notEmpty';
+		$TestModel->validate['title'] = 'notBlank';
 		$data = array('TranslatedItem' => array(
 			'id' => 1,
 			'title' => array('eng' => 'New Title #1', 'deu' => 'Neue Titel #1', 'cze' => 'Novy Titulek #1'),

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -210,8 +210,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$TestModel->validate = array(
 			'user_id' => 'numeric',
-			'title' => array('allowEmpty' => false, 'rule' => 'notEmpty'),
-			'body' => 'notEmpty'
+			'title' => array('allowEmpty' => false, 'rule' => 'notBlank'),
+			'body' => 'notBlank'
 		);
 
 		$data = array('TestValidate' => array(
@@ -380,7 +380,7 @@ class ModelValidationTest extends BaseModelTest {
 			),
 			'title' => array(
 				'allowEmpty' => false,
-				'rule' => 'notEmpty'
+				'rule' => 'notBlank'
 		));
 
 		$data = array('TestValidate' => array(
@@ -427,7 +427,7 @@ class ModelValidationTest extends BaseModelTest {
 			),
 			'title' => array(
 				'allowEmpty' => false,
-				'rule' => 'notEmpty'
+				'rule' => 'notBlank'
 		));
 
 		$data = array('TestValidate' => array(
@@ -577,7 +577,7 @@ class ModelValidationTest extends BaseModelTest {
 		$Something = new Something();
 		$JoinThing = $Something->JoinThing;
 
-		$JoinThing->validate = array('doomed' => array('rule' => 'notEmpty'));
+		$JoinThing->validate = array('doomed' => array('rule' => 'notBlank'));
 
 		$expectedError = array('doomed' => array('This field cannot be left blank'));
 
@@ -620,10 +620,10 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel = new ValidationTest1();
 		$TestModel->validate = array(
 			'title' => array(
-				'rule' => 'notEmpty',
+				'rule' => 'notBlank',
 			),
 			'name' => array(
-				'rule' => 'notEmpty',
+				'rule' => 'notBlank',
 		));
 		$TestModel->Behaviors->attach('ValidationRule', array('fields' => array('name')));
 
@@ -659,7 +659,7 @@ class ModelValidationTest extends BaseModelTest {
 		$Something = new Something();
 		$JoinThing = $Something->JoinThing;
 
-		$JoinThing->validate = array('doomed' => array('rule' => 'notEmpty'));
+		$JoinThing->validate = array('doomed' => array('rule' => 'notBlank'));
 		$expectedError = array('doomed' => array('This field cannot be left blank'));
 
 		$Something->create();
@@ -850,8 +850,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'on' => 'create'
 				)
 			)
@@ -868,8 +868,8 @@ class ModelValidationTest extends BaseModelTest {
 		unset($data['Article']['id']);
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'on' => 'update'
 				)
 			)
@@ -903,8 +903,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'create'
 				)
 			)
@@ -921,8 +921,8 @@ class ModelValidationTest extends BaseModelTest {
 		unset($data['Article']['id']);
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'update'
 				)
 			)
@@ -956,8 +956,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'create',
 					'on' => 'create'
 				)
@@ -969,8 +969,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'update',
 					'on' => 'create'
 				)
@@ -982,8 +982,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'create',
 					'on' => 'update'
 				)
@@ -995,8 +995,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'update',
 					'on' => 'update'
 				)
@@ -1008,8 +1008,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'create',
 					'on' => 'create'
 				)
@@ -1023,8 +1023,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'update',
 					'on' => 'create'
 				)
@@ -1036,8 +1036,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'create',
 					'on' => 'update'
 				)
@@ -1049,8 +1049,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$Article->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => 'update',
 					'on' => 'update'
 				)
@@ -1072,8 +1072,8 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel = new Article();
 		$TestModel->hasMany['Comment']['order'] = array('Comment.created' => 'ASC');
 		$TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->Attachment->validate['attachment'] = 'notEmpty';
-		$TestModel->Comment->validate['comment'] = 'notEmpty';
+		$TestModel->Comment->Attachment->validate['attachment'] = 'notBlank';
+		$TestModel->Comment->validate['comment'] = 'notBlank';
 
 		$data = array(
 			'Article' => array('id' => 2),
@@ -1400,8 +1400,8 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel = new Article();
 		$TestModel->hasMany['Comment']['order'] = array('Comment.created' => 'ASC');
 		$TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->Attachment->validate['attachment'] = 'notEmpty';
-		$TestModel->Comment->validate['comment'] = 'notEmpty';
+		$TestModel->Comment->Attachment->validate['attachment'] = 'notBlank';
+		$TestModel->Comment->validate['comment'] = 'notBlank';
 
 		$data = array(
 			'Article' => array('id' => 2, 'body' => ''),
@@ -1550,7 +1550,7 @@ class ModelValidationTest extends BaseModelTest {
 	public function testValidateAssociated() {
 		$this->loadFixtures('Comment', 'Attachment', 'Article', 'User');
 		$TestModel = new Comment();
-		$TestModel->Attachment->validate = array('attachment' => 'notEmpty');
+		$TestModel->Attachment->validate = array('attachment' => 'notBlank');
 
 		$data = array(
 			'Comment' => array(
@@ -1577,7 +1577,7 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertTrue($result);
 		$this->assertEmpty($TestModel->validationErrors);
 
-		$TestModel->validate = array('comment' => 'notEmpty');
+		$TestModel->validate = array('comment' => 'notBlank');
 		$record = array(
 			'Comment' => array(
 				'user_id' => 1,
@@ -1608,7 +1608,7 @@ class ModelValidationTest extends BaseModelTest {
 
 		$TestModel = new Article();
 		$TestModel->belongsTo = $TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->validate = array('comment' => 'notEmpty');
+		$TestModel->Comment->validate = array('comment' => 'notBlank');
 		$data = array(
 			'Article' => array('id' => 2),
 			'Comment' => array(
@@ -1653,8 +1653,8 @@ class ModelValidationTest extends BaseModelTest {
 
 		$model = new Comment();
 		$model->deleteAll(true);
-		$model->validate = array('comment' => 'notEmpty');
-		$model->Attachment->validate = array('attachment' => 'notEmpty');
+		$model->validate = array('comment' => 'notBlank');
+		$model->Attachment->validate = array('attachment' => 'notBlank');
 		$model->Attachment->bindModel(array('belongsTo' => array('Comment')));
 		$expected = array(
 			'comment' => array('This field cannot be left blank'),
@@ -1682,7 +1682,7 @@ class ModelValidationTest extends BaseModelTest {
  */
 	public function testValidateMany() {
 		$TestModel = new Article();
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$data = array(
 			0 => array('title' => ''),
 			1 => array('title' => 'title 1'),
@@ -1803,13 +1803,13 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertEquals('title', $titleValidator->field);
 		$this->assertCount(1, $titleValidator->getRules());
 		$rule = current($titleValidator->getRules());
-		$this->assertEquals('notEmpty', $rule->rule);
+		$this->assertEquals('notBlank', $rule->rule);
 
 		$titleValidator = $Validator['body'];
 		$this->assertEquals('body', $titleValidator->field);
 		$this->assertCount(1, $titleValidator->getRules());
 		$rule = current($titleValidator->getRules());
-		$this->assertEquals('notEmpty', $rule->rule);
+		$this->assertEquals('notBlank', $rule->rule);
 
 		$titleValidator = $Validator['user_id'];
 		$this->assertEquals('user_id', $titleValidator->field);
@@ -1996,8 +1996,8 @@ class ModelValidationTest extends BaseModelTest {
 		$model = new CustomArticle();
 		$model->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => true,
 					'allowEmpty' => false
 				)
@@ -2050,8 +2050,8 @@ class ModelValidationTest extends BaseModelTest {
 		$model = new CustomArticle();
 		$model->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => true
 				)
 			)
@@ -2203,8 +2203,8 @@ class ModelValidationTest extends BaseModelTest {
 		$model = new CustomArticle();
 		$model->validate = array(
 			'title' => array(
-				'notempty' => array(
-					'rule' => 'notEmpty',
+				'notBlank' => array(
+					'rule' => 'notBlank',
 					'required' => true
 				)
 			)
@@ -2294,7 +2294,7 @@ class ModelValidationTest extends BaseModelTest {
 		$this->loadFixtures('Comment', 'Article', 'User', 'Attachment');
 		$Attachment = ClassRegistry::init('Attachment');
 		$Attachment->Comment->validator()->add('comment', array(
-			array('rule' => 'notEmpty')
+			array('rule' => 'notBlank')
 		));
 		$Attachment->Comment->User->bindModel(array(
 			'hasMany' => array(
@@ -2353,7 +2353,7 @@ class ModelValidationTest extends BaseModelTest {
 		$this->loadFixtures('Comment', 'Article', 'User');
 		$Article = ClassRegistry::init('Article');
 		$Article->Comment->validator()->add('comment', array(
-			array('rule' => 'notEmpty')
+			array('rule' => 'notBlank')
 		));
 
 		$data = array(

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -879,7 +879,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		// Check if Database supports transactions
 
-		$PostModel->validate = array('title' => 'notEmpty');
+		$PostModel->validate = array('title' => 'notBlank');
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => 'New Fifth Post'),
@@ -3413,8 +3413,8 @@ class ModelWriteTest extends BaseModelTest {
 		$model->Attachment->deleteAll(true);
 		$this->assertEquals(array(), $model->Attachment->find('all'));
 
-		$model->validate = array('comment' => 'notEmpty');
-		$model->Attachment->validate = array('attachment' => 'notEmpty');
+		$model->validate = array('comment' => 'notBlank');
+		$model->Attachment->validate = array('attachment' => 'notBlank');
 		$model->Attachment->bindModel(array('belongsTo' => array('Comment')));
 
 		$result = $model->saveAll(
@@ -3496,7 +3496,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertSame($result, array('Article' => true, 'Comment' => array(true, true)));
 
 		$TestModel->validate = array(
-			'title' => 'notEmpty',
+			'title' => 'notBlank',
 			'author_id' => 'numeric'
 		);
 		$result = $TestModel->saveAll(array(
@@ -3701,7 +3701,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$TestModel->Comment->validate['comment'] = 'notEmpty';
+		$TestModel->Comment->validate['comment'] = 'notBlank';
 		$result = $TestModel->saveAll($data, array('deep' => true));
 		$this->assertFalse($result);
 
@@ -3744,8 +3744,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Article();
 		$TestModel->hasMany['Comment']['order'] = array('Comment.created' => 'ASC');
 		$TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->Attachment->validate['attachment'] = 'notEmpty';
-		$TestModel->Comment->validate['comment'] = 'notEmpty';
+		$TestModel->Comment->Attachment->validate['attachment'] = 'notBlank';
+		$TestModel->Comment->validate['comment'] = 'notBlank';
 
 		$result = $TestModel->saveAll(
 			array(
@@ -4155,7 +4155,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$TestModel->Comment->validate['comment'] = 'notEmpty';
+		$TestModel->Comment->validate['comment'] = 'notBlank';
 		$result = $TestModel->saveAll($data, array('deep' => false));
 		$this->assertFalse($result);
 
@@ -4195,8 +4195,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Article();
 		$TestModel->hasMany['Comment']['order'] = array('Comment.created' => 'ASC');
 		$TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->Attachment->validate['attachment'] = 'notEmpty';
-		$TestModel->Comment->validate['comment'] = 'notEmpty';
+		$TestModel->Comment->Attachment->validate['attachment'] = 'notBlank';
+		$TestModel->Comment->validate['comment'] = 'notBlank';
 
 		$result = $TestModel->saveAll(
 			array(
@@ -4416,7 +4416,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Article', 'Comment');
 		$TestModel = new Article();
 		$TestModel->belongsTo = $TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->validate = array('comment' => 'notEmpty');
+		$TestModel->Comment->validate = array('comment' => 'notBlank');
 
 		$result = $TestModel->saveAll(array(
 			'Article' => array('id' => 2),
@@ -4457,7 +4457,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$Post = new TestPost();
 		$Post->validate = array(
-			'title' => array('rule' => array('notEmpty'))
+			'title' => array('rule' => array('notBlank'))
 		);
 
 		// If validation error occurs, rollback() should be called.
@@ -4518,7 +4518,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$Post = new TestPost();
 		$Post->Author->validate = array(
-			'user' => array('rule' => array('notEmpty'))
+			'user' => array('rule' => array('notBlank'))
 		);
 
 		// If validation error occurs, rollback() should be called.
@@ -4618,7 +4618,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Post', 'Author', 'Comment', 'Attachment');
 		$TestModel = new Post();
 
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => 'New Fifth Post'),
@@ -4750,7 +4750,7 @@ class ModelWriteTest extends BaseModelTest {
 		}
 		$this->assertEquals($expected, $result);
 
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => 'New Fifth Post'),
@@ -4878,7 +4878,7 @@ class ModelWriteTest extends BaseModelTest {
 		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
 		$this->assertEquals($expected, $result);
 
-		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
+		$TestModel->validate = array('title' => 'notBlank', 'author_id' => 'numeric');
 		$data = array(
 			array(
 				'id' => '1',
@@ -4904,7 +4904,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$this->assertEquals($errors, $TestModel->validationErrors);
 
-		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
+		$TestModel->validate = array('title' => 'notBlank', 'author_id' => 'numeric');
 		$data = array(
 			array(
 				'id' => '1',
@@ -5006,7 +5006,7 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllValidationOnly() {
 		$this->loadFixtures('Comment', 'Attachment');
 		$TestModel = new Comment();
-		$TestModel->Attachment->validate = array('attachment' => 'notEmpty');
+		$TestModel->Attachment->validate = array('attachment' => 'notBlank');
 
 		$data = array(
 			'Comment' => array(
@@ -5021,7 +5021,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$TestModel = new Article();
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$result = $TestModel->saveAll(
 			array(
 				0 => array('title' => ''),
@@ -5061,7 +5061,7 @@ class ModelWriteTest extends BaseModelTest {
 		$model = new Article();
 		$model->deleteAll(true);
 
-		$model->Comment->validate = array('comment' => 'notEmpty');
+		$model->Comment->validate = array('comment' => 'notBlank');
 		$result = $model->saveAll(array(
 			'Article' => array(
 				'title' => 'Post with Author',
@@ -5198,7 +5198,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Article', 'Comment', 'Attachment');
 		$TestModel = new Article();
 		$TestModel->belongsTo = $TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->validate = array('comment' => 'notEmpty');
+		$TestModel->Comment->validate = array('comment' => 'notBlank');
 
 		$result = $TestModel->saveAll(
 			array(
@@ -5406,7 +5406,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Comment', 'Article', 'User');
 		$Article = ClassRegistry::init('Article');
 		$Article->Comment->validator()->add('comment', array(
-			array('rule' => 'notEmpty')
+			array('rule' => 'notBlank')
 		));
 
 		$data = array(
@@ -5694,8 +5694,8 @@ class ModelWriteTest extends BaseModelTest {
 		$model->Attachment->deleteAll(true);
 		$this->assertEquals(array(), $model->Attachment->find('all'));
 
-		$model->validate = array('comment' => 'notEmpty');
-		$model->Attachment->validate = array('attachment' => 'notEmpty');
+		$model->validate = array('comment' => 'notBlank');
+		$model->Attachment->validate = array('attachment' => 'notBlank');
 		$model->Attachment->bindModel(array('belongsTo' => array('Comment')));
 
 		$result = $model->saveAssociated(
@@ -5789,7 +5789,7 @@ class ModelWriteTest extends BaseModelTest {
 		), array('atomic' => false));
 		$this->assertSame($result, array(true, true, true));
 
-		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
+		$TestModel->validate = array('title' => 'notBlank', 'author_id' => 'numeric');
 		$result = $TestModel->saveMany(array(
 			array(
 				'id' => '1',
@@ -5892,7 +5892,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Article', 'Comment');
 		$TestModel = new Article();
 		$TestModel->belongsTo = $TestModel->hasAndBelongsToMany = array();
-		$TestModel->validate = $TestModel->Comment->validate = array('user_id' => array('notEmpty' => array('rule' => 'notEmpty', 'required' => true)));
+		$TestModel->validate = $TestModel->Comment->validate = array('user_id' => array('notBlank' => array('rule' => 'notBlank', 'required' => true)));
 
 		//empty hasMany data is ignored in save
 		$result = $TestModel->saveAssociated(array(
@@ -5924,7 +5924,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Article', 'Comment');
 		$TestModel = new Article();
 		$TestModel->belongsTo = $TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->validate = array('comment' => 'notEmpty');
+		$TestModel->Comment->validate = array('comment' => 'notBlank');
 
 		$result = $TestModel->saveAssociated(array(
 			'Article' => array('id' => 2),
@@ -5965,7 +5965,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$Post = new TestPost();
 		$Post->validate = array(
-			'title' => array('rule' => array('notEmpty'))
+			'title' => array('rule' => array('notBlank'))
 		);
 
 		// If validation error occurs, rollback() should be called.
@@ -6026,7 +6026,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$Post = new TestPost();
 		$Post->Author->validate = array(
-			'user' => array('rule' => array('notEmpty'))
+			'user' => array('rule' => array('notBlank'))
 		);
 
 		// If validation error occurs, rollback() should be called.
@@ -6126,7 +6126,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Post', 'Author', 'Comment', 'Attachment');
 		$TestModel = new Post();
 
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => 'New Fifth Post'),
@@ -6262,7 +6262,7 @@ class ModelWriteTest extends BaseModelTest {
 		}
 		$this->assertEquals($expected, $result);
 
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => 'New Fifth Post'),
@@ -6395,7 +6395,7 @@ class ModelWriteTest extends BaseModelTest {
 		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
 		$this->assertEquals($expected, $result);
 
-		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
+		$TestModel->validate = array('title' => 'notBlank', 'author_id' => 'numeric');
 		$data = array(
 			array(
 				'id' => '1',
@@ -6421,7 +6421,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$this->assertEquals($errors, $TestModel->validationErrors);
 
-		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
+		$TestModel->validate = array('title' => 'notBlank', 'author_id' => 'numeric');
 		$data = array(
 			array(
 				'id' => '1',
@@ -6509,7 +6509,7 @@ class ModelWriteTest extends BaseModelTest {
  */
 	public function testValidateMany() {
 		$TestModel = new Article();
-		$TestModel->validate = array('title' => 'notEmpty');
+		$TestModel->validate = array('title' => 'notBlank');
 		$data = array(
 				0 => array('title' => ''),
 				1 => array('title' => 'title 1'),
@@ -6545,7 +6545,7 @@ class ModelWriteTest extends BaseModelTest {
 		$model = new Article();
 		$model->deleteAll(true);
 
-		$model->Comment->validate = array('comment' => 'notEmpty');
+		$model->Comment->validate = array('comment' => 'notBlank');
 		$result = $model->saveAssociated(array(
 			'Article' => array(
 				'title' => 'Post with Author',
@@ -6680,7 +6680,7 @@ class ModelWriteTest extends BaseModelTest {
 	public function testValidateAssociated() {
 		$this->loadFixtures('Attachment', 'Article', 'Comment');
 		$TestModel = new Comment();
-		$TestModel->Attachment->validate = array('attachment' => 'notEmpty');
+		$TestModel->Attachment->validate = array('attachment' => 'notBlank');
 
 		$data = array(
 			'Comment' => array(
@@ -6696,7 +6696,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$TestModel = new Article();
 		$TestModel->belongsTo = $TestModel->hasAndBelongsToMany = array();
-		$TestModel->Comment->validate = array('comment' => 'notEmpty');
+		$TestModel->Comment->validate = array('comment' => 'notBlank');
 
 		$data = array(
 			'Article' => array('id' => 2),
@@ -7331,8 +7331,8 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Attachment', 'Comment', 'Article', 'User');
 		$TestModel = new Comment();
 
-		$TestModel->validate = array('comment' => 'notEmpty');
-		$TestModel->Attachment->validate = array('attachment' => 'notEmpty');
+		$TestModel->validate = array('comment' => 'notBlank');
+		$TestModel->Attachment->validate = array('attachment' => 'notBlank');
 
 		$record = array(
 			'Comment' => array(
@@ -7367,7 +7367,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('ArticleFeatured', 'Featured');
 		$Article = new ArticleFeatured();
 		$Article->belongsTo = $Article->hasMany = array();
-		$Article->Featured->validate = array('end_date' => 'notEmpty');
+		$Article->Featured->validate = array('end_date' => 'notBlank');
 
 		$record = array(
 			'ArticleFeatured' => array(

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
@@ -58,7 +58,7 @@ class CakeValidationRuleTest extends CakeTestCase {
  * @return void
  */
 	public function testIsValid() {
-		$def = array('rule' => 'notEmpty', 'message' => 'Can not be empty');
+		$def = array('rule' => 'notBlank', 'message' => 'Can not be empty');
 		$data = array(
 			'fieldName' => ''
 		);
@@ -122,19 +122,19 @@ class CakeValidationRuleTest extends CakeTestCase {
  * @return void
  */
 	public function testIsRequired() {
-		$def = array('rule' => 'notEmpty', 'required' => true);
+		$def = array('rule' => 'notBlank', 'required' => true);
 		$Rule = new CakeValidationRule($def);
 		$this->assertTrue($Rule->isRequired());
 
-		$def = array('rule' => 'notEmpty', 'required' => false);
+		$def = array('rule' => 'notBlank', 'required' => false);
 		$Rule = new CakeValidationRule($def);
 		$this->assertFalse($Rule->isRequired());
 
-		$def = array('rule' => 'notEmpty', 'required' => 'create');
+		$def = array('rule' => 'notBlank', 'required' => 'create');
 		$Rule = new CakeValidationRule($def);
 		$this->assertTrue($Rule->isRequired());
 
-		$def = array('rule' => 'notEmpty', 'required' => 'update');
+		$def = array('rule' => 'notBlank', 'required' => 'update');
 		$Rule = new CakeValidationRule($def);
 		$this->assertFalse($Rule->isRequired());
 
@@ -156,14 +156,14 @@ class CakeValidationRuleTest extends CakeTestCase {
 		$Rule = new CakeValidationRule($def);
 		$this->assertFalse($Rule->isEmptyAllowed());
 
-		$def = array('rule' => 'notEmpty', 'allowEmpty' => false, 'on' => 'update');
+		$def = array('rule' => 'notBlank', 'allowEmpty' => false, 'on' => 'update');
 		$Rule = new CakeValidationRule($def);
 		$this->assertTrue($Rule->isEmptyAllowed());
 
 		$Rule->isUpdate(true);
 		$this->assertFalse($Rule->isEmptyAllowed());
 
-		$def = array('rule' => 'notEmpty', 'allowEmpty' => false, 'on' => 'create');
+		$def = array('rule' => 'notBlank', 'allowEmpty' => false, 'on' => 'create');
 		$Rule = new CakeValidationRule($def);
 		$this->assertFalse($Rule->isEmptyAllowed());
 

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationSetTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationSetTest.php
@@ -41,7 +41,7 @@ class CakeValidationSetTest extends CakeTestCase {
  * @return void
  */
 	public function testValidate() {
-		$Field = new CakeValidationSet('title', 'notEmpty');
+		$Field = new CakeValidationSet('title', 'notBlank');
 		$data = array(
 			'title' => '',
 			'body' => 'a body'
@@ -51,20 +51,20 @@ class CakeValidationSetTest extends CakeTestCase {
 		$expected = array('This field cannot be left blank');
 		$this->assertEquals($expected, $result);
 
-		$Field = new CakeValidationSet('body', 'notEmpty');
+		$Field = new CakeValidationSet('body', 'notBlank');
 
 		$result = $Field->validate($data);
 		$this->assertEmpty($result);
 
 		$Field = new CakeValidationSet('nothere', array(
-			'notEmpty' => array(
-				'rule' => 'notEmpty',
+			'notBlank' => array(
+				'rule' => 'notBlank',
 				'required' => true
 			)
 		));
 
 		$result = $Field->validate($data);
-		$expected = array('notEmpty');
+		$expected = array('notBlank');
 		$this->assertEquals($expected, $result);
 
 		$Field = new CakeValidationSet('body', array(
@@ -83,11 +83,11 @@ class CakeValidationSetTest extends CakeTestCase {
  * @return void
  */
 	public function testGetRule() {
-		$rules = array('notEmpty' => array('rule' => 'notEmpty', 'message' => 'Can not be empty'));
+		$rules = array('notBlank' => array('rule' => 'notBlank', 'message' => 'Can not be empty'));
 		$Field = new CakeValidationSet('title', $rules);
-		$result = $Field->getRule('notEmpty');
+		$result = $Field->getRule('notBlank');
 		$this->assertInstanceOf('CakeValidationRule', $result);
-		$this->assertEquals('notEmpty', $result->rule);
+		$this->assertEquals('notBlank', $result->rule);
 		$this->assertEquals(null, $result->required);
 		$this->assertEquals(false, $result->allowEmpty);
 		$this->assertEquals(null, $result->on);
@@ -101,12 +101,12 @@ class CakeValidationSetTest extends CakeTestCase {
  * @return void
  */
 	public function testGetRules() {
-		$rules = array('notEmpty' => array('rule' => 'notEmpty', 'message' => 'Can not be empty'));
+		$rules = array('notBlank' => array('rule' => 'notBlank', 'message' => 'Can not be empty'));
 		$Field = new CakeValidationSet('title', $rules);
 
 		$result = $Field->getRules();
-		$this->assertEquals(array('notEmpty'), array_keys($result));
-		$this->assertInstanceOf('CakeValidationRule', $result['notEmpty']);
+		$this->assertEquals(array('notBlank'), array_keys($result));
+		$this->assertInstanceOf('CakeValidationRule', $result['notBlank']);
 	}
 
 /**
@@ -115,23 +115,23 @@ class CakeValidationSetTest extends CakeTestCase {
  * @return void
  */
 	public function testSetRule() {
-		$rules = array('notEmpty' => array('rule' => 'notEmpty', 'message' => 'Can not be empty'));
+		$rules = array('notBlank' => array('rule' => 'notBlank', 'message' => 'Can not be empty'));
 		$Field = new CakeValidationSet('title', $rules);
-		$Rule = new CakeValidationRule($rules['notEmpty']);
+		$Rule = new CakeValidationRule($rules['notBlank']);
 
-		$this->assertEquals($Rule, $Field->getRule('notEmpty'));
+		$this->assertEquals($Rule, $Field->getRule('notBlank'));
 
 		$rules = array('validEmail' => array('rule' => 'email', 'message' => 'Invalid email'));
 		$Rule = new CakeValidationRule($rules['validEmail']);
 		$Field->setRule('validEmail', $Rule);
 		$result = $Field->getRules();
-		$this->assertEquals(array('notEmpty', 'validEmail'), array_keys($result));
+		$this->assertEquals(array('notBlank', 'validEmail'), array_keys($result));
 
 		$rules = array('validEmail' => array('rule' => 'email', 'message' => 'Other message'));
 		$Rule = new CakeValidationRule($rules['validEmail']);
 		$Field->setRule('validEmail', $Rule);
 		$result = $Field->getRules();
-		$this->assertEquals(array('notEmpty', 'validEmail'), array_keys($result));
+		$this->assertEquals(array('notBlank', 'validEmail'), array_keys($result));
 		$result = $Field->getRule('validEmail');
 		$this->assertInstanceOf('CakeValidationRule', $result);
 		$this->assertEquals('email', $result->rule);
@@ -148,9 +148,9 @@ class CakeValidationSetTest extends CakeTestCase {
  * @return void
  */
 	public function testSetRules() {
-		$rule = array('notEmpty' => array('rule' => 'notEmpty', 'message' => 'Can not be empty'));
+		$rule = array('notBlank' => array('rule' => 'notBlank', 'message' => 'Can not be empty'));
 		$Field = new CakeValidationSet('title', $rule);
-		$RuleEmpty = new CakeValidationRule($rule['notEmpty']);
+		$RuleEmpty = new CakeValidationRule($rule['notBlank']);
 
 		$rule = array('validEmail' => array('rule' => 'email', 'message' => 'Invalid email'));
 		$RuleEmail = new CakeValidationRule($rule['validEmail']);
@@ -165,15 +165,15 @@ class CakeValidationSetTest extends CakeTestCase {
 		$this->assertEquals(array('validEmail'), array_keys($result));
 		$this->assertTrue(array_pop($result) instanceof CakeValidationRule);
 
-		$rules = array('notEmpty' => $RuleEmpty);
+		$rules = array('notBlank' => $RuleEmpty);
 		$Field->setRules($rules, true);
 		$result = $Field->getRules();
-		$this->assertEquals(array('validEmail', 'notEmpty'), array_keys($result));
+		$this->assertEquals(array('validEmail', 'notBlank'), array_keys($result));
 
-		$rules = array('notEmpty' => array('rule' => 'notEmpty'));
+		$rules = array('notBlank' => array('rule' => 'notBlank'));
 		$Field->setRules($rules, true);
 		$result = $Field->getRules();
-		$this->assertEquals(array('validEmail', 'notEmpty'), array_keys($result));
+		$this->assertEquals(array('validEmail', 'notBlank'), array_keys($result));
 		$this->assertTrue(array_pop($result) instanceof CakeValidationRule);
 		$this->assertTrue(array_pop($result) instanceof CakeValidationRule);
 	}
@@ -185,14 +185,14 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testArrayAccessGet() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 			'numeric' => array('rule' => 'numeric'),
 			'other' => array('rule' => array('other', 1)),
 		));
 
-		$rule = $Set['notEmpty'];
+		$rule = $Set['notBlank'];
 		$this->assertInstanceOf('CakeValidationRule', $rule);
-		$this->assertEquals('notEmpty', $rule->rule);
+		$this->assertEquals('notBlank', $rule->rule);
 
 		$rule = $Set['numeric'];
 		$this->assertInstanceOf('CakeValidationRule', $rule);
@@ -210,12 +210,12 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testArrayAccessExists() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 			'numeric' => array('rule' => 'numeric'),
 			'other' => array('rule' => array('other', 1)),
 		));
 
-		$this->assertTrue(isset($Set['notEmpty']));
+		$this->assertTrue(isset($Set['notBlank']));
 		$this->assertTrue(isset($Set['numeric']));
 		$this->assertTrue(isset($Set['other']));
 		$this->assertFalse(isset($Set['fail']));
@@ -228,7 +228,7 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testArrayAccessSet() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 		));
 
 		$this->assertFalse(isset($Set['other']));
@@ -251,19 +251,19 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testArrayAccessUnset() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 			'numeric' => array('rule' => 'numeric'),
 			'other' => array('rule' => array('other', 1)),
 		));
 
-		unset($Set['notEmpty']);
-		$this->assertFalse(isset($Set['notEmpty']));
+		unset($Set['notBlank']);
+		$this->assertFalse(isset($Set['notBlank']));
 
 		unset($Set['numeric']);
-		$this->assertFalse(isset($Set['notEmpty']));
+		$this->assertFalse(isset($Set['notBlank']));
 
 		unset($Set['other']);
-		$this->assertFalse(isset($Set['notEmpty']));
+		$this->assertFalse(isset($Set['notBlank']));
 	}
 
 /**
@@ -273,7 +273,7 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testIterator() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 			'numeric' => array('rule' => 'numeric'),
 			'other' => array('rule' => array('other', 1)),
 		));
@@ -281,7 +281,7 @@ class CakeValidationSetTest extends CakeTestCase {
 		$i = 0;
 		foreach ($Set as $name => $rule) {
 			if ($i === 0) {
-				$this->assertEquals('notEmpty', $name);
+				$this->assertEquals('notBlank', $name);
 			}
 			if ($i === 1) {
 				$this->assertEquals('numeric', $name);
@@ -302,7 +302,7 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testCount() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 			'numeric' => array('rule' => 'numeric'),
 			'other' => array('rule' => array('other', 1)),
 		));
@@ -319,13 +319,13 @@ class CakeValidationSetTest extends CakeTestCase {
  */
 	public function testRemoveRule() {
 		$Set = new CakeValidationSet('title', array(
-			'notEmpty' => array('rule' => 'notEmpty', 'required' => true),
+			'notBlank' => array('rule' => 'notBlank', 'required' => true),
 			'numeric' => array('rule' => 'numeric'),
 			'other' => array('rule' => array('other', 1)),
 		));
 
-		$Set->removeRule('notEmpty');
-		$this->assertFalse(isset($Set['notEmpty']));
+		$Set->removeRule('notBlank');
+		$this->assertFalse(isset($Set['notBlank']));
 
 		$Set->removeRule('numeric');
 		$this->assertFalse(isset($Set['numeric']));

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -208,7 +208,7 @@ class User extends CakeTestModel {
  *
  * @var array
  */
-	public $validate = array('user' => 'notEmpty', 'password' => 'notEmpty');
+	public $validate = array('user' => 'notBlank', 'password' => 'notBlank');
 
 /**
  * beforeFind() callback used to run ContainableBehaviorTest::testLazyLoad()
@@ -269,8 +269,8 @@ class Article extends CakeTestModel {
  */
 	public $validate = array(
 		'user_id' => 'numeric',
-		'title' => array('required' => false, 'rule' => 'notEmpty'),
-		'body' => array('required' => false, 'rule' => 'notEmpty'),
+		'title' => array('required' => false, 'rule' => 'notBlank'),
+		'body' => array('required' => false, 'rule' => 'notBlank'),
 	);
 
 /**
@@ -424,7 +424,7 @@ class ArticleFeatured extends CakeTestModel {
  *
  * @var array
  */
-	public $validate = array('user_id' => 'numeric', 'title' => 'notEmpty', 'body' => 'notEmpty');
+	public $validate = array('user_id' => 'numeric', 'title' => 'notBlank', 'body' => 'notBlank');
 
 }
 
@@ -802,7 +802,7 @@ class Apple extends CakeTestModel {
  *
  * @var array
  */
-	public $validate = array('name' => 'notEmpty');
+	public $validate = array('name' => 'notBlank');
 
 /**
  * hasOne property
@@ -1197,7 +1197,7 @@ class NodeAfterFind extends CakeTestModel {
  *
  * @var array
  */
-	public $validate = array('name' => 'notEmpty');
+	public $validate = array('name' => 'notBlank');
 
 /**
  * useTable property
@@ -1287,7 +1287,7 @@ class NodeNoAfterFind extends CakeTestModel {
  *
  * @var array
  */
-	public $validate = array('name' => 'notEmpty');
+	public $validate = array('name' => 'notBlank');
 
 /**
  * useTable property
@@ -2191,10 +2191,10 @@ class ValidationTest1 extends CakeTestModel {
  * @var array
  */
 	public $validate = array(
-		'title' => 'notEmpty',
+		'title' => 'notBlank',
 		'published' => 'customValidationMethod',
 		'body' => array(
-			'notEmpty',
+			'notBlank',
 			'/^.{5,}$/s' => 'no matchy',
 			'/^[0-9A-Za-z \\.]{1,}$/s'
 		)
@@ -2270,10 +2270,10 @@ class ValidationTest2 extends CakeTestModel {
  * @var array
  */
 	public $validate = array(
-		'title' => 'notEmpty',
+		'title' => 'notBlank',
 		'published' => 'customValidationMethod',
 		'body' => array(
-			'notEmpty',
+			'notBlank',
 			'/^.{5,}$/s' => 'no matchy',
 			'/^[0-9A-Za-z \\.]{1,}$/s'
 		)
@@ -2394,7 +2394,7 @@ class Story extends CakeTestModel {
  *
  * @var array
  */
-	public $validate = array('title' => 'notEmpty');
+	public $validate = array('title' => 'notBlank');
 }
 
 /**

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -129,15 +129,15 @@ class ValidationTest extends CakeTestCase {
  * @return void
  */
 	public function testNotEmpty() {
-		$this->assertTrue(Validation::notEmpty('abcdefg'));
-		$this->assertTrue(Validation::notEmpty('fasdf '));
-		$this->assertTrue(Validation::notEmpty('fooo' . chr(243) . 'blabla'));
-		$this->assertTrue(Validation::notEmpty('abçďĕʑʘπй'));
-		$this->assertTrue(Validation::notEmpty('José'));
-		$this->assertTrue(Validation::notEmpty('é'));
-		$this->assertTrue(Validation::notEmpty('π'));
-		$this->assertFalse(Validation::notEmpty("\t "));
-		$this->assertFalse(Validation::notEmpty(""));
+		$this->assertTrue(Validation::notBlank('abcdefg'));
+		$this->assertTrue(Validation::notBlank('fasdf '));
+		$this->assertTrue(Validation::notBlank('fooo' . chr(243) . 'blabla'));
+		$this->assertTrue(Validation::notBlank('abçďĕʑʘπй'));
+		$this->assertTrue(Validation::notBlank('José'));
+		$this->assertTrue(Validation::notBlank('é'));
+		$this->assertTrue(Validation::notBlank('π'));
+		$this->assertFalse(Validation::notBlank("\t "));
+		$this->assertFalse(Validation::notBlank(""));
 	}
 
 /**
@@ -147,14 +147,14 @@ class ValidationTest extends CakeTestCase {
  */
 	public function testNotEmptyISO88591AppEncoding() {
 		Configure::write('App.encoding', 'ISO-8859-1');
-		$this->assertTrue(Validation::notEmpty('abcdefg'));
-		$this->assertTrue(Validation::notEmpty('fasdf '));
-		$this->assertTrue(Validation::notEmpty('fooo' . chr(243) . 'blabla'));
-		$this->assertTrue(Validation::notEmpty('abçďĕʑʘπй'));
-		$this->assertTrue(Validation::notEmpty('José'));
-		$this->assertTrue(Validation::notEmpty(utf8_decode('José')));
-		$this->assertFalse(Validation::notEmpty("\t "));
-		$this->assertFalse(Validation::notEmpty(""));
+		$this->assertTrue(Validation::notBlank('abcdefg'));
+		$this->assertTrue(Validation::notBlank('fasdf '));
+		$this->assertTrue(Validation::notBlank('fooo' . chr(243) . 'blabla'));
+		$this->assertTrue(Validation::notBlank('abçďĕʑʘπй'));
+		$this->assertTrue(Validation::notBlank('José'));
+		$this->assertTrue(Validation::notBlank(utf8_decode('José')));
+		$this->assertFalse(Validation::notBlank("\t "));
+		$this->assertFalse(Validation::notBlank(""));
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -81,15 +81,15 @@ class Contact extends CakeTestModel {
 		'non_existing' => array(),
 		'idontexist' => array(),
 		'imrequired' => array('rule' => array('between', 5, 30), 'allowEmpty' => false),
-		'imrequiredonupdate' => array('notEmpty' => array('rule' => 'alphaNumeric', 'on' => 'update')),
+		'imrequiredonupdate' => array('notBlank' => array('rule' => 'alphaNumeric', 'on' => 'update')),
 		'imrequiredoncreate' => array('required' => array('rule' => 'alphaNumeric', 'on' => 'create')),
 		'imrequiredonboth' => array(
 			'required' => array('rule' => 'alphaNumeric'),
 		),
-		'string_required' => 'notEmpty',
+		'string_required' => 'notBlank',
 		'imalsorequired' => array('rule' => 'alphaNumeric', 'allowEmpty' => false),
-		'imrequiredtoo' => array('rule' => 'notEmpty'),
-		'required_one' => array('required' => array('rule' => array('notEmpty'))),
+		'imrequiredtoo' => array('rule' => 'notBlank'),
+		'required_one' => array('required' => array('rule' => array('notBlank'))),
 		'imnotrequired' => array('required' => false, 'rule' => 'alphaNumeric', 'allowEmpty' => true),
 		'imalsonotrequired' => array(
 			'alpha' => array('rule' => 'alphaNumeric', 'allowEmpty' => true),
@@ -3623,9 +3623,9 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$Contact->validationErrors['field'] = array('notEmpty', 'email', 'Something else');
+		$Contact->validationErrors['field'] = array('notBlank', 'email', 'Something else');
 		$result = $this->Form->error('Contact.field', array(
-			'notEmpty' => 'Cannot be empty',
+			'notBlank' => 'Cannot be empty',
 			'email' => 'No good!'
 		));
 		$expected = array(
@@ -3640,13 +3640,13 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 
 		// Testing error messages list options
-		$Contact->validationErrors['field'] = array('notEmpty', 'email');
+		$Contact->validationErrors['field'] = array('notBlank', 'email');
 
 		$result = $this->Form->error('Contact.field', null, array('listOptions' => 'ol'));
 		$expected = array(
 			'div' => array('class' => 'error-message'),
 				'ol' => array(),
-					'<li', 'notEmpty', '/li',
+					'<li', 'notBlank', '/li',
 					'<li', 'email', '/li',
 				'/ol',
 			'/div'
@@ -3657,7 +3657,7 @@ class FormHelperTest extends CakeTestCase {
 		$expected = array(
 			'div' => array('class' => 'error-message'),
 				'ol' => array(),
-					'<li', 'notEmpty', '/li',
+					'<li', 'notBlank', '/li',
 					'<li', 'email', '/li',
 				'/ol',
 			'/div'
@@ -3675,7 +3675,7 @@ class FormHelperTest extends CakeTestCase {
 		$expected = array(
 			'div' => array('class' => 'error-message'),
 				'ul' => array('class' => 'ul-class'),
-					array('li' => array('class' => 'li-class')), 'notEmpty', '/li',
+					array('li' => array('class' => 'li-class')), 'notBlank', '/li',
 					array('li' => array('class' => 'li-class')), 'email', '/li',
 				'/ul',
 			'/div'
@@ -9070,7 +9070,7 @@ class FormHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testFormInputRequiredDetectionModelValidator() {
-		ClassRegistry::getObject('ContactTag')->validator()->add('iwillberequired', 'required', array('rule' => 'notEmpty'));
+		ClassRegistry::getObject('ContactTag')->validator()->add('iwillberequired', 'required', array('rule' => 'notBlank'));
 
 		$this->Form->create('ContactTag');
 		$result = $this->Form->input('ContactTag.iwillberequired');

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthors.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthors.php
@@ -29,8 +29,8 @@ class TestPluginAuthors extends TestPluginAppModel {
 
 	public $validate = array(
 		'field' => array(
-			'notEmpty' => array(
-				'rule' => 'notEmpty',
+			'notBlank' => array(
+				'rule' => 'notBlank',
 				'message' => 'I can haz plugin model validation message',
 			),
 		),

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -49,6 +49,19 @@ class Validation {
 	public static $errors = array();
 
 /**
+ * Backwards compatibility wrapper for Validation::notBlank().
+ *
+ * @param string|array $check Value to check.
+ * @return bool Success.
+ * @deprecated 2.7.0 Use Validation::notBlank() instead.
+ * @see Validation::notBlank()
+ */
+	public function notEmpty($check) {
+		trigger_error('Validation::notEmpty() is deprecated. Use Validation::notBlank() instead.', E_USER_DEPRECATED);
+		return self::notBlank($check);
+	}
+
+/**
  * Checks that a string contains something other than whitespace
  *
  * Returns true if string contains something other than whitespace
@@ -59,7 +72,7 @@ class Validation {
  * @param string|array $check Value to check
  * @return bool Success
  */
-	public static function notEmpty($check) {
+	public static function notBlank($check) {
 		if (is_array($check)) {
 			extract(self::_defaults($check));
 		}
@@ -143,7 +156,7 @@ class Validation {
  * Returns true if $check is in the proper credit card format.
  *
  * @param string|array $check credit card number to validate
- * @param string|array $type 'all' may be passed as a sting, defaults to fast which checks format of most major credit 
+ * @param string|array $type 'all' may be passed as a sting, defaults to fast which checks format of most major credit
  * cards
  *    if an array is used only the values of the array are checked.
  *    Example: array('amex', 'bankcard', 'maestro')


### PR DESCRIPTION
Backport of  https://github.com/cakephp/cakephp/pull/6285

I was not sure about `blank()` and `userDefined()` so I kept them in for now. And `ssn()` is now `personId()` and Localized-plugin-only. Those could be fixed in a follow up PR.
