### PR TITLE
Fix up view block docs.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -551,6 +551,23 @@ class View
     /**
      * Start capturing output for a 'block'
      *
+     * You can use start on a block multiple times to
+     * append or prepend content in a capture mode.
+     *
+     * ```
+     * // Append content to an existing block.
+     * $this->start('content');
+     * echo $this->fetch('content');
+     * echo 'Some new content';
+     * $this->end();
+     *
+     * // Prepend content to an existing block
+     * $this->start('content');
+     * echo 'Some new content';
+     * echo $this->fetch('content');
+     * $this->end();
+     * ```
+     *
      * @param string $name The name of the block to capture for.
      * @return void
      * @see ViewBlock::start()

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -55,15 +55,6 @@ class ViewBlock
     protected $_active = [];
 
     /**
-     * Should the currently captured content be discarded on ViewBlock::end()
-     *
-     * @var bool
-     * @see ViewBlock::end()
-     * @see ViewBlock::startIfEmpty()
-     */
-    protected $_discardActiveBufferOnEnd = false;
-
-    /**
      * Start capturing output for a 'block'
      *
      * Blocks allow you to create slots or blocks of dynamic content in the layout.


### PR DESCRIPTION
Since we removed startIfEmpty() we shouldn't mention it in the docs. Also add an example of capturing mode usage.
