### PR TITLE
Add `Email::configuredTransport()` to enumerate transport key names.

### DIFF
--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1241,6 +1241,16 @@ class Email implements JsonSerializable, Serializable
     }
 
     /**
+     * Returns an array containing the named transport configurations
+     *
+     * @return array Array of configurations.
+     */
+    public static function configuredTransport()
+    {
+        return array_keys(static::$_transportConfig);
+    }
+
+    /**
      * Delete transport configuration.
      *
      * @param string $key The transport name to remove.

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -100,9 +100,12 @@ class EmailTest extends TestCase
         parent::setUp();
         $this->CakeEmail = new TestEmail();
 
-        Email::configTransport('debug', [
-            'className' => 'Debug'
-        ]);
+        $this->transports = [
+            'debug' => [
+                'className' => 'Debug'
+            ]
+        ];
+        Email::configTransport($this->transports);
     }
 
     /**
@@ -879,6 +882,22 @@ class EmailTest extends TestCase
         $instance = new DebugTransport();
         Email::configTransport('debug', $instance);
         $this->assertEquals(['className' => $instance], Email::configTransport('debug'));
+    }
+
+    /**
+     * Test enumerating all transport configurations
+     *
+     * @return void
+     */
+    public function testConfiguredTransport()
+    {
+        $result = Email::configuredTransport();
+        $this->assertInternalType('array', $result, 'Should have config keys');
+        $this->assertEquals(
+            array_keys($this->transports),
+            $result,
+            'Loaded transports should be present in enumeration.'
+        );
     }
 
     /**


### PR DESCRIPTION
This mirrors the ability to call `::configured()` on any class that uses the StaticConfigTrait or `array_keys(::config())` (with no arguments) on any class that uses the InstanceConfigTrait.

Filling this shortcoming would be nice because the key names (normally defined in config/app.php) are removed from Configure when they are `Configure::consume()`d in config/bootstrap.php. There is no other way to programmatically determine what transports the Email class knows about without this.
