### PR TITLE
delete enum

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -786,9 +786,6 @@ class Mysql extends DboSource {
 		if (strpos($col, 'decimal') !== false || strpos($col, 'numeric') !== false) {
 			return 'decimal';
 		}
-		if (strpos($col, 'enum') !== false) {
-			return "enum($vals)";
-		}
 		if (strpos($col, 'set') !== false) {
 			return "set($vals)";
 		}


### PR DESCRIPTION
CakePHP is not support enum.
But there is enum in Mysql.php.
So I guess this enum must be deleted.
