### PR TITLE
foreignKey function does not work as expected

### DIFF
--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -57,7 +57,7 @@ trait ExternalAssociationTrait
     {
         if ($key === null) {
             if ($this->_foreignKey === null) {
-                $this->_foreignKey = $this->_modelKey($this->source()->table());
+                $this->_foreignKey = $this->_modelKey($this->source()->alias());
             }
             return $this->_foreignKey;
         }


### PR DESCRIPTION
foreignKey function does not set correctly _foreignKey attribute. It calls table() instead alias() function
