### PR TITLE
Marking an entity as clean after the afterSave event.

### DIFF
--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -96,8 +96,9 @@ class HasMany extends Association
             throw new InvalidArgumentException($message);
         }
 
+        $foreignKey = (array)$this->foreignKey();
         $properties = array_combine(
-            (array)$this->foreignKey(),
+            $foreignKey,
             $entity->extract((array)$this->bindingKey())
         );
         $target = $this->target();
@@ -113,7 +114,10 @@ class HasMany extends Association
                 $targetEntity = clone $targetEntity;
             }
 
-            $targetEntity->set($properties, ['guard' => false]);
+            if ($properties !== $targetEntity->extract($foreignKey)) {
+                $targetEntity->set($properties, ['guard' => false]);
+            }
+
             if ($target->save($targetEntity, $options)) {
                 $targetEntities[$k] = $targetEntity;
                 continue;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1445,8 +1445,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 ['_primary' => false] + $options->getArrayCopy()
             );
             if ($success || !$options['atomic']) {
-                $entity->clean();
                 $this->dispatchEvent('Model.afterSave', compact('entity', 'options'));
+                $entity->clean();
                 if (!$options['atomic'] && !$options['_primary']) {
                     $entity->isNew(false);
                     $entity->source($this->registryAlias());

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1888,6 +1888,7 @@ class TableTest extends TestCase
         $called = false;
         $listener = function ($e, $entity, $options) use ($data, &$called) {
             $this->assertSame($data, $entity);
+            $this->assertTrue($entity->dirty());
             $called = true;
         };
         $table->eventManager()->on('Model.afterSave', $listener);
@@ -1895,6 +1896,7 @@ class TableTest extends TestCase
         $calledAfterCommit = false;
         $listenerAfterCommit = function ($e, $entity, $options) use ($data, &$calledAfterCommit) {
             $this->assertSame($data, $entity);
+            $this->assertFalse($entity->dirty());
             $calledAfterCommit = true;
         };
         $table->eventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4373,7 +4373,7 @@ class TableTest extends TestCase
                 if ($entity->dirty()) {
                     $counter++;
                 }
-        });
+            });
 
         $savedUser->comments[] = $userTable->Comments->get(5);
         $this->assertCount(3, $savedUser->comments);


### PR DESCRIPTION
By letting the entity be dirty during the event, listeners
can inspect the changes done to the entity during the save process.
I think this is a very important information to have and does not
negatively affect anything else.
