### PR TITLE
Fix TableRegistry::get() when merging pre-configured alias options

### DIFF
--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -184,7 +184,7 @@ class TableRegistry
         }
 
         if (isset(static::$_config[$alias])) {
-            $options += static::$_config[$alias];
+            $options = array_merge($options, static::$_config[$alias]);
         }
         if (empty($options['connection'])) {
             $connectionName = $options['className']::defaultConnectionName();

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -184,7 +184,7 @@ class TableRegistry
         }
 
         if (isset(static::$_config[$alias])) {
-            $options = array_merge($options, static::$_config[$alias]);
+            $options = static::$_config[$alias] + $options;
         }
         if (empty($options['connection'])) {
             $connectionName = $options['className']::defaultConnectionName();

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -169,6 +169,10 @@ class TableRegistry
         list(, $classAlias) = pluginSplit($alias);
         $options = ['alias' => $classAlias] + $options;
 
+        if (isset(static::$_config[$alias])) {
+            $options += static::$_config[$alias];
+        }
+
         if (empty($options['className'])) {
             $options['className'] = Inflector::camelize($alias);
         }
@@ -183,9 +187,6 @@ class TableRegistry
             $options['className'] = 'Cake\ORM\Table';
         }
 
-        if (isset(static::$_config[$alias])) {
-            $options = static::$_config[$alias] + $options;
-        }
         if (empty($options['connection'])) {
             $connectionName = $options['className']::defaultConnectionName();
             $options['connection'] = ConnectionManager::get($connectionName);

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -223,6 +223,20 @@ class TableRegistryTest extends TestCase
     }
 
     /**
+     * Test that get() uses config data `className` set with config()
+     *
+     * @return void
+     */
+    public function testGetWithConfigClassName()
+    {
+        TableRegistry::config('MyUsersTableAlias', [
+            'className' => '\Cake\Test\TestCase\ORM\MyUsersTable',
+        ]);
+        $result = TableRegistry::get('MyUsersTableAlias');
+        $this->assertInstanceOf('\Cake\Test\TestCase\ORM\MyUsersTable', $result, 'Should use config() data className option.');
+    }
+
+    /**
      * Test get with config throws an exception if the alias exists already.
      *
      * @expectedException \RuntimeException


### PR DESCRIPTION
Fixes bug that prevented `TableRegistry::get($alias)` from merging alias options set earlier via `TableRegistry::config($alias, ...)`. See https://gist.github.com/codeguy/1d2fdbe5aafa3d339e7c#comment-1474088 for details.

All unit tests pass.
