### PR TITLE
Don't map text/plain to csv. Backport from 3.0. Refs #1696

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -96,7 +96,7 @@ class CakeResponse {
 		'cpio' => 'application/x-cpio',
 		'cpt' => 'application/mac-compactpro',
 		'csh' => 'application/x-csh',
-		'csv' => array('text/csv', 'application/vnd.ms-excel', 'text/plain'),
+		'csv' => array('text/csv', 'application/vnd.ms-excel'),
 		'dcr' => 'application/x-director',
 		'dir' => 'application/x-director',
 		'dms' => 'application/octet-stream',

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -198,6 +198,20 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	}
 
 /**
+ * Test that RequestHandler does not set extension to csv for text/plain mimetype
+ *
+ * @return void
+ */
+	public function testInitializeContentTypeWithjQueryTextPlainAccept() {
+		$_SERVER['HTTP_ACCEPT'] = 'text/plain, */*; q=0.01';
+		$this->assertNull($this->RequestHandler->ext);
+		Router::parseExtensions('csv');
+
+		$this->RequestHandler->initialize($this->Controller);
+		$this->assertNull($this->RequestHandler->ext);
+	}
+
+/**
  * Test that RequestHandler sets $this->ext when jQuery sends its wonky-ish headers
  * and the application is configured to handle multiple extensions
  *


### PR DESCRIPTION
Backporting https://github.com/cakephp/cakephp/pull/1696
