### PR TITLE
Update MySQL table generation for non-conventional schemas

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -332,9 +332,7 @@ class MysqlSchema extends BaseSchema
         if (isset($data['null']) && $data['null'] === false) {
             $out .= ' NOT NULL';
         }
-        if (in_array($data['type'], ['integer', 'biginteger']) &&
-            ([$name] == (array)$table->primaryKey() || $data['autoIncrement'] === true)
-        ) {
+        if (in_array($data['type'], ['integer', 'biginteger']) && $data['autoIncrement'] === true) {
             $out .= ' AUTO_INCREMENT';
         }
         if (isset($data['null']) && $data['null'] === true) {

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -332,7 +332,13 @@ class MysqlSchema extends BaseSchema
         if (isset($data['null']) && $data['null'] === false) {
             $out .= ' NOT NULL';
         }
-        if (in_array($data['type'], ['integer', 'biginteger']) && $data['autoIncrement'] === true) {
+        $addAutoIncrement = (
+            [$name] == (array)$table->primaryKey() &&
+            !$table->hasAutoIncrement()
+        );
+        if (in_array($data['type'], ['integer', 'biginteger']) &&
+            ($data['autoIncrement'] === true || $addAutoIncrement)
+        ) {
             $out .= ' AUTO_INCREMENT';
         }
         if (isset($data['null']) && $data['null'] === true) {

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -221,9 +221,9 @@ class MysqlSchema extends BaseSchema
     public function describeForeignKeySql($tableName, $config)
     {
         $sql = 'SELECT * FROM information_schema.key_column_usage AS kcu
-			INNER JOIN information_schema.referential_constraints AS rc
-			ON (kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME)
-			WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ? and rc.TABLE_NAME = ?';
+            INNER JOIN information_schema.referential_constraints AS rc
+            ON (kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME)
+            WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ? and rc.TABLE_NAME = ?';
 
         return [$sql, [$config['database'], $tableName, $tableName]];
     }

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -508,6 +508,15 @@ class Table
                 throw new Exception($msg);
             }
         }
+
+        if ($attrs['type'] === static::CONSTRAINT_PRIMARY && count($attrs['columns']) === 1) {
+            $column = $attrs['columns'][0];
+            if (!$this->_hasAutoincrement() &&
+                in_array($this->columnType($column), ['integer', 'biginteger'])
+            ) {
+                $this->_columns[$attrs['columns'][0]]['autoIncrement'] = true;
+            }
+        }
         if ($attrs['type'] === static::CONSTRAINT_FOREIGN) {
             $attrs = $this->_checkForeignKey($attrs);
         } else {
@@ -515,6 +524,21 @@ class Table
         }
         $this->_constraints[$name] = $attrs;
         return $this;
+    }
+
+    /**
+     * Check whether or not a table has an autoIncrement column defined.
+     *
+     * @return bool
+     */
+    protected function _hasAutoincrement()
+    {
+        foreach ($this->_columns as $column) {
+            if (isset($column['autoIncrement']) && $column['autoIncrement']) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -509,14 +509,6 @@ class Table
             }
         }
 
-        if ($attrs['type'] === static::CONSTRAINT_PRIMARY && count($attrs['columns']) === 1) {
-            $column = $attrs['columns'][0];
-            if (!$this->_hasAutoincrement() &&
-                in_array($this->columnType($column), ['integer', 'biginteger'])
-            ) {
-                $this->_columns[$attrs['columns'][0]]['autoIncrement'] = true;
-            }
-        }
         if ($attrs['type'] === static::CONSTRAINT_FOREIGN) {
             $attrs = $this->_checkForeignKey($attrs);
         } else {
@@ -531,7 +523,7 @@ class Table
      *
      * @return bool
      */
-    protected function _hasAutoincrement()
+    public function hasAutoincrement()
     {
         foreach ($this->_columns as $column) {
             if (isset($column['autoIncrement']) && $column['autoIncrement']) {

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -390,6 +390,36 @@ SQL;
         $this->assertArrayHasKey('collation', $result->options());
     }
 
+    public function testDescribeNonPrimaryAutoIncrement()
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+
+        $sql = <<<SQL
+CREATE TEMPORARY TABLE `odd_primary_key` (
+`id` BIGINT UNSIGNED NOT NULL,
+`other_field` INTEGER(11) NOT NULL AUTO_INCREMENT,
+PRIMARY KEY (`id`),
+UNIQUE KEY `other_field` (`other_field`)
+)
+SQL;
+        $connection->execute($sql);
+        $schema = new SchemaCollection($connection);
+        $table = $schema->describe('odd_primary_key');
+
+        $column = $table->column('id');
+        $this->assertNull($column['autoIncrement'], 'should not autoincrement');
+        $this->assertTrue($column['unsigned'], 'should be unsigned');
+
+        $column = $table->column('other_field');
+        $this->assertTrue($column['autoIncrement'], 'should not autoincrement');
+        $this->assertFalse($column['unsigned'], 'should not be unsigned');
+
+        $output = $table->createSql($connection);
+        $this->assertContains('`id` BIGINT UNSIGNED NOT NULL,', $output[0]);
+        $this->assertContains('`other_field` INTEGER(11) NOT NULL AUTO_INCREMENT,', $output[0]);
+    }
+
     /**
      * Column provider for creating column sql
      *
@@ -689,7 +719,7 @@ SQL;
         $table = new Table('articles');
         $table->addColumn('id', [
                 'type' => 'integer',
-                'null' => false
+                'null' => false,
             ])
             ->addConstraint('primary', [
                 'type' => 'primary',

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -396,7 +396,7 @@ SQL;
         $connection = ConnectionManager::get('test');
 
         $sql = <<<SQL
-CREATE TEMPORARY TABLE `odd_primary_key` (
+CREATE TABLE `odd_primary_key` (
 `id` BIGINT UNSIGNED NOT NULL,
 `other_field` INTEGER(11) NOT NULL AUTO_INCREMENT,
 PRIMARY KEY (`id`),
@@ -406,6 +406,7 @@ SQL;
         $connection->execute($sql);
         $schema = new SchemaCollection($connection);
         $table = $schema->describe('odd_primary_key');
+        $connection->execute('DROP TABLE odd_primary_key');
 
         $column = $table->column('id');
         $this->assertNull($column['autoIncrement'], 'should not autoincrement');


### PR DESCRIPTION
When generating schema from a Table instance, we were incorrectly assigning autoIncrement to integer columns just because they were involved in a primary key. In the new implementation, an autoIncrement is only assigned when:
- The primary key has only one column
- That column is integer/bigint.
- There are no other fields flagged as autoIncrement.

This allows MySQL schema generation to handle autoincrements in unique keys correctly.

Refs #6668
