### PR TITLE
Fix available commands list

### DIFF
--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -43,14 +43,14 @@ class CommandTask extends Shell
         $plugins = Plugin::loaded();
         $shellList = array_fill_keys($plugins, null) + ['CORE' => null, 'app' => null];
 
-        $shells = $this->_scanDir(dirname(__DIR__));
-        $shells = array_diff($shells, $skipFiles, $hiddenCommands);
-        $shellList = $this->_appendShells('CORE', $shells, $shellList);
-
         $appPath = App::path('Shell');
         $appShells = $this->_scanDir($appPath[0]);
-        $appShells = array_diff($appShells, $shells, $skipFiles);
+        $appShells = array_diff($appShells, $skipFiles);
         $shellList = $this->_appendShells('app', $appShells, $shellList);
+
+        $shells = $this->_scanDir(dirname(__DIR__));
+        $shells = array_diff($shells, $appShells, $skipFiles, $hiddenCommands);
+        $shellList = $this->_appendShells('CORE', $shells, $shellList);
 
         foreach ($plugins as $plugin) {
             $pluginPath = Plugin::classPath($plugin) . 'Shell';

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -89,8 +89,30 @@ class CommandListShellTest extends TestCase
         $expected = "/\[.*CORE.*\] i18n, orm_cache, plugin, server/";
         $this->assertRegExp($expected, $output);
 
-        $expected = "/\[.*app.*\] sample/";
+        $expected = "/\[.*app.*\] i18m, sample/";
         $this->assertRegExp($expected, $output);
+    }
+
+    /**
+     * If there is an app shell with the same name as a core shell,
+     * tests that the app shell is the one displayed and the core one is hidden.
+     *
+     * @return void
+     */
+    public function testMainAppPriority()
+    {
+        rename(APP . 'Shell' . DS . 'I18mShell.php', APP . 'Shell' . DS . 'I18nShell.php');
+        $this->Shell->main();
+        $output = $this->out->messages();
+        $output = implode("\n", $output);
+
+        $expected = "/\[.*CORE.*\] orm_cache, plugin, server/";
+        $this->assertRegExp($expected, $output);
+
+        $expected = "/\[.*app.*\] i18n, sample/";
+        $this->assertRegExp($expected, $output);
+
+        rename(APP . 'Shell' . DS . 'I18nShell.php', APP . 'Shell' . DS . 'I18mShell.php');
     }
 
     /**

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -120,7 +120,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = "TestPlugin.example TestPlugin.sample " .
-            "TestPluginTwo.example TestPluginTwo.welcome i18n orm_cache plugin server sample testing_dispatch\n";
+            "TestPluginTwo.example TestPluginTwo.welcome i18n orm_cache plugin server i18m sample testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
 

--- a/tests/test_app/TestApp/Shell/I18mShell.php
+++ b/tests/test_app/TestApp/Shell/I18mShell.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * I18mShell file
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         3.0.8
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class SampleShell
+ *
+ */
+namespace TestApp\Shell;
+
+use Cake\Console\Shell;
+
+class I18m extends Shell
+{
+
+    /**
+     * main method
+     *
+     * @return void
+     */
+    public function main()
+    {
+        $this->out('This is the main method called from I18mShell');
+    }
+}


### PR DESCRIPTION
If there is an app Shell with the same name as a core one, the app one should be displayed in the commands list and the core one hidden.

If there is a better way to test than the `CommandListShellTest` test I added, I'm open to suggestions.
It seemed to be the only way to test the behavior and make sure it works in all cases.

Refs #6883 
