### PR TITLE
Fix assertTemplate() not working when cells are rendered.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -307,7 +307,9 @@ abstract class IntegrationTestCase extends TestCase
         $this->_controller = $event->data['controller'];
         $events = $this->_controller->eventManager();
         $events->on('View.beforeRender', function ($event, $viewFile) {
-            $this->_viewName = $viewFile;
+            if (!$this->_viewName) {
+                $this->_viewName = $viewFile;
+            }
         });
         $events->on('View.beforeLayout', function ($event, $viewFile) {
             $this->_layoutName = $viewFile;

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -118,6 +118,19 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Assert that the stored template doesn't change when cells are rendered.
+     *
+     * @return void
+     */
+    public function testAssertTemplateAfterCellRender()
+    {
+        $this->get('/posts/get');
+        $this->assertContains('Template' . DS . 'Posts' . DS . 'get.ctp', $this->_viewName);
+        $this->assertTemplate('get');
+        $this->assertResponseContains('cellcontent');
+    }
+
+    /**
      * Test array URLs
      *
      * @return void

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -47,4 +47,14 @@ class PostsController extends AppController
         ]);
         $this->set('test', 'value');
     }
+
+    /**
+     * Stub get method
+     *
+     * @return void
+     */
+    public function get()
+    {
+        // Do nothing.
+    }
 }

--- a/tests/test_app/TestApp/Template/Posts/get.ctp
+++ b/tests/test_app/TestApp/Template/Posts/get.ctp
@@ -1,0 +1,1 @@
+<?= $this->cell('Articles::doEcho', ['cell', 'content']); ?>


### PR DESCRIPTION
When cells were rendered, the last cell to be rendered would be stored as the template name instead of the first view to be rendered.

Refs #6718
