### PR TITLE
Fix issue generating base / webroot.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -384,6 +384,8 @@ class Request implements ArrayAccess
 
         if (!$baseUrl) {
             $base = dirname(env('PHP_SELF'));
+            // Clean up additional / which cause following code to fail..
+            $base = preg_replace('#/+#', '/', $base);
 
             $indexPos = strpos($base, '/' . $webroot . '/index.php');
             if ($indexPos !== false) {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1300,6 +1300,25 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test that even if mod_rewrite is on, and the url contains index.php
+     * and there are numerous //s that the base/webroot is calculated correctly.
+     *
+     * @return void
+     */
+    public function testBaseUrlWithModRewriteAndExtraSlashes()
+    {
+        $_SERVER['REQUEST_URI'] = '/cakephp/webroot///index.php/bananas/eat';
+        $_SERVER['PHP_SELF'] = '/cakephp/webroot///index.php/bananas/eat';
+        $_SERVER['PATH_INFO'] = '/bananas/eat';
+        $request = Request::createFromGlobals();
+
+        $this->assertEquals('/cakephp', $request->base);
+        $this->assertEquals('/cakephp/', $request->webroot);
+        $this->assertEquals('bananas/eat', $request->url);
+        $this->assertEquals('/cakephp/bananas/eat', $request->here);
+    }
+
+    /**
      * Test base, webroot, and URL parsing when there is no URL rewriting
      *
      * @return void


### PR DESCRIPTION
When a URL contains // it can circumvent the base path generation, which results in unwanted user data in the base/webroot paths. This creates an opportunity for CSS manipulation in old versions of IE, and newer ones via iframe inheritance.
