### PR TITLE
Allow arrays (Hash::flatten'ed) to be used in substitutions

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -178,7 +178,7 @@ class StringTemplate
                 $this->_compiled[$name] = [null, null];
             }
 
-            preg_match_all('#\{\{(\w+)\}\}#', $template, $matches);
+            preg_match_all('#\{\{([\w\d\._]+)\}\}#', $template, $matches);
             $this->_compiled[$name] = [
                 str_replace($matches[0], '%s', $template),
                 $matches[1]


### PR DESCRIPTION
This allows for the standard . notation of arrays to be used within substitions like
attendee.fistname and event.name from e.g. Hash::flatten($entity->toArray());

As the . notation is used in many places, this would make sense here too.
