### PR TITLE
set or disable fallback domain for i18n

### DIFF
--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -118,19 +118,11 @@ class I18n
     public static function translator($name = 'default', $locale = null, callable $loader = null)
     {
         if ($loader !== null) {
-            $packages = static::translators()->getPackages();
             $locale = $locale ?: static::locale();
 
-            if ($name !== 'default') {
-                $loader = function () use ($loader) {
-                    $package = $loader();
-                    if (!$package->getFallback()) {
-                        $package->setFallback('default');
-                    }
-                    return $package;
-                };
-            }
+            $loader = static::translators()->setLoaderFallback($name, $loader);
 
+            $packages = static::translators()->getPackages();
             $packages->set($name, $locale, $loader);
             return;
         }

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -238,6 +238,20 @@ class I18n
     }
 
     /**
+     * Set default fallback domain. If a domain can't provide a translation
+     * messages from the fallback domain are used.
+     *
+     * Get the currently set domain if argument is null.
+     *
+     * @param string|null $name name of the fallback-translator
+     * @return string
+     */
+    public static function defaultFallbackDomain($name = null)
+    {
+        return static::translators()->defaultFallbackDomain($name);
+    }
+
+    /**
      * Sets the name of the default messages formatter to use for future
      * translator instances. By default the `default` and `sprintf` formatters
      * are available.

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -238,20 +238,6 @@ class I18n
     }
 
     /**
-     * Set default fallback domain. If a domain can't provide a translation
-     * messages from the fallback domain are used.
-     *
-     * Get the currently set domain if argument is null.
-     *
-     * @param string|null $name name of the fallback-translator
-     * @return string
-     */
-    public static function defaultFallbackDomain($name = null)
-    {
-        return static::translators()->defaultFallbackDomain($name);
-    }
-
-    /**
      * Sets the name of the default messages formatter to use for future
      * translator instances. By default the `default` and `sprintf` formatters
      * are available.
@@ -267,14 +253,14 @@ class I18n
     }
 
     /**
-     * Set if the default domain fallback is used.
+     * Set if the domain fallback is used.
      *
      * @param bool $enable flag to enable or disable fallback
      * @return void
      */
-    public static function useTranslationFallback($enable = true)
+    public static function useFallback($enable = true)
     {
-        static::translators()->useTranslationFallback($enable);
+        static::translators()->useFallback($enable);
     }
 
     /**

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -113,7 +113,7 @@ class I18n
      * @param string|null $locale The locale for the translator.
      * @param callable|null $loader A callback function or callable class responsible for
      * constructing a translations package instance.
-     * @return \Aura\Intl\Translator The configured translator.
+     * @return \Aura\Intl\Translator|void The configured translator.
      */
     public static function translator($name = 'default', $locale = null, callable $loader = null)
     {

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -267,6 +267,17 @@ class I18n
     }
 
     /**
+     * Set if the default domain fallback is used.
+     *
+     * @param bool $enable flag to enable or disable fallback
+     * @return void
+     */
+    public static function useTranslationFallback($enable = true)
+    {
+        static::translators()->useTranslationFallback($enable);
+    }
+
+    /**
      * Destroys all translator instances and creates a new empty translations
      * collection.
      *

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -174,10 +174,12 @@ class TranslatorRegistry extends TranslatorLocator
      * @param string|null $name fallback domain
      * @return string
      */
-    public function defaultFallbackDomain($name = null) {
+    public function defaultFallbackDomain($name = null)
+    {
         if ($name === null) {
             return $this->_defaultFallbackDomain;
         }
+
         return $this->_defaultFallbackDomain = $name;
     }
 
@@ -252,7 +254,8 @@ class TranslatorRegistry extends TranslatorLocator
      * @param callable $loader invokable loader
      * @return callable loader
      */
-    public function setLoaderFallback($name, callable $loader) {
+    public function setLoaderFallback($name, callable $loader)
+    {
         if ($name !== $this->_defaultFallbackDomain) {
             $loader = function () use ($loader) {
                 $package = $loader();

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -43,6 +43,17 @@ class TranslatorRegistry extends TranslatorLocator
     protected $_defaultFormatter = 'default';
 
     /**
+     * Domain used used as fallback if translation isn't found in specified domain.
+     *
+     * - true: 'default'
+     * - false: disable translation fallback
+     * - string: fallback domain name
+     *
+     * @var string|bool
+     */
+    protected $_defaultFallbackDomain = 'default';
+
+    /**
      * A CacheEngine object that is used to remember translator across
      * requests.
      *
@@ -155,6 +166,22 @@ class TranslatorRegistry extends TranslatorLocator
     }
 
     /**
+     * Set fallback domain. Messages from the fallback domain are used if
+     * a domain can't provide a localization message.
+     *
+     * Get the currently set domain if argument is null.
+     *
+     * @param string|null $name fallback domain
+     * @return string
+     */
+    public function defaultFallbackDomain($name = null) {
+        if ($name === null) {
+            return $this->_defaultFallbackDomain;
+        }
+        return $this->_defaultFallbackDomain = $name;
+    }
+
+    /**
      * Returns a new translator instance for the given name and locale
      * based of conventions.
      *
@@ -226,11 +253,15 @@ class TranslatorRegistry extends TranslatorLocator
      * @return callable loader
      */
     public function setLoaderFallback($name, callable $loader) {
-        if ($name !== 'default') {
+        if ($name !== $this->_defaultFallbackDomain) {
             $loader = function () use ($loader) {
                 $package = $loader();
-                if (!$package->getFallback()) {
-                    $package->setFallback('default');
+                if ($this->_defaultFallbackDomain !== false && !$package->getFallback()) {
+                    $fallback = $this->_defaultFallbackDomain;
+                    if ($fallback === true) {
+                        $fallback = 'default';
+                    }
+                    $package->setFallback($fallback);
                 }
                 return $package;
             };

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -212,6 +212,20 @@ class TranslatorRegistry extends TranslatorLocator
             };
         }
 
+        $loader = $this->setLoaderFallback($name, $loader);
+
+        $this->packages->set($name, $locale, $loader);
+        return parent::get($name, $locale);
+    }
+
+    /**
+     * set lookup fallback for loader
+     *
+     * @param string $name The name of the fallback domain
+     * @param callable $loader invokable loader
+     * @return callable loader
+     */
+    public function setLoaderFallback($name, callable $loader) {
         if ($name !== 'default') {
             $loader = function () use ($loader) {
                 $package = $loader();
@@ -221,8 +235,6 @@ class TranslatorRegistry extends TranslatorLocator
                 return $package;
             };
         }
-
-        $this->packages->set($name, $locale, $loader);
-        return parent::get($name, $locale);
+        return $loader;
     }
 }

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -43,13 +43,6 @@ class TranslatorRegistry extends TranslatorLocator
     protected $_defaultFormatter = 'default';
 
     /**
-     * Domain used as fallback if translation isn't found in original domain
-     *
-     * @var string
-     */
-    protected $_defaultFallbackDomain = 'default';
-
-    /**
      * Enable translation fallback
      *
      * @var bool
@@ -169,30 +162,12 @@ class TranslatorRegistry extends TranslatorLocator
     }
 
     /**
-     * Set fallback domain. Messages from the fallback domain are used if
-     * a domain can't provide a localization message.
-     *
-     * Get the currently set domain if argument is null.
-     *
-     * @param string|null $name fallback domain
-     * @return string
-     */
-    public function defaultFallbackDomain($name = null)
-    {
-        if ($name === null) {
-            return $this->_defaultFallbackDomain;
-        }
-
-        return $this->_defaultFallbackDomain = $name;
-    }
-
-    /**
      * Set if the default domain fallback is used.
      *
      * @param bool $enable flag to enable or disable fallback
      * @return void
      */
-    public function useTranslationFallback($enable = true)
+    public function useFallback($enable = true)
     {
         $this->_fallback = $enable;
     }
@@ -264,19 +239,20 @@ class TranslatorRegistry extends TranslatorLocator
     /**
      * Set domain fallback for loader.
      *
-     * @param string $name The name of the fallback domain
+     * @param string $name The name of the loader domain
      * @param callable $loader invokable loader
      * @return callable loader
      */
     public function setLoaderFallback($name, callable $loader)
     {
-        if (!$this->_fallback || $name === $this->_defaultFallbackDomain) {
+        $fallbackDomain = 'default';
+        if (!$this->_fallback || $name === $fallbackDomain) {
             return $loader;
         }
-        $loader = function () use ($loader) {
+        $loader = function () use ($loader, $fallbackDomain) {
             $package = $loader();
             if (!$package->getFallback()) {
-                $package->setFallback($this->_defaultFallbackDomain);
+                $package->setFallback($fallbackDomain);
             }
             return $package;
         };

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -43,11 +43,11 @@ class TranslatorRegistry extends TranslatorLocator
     protected $_defaultFormatter = 'default';
 
     /**
-     * Enable translation fallback
+     * Use fallback-domain for translation loaders.
      *
      * @var bool
      */
-    protected $_fallback = true;
+    protected $_useFallback = true;
 
     /**
      * A CacheEngine object that is used to remember translator across
@@ -169,7 +169,7 @@ class TranslatorRegistry extends TranslatorLocator
      */
     public function useFallback($enable = true)
     {
-        $this->_fallback = $enable;
+        $this->_useFallback = $enable;
     }
 
     /**
@@ -246,7 +246,7 @@ class TranslatorRegistry extends TranslatorLocator
     public function setLoaderFallback($name, callable $loader)
     {
         $fallbackDomain = 'default';
-        if (!$this->_fallback || $name === $fallbackDomain) {
+        if (!$this->_useFallback || $name === $fallbackDomain) {
             return $loader;
         }
         $loader = function () use ($loader, $fallbackDomain) {

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -524,17 +524,13 @@ class I18nTest extends TestCase
         I18n::translator('default', 'en_US', function () {
             $package = new Package('default');
             $package->setMessages(['Dog' => 'bark']);
-
             return $package;
         });
-        I18n::translator('custom', 'en_US',
-            function () {
-                $package = new Package('default');
-                $package->setMessages([]);
-
-                return $package;
-            }
-        );
+        I18n::translator('custom', 'en_US', function () {
+            $package = new Package('default');
+            $package->setMessages([]);
+            return $package;
+        });
         $result = __d('custom', 'Dog');
         $this->assertEquals('Dog', $result);
     }
@@ -551,21 +547,16 @@ class I18nTest extends TestCase
         I18n::translator($customDomain, 'en_US', function () {
             $package = new Package('default');
             $package->setMessages(['Dog' => 'bark']);
-
             return $package;
         });
-        I18n::translator('custom', 'en_US',
-            function () {
-                $package = new Package('default');
-                $package->setMessages([]);
-
-                return $package;
-            }
-        );
+        I18n::translator('custom', 'en_US', function () {
+            $package = new Package('default');
+            $package->setMessages([]);
+            return $package;
+        });
         $result = __d('custom', 'Dog');
         $this->assertEquals('bark', $result);
     }
-
 
     /**
      * Tests that it is possible to register a generic translators factory for a domain

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -520,7 +520,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackTranslatorDisabled()
     {
-        I18n::useTranslationFallback(false);
+        I18n::useFallback(false);
 
         I18n::translator('default', 'fr_FR', function () {
             $package = new Package('default');
@@ -537,36 +537,6 @@ class I18nTest extends TestCase
         $translator = I18n::translator('custom', 'fr_FR');
         $this->assertEquals('Le moo', $translator->translate('Cow'));
         $this->assertEquals('Dog', $translator->translate('Dog'));
-    }
-
-    /**
-     * Test that a different fallback domain can be set
-     *
-     * @return void
-     */
-    public function testFallbackTranslatorSetFallbackDomain()
-    {
-        $this->assertEquals('default', I18n::defaultFallbackDomain());
-
-        $fallbackDomain = 'foo';
-        I18n::defaultFallbackDomain($fallbackDomain);
-        $this->assertEquals($fallbackDomain, I18n::defaultFallbackDomain());
-
-        I18n::translator($fallbackDomain, 'fr_FR', function () {
-            $package = new Package('default');
-            $package->setMessages(['Dog' => 'Le bark']);
-            return $package;
-        });
-
-        I18n::translator('custom', 'fr_FR', function () {
-            $package = new Package('default');
-            $package->setMessages(['Cow' => 'Le moo']);
-            return $package;
-        });
-
-        $translator = I18n::translator('custom', 'fr_FR');
-        $this->assertEquals('Le moo', $translator->translate('Cow'));
-        $this->assertEquals('Le bark', $translator->translate('Dog'));
     }
 
     /**

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -514,48 +514,59 @@ class I18nTest extends TestCase
     }
 
     /**
-     * Test that the fallback translators can be disabled
+     * Test that the translation fallback can be disabled
      *
      * @return void
      */
-    public function testFallbackTranslatorFallbackDisabled()
+    public function testFallbackTranslatorDisabled()
     {
-        I18n::defaultFallbackDomain(false);
-        I18n::translator('default', 'en_US', function () {
+        I18n::useTranslationFallback(false);
+
+        I18n::translator('default', 'fr_FR', function () {
             $package = new Package('default');
-            $package->setMessages(['Dog' => 'bark']);
+            $package->setMessages(['Dog' => 'Le bark']);
             return $package;
         });
-        I18n::translator('custom', 'en_US', function () {
+
+        I18n::translator('custom', 'fr_FR', function () {
             $package = new Package('default');
-            $package->setMessages([]);
+            $package->setMessages(['Cow' => 'Le moo']);
             return $package;
         });
-        $result = __d('custom', 'Dog');
-        $this->assertEquals('Dog', $result);
+
+        $translator = I18n::translator('custom', 'fr_FR');
+        $this->assertEquals('Le moo', $translator->translate('Cow'));
+        $this->assertEquals('Dog', $translator->translate('Dog'));
     }
 
     /**
-     * Test that an arbitrary fallback domain can be set
+     * Test that a different fallback domain can be set
      *
      * @return void
      */
-    public function testFallbackTranslatorCustomDomain()
+    public function testFallbackTranslatorSetFallbackDomain()
     {
-        $customDomain = 'foo';
-        I18n::defaultFallbackDomain($customDomain);
-        I18n::translator($customDomain, 'en_US', function () {
+        $this->assertEquals('default', I18n::defaultFallbackDomain());
+
+        $fallbackDomain = 'foo';
+        I18n::defaultFallbackDomain($fallbackDomain);
+        $this->assertEquals($fallbackDomain, I18n::defaultFallbackDomain());
+
+        I18n::translator($fallbackDomain, 'fr_FR', function () {
             $package = new Package('default');
-            $package->setMessages(['Dog' => 'bark']);
+            $package->setMessages(['Dog' => 'Le bark']);
             return $package;
         });
-        I18n::translator('custom', 'en_US', function () {
+
+        I18n::translator('custom', 'fr_FR', function () {
             $package = new Package('default');
-            $package->setMessages([]);
+            $package->setMessages(['Cow' => 'Le moo']);
             return $package;
         });
-        $result = __d('custom', 'Dog');
-        $this->assertEquals('bark', $result);
+
+        $translator = I18n::translator('custom', 'fr_FR');
+        $this->assertEquals('Le moo', $translator->translate('Cow'));
+        $this->assertEquals('Le bark', $translator->translate('Dog'));
     }
 
     /**

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -514,6 +514,60 @@ class I18nTest extends TestCase
     }
 
     /**
+     * Test that the fallback translators can be disabled
+     *
+     * @return void
+     */
+    public function testFallbackTranslatorFallbackDisabled()
+    {
+        I18n::defaultFallbackDomain(false);
+        I18n::translator('default', 'en_US', function () {
+            $package = new Package('default');
+            $package->setMessages(['Dog' => 'bark']);
+
+            return $package;
+        });
+        I18n::translator('custom', 'en_US',
+            function () {
+                $package = new Package('default');
+                $package->setMessages([]);
+
+                return $package;
+            }
+        );
+        $result = __d('custom', 'Dog');
+        $this->assertEquals('Dog', $result);
+    }
+
+    /**
+     * Test that an arbitrary fallback domain can be set
+     *
+     * @return void
+     */
+    public function testFallbackTranslatorCustomDomain()
+    {
+        $customDomain = 'foo';
+        I18n::defaultFallbackDomain($customDomain);
+        I18n::translator($customDomain, 'en_US', function () {
+            $package = new Package('default');
+            $package->setMessages(['Dog' => 'bark']);
+
+            return $package;
+        });
+        I18n::translator('custom', 'en_US',
+            function () {
+                $package = new Package('default');
+                $package->setMessages([]);
+
+                return $package;
+            }
+        );
+        $result = __d('custom', 'Dog');
+        $this->assertEquals('bark', $result);
+    }
+
+
+    /**
      * Tests that it is possible to register a generic translators factory for a domain
      * instead of having to create them manually
      *


### PR DESCRIPTION
Introduces a `I18n::defaultFallbackDomain()` to set or get the default domain for translation fallback. Currently the fallback domain is hardcoded to "default".

My personal interest is to disable the fallback. I was puzzled why translation cache files for plugins were dozens of kB when they should be only a few bytes. Apparently the fallback is serialized into every translation cache file. So depending on how big the default domain is and how many languages and localized plugins are used it adds up.
