### PR TITLE
Add __debugInfo() to common class types 

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -666,4 +666,17 @@ class Shell
     {
         exit($status);
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'name' => $this->name,
+            'plugin' => $this->plugin,
+            'command' => $this->command,
+            'tasks' => $this->tasks,
+            'params' => $this->params,
+            'args' => $this->args,
+            'interactive' => $this->interactive,
+        ];
+    }
 }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -667,6 +667,12 @@ class Shell
         exit($status);
     }
 
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -181,6 +181,12 @@ class Component implements EventListenerInterface
         return $events;
     }
 
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -180,4 +180,13 @@ class Component implements EventListenerInterface
         }
         return $events;
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'components' => $this->components,
+            'implementedEvents' => $this->implementedEvents(),
+            '_config' => $this->config(),
+        ];
+    }
 }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -219,4 +219,17 @@ class Helper implements EventListenerInterface
         }
         return $events;
     }
+
+    public function __debugInfo()
+    {
+        return [
+            'helpers' => $this->helpers,
+            'theme' => $this->theme,
+            'plugin' => $this->plugin,
+            'fieldset' => $this->fieldset,
+            'tags' => $this->tags,
+            'implementedEvents' => $this->implementedEvents(),
+            '_config' => $this->config(),
+        ];
+    }
 }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -220,6 +220,12 @@ class Helper implements EventListenerInterface
         return $events;
     }
 
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
     public function __debugInfo()
     {
         return [

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -501,7 +501,7 @@ class ShellTest extends TestCase
         $this->assertTextEquals($contents, file_get_contents($file));
         $this->assertTrue($result, 'Did create file.');
     }
-    
+
     /**
      * Test that there is no user prompt in non-interactive mode while file already exists.
      *
@@ -511,14 +511,14 @@ class ShellTest extends TestCase
     {
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
-        
+
         new Folder($path, true);
-        
+
         touch($file);
         $this->assertTrue(file_exists($file));
-        
+
         $this->io->expects($this->never())->method('askChoice');
-        
+
         $this->Shell->interactive = false;
         $result = $this->Shell->createFile($file, 'My content');
         $this->assertTrue($result);
@@ -965,5 +965,25 @@ TEXT;
 
         $this->Shell = $this->getMock(__NAMESPACE__ . '\ShellTestShell', ['_useLogger'], [$io]);
         $this->Shell->runCommand(['foo', '--quiet']);
+    }
+
+    /**
+     * Tests __debugInfo
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $expected = [
+            'name' => 'ShellTestShell',
+            'plugin' => null,
+            'command' => null,
+            'tasks' => [],
+            'params' => [],
+            'args' => [],
+            'interactive' => true
+        ];
+        $result = $this->Shell->__debugInfo();
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -145,4 +145,27 @@ class ComponentTest extends TestCase
         $this->assertInstanceOf('TestApp\Controller\Component\SomethingWithCookieComponent', $Controller->SomethingWithCookie);
         $this->assertInstanceOf('Cake\Controller\Component\CookieComponent', $Controller->SomethingWithCookie->Cookie);
     }
+
+    /**
+     * Tests __debugInfo
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $Collection = new ComponentRegistry();
+        $Component = new AppleComponent($Collection);
+
+        $expected = [
+            'components' => [
+                'Orange'
+            ],
+            'implementedEvents' => [
+                'Controller.startup' => 'startup'
+            ],
+            '_config' => []
+        ];
+        $result = $Component->__debugInfo();
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -190,5 +190,4 @@ class HelperTest extends TestCase
         $result = $Helper->__debugInfo();
         $this->assertEquals($expected, $result);
     }
-
 }

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -161,4 +161,34 @@ class HelperTest extends TestCase
         $resultA->testprop = 1;
         $this->assertEquals($resultA->testprop, $resultB->testprop);
     }
+
+    /**
+     * Tests __debugInfo
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $Helper = new TestHelper($this->View);
+
+        $expected = [
+            'helpers' => [
+                'Html',
+                'TestPlugin.OtherHelper'
+            ],
+            'theme' => null,
+            'plugin' => null,
+            'fieldset' => [],
+            'tags' => [],
+            'implementedEvents' => [
+            ],
+            '_config' => [
+                'key1' => 'val1',
+                'key2' => ['key2.1' => 'val2.1', 'key2.2' => 'val2.2']
+            ]
+        ];
+        $result = $Helper->__debugInfo();
+        $this->assertEquals($expected, $result);
+    }
+
 }


### PR DESCRIPTION
Prevents timeout or memory-exhaust issues as those would contain huge amount of data (> xxx MB) when debug()ged.
