### PR TITLE
convert numeric to string on hash creation in FormHelper::secure()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -558,6 +558,9 @@ class FormHelper extends Helper
 
         foreach ($fields as $key => $value) {
             if (!is_int($key)) {
+                if (is_numeric($value)) {
+                    $value = (string)$value;
+                }
                 $locked[$key] = $value;
                 unset($fields[$key]);
             }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -557,10 +557,10 @@ class FormHelper extends Helper
         $unlockedFields = $this->_unlockedFields;
 
         foreach ($fields as $key => $value) {
+            if (is_numeric($value)) {
+                $value = (string)$value;
+            }
             if (!is_int($key)) {
-                if (is_numeric($value)) {
-                    $value = (string)$value;
-                }
                 $locked[$key] = $value;
                 unset($fields[$key]);
             }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6443,20 +6443,25 @@ class FormHelperTest extends TestCase
     {
         $hash = Security::hash(
             '/posts/delete/1' .
-            serialize([]) .
+            serialize(['id' => '1']) .
             '' .
             Security::salt()
         );
-        $hash .= '%3A';
+        $hash .= '%3Aid';
         $this->Form->request->params['_Token']['key'] = 'test';
 
-        $result = $this->Form->postLink('Delete', '/posts/delete/1');
+        $result = $this->Form->postLink(
+            'Delete',
+            '/posts/delete/1',
+            ['data' => ['id' => 1]]
+        );
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
                 'name', 'style' => 'display:none;'
             ],
             ['input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'value' => '1']],
             'div' => ['style' => 'display:none;'],
             ['input' => ['type' => 'hidden', 'name' => '_Token[fields]', 'value' => $hash]],
             ['input' => ['type' => 'hidden', 'name' => '_Token[unlocked]', 'value' => '']],


### PR DESCRIPTION
Security hash may contain serialized form data values. Form values in
request are send as strings. For security check to pass numeric values
must be converted to string on form creation. Otherwise the serialized-
output differs and the security-check on the incoming request fails.
