### PR TITLE
Don't set Location headers when failing ajax requests.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -364,7 +364,8 @@ class AuthComponent extends Component
             $response->statusCode(403);
             return $response;
         }
-        return $controller->redirect(null, 403);
+        $this->response->statusCode(403);
+        return $this->response;
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -974,6 +974,28 @@ class AuthComponentTest extends TestCase
     }
 
     /**
+     * test ajax unauthenticated
+     *
+     * @return void
+     * @triggers Controller.startup $this->Controller
+     */
+    public function testAjaxUnauthenticated()
+    {
+        $this->Controller->request = new Request([
+            'url' => '/ajax_auth/add',
+            'environment' => ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        ]);
+        $this->Controller->request->params['action'] = 'add';
+
+        $event = new Event('Controller.startup', $this->Controller);
+        $response = $this->Auth->startup($event);
+
+        $this->assertTrue($event->isStopped());
+        $this->assertEquals(403, $response->statusCode());
+        $this->assertArrayNotHasKey('Location', $response->header());
+    }
+
+    /**
      * testLoginActionRedirect method
      *
      * @return void


### PR DESCRIPTION
Setting a location header and 403 status codes causes infinite loops when AuthComponent is set to protect `/`.

Refs #6880
