### PR TITLE
Add date functions

### DIFF
--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -135,8 +135,7 @@ trait PostgresDialectTrait
                     ->type(' + INTERVAL')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 1) {
-                            $interval = sprintf("'%s'", key($p));
-                            $p = [$interval => 'literal'];
+                            $p = sprintf("'%s'", $p);
                         }
                         return $p;
                     });

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -134,7 +134,7 @@ trait PostgresDialectTrait
                     ->name('')
                     ->type(' + INTERVAL')
                     ->iterateParts(function ($p, $key) {
-                    if ($key === 1) {
+                        if ($key === 1) {
                             $interval = sprintf("'%s'", key($p));
                             $p = [$interval => 'literal'];
                         }

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -143,8 +143,9 @@ trait PostgresDialectTrait
             case 'DAYOFWEEK':
                 $expression
                     ->name('EXTRACT')
-                    ->add(['DOW' => 'literal'], [], true)
-                    ->type(' FROM');
+                    ->type(' ')
+                    ->add(['DOW FROM' => 'literal'], [], true)
+                    ->add([') + (1' => 'literal']); // Postgres starts on index 0 but Sunday should be 1
                 break;
         }
     }

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -129,6 +129,18 @@ trait PostgresDialectTrait
             case 'NOW':
                 $expression->name('LOCALTIMESTAMP')->add([' 0 ' => 'literal']);
                 break;
+            case 'DATE_ADD':
+                $expression
+                    ->name('')
+                    ->type(' + INTERVAL')
+                    ->iterateParts(function ($p, $key) {
+                        if ($key === 1) {
+                            $interval = sprintf("'%s'", key($p));
+                            $p = [$interval => 'literal'];
+                        }
+                        return $p;
+                    });
+                break;
         }
     }
 

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -135,7 +135,7 @@ trait PostgresDialectTrait
                     ->type(' + INTERVAL')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 1) {
-                            $p = sprintf("'%s'", $p);
+                            $p = ['value' => $p, 'type' => null];
                         }
                         return $p;
                     });

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -135,7 +135,7 @@ trait PostgresDialectTrait
                     ->type(' + INTERVAL')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 1) {
-                            $p = ['value' => $p, 'type' => null];
+                            $p = sprintf("'%s'", $p);
                         }
                         return $p;
                     });

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -134,12 +134,18 @@ trait PostgresDialectTrait
                     ->name('')
                     ->type(' + INTERVAL')
                     ->iterateParts(function ($p, $key) {
-                        if ($key === 1) {
+                    if ($key === 1) {
                             $interval = sprintf("'%s'", key($p));
                             $p = [$interval => 'literal'];
                         }
                         return $p;
                     });
+                break;
+            case 'DAYOFWEEK':
+                $expression
+                    ->name('EXTRACT')
+                    ->add(['DOW' => 'literal'], [], true)
+                    ->type(' FROM');
                 break;
         }
     }

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -53,6 +53,21 @@ trait SqliteDialectTrait
     protected $_schemaDialect;
 
     /**
+     * Mapping of date parts.
+     *
+     * @var array
+     */
+    protected $_dateParts = [
+        'day' => 'd',
+        'hour' => 'H',
+        'month' => 'm',
+        'minute' => 'M',
+        'second' => 'S',
+        'week' => 'W',
+        'year' => 'Y'
+    ];
+
+    /**
      * Returns a dictionary of expressions to be transformed when compiling a Query
      * to SQL. Array keys are method names to be called in this class
      *
@@ -99,6 +114,30 @@ trait SqliteDialectTrait
             case 'CURRENT_TIME':
                 $expression->name('TIME')->add(["'now'" => 'literal']);
                 break;
+            case 'EXTRACT':
+                $expression
+                    ->name('STRFTIME')
+                    ->type(' ,')
+                    ->iterateParts(function ($p, $key) {
+                        if ($key === 0) {
+                            $value = rtrim(key($p), 's');
+                            if (isset($this->_dateParts[$value])) {
+                                $p = '%' . $this->_dateParts[$value];
+                            }
+                        }
+                        return $p;
+                    });
+                break;
+            case 'DATE_ADD':
+                $expression
+                    ->name('DATE')
+                    ->type(',')
+                    ->iterateParts(function ($p, $key) {
+                        if ($key === 1) {
+                            $p = key($p);
+                        }
+                        return $p;
+                    });
         }
     }
 

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -120,9 +120,9 @@ trait SqliteDialectTrait
                     ->type(' ,')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 0) {
-                            $value = rtrim($p, 's');
+                            $value = rtrim(strtolower($p), 's');
                             if (isset($this->_dateParts[$value])) {
-                                $p = '%' . $this->_dateParts[$value];
+                                $p = ['value' => '%' . $this->_dateParts[$value], 'type' => null];
                             }
                         }
                         return $p;
@@ -142,8 +142,9 @@ trait SqliteDialectTrait
             case 'DAYOFWEEK':
                 $expression
                     ->name('STRFTIME')
-                    ->type(' ,')
-                    ->add(["'%w'" => 'literal'], [], true);
+                    ->type(' ')
+                    ->add(["'%w', " => 'literal'], [], true)
+                    ->add([') + (1' => 'literal']); // Sqlite starts on index 0 but Sunday should be 1
                 break;
         }
     }

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -138,6 +138,13 @@ trait SqliteDialectTrait
                         }
                         return $p;
                     });
+                break;
+            case 'DAYOFWEEK':
+                $expression
+                    ->name('STRFTIME')
+                    ->type(' ,')
+                    ->add(["'%w'" => 'literal'], [], true);
+                break;
         }
     }
 

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -120,7 +120,7 @@ trait SqliteDialectTrait
                     ->type(' ,')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 0) {
-                            $value = rtrim(key($p), 's');
+                            $value = rtrim($p, 's');
                             if (isset($this->_dateParts[$value])) {
                                 $p = '%' . $this->_dateParts[$value];
                             }
@@ -134,7 +134,7 @@ trait SqliteDialectTrait
                     ->type(',')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 1) {
-                            $p = key($p);
+                            $p = ['value' => $p, 'type' => null];
                         }
                         return $p;
                     });

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -241,7 +241,7 @@ trait SqlserverDialectTrait
                 break;
             case 'DATE_ADD':
                 $params = [];
-                $visitor = function ($p, $key) (&$params) {
+                $visitor = function ($p, $key) use (&$params) {
                     if ($key === 0) {
                         $params[2] = $value;
                     } else {
@@ -250,8 +250,8 @@ trait SqlserverDialectTrait
                         $params[1] = $valueUnit[0];
                     }
                     return $p;
-                });
-                $manipulator = function ($p, $key) ($params) {
+                };
+                $manipulator = function ($p, $key) use ($params) {
                     return $params[$key];
                 };
 
@@ -261,6 +261,13 @@ trait SqlserverDialectTrait
                     ->iterateParts($visitor)
                     ->iterateParts($manipulator)
                     ->add($params[2]);
+                break;
+            case 'DAYOFWEEK':
+                $expression
+                    ->name('DATEPART')
+                    ->type(' ')
+                    ->add(['weekday, ' => 'literal'], [], true)
+                    ->add([') - (1' => 'literal']); // SqlServer starts on index 1
                 break;
         }
     }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -266,8 +266,7 @@ trait SqlserverDialectTrait
                 $expression
                     ->name('DATEPART')
                     ->type(' ')
-                    ->add(['weekday, ' => 'literal'], [], true)
-                    ->add([') - (1' => 'literal']); // SqlServer starts on index 1
+                    ->add(['weekday, ' => 'literal'], [], true);
                 break;
         }
     }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -243,9 +243,9 @@ trait SqlserverDialectTrait
                 $params = [];
                 $visitor = function ($p, $key) use (&$params) {
                     if ($key === 0) {
-                        $params[2] = $value;
+                        $params[2] = $p;
                     } else {
-                        $valueUnit = explode(' ', key($p));
+                        $valueUnit = explode(' ', $p);
                         $params[0] = $valueUnit[1];
                         $params[1] = $valueUnit[0];
                     }

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -246,12 +246,12 @@ trait SqlserverDialectTrait
                         $params[2] = $p;
                     } else {
                         $valueUnit = explode(' ', $p);
-                        $params[0] = $valueUnit[1];
+                        $params[0] = rtrim($valueUnit[1], 's');
                         $params[1] = $valueUnit[0];
                     }
                     return $p;
                 };
-                $manipulator = function ($p, $key) use ($params) {
+                $manipulator = function ($p, $key) use (&$params) {
                     return $params[$key];
                 };
 
@@ -260,7 +260,7 @@ trait SqlserverDialectTrait
                     ->type(',')
                     ->iterateParts($visitor)
                     ->iterateParts($manipulator)
-                    ->add($params[2]);
+                    ->add([$params[2] => 'literal']);
                 break;
             case 'DAYOFWEEK':
                 $expression

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -236,6 +236,32 @@ trait SqlserverDialectTrait
             case 'NOW':
                 $expression->name('GETUTCDATE');
                 break;
+            case 'EXTRACT':
+                $expression->name('DATEPART')->type(' ,');
+                break;
+            case 'DATE_ADD':
+                $params = [];
+                $visitor = function ($p, $key) (&$params) {
+                    if ($key === 0) {
+                        $params[2] = $value;
+                    } else {
+                        $valueUnit = explode(' ', key($p));
+                        $params[0] = $valueUnit[1];
+                        $params[1] = $valueUnit[0];
+                    }
+                    return $p;
+                });
+                $manipulator = function ($p, $key) ($params) {
+                    return $params[$key];
+                };
+
+                $expression
+                    ->name('DATEADD')
+                    ->type(',')
+                    ->iterateParts($visitor)
+                    ->iterateParts($manipulator)
+                    ->add($params[2]);
+                break;
         }
     }
 

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -200,6 +200,32 @@ class FunctionsBuilder
     }
 
     /**
+     * Returns a FunctionExpression representing a call to SQL WEEKDAY function.
+     * 0 - Sunday, 1 - Monday, 2 - Tuesday...
+     *
+     * @param mixed $expression the function argument
+     * @param array $types list of types to bind to the arguments
+     * @return FunctionExpression
+     */
+    public function dayOfWeek($expression, $types = [])
+    {
+        return $this->_literalArgumentFunction('DAYOFWEEK', $expression, $types);
+    }
+
+    /**
+     * Returns a FunctionExpression representing a call to SQL WEEKDAY function.
+     * 0 - Sunday, 1 - Monday, 2 - Tuesday...
+     *
+     * @param mixed $expression the function argument
+     * @param array $types list of types to bind to the arguments
+     * @return FunctionExpression
+     */
+    public function weekday($expression, $types = [])
+    {
+        return $this->dayOfWeek($expression, $types);
+    }
+
+    /**
      * Returns a FunctionExpression representing a call that will return the current
      * date and time. By default it returns both date and time, but you can also
      * make it generate only the date or only the time.

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -201,7 +201,7 @@ class FunctionsBuilder
 
     /**
      * Returns a FunctionExpression representing a call to SQL WEEKDAY function.
-     * 0 - Sunday, 1 - Monday, 2 - Tuesday...
+     * 1 - Sunday, 2 - Monday, 3 - Tuesday...
      *
      * @param mixed $expression the function argument
      * @param array $types list of types to bind to the arguments
@@ -214,7 +214,7 @@ class FunctionsBuilder
 
     /**
      * Returns a FunctionExpression representing a call to SQL WEEKDAY function.
-     * 0 - Sunday, 1 - Monday, 2 - Tuesday...
+     * 1 - Sunday, 2 - Monday, 3 - Tuesday...
      *
      * @param mixed $expression the function argument
      * @param array $types list of types to bind to the arguments

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -155,6 +155,51 @@ class FunctionsBuilder
     }
 
     /**
+     * Returns the specified date part from the SQL expression.
+     *
+     * @param string $part Part of the date to return.
+     * @param string $expression Expression to obtain the date part from.
+     * @param array $types list of types to bind to the arguments
+     * @return FunctionExpression
+     */
+    public function datePart($part, $expression, $types = [])
+    {
+        return $this->extract($part, $expression);
+    }
+
+    /**
+     * Returns the specified date part from the SQL expression.
+     *
+     * @param string $part Part of the date to return.
+     * @param string $expression Expression to obtain the date part from.
+     * @param array $types list of types to bind to the arguments
+     * @return FunctionExpression
+     */
+    public function extract($part, $expression, $types = [])
+    {
+        $expression = $this->_literalArgumentFunction('EXTRACT', $expression, $types);
+        $expression->type(' FROM')->add([$part => 'literal'], [], true);
+        return $expression;
+    }
+
+    /**
+     * Add the time unit to the date expression
+     *
+     * @param string $expression Expression to obtain the date part from.
+     * @param string $value Value to be added. Use negative to substract.
+     * @param string $unit Unit of the value e.g. hour or day.
+     * @param array $types list of types to bind to the arguments
+     * @return FunctionExpression
+     */
+    public function dateAdd($expression, $value, $unit, $types = [])
+    {
+        $interval = $value . ' ' . $unit;
+        $expression = $this->_literalArgumentFunction('DATE_ADD', $expression, $types);
+        $expression->type(', INTERVAL')->add([$interval => 'literal']);
+        return $expression;
+    }
+
+    /**
      * Returns a FunctionExpression representing a call that will return the current
      * date and time. By default it returns both date and time, but you can also
      * make it generate only the date or only the time.

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -160,7 +160,7 @@ class FunctionsBuilder
      * @param string $part Part of the date to return.
      * @param string $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
-     * @return FunctionExpression
+     * @return \Cake\Database\Expression\FunctionExpression
      */
     public function datePart($part, $expression, $types = [])
     {
@@ -173,7 +173,7 @@ class FunctionsBuilder
      * @param string $part Part of the date to return.
      * @param string $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
-     * @return FunctionExpression
+     * @return \Cake\Database\Expression\FunctionExpression
      */
     public function extract($part, $expression, $types = [])
     {
@@ -189,7 +189,7 @@ class FunctionsBuilder
      * @param string $value Value to be added. Use negative to substract.
      * @param string $unit Unit of the value e.g. hour or day.
      * @param array $types list of types to bind to the arguments
-     * @return FunctionExpression
+     * @return \Cake\Database\Expression\FunctionExpression
      */
     public function dateAdd($expression, $value, $unit, $types = [])
     {
@@ -208,7 +208,7 @@ class FunctionsBuilder
      *
      * @param mixed $expression the function argument
      * @param array $types list of types to bind to the arguments
-     * @return FunctionExpression
+     * @return \Cake\Database\Expression\FunctionExpression
      */
     public function dayOfWeek($expression, $types = [])
     {
@@ -221,7 +221,7 @@ class FunctionsBuilder
      *
      * @param mixed $expression the function argument
      * @param array $types list of types to bind to the arguments
-     * @return FunctionExpression
+     * @return \Cake\Database\Expression\FunctionExpression
      */
     public function weekday($expression, $types = [])
     {
@@ -234,7 +234,7 @@ class FunctionsBuilder
      * make it generate only the date or only the time.
      *
      * @param string $type (datetime|date|time)
-     * @return FunctionExpression
+     * @return \Cake\Database\Expression\FunctionExpression
      */
     public function now($type = 'datetime')
     {

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -193,6 +193,9 @@ class FunctionsBuilder
      */
     public function dateAdd($expression, $value, $unit, $types = [])
     {
+        if (!is_numeric($value)) {
+            $value = 0;
+        }
         $interval = $value . ' ' . $unit;
         $expression = $this->_literalArgumentFunction('DATE_ADD', $expression, $types);
         $expression->type(', INTERVAL')->add([$interval => 'literal']);

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -151,4 +151,32 @@ class FunctionsBuilderTest extends TestCase
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals("CURRENT_TIME()", $function->sql(new ValueBinder));
     }
+
+    /**
+     * Tests generating a EXTRACT() function
+     *
+     * @return void
+     */
+    public function testExtract()
+    {
+        $function = $this->functions->extract('day', 'created');
+        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertEquals("EXTRACT(day FROM created)", $function->sql(new ValueBinder));
+
+        $function = $this->functions->datePart('year', 'modified');
+        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertEquals("EXTRACT(year FROM modified)", $function->sql(new ValueBinder));
+    }
+
+    /**
+     * Tests generating a DATE_ADD() function
+     *
+     * @return void
+     */
+    public function testExtract()
+    {
+        $function = $this->functions->dateAdd('created', -3, 'day');
+        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertEquals("DATE_ADD(created, INTERVAL -3 day)", $function->sql(new ValueBinder));
+    }
 }

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -173,10 +173,26 @@ class FunctionsBuilderTest extends TestCase
      *
      * @return void
      */
-    public function testExtract()
+    public function testDateAdd()
     {
         $function = $this->functions->dateAdd('created', -3, 'day');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals("DATE_ADD(created, INTERVAL -3 day)", $function->sql(new ValueBinder));
+    }
+
+    /**
+     * Tests generating a DAYOFWEEK() function
+     *
+     * @return void
+     */
+    public function testDayOfWeek()
+    {
+        $function = $this->functions->dayOfWeek('created');
+        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertEquals("DAYOFWEEK(created)", $function->sql(new ValueBinder));
+
+        $function = $this->functions->weekday('created');
+        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertEquals("DAYOFWEEK(created)", $function->sql(new ValueBinder));
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2681,7 +2681,7 @@ class QueryTest extends TestCase
                 'ye' => $query->func()->extract('year', 'created'),
                 'wd' => $query->func()->weekday('created'),
                 'dow' => $query->func()->dayOfWeek('created'),
-                'addDays' => $query->func()->dateAdd('created', +2, 'day'),
+                'addDays' => $query->func()->dateAdd('created', 2, 'day'),
                 'substractYears' => $query->func()->dateAdd('created', -2, 'year')
             ])
             ->from('comments')

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2669,6 +2669,38 @@ class QueryTest extends TestCase
             (new \DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
             1
         );
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select([
+                'd' => $query->func()->datePart('day', 'created'),
+                'm' => $query->func()->datePart('month', 'created'),
+                'y' => $query->func()->datePart('year', 'created'),
+                'de' => $query->func()->extract('day', 'created'),
+                'me' => $query->func()->extract('month', 'created'),
+                'ye' => $query->func()->extract('year', 'created'),
+                'wd' => $query->func()->weekday('created'),
+                'dow' => $query->func()->dayOfWeek('created'),
+                'addDays' => $query->func()->dateAdd('created', +2, 'days'),
+                'minusYears' => $query->func()->dateAdd('created', -2, 'years')
+            ])
+            ->from('users')
+            ->where(['username' => 'mariano'])
+            ->execute()
+            ->fetchAll('assoc');
+        $expected = [
+            'd' => '17',
+            'm' => '03',
+            'y' => '2007',
+            'de' => '17',
+            'me' => '03',
+            'ye' => '2007',
+            'wd' => '6', // Saturday
+            'dow' => '6',
+            'addDays' => '2007-03-19 01:16:23',
+            'minusYears' => '2005-03-17 01:16:23'
+        ];
+        $this->assertEquals($expected, $result[0]);
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2681,24 +2681,28 @@ class QueryTest extends TestCase
                 'ye' => $query->func()->extract('year', 'created'),
                 'wd' => $query->func()->weekday('created'),
                 'dow' => $query->func()->dayOfWeek('created'),
-                'addDays' => $query->func()->dateAdd('created', +2, 'days'),
-                'minusYears' => $query->func()->dateAdd('created', -2, 'years')
+                'addDays' => $query->func()->dateAdd('created', +2, 'day'),
+                'substractYears' => $query->func()->dateAdd('created', -2, 'year')
             ])
             ->from('users')
             ->where(['username' => 'mariano'])
             ->execute()
             ->fetchAll('assoc');
+        $result[0]['m'] = ltrim($result[0]['m'], '0');
+        $result[0]['me'] = ltrim($result[0]['me'], '0');
+        $result[0]['addDays'] = substr($result[0]['addDays'], 0, 19);
+        $result[0]['substractYears'] = substr($result[0]['substractYears'], 0, 19);
         $expected = [
             'd' => '17',
-            'm' => '03',
+            'm' => '3',
             'y' => '2007',
             'de' => '17',
-            'me' => '03',
+            'me' => '3',
             'ye' => '2007',
             'wd' => '6', // Saturday
             'dow' => '6',
             'addDays' => '2007-03-19 01:16:23',
-            'minusYears' => '2005-03-17 01:16:23'
+            'substractYears' => '2005-03-17 01:16:23'
         ];
         $this->assertEquals($expected, $result[0]);
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2699,10 +2699,10 @@ class QueryTest extends TestCase
             'de' => '18',
             'me' => '3',
             'ye' => '2007',
-            'wd' => '0', // Sunday
-            'dow' => '0',
-            'addDays' => '2007-03-20 01:16:23',
-            'substractYears' => '2005-03-18 01:16:23'
+            'wd' => '1', // Sunday
+            'dow' => '1',
+            'addDays' => '2007-03-20 10:45:23',
+            'substractYears' => '2005-03-18 10:45:23'
         ];
         $this->assertEquals($expected, $result[0]);
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2690,8 +2690,8 @@ class QueryTest extends TestCase
             ->fetchAll('assoc');
         $result[0]['m'] = ltrim($result[0]['m'], '0');
         $result[0]['me'] = ltrim($result[0]['me'], '0');
-        $result[0]['addDays'] = substr($result[0]['addDays'], 0, 19);
-        $result[0]['substractYears'] = substr($result[0]['substractYears'], 0, 19);
+        $result[0]['addDays'] = substr($result[0]['addDays'], 0, 10);
+        $result[0]['substractYears'] = substr($result[0]['substractYears'], 0, 10);
         $expected = [
             'd' => '18',
             'm' => '3',
@@ -2701,8 +2701,8 @@ class QueryTest extends TestCase
             'ye' => '2007',
             'wd' => '1', // Sunday
             'dow' => '1',
-            'addDays' => '2007-03-20 10:45:23',
-            'substractYears' => '2005-03-18 10:45:23'
+            'addDays' => '2007-03-20',
+            'substractYears' => '2005-03-18'
         ];
         $this->assertEquals($expected, $result[0]);
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2684,8 +2684,8 @@ class QueryTest extends TestCase
                 'addDays' => $query->func()->dateAdd('created', +2, 'day'),
                 'substractYears' => $query->func()->dateAdd('created', -2, 'year')
             ])
-            ->from('users')
-            ->where(['username' => 'mariano'])
+            ->from('comments')
+            ->where(['created' => '2007-03-18 10:45:23'])
             ->execute()
             ->fetchAll('assoc');
         $result[0]['m'] = ltrim($result[0]['m'], '0');
@@ -2693,16 +2693,16 @@ class QueryTest extends TestCase
         $result[0]['addDays'] = substr($result[0]['addDays'], 0, 19);
         $result[0]['substractYears'] = substr($result[0]['substractYears'], 0, 19);
         $expected = [
-            'd' => '17',
+            'd' => '18',
             'm' => '3',
             'y' => '2007',
-            'de' => '17',
+            'de' => '18',
             'me' => '3',
             'ye' => '2007',
-            'wd' => '6', // Saturday
-            'dow' => '6',
-            'addDays' => '2007-03-19 01:16:23',
-            'substractYears' => '2005-03-17 01:16:23'
+            'wd' => '0', // Sunday
+            'dow' => '0',
+            'addDays' => '2007-03-20 01:16:23',
+            'substractYears' => '2005-03-18 01:16:23'
         ];
         $this->assertEquals($expected, $result[0]);
     }


### PR DESCRIPTION
Adding
- `EXTRACT` to extract only hour/month/year from the date
- `DATEADD` to add or substract datetime units
- `DAYOFWEEK` to extract the index of the day in week (0=Sunday, 1=Monday, ...)

These functions are important for aggregations. Usually you would be able to extract these things by standart PHP functions but if you wan't to perform `GROUP BY` you need to put this into SQL.

Closes #6716

---

**Additional note:** PostgreSQL doesn't accept variables/placeholders in `GROUP BY`. So rather using `GROUP BY abs(created - DATE(:c0))` you must place the date as _literal_ `GROUP BY abs(created - DATE('2015-01-01 12:04:42'))`
