### PR TITLE
Make select() accept a Table or Association instance

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -125,7 +125,7 @@ class Query extends DatabaseQuery implements JsonSerializable
     }
 
     /**
-     * {@inheritDocs}
+     * {@inheritDoc}
      *
      * If you pass an instance of a `Cake\ORM\Table` or `Cake\ORM\Association` class,
      * all the fields in the schema of the table or the association will be added to

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -125,6 +125,30 @@ class Query extends DatabaseQuery implements JsonSerializable
     }
 
     /**
+     * {@inheritDocs}
+     *
+     * If you pass an instance of a `Cake\ORM\Table` or `Cake\ORM\Association` class,
+     * all the fields in the schema of the table or the association will be added to
+     * the select clause.
+     *
+     * @param array|ExpressionInterface|string|\Cake\ORM\Table|\Cake\ORM\Association $fields fields
+     * to be added to the list.
+     * @param bool $overwrite whether to reset fields with passed list or not
+     */
+    public function select($fields = [], $overwrite = false)
+    {
+        if ($fields instanceof Association) {
+            $fields = $fields->target();
+        }
+
+        if ($fields instanceof Table) {
+            $fields = $this->aliasFields($fields->schema()->columns(), $fields->alias());
+        }
+
+        return parent::select($fields, $overwrite);
+    }
+
+    /**
      * Hints this object to associate the correct types when casting conditions
      * for the database. This is done by extracting the field types from the schema
      * associated to the passed table object. This prevents the user from repeating

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2662,7 +2662,7 @@ class QueryTest extends TestCase
         $table->belongsTo('authors');
         $result = $table
             ->find()
-            ->select(['foo' => 'Authors.id'])
+            ->select(['foo' => '1 + 1'])
             ->select($table)
             ->select($table->authors)
             ->contain(['authors'])
@@ -2670,7 +2670,7 @@ class QueryTest extends TestCase
 
         $expected = $table
             ->find()
-            ->select(['foo' => 'Authors.id'])
+            ->select(['foo' => '1 + 1'])
             ->autoFields(true)
             ->contain(['authors'])
             ->first();

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2650,6 +2650,35 @@ class QueryTest extends TestCase
         $this->assertEquals(2, $result->_matchingData['tags']->id);
     }
 
+     /**
+     * Tests that select() can be called with Table and Association
+     * instance
+     *
+     * @return void
+     */
+    public function testSelectWithTableAndAssociationInstance()
+    {
+        $table = TableRegistry::get('articles');
+        $table->belongsTo('authors');
+        $result = $table
+            ->find()
+            ->select(['foo' => 'Authors.id'])
+            ->select($table)
+            ->select($table->authors)
+            ->contain(['authors'])
+            ->first();
+
+        $expected = $table
+            ->find()
+            ->select(['foo' => 'Authors.id'])
+            ->autoFields(true)
+            ->contain(['authors'])
+            ->first();
+
+        $this->assertNotEmpty($result);
+        $this->assertEquals($expected, $result);
+    }
+
     /**
      * Tests that isEmpty() can be called on a query
      *

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2650,7 +2650,7 @@ class QueryTest extends TestCase
         $this->assertEquals(2, $result->_matchingData['tags']->id);
     }
 
-     /**
+    /**
      * Tests that select() can be called with Table and Association
      * instance
      *

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2662,7 +2662,9 @@ class QueryTest extends TestCase
         $table->belongsTo('authors');
         $result = $table
             ->find()
-            ->select(['foo' => '1 + 1'])
+            ->select(function ($q) {
+                return ['foo' => $q->newExpr('1 + 1')];
+            })
             ->select($table)
             ->select($table->authors)
             ->contain(['authors'])
@@ -2670,7 +2672,9 @@ class QueryTest extends TestCase
 
         $expected = $table
             ->find()
-            ->select(['foo' => '1 + 1'])
+            ->select(function ($q) {
+                return ['foo' => $q->newExpr('1 + 1')];
+            })
             ->autoFields(true)
             ->contain(['authors'])
             ->first();


### PR DESCRIPTION
Closes #6103

I did not implement the suggestion of making it accept a `Cake\Schema\Table` since it would have made the implementation much more difficult, as it would need to infer the aliases from somewhere else.
