### PR TITLE
Return changed properties that were originally null.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -563,7 +563,7 @@ trait EntityTrait
         $result = [];
         foreach ($properties as $property) {
             $original = $this->getOriginal($property);
-            if ($original !== null && $original !== $this->get($property)) {
+            if ($original !== $this->get($property)) {
                 $result[$property] = $original;
             }
         }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -122,6 +122,14 @@ class EntityTest extends TestCase
             'body' => 'no',
         ];
         $this->assertEquals($expected, $result);
+
+        $entity->set('null', 'not null');
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null']);
+        $expected = [
+            'null' => null,
+            'body' => 'no',
+        ];
+        $this->assertEquals($expected, $result);
     }
 
     /**


### PR DESCRIPTION
Null values that are updated should be part of the data returned by extractOriginalChanged(). Without this it is much harder to find properties that used to be null and aren't anymore.

Refs #6966
