### PR TITLE
Added return types in PHP documenation in basics.php, since it raises…

### DIFF
--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -625,7 +625,7 @@ if (!function_exists('__d')) {
  * @param string $domain Domain
  * @param string $msg String to translate
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return translated string
+ * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__d
  */
 	function __d($domain, $msg, $args = null) {
@@ -652,7 +652,7 @@ if (!function_exists('__dn')) {
  * @param string $plural Plural
  * @param int $count Count
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return plural form of translated string
+ * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dn
  */
 	function __dn($domain, $singular, $plural, $count, $args = null) {
@@ -690,7 +690,7 @@ if (!function_exists('__dc')) {
  * @param string $msg Message to translate
  * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return translated string
+ * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dc
  */
 	function __dc($domain, $msg, $category, $args = null) {
@@ -732,7 +732,7 @@ if (!function_exists('__dcn')) {
  * @param int $count Count
  * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return plural form of translated string
+ * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dcn
  */
 	function __dcn($domain, $singular, $plural, $count, $category, $args = null) {
@@ -766,7 +766,7 @@ if (!function_exists('__c')) {
  * @param string $msg String to translate
  * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return translated string
+ * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__c
  */
 	function __c($msg, $category, $args = null) {
@@ -841,7 +841,7 @@ if (!function_exists('__dx')) {
  * @param string $context Context of the text
  * @param string $msg String to translate
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return translated string
+ * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__d
  */
 	function __dx($domain, $context, $msg, $args = null) {
@@ -869,7 +869,7 @@ if (!function_exists('__dxn')) {
  * @param string $plural Plural
  * @param int $count Count
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return plural form of translated string
+ * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dn
  */
 	function __dxn($domain, $context, $singular, $plural, $count, $args = null) {
@@ -908,7 +908,7 @@ if (!function_exists('__dxc')) {
  * @param string $msg Message to translate
  * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return translated string
+ * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dc
  */
 	function __dxc($domain, $context, $msg, $category, $args = null) {
@@ -951,7 +951,7 @@ if (!function_exists('__dxcn')) {
  * @param int $count Count
  * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return plural form of translated string
+ * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dcn
  */
 	function __dxcn($domain, $context, $singular, $plural, $count, $category, $args = null) {
@@ -986,7 +986,7 @@ if (!function_exists('__xc')) {
  * @param string $msg String to translate
  * @param int $category Category
  * @param mixed $args Array with arguments or multiple arguments in function
- * @return translated string
+ * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__c
  */
 	function __xc($context, $msg, $category, $args = null) {
@@ -1025,7 +1025,7 @@ if (!function_exists('fileExistsInPath')) {
  * Searches include path for files.
  *
  * @param string $file File to look for
- * @return Full path to file if exists, otherwise false
+ * @return string Full path to file if exists, otherwise false
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#fileExistsInPath
  */
 	function fileExistsInPath($file) {


### PR DESCRIPTION
Adding @return types to the PHPDocs fixes warning in ie. PHPStorm, like:
- Method _toString is not implemented for translated
