### PR TITLE
back_url

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -775,6 +775,7 @@ class Controller extends Object implements CakeEventListener {
 		extract($this->_parseBeforeRedirect($response, $url, $status, $exit), EXTR_OVERWRITE);
 
 		if ($url !== null) {
+			$url = ($this->request->query['back_url'] === null) ? $url : $this->request->query['back_url'];
 			$this->response->header('Location', Router::url($url, true));
 		}
 

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -334,6 +334,15 @@ class HtmlHelper extends AppHelper {
 	public function link($title, $url = null, $options = array(), $confirmMessage = false) {
 		$escapeTitle = true;
 		if ($url !== null) {
+			
+			if (!empty($options['back_url']) && $url !== '#') :
+	            $options['back_url'] = ($options['back_url'] === true) ? $this->_View->here : $options['back_url'];
+	            $url['?'] = [
+	                'back_url' => $this->url($options['back_url'])
+	            ];
+	            unset($options['back_url']);
+	        endif;
+	        
 			$url = $this->url($url);
 		} else {
 			$url = $this->url($title);
@@ -359,6 +368,8 @@ class HtmlHelper extends AppHelper {
 			$confirmMessage = $options['confirm'];
 			unset($options['confirm']);
 		}
+		
+        
 		if ($confirmMessage) {
 			$options['onclick'] = $this->_confirm($confirmMessage, 'return true;', 'return false;', $options);
 		} elseif (isset($options['default']) && !$options['default']) {


### PR DESCRIPTION
Hola comparto mi snippet de back_url para usar el mismo controlador desde varias vista permitiendo que se al finalizar se redireccione a donde fue enviado y no a la ubicación indicada en el controlador

El controlador usará "array('action' => 'view', $this->MiModelo->id)" como redirección por defecto. En caso de tener algún back_link se usará este último
$this->redirect(array('action' => 'view', $this->MiModelo->id)); // link por defecto

Se usa: 

```
<?php echo $this->Html->link(__('Edit'), array('action' => 'edit', $post['Post']['id']), ['back_url' => true]); ?>
<?php echo $this->Html->link(__('Edit'), array('action' => 'edit', $post['Post']['id']), ['back_url' => ['controller' => 'empresas']]); ?>
```
