### PR TITLE
Extract formatTreeList() from generateTreeList().

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -459,12 +459,15 @@ class TreeBehavior extends ModelBehavior {
  * Note that when using your own find() call this expects the order to be "left" field asc in order
  * to generate the same result as using generateTreeList() directly.
  *
+ * Options:
+ *
+ * - 'keyPath': A string path to the key, i.e. "{n}.Post.id"
+ * - 'valuePath': A string path to the value, i.e. "{n}.Post.title"
+ * - 'spacer': The character or characters which will be repeated
+ *
  * @param Model $Model Model using this behavior
  * @param array $results Result array of a find() call
  * @param array $options Options
- * @param null $keyPath A string path to the key, i.e. "{n}.Post.id"
- * @param null $valuePath A string path to the value, i.e. "{n}.Post.title"
- * @param string $spacer The character or characters which will be repeated
  * @return array An associative array of records, where the id is the key, and the display field is the value
  */
 	public function formatTreeList(Model $Model, array $results, array $options = array()) {

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -1434,6 +1434,29 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	}
 
 /**
+ * Test the formatting options of formatTreeList()
+ *
+ * @return void
+ */
+	public function testFormatTreeList() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->initialize(2, 2);
+
+		$options = array('order' => array('lft' => 'asc'));
+		$records = $this->Tree->find('all', $options);
+
+		$result = $this->Tree->formatTreeList(
+			$records,
+			"{n}.$modelClass.id",
+			array('%s - %s', "{n}.$modelClass.id", "{n}.$modelClass.name")
+		);
+		$this->assertEquals('1 - 1. Root', $result[1]);
+		$this->assertEquals('_2 - 1.1', $result[2]);
+		$this->assertEquals('__3 - 1.1.1', $result[3]);
+	}
+
+/**
  * testArraySyntax method
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -1446,14 +1446,14 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$options = array('order' => array('lft' => 'asc'));
 		$records = $this->Tree->find('all', $options);
 
-		$result = $this->Tree->formatTreeList(
-			$records,
-			"{n}.$modelClass.id",
-			array('%s - %s', "{n}.$modelClass.id", "{n}.$modelClass.name")
-		);
+		$options = array(
+			'keyPath' => "{n}.$modelClass.id",
+			'valuePath' => array('%s - %s', "{n}.$modelClass.id", "{n}.$modelClass.name"),
+			'spacer' => '--');
+		$result = $this->Tree->formatTreeList($records, $options);
 		$this->assertEquals('1 - 1. Root', $result[1]);
-		$this->assertEquals('_2 - 1.1', $result[2]);
-		$this->assertEquals('__3 - 1.1.1', $result[3]);
+		$this->assertEquals('--2 - 1.1', $result[2]);
+		$this->assertEquals('----3 - 1.1.1', $result[3]);
 	}
 
 /**


### PR DESCRIPTION
This issue came up in the IRC a few times.
generateTreeList() does both find + format. Which is too much IMO.

When using custom find() calls (with maybe custom limit or other adjustments) to make a subset of what generateTreeList() does and wanting to format it the same way, it would currently create quite some overhead.
This extraction makes it possible to be DRY and keeps BC.

``` php
$options = array(
    'order' => array('lft' => 'asc'), 
    ...
);
$records = $this->Tree->find('all', $options);

$result = $this->Tree->formatTreeList($records);
```

in 3.x result formatting is easier. I wonder if anything would need to be ported to it so we can make it there a little bit DRYer too.
