### PR TITLE
add breakpoint() convenience function

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -160,5 +160,9 @@ if (!function_exists('breakpoint')) {
         if (PHP_SAPI === 'cli' && class_exists('\Psy\Shell')) {
             return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
         }
+        trigger_error(
+            "psy/psysh must be loaded and you should be in CLI to use the breakpoint method",
+            E_USER_WARNING
+        );
     }
 }

--- a/src/basics.php
+++ b/src/basics.php
@@ -143,3 +143,20 @@ if (!function_exists('json_last_error_msg')) {
     }
 
 }
+
+if (!function_exists('breakpoint')) {
+    /**
+     * Command to return the eval-able code to startup PsySH in interactive debugger
+     * Works the same way as eval(\Psy\sh());
+     * ```
+     * eval(breakpoint());
+     * ```
+     * @return string
+     */
+    function breakpoint()
+    {
+        if (PHP_SAPI === 'cli' && class_exists('\Psy\Shell')) {
+            return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
+        }
+    }
+}

--- a/src/basics.php
+++ b/src/basics.php
@@ -148,6 +148,8 @@ if (!function_exists('breakpoint')) {
     /**
      * Command to return the eval-able code to startup PsySH in interactive debugger
      * Works the same way as eval(\Psy\sh());
+     * psy/psysh must be loaded in your project
+     * @link http://psysh.org/
      * ```
      * eval(breakpoint());
      * ```

--- a/src/basics.php
+++ b/src/basics.php
@@ -161,7 +161,7 @@ if (!function_exists('breakpoint')) {
             return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
         }
         trigger_error(
-            "psy/psysh must be loaded and you should be in CLI to use the breakpoint method",
+            "psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function",
             E_USER_WARNING
         );
     }


### PR DESCRIPTION
### Usage

Wherever you want in your code

``` php
<?php eval(breakpoint()); ?>
```

It's an attemp to ease debugging by providing a convenience function that we can properly document.
Works the same way that eval(Psy\sh()) and allow interactive debugging in CLI

Here is an example with the cake console:
![kjmuhmg08o](https://cloud.githubusercontent.com/assets/4977112/8752907/b542e520-2cb7-11e5-8fc8-19d9d87b2655.gif)

It's probably not perfect but it's really handy in a lot of situation, please test it locally and see how it works for you. I've tested it on mac and windows.

and here an example to debug unit test
![mq1i8pr8bk](https://cloud.githubusercontent.com/assets/4977112/8752915/c079885e-2cb7-11e5-93bb-858410774190.gif)

More information on http://psysh.org/

I was wondering if it would better fit in the Debugger class or maybe in DebugKit.
