### PR TITLE
Bootstrap Configure after the mb_* shims have been defined.

### DIFF
--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -172,17 +172,6 @@ Configure::write('App.imageBaseUrl', IMAGES_URL);
 Configure::write('App.cssBaseUrl', CSS_URL);
 Configure::write('App.jsBaseUrl', JS_URL);
 
-Configure::bootstrap(isset($boot) ? $boot : true);
-
-if (function_exists('mb_internal_encoding')) {
-	$encoding = Configure::read('App.encoding');
-	if (!empty($encoding)) {
-		mb_internal_encoding($encoding);
-	}
-	if (!empty($encoding) && function_exists('mb_regex_encoding')) {
-		mb_regex_encoding($encoding);
-	}
-}
 
 if (!function_exists('mb_stripos')) {
 
@@ -437,4 +426,16 @@ if (!function_exists('mb_encode_mimeheader')) {
 		return Multibyte::mimeEncode($str, $charset, $linefeed);
 	}
 
+}
+
+Configure::bootstrap(isset($boot) ? $boot : true);
+
+if (function_exists('mb_internal_encoding')) {
+	$encoding = Configure::read('App.encoding');
+	if (!empty($encoding)) {
+		mb_internal_encoding($encoding);
+	}
+	if (!empty($encoding) && function_exists('mb_regex_encoding')) {
+		mb_regex_encoding($encoding);
+	}
 }


### PR DESCRIPTION
By bootstrapping after the shims have been defined allows the shims to be used by Inflector which is often involved with bootstrapping.

Refs #7135
