### PR TITLE
Require PHP7 to pass.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
   allow_failures:
-    - php: 7.0
+    - env: COVERALLS=1 DEFAULT=0
 
     - php: hhvm
 


### PR DESCRIPTION
Require PHP7 tests to pass, and allow coverage generation to fail without breaking the build.

PHP7 has been pretty stable lately, while coverage has not. Switch the two around to keep builds passing more often.
