### PR TITLE
Allow cached formatter instances to persist attributes.

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -259,6 +259,8 @@ class Number
      * - `pattern` - An ICU number pattern to use for formatting the number. e.g #,###.00
      * - `useIntlCode` - Whether or not to replace the currency symbol with the international
      *   currency code.
+     * - `persistOptions` - If set to true the options 'places', 'precision' & 'pattern'
+     *   will be set for the cached formatter for 'locale', 'type' pair and persist across calls.
      *
      * @param array $options An array with options.
      * @return \NumberFormatter The configured formatter instance
@@ -285,7 +287,9 @@ class Number
         $hasPrecision = isset($options['precision']);
         $hasPattern = !empty($options['pattern']) || !empty($options['useIntlCode']);
 
-        if ($hasPlaces || $hasPrecision || $hasPattern) {
+        if (empty($options['persistOptions']) &&
+            ($hasPlaces || $hasPrecision || $hasPattern)
+        ) {
             $formatter = clone $formatter;
         }
 

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -538,4 +538,22 @@ class NumberTest extends TestCase
         $result = $this->Number->toReadableSize(512.05 * 1024 * 1024 * 1024);
         $this->assertEquals('512,05 GB', $result);
     }
+
+    /**
+     * test persisting formatter attributes
+     *
+     * @return void
+     */
+    public function testPersistingFormatterAttributes()
+    {
+        Number::formatter([
+            'type' => 'currency',
+            'locale' => 'en_IN',
+            'pattern' => '¤ #,##,##0',
+            'persistOptions' => true
+        ]);
+
+        $result = $this->Number->currency(15000, 'INR', ['locale' => 'en_IN']);
+        $this->assertEquals('₹ 15,000', $result);
+    }
 }


### PR DESCRIPTION
Closes #7193.
