### PR TITLE
Fix offing all event listeners for a specific event

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -277,6 +277,10 @@ class EventManager
             $this->_detachSubscriber($callable, $eventKey);
             return;
         }
+        if ($callable === null && is_string($eventKey)) {
+            unset($this->_listeners[$eventKey]);
+            return;
+        }
         if ($callable === null) {
             foreach (array_keys($this->_listeners) as $name) {
                 $this->off($name, $eventKey);

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -227,6 +227,24 @@ class EventManagerTest extends TestCase
     }
 
     /**
+     * Tests off'ing all listeners for an event
+     */
+    public function testRemoveAllListeners()
+    {
+        $manager = new EventManager();
+        $manager->on('fake.event', ['AClass', 'aMethod']);
+        $manager->on('another.event', ['priority' => 1], 'fakeFunction');
+
+        $manager->off('fake.event');
+
+        $expected = [
+            ['callable' => 'fakeFunction']
+        ];
+        $this->assertEquals($expected, $manager->listeners('another.event'));
+        $this->assertEquals([], $manager->listeners('fake.event'));
+    }
+
+    /**
      * Tests detaching an event from a event key queue
      *
      * @return void


### PR DESCRIPTION
Hi,

Today I encountered a problem when offing all eventlisteners for a specific event.

The documententation states the possibility to delete all eventlisteners by passing the eventname to the off method like:

``` php
$manager->off('My.event');
```

This is not working at the moment. I created a fix and test. WIthout the fix the test is failing.

Hope it helps,

Robbert
