### PR TITLE
Fixed datetime validation to accept correctly meridian

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -415,8 +415,8 @@ class Validation
         }
         $parts = explode(' ', $check);
         if (!empty($parts) && count($parts) > 1) {
-            $time = array_pop($parts);
-            $date = implode(' ', $parts);
+            $date = array_shift($parts);
+            $time = implode(' ', $parts);
             $valid = static::date($date, $dateFormat, $regex) && static::time($time);
         }
         return $valid;

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1535,6 +1535,23 @@ class ValidationTest extends TestCase
     }
 
     /**
+     * Tests that it is possible to pass a median (AM, PM) to the dateTime validation
+     *
+     * @return void
+     */
+    public function testDateTimeWithMeriadian()
+    {
+        $this->assertTrue(Validation::dateTime('10/04/2007 1:50 AM', ['dmy']));
+        $this->assertTrue(Validation::dateTime('12/04/2017 1:38 PM', ['dmy']));
+        $this->assertTrue(Validation::dateTime('10/04/2007 1:50 am', ['dmy']));
+        $this->assertTrue(Validation::dateTime('12/04/2017 1:38 pm', ['dmy']));
+        $this->assertTrue(Validation::dateTime('12/04/2017 1:38pm', ['dmy']));
+        $this->assertTrue(Validation::dateTime('12/04/2017 1:38AM', ['dmy']));
+        $this->assertFalse(Validation::dateTime('12/04/2017 58:38AM', ['dmy']));
+    }
+
+
+    /**
      * testBoolean method
      *
      * @return void
@@ -2239,7 +2256,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::datetime('27/12/2006 1:00pm', 'dmy'));
         $this->assertFalse(Validation::datetime('27/12/2006 9:00', 'dmy'));
 
-        $this->assertTrue(Validation::datetime('27 12 2006 1:00pm', 'dmy'));
+        $this->assertFalse(Validation::datetime('27 12 2006 1:00pm', 'dmy'));
         $this->assertFalse(Validation::datetime('27 12 2006 24:00', 'dmy'));
 
         $this->assertFalse(Validation::datetime('00-00-0000 1:00pm', 'dmy'));


### PR DESCRIPTION
It was reported that sending a date such as `10/04/2007 1:50 AM` (note the space before AM) was not being accepted.
