### PR TITLE
Add an interface for EventDispatcher.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -17,6 +17,7 @@ namespace Cake\Controller;
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\Event;
+use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManagerTrait;
 use Cake\Log\LogTrait;
@@ -80,7 +81,7 @@ use RuntimeException;
  * @property      \Cake\Controller\Component\SecurityComponent $Security
  * @link          http://book.cakephp.org/3.0/en/controllers.html
  */
-class Controller implements EventListenerInterface
+class Controller implements EventListenerInterface, EventDispatcherInterface
 {
 
     use EventManagerTrait;

--- a/src/Datasource/RulesAwareTrait.php
+++ b/src/Datasource/RulesAwareTrait.php
@@ -17,6 +17,7 @@ namespace Cake\Datasource;
 use ArrayObject;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\RulesChecker;
+use Cake\Event\EventDispatcherInterface;
 
 /**
  * A trait that allows a class to build and apply application.
@@ -51,7 +52,7 @@ trait RulesAwareTrait
         $rules = $this->rulesChecker();
         $options = $options ?: new ArrayObject;
         $options = is_array($options) ? new ArrayObject($options) : $options;
-        $hasEvents = method_exists($this, 'dispatchEvent');
+        $hasEvents = ($this instanceof EventDispatcherInterface);
 
         if ($hasEvents) {
             $event = $this->dispatchEvent(

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.7
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Event;
+
+use Cake\Event\EventManager;
+
+/**
+ * Objects implementing this interface can emit events.
+ *
+ * Objects with this interface can trigger events, and have
+ * an event manager retrieved from them.
+ *
+ * The Cake\Event\EventManagerTrait lets you easily implement
+ * this interface.
+ */
+interface EventDispatcherInterface
+{
+    /**
+     * Wrapper for creating and dispatching events.
+     *
+     * Returns a dispatched event.
+     *
+     * @param string $name Name of the event.
+     * @param array|null $data Any value you wish to be transported with this event to
+     * it can be read by listeners.
+     * @param object|null $subject The object that this event applies to
+     * ($this by default).
+     *
+     * @return \Cake\Event\Event
+     */
+    public function dispatchEvent($name, $data = null, $subject = null);
+
+    /**
+     * Returns the Cake\Event\EventManager manager instance for this object.
+     *
+     * You can use this instance to register any new listeners or callbacks to the
+     * object events, or create your own events and trigger them at will.
+     *
+     * @param \Cake\Event\EventManager|null $eventManager the eventManager to set
+     * @return \Cake\Event\EventManager
+     */
+    public function eventManager(EventManager $eventManager = null);
+}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -24,6 +24,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Datasource\RulesAwareTrait;
+use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
@@ -118,7 +119,7 @@ use RuntimeException;
  *
  * @see \Cake\Event\EventManager for reference on the events system.
  */
-class Table implements RepositoryInterface, EventListenerInterface
+class Table implements RepositoryInterface, EventListenerInterface, EventDispatcherInterface
 {
 
     use EventManagerTrait;

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Validation;
 
+use Cake\Event\EventDispatcherInterface;
 use Cake\Validation\Validator;
 
 /**
@@ -96,7 +97,7 @@ trait ValidatorAwareTrait
         if ($validator === null) {
             $validator = new Validator();
             $validator = $this->{'validation' . ucfirst($name)}($validator);
-            if (method_exists($this, 'dispatchEvent')) {
+            if ($this instanceof EventDispatcherInterface) {
                 $this->dispatchEvent('Model.buildValidator', compact('validator', 'name'));
             }
         }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -17,6 +17,7 @@ namespace Cake\View;
 use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Plugin;
+use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
 use Cake\Log\LogTrait;
@@ -56,7 +57,7 @@ use RuntimeException;
  * @property      \Cake\View\Helper\TimeHelper $Time
  * @property      \Cake\View\ViewBlock $Blocks
  */
-class View
+class View implements EventDispatcherInterface
 {
 
     use CellTrait;


### PR DESCRIPTION
Having an interface will let us not duck type on the method and instead use `instanceof`. It also lets us make typehints elsewhere in CakePHP if we need to.

Refs #6689
