### PR TITLE
3.1 View Config

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -376,7 +376,7 @@ class AuthComponent extends Component
         }
 
         if (!empty($this->_config['ajaxLogin'])) {
-            $controller->getview()->viewPath('Element');
+            $controller->viewBuilder()->viewPath('Element');
             $response = $controller->render(
                 $this->_config['ajaxLogin'],
                 $this->RequestHandler->ajaxLayout

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -376,7 +376,7 @@ class AuthComponent extends Component
         }
 
         if (!empty($this->_config['ajaxLogin'])) {
-            $controller->viewBuilder()->viewPath('Element');
+            $controller->viewBuilder()->templatePath('Element');
             $response = $controller->render(
                 $this->_config['ajaxLogin'],
                 $this->RequestHandler->ajaxLayout

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -546,6 +546,7 @@ class RequestHandlerComponent extends Component
         }
         $options += $defaults;
 
+        $builder = $controller->viewBuilder();
         if (array_key_exists($type, $viewClassMap)) {
             $view = $viewClassMap[$type];
         } else {
@@ -555,21 +556,20 @@ class RequestHandlerComponent extends Component
 
         if ($viewClass) {
             $controller->viewClass = $viewClass;
+            $builder->className($viewClass);
         } else {
-            $view = $controller->getView();
-
             if (empty($this->_renderType)) {
-                $view->viewPath($view->viewPath() . DS . $type);
+                $builder->viewPath($builder->viewPath() . DS . $type);
             } else {
-                $view->viewPath(preg_replace(
+                $builder->viewPath(preg_replace(
                     "/([\/\\\\]{$this->_renderType})$/",
                     DS . $type,
-                    $view->viewPath()
+                    $builder->viewPath()
                 ));
             }
 
             $this->_renderType = $type;
-            $view->layoutPath($type);
+            $builder->layoutPath($type);
         }
 
         $response = $this->response;

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -559,12 +559,12 @@ class RequestHandlerComponent extends Component
             $builder->className($viewClass);
         } else {
             if (empty($this->_renderType)) {
-                $builder->viewPath($builder->viewPath() . DS . $type);
+                $builder->templatePath($builder->templatePath() . DS . $type);
             } else {
-                $builder->viewPath(preg_replace(
+                $builder->templatePath(preg_replace(
                     "/([\/\\\\]{$this->_renderType})$/",
                     DS . $type,
-                    $builder->viewPath()
+                    $builder->templatePath()
                 ));
             }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -212,7 +212,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Holds all passed params.
      *
      * @var mixed
-     * @TODO Deprecate and replace with __get + warning
+     * @deprecated 3.1.0 Use `$this->request->params['pass']` instead.
      */
     public $passedArgs = [];
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -187,7 +187,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Controller::render() is called.
      *
      * @var \Cake\View\View
-     * @deprecated 3.1.0 Use getView() instead.
+     * @deprecated 3.1.0 Use viewBuilder() instead.
      */
     public $View;
 
@@ -319,10 +319,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         if (in_array($name, ['layout', 'view', 'theme', 'autoLayout', 'viewPath', 'layoutPath'], true)) {
             trigger_error(
-                sprintf('Controller::$%s is deprecated. Use $this->getView()->%s() instead.', $name, $name),
+                sprintf('Controller::$%s is deprecated. Use $this->viewBuilder()->%s() instead.', $name, $name),
                 E_USER_DEPRECATED
             );
-            return $this->getView()->{$name}();
+            return $this->viewBuilder()->{$name}();
         }
 
         list($plugin, $class) = pluginSplit($this->modelClass, true);
@@ -343,10 +343,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         if (in_array($name, ['layout', 'view', 'theme', 'autoLayout', 'viewPath', 'layoutPath'], true)) {
             trigger_error(
-                sprintf('Controller::$%s is deprecated. Use $this->getView()->%s() instead.', $name, $name),
+                sprintf('Controller::$%s is deprecated. Use $this->viewBuilder()->%s() instead.', $name, $name),
                 E_USER_DEPRECATED
             );
-            $this->getView()->{$name}($value);
+            $this->viewBuilder()->{$name}($value);
             return;
         }
 
@@ -554,49 +554,39 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function render($view = null, $layout = null)
     {
-        $this->View = $this->getView();
-        if (!$this->_view->viewPath()) {
-            $this->_viewPath();
+        $builder = $this->viewBuilder();
+        if (!$builder->viewPath()) {
+            $builder->viewPath($this->_viewPath());
         }
 
         if (!empty($this->request->params['bare'])) {
-            $this->_view->autoLayout(false);
+            $builder->autoLayout(false);
         }
+        $builder->className($this->viewClass);
 
-        $viewClass = $this->viewClass;
+        $this->autoRender = false;
+
         $event = $this->dispatchEvent('Controller.beforeRender');
         if ($event->result instanceof Response) {
-            $this->autoRender = false;
             return $event->result;
         }
         if ($event->isStopped()) {
-            $this->autoRender = false;
             return $this->response;
         }
 
-        // Re-fetch View class to pass view variables set in beforeRender callbacks
-        $this->View = $this->getView();
-
-        if ($viewClass !== $this->viewClass) {
-            $this->View = $this->getView($this->viewClass);
-            if (!$this->_view->viewPath()) {
-                $this->_viewPath();
-            }
-        }
-
-        $this->autoRender = false;
-        if ($this->_view->view() === null &&
+        if ($builder->template() === null &&
             isset($this->request->params['action'])
         ) {
-            $this->_view->view($this->request->params['action']);
+            $builder->template($this->request->params['action']);
         }
 
+        $this->View = $this->_view = $this->createView();
         $this->response->body($this->_view->render($view, $layout));
         return $this->response;
     }
 
     /**
-     * Set View::$viewPath property based on controller name and request prefix.
+     * Get the viewPath based on controller name and request prefix.
      *
      * @return void
      */
@@ -610,7 +600,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             );
             $viewPath = implode(DS, $prefixes) . DS . $viewPath;
         }
-        $this->_view->viewPath($viewPath);
+        return $viewPath;
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -198,7 +198,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @see \Cake\View\View
      */
     protected $_validViewOptions = [
-        'viewVars', 'helpers', 'name', 'plugin', 'passedArgs'
+        'passedArgs'
     ];
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -589,7 +589,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Get the viewPath based on controller name and request prefix.
      *
-     * @return void
+     * @return string
      */
     protected function _viewPath()
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -212,6 +212,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Holds all passed params.
      *
      * @var mixed
+     * @TODO Deprecate and replace with __get + warning
      */
     public $passedArgs = [];
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -318,8 +318,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function __get($name)
     {
         if (in_array($name, ['layout', 'view', 'theme', 'autoLayout', 'viewPath', 'layoutPath'], true)) {
+            $method = $name == 'viewPath' ? 'templatePath' : $name;
             trigger_error(
-                sprintf('Controller::$%s is deprecated. Use $this->viewBuilder()->%s() instead.', $name, $name),
+                sprintf('Controller::$%s is deprecated. Use $this->viewBuilder()->%s() instead.', $name, $method),
                 E_USER_DEPRECATED
             );
             return $this->viewBuilder()->{$name}();
@@ -555,8 +556,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function render($view = null, $layout = null)
     {
         $builder = $this->viewBuilder();
-        if (!$builder->viewPath()) {
-            $builder->viewPath($this->_viewPath());
+        if (!$builder->templatePath()) {
+            $builder->templatePath($this->_viewPath());
         }
 
         if (!empty($this->request->params['bare'])) {

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -56,6 +56,6 @@ class ErrorController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->getView()->viewPath('Error');
+        $this->viewBuilder()->viewPath('Error');
     }
 }

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -56,6 +56,6 @@ class ErrorController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()->viewPath('Error');
+        $this->viewBuilder()->templatePath('Error');
     }
 }

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -329,10 +329,13 @@ class ExceptionRenderer
      */
     protected function _outputMessageSafe($template)
     {
-        $this->controller->helpers = ['Form', 'Html'];
+        $helpers = ['Form', 'Html'];
+        $this->controller->helpers = $helpers;
+        $builder = $this->controller->viewBuilder();
+        $builder->helpers($helpers, false)
+            ->layoutPath('')
+            ->viewPath('Error');
         $view = $this->controller->createView();
-        $view->layoutPath('');
-        $view->viewPath('Error');
 
         $this->controller->response->body($view->render($template, 'error'));
         $this->controller->response->type('html');

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -334,7 +334,7 @@ class ExceptionRenderer
         $builder = $this->controller->viewBuilder();
         $builder->helpers($helpers, false)
             ->layoutPath('')
-            ->viewPath('Error');
+            ->templatePath('Error');
         $view = $this->controller->createView();
 
         $this->controller->response->body($view->render($template, 'error'));

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -42,7 +42,7 @@ abstract class Cell
      * Cell::__toString() is called.
      *
      * @var \Cake\View\View
-     * @deprecated 3.1.0 Use getView() instead.
+     * @deprecated 3.1.0 Use createView() instead.
      */
     public $View;
 
@@ -168,22 +168,22 @@ abstract class Cell
         if ($this->_cache) {
             $cache = $this->_cacheConfig($template);
         }
-        $this->View = $this->getView();
+        $this->View = $this->createView();
 
         $render = function () use ($template) {
             $className = substr(strrchr(get_class($this), "\\"), 1);
             $name = substr($className, 0, -4);
-            $this->_view->viewPath('Cell' . DS . $name);
+            $this->View->viewPath('Cell' . DS . $name);
 
             try {
-                return $this->_view->render($template);
+                return $this->View->render($template);
             } catch (MissingTemplateException $e) {
                 throw new MissingCellViewException(['file' => $template, 'name' => $name]);
             }
         };
 
         if ($cache) {
-            return $this->_view->cache(function () use ($render) {
+            return $this->View->cache(function () use ($render) {
                 echo $render();
             }, $cache);
         }

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -78,13 +78,6 @@ abstract class Cell
     public $response;
 
     /**
-     * The theme name that will be used to render.
-     *
-     * @var string
-     */
-    public $theme;
-
-    /**
      * The helpers this cell uses.
      *
      * This property is copied automatically when using the CellTrait
@@ -100,7 +93,7 @@ abstract class Cell
      * @see \Cake\View\View
      */
     protected $_validViewOptions = [
-        'viewVars', 'helpers', 'viewPath', 'plugin', 'theme'
+        'viewPath'
     ];
 
     /**
@@ -167,14 +160,15 @@ abstract class Cell
         if ($template === null) {
             $template = $this->template;
         }
-        $this->_view = null;
-        $this->View = $this->getView();
-        $this->_view->layout(false);
+        $builder = $this->viewBuilder();
+        $builder->layout(false);
+        $builder->template($template);
 
         $cache = [];
         if ($this->_cache) {
             $cache = $this->_cacheConfig($template);
         }
+        $this->View = $this->getView();
 
         $render = function () use ($template) {
             $className = substr(strrchr(get_class($this), "\\"), 1);

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -104,16 +104,26 @@ trait CellTrait
     {
         $instance = new $className($this->request, $this->response, $this->eventManager(), $options);
         $instance->template = Inflector::underscore($action);
-        $instance->plugin = !empty($plugin) ? $plugin : null;
-        $instance->theme = !empty($this->theme) ? $this->theme : null;
+
+        $builder = $instance->viewBuilder();
+        if (!empty($plugin)) {
+            $builder->plugin($plugin);
+        }
+        if (!empty($this->theme)) {
+            $builder->theme($this->theme);
+        }
         if (!empty($this->helpers)) {
+            $builder->helpers($this->helpers);
             $instance->helpers = $this->helpers;
         }
         if (isset($this->viewClass)) {
+            $builder->className($this->viewClass);
             $instance->viewClass = $this->viewClass;
         }
         if ($this instanceof View) {
-            $instance->viewClass = get_class($this);
+            $class = get_class($this);
+            $builder->className($class);
+            $instance->viewClass = $class;
         }
         return $instance;
     }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -99,6 +99,7 @@ class View implements EventDispatcherInterface
      * Current passed params. Passed to View from the creating Controller for convenience.
      *
      * @var array
+     * @TODO Deprecate and replace with __get + warning
      */
     public $passedArgs = [];
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -99,7 +99,7 @@ class View implements EventDispatcherInterface
      * Current passed params. Passed to View from the creating Controller for convenience.
      *
      * @var array
-     * @TODO Deprecate and replace with __get + warning
+     * @deprecated 3.1.0 Use `$this->request->params['pass']` instead.
      */
     public $passedArgs = [];
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -100,9 +100,16 @@ class ViewBuilder
     protected $options = [];
 
     /**
+     * The helpers to use
+     *
+     * @var array
+     */
+    protected $helpers = [];
+
+    /**
      * Get/set path for view files.
      *
-     * @param string $path Path for view files. If null returns current path.
+     * @param string|null $path Path for view files. If null returns current path.
      * @return string|$this
      */
     public function viewPath($path = null)
@@ -118,7 +125,7 @@ class ViewBuilder
     /**
      * Get/set path for layout files.
      *
-     * @param string $path Path for layout files. If null returns current path.
+     * @param string|null $path Path for layout files. If null returns current path.
      * @return string|void
      */
     public function layoutPath($path = null)
@@ -136,7 +143,7 @@ class ViewBuilder
      * On by default. Setting to off means that layouts will not be
      * automatically applied to rendered views.
      *
-     * @param bool $autoLayout Boolean to turn on/off. If null returns current value.
+     * @param bool|ull $autoLayout Boolean to turn on/off. If null returns current value.
      * @return bool|$this
      */
     public function autoLayout($autoLayout = null)
@@ -152,27 +159,39 @@ class ViewBuilder
     /**
      * The plugin name to use
      *
-     * @param string $theme Plugin name. If null returns current plugin.
+     * @param string|null $name Plugin name. If null returns current plugin.
      * @return string|$this
      */
-    public function plugin($theme = null)
+    public function plugin($name = null)
     {
+        if ($name === null) {
+            return $this->plugin;
+        }
+
+        $this->plugin = $name;
+        return $this;
     }
 
     /**
      * The helpers to use
      *
-     * @param array $helpers Helpers to use.
+     * @param array|null $helpers Helpers to use.
      * @return array|$this
      */
-    public function helpers($helpers = null)
+    public function helpers(array $helpers = null)
     {
+        if ($helpers === null) {
+            return $this->helpers;
+        }
+
+        $this->helpers = array_merge($this->helpers, $helpers);
+        return $this;
     }
 
     /**
      * The view theme to use.
      *
-     * @param string $theme Theme name. If null returns current theme.
+     * @param string|null $theme Theme name. If null returns current theme.
      * @return string|$this
      */
     public function theme($theme = null)
@@ -189,7 +208,7 @@ class ViewBuilder
      * Get/set the name of the view file to render. The name specified is the
      * filename in /app/Template/<SubFolder> without the .ctp extension.
      *
-     * @param string $name View file name to set. If null returns current name.
+     * @param string|null $name View file name to set. If null returns current name.
      * @return string|$this
      */
     public function view($name = null)
@@ -207,7 +226,7 @@ class ViewBuilder
      * The name specified is the filename of the layout in /app/Template/Layout
      * without the .ctp extension.
      *
-     * @param string $name Layout file name to set. If null returns current name.
+     * @param string|null $name Layout file name to set. If null returns current name.
      * @return string|$this
      */
     public function layout($name = null)
@@ -226,26 +245,45 @@ class ViewBuilder
      * @param array|null $options Either an array of options or null to get current options.
      * @return array|$this
      */
-    public function options($options = null)
+    public function options(array $options = null)
     {
+        if ($options === null) {
+            return $this->options;
+        }
+        $this->options = array_merge($this->options, $options);
+        return $this;
     }
 
     /**
      * Get/set the view name
      *
+     * @param string|null $name The name of the view
      * @return array|$this
      */
-    public function name($vars = null)
+    public function name($name = null)
     {
+        if ($name === null) {
+            return $this->name;
+        }
+        $this->name = $name;
+        return $this;
     }
 
     /**
      * Get/set the view classname
      *
+     * @param string|null $name The class name for the view. Can
+     *   be a plugin.class name reference, a short alias, or a fully
+     *   namespaced name.
      * @return array|$this
      */
     public function className($name = null)
     {
+        if ($name === null) {
+            return $this->className;
+        }
+        $this->className = $name;
+        return $this;
     }
 
     /**

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View;
+
+use Cake\Core\App;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\View\View;
+use Cake\View\Exception\MissingViewException;
+
+
+/**
+ * Provides an API for iteratively building a view up.
+ *
+ * Once you have configured the view and established all the context
+ * you can create a view instance with `build()`.
+ */
+class ViewBuilder
+{
+    /**
+     * The subdirectory to the view.
+     *
+     * @var string
+     */
+    protected $viewPath;
+
+    /**
+     * The view file to render.
+     *
+     * @var string
+     */
+    protected $view;
+
+    /**
+     * The plugin name to use.
+     *
+     * @var string
+     */
+    protected $plugin;
+
+    /**
+     * The theme name to use.
+     *
+     * @var string
+     */
+    protected $theme;
+
+    /**
+     * The layout name to render.
+     *
+     * @var string
+     */
+    protected $layout;
+
+    /**
+     * Whether or not autoLayout should be enabled.
+     *
+     * @var bool
+     */
+    protected $autoLayout;
+
+    /**
+     * The layout path to build the view with.
+     *
+     * @var string
+     */
+    protected $layoutPath;
+
+    /**
+     * The view variables to use
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The view variables to use
+     *
+     * @var string
+     */
+    protected $viewClass;
+
+    /**
+     * The view variables to use
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * Get/set path for view files.
+     *
+     * @param string $path Path for view files. If null returns current path.
+     * @return string|$this
+     */
+    public function viewPath($path = null)
+    {
+        if ($path === null) {
+            return $this->viewPath;
+        }
+
+        $this->viewPath = $path;
+        return $this;
+    }
+
+    /**
+     * Get/set path for layout files.
+     *
+     * @param string $path Path for layout files. If null returns current path.
+     * @return string|void
+     */
+    public function layoutPath($path = null)
+    {
+        if ($path === null) {
+            return $this->layoutPath;
+        }
+
+        $this->layoutPath = $path;
+        return $this;
+    }
+
+    /**
+     * Turns on or off CakePHP's conventional mode of applying layout files.
+     * On by default. Setting to off means that layouts will not be
+     * automatically applied to rendered views.
+     *
+     * @param bool $autoLayout Boolean to turn on/off. If null returns current value.
+     * @return bool|$this
+     */
+    public function autoLayout($autoLayout = null)
+    {
+        if ($autoLayout === null) {
+            return $this->autoLayout;
+        }
+
+        $this->autoLayout = $autoLayout;
+        return $this;
+    }
+
+    /**
+     * The plugin name to use
+     *
+     * @param string $theme Plugin name. If null returns current plugin.
+     * @return string|$this
+     */
+    public function plugin($theme = null)
+    {
+    }
+
+    /**
+     * The helpers to use
+     *
+     * @param array $helpers Helpers to use.
+     * @return array|$this
+     */
+    public function helpers($helpers = null)
+    {
+    }
+
+    /**
+     * The view theme to use.
+     *
+     * @param string $theme Theme name. If null returns current theme.
+     * @return string|$this
+     */
+    public function theme($theme = null)
+    {
+        if ($theme === null) {
+            return $this->theme;
+        }
+
+        $this->theme = $theme;
+        return $this;
+    }
+
+    /**
+     * Get/set the name of the view file to render. The name specified is the
+     * filename in /app/Template/<SubFolder> without the .ctp extension.
+     *
+     * @param string $name View file name to set. If null returns current name.
+     * @return string|$this
+     */
+    public function view($name = null)
+    {
+        if ($name === null) {
+            return $this->view;
+        }
+
+        $this->view = $name;
+        return $this;
+    }
+
+    /**
+     * Get/set the name of the layout file to render the view inside of.
+     * The name specified is the filename of the layout in /app/Template/Layout
+     * without the .ctp extension.
+     *
+     * @param string $name Layout file name to set. If null returns current name.
+     * @return string|$this
+     */
+    public function layout($name = null)
+    {
+        if ($name === null) {
+            return $this->layout;
+        }
+
+        $this->layout = $name;
+        return $this;
+    }
+
+    /**
+     * Set additional options for the view.
+     *
+     * @param array|null $options Either an array of options or null to get current options.
+     * @return array|$this
+     */
+    public function options($options = null)
+    {
+    }
+
+    /**
+     * Get/set the view name
+     *
+     * @return array|$this
+     */
+    public function name($vars = null)
+    {
+    }
+
+    /**
+     * Get/set the view classname
+     *
+     * @return array|$this
+     */
+    public function className($name = null)
+    {
+    }
+
+    /**
+     * Using the data in the builder, create a view instance.
+     *
+     * @param array $vars The view variables/context to use.
+     * @param \Cake\Network\Request $request The request to use.
+     * @param \Cake\Network\Response $response The response to use.
+     * @param \Cake\Event\EventManager $events The event manager to use.
+     * @return \Cake\View\View
+     * @throws \Cake\View\Exception\MissingViewException
+     */
+    public function build($vars = [], Request $request = null, Response $response = null, EventManager $events = null)
+    {
+    }
+}

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -15,6 +15,7 @@
 namespace Cake\View;
 
 use Cake\Core\App;
+use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\View\View;
@@ -305,5 +306,27 @@ class ViewBuilder
      */
     public function build($vars = [], Request $request = null, Response $response = null, EventManager $events = null)
     {
+        if ($this->className === 'View') {
+            $className = App::className($this->className, 'View');
+        } else {
+            $className = App::className($this->className, 'View', 'View');
+        }
+        if (!$className) {
+            throw new Exception\MissingViewException([$this->className]);
+        }
+        $data = [
+            'name' => $this->name,
+            'viewPath' => $this->viewPath,
+            'view' => $this->template,
+            'plugin' => $this->plugin,
+            'theme' => $this->theme,
+            'layout' => $this->layout,
+            'autoLayout' => $this->autoLayout,
+            'layoutPath' => $this->layoutPath,
+            'helpers' => $this->helpers,
+            'viewVars' => $vars,
+        ];
+        $data += $this->options;
+        return new $className($request, $response, $events, $data);
     }
 }

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -176,15 +176,18 @@ class ViewBuilder
      * The helpers to use
      *
      * @param array|null $helpers Helpers to use.
+     * @param bool $merge Whether or not to merge existing data with the new data.
      * @return array|$this
      */
-    public function helpers(array $helpers = null)
+    public function helpers(array $helpers = null, $merge = true)
     {
         if ($helpers === null) {
             return $this->helpers;
         }
-
-        $this->helpers = array_merge($this->helpers, $helpers);
+        if ($merge) {
+            $helpers = array_merge($this->helpers, $helpers);
+        }
+        $this->helpers = $helpers;
         return $this;
     }
 
@@ -243,14 +246,18 @@ class ViewBuilder
      * Set additional options for the view.
      *
      * @param array|null $options Either an array of options or null to get current options.
+     * @param bool $merge Whether or not to merge existing data with the new data.
      * @return array|$this
      */
-    public function options(array $options = null)
+    public function options(array $options = null, $merge = true)
     {
         if ($options === null) {
             return $this->options;
         }
-        $this->options = array_merge($this->options, $options);
+        if ($merge) {
+            $options = array_merge($this->options, $options);
+        }
+        $this->options = $options;
         return $this;
     }
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -37,11 +37,11 @@ class ViewBuilder
     protected $viewPath;
 
     /**
-     * The view file to render.
+     * The template file to render.
      *
      * @var string
      */
-    protected $view;
+    protected $template;
 
     /**
      * The plugin name to use.
@@ -90,7 +90,7 @@ class ViewBuilder
      *
      * @var string
      */
-    protected $viewClass;
+    protected $className;
 
     /**
      * The view variables to use
@@ -143,7 +143,7 @@ class ViewBuilder
      * On by default. Setting to off means that layouts will not be
      * automatically applied to rendered views.
      *
-     * @param bool|ull $autoLayout Boolean to turn on/off. If null returns current value.
+     * @param bool|null $autoLayout Boolean to turn on/off. If null returns current value.
      * @return bool|$this
      */
     public function autoLayout($autoLayout = null)
@@ -152,7 +152,7 @@ class ViewBuilder
             return $this->autoLayout;
         }
 
-        $this->autoLayout = $autoLayout;
+        $this->autoLayout = (bool)$autoLayout;
         return $this;
     }
 
@@ -211,13 +211,13 @@ class ViewBuilder
      * @param string|null $name View file name to set. If null returns current name.
      * @return string|$this
      */
-    public function view($name = null)
+    public function template($name = null)
     {
         if ($name === null) {
-            return $this->view;
+            return $this->template;
         }
 
-        $this->view = $name;
+        $this->template = $name;
         return $this;
     }
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -31,11 +31,11 @@ use Cake\View\Exception\MissingViewException;
 class ViewBuilder
 {
     /**
-     * The subdirectory to the view.
+     * The subdirectory to the template.
      *
      * @var string
      */
-    protected $_viewPath;
+    protected $_templatePath;
 
     /**
      * The template file to render.
@@ -108,18 +108,18 @@ class ViewBuilder
     protected $_helpers = [];
 
     /**
-     * Get/set path for view files.
+     * Get/set path for template files.
      *
      * @param string|null $path Path for view files. If null returns current path.
      * @return string|$this
      */
-    public function viewPath($path = null)
+    public function templatePath($path = null)
     {
         if ($path === null) {
-            return $this->_viewPath;
+            return $this->_templatePath;
         }
 
-        $this->_viewPath = $path;
+        $this->_templatePath = $path;
         return $this;
     }
 
@@ -316,7 +316,7 @@ class ViewBuilder
         }
         $data = [
             'name' => $this->_name,
-            'viewPath' => $this->_viewPath,
+            'viewPath' => $this->_templatePath,
             'view' => $this->_template,
             'plugin' => $this->_plugin,
             'theme' => $this->_theme,

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -127,7 +127,7 @@ class ViewBuilder
      * Get/set path for layout files.
      *
      * @param string|null $path Path for layout files. If null returns current path.
-     * @return string|void
+     * @return string|$this
      */
     public function layoutPath($path = null)
     {
@@ -312,7 +312,7 @@ class ViewBuilder
             $className = App::className($this->_className, 'View', 'View');
         }
         if (!$className) {
-            throw new Exception\MissingViewException([$this->_className]);
+            throw new MissingViewException([$this->_className]);
         }
         $data = [
             'name' => $this->_name,

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -18,8 +18,8 @@ use Cake\Core\App;
 use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
-use Cake\View\View;
 use Cake\View\Exception\MissingViewException;
+use Cake\View\View;
 
 
 /**
@@ -297,6 +297,9 @@ class ViewBuilder
     /**
      * Using the data in the builder, create a view instance.
      *
+     * If className() is null, App\View\AppView will be used.
+     * If that class does not exist, then Cake\View\View will be used.
+     *
      * @param array $vars The view variables/context to use.
      * @param \Cake\Network\Request $request The request to use.
      * @param \Cake\Network\Response $response The response to use.
@@ -306,14 +309,19 @@ class ViewBuilder
      */
     public function build($vars = [], Request $request = null, Response $response = null, EventManager $events = null)
     {
-        if ($this->_className === 'View') {
-            $className = App::className($this->_className, 'View');
+        $className = $this->_className;
+        if ($className === null) {
+            $className = App::className('App', 'View', 'View') ?: 'Cake\View\View';
+        }
+        if ($className === 'View') {
+            $className = App::className($className, 'View');
         } else {
-            $className = App::className($this->_className, 'View', 'View');
+            $className = App::className($className, 'View', 'View');
         }
         if (!$className) {
             throw new MissingViewException([$this->_className]);
         }
+
         $data = [
             'name' => $this->_name,
             'viewPath' => $this->_templatePath,

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -35,77 +35,77 @@ class ViewBuilder
      *
      * @var string
      */
-    protected $viewPath;
+    protected $_viewPath;
 
     /**
      * The template file to render.
      *
      * @var string
      */
-    protected $template;
+    protected $_template;
 
     /**
      * The plugin name to use.
      *
      * @var string
      */
-    protected $plugin;
+    protected $_plugin;
 
     /**
      * The theme name to use.
      *
      * @var string
      */
-    protected $theme;
+    protected $_theme;
 
     /**
      * The layout name to render.
      *
      * @var string
      */
-    protected $layout;
+    protected $_layout;
 
     /**
      * Whether or not autoLayout should be enabled.
      *
      * @var bool
      */
-    protected $autoLayout;
+    protected $_autoLayout;
 
     /**
      * The layout path to build the view with.
      *
      * @var string
      */
-    protected $layoutPath;
+    protected $_layoutPath;
 
     /**
      * The view variables to use
      *
      * @var string
      */
-    protected $name;
+    protected $_name;
 
     /**
      * The view variables to use
      *
      * @var string
      */
-    protected $className;
+    protected $_className;
 
     /**
      * The view variables to use
      *
      * @var array
      */
-    protected $options = [];
+    protected $_options = [];
 
     /**
      * The helpers to use
      *
      * @var array
      */
-    protected $helpers = [];
+    protected $_helpers = [];
 
     /**
      * Get/set path for view files.
@@ -116,10 +116,10 @@ class ViewBuilder
     public function viewPath($path = null)
     {
         if ($path === null) {
-            return $this->viewPath;
+            return $this->_viewPath;
         }
 
-        $this->viewPath = $path;
+        $this->_viewPath = $path;
         return $this;
     }
 
@@ -132,10 +132,10 @@ class ViewBuilder
     public function layoutPath($path = null)
     {
         if ($path === null) {
-            return $this->layoutPath;
+            return $this->_layoutPath;
         }
 
-        $this->layoutPath = $path;
+        $this->_layoutPath = $path;
         return $this;
     }
 
@@ -150,10 +150,10 @@ class ViewBuilder
     public function autoLayout($autoLayout = null)
     {
         if ($autoLayout === null) {
-            return $this->autoLayout;
+            return $this->_autoLayout;
         }
 
-        $this->autoLayout = (bool)$autoLayout;
+        $this->_autoLayout = (bool)$autoLayout;
         return $this;
     }
 
@@ -166,10 +166,10 @@ class ViewBuilder
     public function plugin($name = null)
     {
         if ($name === null) {
-            return $this->plugin;
+            return $this->_plugin;
         }
 
-        $this->plugin = $name;
+        $this->_plugin = $name;
         return $this;
     }
 
@@ -183,12 +183,12 @@ class ViewBuilder
     public function helpers(array $helpers = null, $merge = true)
     {
         if ($helpers === null) {
-            return $this->helpers;
+            return $this->_helpers;
         }
         if ($merge) {
-            $helpers = array_merge($this->helpers, $helpers);
+            $helpers = array_merge($this->_helpers, $helpers);
         }
-        $this->helpers = $helpers;
+        $this->_helpers = $helpers;
         return $this;
     }
 
@@ -201,10 +201,10 @@ class ViewBuilder
     public function theme($theme = null)
     {
         if ($theme === null) {
-            return $this->theme;
+            return $this->_theme;
         }
 
-        $this->theme = $theme;
+        $this->_theme = $theme;
         return $this;
     }
 
@@ -218,10 +218,10 @@ class ViewBuilder
     public function template($name = null)
     {
         if ($name === null) {
-            return $this->template;
+            return $this->_template;
         }
 
-        $this->template = $name;
+        $this->_template = $name;
         return $this;
     }
 
@@ -236,10 +236,10 @@ class ViewBuilder
     public function layout($name = null)
     {
         if ($name === null) {
-            return $this->layout;
+            return $this->_layout;
         }
 
-        $this->layout = $name;
+        $this->_layout = $name;
         return $this;
     }
 
@@ -253,12 +253,12 @@ class ViewBuilder
     public function options(array $options = null, $merge = true)
     {
         if ($options === null) {
-            return $this->options;
+            return $this->_options;
         }
         if ($merge) {
-            $options = array_merge($this->options, $options);
+            $options = array_merge($this->_options, $options);
         }
-        $this->options = $options;
+        $this->_options = $options;
         return $this;
     }
 
@@ -271,9 +271,9 @@ class ViewBuilder
     public function name($name = null)
     {
         if ($name === null) {
-            return $this->name;
+            return $this->_name;
         }
-        $this->name = $name;
+        $this->_name = $name;
         return $this;
     }
 
@@ -288,9 +288,9 @@ class ViewBuilder
     public function className($name = null)
     {
         if ($name === null) {
-            return $this->className;
+            return $this->_className;
         }
-        $this->className = $name;
+        $this->_className = $name;
         return $this;
     }
 
@@ -306,27 +306,27 @@ class ViewBuilder
      */
     public function build($vars = [], Request $request = null, Response $response = null, EventManager $events = null)
     {
-        if ($this->className === 'View') {
-            $className = App::className($this->className, 'View');
+        if ($this->_className === 'View') {
+            $className = App::className($this->_className, 'View');
         } else {
-            $className = App::className($this->className, 'View', 'View');
+            $className = App::className($this->_className, 'View', 'View');
         }
         if (!$className) {
-            throw new Exception\MissingViewException([$this->className]);
+            throw new Exception\MissingViewException([$this->_className]);
         }
         $data = [
-            'name' => $this->name,
-            'viewPath' => $this->viewPath,
-            'view' => $this->template,
-            'plugin' => $this->plugin,
-            'theme' => $this->theme,
-            'layout' => $this->layout,
-            'autoLayout' => $this->autoLayout,
-            'layoutPath' => $this->layoutPath,
-            'helpers' => $this->helpers,
+            'name' => $this->_name,
+            'viewPath' => $this->_viewPath,
+            'view' => $this->_template,
+            'plugin' => $this->_plugin,
+            'theme' => $this->_theme,
+            'layout' => $this->_layout,
+            'autoLayout' => $this->_autoLayout,
+            'layoutPath' => $this->_layoutPath,
+            'helpers' => $this->_helpers,
             'viewVars' => $vars,
         ];
-        $data += $this->options;
+        $data += $this->_options;
         return new $className($request, $response, $events, $data);
     }
 }

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -21,7 +21,6 @@ use Cake\Network\Response;
 use Cake\View\Exception\MissingViewException;
 use Cake\View\View;
 
-
 /**
  * Provides an API for iteratively building a view up.
  *

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -130,8 +130,10 @@ trait ViewVarsTrait
             }
         }
 
-        if (isset($this->name)) {
-            $builder->name($this->name);
+        foreach (['name', 'helpers', 'plugin'] as $prop) {
+            if (isset($this->{$prop})) {
+                $builder->{$prop}($this->{$prop});
+            }
         }
 
         return $builder->build(

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -35,15 +35,6 @@ trait ViewVarsTrait
     public $viewClass = null;
 
     /**
-     * View instance.
-     *
-     * Won't be set until after ViewVarsTrait::createView() is called.
-     *
-     * @var \Cake\View\View
-     */
-    public $_view;
-
-    /**
      * Variables for the view
      *
      * @var array
@@ -68,30 +59,6 @@ trait ViewVarsTrait
             $this->_viewBuilder = new ViewBuilder();
         }
         return $this->_viewBuilder;
-    }
-
-    /**
-     * Get a view instance.
-     *
-     * @param string|null $viewClass View class name or null to use $viewClass
-     * @return \Cake\View\View
-     * @throws \Cake\View\Exception\MissingViewException If view class was not found.
-     * @deprecated 3.1.0 Use the viewBuilder() method to define view properties
-     *   before building a view with createView().
-     */
-    public function getView($viewClass = null)
-    {
-        if ($viewClass === null) {
-            $viewClass = $this->viewClass;
-        }
-        if ($viewClass) {
-            $this->_view = null;
-        }
-        if ($this->_view === null) {
-            $this->_view = $this->createView($viewClass);
-        }
-        $this->_view->viewVars = $this->viewVars;
-        return $this->_view;
     }
 
     /**

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -88,11 +88,12 @@ trait ViewVarsTrait
         $deprecatedOptions = ['layout', 'view', 'theme', 'autoLayout', 'viewPath', 'layoutPath'];
         foreach ($deprecatedOptions as $option) {
             if (property_exists($this, $option)) {
-                $builder->{$option}($this->{$option});
+                $method = $option === 'viewPath' ? 'templatePath' : $option;
+                $builder->{$method}($this->{$option});
                 trigger_error(sprintf(
                     'Property $%s is deprecated. Use $this->viewBuilder()->%s() instead in beforeRender().',
                     $option,
-                    $option
+                    $method
                 ), E_USER_DEPRECATED);
             }
         }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -447,8 +447,8 @@ class RequestHandlerComponentTest extends TestCase
             return $this->Controller->response;
         });
         $this->Controller->render();
-        $this->assertEquals('RequestHandlerTest' . DS . 'csv', $this->Controller->getView()->viewPath);
-        $this->assertEquals('csv', $this->Controller->getView()->layoutPath);
+        $this->assertEquals('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('csv', $this->Controller->viewBuilder()->layoutPath());
     }
 
     /**
@@ -610,9 +610,9 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->renderAs($this->Controller, 'rss');
         $this->assertTrue(in_array('Rss', $this->Controller->helpers));
 
-        $this->Controller->getView()->viewPath = 'request_handler_test\\rss';
+        $this->Controller->viewBuilder()->viewPath('request_handler_test\\rss');
         $this->RequestHandler->renderAs($this->Controller, 'js');
-        $this->assertEquals('request_handler_test' . DS . 'js', $this->Controller->getView()->viewPath);
+        $this->assertEquals('request_handler_test' . DS . 'js', $this->Controller->viewBuilder()->viewPath());
     }
 
     /**
@@ -704,12 +704,12 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->render();
 
         $this->RequestHandler->renderAs($this->Controller, 'print');
-        $this->assertEquals('RequestHandlerTest' . DS . 'print', $this->Controller->getView()->viewPath);
-        $this->assertEquals('print', $this->Controller->getView()->layoutPath);
+        $this->assertEquals('RequestHandlerTest' . DS . 'print', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('print', $this->Controller->viewBuilder()->layoutPath());
 
         $this->RequestHandler->renderAs($this->Controller, 'js');
-        $this->assertEquals('RequestHandlerTest' . DS . 'js', $this->Controller->getView()->viewPath);
-        $this->assertEquals('js', $this->Controller->getView()->layoutPath);
+        $this->assertEquals('RequestHandlerTest' . DS . 'js', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('js', $this->Controller->viewBuilder()->layoutPath());
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -447,7 +447,7 @@ class RequestHandlerComponentTest extends TestCase
             return $this->Controller->response;
         });
         $this->Controller->render();
-        $this->assertEquals('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('RequestHandlerTest' . DS . 'csv', $this->Controller->viewBuilder()->templatePath());
         $this->assertEquals('csv', $this->Controller->viewBuilder()->layoutPath());
     }
 
@@ -610,9 +610,9 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->renderAs($this->Controller, 'rss');
         $this->assertTrue(in_array('Rss', $this->Controller->helpers));
 
-        $this->Controller->viewBuilder()->viewPath('request_handler_test\\rss');
+        $this->Controller->viewBuilder()->templatePath('request_handler_test\\rss');
         $this->RequestHandler->renderAs($this->Controller, 'js');
-        $this->assertEquals('request_handler_test' . DS . 'js', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('request_handler_test' . DS . 'js', $this->Controller->viewBuilder()->templatePath());
     }
 
     /**
@@ -704,11 +704,11 @@ class RequestHandlerComponentTest extends TestCase
         $this->Controller->render();
 
         $this->RequestHandler->renderAs($this->Controller, 'print');
-        $this->assertEquals('RequestHandlerTest' . DS . 'print', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('RequestHandlerTest' . DS . 'print', $this->Controller->viewBuilder()->templatePath());
         $this->assertEquals('print', $this->Controller->viewBuilder()->layoutPath());
 
         $this->RequestHandler->renderAs($this->Controller, 'js');
-        $this->assertEquals('RequestHandlerTest' . DS . 'js', $this->Controller->viewBuilder()->viewPath());
+        $this->assertEquals('RequestHandlerTest' . DS . 'js', $this->Controller->viewBuilder()->templatePath());
         $this->assertEquals('js', $this->Controller->viewBuilder()->layoutPath());
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -397,7 +397,7 @@ class ControllerTest extends TestCase
         $request->params['action'] = 'index';
 
         $Controller = new Controller($request, new Response());
-        $Controller->viewBuilder()->viewPath('Posts');
+        $Controller->viewBuilder()->templatePath('Posts');
 
         $result = $Controller->render('index');
         $this->assertRegExp('/posts index/', (string)$result);
@@ -869,7 +869,7 @@ class ControllerTest extends TestCase
             return $e->subject()->response;
         });
         $Controller->render();
-        $this->assertEquals('Admin' . DS . 'Posts', $Controller->viewBuilder()->viewPath());
+        $this->assertEquals('Admin' . DS . 'Posts', $Controller->viewBuilder()->templatePath());
 
         $request->addParams([
             'prefix' => 'admin/super'
@@ -880,7 +880,7 @@ class ControllerTest extends TestCase
             return $e->subject()->response;
         });
         $Controller->render();
-        $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->viewPath());
+        $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->templatePath());
 
         $request = new Request('pages/home');
         $request->addParams([
@@ -891,7 +891,7 @@ class ControllerTest extends TestCase
             return $e->subject()->response;
         });
         $Controller->render();
-        $this->assertEquals('Pages', $Controller->viewBuilder()->viewPath());
+        $this->assertEquals('Pages', $Controller->viewBuilder()->templatePath());
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -402,12 +402,10 @@ class ControllerTest extends TestCase
         $result = $Controller->render('index');
         $this->assertRegExp('/posts index/', (string)$result);
 
-        $Controller->getView()->view = 'index';
-        $Controller->getView()->hasRendered = false;
+        $Controller->viewBuilder()->template('index');
         $result = $Controller->render();
         $this->assertRegExp('/posts index/', (string)$result);
 
-        $Controller->getView()->hasRendered = false;
         $result = $Controller->render('/Element/test_element');
         $this->assertRegExp('/this is the test element/', (string)$result);
     }
@@ -871,7 +869,7 @@ class ControllerTest extends TestCase
             return $e->subject()->response;
         });
         $Controller->render();
-        $this->assertEquals('Admin' . DS . 'Posts', $Controller->getView()->viewPath);
+        $this->assertEquals('Admin' . DS . 'Posts', $Controller->viewBuilder()->viewPath());
 
         $request->addParams([
             'prefix' => 'admin/super'
@@ -882,7 +880,7 @@ class ControllerTest extends TestCase
             return $e->subject()->response;
         });
         $Controller->render();
-        $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->getView()->viewPath);
+        $this->assertEquals('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->viewPath());
 
         $request = new Request('pages/home');
         $request->addParams([
@@ -893,7 +891,7 @@ class ControllerTest extends TestCase
             return $e->subject()->response;
         });
         $Controller->render();
-        $this->assertEquals('Pages', $Controller->getView()->viewPath);
+        $this->assertEquals('Pages', $Controller->viewBuilder()->viewPath());
     }
 
     /**
@@ -979,7 +977,7 @@ class ControllerTest extends TestCase
         $theme = $controller->theme;
 
         // @codingStandardsIgnoreStart
-        $this->assertEquals($theme, @$controller->getView()->theme);
+        $this->assertEquals($theme, @$controller->createView()->theme);
         // @codingStandardsIgnoreEnd
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -397,7 +397,7 @@ class ControllerTest extends TestCase
         $request->params['action'] = 'index';
 
         $Controller = new Controller($request, new Response());
-        $Controller->getView()->viewPath = 'Posts';
+        $Controller->viewBuilder()->viewPath('Posts');
 
         $result = $Controller->render('index');
         $this->assertRegExp('/posts index/', (string)$result);
@@ -421,10 +421,10 @@ class ControllerTest extends TestCase
     {
         $Controller = new Controller(new Request, new Response());
 
-        $Controller->eventManager()->attach(function ($event) {
+        $Controller->eventManager()->on('Controller.beforeRender', function ($event) {
             $controller = $event->subject();
             $controller->viewClass = 'Json';
-        }, 'Controller.beforeRender');
+        });
 
         $Controller->set([
             'test' => 'value',

--- a/tests/TestCase/Controller/PagesControllerTest.php
+++ b/tests/TestCase/Controller/PagesControllerTest.php
@@ -40,7 +40,7 @@ class PagesControllerTest extends TestCase
     {
         $Pages = new PagesController(new Request(), new Response());
 
-        $Pages->getView()->viewPath = 'Posts';
+        $Pages->viewBuilder()->viewPath('Posts');
         $Pages->display('index');
         $this->assertRegExp('/posts index/', $Pages->response->body());
         $this->assertEquals('index', $Pages->viewVars['page']);

--- a/tests/TestCase/Controller/PagesControllerTest.php
+++ b/tests/TestCase/Controller/PagesControllerTest.php
@@ -40,7 +40,7 @@ class PagesControllerTest extends TestCase
     {
         $Pages = new PagesController(new Request(), new Response());
 
-        $Pages->viewBuilder()->viewPath('Posts');
+        $Pages->viewBuilder()->templatePath('Posts');
         $Pages->display('index');
         $this->assertRegExp('/posts index/', $Pages->response->body());
         $this->assertEquals('index', $Pages->viewVars['page']);

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -308,6 +308,7 @@ object(Cake\View\View) {
 	[protected] _stack => []
 	[protected] _eventManager => object(Cake\Event\EventManager) {}
 	[protected] _eventClass => '\Cake\Event\Event'
+	[protected] _viewBuilder => null
 }
 TEXT;
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -279,7 +279,6 @@ object(Cake\View\View) {
 	response => object(Cake\Network\Response) {}
 	elementCache => 'default'
 	viewClass => null
-	_view => null
 	viewVars => []
 	Html => object(Cake\View\Helper\HtmlHelper) {}
 	Form => object(Cake\View\Helper\FormHelper) {}

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -706,7 +706,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
         $ExceptionRenderer->controller->helpers = ['Fail', 'Boom'];
         $ExceptionRenderer->controller->eventManager()->on('Controller.beforeRender', function (Event $event) {
-            $event->subject()->getView()->layoutPath = 'boom';
+            $event->subject()->viewBuilder()->layoutPath('boom');
         });
         $ExceptionRenderer->controller->request = new Request;
 
@@ -726,8 +726,8 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->controller->response = $response;
 
         $ExceptionRenderer->render();
-        $this->assertEquals('', $ExceptionRenderer->controller->getView()->layoutPath);
-        //$this->assertEquals('Error', $ExceptionRenderer->controller->getView()->viewPath);
+        $this->assertEquals('', $ExceptionRenderer->controller->viewBuilder()->layoutPath());
+        $this->assertEquals('Error', $ExceptionRenderer->controller->viewBuilder()->viewPath());
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -727,7 +727,7 @@ class ExceptionRendererTest extends TestCase
 
         $ExceptionRenderer->render();
         $this->assertEquals('', $ExceptionRenderer->controller->viewBuilder()->layoutPath());
-        $this->assertEquals('Error', $ExceptionRenderer->controller->viewBuilder()->viewPath());
+        $this->assertEquals('Error', $ExceptionRenderer->controller->viewBuilder()->templatePath());
     }
 
     /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -168,9 +168,9 @@ class CellTest extends TestCase
         $this->View->theme = 'TestTheme';
         $cell = $this->View->cell('Articles', ['msg' => 'hello world!']);
 
-        $this->assertEquals($this->View->theme, $cell->theme);
+        $this->assertEquals($this->View->theme, $cell->viewBuilder()->theme());
         $this->assertContains('Themed cell content.', $cell->render());
-        $this->assertEquals($cell->View->theme, $cell->theme);
+        $this->assertEquals($cell->View->theme, $cell->viewBuilder()->theme());
     }
 
     /**

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -43,6 +43,19 @@ class ViewBuilderTest extends TestCase
     }
 
     /**
+     * data provider for array properties.
+     *
+     * @return array
+     */
+    public function arrayPropertyProvider()
+    {
+        return [
+            ['helpers', ['Html', 'Form']],
+            ['options', ['key' => 'value']],
+        ];
+    }
+
+    /**
      * Test string property accessor/mutator methods.
      *
      * @dataProvider stringPropertyProvider
@@ -52,6 +65,20 @@ class ViewBuilderTest extends TestCase
     {
         $builder = new ViewBuilder();
         $this->assertNull($builder->{$property}(), 'Default value should be null');
+        $this->assertSame($builder, $builder->{$property}($value), 'Setter returns this');
+        $this->assertSame($value, $builder->{$property}(), 'Getter gets value.');
+    }
+
+    /**
+     * Test array property accessor/mutator methods.
+     *
+     * @dataProvider arrayPropertyProvider
+     * @return void
+     */
+    public function testArrayProperties($property, $value)
+    {
+        $builder = new ViewBuilder();
+        $this->assertSame([], $builder->{$property}(), 'Default value should be empty list');
         $this->assertSame($builder, $builder->{$property}($value), 'Setter returns this');
         $this->assertSame($value, $builder->{$property}(), 'Getter gets value.');
     }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\ViewBuilder;
+
+/**
+ * View builder test case.
+ */
+class ViewBuilderTest extends TestCase
+{
+    /**
+     * data provider for string properties.
+     *
+     * @return array
+     */
+    public function stringPropertyProvider()
+    {
+        return [
+            ['layoutPath', 'Admin/'],
+            ['viewPath', 'Admin/'],
+            ['plugin', 'TestPlugin'],
+            ['layout', 'admin'],
+            ['theme', 'TestPlugin'],
+            ['template', 'edit'],
+            ['name', 'Articles'],
+            ['autoLayout', true],
+            ['className', 'Cake\View\JsonView'],
+        ];
+    }
+
+    /**
+     * Test string property accessor/mutator methods.
+     *
+     * @dataProvider stringPropertyProvider
+     * @return void
+     */
+    public function testStringProperties($property, $value)
+    {
+        $builder = new ViewBuilder();
+        $this->assertNull($builder->{$property}(), 'Default value should be null');
+        $this->assertSame($builder, $builder->{$property}($value), 'Setter returns this');
+        $this->assertSame($value, $builder->{$property}(), 'Getter gets value.');
+    }
+}

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -82,4 +82,44 @@ class ViewBuilderTest extends TestCase
         $this->assertSame($builder, $builder->{$property}($value), 'Setter returns this');
         $this->assertSame($value, $builder->{$property}(), 'Getter gets value.');
     }
+
+    /**
+     * Test array property accessor/mutator methods.
+     *
+     * @dataProvider arrayPropertyProvider
+     * @return void
+     */
+    public function testArrayPropertyMerge($property, $value)
+    {
+        $builder = new ViewBuilder();
+        $builder->{$property}($value);
+
+        $builder->{$property}(['Merged'], true);
+        $this->assertSame(array_merge($value, ['Merged']), $builder->{$property}(), 'Should merge');
+
+        $builder->{$property}($value, false);
+        $this->assertSame($value, $builder->{$property}(), 'Should replace');
+    }
+
+    /**
+     * test building with all the options.
+     *
+     * @return void
+     */
+    public function testBuildComplete()
+    {
+        $this->markTestIncomplete('not done');
+    }
+
+    /**
+     * test missing view class
+     *
+     * @expectedException \Cake\View\Exception\MissingViewException
+     * @expectedExceptionMessage View class "Foo" is missing.
+     * @return void
+     */
+    public function testBuildMissingViewClass()
+    {
+        $this->markTestIncomplete('not done');
+    }
 }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -108,7 +108,39 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildComplete()
     {
-        $this->markTestIncomplete('not done');
+        $request = $this->getMock('Cake\Network\Request');
+        $response = $this->getMock('Cake\Network\Response');
+        $events = $this->getMock('Cake\Event\EventManager');
+
+        $builder = new ViewBuilder();
+        $builder->name('Articles')
+            ->className('Ajax')
+            ->template('edit')
+            ->layout('default')
+            ->viewPath('Articles/')
+            ->helpers(['Form', 'Html'])
+            ->layoutPath('Admin/')
+            ->theme('TestTheme')
+            ->plugin('TestPlugin');
+        $view = $builder->build(
+            ['one' => 'value'],
+            $request,
+            $response,
+            $events
+        );
+        $this->assertInstanceOf('Cake\View\AjaxView', $view);
+        $this->assertEquals('edit', $view->view);
+        $this->assertEquals('default', $view->layout);
+        $this->assertEquals('Articles/', $view->viewPath);
+        $this->assertEquals('Admin/', $view->layoutPath);
+        $this->assertEquals('TestPlugin', $view->plugin);
+        $this->assertEquals('TestTheme', $view->theme);
+        $this->assertSame($request, $view->request);
+        $this->assertSame($response, $view->response);
+        $this->assertSame($events, $view->eventManager());
+        $this->assertSame(['one' => 'value'], $view->viewVars);
+        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $view->Html);
+        $this->assertInstanceOf('Cake\View\Helper\FormHelper', $view->Form);
     }
 
     /**
@@ -120,6 +152,8 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildMissingViewClass()
     {
-        $this->markTestIncomplete('not done');
+        $builder = new ViewBuilder();
+        $builder->className('Foo');
+        $builder->build();
     }
 }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -31,7 +31,7 @@ class ViewBuilderTest extends TestCase
     {
         return [
             ['layoutPath', 'Admin/'],
-            ['viewPath', 'Admin/'],
+            ['templatePath', 'Admin/'],
             ['plugin', 'TestPlugin'],
             ['layout', 'admin'],
             ['theme', 'TestPlugin'],
@@ -117,7 +117,7 @@ class ViewBuilderTest extends TestCase
             ->className('Ajax')
             ->template('edit')
             ->layout('default')
-            ->viewPath('Articles/')
+            ->templatePath('Articles/')
             ->helpers(['Form', 'Html'])
             ->layoutPath('Admin/')
             ->theme('TestTheme')

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\ViewBuilder;
 
@@ -141,6 +142,32 @@ class ViewBuilderTest extends TestCase
         $this->assertSame(['one' => 'value'], $view->viewVars);
         $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $view->Html);
         $this->assertInstanceOf('Cake\View\Helper\FormHelper', $view->Form);
+    }
+
+    /**
+     * Test that the default is AppView.
+     *
+     * @return void
+     */
+    public function testBuildAppViewMissing()
+    {
+        Configure::write('App.namespace', 'Nope');
+        $builder = new ViewBuilder();
+        $view = $builder->build();
+        $this->assertInstanceOf('Cake\View\View', $view);
+    }
+
+    /**
+     * Test that the default is AppView.
+     *
+     * @return void
+     */
+    public function testBuildAppViewPresent()
+    {
+        Configure::write('App.namespace', 'TestApp');
+        $builder = new ViewBuilder();
+        $view = $builder->build();
+        $this->assertInstanceOf('TestApp\View\AppView', $view);
     }
 
     /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1319,7 +1319,7 @@ class ViewTest extends TestCase
         $Controller = new ViewPostsController();
         $Controller->helpers = ['Html'];
         $Controller->set('html', 'I am some test html');
-        $View = $Controller->getView();
+        $View = $Controller->createView();
         $View->viewPath = $Controller->name;
         $result = $View->render('helper_overwrite', false);
 
@@ -1334,7 +1334,7 @@ class ViewTest extends TestCase
      */
     public function testViewFileName()
     {
-        $View = $this->PostsController->getView('Cake\Test\TestCase\View\TestView');
+        $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
         $View->viewPath = 'Posts';
 
         $result = $View->getViewFileName('index');

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -161,7 +161,7 @@ class ViewVarsTraitTest extends TestCase
     }
 
     /**
-     * test that getView() updates viewVars of View instance on each call.
+     * test that createView() updates viewVars of View instance on each call.
      *
      * @return void
      */
@@ -169,23 +169,11 @@ class ViewVarsTraitTest extends TestCase
     {
         $expected = ['one' => 'one'];
         $this->subject->set($expected);
-        $this->assertEquals($expected, $this->subject->getView()->viewVars);
+        $this->assertEquals($expected, $this->subject->createView()->viewVars);
 
         $expected = ['one' => 'one', 'two' => 'two'];
         $this->subject->set($expected);
-        $this->assertEquals($expected, $this->subject->getView()->viewVars);
-    }
-
-    /**
-     * test getView() throws exception if view class cannot be found
-     *
-     * @expectedException \Cake\View\Exception\MissingViewException
-     * @expectedExceptionMessage View class "Foo" is missing.
-     * @return void
-     */
-    public function testGetViewException()
-    {
-        $this->subject->getView('Foo');
+        $this->assertEquals($expected, $this->subject->createView()->viewVars);
     }
 
     /**
@@ -197,6 +185,6 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testCreateViewException()
     {
-        $this->subject->getView('Foo');
+        $this->subject->createView('Foo');
     }
 }

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -32,7 +32,7 @@ class RequestHandlerTestController extends Controller
      */
     public function destination()
     {
-        $this->getView()->viewPath('Posts');
+        $this->viewBuilder()->viewPath('Posts');
         $this->render('index');
     }
 
@@ -56,7 +56,7 @@ class RequestHandlerTestController extends Controller
      */
     public function ajax2_layout()
     {
-        $this->getView()->layout = 'ajax2';
+        $this->viewBuilder()->layout('ajax2');
         $this->destination();
     }
 }

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -32,7 +32,7 @@ class RequestHandlerTestController extends Controller
      */
     public function destination()
     {
-        $this->viewBuilder()->viewPath('Posts');
+        $this->viewBuilder()->templatePath('Posts');
         $this->render('index');
     }
 

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -24,10 +24,10 @@ class TestAppsExceptionRenderer extends ExceptionRenderer
         $response = new Response();
         try {
             $controller = new TestAppsErrorController($request, $response);
-            $controller->getView()->layout = 'banana';
+            $controller->viewBuilder()->layout('banana');
         } catch (\Exception $e) {
             $controller = new Controller($request, $response);
-            $controller->viewPath = 'Error';
+            $controller->viewBuilder()->viewPath('Error');
         }
         return $controller;
     }

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -27,7 +27,7 @@ class TestAppsExceptionRenderer extends ExceptionRenderer
             $controller->viewBuilder()->layout('banana');
         } catch (\Exception $e) {
             $controller = new Controller($request, $response);
-            $controller->viewBuilder()->viewPath('Error');
+            $controller->viewBuilder()->templatePath('Error');
         }
         return $controller;
     }


### PR DESCRIPTION
This set of changes removes the `getView()` method and replaces it with a builder/config object. The goal of these changes are to:
- Continue separating `View` & `Controller` making the contract between them as loose as possible. This decoupling makes using View in other contexts easier.
- Remove view related properties from `Controller`. In the past controllers were a dumping ground for all sorts of properties. By delegating to config/builder we help reinforce what data belongs in which layer, and keep controllers less cluttered.
- Address the issues with the current `getView()` method.

Refs #7201
