### PR TITLE
fixes bug when $params['plugin'] isn't set

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -559,6 +559,7 @@ class Router
 
         $request = static::getRequest(true);
         if ($request) {
+            $request->params += $params;
             $params = $request->params;
             $here = $request->here;
             $base = $request->base;


### PR DESCRIPTION
An "Undefined index: 'plugin'" resulted in line 613 (old 612), if $params['plugin'] isn't set by a 'requestAction'.
Added an array addition in line 562, so the $params variable is forced to have the 'plugin' index.
