### PR TITLE
Use the registryAlias when setting entity source.

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -507,7 +507,7 @@ class ResultSet implements ResultSetInterface
                 )
             );
             if ($this->_hydrate) {
-                $options['source'] = $alias;
+                $options['source'] = $matching['instance']->registryAlias();
                 $entity = new $matching['entityClass']($results['_matchingData'][$alias], $options);
                 $entity->clean();
                 $results['_matchingData'][$alias] = $entity;
@@ -546,7 +546,7 @@ class ResultSet implements ResultSetInterface
             }
 
             $target = $instance->target();
-            $options['source'] = $target->alias();
+            $options['source'] = $target->registryAlias();
             unset($presentAliases[$alias]);
 
             if ($assoc['canBeJoined']) {


### PR DESCRIPTION
We should consistently use registryAlias() when setting the source on entities.

Refs #7187 
