### PR TITLE
Fix missing types for junction tables

### DIFF
--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -64,6 +64,8 @@ class TypeMap
      * $query->defaults(['created' => 'datetime', 'is_visible' => 'boolean']);
      * ```
      *
+     * This method will replace all the existing type maps with the ones provided.
+     *
      * @param array $defaults associative array where keys are field names and values
      * are the correspondent type.
      * @return $this|array
@@ -78,7 +80,20 @@ class TypeMap
     }
 
     /**
-     * Configures a map of fields and their associated types for single-use.
+     * Add additional default types into the type map.
+     *
+     * If a key already exists it will not be overwritten.
+     *
+     * @param array $types The additional types to add.
+     * @return void
+     */
+    public function addDefaults(array $types)
+    {
+        $this->_defaults = $this->_defaults + $types;
+    }
+
+    /**
+     * Sets a map of fields and their associated types for single-use.
      *
      * If called with no arguments it will return the currently configured types.
      *
@@ -87,6 +102,8 @@ class TypeMap
      * ```
      * $query->types(['created' => 'time']);
      * ```
+     *
+     * This method will replace all the existing type maps with the ones provided.
      *
      * @param array $types associative array where keys are field names and values
      * are the correspondent type.

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -941,6 +941,7 @@ class BelongsToMany extends Association
 
         $assoc = $this->target()->association($name);
         $query
+            ->addDefaultTypes($assoc->target())
             ->join($matching + $joins, [], true)
             ->autoFields($query->clause('select') === [])
             ->select($query->aliasFields((array)$assoc->foreignKey(), $name));

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -143,7 +143,7 @@ class Query extends DatabaseQuery implements JsonSerializable
         foreach ($schema->columns() as $f) {
             $fields[$f] = $fields[$alias . '.' . $f] = $schema->columnType($f);
         }
-        $this->defaultTypes($fields);
+        $this->typeMap()->addDefaults($fields);
 
         return $this;
     }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -904,4 +904,24 @@ class QueryRegressionTest extends TestCase
             'Output values for functions are not cast yet.'
         );
     }
+
+    public function testBooleanConditionsInContain()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'through' => 'SpecialTags'
+        ]);
+        $query = $table->find()
+            ->contain(['Tags' => function ($q) {
+                return $q->where(['SpecialTags.highlighted' => false]);
+            }])
+            ->order(['Articles.id' => 'ASC']);
+
+        $result = $query->first();
+        $this->assertEquals(1, $result->id);
+        $this->assertNotEmpty($result->tags);
+        $this->assertNotEmpty($result->tags[0]->_joinData);
+    }
 }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -905,6 +905,11 @@ class QueryRegressionTest extends TestCase
         );
     }
 
+    /**
+     * Test that contain queries map types correctly.
+     *
+     * @return void
+     */
     public function testBooleanConditionsInContain()
     {
         $table = TableRegistry::get('Articles');
@@ -915,13 +920,13 @@ class QueryRegressionTest extends TestCase
         ]);
         $query = $table->find()
             ->contain(['Tags' => function ($q) {
-                return $q->where(['SpecialTags.highlighted' => false]);
+                return $q->where(['SpecialTags.highlighted_time >' => new Time('2014-06-01 00:00:00')]);
             }])
-            ->order(['Articles.id' => 'ASC']);
+            ->where(['Articles.id' => 2]);
 
         $result = $query->first();
-        $this->assertEquals(1, $result->id);
-        $this->assertNotEmpty($result->tags);
-        $this->assertNotEmpty($result->tags[0]->_joinData);
+        $this->assertEquals(2, $result->id);
+        $this->assertNotEmpty($result->tags, 'Missing tags');
+        $this->assertNotEmpty($result->tags[0]->_joinData, 'Missing join data');
     }
 }


### PR DESCRIPTION
contain query builders for belongsToMany associations did not have their types mapped. This meant that non-string/non-int types were not correctly coerced into the database format.

This change fixes that and makes ORM\Query::addDefaultTypes() an additive process vs. a replacement one. I think this should be a safe change as the adds are non-destructive.

Refs #6775
