### PR TITLE
Type hint the constructor param

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -102,7 +102,7 @@ class RouteBuilder
      *   - `routeClass` - The default route class to use when adding routes.
      *   - `extensions` - The extensions to connect when adding routes.
      */
-    public function __construct($collection, $path, array $params = [], array $options = [])
+    public function __construct(RouteCollection $collection, $path, array $params = [], array $options = [])
     {
         $this->_collection = $collection;
         $this->_path = $path;


### PR DESCRIPTION
This is speculative PR, for discussion.

There are a number of reasons for this change.

Two methods are called against the route collection, `connect` and `scope` which means that if it's `null` these methods will generate fatal errors.

As a dependency for the class it makes sense to force the expectation of the params. Otherwise the param could be anything, causing adverse side effects.

The failure of the class is more reliable for the two methods which rely on the collection existing.
