### PR TITLE
RFC: Remove line breaks from urls

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -749,6 +749,7 @@ class Validation
     public static function url($check, $strict = false)
     {
         static::_populateIp();
+        $check = str_replace(PHP_EOL, '', $check);
         $validChars = '([' . preg_quote('!"$&\'()*+,-.@_:;=~[]') . '\/0-9\p{L}\p{N}]|(%[0-9a-f]{2}))';
         $regex = '/^(?:(?:https?|ftps?|sftp|file|news|gopher):\/\/)' . (!empty($strict) ? '' : '?') .
             '(?:' . static::$_pattern['IPv4'] . '|\[' . static::$_pattern['IPv6'] . '\]|' . static::$_pattern['hostname'] . ')(?::[1-9][0-9]{0,4})?' .


### PR DESCRIPTION
**Why?**
At my work we have some affiliate links which are huge, and by huge I mean longer than 255 characters. As such we tend to store them in a `TEXT` field. If a user puts a line break after the url the field will fail validation, even though it "looks correct" to the user.

**Why change the core?**
I think for such a small change this will go a fair way to helping make the validation more robust against unintended characters. Also I think that no url will ever contain a line break, so it's safe to strip them from the string before it's validated.
