### PR TITLE
Properties should not be accessible after dumping.

### DIFF
--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -29,6 +29,12 @@ class DebuggerTestCaseDebugger extends Debugger
 {
 }
 
+class SecretThing
+{
+    private $secret = 'shhh';
+    protected $hidden = 'hide';
+}
+
 class DebuggableThing
 {
 
@@ -350,6 +356,26 @@ TEXT;
         fclose($file);
         $result = Debugger::exportVar($file);
         $this->assertTextEquals('unknown', $result);
+    }
+
+    /**
+     * test exportVar() doesn't modify accessibility.
+     *
+     * @return void
+     */
+    public function testExportVarAccessible()
+    {
+        $subject = new SecretThing();
+        $result = Debugger::exportVar($subject);
+        $expected = <<<TEXT
+object(Cake\Test\TestCase\Error\SecretThing) {
+	[protected] hidden => 'hide'
+	[private] secret => 'shhh'
+}
+TEXT;
+        $this->assertTextEquals($expected, $result);
+        $this->assertFalse(isset($subject->hidden));
+        $this->assertFalse(isset($subject->secret));
     }
 
     /**


### PR DESCRIPTION
Adds tests for #6822. @lorenzo I wasn't able to reproduce the issue you had with a userland class. What version of PHP did you bump into this with?
