### PR TITLE
Provide initialize command to create PO from POT.

### DIFF
--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -81,10 +81,9 @@ class I18nShell extends Shell
         }
 
         $this->_paths = [APP];
-        if (!empty($this->params['plugin'])) {
-            $plugin = Inflector::camelize($this->params['plugin']);
+        if ($this->param('plugin')) {
+            $plugin = Inflector::camelize($this->param('plugin'));
             $this->_paths = [Plugin::classPath($plugin)];
-            $this->params['plugin'] = $plugin;
         }
 
         $response = $this->in('What folder?', null, rtrim($this->_paths[0], DS) . DS . 'Locale');
@@ -103,7 +102,7 @@ class I18nShell extends Shell
             $filename = $fileinfo->getFilename();
             $newFilename = $fileinfo->getBasename('.pot');
             $newFilename = $newFilename . '.po';
-            if (empty($this->params['force']) && is_file($targetFolder . $newFilename)) {
+            if (!$this->param('force') && is_file($targetFolder . $newFilename)) {
                 $this->err('File ' . $newFilename . ' exists, skipping. Use --force or -f to force overwriting');
                 continue;
             }

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -78,8 +78,8 @@ class I18nShell extends Shell
         if (!$language) {
             $language = strtolower($this->in('What language? Please use the two-letter ISO code, e.g. `en`.'));
         }
-        if (strlen($language) !== 2) {
-            return $this->error('Must be a two-letter ISO code');
+        if (strlen($language) < 2) {
+            return $this->error('Invalid language code. Valid is `en`, `eng`, `en_US` etc.');
         }
 
         $this->_paths = [APP];

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -70,9 +70,11 @@ class I18nShell extends Shell
     /**
      * Inits PO file from POT file.
      *
-     * @return void
+     * @param string|null $language Language code to use.
+     * @return void|int
      */
-    public function init($language = null) {
+    public function init($language = null)
+    {
         if (!$language) {
             $language = strtolower($this->in('What language? Please use the two-letter ISO code, e.g. `en`.'));
         }

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -76,7 +76,7 @@ class I18nShell extends Shell
     public function init($language = null)
     {
         if (!$language) {
-            $language = strtolower($this->in('What language? Please use the two-letter ISO code, e.g. `en`.'));
+            $language = strtolower($this->in('Please specify language code, e.g. `en`, `eng`, `en_US` etc.'));
         }
         if (strlen($language) < 2) {
             return $this->error('Invalid language code. Valid is `en`, `eng`, `en_US` etc.');

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -102,12 +102,8 @@ class I18nShell extends Shell
             $filename = $fileinfo->getFilename();
             $newFilename = $fileinfo->getBasename('.pot');
             $newFilename = $newFilename . '.po';
-            if (!$this->param('force') && is_file($targetFolder . $newFilename)) {
-                $this->err('File ' . $newFilename . ' exists, skipping. Use --force or -f to force overwriting');
-                continue;
-            }
 
-            copy($sourceFolder . $filename, $targetFolder . $newFilename);
+            $this->createFile($targetFolder . $newFilename, file_get_contents($sourceFolder . $filename));
             $count++;
         }
 

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -42,13 +42,17 @@ class I18nShell extends Shell
         $this->out('<info>I18n Shell</info>');
         $this->hr();
         $this->out('[E]xtract POT file from sources');
+        $this->out('[I]inialize a language from POT file');
         $this->out('[H]elp');
         $this->out('[Q]uit');
 
-        $choice = strtolower($this->in('What would you like to do?', ['E', 'H', 'Q']));
+        $choice = strtolower($this->in('What would you like to do?', ['E', 'I', 'H', 'Q']));
         switch ($choice) {
             case 'e':
                 $this->Extract->main();
+                break;
+            case 'i':
+                $this->init();
                 break;
             case 'h':
                 $this->out($this->OptionParser->help());
@@ -64,6 +68,54 @@ class I18nShell extends Shell
     }
 
     /**
+     * Inits PO file from POT file.
+     *
+     * @return void
+     */
+    public function init($language = null) {
+        if (!$language) {
+            $language = strtolower($this->in('What language? Please use the two-letter ISO code, e.g. `en`.'));
+        }
+        if (strlen($language) !== 2) {
+            return $this->error('Must be a two-letter ISO code');
+        }
+
+        $this->_paths = [APP];
+        if (!empty($this->params['plugin'])) {
+            $plugin = Inflector::camelize($this->params['plugin']);
+            $this->_paths = [Plugin::classPath($plugin)];
+            $this->params['plugin'] = $plugin;
+        }
+
+        $response = $this->in('What folder?', null, rtrim($this->_paths[0], DS) . DS . 'Locale');
+        $sourceFolder = rtrim($response, DS) . DS;
+        $targetFolder = $sourceFolder . $language . DS;
+        if (!is_dir($targetFolder)) {
+            mkdir($targetFolder, 0770, true);
+        }
+
+        $count = 0;
+        $iterator = new \DirectoryIterator($sourceFolder);
+        foreach ($iterator as $fileinfo) {
+            if (!$fileinfo->isFile()) {
+                continue;
+            }
+            $filename = $fileinfo->getFilename();
+            $newFilename = $fileinfo->getBasename('.pot');
+            $newFilename = $newFilename . '.po';
+            if (empty($this->params['force']) && is_file($targetFolder . $newFilename)) {
+                $this->err('File ' . $newFilename . ' exists, skipping. Use --force or -f to force overwriting');
+                continue;
+            }
+
+            copy($sourceFolder . $filename, $targetFolder . $newFilename);
+            $count++;
+        }
+
+        $this->out('Generated ' . $count . ' PO files in ' . $targetFolder);
+    }
+
+    /**
      * Gets the option parser instance and configures it.
      *
      * @return \Cake\Console\ConsoleOptionParser
@@ -71,12 +123,34 @@ class I18nShell extends Shell
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
+        $initParser = [
+            'options' => [
+                'plugin' => [
+                    'help' => 'Plugin name.',
+                    'short' => 'p'
+                ],
+                'force' => [
+                    'help' => 'Force overwriting.',
+                    'short' => 'f',
+                    'boolean' => true
+                ]
+            ],
+            'arguments' => [
+                'language' => [
+                    'help' => 'Two-letter language code.'
+                ]
+            ]
+        ];
 
         $parser->description(
             'I18n Shell generates .pot files(s) with translations.'
         )->addSubcommand('extract', [
             'help' => 'Extract the po translations from your application',
             'parser' => $this->Extract->getOptionParser()
+        ])
+        ->addSubcommand('init', [
+            'help' => 'Init PO language file from POT file',
+            'parser' => $initParser
         ]);
 
         return $parser;

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -64,7 +64,6 @@ class I18nShellTest extends TestCase
      */
     public function testInit()
     {
-
         $deDir = $this->localeDir . 'de' . DS;
         if (!is_dir($deDir)) {
             mkdir($deDir, 0770, true);

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.8
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Shell;
+
+use Cake\Cache\Cache;
+use Cake\Datasource\ConnectionManager;
+use Cake\Shell\I18nShell;
+use Cake\TestSuite\TestCase;
+
+/**
+ * I18nShell test.
+ */
+class I18nShellTest extends TestCase
+{
+
+    /**
+     * setup method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->shell = new I18nShell($this->io);
+    }
+
+    /**
+     * Teardown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Tests that init() creates the PO files from POT files.
+     *
+     * @return void
+     */
+    public function testInit()
+    {
+        $localeDir = TMP . 'Locale' . DS;
+        $deDir = $localeDir . 'de' . DS;
+        if (!is_dir($deDir)) {
+            mkdir($deDir, 0770, true);
+        }
+        file_put_contents($localeDir . 'default.pot', 'Testing POT file.');
+        file_put_contents($localeDir . 'cake.pot', 'Testing POT file.');
+        if (file_exists($deDir . 'default.po')) {
+            unlink($deDir . 'default.po');
+        }
+        if (file_exists($deDir . 'default.po')) {
+            unlink($deDir . 'cake.po');
+        }
+
+        $this->shell->io()->expects($this->at(0))
+            ->method('ask')
+            ->will($this->returnValue('de'));
+        $this->shell->io()->expects($this->at(1))
+            ->method('ask')
+            ->will($this->returnValue($localeDir));
+
+        $this->shell->params['verbose'] = true;
+        $this->shell->init();
+
+        $this->assertTrue(file_exists($deDir . 'default.po'));
+        $this->assertTrue(file_exists($deDir . 'cake.po'));
+    }
+}

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -78,7 +78,7 @@ class I18nShellTest extends TestCase
         $this->shell->params['verbose'] = true;
         $this->shell->init();
 
-        $this->assertTrue(file_exists($deDir . 'default.po'));
-        $this->assertTrue(file_exists($deDir . 'cake.po'));
+        $this->assertFileExists($deDir . 'default.po');
+        $this->assertFileExists($deDir . 'cake.po');
     }
 }

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -35,6 +35,8 @@ class I18nShellTest extends TestCase
         parent::setUp();
         $this->io = $this->getMock('Cake\Console\ConsoleIo');
         $this->shell = new I18nShell($this->io);
+
+        $this->localeDir = TMP . 'Locale' . DS;
     }
 
     /**
@@ -45,6 +47,14 @@ class I18nShellTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
+
+        $deDir = $this->localeDir . 'de' . DS;
+
+        unlink($this->localeDir . 'default.pot');
+        unlink($this->localeDir . 'cake.pot');
+
+        unlink($deDir . 'default.po');
+        unlink($deDir . 'cake.po');
     }
 
     /**
@@ -54,13 +64,13 @@ class I18nShellTest extends TestCase
      */
     public function testInit()
     {
-        $localeDir = TMP . 'Locale' . DS;
-        $deDir = $localeDir . 'de' . DS;
+
+        $deDir = $this->localeDir . 'de' . DS;
         if (!is_dir($deDir)) {
             mkdir($deDir, 0770, true);
         }
-        file_put_contents($localeDir . 'default.pot', 'Testing POT file.');
-        file_put_contents($localeDir . 'cake.pot', 'Testing POT file.');
+        file_put_contents($this->localeDir . 'default.pot', 'Testing POT file.');
+        file_put_contents($this->localeDir . 'cake.pot', 'Testing POT file.');
         if (file_exists($deDir . 'default.po')) {
             unlink($deDir . 'default.po');
         }
@@ -73,7 +83,7 @@ class I18nShellTest extends TestCase
             ->will($this->returnValue('de'));
         $this->shell->io()->expects($this->at(1))
             ->method('ask')
-            ->will($this->returnValue($localeDir));
+            ->will($this->returnValue($this->localeDir));
 
         $this->shell->params['verbose'] = true;
         $this->shell->init();


### PR DESCRIPTION
Allow I18n Shell to create language PO files from template POT files.

```
cake i18n init de
```

for all `src/Locale/{domain}.pot` files in Locale those will be initialized for `de` (German) as

```
src/Locale/de/{domain}.po
```

Using `-f` you can force overwrite existing PO files if desired. Otherwise those will be skipped.
This is especially useful for creating new languages or making sure all POT domains have been initialized as PO file.
