### PR TITLE
ORM auto-alias

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -153,7 +153,7 @@ class QueryCompiler
         $normalized = [];
         $parts = $this->_stringifyExpressions($parts, $generator);
         foreach ($parts as $k => $p) {
-            if (!is_numeric($k)) {
+            if ($query->autoAlias() && !is_numeric($k)) {
                 $p = $p . ' AS ' . $driver->quoteIdentifier($k);
             }
             $normalized[] = $p;

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -153,7 +153,7 @@ class QueryCompiler
         $normalized = [];
         $parts = $this->_stringifyExpressions($parts, $generator);
         foreach ($parts as $k => $p) {
-            if ($query->autoAlias() && !is_numeric($k)) {
+            if (!is_numeric($k)) {
                 $p = $p . ' AS ' . $driver->quoteIdentifier($k);
             }
             $normalized[] = $p;

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -79,6 +79,14 @@ class Query extends DatabaseQuery implements JsonSerializable
     protected $_autoFields;
 
     /**
+     * Tracks whether or not the original query should create
+     * aliases for the fields.
+     *
+     * @var bool
+     */
+    protected $_autoAlias = true;
+
+    /**
      * Whether to hydrate results into entity objects
      *
      * @var bool
@@ -850,6 +858,24 @@ class Query extends DatabaseQuery implements JsonSerializable
             return $this->_autoFields;
         }
         $this->_autoFields = (bool)$value;
+        return $this;
+    }
+
+    /**
+     * Get/Set whether or not the ORM aliasing fields automatically.
+     *
+     * By default calling select() will enable auto-alias. You can disable
+     * auto-alias with this method.
+     *
+     * @param bool|null $value The value to set or null to read the current value.
+     * @return bool|$this Either the current value or the query object.
+     */
+    public function autoAlias($value = null)
+    {
+        if ($value === null) {
+            return $this->_autoAlias;
+        }
+        $this->_autoAlias = (bool)$value;
         return $this;
     }
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -375,6 +375,10 @@ class Query extends DatabaseQuery implements JsonSerializable
             $aliasedField = $alias . '.' . $field;
         }
 
+        if ($this->_autoAlias === false) {
+            return [$aliasedField];
+        }
+
         return [$key => $aliasedField];
     }
 
@@ -391,7 +395,8 @@ class Query extends DatabaseQuery implements JsonSerializable
         $aliased = [];
         foreach ($fields as $alias => $field) {
             if (is_numeric($alias) && is_string($field)) {
-                $aliased += $this->aliasField($field, $defaultAlias);
+                $aliasField = $this->aliasField($field, $defaultAlias);
+                $aliased = array_merge($aliased, $aliasField);
                 continue;
             }
             $aliased[$alias] = $field;


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/issues/7050

Before the changes you need to do:

```
$columns = $this->schema()->columns();
$subQuery = $this->find();
$subQuery->select(array_combine($columns, $columns));
$query = $this->find()->from(['Geolocations' => $subQuery]);
```

With the changes you can do:

```
$subQuery = $this->find()->autoAlias(false);
$query = $this->find()->from(['Geolocations' => $subQuery]);
```

If you are fine with the changes, I will do the test cases.
