### PR TITLE
Add orderAsc() and orderDesc() to solve sorting on expressions

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -65,7 +65,7 @@ trait SqlserverDialectTrait
         }
 
         if ($offset !== null && !$query->clause('order')) {
-            $query->order($query->newExpr()->add('SELECT NULL'));
+            $query->order($query->newExpr()->add('(SELECT NULL)'));
         }
 
         if ($this->_version() < 11 && $offset !== null) {

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -49,7 +49,7 @@ class OrderByExpression extends QueryExpression
         $order = [];
         foreach ($this->_conditions as $k => $direction) {
             if ($direction instanceof ExpressionInterface) {
-                $direction = sprintf('(%s)', $direction->sql($generator));
+                $direction = $direction->sql($generator);
             }
             $order[] = is_numeric($k) ? $direction : sprintf('%s %s', $k, $direction);
         }

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -15,6 +15,8 @@
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\FieldInterface;
+use Cake\Database\Expression\FieldTrait;
 use Cake\Database\ValueBinder;
 
 /**
@@ -22,14 +24,9 @@ use Cake\Database\ValueBinder;
  *
  * @internal
  */
-class OrderClauseExpression implements ExpressionInterface
+class OrderClauseExpression implements ExpressionInterface, FieldInterface
 {
-    /**
-     * The field being sorted on.
-     *
-     * @var \Cake\Database\ExpressionInterface|string
-     */
-    protected $_field;
+    use FieldTrait;
 
     /**
      * The direction of sorting.

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -68,8 +68,8 @@ class OrderClauseExpression implements ExpressionInterface
     public function traverse(callable $visitor)
     {
         if ($this->_field instanceof ExpressionInterface) {
-            $callable($this->_field);
-            $this->_field->traverse($callable);
+            $visitor($this->_field);
+            $this->_field->traverse($visitor);
         }
     }
 }

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
+
+/**
+ * An expression object for complex ORDER BY clauses
+ *
+ * @internal
+ */
+class OrderClauseExpression implements ExpressionInterface
+{
+    /**
+     * The field being sorted on.
+     *
+     * @var \Cake\Database\ExpressionInterface|string
+     */
+    protected $_field;
+
+    /**
+     * The direction of sorting.
+     *
+     * @var string
+     */
+    protected $_direction;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Database\ExpressionInterface|string $field The field to order on.
+     * @param string $direction The direction to sort on.
+     */
+    public function __construct($field, $direction)
+    {
+        $this->_field = $field;
+        $this->_direction = strtolower($direction) === 'asc' ? 'ASC' : 'DESC';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sql(ValueBinder $generator)
+    {
+        $field = $this->_field;
+        if ($field instanceof ExpressionInterface) {
+            $field = $field->sql($generator);
+        }
+        return sprintf("%s %s", $field, $this->_direction);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function traverse(callable $visitor)
+    {
+        if ($this->_field instanceof ExpressionInterface) {
+            $callable($this->_field);
+            $this->_field->traverse($callable);
+        }
+    }
+}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -16,6 +16,7 @@ namespace Cake\Database;
 
 use Cake\Database\Exception;
 use Cake\Database\Expression\OrderByExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\ValuesExpression;
 use Cake\Database\Statement\CallbackStatement;
@@ -926,6 +927,9 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * ``ORDER BY (id %2 = 0), title ASC``
      *
+     * If you need to set complex expressions as order conditions, you
+     * should use `orderAsc()` or `orderDesc()`.
+     *
      * @param array|\Cake\Database\ExpressionInterface|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
      * @return $this
@@ -941,9 +945,61 @@ class Query implements ExpressionInterface, IteratorAggregate
         }
 
         if (!$this->_parts['order']) {
-            $this->_parts['order'] = new OrderByExpression;
+            $this->_parts['order'] = new OrderByExpression();
         }
         $this->_conjugate('order', $fields, '', []);
+        return $this;
+    }
+
+    /**
+     * Add an ORDER BY clause with an ASC direction.
+     *
+     * This method allows you to set complex expressions
+     * as order conditions unlike order()
+     *
+     * @param string|\Cake\Database\QueryExpression $field The field to order on.
+     * @param bool $overwrite Whether or not to reset the order clauses.
+     * @return $this
+     */
+    public function orderAsc($field, $overwrite = false)
+    {
+        if ($overwrite) {
+            $this->_parts['order'] = null;
+        }
+        if (!$field) {
+            return $this;
+        }
+
+        if (!$this->_parts['order']) {
+            $this->_parts['order'] = new OrderByExpression();
+        }
+        $this->_parts['order']->add(new OrderClauseExpression($field, 'ASC'));
+        return $this;
+    }
+
+    /**
+     * Add an ORDER BY clause with an ASC direction.
+     *
+     * This method allows you to set complex expressions
+     * as order conditions unlike order()
+     *
+     * @param string|\Cake\Database\QueryExpression $field The field to order on.
+     * @param bool $overwrite Whether or not to reset the order clauses.
+     * @return $this
+     */
+    public function orderDesc($field, $overwrite = false)
+    {
+        if ($overwrite) {
+            $this->_parts['order'] = null;
+        }
+        if (!$field) {
+            return $this;
+        }
+
+        if (!$this->_parts['order']) {
+            $this->_parts['order'] = new OrderByExpression();
+        }
+        $this->_parts['order']->add(new OrderClauseExpression($field, 'DESC'));
         return $this;
     }
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1504,6 +1504,8 @@ class QueryTest extends TestCase
         $query->select(['id'])
             ->from('articles')
             ->orderAsc('id');
+
+        $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
             ['id' => 1],
@@ -1511,6 +1513,11 @@ class QueryTest extends TestCase
             ['id' => 3],
         ];
         $this->assertEquals($expected, $result);
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <articles> ORDER BY <id> ASC',
+            $sql,
+            !$this->autoQuote
+        );
 
         $query = new Query($this->connection);
         $query->select(['id'])
@@ -1537,6 +1544,7 @@ class QueryTest extends TestCase
         $query->select(['id'])
             ->from('articles')
             ->orderDesc('id');
+        $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
             ['id' => 3],
@@ -1544,6 +1552,11 @@ class QueryTest extends TestCase
             ['id' => 1],
         ];
         $this->assertEquals($expected, $result);
+        $this->assertQuotedQuery(
+            'SELECT <id> FROM <articles> ORDER BY <id> DESC',
+            $sql,
+            !$this->autoQuote
+        );
 
         $query = new Query($this->connection);
         $query->select(['id'])

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1522,7 +1522,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderAsc($query->func()->concat(['id' => 'literal', 'test']));
+            ->orderAsc($query->func()->concat(['id' => 'literal', '3']));
 
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1561,7 +1561,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderDesc($query->func()->concat(['id' => 'literal', 'test']));
+            ->orderDesc($query->func()->concat(['id' => 'literal', '3']));
 
         $result = $query->execute()->fetchAll('assoc');
         $expected = [

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1494,6 +1494,72 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test orderAsc() and its input types.
+     *
+     * @return void
+     */
+    public function testSelectOrderAsc()
+    {
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->orderAsc('id');
+        $result = $query->execute()->fetchAll('assoc');
+        $expected = [
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+        ];
+        $this->assertEquals($expected, $result);
+
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->orderAsc($query->func()->concat(['id' => 'literal', 'test']));
+
+        $result = $query->execute()->fetchAll('assoc');
+        $expected = [
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test orderDesc() and its input types.
+     *
+     * @return void
+     */
+    public function testSelectOrderDesc()
+    {
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->orderDesc('id');
+        $result = $query->execute()->fetchAll('assoc');
+        $expected = [
+            ['id' => 3],
+            ['id' => 2],
+            ['id' => 1],
+        ];
+        $this->assertEquals($expected, $result);
+
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('articles')
+            ->orderDesc($query->func()->concat(['id' => 'literal', 'test']));
+
+        $result = $query->execute()->fetchAll('assoc');
+        $expected = [
+            ['id' => 3],
+            ['id' => 2],
+            ['id' => 1],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Tests that group by fields can be passed similar to select fields
      * and that it sends the correct query to the database
      *

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1022,4 +1022,26 @@ class QueryRegressionTest extends TestCase
 
         $this->assertEquals([['name' => 'nate', 'tag' => 'tag1']], $results);
     }
+
+    /**
+     * Test expression based ordering with unions.
+     *
+     * @return void
+     */
+    public function testComplexOrderWithUnion()
+    {
+        $table = TableRegistry::get('Comments');
+        $query = $table->find();
+        $inner = $table->find()->where(['id >' => 3]);
+        $inner2 = $table->find()->where(['id <' => 3]);
+
+        $order = $query->func()->concat(['inside__comment' => 'literal', 'test']);
+
+        $query->select(['inside__comment' => 'Comments__comment'])
+            ->from(['inside' => $inner->unionAll($inner2)])
+            ->orderAsc($order);
+
+        $results = $query->toArray();
+        $this->assertCount(5, $results);
+    }
 }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1032,12 +1032,16 @@ class QueryRegressionTest extends TestCase
     {
         $table = TableRegistry::get('Comments');
         $query = $table->find();
-        $inner = $table->find()->where(['id >' => 3]);
-        $inner2 = $table->find()->where(['id <' => 3]);
+        $inner = $table->find()
+            ->select(['content' => 'comment'])
+            ->where(['id >' => 3]);
+        $inner2 = $table->find()
+            ->select(['content' => 'comment'])
+            ->where(['id <' => 3]);
 
-        $order = $query->func()->concat(['inside__comment' => 'literal', 'test']);
+        $order = $query->func()->concat(['content' => 'literal', 'test']);
 
-        $query->select(['inside__comment' => 'Comments__comment'])
+        $query->select(['inside.content'])
             ->from(['inside' => $inner->unionAll($inner2)])
             ->orderAsc($order);
 


### PR DESCRIPTION
The current order() method has a limitation which makes it impossible to use expression objects that also have direction. These new methods makeit easier to support directed expression objects.

I've introduced a new expression object as I felt keeping OrderByExpression simple was worth the extra bit of cost. Additionally this makes SQL injection in the ORM internals more difficult as we rely on the callers to provide a safe expression. I also experimented with an array format, but felt it left us vulnerable to the issues we've had in the past around request data manipulation.

Refs #7163
