### PR TITLE
3.1 BehaviorRegistry::setTable()

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -58,7 +58,7 @@ class BehaviorRegistry extends ObjectRegistry
     /**
      * Constructor
      *
-     * @param \Cake\ORM\Table $table The table this registry is attached to.
+     * @param \Cake\ORM\Table|null $table The table this registry is attached to.
      */
     public function __construct($table = null)
     {

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -58,9 +58,22 @@ class BehaviorRegistry extends ObjectRegistry
     /**
      * Constructor
      *
-     * @param \Cake\ORM\Table $table The table this registry is attached to
+     * @param \Cake\ORM\Table $table The table this registry is attached to.
      */
-    public function __construct(Table $table)
+    public function __construct(Table $table = null)
+    {
+        if ($table !== null) {
+            $this->setTable($table);
+        }
+    }
+
+    /**
+     * Attaches a table instance to this registry.
+     *
+     * @param \Cake\ORM\Table $table The table this registry is attached to.
+     * @return void
+     */
+    public function setTable(Table $table)
     {
         $this->_table = $table;
         $this->eventManager($table->eventManager());

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -60,7 +60,7 @@ class BehaviorRegistry extends ObjectRegistry
      *
      * @param \Cake\ORM\Table $table The table this registry is attached to.
      */
-    public function __construct(Table $table = null)
+    public function __construct($table = null)
     {
         if ($table !== null) {
             $this->setTable($table);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -279,12 +279,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
         $this->_eventManager = $eventManager ?: new EventManager();
-        if ($behaviors) {
-            $behaviors->setTable($this);
-        } else {
-            $behaviors = new BehaviorRegistry($this);
-        }
-        $this->_behaviors = $behaviors;
+        $this->_behaviors = $behaviors ?: new BehaviorRegistry();
+        $this->_behaviors->setTable($this);
         $this->_associations = $associations ?: new AssociationCollection();
 
         $this->initialize($config);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -279,7 +279,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
         $this->_eventManager = $eventManager ?: new EventManager();
-        $this->_behaviors = $behaviors ?: new BehaviorRegistry($this);
+        if ($behaviors) {
+            $behaviors->setTable($this);
+        } else {
+            $behaviors = new BehaviorRegistry($this);
+        }
+        $this->_behaviors = $behaviors;
         $this->_associations = $associations ?: new AssociationCollection();
 
         $this->initialize($config);

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -350,4 +350,17 @@ class BehaviorRegistryTest extends TestCase
 
         $this->assertEquals(['Sluggable'], $this->Behaviors->loaded());
     }
+
+    /**
+     * Test setTable() method.
+     *
+     * @return void
+     */
+    public function testSetTable()
+    {
+        $table = $this->getMock('Cake\ORM\Table');
+        $table->expects($this->once())->method('eventManager');
+
+        $this->Behaviors->setTable($table);
+    }
 }


### PR DESCRIPTION
Following #6845

I've made `$table` parameter in a constructor optional, so I suppose this should be targetting 3.1
