### PR TITLE
Explicit definition of the code coverage

### DIFF
--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -23,6 +23,7 @@ App::uses('Folder', 'Utility');
  * FileTest class
  *
  * @package       Cake.Test.Case.Utility
+ * @coversDefaultClass File
  */
 class FileTest extends CakeTestCase {
 
@@ -62,6 +63,15 @@ class FileTest extends CakeTestCase {
  * testBasic method
  *
  * @return void
+ * @covers ::__construct
+ * @covers ::info
+ * @covers ::ext
+ * @covers ::name
+ * @covers ::md5
+ * @covers ::size
+ * @covers ::owner
+ * @covers ::group
+ * @covers ::Folder
  */
 	public function testBasic() {
 		$file = CAKE . DS . 'LICENSE.txt';
@@ -126,6 +136,7 @@ class FileTest extends CakeTestCase {
  * testPermission method
  *
  * @return void
+ * @covers ::perms
  */
 	public function testPermission() {
 		$this->skipIf(DIRECTORY_SEPARATOR === '\\', 'File permissions tests not supported on Windows.');
@@ -172,6 +183,7 @@ class FileTest extends CakeTestCase {
  * testRead method
  *
  * @return void
+ * @covers ::read
  */
 	public function testRead() {
 		$file = __FILE__;
@@ -203,6 +215,7 @@ class FileTest extends CakeTestCase {
  * testOffset method
  *
  * @return void
+ * @covers ::offset
  */
 	public function testOffset() {
 		$this->File->close();
@@ -235,6 +248,7 @@ class FileTest extends CakeTestCase {
  * testOpen method
  *
  * @return void
+ * @covers ::open
  */
 	public function testOpen() {
 		$this->File->handle = null;
@@ -259,6 +273,7 @@ class FileTest extends CakeTestCase {
  * testClose method
  *
  * @return void
+ * @covers ::close
  */
 	public function testClose() {
 		$this->File->handle = null;
@@ -276,6 +291,9 @@ class FileTest extends CakeTestCase {
  * testCreate method
  *
  * @return void
+ * @covers ::create
+ * @covers ::exists
+ * @covers ::clearStatCache
  */
 	public function testCreate() {
 		$tmpFile = TMP . 'tests' . DS . 'cakephp.file.test.tmp';
@@ -287,6 +305,8 @@ class FileTest extends CakeTestCase {
  * testOpeningNonExistentFileCreatesIt method
  *
  * @return void
+ * @covers ::open
+ * @covers ::create
  */
 	public function testOpeningNonExistentFileCreatesIt() {
 		$someFile = new File(TMP . 'some_file.txt', false);
@@ -300,6 +320,7 @@ class FileTest extends CakeTestCase {
  * testPrepare method
  *
  * @return void
+ * @covers ::prepare
  */
 	public function testPrepare() {
 		$string = "some\nvery\ncool\r\nteststring here\n\n\nfor\r\r\n\n\r\n\nhere";
@@ -320,6 +341,7 @@ class FileTest extends CakeTestCase {
  * testReadable method
  *
  * @return void
+ * @covers ::readable
  */
 	public function testReadable() {
 		$someFile = new File(TMP . 'some_file.txt', false);
@@ -333,6 +355,7 @@ class FileTest extends CakeTestCase {
  * testWritable method
  *
  * @return void
+ * @covers ::writable
  */
 	public function testWritable() {
 		$someFile = new File(TMP . 'some_file.txt', false);
@@ -346,6 +369,7 @@ class FileTest extends CakeTestCase {
  * testExecutable method
  *
  * @return void
+ * @covers ::executable
  */
 	public function testExecutable() {
 		$someFile = new File(TMP . 'some_file.txt', false);
@@ -359,6 +383,7 @@ class FileTest extends CakeTestCase {
  * testLastAccess method
  *
  * @return void
+ * @covers ::lastAccess
  */
 	public function testLastAccess() {
 		$someFile = new File(TMP . 'some_file.txt', false);
@@ -373,6 +398,7 @@ class FileTest extends CakeTestCase {
  * testLastChange method
  *
  * @return void
+ * @covers ::lastChange
  */
 	public function testLastChange() {
 		$someFile = new File(TMP . 'some_file.txt', false);
@@ -391,6 +417,7 @@ class FileTest extends CakeTestCase {
  * testWrite method
  *
  * @return void
+ * @covers ::write
  */
 	public function testWrite() {
 		if (!$tmpFile = $this->_getTmpFile()) {
@@ -421,6 +448,7 @@ class FileTest extends CakeTestCase {
  * testAppend method
  *
  * @return void
+ * @covers ::append
  */
 	public function testAppend() {
 		if (!$tmpFile = $this->_getTmpFile()) {
@@ -457,6 +485,7 @@ class FileTest extends CakeTestCase {
  * testDelete method
  *
  * @return void
+ * @covers ::delete
  */
 	public function testDelete() {
 		if (!$tmpFile = $this->_getTmpFile()) {
@@ -482,6 +511,7 @@ class FileTest extends CakeTestCase {
  * active filehandles open.
  *
  * @return void
+ * @covers ::delete
  */
 	public function testDeleteAfterRead() {
 		if (!$tmpFile = $this->_getTmpFile()) {
@@ -499,6 +529,7 @@ class FileTest extends CakeTestCase {
  * testCopy method
  *
  * @return void
+ * @covers ::copy
  */
 	public function testCopy() {
 		$dest = TMP . 'tests' . DS . 'cakephp.file.test.tmp';
@@ -527,6 +558,7 @@ class FileTest extends CakeTestCase {
  * Test mime()
  *
  * @return void
+ * @covers ::mime
  */
 	public function testMime() {
 		$this->skipIf(!function_exists('finfo_open') && !function_exists('mime_content_type'), 'Not able to read mime type');
@@ -566,6 +598,7 @@ class FileTest extends CakeTestCase {
  * testReplaceText method
  *
  * @return void
+ * @covers ::replaceText
  */
 	public function testReplaceText() {
 		$TestFile = new File(dirname(__FILE__) . '/../../test_app/Vendor/welcome.php');
@@ -603,6 +636,7 @@ class FileTest extends CakeTestCase {
  * do not exist.
  *
  * @return void
+ * @covers ::pwd
  */
 	public function testNoPartialPathBeingSetForNonExistentPath() {
 		$tmpFile = new File('/non/existent/file');


### PR DESCRIPTION
Refs: #2109 

Using `@coversDefaultClass`, `@covers` and possibly in some cases `@coversNothing`.

https://phpunit.de/manual/3.7/en/appendixes.annotations.html#appendixes.annotations.covers

This is just the start and kind of a proof of feasibility.
Yes this is done by hand and thus this will be tedious, but worthwhile in sense of we finally get a picture of what we **actually** covered with tests and not just a percentage number that means not much.

For example `File::safe()` was only covered implicitly and was not tested through an assertion...

I targeted 2.7 because I plan to go through the classes one by one.
This way we don't need to merge it from 2.6.x.
But that does not mean we have to wait with the release until i'm finished. :laughing: 
