### PR TITLE
Set correct permission on generated folders.

### DIFF
--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -92,7 +92,7 @@ class I18nShell extends Shell
         $sourceFolder = rtrim($response, DS) . DS;
         $targetFolder = $sourceFolder . $language . DS;
         if (!is_dir($targetFolder)) {
-            mkdir($targetFolder, 0770, true);
+            mkdir($targetFolder, 0775, true);
         }
 
         $count = 0;


### PR DESCRIPTION
Not having world readable on generated folders makes it hard for webservers to read the locale files.

Refs #7002
