### PR TITLE
Port the Inflector fixes from #6635 to 3.0

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -641,7 +641,11 @@ class Inflector
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = ucwords(str_replace($delimiter, ' ', $string));
+            $result = explode(' ', str_replace($delimiter, ' ', $string));
+            foreach ($result as &$word) {
+                $word = mb_strtoupper(mb_substr($word, 0, 1)) . mb_substr($word, 1);
+            }
+            $result = implode(' ', $result);
             static::_cache($cacheKey, $string, $result);
         }
 
@@ -662,7 +666,7 @@ class Inflector
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', $delimiter . '\\1', $string));
+            $result = mb_strtolower(preg_replace('/(?<=\\w)([A-Z])/', $delimiter . '\\1', $string));
             static::_cache($cacheKey, $string, $result);
         }
 

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -408,12 +408,14 @@ class InflectorTest extends TestCase
         $this->assertSame('test_thing_extra', Inflector::underscore('TestThingExtra'));
         $this->assertSame('test_thing_extra', Inflector::underscore('testThingExtra'));
         $this->assertSame('test_this_thing', Inflector::underscore('test-this-thing'));
+        $this->assertSame(Inflector::underscore('testThingExtrå'), 'test_thing_extrå');
 
         // Identical checks test the cache code path.
         $this->assertSame('test_thing', Inflector::underscore('TestThing'));
         $this->assertSame('test_thing', Inflector::underscore('testThing'));
         $this->assertSame('test_thing_extra', Inflector::underscore('TestThingExtra'));
         $this->assertSame('test_thing_extra', Inflector::underscore('testThingExtra'));
+        $this->assertSame(Inflector::underscore('testThingExtrå'), 'test_thing_extrå');
 
         // Test stupid values
         $this->assertSame('', Inflector::underscore(''));
@@ -514,6 +516,8 @@ class InflectorTest extends TestCase
         $this->assertEquals('File Systems', Inflector::humanize('file_systems'));
         $this->assertSame('', Inflector::humanize(null));
         $this->assertSame('', Inflector::humanize(false));
+        $this->assertSame(Inflector::humanize('hello_wörld'), 'Hello Wörld');
+        $this->assertSame(Inflector::humanize('福岡_city'), '福岡 City');
     }
 
     /**


### PR DESCRIPTION
Bring the fixes for humanize()/underscore() into 3.0.
