### PR TITLE
avoid the extra '/' in viewPath if prefix is set to false

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -375,7 +375,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         if (!$this->viewPath) {
             $viewPath = $this->name;
-            if (isset($request->params['prefix'])) {
+            if (!empty($request->params['prefix'])) {
                 $prefixes = array_map(
                     'Cake\Utility\Inflector::camelize',
                     explode('/', $request->params['prefix'])

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -871,6 +871,9 @@ class ControllerTest extends TestCase
         $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewPath);
 
         $request = new Request('pages/home');
+        $request->addParams([
+            'prefix' => false
+        ]);
         $Controller = new \TestApp\Controller\PagesController($request, $response);
         $this->assertEquals('Pages', $Controller->viewPath);
     }


### PR DESCRIPTION
This would cause for example the `assertTemplate()` to fail if the route is define with 'prefix' => false
