### PR TITLE
enable colors for windows ConEmu users...

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -163,7 +163,7 @@ class ConsoleOutput
     {
         $this->_output = fopen($stream, 'w');
 
-        if ((DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && (!(bool)env('ANSICON') || env('ConEmuANSI') !== 'ON')) ||
             (function_exists('posix_isatty') && !posix_isatty($this->_output))
         ) {
             $this->_outputAs = self::PLAIN;

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -57,7 +57,7 @@ class ConsoleLog extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        if ((DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && (!(bool)env('ANSICON') || env('ConEmuANSI') !== 'ON')) ||
             (function_exists('posix_isatty') && !posix_isatty($this->_output))
         ) {
             $this->_defaultConfig['outputAs'] = ConsoleOutput::PLAIN;

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -68,7 +68,7 @@ class ConsoleLogTest extends TestCase
      */
     public function testDefaultOutputAs()
     {
-        if ((DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && (!(bool)env('ANSICON') || env('ConEmuANSI') !== 'ON')) ||
             (function_exists('posix_isatty') && !posix_isatty(null))
         ) {
             $expected = ConsoleOutput::PLAIN;


### PR DESCRIPTION
in the same way that ansicon.

[ConEmu](http://gooseberrycreative.com/cmder/) is used in [Cmder](http://gooseberrycreative.com/cmder/) for example.

I thought this change was small enougth to fit into 3.0 but I could target 3.1 if you prefer
