### PR TITLE
Fixing issue in contain/mathching regarding dot notation

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -281,7 +281,10 @@ class EagerLoader
                 $options = isset($options['config']) ?
                     $options['config'] + $options['associations'] :
                     $options;
-                $options = $this->_reformatContain($options, []);
+                $options = $this->_reformatContain(
+                    $options,
+                    isset($pointer[$table]) ? $pointer[$table] : []
+                );
             }
 
             if ($options instanceof Closure) {

--- a/tests/Fixture/SpecialTagsFixture.php
+++ b/tests/Fixture/SpecialTagsFixture.php
@@ -47,7 +47,7 @@ class SpecialTagsFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['article_id' => 1, 'tag_id' => 3, 'highlighted' => false, 'highlighted_time' => null, 'author_id' => null],
-        ['article_id' => 2, 'tag_id' => 1, 'highlighted' => true, 'highlighted_time' => '2014-06-01 10:10:00', 'author_id' => null]
+        ['article_id' => 1, 'tag_id' => 3, 'highlighted' => false, 'highlighted_time' => null, 'author_id' => 1],
+        ['article_id' => 2, 'tag_id' => 1, 'highlighted' => true, 'highlighted_time' => '2014-06-01 10:10:00', 'author_id' => 2]
     ];
 }


### PR DESCRIPTION
Previously it was impossible to use dot notation on two
different calls to matching/contain when part of the string was
shared (for example Articles.SpecialTags.Tags and Articles.SpecialTags.Authors)

The issue was that the second call would override the settings
created for the first one.
