### PR TITLE
Use the RepositoryInterface in the Paginator.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -15,6 +15,7 @@
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Datasource\RepositoryInterface;
 use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
@@ -295,11 +296,11 @@ class PaginatorComponent extends Component
      * Any columns listed in the sort whitelist will be implicitly trusted. You can use this to sort
      * on synthetic columns, or columns added in custom find operations that may not exist in the schema.
      *
-     * @param Table $object The model being paginated.
+     * @param \Cake\Datasource\RepositoryInterface $object Repository object.
      * @param array $options The pagination options being used for this request.
      * @return array An array of options with sort + direction removed and replaced with order if possible.
      */
-    public function validateSort(Table $object, array $options)
+    public function validateSort(RepositoryInterface $object, array $options)
     {
         if (isset($options['sort'])) {
             $direction = null;
@@ -331,19 +332,18 @@ class PaginatorComponent extends Component
         }
 
         $options['order'] = $this->_prefix($object, $options['order'], $inWhitelist);
-
         return $options;
     }
 
     /**
      * Prefixes the field with the table alias if possible.
      *
-     * @param \Cake\ORM\Table $object Table object.
+     * @param \Cake\Datasource\RepositoryInterface $object Repository object.
      * @param array $order Order array.
      * @param bool $whitelisted Whether or not the field was whitelisted
      * @return array Final order array.
      */
-    protected function _prefix(Table $object, $order, $whitelisted = false)
+    protected function _prefix(RepositoryInterface $object, $order, $whitelisted = false)
     {
         $tableAlias = $object->alias();
         $tableOrder = [];

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -24,6 +24,22 @@ interface RepositoryInterface
 {
 
     /**
+     * Returns the table alias or sets a new one
+     *
+     * @param string|null $alias the new table alias
+     * @return string
+     */
+    public function alias($alias = null);
+
+    /**
+     * Test to see if a Repository has a specific field/column.
+     *
+     * @param string $field The field to check for.
+     * @return bool True if the field exists, false if it does not.
+     */
+    public function hasField($field);
+
+    /**
      * Creates a new Query for this repository and applies some defaults based on the
      * type of search that was selected.
      *

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -346,10 +346,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Returns the table alias or sets a new one
-     *
-     * @param string|null $alias the new table alias
-     * @return string
+     * {@inheritDoc}
      */
     public function alias($alias = null)
     {


### PR DESCRIPTION
We half did this correctly, but there were a few typehints that hinted against Table instead of RepositoryInterface. Changing these, and broadening the interface to contain the methods that PaginatorComponent relies on as well. This makes it possible for the ElasticSearch plugin to be compatible with PaginatorComponent.
