### PR TITLE
Remove edge case that creates issues with redirecting to itself.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -501,13 +501,13 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Redirects to given $url, after turning off $this->autoRender.
      * Script execution is halted after the redirect.
      *
-     * @param string|array $url A string or array-based URL pointing to another location within the app,
+     * @param string|array|null $url A string or array-based URL pointing to another location within the app,
      *     or an absolute URL
      * @param int $status HTTP status code (eg: 301)
      * @return void|\Cake\Network\Response
      * @link http://book.cakephp.org/3.0/en/controllers.html#Controller::redirect
      */
-    public function redirect($url, $status = 302)
+    public function redirect($url = null, $status = 302)
     {
         $this->autoRender = false;
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -507,7 +507,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @return void|\Cake\Network\Response
      * @link http://book.cakephp.org/3.0/en/controllers.html#Controller::redirect
      */
-    public function redirect($url = null, $status = 302)
+    public function redirect($url, $status = 302)
     {
         $this->autoRender = false;
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -524,7 +524,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             return;
         }
 
-        if ($url !== null && !$response->location()) {
+        if (!$response->location()) {
             $response->location(Router::url($url, true));
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -483,7 +483,7 @@ class ControllerTest extends TestCase
         $Controller = new Controller(null);
         $Controller->response = new Response();
 
-        $response = $Controller->redirect();
+        $response = $Controller->redirect(null);
         $this->assertEquals(302, $response->statusCode());
         $this->assertEquals('http://localhost/', $response->header()['Location']);
         $this->assertFalse($Controller->autoRender);

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -464,8 +464,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectByCode($code, $msg)
     {
-        $Controller = new Controller(null);
-        $Controller->response = new Response();
+        $Controller = new Controller(null, new Response());
 
         $response = $Controller->redirect('http://cakephp.org', (int)$code, false);
         $this->assertEquals($code, $response->statusCode());
@@ -480,8 +479,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectSameUrl()
     {
-        $Controller = new Controller(null);
-        $Controller->response = new Response();
+        $Controller = new Controller(null, new Response());
 
         $response = $Controller->redirect(null);
         $this->assertEquals(302, $response->statusCode());
@@ -496,8 +494,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectBeforeRedirectModifyingUrl()
     {
-        $Controller = new Controller(null);
-        $Controller->response = new Response();
+        $Controller = new Controller(null, new Response());
 
         $Controller->eventManager()->attach(function ($event, $url, $response) {
             $response->location('http://book.cakephp.org');

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -474,6 +474,22 @@ class ControllerTest extends TestCase
     }
 
     /**
+     * testRedirect method
+     *
+     * @return void
+     */
+    public function testRedirectSameUrl()
+    {
+        $Controller = new Controller(null);
+        $Controller->response = new Response();
+
+        $response = $Controller->redirect();
+        $this->assertEquals(302, $response->statusCode());
+        $this->assertEquals('http://localhost/', $response->header()['Location']);
+        $this->assertFalse($Controller->autoRender);
+    }
+
+    /**
      * test that beforeRedirect callbacks can set the URL that is being redirected to.
      *
      * @return void


### PR DESCRIPTION
After https://github.com/cakephp/cakephp/issues/6705 I played around with returning all parent calls.
This opened an issue with testing controllers and redirect(null).
Tests that worked before suddenly break when using `return parent::...()`.

We should remove that edge case as it is perfectly fine to redirect to itself (null => same URL), and currently the location header is not properly set in this case.
