### PR TITLE
Disabled cache warning

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -495,7 +495,9 @@ class Cache {
  */
 	public static function isInitialized($config = 'default') {
 		if (Configure::read('Cache.disable')) {
-			trigger_error('Cache is disabled in your config/core.php');
+			if (Configure::read('debug') > 1) {
+				trigger_error('Cache is disabled in your config/core.php');
+			}
 			return false;
 		}
 		return isset(self::$_engines[$config]);

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -495,6 +495,7 @@ class Cache {
  */
 	public static function isInitialized($config = 'default') {
 		if (Configure::read('Cache.disable')) {
+			trigger_error('Cache is disabled in your config/core.php');
 			return false;
 		}
 		return isset(self::$_engines[$config]);


### PR DESCRIPTION
I think this change will help developers to track down problems with cache not working by helpfully pointing them directly to the problem in the code.

As most developers will want cache to be enabled in production so that the core caching works, throwing a warning when in development mode seems logical to me.
