### PR TITLE
Allow modulus of 0.

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -604,7 +604,7 @@ class PaginatorHelper extends Helper
      * - `after` Content to be inserted after the numbers, but before the last links.
      * - `model` Model to create numbers for, defaults to PaginatorHelper::defaultModel()
      * - `modulus` How many numbers to include on either side of the current page, defaults to 8.
-     *    Set to `false` to disable.
+     *    Set to `false` to disable and to show all numbers.
      * - `first` Whether you want first links generated, set to an integer to define the number of 'first'
      *    links to generate.
      * - `last` Whether you want last links generated, set to an integer to define the number of 'last'

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -603,7 +603,8 @@ class PaginatorHelper extends Helper
      * - `before` Content to be inserted before the numbers, but after the first links.
      * - `after` Content to be inserted after the numbers, but before the last links.
      * - `model` Model to create numbers for, defaults to PaginatorHelper::defaultModel()
-     * - `modulus` how many numbers to include on either side of the current page, defaults to 8.
+     * - `modulus` How many numbers to include on either side of the current page, defaults to 8.
+     *    Set to `false` to disable.
      * - `first` Whether you want first links generated, set to an integer to define the number of 'first'
      *    links to generate.
      * - `last` Whether you want last links generated, set to an integer to define the number of 'last'

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -641,7 +641,7 @@ class PaginatorHelper extends Helper
             $templater->{$method}($options['templates']);
         }
 
-        if ($options['modulus'] && $params['pageCount'] > $options['modulus']) {
+        if ($options['modulus'] !== false && $params['pageCount'] > $options['modulus']) {
             $out = $this->_modulusNumbers($templater, $params, $options);
         } else {
             $out = $this->_numbers($templater, $params, $options);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1535,6 +1535,18 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
+
+        $this->Paginator->request->params['paging']['Client']['page'] = 3;
+        $result = $this->Paginator->numbers(['first' => 2, 'modulus' => 0, 'last' => 2]);
+        $expected = [
+            ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
+            ['li' => ['class' => 'active']], '<a href=""', '3', '/a', '/li',
+            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1379,8 +1379,8 @@ class PaginatorHelperTest extends TestCase
                 'pageCount' => 3,
             ]
         ];
-        $options = ['modulus' => 10];
-        $result = $this->Paginator->numbers($options);
+
+        $result = $this->Paginator->numbers(['modulus' => 10]);
         $expected = [
             ['li' => ['class' => 'active']], '<a href=""', '1', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
@@ -1545,6 +1545,36 @@ class PaginatorHelperTest extends TestCase
             ['li' => ['class' => 'ellipsis']], '...', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Tests that disabling modulus displays all page links.
+     *
+     * @return void
+     */
+    public function testModulusDisabled()
+    {
+        $this->Paginator->request->params['paging'] = [
+            'Client' => [
+                'page' => 4,
+                'current' => 2,
+                'count' => 30,
+                'prevPage' => 1,
+                'nextPage' => 1,
+                'pageCount' => 6,
+            ]
+        ];
+
+        $result = $this->Paginator->numbers(['modulus' => false]);
+        $expected = [
+            ['li' => []], '<a href="/index"', '1', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=3']], '3', '/a', '/li',
+            ['li' => ['class' => 'active']], ['a' => ['href' => '']], '4', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
+            ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
     }


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/7143

While it sounds like an edge case, providing ALL numbers for pages >> 1000 with modulus 0 sounds way worse. Also, this sounds like a valid use case in combination with prev/next links.
