### PR TITLE
3.0 Missing use statement

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -29,6 +29,7 @@ use Cake\Collection\Iterator\StoppableIterator;
 use Cake\Collection\Iterator\TreeIterator;
 use Cake\Collection\Iterator\UnfoldIterator;
 use Cake\Collection\Iterator\ZipIterator;
+use Countable;
 use Iterator;
 use LimitIterator;
 use RecursiveIteratorIterator;

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -69,7 +69,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * will be returned. Otherwise the hidden properties will be set.
      *
      * @param null|array $properties Either an array of properties to hide or null to get properties
-     * @return array|\Cake\DataSource\EntityInterface
+     * @return array|\Cake\Datasource\EntityInterface
      */
     public function hiddenProperties($properties = null);
 
@@ -80,7 +80,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * will be returned. Otherwise the virtual properties will be set.
      *
      * @param null|array $properties Either an array of properties to treat as virtual or null to get properties
-     * @return array|\Cake\DataSource\EntityInterface
+     * @return array|\Cake\Datasource\EntityInterface
      */
     public function virtualProperties($properties = null);
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1656,7 +1656,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Will delete the entity provided. Will remove rows from any
      * dependent associations, and clear out join tables for BelongsToMany associations.
      *
-     * @param \Cake\DataSource\EntityInterface $entity The entity to delete.
+     * @param \Cake\Datasource\EntityInterface $entity The entity to delete.
      * @param \ArrayObject $options The options for the delete.
      * @throws \InvalidArgumentException if there are no primary key values of the
      * passed entity

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -256,7 +256,7 @@ class EntityContext implements ContextInterface
      *
      * @param array|null $path Each one of the parts in a path for a field name
      *  or null to get the entity passed in contructor context.
-     * @return \Cake\DataSource\EntityInterface|\Traversable|array|bool
+     * @return \Cake\Datasource\EntityInterface|\Traversable|array|bool
      * @throws \RuntimeException When properties cannot be read.
      */
     public function entity($path = null)


### PR DESCRIPTION
and case correction for  `Cake\Datasource\EntityInterface`
