### PR TITLE
LocaleSelectorFilter now sets the current locale (issue #7208)

### DIFF
--- a/src/Routing/Filter/LocaleSelectorFilter.php
+++ b/src/Routing/Filter/LocaleSelectorFilter.php
@@ -17,6 +17,7 @@ namespace Cake\Routing\Filter;
 use Cake\Event\Event;
 use Cake\Routing\DispatcherFilter;
 use Locale;
+use Cake\I18n\I18n;
 
 /**
  * Sets the runtime default locale for the request based on the
@@ -48,7 +49,7 @@ class LocaleSelectorFilter extends DispatcherFilter
     }
 
     /**
-     * Inspects the request for the Accept-Language header and sets the default
+     * Inspects the request for the Accept-Language header and sets the
      * Locale for the current runtime if it matches the list of valid locales
      * as passed in the configuration.
      *
@@ -64,6 +65,6 @@ class LocaleSelectorFilter extends DispatcherFilter
             return;
         }
 
-        Locale::setDefault($locale);
+        I18n::locale($locale);
     }
 }

--- a/src/Routing/Filter/LocaleSelectorFilter.php
+++ b/src/Routing/Filter/LocaleSelectorFilter.php
@@ -15,9 +15,9 @@
 namespace Cake\Routing\Filter;
 
 use Cake\Event\Event;
+use Cake\I18n\I18n;
 use Cake\Routing\DispatcherFilter;
 use Locale;
-use Cake\I18n\I18n;
 
 /**
  * Sets the runtime default locale for the request based on the

--- a/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
+++ b/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
@@ -15,11 +15,11 @@
 namespace Cake\Test\TestCase\Routing\Filter;
 
 use Cake\Event\Event;
+use Cake\I18n\I18n;
 use Cake\Network\Request;
 use Cake\Routing\Filter\LocaleSelectorFilter;
 use Cake\TestSuite\TestCase;
 use Locale;
-use Cake\I18n\I18n;
 
 /**
  * Locale selector filter test.

--- a/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
+++ b/tests/TestCase/Routing/Filter/LocaleSelectorFilterTest.php
@@ -19,6 +19,7 @@ use Cake\Network\Request;
 use Cake\Routing\Filter\LocaleSelectorFilter;
 use Cake\TestSuite\TestCase;
 use Locale;
+use Cake\I18n\I18n;
 
 /**
  * Locale selector filter test.
@@ -63,19 +64,19 @@ class LocaleSelectorFilterTest extends TestCase
             'environment' => ['HTTP_ACCEPT_LANGUAGE' => 'en-GB,en;q=0.8,es;q=0.6,da;q=0.4']
         ]);
         $filter->beforeDispatch(new Event('name', null, ['request' => $request]));
-        $this->assertEquals('en_GB', Locale::getDefault());
+        $this->assertEquals('en_GB', I18n::locale());
 
         $request = new Request([
             'environment' => ['HTTP_ACCEPT_LANGUAGE' => 'es_VE,en;q=0.8,es;q=0.6,da;q=0.4']
         ]);
         $filter->beforeDispatch(new Event('name', null, ['request' => $request]));
-        $this->assertEquals('es_VE', Locale::getDefault());
+        $this->assertEquals('es_VE', I18n::locale());
 
         $request = new Request([
             'environment' => ['HTTP_ACCEPT_LANGUAGE' => 'en;q=0.4,es;q=0.6,da;q=0.8']
         ]);
         $filter->beforeDispatch(new Event('name', null, ['request' => $request]));
-        $this->assertEquals('da', Locale::getDefault());
+        $this->assertEquals('da', I18n::locale());
     }
 
     /**
@@ -97,7 +98,7 @@ class LocaleSelectorFilterTest extends TestCase
             ]
         ]);
         $filter->beforeDispatch(new Event('name', null, ['request' => $request]));
-        $this->assertEquals('es_VE', Locale::getDefault());
+        $this->assertEquals('es_VE', I18n::locale());
 
         Locale::setDefault('en_US');
         $request = new Request([
@@ -106,6 +107,6 @@ class LocaleSelectorFilterTest extends TestCase
             ]
         ]);
         $filter->beforeDispatch(new Event('name', null, ['request' => $request]));
-        $this->assertEquals('en_US', Locale::getDefault());
+        $this->assertEquals('en_US', I18n::locale());
     }
 }


### PR DESCRIPTION
LocaleSelectorFilter now sets the current locale based on the HTTP
Accept header, not the default one that is stablished application wide.

fixes #7208
