### PR TITLE
Ajax requests not properly returning 403

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -373,7 +373,9 @@ class AuthComponent extends Component {
 			$this->_stop();
 			return false;
 		}
-		$controller->redirect(null, 403);
+		$controller->response->statusCode(403);
+		$controller->response->send();
+		$this->_stop();
 		return false;
 	}
 


### PR DESCRIPTION
When an AJAX request is made to a page that's not authorized, an infinite redirect loop to  /status:403/exit:1  is triggered. This bug has existed at least since CakePHP v2.3.0. The main use case is when a user's session has expired and they try to use an authenticated feature as a logged-out user.
