### PR TITLE
Re-fetch View class to pass view variables set in beforeRender callbacks

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -572,6 +572,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             return $this->response;
         }
 
+        // Re-fetch View class to pass view variables set in beforeRender callbacks
+        $this->View = $this->getView();
+
         if ($viewClass !== $this->viewClass) {
             $this->View = $this->getView($this->viewClass);
             if (!$this->_view->viewPath()) {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -28,6 +28,7 @@ use Cake\TestSuite\Fixture\TestModel;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Hash;
+use TestApp\Controller\Admin\PostsController;
 use TestPlugin\Controller\TestPluginController;
 
 /**
@@ -967,5 +968,26 @@ class ControllerTest extends TestCase
         // @codingStandardsIgnoreStart
         $this->assertEquals($theme, @$controller->getView()->theme);
         // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * Test that view variables are being set after the beforeRender event gets dispatched
+     *
+     * @return void
+     */
+    public function testBeforeRenderViewVariables()
+    {
+        $controller = new PostsController();
+
+        $controller->eventManager()->on('Controller.beforeRender', function (Event $event) {
+            /* @var Controller $controller */
+            $controller = $event->subject();
+
+            $controller->set('testVariable', 'test');
+        });
+
+        $controller->render('index');
+
+        $this->assertArrayHasKey('testVariable', $controller->View->viewVars);
     }
 }


### PR DESCRIPTION
As discusses in #7180 
