### PR TITLE
Allow Primary Key Updates

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1510,9 +1510,8 @@ class Table implements RepositoryInterface, EventListenerInterface
     protected function _update($entity, $data)
     {
         $primaryColumns = (array)$this->primaryKey();
-        $primaryKey = $entity->extract($primaryColumns);
+        $primaryKey = $entity->extractOriginal($primaryColumns);
 
-        $data = array_diff_key($data, $primaryKey);
         if (empty($data)) {
             return $entity;
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2362,13 +2362,13 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests that when updating the primary key is not passed to the list of
-     * attributes to change
+     * Tests that when updating the primary key is passed to the list of
+     * attributes to change, the key is updated.
      *
      * @group save
      * @return void
      */
-    public function testSaveUpdatePrimaryKeyNotModified()
+    public function testSaveUpdatePrimaryKeyModified()
     {
         $table = $this->getMock(
             '\Cake\ORM\Table',
@@ -2402,7 +2402,7 @@ class TableTest extends TestCase
             'id' => 2,
             'username' => 'baggins'
         ], ['markNew' => false]);
-        $this->assertSame($entity, $table->save($entity));
+        $this->assertNotSame($entity, $table->save($entity));
     }
 
     /**


### PR DESCRIPTION
This will allow primary keys to be changed. It is up to the end
developer to handle any integrity issues, security risks, or foreign key
relation issues as a result of updating the primary key column.

This will resolve issue https://github.com/cakephp/cakephp/issues/6465
with this ORM enhancement.
