### PR TITLE
Cleanup method calls.

### DIFF
--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1570,7 +1570,7 @@ class CakeEmailTest extends CakeTestCase {
 			$server .= ':' . env('SERVER_PORT');
 		}
 
-		$expected = '<img src="http://' . $server . '/img/image.gif" alt="cool image" width="100" height="100" />';
+		$expected = '<img src="http://' . $server . '/img/image.gif" alt="cool image" width="100" height="100"/>';
 		$result = $this->CakeEmail->send();
 		$this->assertContains($expected, $result['message']);
 	}

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1755,7 +1755,6 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$result = $this->Html->meta('keywords', 'these, are, some, meta, keywords');
 		$this->assertTags($result, array('meta' => array('name' => 'keywords', 'content' => 'these, are, some, meta, keywords')));
-		$this->assertRegExp('/\s+\/>$/', $result);
 
 		$result = $this->Html->meta('description', 'this is the meta description');
 		$this->assertTags($result, array('meta' => array('name' => 'description', 'content' => 'this is the meta description')));

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -2857,7 +2857,7 @@ class PaginatorHelperTest extends CakeTestCase {
 				'paramType' => 'querystring'
 			)
 		);
-		$expected = '<link href="/?page=2" rel="next" />';
+		$expected = '<link href="/?page=2" rel="next"/>';
 		$result = $this->Paginator->meta();
 		$this->assertSame($expected, $result);
 	}
@@ -2878,7 +2878,7 @@ class PaginatorHelperTest extends CakeTestCase {
 				'paramType' => 'querystring'
 			)
 		);
-		$expected = '<link href="/?page=2" rel="next" />';
+		$expected = '<link href="/?page=2" rel="next"/>';
 		$this->Paginator->meta(array('block' => true));
 		$result = $this->View->fetch('meta');
 		$this->assertSame($expected, $result);
@@ -2900,7 +2900,7 @@ class PaginatorHelperTest extends CakeTestCase {
 				'paramType' => 'querystring'
 			)
 		);
-		$expected = '<link href="/" rel="prev" />';
+		$expected = '<link href="/" rel="prev"/>';
 		$result = $this->Paginator->meta();
 		$this->assertSame($expected, $result);
 	}
@@ -2921,8 +2921,8 @@ class PaginatorHelperTest extends CakeTestCase {
 				'paramType' => 'querystring'
 			)
 		);
-		$expected = '<link href="/?page=4" rel="prev" />';
-		$expected .= '<link href="/?page=6" rel="next" />';
+		$expected = '<link href="/?page=4" rel="prev"/>';
+		$expected .= '<link href="/?page=6" rel="next"/>';
 		$result = $this->Paginator->meta();
 		$this->assertSame($expected, $result);
 	}

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -279,12 +279,12 @@ class HtmlHelper extends AppHelper {
 		if (isset($options['link'])) {
 			$options['link'] = $this->assetUrl($options['link']);
 			if (isset($options['rel']) && $options['rel'] === 'icon') {
-				$out = sprintf($this->_tags['metalink'], $options['link'], $this->_parseAttributes($options, array('block', 'link'), ' ', ' '));
+				$out = sprintf($this->_tags['metalink'], $options['link'], $this->_parseAttributes($options, array('block', 'link')));
 				$options['rel'] = 'shortcut icon';
 			}
-			$out .= sprintf($this->_tags['metalink'], $options['link'], $this->_parseAttributes($options, array('block', 'link'), ' ', ' '));
+			$out .= sprintf($this->_tags['metalink'], $options['link'], $this->_parseAttributes($options, array('block', 'link')));
 		} else {
-			$out = sprintf($this->_tags['meta'], $this->_parseAttributes($options, array('block', 'type'), ' ', ' '));
+			$out = sprintf($this->_tags['meta'], $this->_parseAttributes($options, array('block', 'type')));
 		}
 
 		if (empty($options['block'])) {
@@ -565,7 +565,7 @@ class HtmlHelper extends AppHelper {
 				$url = str_replace(Configure::read('App.jsBaseUrl'), 'cjs/', $url);
 			}
 		}
-		$attributes = $this->_parseAttributes($options, array('block', 'once'), ' ');
+		$attributes = $this->_parseAttributes($options, array('block', 'once'));
 		$out = sprintf($this->_tags['javascriptlink'], $url, $attributes);
 
 		if (empty($options['block'])) {
@@ -601,7 +601,7 @@ class HtmlHelper extends AppHelper {
 		}
 		unset($options['inline'], $options['safe']);
 
-		$attributes = $this->_parseAttributes($options, array('block'), ' ');
+		$attributes = $this->_parseAttributes($options, array('block'));
 		$out = sprintf($this->_tags['javascriptblock'], $attributes, $script);
 
 		if (empty($options['block'])) {
@@ -828,7 +828,7 @@ class HtmlHelper extends AppHelper {
 			unset($options['url']);
 		}
 
-		$image = sprintf($this->_tags['image'], $path, $this->_parseAttributes($options, null, ' ', ' '));
+		$image = sprintf($this->_tags['image'], $path, $this->_parseAttributes($options));
 
 		if ($url) {
 			return sprintf($this->_tags['link'], $this->url($url), null, $image);
@@ -939,7 +939,7 @@ class HtmlHelper extends AppHelper {
 		} else {
 			$tag = 'tag';
 		}
-		return sprintf($this->_tags[$tag], $name, $this->_parseAttributes($options, null, ' ', ''), $text, $name);
+		return sprintf($this->_tags[$tag], $name, $this->_parseAttributes($options), $text, $name);
 	}
 
 /**
@@ -957,7 +957,7 @@ class HtmlHelper extends AppHelper {
 		array_shift($args);
 		foreach ($args as &$arg) {
 			if (is_array($arg)) {
-				$arg = $this->_parseAttributes($arg, null, ' ', '');
+				$arg = $this->_parseAttributes($arg);
 			}
 		}
 		return vsprintf($this->_tags[$tag], $args);
@@ -1008,7 +1008,7 @@ class HtmlHelper extends AppHelper {
 		if ($text === null) {
 			$tag = 'parastart';
 		}
-		return sprintf($this->_tags[$tag], $this->_parseAttributes($options, null, ' ', ''), $text);
+		return sprintf($this->_tags[$tag], $this->_parseAttributes($options), $text);
 	}
 
 /**
@@ -1144,7 +1144,7 @@ class HtmlHelper extends AppHelper {
 			$options = array();
 		}
 		$items = $this->_nestedListItem($list, $options, $itemOptions, $tag);
-		return sprintf($this->_tags[$tag], $this->_parseAttributes($options, null, ' ', ''), $items);
+		return sprintf($this->_tags[$tag], $this->_parseAttributes($options), $items);
 	}
 
 /**
@@ -1170,7 +1170,7 @@ class HtmlHelper extends AppHelper {
 			} elseif (isset($itemOptions['odd']) && $index % 2 !== 0) {
 				$itemOptions['class'] = $itemOptions['odd'];
 			}
-			$out .= sprintf($this->_tags['li'], $this->_parseAttributes($itemOptions, array('even', 'odd'), ' ', ''), $item);
+			$out .= sprintf($this->_tags['li'], $this->_parseAttributes($itemOptions, array('even', 'odd')), $item);
 			$index++;
 		}
 		return $out;


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/6849.
It turns out those method calls could be written way simpler (and closer to 3.x).

But since this would break a few tests (which I could adjust) I wonder if we should postpone that for a later 2.x version?
