### PR TITLE
Also provide response in components.

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -70,6 +70,13 @@ class Component implements EventListenerInterface
     public $request;
 
     /**
+     * Response object
+     *
+     * @var \Cake\Network\Response
+     */
+    public $response;
+
+    /**
      * Component registry class used to lazy load components.
      *
      * @var \Cake\Controller\ComponentRegistry

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -111,6 +111,7 @@ class Component implements EventListenerInterface
         $controller = $registry->getController();
         if ($controller) {
             $this->request =& $controller->request;
+            $this->response =& $controller->response;
         }
 
         $this->config($config);


### PR DESCRIPTION
It was quite counter-intuitive that I could access

```
$this->request
```

by default inside components, but

```
$this->response
```

threw an error.
I think those should be available both or not at all for consistency in a controller context.
