### PR TITLE
Cleanup redirect().

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -524,7 +524,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             return;
         }
 
-        if ($url !== null && !$response->location()) {
+        if (!$response->location()) {
             $response->location(Router::url($url, true));
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -464,8 +464,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectByCode($code, $msg)
     {
-        $Controller = new Controller(null);
-        $Controller->response = new Response();
+        $Controller = new Controller(null, new Response());
 
         $response = $Controller->redirect('http://cakephp.org', (int)$code, false);
         $this->assertEquals($code, $response->statusCode());
@@ -480,8 +479,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectBeforeRedirectModifyingUrl()
     {
-        $Controller = new Controller(null);
-        $Controller->response = new Response();
+        $Controller = new Controller(null, new Response());
 
         $Controller->eventManager()->attach(function ($event, $url, $response) {
             $response->location('http://book.cakephp.org');


### PR DESCRIPTION
Reopened https://github.com/cakephp/cakephp/pull/6708 as cleanup. Following the above logic the null check makes no sense because you are not allowed to pass it in in the first place.
And passing null + keeping that check creates an inconsistency that can be considered a bug.
