### PR TITLE
Allow `.` in ObjectRegistry keys.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -69,7 +69,12 @@ abstract class ObjectRegistry
      */
     public function load($objectName, $config = [])
     {
-        list(, $name) = pluginSplit($objectName);
+        if (empty($config) && !isset($this->_loaded[$objectName])) {
+            list(, $name) = pluginSplit($objectName);
+        } else {
+            $name = $objectName;
+        }
+
         $loaded = isset($this->_loaded[$name]);
         if ($loaded && !empty($config)) {
             $this->_checkDuplicate($name, $config);

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -251,6 +251,26 @@ class CacheTest extends TestCase
     }
 
     /**
+     * test config() with dotted name
+     *
+     * @return void
+     */
+    public function testConfigDottedAlias()
+    {
+        Cache::config('cache.dotted', [
+            'className' => 'File',
+            'path' => TMP,
+            'prefix' => 'cache_value_'
+        ]);
+
+        $engine = Cache::engine('cache.dotted');
+        $this->assertContains('cache.dotted', Cache::configured());
+        $this->assertNotContains('dotted', Cache::configured());
+        $this->assertInstanceOf('Cake\Cache\Engine\FileEngine', $engine);
+        Cache::drop('cache.dotted');
+    }
+
+    /**
      * testGroupConfigs method
      */
     public function testGroupConfigs()

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -196,6 +196,32 @@ class HelperRegistryTest extends TestCase
     }
 
     /**
+     * test loading helpers with dotted aliases
+     *
+     * @return void
+     */
+    public function testLoadPluginHelperDottedAlias()
+    {
+        Plugin::load(['TestPlugin']);
+
+        $result = $this->Helpers->load('thing.helper', [
+            'className' => 'TestPlugin.OtherHelper',
+        ]);
+        $this->assertInstanceOf('TestPlugin\View\Helper\OtherHelperHelper', $result, 'Helper class is wrong.');
+        $this->assertInstanceOf(
+            'TestPlugin\View\Helper\OtherHelperHelper',
+            $this->Helpers->get('thing.helper'),
+            'Class is wrong'
+        );
+        $this->assertTrue($this->Helpers->has('thing.helper'));
+        $this->assertFalse($this->Helpers->has('thing'));
+        $this->assertFalse($this->Helpers->has('helper'));
+
+        $this->Helpers->unload('thing.helper');
+        $this->assertFalse($this->Helpers->has('thing.helper'), 'Should be gone now.');
+    }
+
+    /**
      * Test reset.
      *
      * @return void


### PR DESCRIPTION
Allow `.` in object registry keys when a configuration array is present. This allows cache engines to have dotted names, and also helpers. Doing this with helpers is a bit silly as you'll end up with helper names you cannot use. But for Cache it makes sense.

Refs #6919
