### PR TITLE
Disable SNI in HttpSocket

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -719,7 +719,7 @@ class HttpSocket extends CakeSocket {
 			unset($this->config[$key]);
 		}
 		if (version_compare(PHP_VERSION, '5.3.2', '>=')) {
-			if (empty($this->config['context']['ssl']['SNI_enabled'])) {
+			if (!isset($this->config['context']['ssl']['SNI_enabled'])) {
 				$this->config['context']['ssl']['SNI_enabled'] = true;
 			}
 			if (version_compare(PHP_VERSION, '5.6.0', '>=')) {


### PR DESCRIPTION
SNI could not be disabled because when you set it to false, it is empty, causing it to set to true again.
