### PR TITLE
Making HelperRegistry accept a ConsoleIO in a setter

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -107,7 +107,8 @@ class ConsoleIo
         $this->_out = $out ? $out : new ConsoleOutput('php://stdout');
         $this->_err = $err ? $err : new ConsoleOutput('php://stderr');
         $this->_in = $in ? $in : new ConsoleInput('php://stdin');
-        $this->_helpers = $helpers ? $helpers : new HelperRegistry($this);
+        $this->_helpers = $helpers ? $helpers : new HelperRegistry();
+        $this->_helpers->setIo($this);
     }
 
     /**

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -34,11 +34,11 @@ class HelperRegistry extends ObjectRegistry
     protected $_io;
 
     /**
-     * Constructor
+     * Sets The IO instance that should be passed to the shell helpers
      *
      * @param \Cake\Console\ConsoleIo $io An io instance.
      */
-    public function __construct(ConsoleIo $io)
+    public function setIo(ConsoleIo $io)
     {
         $this->_io = $io;
     }

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -37,6 +37,7 @@ class HelperRegistry extends ObjectRegistry
      * Sets The IO instance that should be passed to the shell helpers
      *
      * @param \Cake\Console\ConsoleIo $io An io instance.
+     * @return void
      */
     public function setIo(ConsoleIo $io)
     {

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -35,7 +35,8 @@ class HelperRegistryTest extends TestCase
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
         $io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
-        $this->helpers = new HelperRegistry($io);
+        $this->helpers = new HelperRegistry();
+        $this->helpers->setIo($io);
     }
 
     /**


### PR DESCRIPTION
Passing it in the constructor was problematic as both classes depend on each other.

The problem was evident when I tried to use the https://github.com/lorenzo/piping-bag plugin. Since it will to inject all dependencies form the outside, it was impossible to construct one object without the other.
