### PR TITLE
Fix Hash::maxDimensions

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -756,18 +756,16 @@ class Hash {
  * number of dimensions in a mixed array.
  *
  * @param array $data Array to count dimensions on
+ * @param int $count counts current depth of this iteration
  * @return int The maximum number of dimensions in $data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::maxDimensions
  */
-	public static function maxDimensions(array $data) {
-		$depth = array();
+ 
+	public static function maxDimensions($data, $count = 0) {
+		$depth = array($count);
 		if (is_array($data) && reset($data) !== false) {
 			foreach ($data as $value) {
-				if (is_array($value)) {
-					$depth[] = self::dimensions($value) + 1;
-				} else {
-					$depth[] = 1;
-				}
+				$depth[] = static::maxDimensions($value, $count + 1 );
 			}
 		}
 		return empty($depth) ? 0 : max($depth);

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -760,7 +760,6 @@ class Hash {
  * @return int The maximum number of dimensions in $data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::maxDimensions
  */
- 
 	public static function maxDimensions($data, $count = 0) {
 		$depth = array($count);
 		if (is_array($data) && reset($data) !== false) {


### PR DESCRIPTION
*\* Closed the 2.8 pull request and opened this one instead.   Issue #7022 **

The current Hash::maxDimensions function calls Hash::dimensions to try to get the maximum depth of the passed in array.  However, this ends up only getting the depth of the first element of each 1st dimension element in the array passed to maxDimensions.  The function needs to be called recursively in order to get the depth of ALL of the elements in all of the dimensions of the passed in array.

I made the maxDimensions function more closely resemble the deprecated Set::countDim function in order to restore the correct functionality.

Example:

``` php
$data = array(
             0 => array(
                 0 => 'Some Value',
                 1 => array(
                     0 => 'Some other Value'
                 )
             ),
             1 => array(
                 0 => 'Some Value',
             )
         );
```

Returns 2 under the current version of maxDimensions.
Returns 3 with the changes proposed above.
