### PR TITLE
Issue 6874 - 2.7.0-RC Auth doesn't use the new Flash component

### DIFF
--- a/lib/Cake/Console/Templates/skel/View/Elements/Flash/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Elements/Flash/default.ctp
@@ -1,0 +1,1 @@
+<div id="<?php echo $key; ?>Message" class="<?php echo !empty($params['class']) ? $params['class'] : 'message'; ?>"><?php echo $message; ?></div>

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -50,7 +50,7 @@ class AuthComponent extends Component {
  *
  * @var array
  */
-	public $components = array('Session', 'RequestHandler');
+	public $components = array('Session', 'Flash', 'RequestHandler');
 
 /**
  * An array of authentication objects to use for authenticating users. You can configure
@@ -840,7 +840,7 @@ class AuthComponent extends Component {
 		if ($message === false) {
 			return;
 		}
-		$this->Session->setFlash($message, $this->flash['element'], $this->flash['params'], $this->flash['key']);
+		$this->Flash->set($message, $this->flash);
 	}
 
 }

--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -84,7 +84,7 @@ class FlashComponent extends Component {
 			$options['element'] = 'Flash/' . $element;
 		}
 
-		CakeSession::write('Flash.' . $options['key'], array(
+		CakeSession::write('Message.' . $options['key'], array(
 			'message' => $message,
 			'key' => $options['key'],
 			'element' => $options['element'],

--- a/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
@@ -197,7 +197,6 @@ class ProjectTaskTest extends CakeTestCase {
 			'Test' . DS . 'Case' . DS . 'View' . DS . 'Helper' => 'empty',
 			'Test' . DS . 'Fixture' => 'empty',
 			'Vendor' => 'empty',
-			'View' . DS . 'Elements' => 'empty',
 			'View' . DS . 'Scaffolds' => 'empty',
 			'tmp' . DS . 'cache' . DS . 'models' => 'empty',
 			'tmp' . DS . 'cache' . DS . 'persistent' => 'empty',

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -165,7 +165,7 @@ class AuthTestController extends Controller {
  *
  * @var array
  */
-	public $components = array('Session', 'Auth');
+	public $components = array('Session', 'Flash', 'Auth');
 
 /**
  * testUrl property
@@ -1093,9 +1093,9 @@ class AuthComponentTest extends CakeTestCase {
 			array('on', 'redirect'),
 			array($CakeRequest, $CakeResponse)
 		);
-		$this->Auth->Session = $this->getMock(
-			'SessionComponent',
-			array('setFlash'),
+		$this->Auth->Flash = $this->getMock(
+			'FlashComponent',
+			array('set'),
 			array($Controller->Components)
 		);
 
@@ -1105,8 +1105,8 @@ class AuthComponentTest extends CakeTestCase {
 		$Controller->expects($this->once())
 			->method('redirect')
 			->with($this->equalTo($expected));
-		$this->Auth->Session->expects($this->once())
-			->method('setFlash');
+		$this->Auth->Flash->expects($this->once())
+			->method('set');
 		$this->Auth->startup($Controller);
 	}
 
@@ -1132,9 +1132,9 @@ class AuthComponentTest extends CakeTestCase {
 			array('on', 'redirect'),
 			array($CakeRequest, $CakeResponse)
 		);
-		$this->Auth->Session = $this->getMock(
-			'SessionComponent',
-			array('setFlash'),
+		$this->Auth->Flash = $this->getMock(
+			'FlashComponent',
+			array('set'),
 			array($Controller->Components)
 		);
 
@@ -1144,8 +1144,8 @@ class AuthComponentTest extends CakeTestCase {
 		$Controller->expects($this->once())
 			->method('redirect')
 			->with($this->equalTo($expected));
-		$this->Auth->Session->expects($this->never())
-			->method('setFlash');
+		$this->Auth->Flash->expects($this->never())
+			->method('set');
 		$this->Auth->startup($Controller);
 	}
 
@@ -1514,10 +1514,10 @@ class AuthComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testFlashSettings() {
-		$this->Auth->Session = $this->getMock('SessionComponent', array(), array(), '', false);
-		$this->Auth->Session->expects($this->once())
-			->method('setFlash')
-			->with('Auth failure', 'custom', array(1), 'auth-key');
+		$this->Auth->Flash = $this->getMock('FlashComponent', array(), array(), '', false);
+		$this->Auth->Flash->expects($this->once())
+			->method('set')
+			->with('Auth failure', array('element' => 'custom', 'params' => array(1), 'key' => 'auth-key'));
 
 		$this->Auth->flash = array(
 			'element' => 'custom',

--- a/lib/Cake/Test/Case/Controller/Component/FlashComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/FlashComponentTest.php
@@ -55,7 +55,7 @@ class FlashComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testSet() {
-		$this->assertNull(CakeSession::read('Flash.flash'));
+		$this->assertNull(CakeSession::read('Message.flash'));
 
 		$this->Flash->set('This is a test message');
 		$expected = array(
@@ -64,7 +64,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/default',
 			'params' => array()
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->set('This is a test message', array(
@@ -77,7 +77,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/test',
 			'params' => array('foo' => 'bar')
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->set('This is a test message', array('element' => 'MyPlugin.alert'));
@@ -87,7 +87,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'MyPlugin.Flash/alert',
 			'params' => array()
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->set('This is a test message', array('key' => 'foobar'));
@@ -97,7 +97,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/default',
 			'params' => array()
 		);
-		$result = CakeSession::read('Flash.foobar');
+		$result = CakeSession::read('Message.foobar');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -107,7 +107,7 @@ class FlashComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testSetWithException() {
-		$this->assertNull(CakeSession::read('Flash.flash'));
+		$this->assertNull(CakeSession::read('Message.flash'));
 
 		$this->Flash->set(new Exception('This is a test message', 404));
 		$expected = array(
@@ -116,7 +116,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/default',
 			'params' => array('code' => 404)
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -126,7 +126,7 @@ class FlashComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testSetWithComponentConfiguration() {
-		$this->assertNull(CakeSession::read('Flash.flash'));
+		$this->assertNull(CakeSession::read('Message.flash'));
 
 		$FlashWithSettings = $this->Components->load('Flash', array('element' => 'test'));
 		$FlashWithSettings->set('This is a test message');
@@ -136,7 +136,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/test',
 			'params' => array()
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -146,7 +146,7 @@ class FlashComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testCall() {
-		$this->assertNull(CakeSession::read('Flash.flash'));
+		$this->assertNull(CakeSession::read('Message.flash'));
 
 		$this->Flash->success('It worked');
 		$expected = array(
@@ -155,7 +155,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/success',
 			'params' => array()
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->error('It did not work', array('element' => 'error_thing'));
@@ -165,7 +165,7 @@ class FlashComponentTest extends CakeTestCase {
 			'element' => 'Flash/error',
 			'params' => array()
 		);
-		$result = CakeSession::read('Flash.flash');
+		$result = CakeSession::read('Message.flash');
 		$this->assertEquals($expected, $result, 'Element is ignored in magic call.');
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
@@ -120,7 +120,7 @@ class FlashHelperTest extends CakeTestCase {
  * @expectedException UnexpectedValueException
  */
 	public function testFlashThrowsException() {
-		CakeSession::write('Flash.foo', 'bar');
+		CakeSession::write('Message.foo', 'bar');
 		$this->Flash->render('foo');
 	}
 

--- a/lib/Cake/View/Elements/Flash/default.ctp
+++ b/lib/Cake/View/Elements/Flash/default.ctp
@@ -1,0 +1,1 @@
+<div id="<?php echo $key; ?>Message" class="<?php echo !empty($params['class']) ? $params['class'] : 'message'; ?>"><?php echo $message; ?></div>

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -85,15 +85,6 @@ class FlashHelper extends AppHelper {
 		$flash = $options + $flash;
 		CakeSession::delete("Message.$key");
 
-		// backwards compatibility with Session->setFlash()
-		if ($flash['element'] === 'default') {
-			$class = 'message';
-			if (!empty($flash['params']['class'])) {
-				$class = $flash['params']['class'];
-			}
-			return '<div id="' . $key . 'Message" class="' . $class . '">' . $flash['message'] . '</div>';
-		}
-
 		return $this->_View->element($flash['element'], $flash);
 	}
 }

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -86,7 +86,7 @@ class FlashHelper extends AppHelper {
 		CakeSession::delete("Message.$key");
 
 		// backwards compatibility with Session->setFlash()
-		if($flash['element'] === 'default') {
+		if ($flash['element'] === 'default') {
 			$class = 'message';
 			if (!empty($flash['params']['class'])) {
 				$class = $flash['params']['class'];

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -61,7 +61,7 @@ class FlashHelper extends AppHelper {
  * ));
  * ```
  *
- * @param string $key The [Flash.]key you are rendering in the view.
+ * @param string $key The [Message.]key you are rendering in the view.
  * @param array $options Additional options to use for the creation of this flash message.
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string|null Rendered flash message or null if flash key does not exist
@@ -69,11 +69,11 @@ class FlashHelper extends AppHelper {
  * @throws UnexpectedValueException If value for flash settings key is not an array.
  */
 	public function render($key = 'flash', $options = array()) {
-		if (!CakeSession::check("Flash.$key")) {
+		if (!CakeSession::check("Message.$key")) {
 			return;
 		}
 
-		$flash = CakeSession::read("Flash.$key");
+		$flash = CakeSession::read("Message.$key");
 
 		if (!is_array($flash)) {
 			throw new UnexpectedValueException(sprintf(
@@ -83,7 +83,16 @@ class FlashHelper extends AppHelper {
 		}
 
 		$flash = $options + $flash;
-		CakeSession::delete("Flash.$key");
+		CakeSession::delete("Message.$key");
+
+		// backwards compatibility with Session->setFlash
+        if($flash['element'] === 'default') {
+            $class = 'message';
+            if (!empty($flash['params']['class'])) {
+                $class = $flash['params']['class'];
+            }
+            return '<div id="' . $key . 'Message" class="' . $class . '">' . $flash['message'] . '</div>';
+        }
 
 		return $this->_View->element($flash['element'], $flash);
 	}

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -86,13 +86,13 @@ class FlashHelper extends AppHelper {
 		CakeSession::delete("Message.$key");
 
 		// backwards compatibility with Session->setFlash
-        if($flash['element'] === 'default') {
-            $class = 'message';
-            if (!empty($flash['params']['class'])) {
-                $class = $flash['params']['class'];
-            }
-            return '<div id="' . $key . 'Message" class="' . $class . '">' . $flash['message'] . '</div>';
-        }
+		if($flash['element'] === 'default') {
+			$class = 'message';
+			if (!empty($flash['params']['class'])) {
+				$class = $flash['params']['class'];
+			}
+			return '<div id="' . $key . 'Message" class="' . $class . '">' . $flash['message'] . '</div>';
+		}
 
 		return $this->_View->element($flash['element'], $flash);
 	}

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -85,7 +85,7 @@ class FlashHelper extends AppHelper {
 		$flash = $options + $flash;
 		CakeSession::delete("Message.$key");
 
-		// backwards compatibility with Session->setFlash
+		// backwards compatibility with Session->setFlash()
 		if($flash['element'] === 'default') {
 			$class = 'message';
 			if (!empty($flash['params']['class'])) {


### PR DESCRIPTION
#6874

Replaced "Flash." to "Message." for backwards compatibility.
Ported the default element functionality from `Session->flash` into `Flash->render`
