### PR TITLE
Added __call() on QueryExpression to allow for and() and or() to be called

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -469,6 +469,22 @@ class QueryExpression implements ExpressionInterface, Countable
     }
 
     /**
+     * Helps calling the `and()` and `or()` methods transparently.
+     *
+     * @param string $method The method name.
+     * @param array $args The argumemts to pass to the method.
+     * @return \Cake\Database\Expression\QueryExpression
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $args)
+    {
+        if (in_array($method, ['and', 'or'])) {
+            return call_user_func_array([$this, $method . '_'], $args);
+        }
+        throw new \BadMethodCallException;
+    }
+
+    /**
      * Auxiliary function used for decomposing a nested array of conditions and build
      * a tree structure inside this object to represent the full SQL expression.
      * String conditions are stored directly in the conditions, while any other

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -481,7 +481,7 @@ class QueryExpression implements ExpressionInterface, Countable
         if (in_array($method, ['and', 'or'])) {
             return call_user_func_array([$this, $method . '_'], $args);
         }
-        throw new \BadMethodCallException;
+        throw new \BadMethodCallException(sprintf('Method %s does not exist', $method));
     }
 
     /**

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\CaseExpression;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests CaseExpression class
+ */
+class QueryExpressionTest extends TestCase
+{
+
+    /**
+     * Test and() and or() calls work transparently
+     *
+     * @return void
+     */
+    public function testAndOrCalls()
+    {
+        $expr = new QueryExpression();
+        $expected = '\Cake\Database\Expression\QueryExpression';
+        $this->assertInstanceOf($expected, $expr->and([]));
+        $this->assertInstanceOf($expected, $expr->or([]));
+    }
+}


### PR DESCRIPTION
Copy/pasted straight from the referenced PR in #6477 
