### PR TITLE
ViewBlock able to prepend with capturing mode

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -590,12 +590,7 @@ class View implements EventDispatcherInterface
      */
     public function append($name, $value = null)
     {
-        if ($value !== null) {
-            $this->Blocks->concat($name, $value);
-            return;
-        }
-        $this->Blocks->start($name);
-        echo $this->Blocks->get($name);
+        $this->Blocks->concat($name, $value);
     }
 
     /**

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -111,7 +111,7 @@ class ViewBlock
             $mode   = end($this->_active);
             $active = key($this->_active);
             $content = ob_get_clean();
-            if($mode === ViewBlock::OVERRIDE) {
+            if ($mode === ViewBlock::OVERRIDE) {
                 $this->_blocks[$active] = $content;
             } else {
                 $this->concat($active, $content, $mode);
@@ -136,7 +136,7 @@ class ViewBlock
      */
     public function concat($name, $value = null, $mode = ViewBlock::APPEND)
     {
-        if($value === null) {
+        if ($value === null) {
             $this->start($name, $mode);
             return;
         }

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -27,6 +27,13 @@ class ViewBlock
 {
 
     /**
+     * Override content
+     *
+     * @var string
+     */
+    const OVERRIDE = 'override';
+
+    /**
      * Append content
      *
      * @var string
@@ -72,15 +79,18 @@ class ViewBlock
      * using View::get();
      *
      * @param string $name The name of the block to capture for.
+     * @param string $mode If ViewBlock::OVERRIDE existing content will be overridden by new content.
+     *   If ViewBlock::APPEND content will be appended to existing content.
+     *   If ViewBlock::PREPEND it will be prepended.
      * @throws \Cake\Core\Exception\Exception When starting a block twice
      * @return void
      */
-    public function start($name)
+    public function start($name, $mode = ViewBlock::OVERRIDE)
     {
-        if (in_array($name, $this->_active)) {
+        if (in_array($name, array_keys($this->_active))) {
             throw new Exception(sprintf("A view block with the name '%s' is already/still open.", $name));
         }
-        $this->_active[] = $name;
+        $this->_active[$name] = $mode;
         ob_start();
     }
 
@@ -98,9 +108,14 @@ class ViewBlock
             return;
         }
         if (!empty($this->_active)) {
-            $active = end($this->_active);
+            $mode   = end($this->_active);
+            $active = key($this->_active);
             $content = ob_get_clean();
-            $this->_blocks[$active] = $content;
+            if($mode === ViewBlock::OVERRIDE) {
+                $this->_blocks[$active] = $content;
+            } else {
+                $this->concat($active, $content, $mode);
+            }
             array_pop($this->_active);
         }
     }
@@ -119,8 +134,13 @@ class ViewBlock
      *   If ViewBlock::PREPEND it will be prepended.
      * @return void
      */
-    public function concat($name, $value, $mode = ViewBlock::APPEND)
+    public function concat($name, $value = null, $mode = ViewBlock::APPEND)
     {
+        if($value === null) {
+            $this->start($name, $mode);
+            return;
+        }
+
         if (!isset($this->_blocks[$name])) {
             $this->_blocks[$name] = '';
         }

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -108,10 +108,10 @@ class ViewBlock
             return;
         }
         if (!empty($this->_active)) {
-            $mode   = end($this->_active);
+            $mode = end($this->_active);
             $active = key($this->_active);
             $content = ob_get_clean();
-            if($mode === ViewBlock::OVERRIDE) {
+            if ($mode === ViewBlock::OVERRIDE) {
                 $this->_blocks[$active] = $content;
             } else {
                 $this->concat($active, $content, $mode);
@@ -136,7 +136,7 @@ class ViewBlock
      */
     public function concat($name, $value = null, $mode = ViewBlock::APPEND)
     {
-        if($value === null) {
+        if ($value === null) {
             $this->start($name, $mode);
             return;
         }

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -111,12 +111,12 @@ class ViewBlock
             $mode   = end($this->_active);
             $active = key($this->_active);
             $content = ob_get_clean();
+            array_pop($this->_active);
             if($mode === ViewBlock::OVERRIDE) {
                 $this->_blocks[$active] = $content;
             } else {
                 $this->concat($active, $content, $mode);
             }
-            array_pop($this->_active);
         }
     }
 

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -111,12 +111,12 @@ class ViewBlock
             $mode   = end($this->_active);
             $active = key($this->_active);
             $content = ob_get_clean();
-            array_pop($this->_active);
             if($mode === ViewBlock::OVERRIDE) {
                 $this->_blocks[$active] = $content;
             } else {
                 $this->concat($active, $content, $mode);
             }
+            array_pop($this->_active);
         }
     }
 
@@ -207,7 +207,8 @@ class ViewBlock
      */
     public function active()
     {
-        return end($this->_active);
+        end($this->_active);
+        return key($this->_active);
     }
 
     /**


### PR DESCRIPTION
Hi,

I needed to prepend ViewBlocks with the buffering/capturing mode but View and ViewBlock only allowed capturing appending.
So I modified ViewBlock code to handle both appending and prepending with capturing. I had to add a third const OVERRIDE in ViewBlock to keep the consistency with existing code.
I also had to change the way the ViewBlock::_active array is built to recall what kind of concatenation ViewBlock::end() should make. So the keys of the array are now the name of the block and the value is the concatenation mode (OVERRIDE | APPEND | PREPEND).

Tell me if I should change some code/documentation.
