### PR TITLE
Issue 6835 - Adding ids option support for hasMany/belongsToMany associations

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -223,6 +223,9 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->one($value, (array)$options);
         }
+        if($this->_isAssociatedByIdsInvalid($assoc, $value, (array)$options)){
+            return [];
+        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
         }
@@ -374,6 +377,13 @@ class Marshaller
         }
 
         return $target->find()->where($filter)->toArray();
+    }
+
+    protected function _isAssociatedByIdsInvalid($assoc, $value, $options){
+        if($assoc->type() === Association::MANY_TO_MANY || $assoc->type() === Association::ONE_TO_MANY){
+            return array_key_exists('ids', $options) && $options['ids'] && !array_key_exists('_ids', $value);
+        }
+        return false;
     }
 
     /**
@@ -593,6 +603,9 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->merge($original, $value, (array)$options);
         }
+        if($this->_isAssociatedByIdsInvalid($assoc, $value, (array)$options)){
+            return [];
+        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_mergeBelongsToMany($original, $assoc, $value, (array)$options);
         }
@@ -613,12 +626,11 @@ class Marshaller
     {
         $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
-        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
 
         if ($hasIds && is_array($value['_ids'])) {
             return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds || $_ids) {
+        if ($hasIds) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -224,11 +224,11 @@ class Marshaller
             return $marshaller->one($value, (array)$options);
         }
         if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
-            $hasIds = array_key_exists('_ids', $data);
+            $hasIds = array_key_exists('_ids', $value);
             $idsOption = array_key_exists('ids', $options) && $options['ids'];
 
-            if ($hasIds && is_array($data['_ids'])) {
-                return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+            if ($hasIds && is_array($value['_ids'])) {
+                return $this->_loadAssociatedByIds($assoc, $value['_ids']);
             }
             if ($hasIds || $idsOption) {
                 return [];
@@ -614,11 +614,11 @@ class Marshaller
     {
         $associated = isset($options['associated']) ? $options['associated'] : [];
 
-        $hasIds = array_key_exists('_ids', $data);
+        $hasIds = array_key_exists('_ids', $value);
         $idsOption = array_key_exists('ids', $options) && $options['ids'];
 
-        if ($hasIds && is_array($data['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+        if ($hasIds && is_array($value['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
         if ($hasIds || $idsOption) {
             return [];

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -86,6 +86,10 @@ class Marshaller
     /**
      * Hydrate one entity and its associated data.
      *
+     * When marshalling HasMany or BelongsToMany associations, `_ids` format can be used.
+     * `ids` option can also be used to determine whether the association must use the `_ids` 
+     * format.
+     *
      * ### Options:
      *
      * * associated: Associations listed here will be marshalled as well.
@@ -233,7 +237,7 @@ class Marshaller
             if ($hasIds || $idsOption) {
                 return [];
             }
-        }        
+        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
         }
@@ -398,7 +402,8 @@ class Marshaller
      *
      * When merging HasMany or BelongsToMany associations, all the entities in the
      * `$data` array will appear, those that can be matched by primary key will get
-     * the data merged, but those that cannot, will be discarded.
+     * the data merged, but those that cannot, will be discarded. `ids` option can be used
+     * to determine whether the association must use the `_ids` format.
      *
      * ### Options:
      *

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -613,10 +613,12 @@ class Marshaller
     {
         $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
+        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
+
         if ($hasIds && is_array($value['_ids'])) {
             return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds) {
+        if ($hasIds || $_ids) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -87,7 +87,7 @@ class Marshaller
      * Hydrate one entity and its associated data.
      *
      * When marshalling HasMany or BelongsToMany associations, `_ids` format can be used.
-     * `ids` option can also be used to determine whether the association must use the `_ids` 
+     * `ids` option can also be used to determine whether the association must use the `_ids`
      * format.
      *
      * ### Options:

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -223,11 +223,19 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->one($value, (array)$options);
         }
+        if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
+            $hasIds = array_key_exists('_ids', $data);
+            $idsOption = array_key_exists('ids', $options) && $options['ids'];
+
+            if ($hasIds && is_array($data['_ids'])) {
+                return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+            }
+            if ($hasIds || $idsOption) {
+                return [];
+            }
+        }        
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
-        }
-        if ($assoc->type() === Association::ONE_TO_MANY && array_key_exists('_ids', $value) && is_array($value['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
         return $marshaller->many($value, (array)$options);
     }
@@ -272,15 +280,8 @@ class Marshaller
      */
     protected function _belongsToMany(Association $assoc, array $data, $options = [])
     {
-        // Accept _ids = [1, 2]
         $associated = isset($options['associated']) ? $options['associated'] : [];
-        $hasIds = array_key_exists('_ids', $data);
-        if ($hasIds && is_array($data['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
-        }
-        if ($hasIds) {
-            return [];
-        }
+
         $data = array_values($data);
 
         $primaryKey = array_flip($assoc->target()->schema()->primaryKey());
@@ -611,14 +612,15 @@ class Marshaller
      */
     protected function _mergeBelongsToMany($original, $assoc, $value, $options)
     {
-        $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
-        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
 
-        if ($hasIds && is_array($value['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
+        $hasIds = array_key_exists('_ids', $data);
+        $idsOption = array_key_exists('ids', $options) && $options['ids'];
+
+        if ($hasIds && is_array($data['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
         }
-        if ($hasIds || $_ids) {
+        if ($hasIds || $idsOption) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -223,9 +223,6 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->one($value, (array)$options);
         }
-        if($this->_isAssociatedByIdsInvalid($assoc, $value, (array)$options)){
-            return [];
-        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
         }
@@ -377,13 +374,6 @@ class Marshaller
         }
 
         return $target->find()->where($filter)->toArray();
-    }
-
-    protected function _isAssociatedByIdsInvalid($assoc, $value, $options){
-        if($assoc->type() === Association::MANY_TO_MANY || $assoc->type() === Association::ONE_TO_MANY){
-            return array_key_exists('ids', $options) && $options['ids'] && !array_key_exists('_ids', $value);
-        }
-        return false;
     }
 
     /**
@@ -603,9 +593,6 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->merge($original, $value, (array)$options);
         }
-        if($this->_isAssociatedByIdsInvalid($assoc, $value, (array)$options)){
-            return [];
-        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_mergeBelongsToMany($original, $assoc, $value, (array)$options);
         }
@@ -626,11 +613,12 @@ class Marshaller
     {
         $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
+        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
 
         if ($hasIds && is_array($value['_ids'])) {
             return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds) {
+        if ($hasIds || $_ids) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -223,19 +223,11 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->one($value, (array)$options);
         }
-        if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
-            $hasIds = array_key_exists('_ids', $data);
-            $idsOption = array_key_exists('ids', $options) && $options['ids'];
-
-            if ($hasIds && is_array($data['_ids'])) {
-                return $this->_loadAssociatedByIds($assoc, $data['_ids']);
-            }
-            if ($hasIds || $idsOption) {
-                return [];
-            }
-        }        
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
+        }
+        if ($assoc->type() === Association::ONE_TO_MANY && array_key_exists('_ids', $value) && is_array($value['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
         return $marshaller->many($value, (array)$options);
     }
@@ -280,8 +272,15 @@ class Marshaller
      */
     protected function _belongsToMany(Association $assoc, array $data, $options = [])
     {
+        // Accept _ids = [1, 2]
         $associated = isset($options['associated']) ? $options['associated'] : [];
-
+        $hasIds = array_key_exists('_ids', $data);
+        if ($hasIds && is_array($data['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+        }
+        if ($hasIds) {
+            return [];
+        }
         $data = array_values($data);
 
         $primaryKey = array_flip($assoc->target()->schema()->primaryKey());
@@ -612,15 +611,14 @@ class Marshaller
      */
     protected function _mergeBelongsToMany($original, $assoc, $value, $options)
     {
+        $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
+        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
 
-        $hasIds = array_key_exists('_ids', $data);
-        $idsOption = array_key_exists('ids', $options) && $options['ids'];
-
-        if ($hasIds && is_array($data['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+        if ($hasIds && is_array($value['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds || $idsOption) {
+        if ($hasIds || $_ids) {
             return [];
         }
 


### PR DESCRIPTION
#6835

Example

``` php
        $entity = $this->Users->patchEntity(
            $entity, 
            $this->request->data,[
            'associated'=>[
            'Tags'=>[
                    'ids' => true
                ]
            ]
        ]);
```

Only tags in _ids param will be linked. Any other array will be ignored.

``` php
        $data = [
        ........
            'tags' =>[
                '_ids' =>[....]
            ]
        ]
```
