### PR TITLE
Extract methods into the ConnectionInterface.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -123,9 +123,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get the configuration data used to create the connection.
-     *
-     * @return array
+     * {@inheritDoc}
      */
     public function config()
     {
@@ -133,9 +131,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get the configuration name for this connection.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function configName()
     {
@@ -533,13 +529,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Executes a callable function inside a transaction, if any exception occurs
-     * while executing the passed callable, the transaction will be rolled back
-     * If the result of the callable function is ``false``, the transaction will
-     * also be rolled back. Otherwise the transaction is committed after executing
-     * the callback.
-     *
-     * The callback will receive the connection instance as its first argument.
+     * {@inheritDoc}
      *
      * ### Example:
      *
@@ -548,11 +538,6 @@ class Connection implements ConnectionInterface
      *   $connection->newQuery()->delete('users')->execute();
      * });
      * ```
-     *
-     * @param callable $callback the code to be executed inside a transaction
-     * @return mixed result from the $callback function
-     * @throws \Exception Will re-throw any exception raised in $callback after
-     *   rolling back the transaction.
      */
     public function transactional(callable $callback)
     {
@@ -571,6 +556,32 @@ class Connection implements ConnectionInterface
         }
 
         $this->commit();
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * ### Example:
+     *
+     * ```
+     * $connection->disableConstraints(function ($connection) {
+     *   $connection->newQuery()->delete('users')->execute();
+     * });
+     * ```
+     */
+    public function disableConstraints(callable $callback)
+    {
+        $this->disableForeignKeys();
+
+        try {
+            $result = $callback($this);
+        } catch (\Exception $e) {
+            $this->enableForeignKeys();
+            throw $e;
+        }
+
+        $this->enableForeignKeys();
         return $result;
     }
 
@@ -620,21 +631,6 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Enables or disables query logging for this connection.
-     *
-     * @param bool $enable whether to turn logging on or disable it.
-     *   Use null to read current value.
-     * @return bool
-     */
-    public function logQueries($enable = null)
-    {
-        if ($enable === null) {
-            return $this->_logQueries;
-        }
-        $this->_logQueries = $enable;
-    }
-
-    /**
      * Enables or disables metadata caching for this connection
      *
      * Changing this setting will not modify existing schema collections objects.
@@ -650,11 +646,18 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Sets the logger object instance. When called with no arguments
-     * it returns the currently setup logger instance.
-     *
-     * @param object $instance logger object instance
-     * @return object logger instance
+     * {@inheritDoc}
+     */
+    public function logQueries($enable = null)
+    {
+        if ($enable === null) {
+            return $this->_logQueries;
+        }
+        $this->_logQueries = $enable;
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function logger($instance = null)
     {

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -43,7 +43,7 @@ interface ConnectionInterface
      *
      * The callback will receive the connection instance as its first argument.
      *
-     * @param callable $callable The callback to execute within a transaction.
+     * @param callable $transaction The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
      *   rolling back the transaction.
@@ -55,7 +55,7 @@ interface ConnectionInterface
      *
      * Constraints should be re-enabled after the callback succeeds/fails.
      *
-     * @param callable $callable The callback to execute within a transaction.
+     * @param callable $operation The callback to execute within a transaction.
      * @return mixed The return value of the callback.
      * @throws \Exception Will re-throw any exception raised in $callback after
      *   rolling back the transaction.

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -20,5 +20,63 @@ namespace Cake\Datasource;
  */
 interface ConnectionInterface
 {
+    /**
+     * Get the configuration name for this connection.
+     *
+     * @return string
+     */
+    public function configName();
 
+    /**
+     * Get the configuration data used to create the connection.
+     *
+     * @return array
+     */
+    public function config();
+
+    /**
+     * Executes a callable function inside a transaction, if any exception occurs
+     * while executing the passed callable, the transaction will be rolled back
+     * If the result of the callable function is ``false``, the transaction will
+     * also be rolled back. Otherwise the transaction is committed after executing
+     * the callback.
+     *
+     * The callback will receive the connection instance as its first argument.
+     *
+     * @param callable $callable The callback to execute within a transaction.
+     * @return mixed The return value of the callback.
+     * @throws \Exception Will re-throw any exception raised in $callback after
+     *   rolling back the transaction.
+     */
+    public function transactional(callable $transaction);
+
+    /**
+     * Run an operation with constraints disabled.
+     *
+     * Constraints should be re-enabled after the callback succeeds/fails.
+     *
+     * @param callable $callable The callback to execute within a transaction.
+     * @return mixed The return value of the callback.
+     * @throws \Exception Will re-throw any exception raised in $callback after
+     *   rolling back the transaction.
+     */
+    public function disableConstraints(callable $operation);
+
+    /**
+     * Enables or disables query logging for this connection.
+     *
+     * @param bool $enable whether to turn logging on or disable it.
+     *   Use null to read current value.
+     * @return bool
+     */
+    public function logQueries($enable = null);
+
+    /**
+     * Sets the logger object instance. When called with no arguments
+     * it returns the currently setup logger instance.
+     *
+     * @param object $instance logger object instance
+     * @return object logger instance
+     */
+    public function logger($instance = null);
 }

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -284,9 +284,9 @@ class FixtureManager
                 $db->logQueries(false);
             }
             $db->transactional(function ($db) use ($fixtures, $operation) {
-                $db->disableForeignKeys();
-                $operation($db, $fixtures);
-                $db->enableForeignKeys();
+                $db->disableConstraints(function ($db) use ($fixtures, $operation) {
+                    $operation($db, $fixtures);
+                });
             });
             if ($logQueries) {
                 $db->logQueries(true);


### PR DESCRIPTION
This builds a very minimal interface for connections. I've tried to focus it on only what is needed for fixture interoperability and ConnectionManager functionality. Trying to abstract anything else seemed
foolish at this point.

I added a new `disableConstraints()` method to Connection. This method works like `transactional()` and aims to hide the implementation of if/how foreign keys/constraints are managed in a connection.

Refs #6288
