### PR TITLE
Only array-wrap 'order' if it's not already an array

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3067,7 +3067,7 @@ class Model extends Object implements CakeEventListener {
 			$query['order'] = $this->order;
 		}
 
-		$query['order'] = array($query['order']);
+		$query['order'] = (array)$query['order'];
 
 		if ($query['callbacks'] === true || $query['callbacks'] === 'before') {
 			$event = new CakeEvent('Model.beforeFind', $this, array($query));


### PR DESCRIPTION
While working on a beforeFind() callback, I noticed my order parameter was getting double-wrapped in an array.  Is there a reason for this, or is it an oversight?  I haven't figured out how to run the tests yet because I haven't figured out how to set up the test DB in 2.x yet, but it doesn't seem to break anything major.  The only concern I can see is if other third-part plugins/etc operate on the assumption that arrays will be double-wrapped - but that would break for string-only orders, which is what I assume this was intended to handle.
