### PR TITLE
Consolidate template whitespace

### DIFF
--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -91,7 +91,7 @@ class HtmlHelper extends AppHelper {
 		'fieldsetstart' => '<fieldset><legend>%s</legend>',
 		'fieldsetend' => '</fieldset>',
 		'legend' => '<legend>%s</legend>',
-		'css' => '<link rel="%s" type="text/css" href="%s" %s/>',
+		'css' => '<link rel="%s" type="text/css" href="%s"%s/>',
 		'style' => '<style type="text/css"%s>%s</style>',
 		'charset' => '<meta http-equiv="Content-Type" content="text/html; charset=%s" />',
 		'ul' => '<ul%s>%s</ul>',
@@ -472,7 +472,7 @@ class HtmlHelper extends AppHelper {
 		if ($options['rel'] === 'import') {
 			$out = sprintf(
 				$this->_tags['style'],
-				$this->_parseAttributes($options, array('rel', 'block'), '', ' '),
+				$this->_parseAttributes($options, array('rel', 'block')),
 				'@import url(' . $url . ');'
 			);
 		} else {
@@ -480,7 +480,7 @@ class HtmlHelper extends AppHelper {
 				$this->_tags['css'],
 				$options['rel'],
 				$url,
-				$this->_parseAttributes($options, array('rel', 'block'), '', ' ')
+				$this->_parseAttributes($options, array('rel', 'block'))
 			);
 		}
 


### PR DESCRIPTION
Instead of https://github.com/cakephp/cakephp/commit/705f44e30a55c92b8f92a5fd6d61573f037f0c37 we should probably consolidate them.
ALso, there was still a whitespace missing in "style" template.
They were removed without the need to do so. This fixes it.
