### PR TITLE
Don't stop reading when only a '0' has been read.

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -378,7 +378,7 @@ class HttpSocket extends CakeSocket {
 
 		$response = null;
 		$inHeader = true;
-		while ($data = $this->read()) {
+		while (($data = $this->read()) !== false) {
 			if ($this->_contentResource) {
 				if ($inHeader) {
 					$response .= $data;

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -307,6 +307,10 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testRequest() {
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->returnValue(false));
+
 		$this->Socket->reset();
 
 		$response = $this->Socket->request(true);
@@ -589,6 +593,10 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testGetWithSchemeAndPort() {
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->returnValue(false));
+
 		$this->Socket->reset();
 		$request = array(
 			'uri' => array(
@@ -609,6 +617,10 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testRequestWithStringQuery() {
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->returnValue(false));
+
 		$this->Socket->reset();
 		$request = array(
 			'uri' => array(
@@ -642,14 +654,18 @@ class HttpSocketTest extends CakeTestCase {
  */
 	public function testRequest2() {
 		$this->Socket->reset();
+
 		$request = array('uri' => 'htpp://www.cakephp.org/');
 		$number = mt_rand(0, 9999999);
 		$this->Socket->expects($this->any())->method('connect')->will($this->returnValue(true));
 		$serverResponse = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>Hello, your lucky number is " . $number . "</h1>";
 		$this->Socket->expects($this->at(0))->method('write')
 			->with("GET / HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n");
-		$this->Socket->expects($this->at(0))->method('read')->will($this->returnValue(false));
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse, false));
+
 		$response = (string)$this->Socket->request($request);
 		$this->assertEquals($response, "<h1>Hello, your lucky number is " . $number . "</h1>");
 	}
@@ -662,7 +678,11 @@ class HttpSocketTest extends CakeTestCase {
 	public function testRequest3() {
 		$request = array('uri' => 'htpp://www.cakephp.org/');
 		$serverResponse = "HTTP/1.x 200 OK\r\nSet-Cookie: foo=bar\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a cookie test!</h1>";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse, false));
+
 		$this->Socket->connected = true;
 		$this->Socket->request($request);
 		$result = $this->Socket->response['cookies'];
@@ -711,9 +731,10 @@ class HttpSocketTest extends CakeTestCase {
  */
 	public function testRequestWithResource() {
 		$serverResponse = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
-		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
-		$this->Socket->expects($this->at(4))->method('read')->will($this->returnValue($serverResponse));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse, false, $serverResponse, false));
 		$this->Socket->connected = true;
 
 		$f = fopen(TMP . 'download.txt', 'w');
@@ -744,8 +765,10 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->config['request']['cookies'] = array();
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nSet-Cookie: foo=bar\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
+
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
+
 		$expected = array('www.cakephp.org' => array('foo' => array('value' => 'bar')));
 		$this->Socket->request('http://www.cakephp.org/');
 		$this->assertEquals($expected, $this->Socket->config['request']['cookies']);
@@ -781,8 +804,9 @@ class HttpSocketTest extends CakeTestCase {
 	public function testRequestCustomResponse() {
 		$this->Socket->connected = true;
 		$serverResponse = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
-		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse, false));
 
 		$this->Socket->responseClass = 'CustomResponse';
 		$response = $this->Socket->request('http://www.cakephp.org/');
@@ -817,6 +841,8 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->expects($this->at(4))
 			->method('read')
 			->will($this->returnValue($serverResponse2));
+		$this->Socket->expects($this->any())
+			->method('read')->will($this->returnValue(false));
 
 		$response = $this->Socket->request($request);
 		$this->assertEquals('<h1>You have been redirected</h1>', $response->body());
@@ -834,8 +860,10 @@ class HttpSocketTest extends CakeTestCase {
 		);
 		$serverResponse1 = "HTTP/1.x 302 Found\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\nLocation: http://localhost/anotheruri\r\n\r\n";
 		$serverResponse2 = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>You have been redirected</h1>";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse1));
-		$this->Socket->expects($this->at(4))->method('read')->will($this->returnValue($serverResponse2));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse1, false, $serverResponse2, false));
 
 		$response = $this->Socket->request($request);
 		$this->assertEquals('<h1>You have been redirected</h1>', $response->body());
@@ -853,8 +881,10 @@ class HttpSocketTest extends CakeTestCase {
 		);
 		$serverResponse1 = "HTTP/1.x 302 Found\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\nLocation: http://localhost/anotheruri\r\n\r\n";
 		$serverResponse2 = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>You have been redirected</h1>";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse1));
-		$this->Socket->expects($this->at(4))->method('read')->will($this->returnValue($serverResponse2));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse1, false, $serverResponse2, false));
 
 		$this->Socket->request($request);
 		$this->assertEquals(1, $this->Socket->request['redirect']);
@@ -872,8 +902,10 @@ class HttpSocketTest extends CakeTestCase {
 		);
 		$serverResponse1 = "HTTP/1.x 302 Found\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\nLocation: http://localhost/oneruri\r\n\r\n";
 		$serverResponse2 = "HTTP/1.x 302 Found\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\nLocation: http://localhost/anotheruri\r\n\r\n";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse1));
-		$this->Socket->expects($this->at(4))->method('read')->will($this->returnValue($serverResponse2));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse1, false, $serverResponse2, false));
 
 		$response = $this->Socket->request($request);
 		$this->assertEquals(0, $this->Socket->request['redirect']);
@@ -1113,6 +1145,9 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testAuth() {
+		$this->Socket->expects($this->any())
+			->method('read')->will($this->returnValue(false));
+
 		$this->Socket->get('http://mark:secret@example.com/test');
 		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 
@@ -1154,6 +1189,9 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testConsecutiveGetResetsAuthCredentials() {
+		$this->Socket->expects($this->any())
+			->method('read')->will($this->returnValue(false));
+
 		$this->Socket->get('http://mark:secret@example.com/test');
 		$this->assertEquals('mark', $this->Socket->request['uri']['user']);
 		$this->assertEquals('secret', $this->Socket->request['uri']['pass']);
@@ -1813,6 +1851,9 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testConfigContext() {
+		$this->Socket->expects($this->any())
+			->method('read')->will($this->returnValue(false));
+
 		$this->Socket->reset();
 		$this->Socket->request('http://example.com');
 		$this->assertTrue($this->Socket->config['context']['ssl']['verify_peer']);
@@ -1869,8 +1910,10 @@ class HttpSocketTest extends CakeTestCase {
 	public function testResponseStatusParsing($status, $code, $msg = '') {
 		$this->Socket->connected = true;
 		$serverResponse = $status . "\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\n\r\n<h1>This is a test!</h1>";
-		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
-		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
+
+		$this->Socket->expects($this->any())
+			->method('read')
+			->will($this->onConsecutiveCalls($serverResponse, false));
 
 		$response = $this->Socket->request('http://www.cakephp.org/');
 		$this->assertInstanceOf('HttpSocketResponse', $response);


### PR DESCRIPTION
Make tests simpler by using onConsecutiveCalls() instead of trying to maintain mock method indexes.

Refs #7121
