### PR TITLE
Generate .pot files without references

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -49,11 +49,11 @@ class ExtractTask extends AppShell {
 	protected $_merge = false;
 
 /**
- * Add headers for each sentence showing references
+ * Write lines with locations of each message string
  *
  * @var bool
  */
-	protected $_headers = true;
+	protected $_locations = true;
 
 /**
  * Current file being processed
@@ -231,8 +231,8 @@ class ExtractTask extends AppShell {
 			$this->_merge = strtolower($response) === 'y';
 		}
 
-		if (isset($this->params['headers'])) {
-			$this->_headers = !(strtolower($this->params['headers']) === 'no');
+		if (isset($this->params['locations'])) {
+			$this->_locations = !(strtolower($this->params['locations']) === 'no');
 		}
 
 		if (empty($this->_files)) {
@@ -327,8 +327,8 @@ class ExtractTask extends AppShell {
 		))->addOption('merge', array(
 			'help' => __d('cake_console', 'Merge all domain and category strings into the default.po file.'),
 			'choices' => array('yes', 'no')
-		))->addOption('headers', array(
-			'help' => __d('cake_console', 'Add headers for each sentence showing references'),
+		))->addOption('locations', array(
+			'help' => __d('cake_console', 'Write lines with locations of each message string'),
 			'choices' => array('yes', 'no')
 		))->addOption('output', array(
 			'help' => __d('cake_console', 'Full path to output directory.')
@@ -587,7 +587,7 @@ class ExtractTask extends AppShell {
 					foreach ($contexts as $context => $details) {
 						$plural = $details['msgid_plural'];
 						$header = '';
-						if ($this->_headers) {
+						if ($this->_locations) {
 							$files = $details['references'];
 							$occurrences = array();
 							foreach ($files as $file => $lines) {

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -49,13 +49,6 @@ class ExtractTask extends AppShell {
 	protected $_merge = false;
 
 /**
- * Write lines with locations of each message string
- *
- * @var bool
- */
-	protected $_locations = true;
-
-/**
  * Current file being processed
  *
  * @var string
@@ -231,10 +224,6 @@ class ExtractTask extends AppShell {
 			$this->_merge = strtolower($response) === 'y';
 		}
 
-		if (isset($this->params['locations'])) {
-			$this->_locations = !(strtolower($this->params['locations']) === 'no');
-		}
-
 		if (empty($this->_files)) {
 			$this->_searchFiles();
 		}
@@ -327,9 +316,10 @@ class ExtractTask extends AppShell {
 		))->addOption('merge', array(
 			'help' => __d('cake_console', 'Merge all domain and category strings into the default.po file.'),
 			'choices' => array('yes', 'no')
-		))->addOption('locations', array(
-			'help' => __d('cake_console', 'Write lines with locations of each message string'),
-			'choices' => array('yes', 'no')
+		))->addOption('no-location', array(
+			'boolean' => true,
+			'default' => false,
+			'help' => __d('cake_console', 'Do not write lines with locations'),
 		))->addOption('output', array(
 			'help' => __d('cake_console', 'Full path to output directory.')
 		))->addOption('files', array(
@@ -587,7 +577,7 @@ class ExtractTask extends AppShell {
 					foreach ($contexts as $context => $details) {
 						$plural = $details['msgid_plural'];
 						$header = '';
-						if ($this->_locations) {
+						if (empty($this->params['no-location'])) {
 							$files = $details['references'];
 							$occurrences = array();
 							foreach ($files as $file => $lines) {

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -233,7 +233,7 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->Task->params['output'] = $this->path . DS;
 		$this->Task->params['extract-core'] = 'no';
 		$this->Task->params['merge'] = 'no';
-		$this->Task->params['locations'] = 'no';
+		$this->Task->params['no-location'] = true;
 
 		$this->Task->expects($this->never())->method('err');
 		$this->Task->expects($this->any())->method('in')

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -222,18 +222,18 @@ class ExtractTaskTest extends CakeTestCase {
 	}
 
  /**
- * testExtractWithoutHeaders method
+ * testExtractWithoutLocations method
  *
  * @return void
  */
-	public function testExtractWithoutHeaders() {
+	public function testExtractWithoutLocations() {
 		$this->Task->interactive = false;
 
 		$this->Task->params['paths'] = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Pages';
 		$this->Task->params['output'] = $this->path . DS;
 		$this->Task->params['extract-core'] = 'no';
 		$this->Task->params['merge'] = 'no';
-		$this->Task->params['headers'] = 'no';
+		$this->Task->params['locations'] = 'no';
 
 		$this->Task->expects($this->never())->method('err');
 		$this->Task->expects($this->any())->method('in')

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -221,7 +221,7 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->assertNotRegExp($pattern, $result);
 	}
 
- /**
+/**
  * testExtractWithoutLocations method
  *
  * @return void

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -221,6 +221,35 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->assertNotRegExp($pattern, $result);
 	}
 
+ /**
+ * testExtractWithoutHeaders method
+ *
+ * @return void
+ */
+	public function testExtractWithoutHeaders() {
+		$this->Task->interactive = false;
+
+		$this->Task->params['paths'] = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Pages';
+		$this->Task->params['output'] = $this->path . DS;
+		$this->Task->params['extract-core'] = 'no';
+		$this->Task->params['merge'] = 'no';
+		$this->Task->params['headers'] = 'no';
+
+		$this->Task->expects($this->never())->method('err');
+		$this->Task->expects($this->any())->method('in')
+			->will($this->returnValue('y'));
+		$this->Task->expects($this->never())->method('_stop');
+
+		$this->Task->execute();
+		$this->assertTrue(file_exists($this->path . DS . 'LC_NUMERIC' . DS . 'default.pot'));
+		$this->assertFalse(file_exists($this->path . DS . 'LC_TIME' . DS . 'default.pot'));
+
+		$result = file_get_contents($this->path . DS . 'default.pot');
+
+		$pattern = '/\n\#: .*\n/';
+		$this->assertNotRegExp($pattern, $result);
+	}
+
 /**
  * test exclusions
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -241,8 +241,7 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->Task->expects($this->never())->method('_stop');
 
 		$this->Task->execute();
-		$this->assertTrue(file_exists($this->path . DS . 'LC_NUMERIC' . DS . 'default.pot'));
-		$this->assertFalse(file_exists($this->path . DS . 'LC_TIME' . DS . 'default.pot'));
+		$this->assertTrue(file_exists($this->path . DS . 'default.pot'));
 
 		$result = file_get_contents($this->path . DS . 'default.pot');
 


### PR DESCRIPTION
Sometimes we want to review the diff of .pot files after do wording changes and it becomes hard to do because we have in the diff many changes in references header of sentences. It happens when many lines of our app were moved.

This PR allow us to avoid this situation, by removing these lines from .pot . If we perform extraction with --headers=no , then we will not to deal with this.
