### PR TITLE
Remove accessor cache.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -116,13 +116,6 @@ trait EntityTrait
     protected $_registryAlias;
 
     /**
-     * Holds a list of properties that were mutated using the get accessor
-     *
-     * @var array
-     */
-    protected $_mutated = [];
-
-    /**
      * Magic getter to access properties that have been set in this entity
      *
      * @param string $property Name of the property to access
@@ -263,7 +256,6 @@ trait EntityTrait
             $this->_properties[$p] = $value;
         }
 
-        $this->_mutated = [];
         return $this;
     }
 
@@ -280,10 +272,6 @@ trait EntityTrait
             throw new InvalidArgumentException('Cannot get an empty property');
         }
 
-        if (array_key_exists($property, $this->_mutated)) {
-            return $this->_mutated[$property];
-        }
-
         $value = null;
         $method = '_get' . Inflector::camelize($property);
 
@@ -293,7 +281,6 @@ trait EntityTrait
 
         if ($this->_methodExists($method)) {
             $result = $this->{$method}($value);
-            $this->_mutated[$property] = $result;
             return $result;
         }
         return $value;
@@ -367,7 +354,6 @@ trait EntityTrait
             unset($this->_dirty[$p]);
         }
 
-        $this->_mutated = [];
         return $this;
     }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -227,7 +227,8 @@ class EntityTest extends TestCase
     public function testGetCustomGetters()
     {
         $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
-        $entity->expects($this->once())->method('_getName')
+        $entity->expects($this->any())
+            ->method('_getName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
                 return 'Dr. ' . $name;
@@ -245,7 +246,8 @@ class EntityTest extends TestCase
     public function testGetCustomGettersAfterSet()
     {
         $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
-        $entity->expects($this->exactly(2))->method('_getName')
+        $entity->expects($this->any())
+            ->method('_getName')
             ->will($this->returnCallback(function ($name) {
                 return 'Dr. ' . $name;
             }));
@@ -275,28 +277,6 @@ class EntityTest extends TestCase
 
         $entity->unsetProperty('name');
         $this->assertEquals('Dr. ', $entity->get('name'));
-    }
-
-    /**
-     * Tests that the get cache is cleared by setting any property.
-     * This is because virtual properties can often rely on other
-     * properties in the entity.
-     *
-     * @return void
-     */
-    public function testGetCacheClearedBySet()
-    {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
-        $entity->last_name = 'Smith';
-        $entity->name = 'John';
-        $entity->expects($this->any())->method('_getName')
-            ->will($this->returnCallback(function ($name) use ($entity) {
-                return 'Dr. ' . $name . ' ' . $entity->last_name;
-            }));
-        $this->assertEquals('Dr. John Smith', $entity->get('name'));
-
-        $entity->last_name = 'Jones';
-        $this->assertEquals('Dr. John Jones', $entity->get('name'));
     }
 
     /**


### PR DESCRIPTION
While this feature was intended to help with performance and make implementing lazy loaded associations easier, it causes a number of annoying subtle bugs that we'd rather not have.

Refs #6574
