### PR TITLE
Add missing parameter to rawQuery()

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -402,7 +402,7 @@ class DboSource extends DataSource {
  */
 	public function rawQuery($sql, $params = array()) {
 		$this->took = $this->numRows = false;
-		return $this->execute($sql, $params);
+		return $this->execute($sql, array(), $params);
 	}
 
 /**


### PR DESCRIPTION
Previously bound parameters were put in the incorrect position.

Refs #6992
