### PR TITLE
Disallow direct controller names

### DIFF
--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -73,6 +73,9 @@ class ControllerFactoryFilter extends DispatcherFilter
             );
             $namespace .= '/' . implode('/', $prefixes);
         }
+        if (strpos($controller, '\\') !== false || strpos($controller, '.') !== false) {
+            return false;
+        }
         $className = false;
         if ($pluginPath . $controller) {
             $className = App::classname($pluginPath . $controller, $namespace, 'Controller');

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -23,7 +23,6 @@ use Cake\Network\Response;
 use Cake\Network\Session;
 use Cake\Routing\Dispatcher;
 use Cake\Routing\Filter\ControllerFactoryFilter;
-use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
 
@@ -407,6 +406,54 @@ class DispatcherTest extends TestCase
             'TestPlugin\Controller\Admin\CommentsController',
             $this->dispatcher->controller
         );
+    }
+
+    /**
+     * test forbidden controller names.
+     *
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class TestPlugin.Tests could not be found.
+     * @return void
+     */
+    public function testDispatchBadPluginName()
+    {
+        Plugin::load('TestPlugin');
+
+        $request = new Request([
+            'url' => 'TestPlugin.Tests/index',
+            'params' => [
+                'plugin' => '',
+                'controller' => 'TestPlugin.Tests',
+                'action' => 'index',
+                'pass' => [],
+                'return' => 1
+            ]
+        ]);
+        $response = $this->getMock('Cake\Network\Response');
+        $this->dispatcher->dispatch($request, $response);
+    }
+
+    /**
+     * test forbidden controller names.
+     *
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class TestApp\Controller\PostsController could not be found.
+     * @return void
+     */
+    public function testDispatchBadName()
+    {
+        $request = new Request([
+            'url' => 'TestApp%5CController%5CPostsController/index',
+            'params' => [
+                'plugin' => '',
+                'controller' => 'TestApp\Controller\PostsController',
+                'action' => 'index',
+                'pass' => [],
+                'return' => 1
+            ]
+        ]);
+        $response = $this->getMock('Cake\Network\Response');
+        $this->dispatcher->dispatch($request, $response);
     }
 
     /**


### PR DESCRIPTION
Controller names with the default routing should not allow direct plugin, or fully qualified namespace names.
