### PR TITLE
3.0 - Fix misleading exceptions for invalid transport configs

### DIFF
--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1013,8 +1013,14 @@ class Email implements JsonSerializable, Serializable
      */
     protected function _constructTransport($name)
     {
-        if (!isset(static::$_transportConfig[$name]['className'])) {
+        if (!isset(static::$_transportConfig[$name])) {
             throw new InvalidArgumentException(sprintf('Transport config "%s" is missing.', $name));
+        }
+
+        if (!isset(static::$_transportConfig[$name]['className'])) {
+            throw new InvalidArgumentException(
+                sprintf('Transport config "%s" is invalid, the required `className` option is missing', $name)
+            );
         }
 
         $config = static::$_transportConfig[$name];

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -814,6 +814,20 @@ class EmailTest extends TestCase
     }
 
     /**
+     * Test that using misconfigured transports fails.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Transport config "debug" is invalid, the required `className` option is missing
+     */
+    public function testTransportMissingClassName()
+    {
+        Email::dropTransport('debug');
+        Email::configTransport('debug', []);
+
+        $this->CakeEmail->transport('debug');
+    }
+
+    /**
      * Test configuring a transport.
      *
      * @return void


### PR DESCRIPTION
The exception that is thrown in case the `className` option is not being set is a little misleading, as it's not the transport config that is missing.

I was unsure wich way to go, the one in this PR that uses a separate check for the `className` option when about to be used, or one that would check the transport configs when they are being set (`Email::configTransport()`), and then rely on the internal state not being changed anymore... Any thoughts?
