### PR TITLE
Desugar the shell helper interface.

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -389,20 +389,4 @@ class ConsoleIo
         $name = ucfirst($name);
         return $this->_helpers->load($name, $settings);
     }
-
-    /**
-     * Convenience wrapper around helper()
-     *
-     * @param string $method The helper to invoke.
-     * @param array $args The arguments for the helper.
-     * @return mixed
-     */
-    public function __call($method, $args)
-    {
-        $helper = $this->helper($method);
-        if (count($args) === 1 && isset($args[0]) && is_array($args[0])) {
-            $args = $args[0];
-        }
-        return $helper->output($args);
-    }
 }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -721,6 +721,21 @@ class Shell
     }
 
     /**
+     * Render a Console Helper
+     *
+     * Create and render the output for a helper object. If the helper
+     * object has not already been loaded, it will be loaded and constructed.
+     *
+     * @param string $name The name of the helper to render
+     * @param array $settings Configuration data for the helper.
+     * @return \Cake\Console\Helper The created helper instance.
+     */
+    public function helper($name, array $settings = [])
+    {
+        return $this->_io->helper($name, $settings);
+    }
+
+    /**
      * Stop execution of the current script. Wraps exit() making
      * testing easier.
      *

--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -40,7 +40,7 @@ class RoutesShell extends Shell
         foreach (Router::routes() as $route) {
             $output[] = [$route->getName(), $route->template, json_encode($route->defaults)];
         }
-        $this->_io->table($output);
+        $this->helper('table')->output($output);
     }
 
     /**
@@ -57,7 +57,7 @@ class RoutesShell extends Shell
                 ['Route name', 'URI template', 'Defaults'],
                 ['', $url, json_encode($route)]
             ];
-            $this->_io->table($output);
+            $this->helper('table')->output($output);
         } catch (MissingRouteException $e) {
             $this->err("<warning>'$url' did not match any routes.</warning>");
             return false;

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -349,7 +349,7 @@ class ExtractTask extends Shell
      */
     protected function _extractTokens()
     {
-        $progress = $this->_io->helper('progress');
+        $progress = $this->helper('progress');
         $progress->init(['total' => count($this->_files)]);
         $isVerbose = $this->param('verbose');
 

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -372,22 +372,4 @@ class ConsoleIoTest extends TestCase
         $this->assertInstanceOf('Cake\Console\Helper', $helper);
         $helper->output(['well', 'ish']);
     }
-
-    /**
-     * Test the helper __call.
-     *
-     * @return void
-     */
-    public function testHelperCall()
-    {
-        $this->out->expects($this->at(0))
-            ->method('write')
-            ->with('It works!well ish');
-        $this->out->expects($this->at(1))
-            ->method('write')
-            ->with('It works!well ish');
-
-        $this->io->simple('well', 'ish');
-        $this->io->simple(['well', 'ish']);
-    }
 }

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -35,7 +35,12 @@ class RoutesShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', ['table', 'out', 'err']);
+        $this->io = $this->getMock('Cake\Console\ConsoleIo', ['helper', 'out', 'err']);
+        $this->table = $this->getMock('Cake\Shell\Helper\TableHelper', [], [$this->io]);
+        $this->io->expects($this->any())
+            ->method('helper')
+            ->with('table')
+            ->will($this->returnValue($this->table));
 
         $this->shell = new RoutesShell($this->io);
         Router::connect('/articles/:action/*', ['controller' => 'Articles']);
@@ -61,8 +66,8 @@ class RoutesShellTest extends TestCase
      */
     public function testMain()
     {
-        $this->io->expects($this->at(0))
-            ->method('table')
+        $this->table->expects($this->once())
+            ->method('output')
             ->with(
                 $this->logicalAnd(
                     $this->contains(['Route name', 'URI template', 'Defaults']),
@@ -83,8 +88,8 @@ class RoutesShellTest extends TestCase
      */
     public function testCheck()
     {
-        $this->io->expects($this->at(0))
-            ->method('table')
+        $this->table->expects($this->once())
+            ->method('output')
             ->with(
                 $this->logicalAnd(
                     $this->contains(['Route name', 'URI template', 'Defaults']),


### PR DESCRIPTION
Remove the `__call` support from ConsoleIo. When talking with @AD7six about shell helpers he pointed out that `$this->_io->table($args)` was a bit funny looking and provided a bit too much magic. Given that this method format is limited in what it can do we came to the conclusion that it would be better for now o have fewer ways to interact with the helpers.
