### PR TITLE
Increase shutdown memory for Fatal Error handling

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -68,6 +68,8 @@
  * - `renderer` - string - The class responsible for rendering uncaught exceptions. If you choose a custom class you
  *   should place the file for that class in app/Lib/Error. This class needs to implement a render method.
  * - `log` - boolean - Should Exceptions be logged?
+ * - `extraFatalErrorMemory` - integer - Increases memory limit at shutdown so fatal errors are logged. Specify
+ *   amount in megabytes or use 0 to disable (default: 4 MB)
  * - `skipLog` - array - list of exceptions to skip for logging. Exceptions that
  *   extend one of the listed exceptions will also be skipped for logging.
  *   Example: `'skipLog' => array('NotFoundException', 'UnauthorizedException')`


### PR DESCRIPTION
When a script runs out of memory and triggers a fatal error there often is not enough additional memory left to execute the Cache::write() calls in the shutdown() hook causing execution to stop prematurely. If those Cache calls are skipped over, then the code usually stops prematurely somewhere in the middle of the error handler.

This patch has been tested and verified using the function below. It allows the shutdown() hook to complete gracefully by providing additional memory.

This problem exists on all 2.X versions  (and possibly in 3.X as well)

$x = array();
while(true){  $x[] = rand(); }
