### PR TITLE
Make fixture import from table aware of records found

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -414,19 +414,26 @@ class FixtureTask extends BakeTask {
  * @return array Array of records.
  */
 	protected function _getRecordsFromTable($modelName, $useTable = null) {
+		$modelObject = new Model(array('name' => $modelName, 'table' => $useTable, 'ds' => $this->connection));
 		if ($this->interactive) {
 			$condition = null;
 			$prompt = __d('cake_console', "Please provide a SQL fragment to use as conditions\nExample: WHERE 1=1");
 			while (!$condition) {
 				$condition = $this->in($prompt, null, 'WHERE 1=1');
 			}
+
+			$recordsFound = $modelObject->find('count', array(
+				'conditions' => $condition,
+				'recursive' => -1,
+			));
+
 			$prompt = __d('cake_console', "How many records do you want to import?");
-			$recordCount = $this->in($prompt, null, 10);
+			$recordCount = $this->in($prompt, null, ($recordsFound < 10 ) ? $recordsFound : 10);
 		} else {
 			$condition = 'WHERE 1=1';
 			$recordCount = (isset($this->params['count']) ? $this->params['count'] : 10);
 		}
-		$modelObject = new Model(array('name' => $modelName, 'table' => $useTable, 'ds' => $this->connection));
+
 		$records = $modelObject->find('all', array(
 			'conditions' => $condition,
 			'recursive' => -1,

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -186,6 +186,9 @@ class FixtureTaskTest extends CakeTestCase {
 		$this->Task->interactive = true;
 		$this->Task->expects($this->at(0))->method('in')
 			->will($this->returnValue('WHERE 1=1'));
+		$this->Task->expects($this->at(1))->method('in')
+			->with($this->anything(), $this->anything(), '3')
+			->will($this->returnValue('2'));
 
 		$this->Task->connection = 'test';
 		$this->Task->path = '/my/path/';
@@ -197,9 +200,8 @@ class FixtureTaskTest extends CakeTestCase {
 		$this->assertContains('class ArticleFixture extends CakeTestFixture', $result);
 		$this->assertContains('public $records', $result);
 		$this->assertContains('public $import', $result);
-		$this->assertContains("'title' => 'First Article'", $result, 'Missing import data %s');
-		$this->assertContains('Second Article', $result, 'Missing import data %s');
-		$this->assertContains('Third Article', $result, 'Missing import data %s');
+		$this->assertContains("'title' => 'First Article'", $result, 'Missing import data');
+		$this->assertContains('Second Article', $result, 'Missing import data');
 	}
 
 /**


### PR DESCRIPTION
I found it sad, that the fixture bake task does not hint at how many records I _could_ import from the table.

I targeted 2.7 because it is a very small feature addition.
