### PR TITLE
Backport utf8 fix for CakeText::tokenize().

### DIFF
--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -7694,8 +7694,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Article();
 		$TestModel->Comment->validate = array(
 			'comment' => array(
-				'notEmpty' => array(
-					'rule' => array('notEmpty'),
+				'notBlank' => array(
+					'rule' => array('notBlank'),
 				)
 			)
 		);
@@ -7717,7 +7717,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals(array(
 			array(
 				'Comment' => array(
-					array('comment' => array('notEmpty'))
+					array('comment' => array('notBlank'))
 				)
 			)
 		), $TestModel->validationErrors);
@@ -7733,8 +7733,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new UserHasOneArticle();
 		$TestModel->Article->Comment->validate = array(
 			'comment' => array(
-				'notEmpty' => array(
-					'rule' => array('notEmpty'),
+				'notBlank' => array(
+					'rule' => array('notBlank'),
 				)
 			)
 		);
@@ -7759,7 +7759,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals(array(
 			'Article' => array(
 				'Comment' => array(
-					array('comment' => array('notEmpty'))
+					array('comment' => array('notBlank'))
 				)
 			)
 		), $TestModel->validationErrors);
@@ -7775,8 +7775,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new ArticlesTagBelongsToArticle();
 		$TestModel->Article->Comment->validate = array(
 			'comment' => array(
-				'notEmpty' => array(
-					'rule' => array('notEmpty'),
+				'notBlank' => array(
+					'rule' => array('notBlank'),
 				)
 			)
 		);
@@ -7800,7 +7800,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals(array(
 			'Article' => array(
 				'Comment' => array(
-					array('comment' => array('notEmpty'))
+					array('comment' => array('notBlank'))
 				)
 			)
 		), $TestModel->validationErrors);

--- a/lib/Cake/Test/Case/Utility/CakeTextTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTextTest.php
@@ -304,6 +304,11 @@ class CakeTextTest extends CakeTestCase {
 		$expected = array('tagA', '"single tag"', 'tagB');
 		$this->assertEquals($expected, $result);
 
+		// Ideographic width space.
+		$result = CakeText::tokenize("tagA\xe3\x80\x80\"single\xe3\x80\x80tag\"\xe3\x80\x80tagB", "\xe3\x80\x80", '"', '"');
+		$expected = array('tagA', '"single　tag"', 'tagB');
+		$this->assertEquals($expected, $result);
+
 		$result = CakeText::tokenize('');
 		$expected = array();
 		$this->assertEquals($expected, $result);

--- a/lib/Cake/Utility/CakeText.php
+++ b/lib/Cake/Utility/CakeText.php
@@ -115,15 +115,15 @@ class CakeText {
 		$offset = 0;
 		$buffer = '';
 		$results = array();
-		$length = strlen($data);
+		$length = mb_strlen($data);
 		$open = false;
 
 		while ($offset <= $length) {
 			$tmpOffset = -1;
 			$offsets = array(
-				strpos($data, $separator, $offset),
-				strpos($data, $leftBound, $offset),
-				strpos($data, $rightBound, $offset)
+				mb_strpos($data, $separator, $offset),
+				mb_strpos($data, $leftBound, $offset),
+				mb_strpos($data, $rightBound, $offset)
 			);
 			for ($i = 0; $i < 3; $i++) {
 				if ($offsets[$i] !== false && ($offsets[$i] < $tmpOffset || $tmpOffset == -1)) {
@@ -131,22 +131,23 @@ class CakeText {
 				}
 			}
 			if ($tmpOffset !== -1) {
-				$buffer .= substr($data, $offset, ($tmpOffset - $offset));
-				if (!$depth && $data{$tmpOffset} === $separator) {
+				$buffer .= mb_substr($data, $offset, ($tmpOffset - $offset));
+				$char = mb_substr($data, $tmpOffset, 1);
+				if (!$depth && $char === $separator) {
 					$results[] = $buffer;
 					$buffer = '';
 				} else {
-					$buffer .= $data{$tmpOffset};
+					$buffer .= $char;
 				}
 				if ($leftBound !== $rightBound) {
-					if ($data{$tmpOffset} === $leftBound) {
+					if ($char === $leftBound) {
 						$depth++;
 					}
-					if ($data{$tmpOffset} === $rightBound) {
+					if ($char === $rightBound) {
 						$depth--;
 					}
 				} else {
-					if ($data{$tmpOffset} === $leftBound) {
+					if ($char === $leftBound) {
 						if (!$open) {
 							$depth++;
 							$open = true;
@@ -157,7 +158,7 @@ class CakeText {
 				}
 				$offset = ++$tmpOffset;
 			} else {
-				$results[] = $buffer . substr($data, $offset);
+				$results[] = $buffer . mb_substr($data, $offset);
 				$offset = $length + 1;
 			}
 		}


### PR DESCRIPTION
Backport https://github.com/cakephp/cakephp/pull/7000 to 2.x.
