### PR TITLE
escape fix

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1641,7 +1641,7 @@ class FormHelper extends Helper
      */
     public function postLink($title, $url = null, array $options = [])
     {
-        $options += ['block' => null, 'confirm' => null];
+        $options += ['escape' => true, 'block' => null, 'confirm' => null];
 
         $requestMethod = 'POST';
         if (!empty($options['method'])) {


### PR DESCRIPTION
This 'escape' => true provide a fix for the 'confirm' msg break.
