### PR TITLE
Fix incorrectly hydrated association data

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -385,6 +385,13 @@ class EagerLoader
                 sprintf('%s is not associated with %s', $parent->alias(), $alias)
             );
         }
+        if ($instance->alias() !== $alias) {
+            throw new InvalidArgumentException(sprintf(
+                "You have contained '%s' but that association was bound as '%s'.",
+                $alias,
+                $instance->alias()
+            ));
+        }
 
         $paths += ['aliasPath' => '', 'propertyPath' => '', 'root' => $alias];
         $paths['aliasPath'] .= '.' . $alias;

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -385,11 +385,11 @@ class EagerLoaderTest extends TestCase
     {
         $contains = [
             'clients' => [
-            'orders' => [
+                'orders' => [
                     'orderTypes',
                     'stuff' => ['stuffTypes']
                 ],
-            'companies' => [
+                'companies' => [
                     'categories'
                 ]
             ]

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -376,6 +376,21 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
+     * Check that normalizing contains checks alias names.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage You have contained 'Clients' but that association was bound as 'clients'
+     * @return void
+     */
+    public function testNormalizedChecksAliasNames()
+    {
+        $contains = ['Clients'];
+        $loader = new EagerLoader;
+        $loader->contain($contains);
+        $loader->normalized($this->table);
+    }
+
+    /**
      * Tests that the path for gettings to a deep assocition is materialized in an
      * array key
      *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3277,7 +3277,7 @@ class TableTest extends TestCase
     public function testSaveBelongsToManyJoinData()
     {
         $articles = TableRegistry::get('Articles');
-        $article = $articles->get(1, ['contain' => ['Tags']]);
+        $article = $articles->get(1, ['contain' => ['tags']]);
         $data = [
             'tags' => [
                 ['id' => 1, '_joinData' => ['highlighted' => 1]],
@@ -3376,7 +3376,7 @@ class TableTest extends TestCase
             'saveStrategy' => 'replace',
         ]);
 
-        $entity = $table->get(1, ['contain' => 'Tags']);
+        $entity = $table->get(1, ['contain' => 'tags']);
         $this->assertCount(2, $entity->tags, 'Fixture data did not change.');
 
         $entity->tags = [];
@@ -3384,7 +3384,7 @@ class TableTest extends TestCase
         $this->assertSame($result, $entity);
         $this->assertSame([], $entity->tags, 'No tags on the entity.');
 
-        $entity = $table->get(1, ['contain' => 'Tags']);
+        $entity = $table->get(1, ['contain' => 'tags']);
         $this->assertSame([], $entity->tags, 'No tags in the db either.');
     }
 
@@ -3401,7 +3401,7 @@ class TableTest extends TestCase
             'saveStrategy' => 'replace',
         ]);
 
-        $entity = $table->get(1, ['contain' => 'Tags']);
+        $entity = $table->get(1, ['contain' => 'tags']);
         $this->assertCount(2, $entity->tags, 'Fixture data did not change.');
 
         $tag = new \Cake\ORM\Entity([
@@ -3413,7 +3413,7 @@ class TableTest extends TestCase
         $this->assertCount(1, $entity->tags, 'Only one tag left.');
         $this->assertEquals($tag, $entity->tags[0]);
 
-        $entity = $table->get(1, ['contain' => 'Tags']);
+        $entity = $table->get(1, ['contain' => 'tags']);
         $this->assertCount(1, $entity->tags, 'Only one tag in the db.');
         $this->assertEquals($tag->id, $entity->tags[0]->id);
     }
@@ -3425,8 +3425,8 @@ class TableTest extends TestCase
      */
     public function testSaveBelongsToManyIgnoreNonEntityData()
     {
-        $articles = TableRegistry::get('Articles');
-        $article = $articles->get(1, ['contain' => ['Tags']]);
+        $articles = TableRegistry::get('articles');
+        $article = $articles->get(1, ['contain' => ['tags']]);
         $article->tags = [
             '_ids' => [2, 1]
         ];


### PR DESCRIPTION
When someone typo's an alias name in a `contain` call, they shouldn't get incorrectly hydrated data. Instead we should raise an exception as we don't have a way of easily fixing their mistake.

Refs #7110 
