### PR TITLE
Pass the base and webroot properties into sub-requests.

### DIFF
--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -127,6 +127,11 @@ trait RequestActionTrait
                 $params['params']['pass'] = [];
             }
         }
+        $current = Router::getRequest();
+        if ($current) {
+            $params['base'] = $current->base;
+            $params['webroot'] = $current->webroot;
+        }
 
         $params['post'] = $params['query'] = [];
         if (isset($extra['post'])) {

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\Routing;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Network\Request;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
@@ -220,6 +221,24 @@ class RequestActionTraitTest extends TestCase
         $this->assertEquals('RequestAction', $result['params']['controller']);
         $this->assertEquals('params_pass', $result['params']['action']);
         $this->assertNull($result['params']['plugin']);
+    }
+
+    /**
+     * Test that requestAction() is populates the base and webroot properties properly
+     *
+     * @return void
+     */
+    public function testRequestActionBaseAndWebroot()
+    {
+        $request = new Request([
+            'base' => '/subdir',
+            'webroot' => '/subdir/'
+        ]);
+        Router::setRequestInfo($request);
+        $result = $this->object->requestAction('/request_action/params_pass');
+        $result = json_decode($result, true);
+        $this->assertEquals($request->base, $result['base']);
+        $this->assertEquals($request->webroot, $result['webroot']);
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -116,6 +116,8 @@ class RequestActionController extends AppController
     public function params_pass()
     {
         $this->response->body(json_encode([
+            'base' => $this->request->base,
+            'webroot' => $this->request->webroot,
             'params' => $this->request->params,
             'query' => $this->request->query,
             'url' => $this->request->url,


### PR DESCRIPTION
Clone the root request's base and webroot properties into sub-requests. This is necessary to allow images URLs to be generated correctly in views rendered inside a requestAction() call.

Refs #6598
