### PR TITLE
3.1 - Email ViewBuilder

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1966,7 +1966,7 @@ class Email implements JsonSerializable, Serializable
     /**
      * Serializes the Email object.
      *
-     * @return void.
+     * @return string
      */
     public function serialize()
     {

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1814,7 +1814,7 @@ class Email implements JsonSerializable, Serializable
         $View = $this->createView();
         $View->loadHelpers();
 
-        list($templatePlugin) = pluginSplit($View->view());
+        list($templatePlugin) = pluginSplit($View->template());
         list($layoutPlugin) = pluginSplit($View->layout());
         if ($templatePlugin) {
             $View->plugin = $templatePlugin;
@@ -1828,7 +1828,7 @@ class Email implements JsonSerializable, Serializable
 
         foreach ($types as $type) {
             $View->hasRendered = false;
-            $View->viewPath('Email/' . $type);
+            $View->templatePath('Email/' . $type);
             $View->layoutPath('Email/' . $type);
 
             $render = $View->render();

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1803,7 +1803,8 @@ class Email implements JsonSerializable, Serializable
     {
         $types = $this->_getTypes();
         $rendered = [];
-        if (empty($this->viewBuilder()->template())) {
+        $template = $this->viewBuilder()->template();
+        if (empty($template)) {
             foreach ($types as $type) {
                 $rendered[$type] = $this->_encodeString($content, $this->charset);
             }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1891,12 +1891,12 @@ class Email implements JsonSerializable, Serializable
     public function jsonSerialize()
     {
         $properties = [
-            '_to', '_from', '_sender', '_replyTo', '_cc', '_bcc', '_subject', '_returnPath', '_readReceipt',
-            '_template', '_layout', '_viewRender', '_viewVars', '_theme', '_helpers', '_emailFormat',
-            '_emailPattern', '_attachments', '_domain', '_messageId', '_headers', 'charset', 'headerCharset',
+            '_to', '_from', '_sender', '_replyTo', '_cc', '_bcc', '_subject',
+            '_returnPath', '_readReceipt', '_emailFormat', '_emailPattern', '_domain',
+            '_attachments', '_messageId', '_headers', 'viewVars', 'charset', 'headerCharset'
         ];
 
-        $array = [];
+        $array = ['viewConfig' => $this->viewBuilder()->jsonSerialize()];
 
         foreach ($properties as $property) {
             $array[$property] = $this->{$property};
@@ -1909,7 +1909,7 @@ class Email implements JsonSerializable, Serializable
             }
         });
 
-        array_walk_recursive($array['_viewVars'], [$this, '_checkViewVars']);
+        array_walk_recursive($array['viewVars'], [$this, '_checkViewVars']);
 
         return array_filter($array, function ($i) {
             return !is_array($i) && strlen($i) || !empty($i);
@@ -1950,6 +1950,11 @@ class Email implements JsonSerializable, Serializable
      */
     public function createFromArray($config)
     {
+        if (isset($config['viewConfig'])) {
+            $this->viewBuilder()->createFromArray($config['viewConfig']);
+            unset($config['viewConfig']);
+        }
+
         foreach ($config as $property => $value) {
             $this->{$property} = $value;
         }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1812,7 +1812,6 @@ class Email implements JsonSerializable, Serializable
         }
 
         $View = $this->createView();
-        $View->loadHelpers();
 
         list($templatePlugin) = pluginSplit($View->template());
         list($layoutPlugin) = pluginSplit($View->layout());

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -383,7 +383,7 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * Serializes the view builder object.
      *
-     * @return void
+     * @return string
      */
     public function serialize()
     {

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -20,6 +20,8 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\View\Exception\MissingViewException;
 use Cake\View\View;
+use JsonSerializable;
+use Serializable;
 
 /**
  * Provides an API for iteratively building a view up.
@@ -27,7 +29,7 @@ use Cake\View\View;
  * Once you have configured the view and established all the context
  * you can create a view instance with `build()`.
  */
-class ViewBuilder
+class ViewBuilder implements JsonSerializable, Serializable
 {
     /**
      * The subdirectory to the template.
@@ -337,5 +339,66 @@ class ViewBuilder
         ];
         $data += $this->_options;
         return new $className($request, $response, $events, $data);
+    }
+
+    /**
+     * Serializes the view builder object to a value that can be natively
+     * serialized and re-used to clone this builder instance.
+     *
+     * @return array Serializable array of configuration properties.
+     */
+    public function jsonSerialize()
+    {
+        $properties = [
+            '_templatePath', '_template', '_plugin', '_theme', '_layout', '_autoLayout',
+            '_layoutPath', '_name', '_className', '_options', '_helpers'
+        ];
+
+        $array = [];
+
+        foreach ($properties as $property) {
+            $array[$property] = $this->{$property};
+        }
+
+        return array_filter($array, function ($i) {
+            return !is_array($i) && strlen($i) || !empty($i);
+        });
+    }
+
+    /**
+     * Configures a view builder instance from serialized config.
+     *
+     * @param array $config View builder configuration array.
+     * @return $this Configured view builder instance.
+     */
+    public function createFromArray($config)
+    {
+        foreach ($config as $property => $value) {
+            $this->{$property} = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Serializes the view builder object.
+     *
+     * @return void
+     */
+    public function serialize()
+    {
+        $array = $this->jsonSerialize();
+        return serialize($array);
+    }
+
+    /**
+     * Unserializes the view builder object.
+     *
+     * @param string $data Serialized string.
+     * @return $this Configured view builder instance.
+     */
+    public function unserialize($data)
+    {
+        return $this->createFromArray(unserialize($data));
     }
 }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -14,6 +14,7 @@
 namespace Cake\View;
 
 use Cake\Core\App;
+use Cake\Event\EventManagerTrait;
 use Cake\View\ViewBuilder;
 
 /**
@@ -106,9 +107,9 @@ trait ViewVarsTrait
 
         return $builder->build(
             $this->viewVars,
-            $this->request,
-            $this->response,
-            $this->eventManager(),
+            isset($this->request) ? $this->request : null,
+            isset($this->response) ? $this->response : null,
+            $this instanceof EventManagerTrait ? $this->eventManager() : null,
             $viewOptions
         );
     }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -14,7 +14,7 @@
 namespace Cake\View;
 
 use Cake\Core\App;
-use Cake\Event\EventManagerTrait;
+use Cake\Event\EventDispatcherInterface;
 use Cake\View\ViewBuilder;
 
 /**
@@ -109,7 +109,7 @@ trait ViewVarsTrait
             $this->viewVars,
             isset($this->request) ? $this->request : null,
             isset($this->response) ? $this->response : null,
-            $this instanceof EventManagerTrait ? $this->eventManager() : null,
+            $this instanceof EventDispatcherInterface ? $this->eventManager() : null,
             $viewOptions
         );
     }

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2648,7 +2648,6 @@ XML;
             ->cc(['mark@cakephp.org', 'juan@cakephp.org' => 'Juan Basso'])
             ->bcc('phpnut@cakephp.org')
             ->subject('Test Serialize')
-            ->template('default', 'test')
             ->messageId('<uuid@server.com>')
             ->domain('foo.bar')
             ->viewVars([
@@ -2664,9 +2663,13 @@ XML;
                 ]
             ]);
 
+        $this->CakeEmail->viewBuilder()
+            ->template('default')
+            ->layout('test');
+
         $result = json_decode(json_encode($this->CakeEmail), true);
-        $this->assertContains('test', $result['_viewVars']['exception']);
-        unset($result['_viewVars']['exception']);
+        $this->assertContains('test', $result['viewVars']['exception']);
+        unset($result['viewVars']['exception']);
 
         $encode = function ($path) {
             return chunk_split(base64_encode(file_get_contents($path)), 76, "\r\n");
@@ -2679,16 +2682,18 @@ XML;
             '_cc' => ['mark@cakephp.org' => 'mark@cakephp.org', 'juan@cakephp.org' => 'Juan Basso'],
             '_bcc' => ['phpnut@cakephp.org' => 'phpnut@cakephp.org'],
             '_subject' => 'Test Serialize',
-            '_template' => 'default',
-            '_layout' => 'test',
-            '_viewRender' => 'Cake\View\View',
-            '_helpers' => ['Html'],
             '_emailFormat' => 'text',
             '_messageId' => '<uuid@server.com>',
             '_domain' => 'foo.bar',
             'charset' => 'utf-8',
             'headerCharset' => 'utf-8',
-            '_viewVars' => [
+            'viewConfig' => [
+                '_template' => 'default',
+                '_layout' => 'test',
+                '_helpers' => ['Html'],
+                '_className' => 'Cake\View\View',
+            ],
+            'viewVars' => [
                 'users' => [
                     'id' => 1,
                     'username' => 'mariano'
@@ -2712,10 +2717,9 @@ XML;
         ];
         $this->assertEquals($expected, $result);
 
-        debug(unserialize(serialize($this->CakeEmail)));
         $result = json_decode(json_encode(unserialize(serialize($this->CakeEmail))), true);
-        $this->assertContains('test', $result['_viewVars']['exception']);
-        unset($result['_viewVars']['exception']);
+        $this->assertContains('test', $result['viewVars']['exception']);
+        unset($result['viewVars']['exception']);
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -682,11 +682,11 @@ class EmailTest extends TestCase
         $this->assertSame($expected, $this->CakeEmail->template());
 
         $this->CakeEmail->template('template', null);
-        $expected = ['template' => 'template', 'layout' => null];
+        $expected = ['template' => 'template', 'layout' => false];
         $this->assertSame($expected, $this->CakeEmail->template());
 
         $this->CakeEmail->template(null, null);
-        $expected = ['template' => null, 'layout' => null];
+        $expected = ['template' => '', 'layout' => false];
         $this->assertSame($expected, $this->CakeEmail->template());
     }
 
@@ -717,7 +717,7 @@ class EmailTest extends TestCase
         $this->assertSame(['value' => 12345], $this->CakeEmail->viewVars());
 
         $this->CakeEmail->viewVars(['name' => 'CakePHP']);
-        $this->assertSame(['value' => 12345, 'name' => 'CakePHP'], $this->CakeEmail->viewVars());
+        $this->assertEquals(['value' => 12345, 'name' => 'CakePHP'], $this->CakeEmail->viewVars());
 
         $this->CakeEmail->viewVars(['value' => 4567]);
         $this->assertSame(['value' => 4567, 'name' => 'CakePHP'], $this->CakeEmail->viewVars());
@@ -1875,7 +1875,7 @@ class EmailTest extends TestCase
         $this->assertSame($instance->to(), ['debug@cakephp.org' => 'debug@cakephp.org']);
         $this->assertSame($instance->subject(), 'Update ok');
         $this->assertSame($instance->template(), ['template' => 'custom', 'layout' => 'custom_layout']);
-        $this->assertSame($instance->viewVars(), ['value' => 123, 'name' => 'CakePHP']);
+        $this->assertEquals($instance->viewVars(), ['value' => 123, 'name' => 'CakePHP']);
         $this->assertSame($instance->cc(), ['cake@cakephp.org' => 'Myself']);
 
         $configs = ['from' => 'root@cakephp.org', 'message' => 'Message from configs', 'transport' => 'debug'];
@@ -1938,7 +1938,7 @@ class EmailTest extends TestCase
 
         $this->CakeEmail->reset();
         $this->assertSame([], $this->CakeEmail->to());
-        $this->assertNull($this->CakeEmail->theme());
+        $this->assertFalse($this->CakeEmail->theme());
         $this->assertSame(Email::EMAIL_PATTERN, $this->CakeEmail->emailPattern());
     }
 
@@ -2712,6 +2712,7 @@ XML;
         ];
         $this->assertEquals($expected, $result);
 
+        debug(unserialize(serialize($this->CakeEmail)));
         $result = json_decode(json_encode(unserialize(serialize($this->CakeEmail))), true);
         $this->assertContains('test', $result['_viewVars']['exception']);
         unset($result['_viewVars']['exception']);

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -212,4 +212,30 @@ class ViewBuilderTest extends TestCase
         $result = json_decode(json_encode(unserialize(serialize($builder))), true);
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * testCreateFromArray()
+     *
+     * @return void
+     */
+    public function testCreateFromArray()
+    {
+        $builder = new ViewBuilder();
+
+        $builder
+            ->template('default')
+            ->layout('test')
+            ->helpers(['Html'])
+            ->className('JsonView');
+
+        $result = json_encode($builder);
+
+        $builder = new ViewBuilder();
+        $builder->createFromArray(json_decode($result, true));
+
+        $this->assertEquals('default', $builder->template());
+        $this->assertEquals('test', $builder->layout());
+        $this->assertEquals(['Html'], $builder->helpers());
+        $this->assertEquals('JsonView', $builder->className());
+    }
 }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -183,4 +183,33 @@ class ViewBuilderTest extends TestCase
         $builder->className('Foo');
         $builder->build();
     }
+
+    /**
+     * testJsonSerialize()
+     *
+     * @return void
+     */
+    public function testJsonSerialize()
+    {
+        $builder = new ViewBuilder();
+
+        $builder
+            ->template('default')
+            ->layout('test')
+            ->helpers(['Html'])
+            ->className('JsonView');
+
+        $result = json_decode(json_encode($builder), true);
+
+        $expected = [
+            '_template' => 'default',
+            '_layout' => 'test',
+            '_helpers' => ['Html'],
+            '_className' => 'JsonView',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = json_decode(json_encode(unserialize(serialize($builder))), true);
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
- With the view related properties removed I am not quite sure how to update `jsonSerialize()` (hence the related failing test case for it)
- Should we deprecate the view config related method of Email class?
