### PR TITLE
Added negative lookahead

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -323,7 +323,7 @@ class Sqlite extends DboSource {
 				$j++;
 				continue;
 			}
-			if (preg_match('/\bAS\s+(.*)/i', $selects[$j], $matches)) {
+			if (preg_match('/\bAS(?!.*\bAS\b)\s+(.*)/i', $selects[$j], $matches)) {
 				$columnName = trim($matches[1], '"');
 			} else {
 				$columnName = trim(str_replace('"', '', $selects[$j]));


### PR DESCRIPTION
It is possible to have multiple occurrences of 'as' in a field name.
Use the last occurrence of 'as' when extracting field name.

Tested with following examples:
- "WeldCheck"."weld_id"
- count(*) as WeldCheck__num_measurements
- count(case decision when 2 then 1 else null end) as WeldCheck__num_failures
- avg(cast (WeldMeasurement.surface_indentation as bigint)) as WeldCheck__avg_indentation
- avg(cast (WeldMeasurement.circle_diameter as bigint)) as WeldCheck__avg_diameter

Sorry for the messed up history.  I created a pull request against my own branch.
