### PR TITLE
Make sure that the core required routing parameters are set.

### DIFF
--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -118,8 +118,9 @@ trait RequestActionTrait
                 'url' => $url
             ];
         } elseif (is_array($url)) {
+            $defaultParams = ['plugin' => null, 'controller' => null, 'action' => null];
             $params = [
-                'params' => $url,
+                'params' => $url + $defaultParams,
                 'base' => false,
                 'url' => Router::reverse($url)
             ];

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -195,6 +195,22 @@ class RequestActionTraitTest extends TestCase
     }
 
     /**
+     * Test that the required parameter names are seeded by requestAction.
+     *
+     * @return void
+     */
+    public function testRequestActionArraySetParamNames()
+    {
+        $result = $this->object->requestAction(
+            ['controller' => 'RequestAction', 'action' => 'params_pass']
+        );
+        $result = json_decode($result, true);
+        $this->assertArrayHasKey('action', $result['params']);
+        $this->assertArrayHasKey('controller', $result['params']);
+        $this->assertArrayHasKey('plugin', $result['params']);
+    }
+
+    /**
      * Test that requestAction() does not forward the 0 => return value.
      *
      * @return void

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -116,6 +116,7 @@ class RequestActionController extends AppController
     public function params_pass()
     {
         $this->response->body(json_encode([
+            'params' => $this->request->params,
             'base' => $this->request->base,
             'webroot' => $this->request->webroot,
             'params' => $this->request->params,


### PR DESCRIPTION
requestAction() should set the default routing parameters when the array form is used.

I felt this was a less invasive change than the one proposed in #7045. It also fixes the issues at the root, and doesn't try to address a symptom of the problem

Refs #7045
