### PR TITLE
Fix: unused parenthesis for parameters of FunctionExpression.

### DIFF
--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -127,7 +127,7 @@ class FunctionExpression extends QueryExpression
         $parts = [];
         foreach ($this->_conditions as $condition) {
             if ($condition instanceof ExpressionInterface) {
-                $condition = $condition->sql($generator);
+                $condition = sprintf('(%s)', $condition->sql($generator));
             } elseif (is_array($condition)) {
                 $p = $generator->placeholder('param');
                 $generator->bind($p, $condition['value'], $condition['type']);

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -79,7 +79,7 @@ class FunctionExpressionTest extends TestCase
         $binder = new ValueBinder;
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
-        $this->assertEquals("Wrapper(bar, MyFunction(:c0, :c1))", $g->sql($binder));
+        $this->assertEquals("Wrapper(bar, (MyFunction(:c0, :c1)))", $g->sql($binder));
     }
 
     /**


### PR DESCRIPTION
I sent pull request about #6733 

Now I use CakePHP 3.x for creating new Behavior.
This fix work in my behavior, therefore it is OK.
