### PR TITLE
Fix auto-prefixing of custom fields in pagination.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -318,7 +318,7 @@ class PaginatorComponent extends Component
             return $options;
         }
 
-        $validate = true;
+        $inWhitelist = false;
         if (!empty($options['sortWhitelist'])) {
             $field = key($options['order']);
             $inWhitelist = in_array($field, $options['sortWhitelist'], true);
@@ -326,10 +326,9 @@ class PaginatorComponent extends Component
                 $options['order'] = [];
                 return $options;
             }
-            $validate = false;
         }
 
-        $options['order'] = $this->_prefix($object, $options['order'], $validate);
+        $options['order'] = $this->_prefix($object, $options['order'], $inWhitelist);
 
         return $options;
     }
@@ -339,29 +338,36 @@ class PaginatorComponent extends Component
      *
      * @param \Cake\ORM\Table $object Table object.
      * @param array $order Order array.
-     * @param bool $validate If field should be validated. Defaults to false.
+     * @param bool $whitelisted Whether or not the field was whitelisted
      * @return array Final order array.
      */
-    protected function _prefix(Table $object, $order, $validate = false)
+    protected function _prefix(Table $object, $order, $whitelisted = false)
     {
         $tableAlias = $object->alias();
         $tableOrder = [];
         foreach ($order as $key => $value) {
-            $field = $key;
-            $alias = $tableAlias;
             if (is_numeric($key)) {
                 $tableOrder[] = $value;
-            } else {
-                if (strpos($key, '.') !== false) {
-                    list($alias, $field) = explode('.', $key);
-                }
-                $correctAlias = ($tableAlias === $alias);
+                continue;
+            }
+            $field = $key;
+            $alias = $tableAlias;
 
-                if (!$correctAlias && !$validate) {
-                    $tableOrder[$alias . '.' . $field] = $value;
-                } elseif ($correctAlias && (!$validate || $object->hasField($field))) {
-                    $tableOrder[$tableAlias . '.' . $field] = $value;
+            if (strpos($key, '.') !== false) {
+                list($alias, $field) = explode('.', $key);
+            }
+            $correctAlias = ($tableAlias === $alias);
+
+            if ($correctAlias && $whitelisted) {
+                // Disambiguate fields in schema. As id is quite common.
+                if ($object->hasField($field)) {
+                    $field = $alias . '.' . $field;
                 }
+                $tableOrder[$field] = $value;
+            } elseif ($correctAlias && $object->hasField($field)) {
+                $tableOrder[$tableAlias . '.' . $field] = $value;
+            } elseif (!$correctAlias && $whitelisted) {
+                $tableOrder[$alias . '.' . $field] = $value;
             }
         }
         return $tableOrder;

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -555,7 +555,9 @@ class PaginatorComponentTest extends TestCase
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
-        $model->expects($this->never())->method('hasField');
+        $model->expects($this->once())
+            ->method('hasField')
+            ->will($this->returnValue(true));
 
         $options = [
             'sort' => 'body',
@@ -565,7 +567,40 @@ class PaginatorComponentTest extends TestCase
         $result = $this->Paginator->validateSort($model, $options);
 
         $expected = ['model.body' => 'asc'];
-        $this->assertEquals($expected, $result['order']);
+        $this->assertEquals(
+            $expected,
+            $result['order'],
+            'Trusted fields in schema should be prefixed'
+        );
+    }
+
+    /**
+     * test that fields in the whitelist are not validated
+     *
+     * @return void
+     */
+    public function testValidateSortWhitelistNotInSchema()
+    {
+        $model = $this->getMock('Cake\ORM\Table');
+        $model->expects($this->any())
+            ->method('alias')
+            ->will($this->returnValue('model'));
+        $model->expects($this->once())->method('hasField')
+            ->will($this->returnValue(false));
+
+        $options = [
+            'sort' => 'score',
+            'direction' => 'asc',
+            'sortWhitelist' => ['score']
+        ];
+        $result = $this->Paginator->validateSort($model, $options);
+
+        $expected = ['score' => 'asc'];
+        $this->assertEquals(
+            $expected,
+            $result['order'],
+            'Trusted fields not in schema should not be altered'
+        );
     }
 
     /**
@@ -579,7 +614,9 @@ class PaginatorComponentTest extends TestCase
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
-        $model->expects($this->never())->method('hasField');
+        $model->expects($this->once())
+            ->method('hasField')
+            ->will($this->returnValue(true));
 
         $options = [
             'order' => [


### PR DESCRIPTION
Fields that have been whitelisted should not be prefixed if they are not part of the model's schema. Auto-prefixing causes issues with computed columns that need sorting on. These fields when whitelisted should not be altered. However, whitelisted fields that are present in the schema should be prefixed as they could collide with other columns in joined tables as seen in #6597

Refs #6725
