### PR TITLE
FormHelper::radio() return broken id attribute when multibyte value options

### DIFF
--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -399,12 +399,14 @@ class InflectorTest extends CakeTestCase {
 		$this->assertSame(Inflector::underscore('testThing'), 'test_thing');
 		$this->assertSame(Inflector::underscore('TestThingExtra'), 'test_thing_extra');
 		$this->assertSame(Inflector::underscore('testThingExtra'), 'test_thing_extra');
+		$this->assertSame(Inflector::underscore('testThingExtrå'), 'test_thing_extrå');
 
 		// Identical checks test the cache code path.
 		$this->assertSame(Inflector::underscore('TestThing'), 'test_thing');
 		$this->assertSame(Inflector::underscore('testThing'), 'test_thing');
 		$this->assertSame(Inflector::underscore('TestThingExtra'), 'test_thing_extra');
 		$this->assertSame(Inflector::underscore('testThingExtra'), 'test_thing_extra');
+		$this->assertSame(Inflector::underscore('testThingExtrå'), 'test_thing_extrå');
 
 		// Test stupid values
 		$this->assertSame(Inflector::underscore(''), '');
@@ -457,6 +459,8 @@ class InflectorTest extends CakeTestCase {
 		$this->assertEquals(Inflector::humanize('posts'), 'Posts');
 		$this->assertEquals(Inflector::humanize('posts_tags'), 'Posts Tags');
 		$this->assertEquals(Inflector::humanize('file_systems'), 'File Systems');
+		$this->assertEquals(Inflector::humanize('hello_wörld'), 'Hello Wörld');
+		$this->assertEquals(Inflector::humanize('福岡_city'), '福岡 City');
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -3902,6 +3902,25 @@ class FormHelperTest extends CakeTestCase {
 			'/fieldset'
 		);
 		$this->assertTags($result, $expected);
+
+		$result = $this->Form->radio(
+			'Model.multibyte',
+			array('男性' => '男性')
+		);
+		$expected = array(
+			'input' => array(
+				'type' => 'hidden', 'name' => 'data[Model][multibyte]',
+				'id' => 'ModelMultibyte_', 'value' => '',
+			),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][multibyte]',
+				'id' => 'ModelMultibyte男性', 'value' => '男性')
+			),
+			array('label' => array('for' => 'ModelMultibyte男性')),
+			'男性',
+			'/label',
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -479,7 +479,12 @@ class Inflector {
  */
 	public static function underscore($camelCasedWord) {
 		if (!($result = self::_cache(__FUNCTION__, $camelCasedWord))) {
-			$result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $camelCasedWord));
+			$underscoredWord = preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $camelCasedWord);
+			if (function_exists('mb_convert_case')) {
+				$result = mb_convert_case($underscoredWord, MB_CASE_LOWER, Configure::read('App.encoding'));
+			} else {
+				$result = strtolower($underscoredWord);
+			}
 			self::_cache(__FUNCTION__, $camelCasedWord, $result);
 		}
 		return $result;
@@ -495,8 +500,9 @@ class Inflector {
  */
 	public static function humanize($lowerCaseAndUnderscoredWord) {
 		if (!($result = self::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord))) {
+			$lowerCaseAndUnderscoredWord = self::underscore($lowerCaseAndUnderscoredWord);
 			$result = str_replace('_', ' ', $lowerCaseAndUnderscoredWord);
-			if (function_exists('mb_convert_case') && Multibyte::checkMultibyte($result)) {
+			if (function_exists('mb_convert_case')) {
 				$result = mb_convert_case($result, MB_CASE_TITLE, Configure::read('App.encoding'));
 			} else {
 				$result = ucwords($result);

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -495,7 +495,12 @@ class Inflector {
  */
 	public static function humanize($lowerCaseAndUnderscoredWord) {
 		if (!($result = self::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord))) {
-			$result = ucwords(str_replace('_', ' ', $lowerCaseAndUnderscoredWord));
+			$result = str_replace('_', ' ', $lowerCaseAndUnderscoredWord);
+			if (function_exists('mb_convert_case') && Multibyte::checkMultibyte($result)) {
+				$result = mb_convert_case($result, MB_CASE_TITLE, Configure::read('App.encoding'));
+			} else {
+				$result = ucwords($result);
+			}
 			self::_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord, $result);
 		}
 		return $result;


### PR DESCRIPTION
In CakePHP 2.6.4

```
echo $this->Form->radio('Model.multibyte', ['男性' => '男性']);
```

I expects return like,

```
<input type="hidden" name="data[Model][multibyte]" id="ModelMultibyte_" value=""/>
<input type="radio" name="data[Model][multibyte]" id="ModelMultibyte男性" value="男性" />
<label for="ModelMultibyte男性">男性</label>
```

But, actual result is,

```
<input type="hidden" name="data[Model][multibyte]" id="ModelMultibyte_" value=""/>
<input type="radio" name="data[Model][multibyte]" id="ModelMultibyteǔ�性" value="男性" />
<label for="ModelMultibyteǔ�性">男性</label>
```

I traced the `FormHelper::radio()` method, and I found the method call `Inflector::humanize()` with multibyte string.
in Inflector::humanize() using `ucwords`, but `ucwords` not support multibyte string.

To solve this problem, `Inflector::humanize()` will use `mb_convert_case()` if the function exists.
