### PR TITLE
Don't allow overridden methods to count as actions.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -28,6 +28,7 @@ use Cake\Routing\Router;
 use Cake\Utility\MergeVariablesTrait;
 use Cake\View\ViewVarsTrait;
 use LogicException;
+use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use RuntimeException;
@@ -653,15 +654,16 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function isAction($action)
     {
+        $baseClass = new ReflectionClass('Cake\Controller\Controller');
+        if ($baseClass->hasMethod($action)) {
+            return false;
+        }
         try {
             $method = new ReflectionMethod($this, $action);
         } catch (ReflectionException $e) {
             return false;
         }
         if (!$method->isPublic()) {
-            return false;
-        }
-        if ($method->getDeclaringClass()->name === 'Cake\Controller\Controller') {
             return false;
         }
         return true;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -92,7 +92,8 @@ class TestController extends ControllerTestAppController
      * @param \Cake\Event\Event $event
      * @retun void
      */
-    public function beforeFilter(Event $event) {
+    public function beforeFilter(Event $event)
+    {
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -87,6 +87,15 @@ class TestController extends ControllerTestAppController
     public $modelClass = 'Comments';
 
     /**
+     * beforeFilter handler
+     *
+     * @param \Cake\Event\Event $event
+     * @retun void
+     */
+    public function beforeFilter(Event $event) {
+    }
+
+    /**
      * index method
      *
      * @param mixed $testId


### PR DESCRIPTION
Disallow overridden methods from being actions. While you could override the signatures and disable strict warnings. I feel that's a bad practice to enable and the defaults provided by the framework should be as safe as possible.
