### PR TITLE
FindAllByField accept arrays now

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1786,15 +1786,15 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     count($fields)
                 ));
             }
-			foreach ($fields as $field) {
-				$value = array_shift($args);
+            foreach ($fields as $field) {
+                $value = array_shift($args);
 
-				if(is_array($value)) {
-					$field .= ' IN';
-				}
+                if (is_array($value)) {
+                    $field .= ' IN';
+                }
 
-				$conditions[$this->aliasField($field)] = $value;
-			}
+                $conditions[$this->aliasField($field)] = $value;
+            }
             return $conditions;
         };
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1786,9 +1786,15 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     count($fields)
                 ));
             }
-            foreach ($fields as $field) {
-                $conditions[$this->aliasField($field)] = array_shift($args);
-            }
+			foreach ($fields as $field) {
+				$value = array_shift($args);
+
+				if(is_array($value)) {
+					$field .= ' IN';
+				}
+
+				$conditions[$this->aliasField($field)] = $value;
+			}
             return $conditions;
         };
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3054,6 +3054,25 @@ class TableTest extends TestCase
      *
      * @return void
      */
+    public function testMagicFindAllAcceptingArray()
+    {
+        $table = TableRegistry::get('Users');
+
+        $result = $table->findAllByUsername(['nate', 'larry']);
+        $this->assertInstanceOf('Cake\ORM\Query', $result);
+        $this->assertNull($result->clause('limit'));
+        $expected = new QueryExpression(
+            ['Users.username IN' => ['nate', 'larry']],
+            $this->usersTypeMap
+        );
+        $this->assertEquals($expected, $result->clause('where'));
+    }
+
+    /**
+     * Test magic findAllByXX method.
+     *
+     * @return void
+     */
     public function testMagicFindAllOr()
     {
         $table = TableRegistry::get('Users');


### PR DESCRIPTION
Hi,
I've found that it could be useful to be able to use findAllByX() with array as first parameter.
What do you think?
