### PR TITLE
3.0 - ViewVarsTrait updates

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -180,13 +180,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public $components = [];
 
     /**
-     * The name of the View class this controller sends output to.
-     *
-     * @var string
-     */
-    public $viewClass = null;
-
-    /**
      * The path to this controllers view templates.
      * Example `Articles`
      *

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -181,21 +181,18 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
     /**
      * The path to this controllers view templates.
-     * Example `Articles`
-     *
-     * Set automatically using conventions in Controller::__construct().
+     * Example `Articles`.
      *
      * @var string
      */
     public $viewPath;
 
     /**
-     * The name of the view file to render. The name specified
-     * is the filename in /app/Template/<SubFolder> without the .ctp extension.
+     * The name of the layouts subfolder containing layouts.
      *
      * @var string
      */
-    public $view = null;
+    public $layoutPath;
 
     /**
      * Instance of the View created during rendering. Won't be set until after
@@ -213,8 +210,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @see \Cake\View\View
      */
     protected $_validViewOptions = [
-        'viewVars', 'autoLayout', 'helpers', 'view', 'layout', 'name', 'theme', 'layoutPath',
-        'viewPath', 'plugin', 'passedArgs'
+        'viewVars', 'helpers', 'name', 'layoutPath', 'viewPath', 'plugin', 'passedArgs'
     ];
 
     /**
@@ -332,11 +328,40 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function __get($name)
     {
+        if (in_array($name, ['layout', 'view', 'theme', 'autoLayout'], true)) {
+            trigger_error(
+                sprintf('Controller::$%s is deprecated. Use $this->getView()->$%s instead.', $name, $name),
+                E_USER_DEPRECATED
+            );
+            return $this->getView()->{$name};
+        }
+
         list($plugin, $class) = pluginSplit($this->modelClass, true);
         if ($class !== $name) {
             return false;
         }
         return $this->loadModel($plugin . $class);
+    }
+
+    /**
+     * Magic setter for removed properties.
+     *
+     * @param string $name Property name.
+     * @param mixed $value Value to set.
+     * @return void
+     */
+    public function __set($name, $value)
+    {
+        if (in_array($name, ['layout', 'view', 'theme', 'autoLayout'], true)) {
+            trigger_error(
+                sprintf('Controller::$%s is deprecated. Use $this->getView()->$%s instead.', $name, $name),
+                E_USER_DEPRECATED
+            );
+            $this->getView()->{$name} = $value;
+            return;
+        }
+
+        $this->{$name} = $value;
     }
 
     /**
@@ -346,12 +371,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * - $this->request - To the $request parameter
      * - $this->plugin - To the $request->params['plugin']
-     * - $this->autoRender - To false if $request->params['return'] == 1
-     * - $this->passedArgs - The combined results of params['named'] and params['pass]
-     * - View::$passedArgs - $this->passedArgs
+     * - $this->passedArgs - Same as $request->params['pass]
      * - View::$plugin - $this->plugin
-     * - View::$view - To the $request->params['action']
-     * - View::$autoLayout - To the false if $request->params['bare']; is set.
      *
      * @param \Cake\Network\Request $request Request instance.
      * @return void
@@ -360,7 +381,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         $this->request = $request;
         $this->plugin = isset($request->params['plugin']) ? $request->params['plugin'] : null;
-        $this->view = isset($request->params['action']) ? $request->params['action'] : null;
 
         if (isset($request->params['pass'])) {
             $this->passedArgs = $request->params['pass'];
@@ -542,7 +562,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function setAction($action)
     {
         $this->request->params['action'] = $action;
-        $this->view = $action;
         $args = func_get_args();
         unset($args[0]);
         return call_user_func_array([&$this, $action], $args);
@@ -575,6 +594,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $this->autoRender = false;
         $this->View = $this->getView();
+        if ($this->_view->view === null) {
+            $this->_view->view = isset($this->request->params['action']) ? $this->request->params['action'] : null;
+        }
         $this->response->body($this->_view->render($view, $layout));
         return $this->response;
     }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -202,6 +202,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Controller::render() is called.
      *
      * @var \Cake\View\View
+     * @deprecated 3.0.8 Use getView() instead.
      */
     public $View;
 
@@ -558,7 +559,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function render($view = null, $layout = null)
     {
         if (!empty($this->request->params['bare'])) {
-            $this->getView()->autoLayout = false;
+            $this->View = $this->getView();
+            $this->_view->autoLayout = false;
         }
 
         $event = $this->dispatchEvent('Controller.beforeRender');
@@ -572,7 +574,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         $this->autoRender = false;
-        $this->response->body($this->getView()->render($view, $layout));
+        $this->View = $this->getView();
+        $this->response->body($this->_view->render($view, $layout));
         return $this->response;
     }
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -322,12 +322,11 @@ class ExceptionRenderer
     protected function _outputMessageSafe($template)
     {
         $this->controller->layoutPath = null;
-        $this->controller->subDir = null;
         $this->controller->viewPath = 'Error';
-        $this->controller->layout = 'error';
         $this->controller->helpers = ['Form', 'Html'];
 
         $view = $this->controller->createView();
+        $view->layout = 'error';
         $this->controller->response->body($view->render($template, 'error'));
         $this->controller->response->type('html');
         return $this->controller->response;

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -40,6 +40,7 @@ abstract class Cell
      * Cell::__toString() is called.
      *
      * @var \Cake\View\View
+     * @deprecated 3.0.8 Use getView() instead.
      */
     public $View;
 
@@ -164,9 +165,9 @@ abstract class Cell
         if ($template === null) {
             $template = $this->template;
         }
-        $this->View = null;
-        $this->getView();
-        $this->View->layout = false;
+        $this->_view = null;
+        $this->View = $this->getView();
+        $this->_view->layout = false;
 
         $cache = [];
         if ($this->_cache) {
@@ -177,17 +178,17 @@ abstract class Cell
             $className = explode('\\', get_class($this));
             $className = array_pop($className);
             $name = substr($className, 0, strrpos($className, 'Cell'));
-            $this->View->subDir = 'Cell' . DS . $name;
+            $this->_view->subDir = 'Cell' . DS . $name;
 
             try {
-                return $this->View->render($template);
+                return $this->_view->render($template);
             } catch (MissingTemplateException $e) {
                 throw new MissingCellViewException(['file' => $template, 'name' => $name]);
             }
         };
 
         if ($cache) {
-            return $this->View->cache(function () use ($render) {
+            return $this->_view->cache(function () use ($render) {
                 echo $render();
             }, $cache);
         }

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -75,13 +75,6 @@ abstract class Cell
     public $response;
 
     /**
-     * The name of the View class this cell sends output to.
-     *
-     * @var string
-     */
-    public $viewClass = null;
-
-    /**
      * The theme name that will be used to render.
      *
      * @var string

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -58,6 +58,7 @@ trait ViewVarsTrait
     public function getView($viewClass = null)
     {
         if ($viewClass === null && $this->_view) {
+            $this->_view->viewVars = $this->viewVars;
             return $this->_view;
         }
 
@@ -81,6 +82,7 @@ trait ViewVarsTrait
         }
 
         if ($this->_view && $this->_view instanceof $className) {
+            $this->_view->viewVars = $this->viewVars;
             return $this->_view;
         }
 
@@ -109,7 +111,7 @@ trait ViewVarsTrait
         }
 
         $viewOptions = [];
-        foreach ($this->_validViewOptions as $option) {
+        foreach ($this->viewOptions() as $option) {
             if (property_exists($this, $option)) {
                 $viewOptions[$option] = $this->{$option};
             }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -26,6 +26,13 @@ trait ViewVarsTrait
 {
 
     /**
+     * The name of default View class.
+     *
+     * @var string
+     */
+    public $viewClass = null;
+
+    /**
      * Variables for the view
      *
      * @var array

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -33,6 +33,15 @@ trait ViewVarsTrait
     public $viewClass = null;
 
     /**
+     * View instance.
+     *
+     * Won't be set until after ViewVarsTrait::createView() is called.
+     *
+     * @var \Cake\View\View
+     */
+    public $_view;
+
+    /**
      * Variables for the view
      *
      * @var array
@@ -48,8 +57,8 @@ trait ViewVarsTrait
      */
     public function getView($viewClass = null)
     {
-        if ($viewClass === null && $this->View) {
-            return $this->View;
+        if ($viewClass === null && $this->_view) {
+            return $this->_view;
         }
 
         if ($viewClass === null) {
@@ -71,11 +80,11 @@ trait ViewVarsTrait
             throw new Exception\MissingViewException(['class' => $viewClass]);
         }
 
-        if ($this->View && $this->View instanceof $className) {
-            return $this->View;
+        if ($this->_view && $this->_view instanceof $className) {
+            return $this->_view;
         }
 
-        return $this->View = $this->createView();
+        return $this->_view = $this->createView();
     }
 
     /**

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -59,6 +59,11 @@ trait ViewVarsTrait
     {
         if ($viewClass === null && $this->_view) {
             $this->_view->viewVars = $this->viewVars;
+            foreach (['viewPath', 'layoutPath'] as $var) {
+                if (isset($this->{$var})) {
+                    $this->_view->{$var} = $this->{$var};
+                }
+            }
             return $this->_view;
         }
 
@@ -83,6 +88,11 @@ trait ViewVarsTrait
 
         if ($this->_view && $this->_view instanceof $className) {
             $this->_view->viewVars = $this->viewVars;
+            foreach (['viewPath', 'layoutPath'] as $var) {
+                if (isset($this->{$var})) {
+                    $this->_view->{$var} = $this->{$var};
+                }
+            }
             return $this->_view;
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -384,7 +384,7 @@ class ControllerTest extends TestCase
         $result = $Controller->render('index');
         $this->assertRegExp('/posts index/', (string)$result);
 
-        $Controller->view = 'index';
+        $Controller->getView()->view = 'index';
         $Controller->getView()->hasRendered = false;
         $result = $Controller->render();
         $this->assertRegExp('/posts index/', (string)$result);
@@ -392,7 +392,6 @@ class ControllerTest extends TestCase
         $Controller->getView()->hasRendered = false;
         $result = $Controller->render('/Element/test_element');
         $this->assertRegExp('/this is the test element/', (string)$result);
-        $Controller->view = null;
     }
 
     /**
@@ -642,7 +641,6 @@ class ControllerTest extends TestCase
         $expected = ['testId' => 1, 'test2Id' => 2];
         $this->assertSame($expected, $TestController->request->data);
         $this->assertSame('view', $TestController->request->params['action']);
-        $this->assertSame('view', $TestController->view);
     }
 
     /**

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -278,6 +278,8 @@ object(Cake\View\View) {
 	request => object(Cake\Network\Request) {}
 	response => object(Cake\Network\Response) {}
 	elementCache => 'default'
+	viewClass => null
+	_view => null
 	viewVars => []
 	Html => object(Cake\View\Helper\HtmlHelper) {}
 	Form => object(Cake\View\Helper\FormHelper) {}

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -694,11 +694,11 @@ class ExceptionRendererTest extends TestCase
     }
 
     /**
-     * Test that missing subDir/layoutPath don't cause other fatal errors.
+     * Test that missing layoutPath don't cause other fatal errors.
      *
      * @return void
      */
-    public function testMissingSubdirRenderSafe()
+    public function testMissingLayoutPathRenderSafe()
     {
         $exception = new NotFoundException();
         $ExceptionRenderer = new ExceptionRenderer($exception);
@@ -706,7 +706,6 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
         $ExceptionRenderer->controller->helpers = ['Fail', 'Boom'];
         $ExceptionRenderer->controller->layoutPath = 'boom';
-        $ExceptionRenderer->controller->subDir = 'boom';
         $ExceptionRenderer->controller->request = new Request;
 
         $ExceptionRenderer->controller->expects($this->once())
@@ -726,7 +725,6 @@ class ExceptionRendererTest extends TestCase
 
         $ExceptionRenderer->render();
         $this->assertEquals('', $ExceptionRenderer->controller->layoutPath);
-        $this->assertEquals('', $ExceptionRenderer->controller->subDir);
         $this->assertEquals('Error', $ExceptionRenderer->controller->viewPath);
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1275,8 +1275,8 @@ class ViewTest extends TestCase
      */
     public function testRenderUsingViewProperty()
     {
-        $this->PostsController->view = 'cache_form';
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
+        $View->view = 'cache_form';
 
         $this->assertEquals('cache_form', $View->view);
         $result = $View->render();
@@ -1828,10 +1828,10 @@ TEXT;
         $this->ThemeController->plugin = null;
         $this->ThemeController->name = 'Posts';
         $this->ThemeController->viewPath = 'Posts';
-        $this->ThemeController->layout = 'whatever';
-        $this->ThemeController->theme = 'TestTheme';
 
         $View = $this->ThemeController->createView();
+        $View->layout = 'whatever';
+        $View->theme = 'TestTheme';
         $View->element('test_element');
 
         $start = memory_get_usage();

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -169,14 +169,10 @@ class ViewVarsTraitTest extends TestCase
     {
         $expected = ['one' => 'one'];
         $this->subject->set($expected);
-        $this->subject->getView();
-
         $this->assertEquals($expected, $this->subject->getView()->viewVars);
 
         $expected = ['one' => 'one', 'two' => 'two'];
         $this->subject->set($expected);
-        $this->subject->getView();
-
         $this->assertEquals($expected, $this->subject->getView()->viewVars);
     }
 

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Controller\Controller;
 use Cake\TestSuite\TestCase;
 use Cake\View\ViewVarsTrait;
 
@@ -32,7 +33,7 @@ class ViewVarsTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = $this->getObjectForTrait('Cake\View\ViewVarsTrait');
+        $this->subject = new Controller;
     }
 
     /**
@@ -100,7 +101,7 @@ class ViewVarsTraitTest extends TestCase
         $option = 'newOption';
         $this->subject->viewOptions($option);
 
-        $this->assertContains($option, $this->subject->_validViewOptions);
+        $this->assertContains($option, $this->subject->viewOptions());
     }
 
     /**
@@ -110,7 +111,7 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testAddTwoViewOption()
     {
-        $this->subject->_validViewOptions = ['oldOption'];
+        $this->subject->viewOptions(['oldOption'], false);
         $option = ['newOption', 'anotherOption'];
         $result = $this->subject->viewOptions($option);
         $expects = ['oldOption', 'newOption', 'anotherOption'];
@@ -120,13 +121,13 @@ class ViewVarsTraitTest extends TestCase
     }
 
     /**
-     * test empty params reads _validViewOptions.
+     * test empty params reads _viewOptions.
      *
      * @return void
      */
     public function testReadingViewOptions()
     {
-        $expected = $this->subject->_validViewOptions = ['one', 'two', 'three'];
+        $expected = $this->subject->viewOptions(['one', 'two', 'three'], false);
         $result = $this->subject->viewOptions();
 
         $this->assertEquals($expected, $result);
@@ -139,7 +140,7 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testMergeFalseViewOptions()
     {
-        $this->subject->_validViewOptions = ['one', 'two', 'three'];
+        $this->subject->viewOptions(['one', 'two', 'three'], false);
         $expected = ['four', 'five', 'six'];
         $result = $this->subject->viewOptions($expected, false);
 
@@ -147,16 +148,36 @@ class ViewVarsTraitTest extends TestCase
     }
 
     /**
-     * test _validViewOptions is undefined and $opts is null, an empty array is returned.
+     * test _viewOptions is undefined and $opts is null, an empty array is returned.
      *
      * @return void
      */
     public function testUndefinedValidViewOptions()
     {
-        $result = $this->subject->viewOptions();
+        $result = $this->subject->viewOptions([], false);
 
         $this->assertTrue(is_array($result));
         $this->assertTrue(empty($result));
+    }
+
+    /**
+     * test that getView() updates viewVars of View instance on each call.
+     *
+     * @return void
+     */
+    public function testUptoDateViewVars()
+    {
+        $expected = ['one' => 'one'];
+        $this->subject->set($expected);
+        $this->subject->getView();
+
+        $this->assertEquals($expected, $this->subject->getView()->viewVars);
+
+        $expected = ['one' => 'one', 'two' => 'two'];
+        $this->subject->set($expected);
+        $this->subject->getView();
+
+        $this->assertEquals($expected, $this->subject->getView()->viewVars);
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -26,13 +26,6 @@ class RequestHandlerTestController extends Controller
 {
 
     /**
-     * uses property
-     *
-     * @var mixed
-     */
-    public $uses = null;
-
-    /**
      * test method for ajax redirection
      *
      * @return void
@@ -63,7 +56,7 @@ class RequestHandlerTestController extends Controller
      */
     public function ajax2_layout()
     {
-        $this->layout = 'ajax2';
+        $this->getView()->layout = 'ajax2';
         $this->destination();
     }
 }

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -24,7 +24,7 @@ class TestAppsExceptionRenderer extends ExceptionRenderer
         $response = new Response();
         try {
             $controller = new TestAppsErrorController($request, $response);
-            $controller->layout = 'banana';
+            $controller->getView()->layout = 'banana';
         } catch (\Exception $e) {
             $controller = new Controller($request, $response);
             $controller->viewPath = 'Error';


### PR DESCRIPTION
- $viewClass is now defined in ViewVarsTrait instead of implementing classes. Inline with @markstory's comment [here](https://github.com/cakephp/cakephp/pull/6788#discussion_r32285599).
- Added ViewVarsTrait::$_view and deprecated Controller::$View and Cell::$View. Better to use getters instead of public properties.
- Multiple calls to ViewVarsTrait::getView() now sets the up to date viewVars list to View instance.

This can be merged after 3.0.7 release :)
