### PR TITLE
enable colors for windows ConEmu user

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -154,8 +154,8 @@ class ConsoleOutput
     /**
      * Construct the output object.
      *
-     * Checks for a pretty console environment. Ansicon allows pretty consoles
-     * on windows, and is supported.
+     * Checks for a pretty console environment. Ansicon and ConEmu allows
+     *  pretty consoles on windows, and is supported.
      *
      * @param string $stream The identifier of the stream to write output to.
      */
@@ -163,7 +163,7 @@ class ConsoleOutput
     {
         $this->_output = fopen($stream, 'w');
 
-        if ((DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
             (function_exists('posix_isatty') && !posix_isatty($this->_output))
         ) {
             $this->_outputAs = self::PLAIN;

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -57,7 +57,7 @@ class ConsoleLog extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        if ((DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
             (function_exists('posix_isatty') && !posix_isatty($this->_output))
         ) {
             $this->_defaultConfig['outputAs'] = ConsoleOutput::PLAIN;

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -68,7 +68,7 @@ class ConsoleLogTest extends TestCase
      */
     public function testDefaultOutputAs()
     {
-        if ((DS === '\\' && !(bool)env('ANSICON')) ||
+        if ((DS === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
             (function_exists('posix_isatty') && !posix_isatty(null))
         ) {
             $expected = ConsoleOutput::PLAIN;


### PR DESCRIPTION
in the same way that ansicon.

[ConEmu](http://conemu.github.io/) is used in [Cmder](http://gooseberrycreative.com/cmder/) for example.

I thought this change was small enougth to fit into 3.0 but I could target 3.1 if you prefer
