### PR TITLE
Datetime widget fixes

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2207,7 +2207,10 @@ class FormHelper extends Helper
     protected function _datetimeOptions($options)
     {
         foreach ($this->_datetimeParts as $type) {
-            if (!isset($options[$type])) {
+            if (!array_key_exists($type, $options)) {
+                $options[$type] = [];
+            }
+            if ($options[$type] === true) {
                 $options[$type] = [];
             }
 

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -39,8 +39,9 @@ class SelectBoxWidget extends BasicWidget
      *    When true, the select element will be disabled.
      * - `val` - Either a string or an array of options to mark as selected.
      * - `empty` - Set to true to add an empty option at the top of the
-     *   option elements. Set to a string to define the display value of the
-     *   empty option.
+     *   option elements. Set to a string to define the display text of the
+     *   empty option. If an array is used the key will set the value of the empty
+     *   option while, the value will set the display text.
      * - `escape` - Set to false to disable HTML escaping.
      *
      * ### Options format
@@ -147,8 +148,7 @@ class SelectBoxWidget extends BasicWidget
         }
 
         if (!empty($data['empty'])) {
-            $value = $data['empty'] === true ? '' : $data['empty'];
-            $options = ['' => $value] + (array)$options;
+            $options = $this->_emptyValue($data['empty']) + (array)$options;
         }
         if (empty($options)) {
             return [];
@@ -160,6 +160,26 @@ class SelectBoxWidget extends BasicWidget
             $disabled = $data['disabled'];
         }
         return $this->_renderOptions($options, $disabled, $selected, $data['escape']);
+    }
+
+    /**
+     * Generate the empty value based on the input.
+     *
+     * @param string|bool|array $value The provided empty value.
+     * @return array The generated option key/value.
+     */
+    protected function _emptyValue($value)
+    {
+        if ($value === true) {
+            return ['' => ''];
+        }
+        if (is_scalar($value)) {
+            return ['' => $value];
+        }
+        if (is_array($value)) {
+            return $value;
+        }
+        return [];
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5402,6 +5402,26 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * test datetime second=true
+     *
+     * @return void
+     */
+    public function testDateTimeSecondOptions()
+    {
+        $result = $this->Form->dateTime('updated', ['second' => true]);
+        $this->assertContains('updated[second]', $result, 'Should have seconds');
+
+        $result = $this->Form->dateTime('updated', ['second' => []]);
+        $this->assertContains('updated[second]', $result, 'Should have seconds');
+
+        $result = $this->Form->dateTime('updated', ['second' => null]);
+        $this->assertNotContains('updated[second]', $result, 'Should not have seconds');
+
+        $result = $this->Form->dateTime('updated', ['second' => false]);
+        $this->assertNotContains('updated[second]', $result, 'Should not have seconds');
+    }
+
+    /**
      * testMonth method
      *
      * @return void

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -110,6 +110,23 @@ class DateTimeWidgetTest extends TestCase
     }
 
     /**
+     * Test empty with custom values.
+     *
+     * @return void
+     */
+    public function testRenderEmptyCustom()
+    {
+        $result = $this->DateTime->render([
+            'val' => '',
+            'year' =>  [
+                'empty' => ['nope' => '(choose one)'],
+            ]
+        ], $this->context);
+        $this->assertContains('<option value="nope">(choose one)</option>', $result);
+        $this->assertNotContains('<optgroup', $result, 'No optgroups should be present.');
+    }
+
+    /**
      * Data provider for testing various acceptable selected values.
      *
      * @return array

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -471,7 +471,7 @@ class DateTimeWidgetTest extends TestCase
             'no 13 in value'
         );
     }
-    
+
     /**
      * Test rendering month widget with names.
      *
@@ -899,7 +899,6 @@ class DateTimeWidgetTest extends TestCase
             'hour' => false,
             'minute' => [
                 'data-foo' => 'test',
-                
             ],
             'empty' => '-',
             'default' => '',

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -118,7 +118,7 @@ class DateTimeWidgetTest extends TestCase
     {
         $result = $this->DateTime->render([
             'val' => '',
-            'year' =>  [
+            'year' => [
                 'empty' => ['nope' => '(choose one)'],
             ]
         ], $this->context);

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -671,6 +671,17 @@ class SelectBoxWidgetTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
+        $data['empty'] = ['99' => '(choose one)'];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
+            ['option' => ['value' => '99']], '(choose one)', '/option',
+            ['option' => ['value' => 'a']], 'Albatross', '/option',
+            ['option' => ['value' => 'b']], 'Budgie', '/option',
+            '/select'
+        ];
+        $this->assertHtml($expected, $result);
+
         $data['empty'] = 'empty';
         $data['val'] = '';
         $result = $select->render($data, $this->context);


### PR DESCRIPTION
- Fix `second => true` not working. Related to #6518
- Fix #7123
