### PR TITLE
3.0 - Made code "dryer"

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -629,9 +629,7 @@ abstract class Association
      */
     protected function _dispatchBeforeFind($query)
     {
-        $table = $this->target();
-        $options = $query->getOptions();
-        $table->dispatchEvent('Model.beforeFind', [$query, new \ArrayObject($options), false]);
+        $query->triggerBeforeFind();
     }
 
     /**


### PR DESCRIPTION
Also fix a personal bug on a project where I had to write a custom Query class extending `\Cake\ORM\Query` to overwrite `triggerBeforeFind()` method. My custom `triggerBeforeFind()` method was not called for associations queries.
