### PR TITLE
Make StringTemplate::format() return null if template not found.

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -220,16 +220,16 @@ class StringTemplate
      *
      * @param string $name The template name.
      * @param array $data The data to insert.
-     * @return string
+     * @return string|null Formatted string or null if template not found.
      */
     public function format($name, array $data)
     {
         if (!isset($this->_compiled[$name])) {
-            return '';
+            return null;
         }
         list($template, $placeholders) = $this->_compiled[$name];
         if ($template === null) {
-            return '';
+            return null;
         }
         $replace = [];
         foreach ($placeholders as $placeholder) {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -89,11 +89,18 @@ class StringTemplateTest extends TestCase
     public function testFormat()
     {
         $templates = [
-            'link' => '<a href="{{url}}">{{text}}</a>'
+            'link' => '<a href="{{url}}">{{text}}</a>',
+            'text' => '{{text}}'
         ];
         $this->template->add($templates);
 
         $result = $this->template->format('not there', []);
+        $this->assertNull($result);
+
+        $result = $this->template->format('text', ['text' => '']);
+        $this->assertSame('', $result);
+
+        $result = $this->template->format('text', []);
         $this->assertSame('', $result);
 
         $result = $this->template->format('link', [


### PR DESCRIPTION
This makes is possible to distinguish error case versus a formatted string
which could be empty.
