### PR TITLE
Fix issue with overlapping irregular inflections.

### DIFF
--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -184,6 +184,29 @@ class InflectorTest extends CakeTestCase {
 	}
 
 /**
+ * Test that overlapping irregulars don't collide.
+ *
+ * @return void
+ */
+	public function testSingularizeMultiWordIrregular() {
+		Inflector::rules('singular', array(
+			'irregular' => array(
+				'preguntas_frecuentes' => 'pregunta_frecuente',
+				'categorias_preguntas_frecuentes' => 'categoria_pregunta_frecuente',
+			)
+		));
+		$this->assertEquals('pregunta_frecuente', Inflector::singularize('preguntas_frecuentes'));
+		$this->assertEquals(
+			'categoria_pregunta_frecuente',
+			Inflector::singularize('categorias_preguntas_frecuentes')
+		);
+		$this->assertEquals(
+			'faq_categoria_pregunta_frecuente',
+			Inflector::singularize('faq_categorias_preguntas_frecuentes')
+		);
+	}
+
+/**
  * testInflectingPlurals method
  *
  * @return void
@@ -254,6 +277,29 @@ class InflectorTest extends CakeTestCase {
 		$this->assertEquals(Inflector::pluralize('sieve'), 'sieves');
 		$this->assertEquals(Inflector::pluralize('blue_octopus'), 'blue_octopuses');
 		$this->assertEquals(Inflector::pluralize(''), '');
+	}
+
+/**
+ * Test that overlapping irregulars don't collide.
+ *
+ * @return void
+ */
+	public function testPluralizeMultiWordIrregular() {
+		Inflector::rules('plural', array(
+			'irregular' => array(
+				'pregunta_frecuente' => 'preguntas_frecuentes',
+				'categoria_pregunta_frecuente' => 'categorias_preguntas_frecuentes',
+			)
+		));
+		$this->assertEquals('preguntas_frecuentes', Inflector::pluralize('pregunta_frecuente'));
+		$this->assertEquals(
+			'categorias_preguntas_frecuentes',
+			Inflector::pluralize('categoria_pregunta_frecuente')
+		);
+		$this->assertEquals(
+			'faq_categorias_preguntas_frecuentes',
+			Inflector::pluralize('faq_categoria_pregunta_frecuente')
+		);
 	}
 
 /**

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -386,8 +386,10 @@ class Inflector {
 			self::$_plural['cacheIrregular'] = '(?:' . implode('|', array_keys(self::$_plural['merged']['irregular'])) . ')';
 		}
 
-		if (preg_match('/(.*(?:\\b|_))(' . self::$_plural['cacheIrregular'] . ')$/i', $word, $regs)) {
-			self::$_cache['pluralize'][$word] = $regs[1] . substr($regs[2], 0, 1) . substr(self::$_plural['merged']['irregular'][strtolower($regs[2])], 1);
+		if (preg_match('/(.*?(?:\\b|_))(' . self::$_plural['cacheIrregular'] . ')$/i', $word, $regs)) {
+			self::$_cache['pluralize'][$word] = $regs[1] .
+				substr($regs[2], 0, 1) .
+				substr(self::$_plural['merged']['irregular'][strtolower($regs[2])], 1);
 			return self::$_cache['pluralize'][$word];
 		}
 
@@ -435,8 +437,10 @@ class Inflector {
 			self::$_singular['cacheIrregular'] = '(?:' . implode('|', array_keys(self::$_singular['merged']['irregular'])) . ')';
 		}
 
-		if (preg_match('/(.*(?:\\b|_))(' . self::$_singular['cacheIrregular'] . ')$/i', $word, $regs)) {
-			self::$_cache['singularize'][$word] = $regs[1] . substr($regs[2], 0, 1) . substr(self::$_singular['merged']['irregular'][strtolower($regs[2])], 1);
+		if (preg_match('/(.*?(?:\\b|_))(' . self::$_singular['cacheIrregular'] . ')$/i', $word, $regs)) {
+			self::$_cache['singularize'][$word] = $regs[1] .
+				substr($regs[2], 0, 1) .
+				substr(self::$_singular['merged']['irregular'][strtolower($regs[2])], 1);
 			return self::$_cache['singularize'][$word];
 		}
 


### PR DESCRIPTION
When irregular inflections overlap we should choose the longest match, not the shortest.

Refs #6659
