### PR TITLE
Allow empty sortWhitelist to not allow sorting at all.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -115,6 +115,8 @@ class PaginatorComponent extends Component
      * ];
      * ```
      *
+     * Passing an empty array as whitelist disallows sorting altogether.
+     *
      * ### Paginating with custom finders
      *
      * You can paginate with any find type defined on your table using the `finder` option.
@@ -319,7 +321,7 @@ class PaginatorComponent extends Component
         }
 
         $inWhitelist = false;
-        if (!empty($options['sortWhitelist'])) {
+        if (isset($options['sortWhitelist'])) {
             $field = key($options['order']);
             $inWhitelist = in_array($field, $options['sortWhitelist'], true);
             if (!$inWhitelist) {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -575,6 +575,34 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
+     * test that whitelist as empty array does not allow any sorting
+     *
+     * @return void
+     */
+    public function testValidateSortWhitelistEmpty()
+    {
+        $model = $this->getMock('Cake\ORM\Table');
+        $model->expects($this->any())
+            ->method('alias')
+            ->will($this->returnValue('model'));
+        $model->expects($this->any())->method('hasField')
+            ->will($this->returnValue(true));
+
+        $options = [
+            'order' => [
+                'body' => 'asc',
+                'foo.bar' => 'asc'
+            ],
+            'sort' => 'body',
+            'direction' => 'asc',
+            'sortWhitelist' => []
+        ];
+        $result = $this->Paginator->validateSort($model, $options);
+
+        $this->assertSame([], $result['order'], 'No sort should be applied');
+    }
+
+    /**
      * test that fields in the whitelist are not validated
      *
      * @return void


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/6843
