### PR TITLE
Don't modify the where clause on empty inputs.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -755,9 +755,6 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function where($conditions = null, $types = [], $overwrite = false)
     {
-        if (empty($conditions)) {
-            return $this;
-        }
         if ($overwrite) {
             $this->_parts['where'] = $this->newExpr();
         }
@@ -1646,6 +1643,9 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     protected function _conjugate($part, $append, $conjunction, $types)
     {
+        if (empty($append)) {
+            return;
+        }
         $expression = $this->_parts[$part] ?: $this->newExpr();
 
         if (!is_string($append) && is_callable($append)) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -755,6 +755,9 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function where($conditions = null, $types = [], $overwrite = false)
     {
+        if (empty($conditions)) {
+            return $this;
+        }
         if ($overwrite) {
             $this->_parts['where'] = $this->newExpr();
         }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1180,6 +1180,23 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Tests that empty values don't set where clauses.
+     *
+     * @return void
+     */
+    public function testWhereEmptyValues()
+    {
+        $query = new Query($this->connection);
+        $query->from('comments')
+            ->where('');
+
+        $this->assertNull($query->clause('where'));
+
+        $query->where([]);
+        $this->assertNull($query->clause('where'));
+    }
+
+    /**
      * Tests that it is possible to use a between expression
      * in a where condition
      *

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -78,6 +78,22 @@ class AssociationProxyTest extends TestCase
     }
 
     /**
+     * Test that find() with empty conditions generates valid SQL
+     *
+     * @return void
+     */
+    public function testFindEmptyConditions()
+    {
+        $table = TableRegistry::get('Users');
+        $table->hasMany('Articles', [
+            'foreignKey' => 'author_id',
+            'conditions' => '',
+        ]);
+        $query = $table->Articles->find('list', ['limit' => 2]);
+        $this->assertCount(2, $query->all());
+    }
+
+    /**
      * Tests that the proxied updateAll will preserve conditions set for the association
      *
      * @return void


### PR DESCRIPTION
When we get '' or [] we can safely assume that no where clause should be set, as it would result in an invalid query.

Refs #7028
