### PR TITLE
use the defined route name in the routes shell

### DIFF
--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -38,7 +38,8 @@ class RoutesShell extends Shell
             ['Route name', 'URI template', 'Defaults']
         ];
         foreach (Router::routes() as $route) {
-            $output[] = [$route->getName(), $route->template, json_encode($route->defaults)];
+            $name = isset($route->options['_name']) ? $route->options['_name'] : $route->getName();
+            $output[] = [$name, $route->template, json_encode($route->defaults)];
         }
         $this->helper('table')->output($output);
     }

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -45,6 +45,7 @@ class RoutesShellTest extends TestCase
         $this->shell = new RoutesShell($this->io);
         Router::connect('/articles/:action/*', ['controller' => 'Articles']);
         Router::connect('/bake/:controller/:action', ['plugin' => 'Bake']);
+        Router::connect('/tests/:action/*', ['controller' => 'Tests'], ['_name' => 'testName']);
     }
 
     /**
@@ -75,6 +76,16 @@ class RoutesShellTest extends TestCase
                         'articles:_action',
                         '/articles/:action/*',
                         '{"controller":"Articles","action":"index","plugin":null}'
+                    ]),
+                    $this->contains([
+                        'bake._controller:_action',
+                        '/bake/:controller/:action',
+                        '{"plugin":"Bake","action":"index"}',
+                    ]),
+                    $this->contains([
+                        'testName',
+                        '/tests/:action/*',
+                        '{"controller":"Tests","action":"index","plugin":null}'
                     ])
                 )
             );


### PR DESCRIPTION
In the column "Route Name" I would expect to get the name defined by named route if it exists.

Without this modification, the test that I added would return `tests:_action` instead of `testName`.
