### PR TITLE
Adding UrlHelper as @property comment to Cake\View\View

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -55,6 +55,7 @@ use RuntimeException;
  * @property      \Cake\View\Helper\SessionHelper $Session
  * @property      \Cake\View\Helper\TextHelper $Text
  * @property      \Cake\View\Helper\TimeHelper $Time
+ * @property      \Cake\View\Helper\UrlHelper $Url
  * @property      \Cake\View\ViewBlock $Blocks
  */
 class View implements EventDispatcherInterface


### PR DESCRIPTION
Fixes #7018 to enable autocompletion of Url Helper as a View property.
