### PR TITLE
typo in ORM README

### DIFF
--- a/src/ORM/README.md
+++ b/src/ORM/README.md
@@ -35,7 +35,7 @@ mappers if no explicit connection is defined.
 ## Creating Associations
 
 In your table classes you can define the relations between your tables. CakePHP
-supports 4 association types out of the box:
+ORM supports 4 association types out of the box:
 
 * belongsTo - E.g. Many articles belong to a user.
 * hasOne - E.g. A user has one profile
@@ -85,7 +85,7 @@ $data = [
 ];
 
 $articles = TableRegistry::get('Articles');
-$article = $articles->newEnitity($data, [
+$article = $articles->newEntity($data, [
 	'associated' => ['Tags', 'Comments']
 ]);
 $articles->save($article, [
@@ -109,5 +109,5 @@ $articles->delete($article);
 
 ## Additional Documentation
 
-Consult [the CakePHP documentation](http://book.cakephp.org/3.0/en/orm.html)
+Consult [the CakePHP ORM documentation](http://book.cakephp.org/3.0/en/orm.html)
 for more in-depth documentation.

--- a/src/ORM/README.md
+++ b/src/ORM/README.md
@@ -34,8 +34,8 @@ mappers if no explicit connection is defined.
 
 ## Creating Associations
 
-In your table classes you can define the relations between your tables. CakePHP
-ORM supports 4 association types out of the box:
+In your table classes you can define the relations between your tables. CakePHP's ORM 
+supports 4 association types out of the box:
 
 * belongsTo - E.g. Many articles belong to a user.
 * hasOne - E.g. A user has one profile


### PR DESCRIPTION
A small typo and i added "ORM" at each occurence of CakePHP (especially significant for the ORM splitted repository)
