### PR TITLE
Consistently remove plugin names in object collections.

### DIFF
--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -583,4 +583,33 @@ class ObjectCollectionTest extends CakeTestCase {
 		$this->assertTrue($this->Objects->trigger($event));
 	}
 
+/**
+ * test that the various methods ignore plugin prefixes
+ *
+ * plugin prefixes should be removed consistently as load() will
+ * remove them. Furthermore the __get() method does not support
+ * names with '.' in them.
+ *
+ * @return void
+ */
+	public function testPluginPrefixes() {
+		$this->Objects->load('TestPlugin.First');
+		$this->assertTrue($this->Objects->loaded('First'));
+		$this->assertTrue($this->Objects->loaded('TestPlugin.First'));
+
+		$this->assertTrue($this->Objects->enabled('First'));
+		$this->assertTrue($this->Objects->enabled('TestPlugin.First'));
+
+		$this->assertNull($this->Objects->disable('TestPlugin.First'));
+		$this->assertFalse($this->Objects->enabled('First'));
+		$this->assertFalse($this->Objects->enabled('TestPlugin.First'));
+
+		$this->assertNull($this->Objects->enable('TestPlugin.First'));
+		$this->assertTrue($this->Objects->enabled('First'));
+		$this->assertTrue($this->Objects->enabled('TestPlugin.First'));
+		$this->Objects->setPriority('TestPlugin.First', 1000);
+
+		$result = $this->Objects->prioritize();
+		$this->assertEquals(1000, $result['First'][0]);
+	}
 }

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -176,6 +176,7 @@ abstract class ObjectCollection {
 	public function enable($name, $prioritize = true) {
 		$enabled = false;
 		foreach ((array)$name as $object) {
+			list(, $object) = pluginSplit($object);
 			if (isset($this->_loaded[$object]) && !isset($this->_enabled[$object])) {
 				$priority = $this->defaultPriority;
 				if (isset($this->_loaded[$object]->settings['priority'])) {
@@ -219,6 +220,7 @@ abstract class ObjectCollection {
 			$name = array($name => $priority);
 		}
 		foreach ($name as $object => $objectPriority) {
+			list(, $object) = pluginSplit($object);
 			if (isset($this->_loaded[$object])) {
 				if ($objectPriority === null) {
 					$objectPriority = $this->defaultPriority;
@@ -241,6 +243,7 @@ abstract class ObjectCollection {
  */
 	public function disable($name) {
 		foreach ((array)$name as $object) {
+			list(, $object) = pluginSplit($object);
 			unset($this->_enabled[$object]);
 		}
 	}
@@ -255,6 +258,7 @@ abstract class ObjectCollection {
  */
 	public function enabled($name = null) {
 		if (!empty($name)) {
+			list(, $name) = pluginSplit($name);
 			return isset($this->_enabled[$name]);
 		}
 		return array_keys($this->_enabled);
@@ -283,6 +287,7 @@ abstract class ObjectCollection {
  */
 	public function loaded($name = null) {
 		if (!empty($name)) {
+			list(, $name) = pluginSplit($name);
 			return isset($this->_loaded[$name]);
 		}
 		return array_keys($this->_loaded);


### PR DESCRIPTION
We were sometimes removing plugin prefixes (set, and some subclass methods). But many other methods were missing the pluginSplit() feature. This change makes all of the methods in ObjectCollection strip plugin prefixes, which increases consistency across the framework.

Refs #7098
