### PR TITLE
Improve extract in debug mode to auto-create the folder.

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -16,7 +16,6 @@ namespace Cake\Shell\Task;
 
 use Cake\Console\Shell;
 use Cake\Core\App;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\File;
 use Cake\Filesystem\Folder;
@@ -705,7 +704,7 @@ class ExtractTask extends Shell
      */
     protected function _isPathUsable($path)
     {
-        if (Configure::read('debug') && !is_dir($path)) {
+        if (!is_dir($path)) {
             mkdir($path, 0770, true);
         }
         return is_dir($path) && is_writable($path);

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -16,6 +16,7 @@ namespace Cake\Shell\Task;
 
 use Cake\Console\Shell;
 use Cake\Core\App;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\File;
 use Cake\Filesystem\Folder;
@@ -704,6 +705,9 @@ class ExtractTask extends Shell
      */
     protected function _isPathUsable($path)
     {
+        if (Configure::read('debug') && !is_dir($path)) {
+            mkdir($path, 0770, true);
+        }
         return is_dir($path) && is_writable($path);
     }
 }


### PR DESCRIPTION
Without this it would just ask on and on about what folder it should create it in.
If in debug mode, we also have cache and log folders auto-created, so in this case it should be totally fine to not hazzle the user to manually create the i18n folders here.
Small convenience helper for faster development.
