### PR TITLE
Removed pass by reference

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -781,7 +781,7 @@ class Hash
         while ($elem = array_shift($data)) {
             if (is_array($elem)) {
                 $depth += 1;
-                $data =& $elem;
+                $data = $elem;
             } else {
                 break;
             }


### PR DESCRIPTION
There does not seem to be a good reason to pass by reference here.  Really PHP always passes by reference anyway.

Reasons:
http://php.net/manual/en/language.references.php
http://derickrethans.nl/files/phparch-php-variables-article.pdf
