### PR TITLE
Making the PHPCS build run on PHP7 as it is faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - php: 5.4
       env: COVERALLS=1 DEFAULT=0
 
-    - php: 5.4
+    - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
     - php: hhvm


### PR DESCRIPTION
This will hopefully give us faster feedback on each build
