### PR TITLE
Always use a fresh EventManager for tests

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -14,7 +14,6 @@
 namespace Cake\TestSuite;
 
 use Cake\Core\Configure;
-use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\Routing\DispatcherFactory;
@@ -98,17 +97,6 @@ abstract class IntegrationTestCase extends TestCase
      * @var \Cake\Network\Session
      */
     protected $_requestSession;
-
-    /**
-     * Resets the EventManager for before each test.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        parent::setUp();
-        EventManager::instance(new EventManager());
-    }
 
     /**
      * Clears the state used for requests.

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -16,6 +16,7 @@ namespace Cake\TestSuite;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
+use Cake\Event\EventManager;
 use Cake\ORM\Exception\MissingTableClassException;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
@@ -100,6 +101,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         if (class_exists('Cake\Routing\Router', false)) {
             Router::reload();
         }
+ 
+        EventManager::instance(new EventManager());
     }
 
     /**

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase;
 use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
 use Cake\Filesystem\Folder;
 use Cake\Log\Log;
 use Cake\Network\Response;
@@ -559,5 +560,30 @@ EXPECTED;
         $collection = collection($items);
         $this->assertInstanceOf('Cake\Collection\Collection', $collection);
         $this->assertSame($items, $collection->toArray());
+    }
+
+    /**
+     * Test that works in tandem with testEventManagerReset2 to
+     * test the EventManager reset.
+     *
+     * The return value is passed to testEventManagerReset2 as
+     * an arguments.
+     *
+     * @return \Cake\Event\EventManager
+     */
+    public function testEventManagerReset1()
+    {
+        return EventManager::instance();
+    }
+
+    /**
+     * Test if the EventManager is reset between tests.
+     *
+     * @depends testEventManagerReset1
+     * @return void
+     */
+    public function testEventManagerReset2($prevEventManager)
+    {
+        $this->assertNotSame($prevEventManager, EventManager::instance());
     }
 }


### PR DESCRIPTION
Hi,

A while ago @berrygoudswaard did a pull request so the eventmanager is refreshed every integration test. (https://github.com/cakephp/cakephp/commit/93577235c8e1ed9ace81f9152e3ba2b878155323)

I think it is better to do it  before every test. So I moved his part to the TestCase.php. In the IntegrationTestCaseTest.php are still two tests which do exactly the same (I copied them).

Should I leave them there, or do you think these can be deleted since they test exactly the same.
