### PR TITLE
Backport param() access.

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -500,6 +500,19 @@ class Shell extends Object {
 	}
 
 /**
+ * Safely access the values in $this->params.
+ *
+ * @param string $name The name of the parameter to get.
+ * @return string|bool|null Value. Will return null if it doesn't exist.
+ */
+	public function param($name) {
+		if (!isset($this->params[$name])) {
+			return null;
+		}
+		return $this->params[$name];
+	}
+
+/**
  * Prompts the user for input, and returns it.
  *
  * @param string $prompt Prompt text.

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -856,6 +856,51 @@ TEXT;
 	}
 
 /**
+ * Test reading params
+ *
+ * @dataProvider paramReadingDataProvider
+ */
+	public function testParamReading($toRead, $expected) {
+		$this->Shell->params = array(
+			'key' => 'value',
+			'help' => false,
+			'emptykey' => '',
+			'truthy' => true
+		);
+		$this->assertSame($expected, $this->Shell->param($toRead));
+	}
+
+/**
+ * Data provider for testing reading values with Shell::param()
+ *
+ * @return array
+ */
+	public function paramReadingDataProvider() {
+		return array(
+			array(
+				'key',
+				'value',
+			),
+			array(
+				'help',
+				false,
+			),
+			array(
+				'emptykey',
+				'',
+			),
+			array(
+				'truthy',
+				true,
+			),
+			array(
+				'does_not_exist',
+				null,
+			)
+		);
+	}
+
+/**
  * Test that option parsers are created with the correct name/command.
  *
  * @return void


### PR DESCRIPTION
Backport 3.x Shell::param() to access $this->params[...] notice-free.

Refs https://github.com/cakephp/cakephp/pull/6882#discussion_r33202348 
