### PR TITLE
Only log exception attributes when debug is on.

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -259,7 +259,9 @@ abstract class BaseErrorHandler
             get_class($exception),
             $exception->getMessage()
         );
-        if (method_exists($exception, 'getAttributes')) {
+        $debug = Configure::read('debug');
+
+        if ($debug && method_exists($exception, 'getAttributes')) {
             $attributes = $exception->getAttributes();
             if ($attributes) {
                 $message .= "\nException Attributes: " . var_export($exception->getAttributes(), true);

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -26,6 +26,7 @@ use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Exception\NotFoundException;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\Routing\Exception\MissingControllerException;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
@@ -277,6 +278,45 @@ class ErrorHandlerTest extends TestCase
             'log' => true,
             'trace' => false,
         ]);
+        $errorHandler->handleException($error);
+    }
+
+    /**
+     * test logging attributes with/without debug
+     *
+     * @return void
+     */
+    public function testHandleExceptionLogAttributes()
+    {
+        $errorHandler = new TestErrorHandler([
+            'log' => true,
+            'trace' => true,
+        ]);
+
+        $error = new MissingControllerException(['class' => 'Derp']);
+
+        $this->_logger->expects($this->at(0))
+            ->method('log')
+            ->with('error', $this->logicalAnd(
+                $this->stringContains(
+                    '[Cake\Routing\Exception\MissingControllerException] ' .
+                    'Controller class Derp could not be found.'
+                ),
+                $this->stringContains('Exception Attributes:')
+            ));
+
+        $this->_logger->expects($this->at(1))
+            ->method('log')
+            ->with('error', $this->logicalAnd(
+                $this->stringContains(
+                    '[Cake\Routing\Exception\MissingControllerException] ' .
+                    'Controller class Derp could not be found.'
+                ),
+                $this->logicalNot($this->stringContains('Exception Attributes:'))
+            ));
+        $errorHandler->handleException($error);
+
+        Configure::write('debug', false);
         $errorHandler->handleException($error);
     }
 


### PR DESCRIPTION
Elide the exception attributes when debug is false.

Refs #6957
