### PR TITLE
Add CookieAuthenticate class for "remember me" use

### DIFF
--- a/src/Auth/CookieAuthenticate.php
+++ b/src/Auth/CookieAuthenticate.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Auth;
+
+use Cake\Auth\BaseAuthenticate;
+use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Component\CookieComponent;
+use Cake\Controller\Exception\MissingComponentException;
+use Cake\Event\Event;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\Routing\Router;
+
+/**
+ * Cookie-based adapter for AuthComponent.
+ *
+ * Provides the ability to authenticate using COOKIE
+ *
+ * ```
+ *    $this->Auth->config('authenticate', [
+ *        'Authenticate.Cookie' => [
+ *            'fields' => [
+ *                'identifier' => 'username',
+ *                'token' => 'password'
+ *                'tokenCreated' => null
+ *             ],
+ *            'userModel' => 'Users',
+ *            'scope' => ['Users.active' => 1],
+ *            'crypt' => 'aes',
+ *            'cookie' => [
+ *                'name' => 'RememberMe',
+ *                'time' => '+2 weeks',
+ *            ]
+ *        ]
+ *    ]);
+ * ```
+ */
+class CookieAuthenticate extends BaseAuthenticate
+{
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Controller\ComponentRegistry $registry The Component registry
+     *   used on this request.
+     * @param array $config Array of config to use.
+     */
+    public function __construct(ComponentRegistry $registry, $config)
+    {
+        $this->_registry = $registry;
+
+        $this->config([
+            'cookie' => [
+                'name' => 'RememberMe',
+                'expires' => '+2 weeks',
+            ],
+            'crypt' => 'aes',
+            'fields' => ['tokenCreated' => null]
+        ]);
+
+        $aliases = [
+            'identifier' => 'username',
+            'token' => 'password'
+        ];
+
+        foreach ($aliases as $alias => $field) {
+            if (isset($config['fields'][$alias])) {
+                $config['fields'][$field] = $config['fields'][$alias];
+                unset($config['fields'][$alias]);
+            }
+        }
+        $this->config($config);
+    }
+
+    /**
+     * Authenticates the identity contained in the cookie.  Will use the
+     * `userModel` config, and `fields` config to find COOKIE data that is used
+     * to find a matching record in the model specified by `userModel`. Will return
+     * false if there is no cookie data, either identifier or token is missing,
+     * or if the scope conditions have not been met.
+     *
+     * @param Request $request The unused request object.
+     * @return mixed False on login failure. An array of User data on success.
+     * @throws \RuntimeException If CookieComponent is not loaded.
+     */
+    public function getUser(Request $request)
+    {
+        if (!isset($this->_registry->Cookie) ||
+        !$this->_registry->Cookie instanceof CookieComponent
+        ) {
+            throw new MissingComponentException(['class' => 'CookieComponent']);
+        }
+
+        $cookieConfig = $this->_config['cookie'];
+        $cookieName = $this->_config['cookie']['name'];
+        unset($cookieConfig['name']);
+        $this->_registry->Cookie->configKey($cookieName, $cookieConfig);
+
+        $data = $this->_registry->Cookie->read($cookieName);
+        if (empty($data)) {
+            return false;
+        }
+
+        extract($this->_config['fields']);
+
+        if (empty($data[$username]) || empty($data[$password])) {
+            return false;
+        }
+
+        $user = $this->_findUser($data[$username], $data[$password]);
+
+        if ($tokenCreated !== null) {
+            $expiration = str_replace('+', '', $this->config('cookie.expires'));
+            if (!$user[$tokenCreated]->wasWithinLast($expiration)) {
+                return false;
+            }
+
+            if (isset($user['password'])) {
+                unset($user['password']);
+            }
+        }
+
+        if ($user) {
+            $request->session()->write(
+                $this->_registry->Auth->sessionKey,
+                $user
+            );
+            return $user;
+        }
+
+        return false;
+    }
+
+    /**
+     * Authenticate user
+     *
+     * @param Request $request Request object.
+     * @param Response $response Response object.
+     * @return array|bool Array of user info on success, false on falure.
+     */
+    public function authenticate(Request $request, Response $response)
+    {
+        return $this->getUser($request);
+    }
+
+    /**
+     * Called from AuthComponent::logout()
+     *
+     * @param \Cake\Event\Event $event The dispatched Auth.logout event.
+     * @param array $user User record.
+     * @return void
+     */
+    public function logout(Event $event, array $user)
+    {
+        $this->_registry->Cookie->delete($this->_config['cookie']['name']);
+    }
+}
+

--- a/tests/Fixture/CookieUsersFixture.php
+++ b/tests/Fixture/CookieUsersFixture.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class UserFixture
+ *
+ */
+class CookieUsersFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'user_name' => ['type' => 'string', 'null' => false],
+        'email' => ['type' => 'string', 'null' => false],
+        'password' => ['type' => 'string', 'null' => false],
+        'token' => ['type' => 'string', 'null' => false],
+        'created' => 'datetime',
+        'updated' => 'datetime',
+        'uuid' => ['type' => 'string', 'null' => false],
+        'remember_me_token' => ['type' => 'string', 'null' => false],
+        'remember_me_token_created' => 'datetime',
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'user_name' => 'mariano',
+            'email' => 'mariano@example.com',
+            'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+            'token' => '12345', 'created' => '2007-03-17 01:16:23',
+            'updated' => '2007-03-17 01:18:31',
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token' => 'a4e4243a-946f-44b4-8250-886c4e068de2',
+            'remember_me_token_created' => '2015-05-31 16:01:03'
+        ],
+        [
+            'user_name' => 'nate',
+            'email' => 'nate@example.com',
+            'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+            'token' => '23456',
+            'created' => '2007-03-17 01:18:23',
+            'updated' => '2007-03-17 01:20:31',
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token' => 'a4e4243a-946f-44b4-8250-886c4e068de2',
+            'remember_me_token_created' => '2015-03-31 16:01:03'
+        ],
+        [
+            'user_name' => 'larry',
+            'email' => 'larry@example.com',
+            'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+            'token' => '34567',
+            'created' => '2007-03-17 01:20:23',
+            'updated' => '2007-03-17 01:22:31',
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token' => 'a4e4243a-946f-44b4-8250-886c4e068de2',
+            'remember_me_token_created' => '2015-03-31 16:01:03'
+        ],
+        [
+            'user_name' => 'garrett',
+            'email' => 'garrett@example.com',
+            'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+            'token' => '45678',
+            'created' => '2007-03-17 01:22:23',
+            'updated' => '2007-03-17 01:24:31',
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token' => 'a4e4243a-946f-44b4-8250-886c4e068de2',
+            'remember_me_token_created' => '2015-03-31 16:01:03'
+        ],
+        [
+            'user_name' => 'chartjes',
+            'email' => 'chartjes@example.com',
+            'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+            'token' => '56789',
+            'created' => '2007-03-17 01:22:23',
+            'updated' => '2007-03-17 01:24:31',
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token' => 'a4e4243a-946f-44b4-8250-886c4e068de2',
+            'remember_me_token_created' => '2015-03-31 16:01:03'
+        ]
+    ];
+}

--- a/tests/TestCase/Auth/CookieAuthenticateTest.php
+++ b/tests/TestCase/Auth/CookieAuthenticateTest.php
@@ -1,0 +1,105 @@
+<?php
+NAmespace Cake\Auth\Test\TestCase\Auth;
+
+use Cake\Auth\BasicAuthenticate;
+use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\I18n\Time;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\ORM\TableRegistry;
+use Cake\Routing\Router;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
+use Cake\Auth\CookieAuthenticate;
+
+/**
+ * Test case for FormAuthentication
+ */
+class CookieAuthenticateTest extends TestCase
+{
+
+    public $fixtures = ['core.cookie_users'];
+
+    /**
+     * setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new Request('posts/index');
+        Router::setRequestInfo($this->request);
+        $this->response = $this->getMock('Cake\Network\Response');
+
+        Security::salt('this_is_a_random_key_that_is_at_least_256_bits_long');
+        $this->Registry = new ComponentRegistry(new Controller($this->request, $this->response));
+        $this->Registry->load('Cookie');
+        $this->Registry->load('Auth');
+    }
+
+    /**
+     * tearDown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->Registry->Cookie->delete('RememberMe');
+    }
+
+    /**
+     *
+     * test authenticate with token and token expiration
+     *
+     * @group cookie
+     *
+     * @return void
+     */
+    public function testCookieAuthenticate()
+    {
+        $config = [
+            'fields' => [
+                'identifier' => 'uuid',
+                'token' => 'remember_me_token',
+                'tokenCreated' => 'remember_me_token_created',
+            ],
+            'userModel' => 'CookieUsers',
+        ];
+        
+        $cookieData = [
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token' => 'a4e4243a-946f-44b4-8250-886c4e068de2'
+        ];
+        
+        $this->Registry->Cookie->write('RememberMe', $cookieData);
+
+        $expected = [
+            'id' => 1,
+            'user_name' => 'mariano',
+            'email' => 'mariano@example.com',
+            'token' => '12345',
+            'created' => new Time('2007-03-17 01:16:23'),
+            'updated' => new Time('2007-03-17 01:18:31'),
+            'uuid' => 'e99a6234-22d0-4676-b4e1-4c58b9c937d5',
+            'remember_me_token_created' => new Time('2015-05-31 16:01:03')
+        ];
+
+        $CookieUsers = TableRegistry::get('CookieUsers');
+        $user = $CookieUsers->get(1);
+        $user->remember_me_token = password_hash($cookieData['remember_me_token'], PASSWORD_DEFAULT);
+        $CookieUsers->save($user);
+        
+        $this->auth = new CookieAuthenticate($this->Registry, $config);
+        
+        $result = $this->auth->authenticate($this->request, $this->response);
+        $this->assertEquals($expected, $result);
+
+        // Ensure Cookie expiry tampering does not succeed
+        // todo
+    }
+}


### PR DESCRIPTION
This shouldn't be pulled in yet.  It's missing a test or two and probably needs code review in general.

The idea here is that "Remember Me"/ Cookie authentication is pervasive enough to warrant inclusion in core cakephp.

This is based on discussions with @ADmad in https://github.com/FriendsOfCake/Authenticate/issues/53

I just wanted to open it up for discussion here to see if anyone has an opinion on this, since it would be adding some functionality to cakephp and would probably also need some documentation added to the book if it were to be added.
