### PR TITLE
Fix notice errors when reading header information.

### DIFF
--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -266,8 +266,8 @@ class Stream
             throw new Exception('Connection timed out ' . $url);
         }
         $headers = $meta['wrapper_data'];
-        if (isset($meta['wrapper_type']) && strtolower($meta['wrapper_type']) === 'curl') {
-            $headers = $meta['wrapper_data']['headers'];
+        if (isset($headers['headers']) && is_array($headers['headers'])) {
+            $headers = $headers['headers'];
         }
         return $this->createResponses($headers, $content);
     }


### PR DESCRIPTION
Stream providers other than curl nest headers under wrapper_data.headers. Instead of sniffing for curl we can just sniff for the headers key.

Refs #7126
