### PR TITLE
Minor improvements to building request bodies

### DIFF
--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -76,11 +76,12 @@ class FormData implements Countable
      * If the $value is an array, multiple parts will be added.
      * Files will be read from their current position and saved in memory.
      *
-     * @param string $name The name of the part.
+     * @param string|\Cake\Network\Http\FormData $name The name of the part to add,
+     *   or the part data object.
      * @param mixed $value The value for the part.
      * @return $this
      */
-    public function add($name, $value)
+    public function add($name, $value = null)
     {
         if (is_array($value)) {
             $this->addRecursive($name, $value);
@@ -93,6 +94,8 @@ class FormData implements Countable
                 E_USER_DEPRECATED
             );
             $this->_parts[] = $this->addFile($name, $value);
+        } elseif ($name instanceof Part && $value === null) {
+            $this->_parts[] = $name;
         } else {
             $this->_parts[] = $this->newPart($name, $value);
         }

--- a/src/Network/Http/FormData/Part.php
+++ b/src/Network/Http/FormData/Part.php
@@ -112,7 +112,7 @@ class Part
     public function contentId($id = null)
     {
         if ($id === null) {
-            return $this->_contentId = $id;
+            return $this->_contentId;
         }
         $this->_contentId = $id;
     }

--- a/tests/TestCase/Network/Http/FormDataTest.php
+++ b/tests/TestCase/Network/Http/FormDataTest.php
@@ -91,6 +91,34 @@ class FormDataTest extends TestCase
     }
 
     /**
+     * Test adding a part object.
+     *
+     * @return void
+     */
+    public function testAddPartObject()
+    {
+        $data = new FormData();
+        $boundary = $data->boundary();
+
+        $part = $data->newPart('test', 'value');
+        $part->contentId('abc123');
+        $data->add($part);
+
+        $this->assertCount(1, $data, 'Should have 1 part');
+        $expected = [
+            '--' . $boundary,
+            'Content-Disposition: form-data; name="test"',
+            'Content-ID: <abc123>',
+            '',
+            'value',
+            '--' . $boundary . '--',
+            '',
+            '',
+        ];
+        $this->assertEquals(implode("\r\n", $expected), (string)$data);
+    }
+
+    /**
      * Test adding parts that are arrays.
      *
      * @return void


### PR DESCRIPTION
Today I was working with an API that needed Content-ID set in the request bodies, and Http/Client did not make that easy. By allowing parts to be built and then added to the payload we can afford more use cases pretty easily.
