### PR TITLE
Add the ability to read value from an array entity context

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -222,6 +222,8 @@ class EntityContext implements ContextInterface
 
         if ($entity instanceof EntityInterface) {
             return $entity->get(array_pop($parts));
+        } elseif (is_array($entity)) {
+            return $entity[array_pop($parts)];
         }
         return null;
     }

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -458,6 +458,9 @@ class EntityContextTest extends TestCase
         $row = new Article([
             'title' => 'Test entity',
             'types' => [1, 2, 3],
+            'tag' => [
+                'name' => 'Test tag',
+            ],
             'author' => new Entity([
                 'roles' => ['admin', 'publisher']
             ])
@@ -471,6 +474,9 @@ class EntityContextTest extends TestCase
 
         $result = $context->val('author.roles');
         $this->assertEquals($row->author->roles, $result);
+
+        $result = $context->val('tag.name');
+        $this->assertEquals($row->tag['name'], $result);
     }
 
     /**


### PR DESCRIPTION
Currently it is not possible to do something like 

``` php
echo $this->Form->input('field.name');
```

where `field` is an array (for example a field that stores json/serialised data). This PR makes this possible.
