### PR TITLE
bug:DBOSource isConnected method doesn't check the real status of connection

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -857,7 +857,13 @@ class DboSource extends DataSource {
  * @return bool True if the database is connected, else false
  */
 	public function isConnected() {
-		return $this->connected;
+	    try{
+            $connected = $this->_connection->query('Select 1');
+        }catch (Exception $e){
+            $connected = false;
+        }
+        $this->connected = ! empty($connected);
+        return $this->connected;
 	}
 
 /**


### PR DESCRIPTION
Hotfix purpose:
check the presence of connection to db by executing a dumb query
