### PR TITLE
Fix incorrectly quoted table aliases in virtual fields.

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2869,10 +2869,17 @@ class DboSource extends DataSource {
 		if (!empty($this->endQuote)) {
 			$end = preg_quote($this->endQuote);
 		}
+		// Remove quotes and requote all the Model.field names.
 		$conditions = str_replace(array($start, $end), '', $conditions);
 		$conditions = preg_replace_callback(
 			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*)/i',
 			array(&$this, '_quoteMatchedField'),
+			$conditions
+		);
+		// Quote `table_name AS Alias`
+		$conditions = preg_replace(
+			'/(\s[a-z0-9\\-_.' . $start . $end . ']*' . $end . ')\s+AS\s+([a-z0-9\\-_]+)/i',
+			'\1 AS ' . $this->startQuote . '\2' . $this->endQuote,
 			$conditions
 		);
 		if ($conditions !== null) {

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7837,6 +7837,38 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * Test virtualfields that contain subqueries get correctly
+ * quoted allowing reserved words to be used.
+ *
+ * @return void
+ */
+	public function testVirtualFieldSubqueryReservedWords() {
+		$this->loadFixtures('User');
+		$user = ClassRegistry::init('User');
+		$user->cacheMethods = false;
+		$ds = $user->getDataSource();
+
+		$sub = $ds->buildStatement(
+			array(
+				'fields' => array('Table.user'),
+				'table' => $ds->fullTableName($user),
+				'alias' => 'Table',
+				'limit' => 1,
+				'conditions' => array(
+					"Table.id > 1"
+				)
+			),
+			$user
+		);
+		$user->virtualFields = array(
+			'sub_test' => $sub
+		);
+
+		$result = $user->field('sub_test', array('id' => 1));
+		$this->assertNotEmpty($result);
+	}
+
+/**
  * testVirtualFieldsOrder()
  *
  * Test correct order on virtual fields

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7864,7 +7864,7 @@ class ModelReadTest extends BaseModelTest {
 			'sub_test' => $sub
 		);
 
-		$result = $user->field('sub_test', array('id' => 1));
+		$result = $user->find('first');
 		$this->assertNotEmpty($result);
 	}
 


### PR DESCRIPTION
DboSource::_quoteFields() is already a bit of a mess, and while I'm not happy about having to add more regex replacement, it seems to be the only reasonable solution given that the code is already 'parsing' SQLto apply identifier quoting.

Fixes #6602
