### PR TITLE
Fix getOriginal() not preserving nulls.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -237,8 +237,8 @@ trait EntityTrait
 
             $this->dirty($p, true);
 
-            if (!isset($this->_original[$p]) &&
-                isset($this->_properties[$p]) &&
+            if (!array_key_exists($p, $this->_original) &&
+                array_key_exists($p, $this->_properties) &&
                 $this->_properties[$p] !== $value
             ) {
                 $this->_original[$p] = $this->_properties[$p];
@@ -298,7 +298,7 @@ trait EntityTrait
         if (!strlen((string)$property)) {
             throw new InvalidArgumentException('Cannot get an empty property');
         }
-        if (isset($this->_original[$property])) {
+        if (array_key_exists($property, $this->_original)) {
             return $this->_original[$property];
         }
         return $this->get($property);
@@ -539,10 +539,7 @@ trait EntityTrait
     {
         $result = [];
         foreach ($properties as $property) {
-            $original = $this->getOriginal($property);
-            if ($original !== null) {
-                $result[$property] = $original;
-            }
+            $result[$property] = $this->getOriginal($property);
         }
         return $result;
     }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -72,6 +72,29 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Test that getOriginal() retains falsey values.
+     *
+     * @return void
+     */
+    public function testGetOriginal()
+    {
+        $entity = new Entity(
+            ['false' => false, 'null' => null, 'zero' => 0, 'empty' => ''],
+            ['markNew' => true]
+        );
+        $this->assertNull($entity->getOriginal('null'));
+        $this->assertFalse($entity->getOriginal('false'));
+        $this->assertSame(0, $entity->getOriginal('zero'));
+        $this->assertSame('', $entity->getOriginal('empty'));
+
+        $entity->set(['false' => 'y', 'null' => 'y', 'zero' => 'y', 'empty' => '']);
+        $this->assertNull($entity->getOriginal('null'));
+        $this->assertFalse($entity->getOriginal('false'));
+        $this->assertSame(0, $entity->getOriginal('zero'));
+        $this->assertSame('', $entity->getOriginal('empty'));
+    }
+
+    /**
      * Test extractOriginal()
      *
      * @return void
@@ -81,18 +104,20 @@ class EntityTest extends TestCase
         $entity = new Entity([
             'id' => 1,
             'title' => 'original',
-            'body' => 'no'
+            'body' => 'no',
+            'null' => null,
         ], ['markNew' => true]);
         $entity->set('body', 'updated body');
-        $result = $entity->extractOriginal(['id', 'title', 'body']);
+        $result = $entity->extractOriginal(['id', 'title', 'body', 'null']);
         $expected = [
             'id' => 1,
             'title' => 'original',
-            'body' => 'no'
+            'body' => 'no',
+            'null' => null,
         ];
         $this->assertEquals($expected, $result);
 
-        $result = $entity->extractOriginalChanged(['id', 'title', 'body']);
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null']);
         $expected = [
             'body' => 'no',
         ];


### PR DESCRIPTION
getOriginal() and extractOriginal() should preserve null values if that was the 'original' value.

Refs #6613
