### PR TITLE
XmlView: check _serialize keys before using them

### DIFF
--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -148,7 +148,9 @@ class XmlView extends View
                 if (is_numeric($alias)) {
                     $alias = $key;
                 }
-                $data[$rootNode][$alias] = $this->viewVars[$key];
+                if (array_key_exists($key, $this->viewVars)) {
+                    $data[$rootNode][$alias] = $this->viewVars[$key];
+                }
             }
         } else {
             $data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;


### PR DESCRIPTION
Before adding a view var to `$data`, make sure it exists.

this fixes #7067
