### PR TITLE
Fix incorrect default order by clause.

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -99,9 +99,9 @@ trait SqlserverDialectTrait
     protected function _pagingSubquery($original, $limit, $offset)
     {
         $field = '_cake_paging_._cake_page_rownum_';
+        $order = $original->clause('order') ?: new OrderByExpression('(SELECT NULL)');
 
         $query = clone $original;
-        $order = $query->clause('order') ?: new OrderByExpression('NULL');
         $query->select([
                 '_cake_page_rownum_' => new UnaryExpression('ROW_NUMBER() OVER', $order)
             ])->limit(null)


### PR DESCRIPTION
Instead of NULL, the ORDER BY for SQLServer needs to be a select statement. For compatibility with SQLServer2008 this statement needs to be wrapped in parentheses as well.

Getting the order by clause _before_ a clone is made is important as the clone hook on ORM\Query removes the order clause, which was causing the query to get the incorrect (but now correct fallback clause).

No new tests were added as a number of tests are currently failing, but we didn't know because AppVeyor is failing due to incorrect dependencies being installed.

Refs #6730
