### PR TITLE
RFC Add name prefixes for routes.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -184,12 +184,19 @@ class RouteBuilder
     }
 
     /**
-     * Get the name prefix for this scope.
+     * Get/set the name prefix for this scope.
      *
+     * Modifying the name prefix will only change the prefix
+     * used for routes connected after the prefix is changed.
+     *
+     * @param string|null $value Either the value to set or null.
      * @return string
      */
-    public function namePrefix()
+    public function namePrefix($value = null)
     {
+        if ($value !== null) {
+            $this->_namePrefix = $value;
+        }
         return $this->_namePrefix;
     }
 
@@ -419,6 +426,9 @@ class RouteBuilder
 
         if (empty($options['routeClass'])) {
             $options['routeClass'] = $this->_routeClass;
+        }
+        if (isset($options['_name']) && $this->_namePrefix) {
+            $options['_name'] = $this->_namePrefix . $options['_name'];
         }
 
         $route = $this->_makeRoute($route, $defaults, $options);

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -110,7 +110,7 @@ class RouteBuilder
      * @param \Cake\Routing\RouteCollection $collection The route collection to append routes into.
      * @param string $path The path prefix the scope is for.
      * @param array $params The scope's routing parameters.
-     * @param array $options Options list. Valid keys are:
+     * @param array $options Options list.
      */
     public function __construct($collection, $path, array $params = [], array $options = [])
     {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -85,6 +85,13 @@ class RouteBuilder
     protected $_params;
 
     /**
+     * Name prefix for connected routes.
+     *
+     * @var string
+     */
+    protected $_namePrefix = '';
+
+    /**
      * The route collection routes should be added to.
      *
      * @var \Cake\Routing\RouteCollection
@@ -94,13 +101,16 @@ class RouteBuilder
     /**
      * Constructor
      *
+     * ### Options
+     *
+     * - `routeClass` - The default route class to use when adding routes.
+     * - `extensions` - The extensions to connect when adding routes.
+     * - `namePrefix` - The prefix to append to all route names.
+     *
      * @param \Cake\Routing\RouteCollection $collection The route collection to append routes into.
      * @param string $path The path prefix the scope is for.
      * @param array $params The scope's routing parameters.
      * @param array $options Options list. Valid keys are:
-     *
-     *   - `routeClass` - The default route class to use when adding routes.
-     *   - `extensions` - The extensions to connect when adding routes.
      */
     public function __construct($collection, $path, array $params = [], array $options = [])
     {
@@ -112,6 +122,9 @@ class RouteBuilder
         }
         if (isset($options['extensions'])) {
             $this->_extensions = $options['extensions'];
+        }
+        if (isset($options['namePrefix'])) {
+            $this->_namePrefix = $options['namePrefix'];
         }
     }
 
@@ -168,6 +181,16 @@ class RouteBuilder
     public function params()
     {
         return $this->_params;
+    }
+
+    /**
+     * Get the name prefix for this scope.
+     *
+     * @return string
+     */
+    public function namePrefix()
+    {
+        return $this->_namePrefix;
     }
 
     /**
@@ -585,10 +608,17 @@ class RouteBuilder
         if ($this->_path !== '/') {
             $path = $this->_path . $path;
         }
+        $namePrefix = $this->_namePrefix;
+        if (isset($params['_namePrefix'])) {
+            $namePrefix .= $params['_namePrefix'];
+        }
+        unset($params['_namePrefix']);
+
         $params = $params + $this->_params;
         $builder = new static($this->_collection, $path, $params, [
             'routeClass' => $this->_routeClass,
-            'extensions' => $this->_extensions
+            'extensions' => $this->_extensions,
+            'namePrefix' => $namePrefix,
         ]);
         $callback($builder);
     }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -875,7 +875,7 @@ class Router
     {
         $builder = new RouteBuilder(static::$_collection, '/', [], [
             'routeClass' => static::defaultRouteClass(),
-            'extensions' => static::$_defaultExtensions
+            'extensions' => static::$_defaultExtensions,
         ]);
         $builder->scope($path, $params, $callback);
     }
@@ -939,6 +939,9 @@ class Router
         $params = ['plugin' => $name];
         if (empty($options['path'])) {
             $options['path'] = '/' . Inflector::underscore($name);
+        }
+        if (isset($options['_namePrefix'])) {
+            $params['_namePrefix'] = $options['_namePrefix'];
         }
         static::scope($options['path'], $params, $callback);
     }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -614,4 +614,25 @@ class RouteBuilderTest extends TestCase
             $this->assertEquals(['prefix' => 'api'], $routes->params());
         });
     }
+
+    /**
+     * Test using name prefixes.
+     *
+     * @return void
+     */
+    public function testNamePrefixes()
+    {
+        $routes = new RouteBuilder($this->collection, '/api', [], ['namePrefix' => 'api:']);
+        $routes->scope('/v1', ['version' => 1, '_namePrefix' => 'v1:'], function ($routes) {
+            $this->assertEquals('api:v1:', $routes->namePrefix());
+            $routes->connect('/ping', ['controller' => 'Pings'], ['_name' => 'ping']);
+
+            $routes->namePrefix('web:');
+            $routes->connect('/pong', ['controller' => 'Pongs'], ['_name' => 'pong']);
+        });
+
+        $all = $this->collection->named();
+        $this->assertArrayHasKey('api:v1:ping', $all);
+        $this->assertArrayHasKey('web:pong', $all);
+    }
 }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2791,6 +2791,7 @@ class RouterTest extends TestCase
             $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
             $this->assertEquals('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
+            $this->assertEquals('', $routes->namePrefix());
 
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
@@ -2845,6 +2846,23 @@ class RouterTest extends TestCase
     }
 
     /**
+     * Test the scope() method
+     *
+     * @return void
+     */
+    public function testScopeNamePrefix()
+    {
+        Router::scope('/path', ['param' => 'value', '_namePrefix' => 'path:'], function ($routes) {
+            $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
+            $this->assertEquals('/path', $routes->path());
+            $this->assertEquals(['param' => 'value'], $routes->params());
+            $this->assertEquals('path:', $routes->namePrefix());
+
+            $routes->connect('/articles', ['controller' => 'Articles']);
+        });
+    }
+
+    /**
      * Test that prefix() creates a scope.
      *
      * @return void
@@ -2854,6 +2872,12 @@ class RouterTest extends TestCase
         Router::prefix('admin', function ($routes) {
             $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
             $this->assertEquals('/admin', $routes->path());
+            $this->assertEquals(['prefix' => 'admin'], $routes->params());
+        });
+
+        Router::prefix('admin', ['_namePrefix' => 'admin:'], function ($routes) {
+            $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
+            $this->assertEquals('admin:', $routes->namePrefix());
             $this->assertEquals(['prefix' => 'admin'], $routes->params());
         });
     }
@@ -2897,6 +2921,11 @@ class RouterTest extends TestCase
             $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
             $this->assertEquals('/debugger', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
+        });
+
+        Router::plugin('Contacts', ['_namePrefix' => 'contacts:'], function ($routes) {
+            $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
+            $this->assertEquals('contacts:', $routes->namePrefix());
         });
     }
 


### PR DESCRIPTION
Building out named routes can be much less tedious if each scope can define a name prefix. This adds the ability to track the name prefix through the various route builders.
- Routes will only get names if they have a `_name`. Nameless routes will _not_ have the prefix applied.
-  Name Prefixes can be nested and stacked up.
