### PR TITLE
Fix value where `literal` values did not work with case statements

### DIFF
--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -111,6 +111,8 @@ class CaseExpression implements ExpressionInterface
      */
     protected function _addExpressions($conditions, $values, $types)
     {
+        $rawValues = array_values($values);
+        $keyValues = array_keys($values);
         foreach ($conditions as $k => $c) {
             $numericKey = is_numeric($k);
 
@@ -123,10 +125,10 @@ class CaseExpression implements ExpressionInterface
             }
             array_push($this->_conditions, $c);
 
-            $value = !empty($values[$k]) ? $values[$k] : 1;
+            $value = !empty($rawValues[$k]) ? $rawValues[$k] : 1;
 
             if ($value === 'literal') {
-                $value = $k;
+                $value = $keyValues[$k];
                 array_push($this->_values, $value);
                 continue;
             } elseif ($value instanceof ExpressionInterface) {

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -33,18 +33,23 @@ class CaseExpressionTest extends TestCase
     {
         $expr = new QueryExpression();
         $expr->eq('test', 'true');
+        $expr2 = new QueryExpression();
+        $expr2->eq('test2', 'false');
+
         $caseExpression = new CaseExpression($expr, 'foobar');
         $expected = 'CASE WHEN test = :c0 THEN :c1 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
-        $expr2 = new QueryExpression();
-        $expr2->eq('test2', 'false');
         $caseExpression->add($expr2);
         $expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN :c3 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
         $caseExpression = new CaseExpression([$expr], ['foobar', 'else']);
         $expected = 'CASE WHEN test = :c0 THEN :c1 ELSE :c2 END';
+        $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
+
+        $caseExpression = new CaseExpression([$expr], ['foobar' => 'literal', 'else']);
+        $expected = 'CASE WHEN test = :c0 THEN foobar ELSE :c1 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
     }
 


### PR DESCRIPTION
This corrects the issue as reported in #7186 
