### PR TITLE
Update CakeSocket.php

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -137,11 +137,11 @@ class CakeSocket {
 		if (!empty($this->config['context'])) {
 			$context = stream_context_create($this->config['context']);
 		} else {
-		    $options = [];
-		    if (!empty($this->config['ssl'])) {
-		        $options = array('ssl' => $this->config['ssl']);
-		    }
-		    $context = stream_context_create($options);
+			$options = array;
+			if (!empty($this->config['ssl'])) {
+				$options = array('ssl' => $this->config['ssl']);
+			}
+			$context = stream_context_create($options);
 		}
 
 		$connectAs = STREAM_CLIENT_CONNECT;

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -137,7 +137,7 @@ class CakeSocket {
 		if (!empty($this->config['context'])) {
 			$context = stream_context_create($this->config['context']);
 		} else {
-			$options = array;
+			$options = array();
 			if (!empty($this->config['ssl'])) {
 				$options = array('ssl' => $this->config['ssl']);
 			}

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -137,7 +137,11 @@ class CakeSocket {
 		if (!empty($this->config['context'])) {
 			$context = stream_context_create($this->config['context']);
 		} else {
-			$context = stream_context_create();
+		    $options = [];
+		    if (!empty($this->config['ssl'])) {
+		        $options = array('ssl' => $this->config['ssl']);
+		    }
+		    $context = stream_context_create($options);
 		}
 
 		$connectAs = STREAM_CLIENT_CONNECT;


### PR DESCRIPTION
This fix allows user to disable certificate verification with EmailConfig:

``` php
class EmailConfig
{
    public $Send = array(
        'transport' => 'Smtp',
        'host' => 'smtp.example.com',
        'tls' => true,
        'port' => 587,
        'username' => 'username',
        'password' => 'password',
        'timeout' => 30,
        'client' => null,
        'charset' => 'utf-8',
        'headerCharset' => 'utf-8',
        'log' => false,
        'ssl' => array(
            'allow_self_signed' => true, 
            'verify_peer' => false
        ),
    );
}
```
