### PR TITLE
3.1 - Sync View property and method names.

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -173,7 +173,7 @@ abstract class Cell
         $render = function () use ($template) {
             $className = substr(strrchr(get_class($this), "\\"), 1);
             $name = substr($className, 0, -4);
-            $this->View->viewPath('Cell' . DS . $name);
+            $this->View->templatePath('Cell' . DS . $name);
 
             try {
                 return $this->View->render($template);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -37,8 +37,8 @@ use RuntimeException;
  * in from the controller to render the results of the controller action. Often this is HTML,
  * but can also take the form of JSON, XML, PDF's or streaming files.
  *
- * CakePHP uses a two-step-view pattern. This means that the view content is rendered first,
- * and then inserted into the selected layout. This also means you can pass data from the view to the
+ * CakePHP uses a two-step-view pattern. This means that the template content is rendered first,
+ * and then inserted into the selected layout. This also means you can pass data from the template to the
  * layout using `$this->set()`
  *
  * View class supports using plugins as themes. You can set
@@ -126,7 +126,7 @@ class View implements EventDispatcherInterface
     public $template = null;
 
     /**
-     * The name of the layout file to render the view inside of. The name specified
+     * The name of the layout file to render the template inside of. The name specified
      * is the filename of the layout in /app/Template/Layout without the .ctp
      * extension.
      *
@@ -143,7 +143,7 @@ class View implements EventDispatcherInterface
 
     /**
      * Turns on or off CakePHP's conventional mode of applying layout files. On by default.
-     * Setting to off means that layouts will not be automatically applied to rendered views.
+     * Setting to off means that layouts will not be automatically applied to rendered templates.
      *
      * @var bool
      */
@@ -157,7 +157,7 @@ class View implements EventDispatcherInterface
     protected $_ext = '.ctp';
 
     /**
-     * Sub-directory for this view file. This is often used for extension based routing.
+     * Sub-directory for this template file. This is often used for extension based routing.
      * Eg. With an `xml` extension, $subDir would be `xml/`
      *
      * @var string
@@ -377,7 +377,7 @@ class View implements EventDispatcherInterface
     /**
      * Turns on or off CakePHP's conventional mode of applying layout files.
      * On by default. Setting to off means that layouts will not be
-     * automatically applied to rendered views.
+     * automatically applied to rendered templates.
      *
      * @param bool $autoLayout Boolean to turn on/off. If null returns current value.
      * @return bool|void
@@ -423,7 +423,7 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Get/set the name of the layout file to render the view inside of.
+     * Get/set the name of the layout file to render the template inside of.
      * The name specified is the filename of the layout in /app/Template/Layout
      * without the .ctp extension.
      *
@@ -532,9 +532,9 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Renders view for given view file and layout.
+     * Renders view for given template file and layout.
      *
-     * Render triggers helper callbacks, which are fired before and after the view are rendered,
+     * Render triggers helper callbacks, which are fired before and after the template are rendered,
      * as well as before and after the layout. The helper callbacks are called:
      *
      * - `beforeRender`
@@ -542,11 +542,11 @@ class View implements EventDispatcherInterface
      * - `beforeLayout`
      * - `afterLayout`
      *
-     * If View::$autoRender is false and no `$layout` is provided, the view will be returned bare.
+     * If View::$autoRender is false and no `$layout` is provided, the template will be returned bare.
      *
-     * View and layout names can point to plugin views/layouts. Using the `Plugin.view` syntax
-     * a plugin view/layout can be used instead of the app ones. If the chosen plugin is not found
-     * the view will be located along the regular view path cascade.
+     * Template and layout names can point to plugin templates/layouts. Using the `Plugin.template` syntax
+     * a plugin template/layout can be used instead of the app ones. If the chosen plugin is not found
+     * the template will be located along the regular view path cascade.
      *
      * @param string|null $view Name of view file to use
      * @param string|null $layout Layout to use.
@@ -582,7 +582,7 @@ class View implements EventDispatcherInterface
      * Renders a layout. Returns output from _render(). Returns false on error.
      * Several variables are created for use in layout.
      *
-     * @param string $content Content to render in a view, wrapped by the surrounding layout.
+     * @param string $content Content to render in a template, wrapped by the surrounding layout.
      * @param string|null $layout Layout name
      * @return mixed Rendered output, or false on error
      * @throws \Cake\Core\Exception\Exception if there is an error in the view.
@@ -762,12 +762,12 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Provides view or element extension/inheritance. Views can extends a
+     * Provides template or element extension/inheritance. Views can extends a
      * parent view and populate blocks in the parent template.
      *
-     * @param string $name The view or element to 'extend' the current one with.
+     * @param string $name The template or element to 'extend' the current one with.
      * @return void
-     * @throws \LogicException when you extend a view with itself or make extend loops.
+     * @throws \LogicException when you extend a template with itself or make extend loops.
      * @throws \LogicException when you extend an element which doesn't exist
      */
     public function extend($name)
@@ -893,8 +893,8 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Renders and returns output for given view filename with its
-     * array of data. Handles parent/extended views.
+     * Renders and returns output for given template filename with its
+     * array of data. Handles parent/extended templates.
      *
      * @param string $viewFile Filename of the view
      * @param array $data Data to include in rendered view. If empty the current

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -871,6 +871,7 @@ class View implements EventDispatcherInterface
      *
      * @param string $name Name to property.
      * @param mixed $value Value for property.
+     * @return void
      */
     public function __set($name, $value)
     {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -111,19 +111,19 @@ class View implements EventDispatcherInterface
     public $helpers = [];
 
     /**
-     * The name of the views subfolder containing views for this View.
+     * The name of the subfolder containing templates for this View.
      *
      * @var string
      */
-    public $viewPath = null;
+    public $templatePath = null;
 
     /**
-     * The name of the view file to render. The name specified
+     * The name of the template file to render. The name specified
      * is the filename in /app/Template/<SubFolder> without the .ctp extension.
      *
      * @var string
      */
-    public $view = null;
+    public $template = null;
 
     /**
      * The name of the layout file to render the view inside of. The name specified
@@ -339,18 +339,18 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Get/set path for view files.
+     * Get/set path for templates files.
      *
-     * @param string $path Path for view files. If null returns current path.
+     * @param string $path Path for template files. If null returns current path.
      * @return string|void
      */
-    public function viewPath($path = null)
+    public function templatePath($path = null)
     {
         if ($path === null) {
-            return $this->viewPath;
+            return $this->templatePath;
         }
 
-        $this->viewPath = $path;
+        $this->templatePath = $path;
     }
 
     /**
@@ -401,19 +401,19 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Get/set the name of the view file to render. The name specified is the
+     * Get/set the name of the template file to render. The name specified is the
      * filename in /app/Template/<SubFolder> without the .ctp extension.
      *
-     * @param string $name View file name to set. If null returns current name.
+     * @param string $name Template file name to set. If null returns current name.
      * @return string|void
      */
-    public function view($name = null)
+    public function template($name = null)
     {
         if ($name === null) {
-            return $this->view;
+            return $this->template;
         }
 
-        $this->view = $name;
+        $this->template = $name;
     }
 
     /**
@@ -598,7 +598,7 @@ class View implements EventDispatcherInterface
 
         $title = $this->Blocks->get('title');
         if ($title === '') {
-            $title = Inflector::humanize($this->viewPath);
+            $title = Inflector::humanize($this->templatePath);
             $this->Blocks->set('title', $title);
         }
 
@@ -837,12 +837,39 @@ class View implements EventDispatcherInterface
      */
     public function __get($name)
     {
+        if ($name === 'view') {
+            return $this->template;
+        }
+        if ($name === 'viewPath') {
+            return $this->templatePath;
+        }
+
         $registry = $this->helpers();
         if (isset($registry->{$name})) {
             $this->{$name} = $registry->{$name};
             return $registry->{$name};
         }
         return $this->{$name};
+    }
+
+    /**
+     * Magic setter for deprecated properties.
+     *
+     * @param string $name Name to property.
+     * @param mixed $value Value for property.
+     */
+    public function __set($name, $value)
+    {
+        if ($name === 'view') {
+            $this->template = $value;
+            return;
+        }
+        if ($name === 'viewPath') {
+            $this->templatePath = $value;
+            return;
+        }
+
+        $this->{$name} = $value;
     }
 
     /**
@@ -971,12 +998,12 @@ class View implements EventDispatcherInterface
         if ($this->subDir !== null) {
             $subDir = $this->subDir . DS;
         }
-        if ($this->viewPath) {
-            $viewPath = $this->viewPath . DS;
+        if ($this->templatePath) {
+            $viewPath = $this->templatePath . DS;
         }
 
         if ($name === null) {
-            $name = $this->view;
+            $name = $this->template;
         }
 
         list($plugin, $name) = $this->pluginSplit($name);
@@ -990,7 +1017,7 @@ class View implements EventDispatcherInterface
                     return $name;
                 }
                 $name = trim($name, DS);
-            } elseif (!$plugin || $this->viewPath !== $this->name) {
+            } elseif (!$plugin || $this->templatePath !== $this->name) {
                 $name = $viewPath . $subDir . $name;
             } else {
                 $name = DS . $subDir . $name;

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -268,8 +268,16 @@ class View implements EventDispatcherInterface
      * Constant for view file type 'view'
      *
      * @var string
+     * @deprecated 3.0.1 Use TYPE_TEMPLATE instead.
      */
     const TYPE_VIEW = 'view';
+
+    /**
+     * Constant for view file type 'template'.
+     *
+     * @var string
+     */
+    const TYPE_TEMPLATE = 'view';
 
     /**
      * Constant for view file type 'element'
@@ -562,7 +570,7 @@ class View implements EventDispatcherInterface
         }
 
         if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {
-            $this->_currentType = static::TYPE_VIEW;
+            $this->_currentType = static::TYPE_TEMPLATE;
             $this->dispatchEvent('View.beforeRender', [$viewFileName]);
             $this->Blocks->set('content', $this->_render($viewFileName));
             $this->dispatchEvent('View.afterRender', [$viewFileName]);
@@ -772,7 +780,7 @@ class View implements EventDispatcherInterface
      */
     public function extend($name)
     {
-        if ($name[0] === '/' || $this->_currentType === static::TYPE_VIEW) {
+        if ($name[0] === '/' || $this->_currentType === static::TYPE_TEMPLATE) {
             $parent = $this->_getViewFileName($name);
         } else {
             switch ($this->_currentType) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -993,13 +993,13 @@ class View implements EventDispatcherInterface
      */
     protected function _getViewFileName($name = null)
     {
-        $viewPath = $subDir = '';
+        $templatePath = $subDir = '';
 
         if ($this->subDir !== null) {
             $subDir = $this->subDir . DS;
         }
         if ($this->templatePath) {
-            $viewPath = $this->templatePath . DS;
+            $templatePath = $this->templatePath . DS;
         }
 
         if ($name === null) {
@@ -1010,7 +1010,7 @@ class View implements EventDispatcherInterface
         $name = str_replace('/', DS, $name);
 
         if (strpos($name, DS) === false && $name[0] !== '.') {
-            $name = $viewPath . $subDir . Inflector::underscore($name);
+            $name = $templatePath . $subDir . Inflector::underscore($name);
         } elseif (strpos($name, DS) !== false) {
             if ($name[0] === DS || $name[1] === ':') {
                 if (is_file($name)) {
@@ -1018,7 +1018,7 @@ class View implements EventDispatcherInterface
                 }
                 $name = trim($name, DS);
             } elseif (!$plugin || $this->templatePath !== $this->name) {
-                $name = $viewPath . $subDir . $name;
+                $name = $templatePath . $subDir . $name;
             } else {
                 $name = DS . $subDir . $name;
             }
@@ -1185,11 +1185,11 @@ class View implements EventDispatcherInterface
                 return $this->_pathsForPlugin[$plugin];
             }
         }
-        $viewPaths = App::path('Template');
+        $templatePaths = App::path('Template');
         $pluginPaths = $themePaths = [];
         if (!empty($plugin)) {
-            for ($i = 0, $count = count($viewPaths); $i < $count; $i++) {
-                $pluginPaths[] = $viewPaths[$i] . 'Plugin' . DS . $plugin . DS;
+            for ($i = 0, $count = count($templatePaths); $i < $count; $i++) {
+                $pluginPaths[] = $templatePaths[$i] . 'Plugin' . DS . $plugin . DS;
             }
             $pluginPaths = array_merge($pluginPaths, App::path('Template', $plugin));
         }
@@ -1198,7 +1198,7 @@ class View implements EventDispatcherInterface
             $themePaths = App::path('Template', Inflector::camelize($this->theme));
 
             if ($plugin) {
-                for ($i = 0, $count = count($viewPaths); $i < $count; $i++) {
+                for ($i = 0, $count = count($templatePaths); $i < $count; $i++) {
                     array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DS . $plugin . DS);
                 }
             }
@@ -1207,7 +1207,7 @@ class View implements EventDispatcherInterface
         $paths = array_merge(
             $themePaths,
             $pluginPaths,
-            $viewPaths,
+            $templatePaths,
             [dirname(__DIR__) . DS . 'Template' . DS]
         );
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -217,8 +217,8 @@ class View implements EventDispatcherInterface
      * @var array
      */
     protected $_passedVars = [
-        'viewVars', 'autoLayout', 'helpers', 'view', 'layout', 'name', 'theme',
-        'layoutPath', 'viewPath', 'plugin', 'passedArgs'
+        'viewVars', 'autoLayout', 'helpers', 'template', 'layout', 'name', 'theme',
+        'layoutPath', 'templatePath', 'plugin', 'passedArgs'
     ];
 
     /**
@@ -300,6 +300,12 @@ class View implements EventDispatcherInterface
         EventManager $eventManager = null,
         array $viewOptions = []
     ) {
+        if (isset($viewOptions['view'])) {
+            $this->template($viewOptions['view']);
+        }
+        if (isset($viewOptions['viewPath'])) {
+            $this->templatePath($viewOptions['viewPath']);
+        }
         foreach ($this->_passedVars as $var) {
             if (isset($viewOptions[$var])) {
                 $this->{$var} = $viewOptions[$var];

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -325,8 +325,8 @@ class ViewBuilder
 
         $data = [
             'name' => $this->_name,
-            'viewPath' => $this->_templatePath,
-            'view' => $this->_template,
+            'templatePath' => $this->_templatePath,
+            'template' => $this->_template,
             'plugin' => $this->_plugin,
             'theme' => $this->_theme,
             'layout' => $this->_layout,

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -266,8 +266,8 @@ object(Cake\View\View) {
 		(int) 0 => 'Html',
 		(int) 1 => 'Form'
 	]
-	viewPath => null
-	view => null
+	templatePath => null
+	template => null
 	layout => 'default'
 	layoutPath => null
 	autoLayout => true
@@ -290,12 +290,12 @@ object(Cake\View\View) {
 		(int) 0 => 'viewVars',
 		(int) 1 => 'autoLayout',
 		(int) 2 => 'helpers',
-		(int) 3 => 'view',
+		(int) 3 => 'template',
 		(int) 4 => 'layout',
 		(int) 5 => 'name',
 		(int) 6 => 'theme',
 		(int) 7 => 'layoutPath',
-		(int) 8 => 'viewPath',
+		(int) 8 => 'templatePath',
 		(int) 9 => 'plugin',
 		(int) 10 => 'passedArgs'
 	]

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -566,7 +566,7 @@ class ViewTest extends TestCase
         $result = $View->getViewFileName('TestPlugin.home');
         $this->assertPathEquals($expected, $result, 'Plugin is missing the view, cascade to app.');
 
-        $View->viewPath = 'Tests';
+        $View->templatePath('Tests');
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'src' . DS .
             'Template' . DS . 'Tests' . DS . 'index.ctp';
         $result = $View->getViewFileName('TestPlugin.index');
@@ -983,7 +983,7 @@ class ViewTest extends TestCase
     public function testViewEvent()
     {
         $View = $this->PostsController->createView();
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
         $View->autoLayout = false;
         $listener = new TestViewEventListenerInterface();
 
@@ -1091,7 +1091,7 @@ class ViewTest extends TestCase
     public function testHelperCallbackTriggering()
     {
         $View = $this->PostsController->createView();
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
 
         $manager = $this->getMock('Cake\Event\EventManager');
         $View->eventManager($manager);
@@ -1183,7 +1183,7 @@ class ViewTest extends TestCase
             'Html'
         ];
         $View = $this->PostsController->createView();
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
         $View->render('index');
         $this->assertEquals('Valuation', $View->helpers()->TestBeforeAfter->property);
     }
@@ -1202,7 +1202,7 @@ class ViewTest extends TestCase
         $this->PostsController->set('variable', 'values');
 
         $View = $this->PostsController->createView();
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
 
         $content = 'This is my view output';
         $result = $View->renderLayout($content, 'default');
@@ -1219,7 +1219,7 @@ class ViewTest extends TestCase
     {
         $this->PostsController->helpers = ['Form', 'Number'];
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
 
         $result = $View->render('index', false);
         $this->assertEquals('posts index', $result);
@@ -1230,7 +1230,7 @@ class ViewTest extends TestCase
 
         $this->PostsController->helpers = ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper'];
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
 
         $result = $View->render('index', false);
         $this->assertEquals('posts index', $result);
@@ -1248,7 +1248,7 @@ class ViewTest extends TestCase
     public function testRender()
     {
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
         $result = $View->render('index');
 
         $this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\"\/>\s*<title>/", $result);
@@ -1267,7 +1267,7 @@ class ViewTest extends TestCase
         Configure::write('Cache.check', true);
 
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = $this->PostsController->name;
+        $View->templatePath($this->PostsController->name);
         $result = $View->render('index');
 
         $this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\"\/>\s*<title>/", $result);
@@ -1282,8 +1282,8 @@ class ViewTest extends TestCase
     public function testRenderUsingViewProperty()
     {
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = $this->PostsController->name;
-        $View->view = 'cache_form';
+        $View->templatePath($this->PostsController->name);
+        $View->template('cache_form');
 
         $this->assertEquals('cache_form', $View->view);
         $result = $View->render();
@@ -1301,7 +1301,7 @@ class ViewTest extends TestCase
         $this->PostsController->plugin = 'TestPlugin';
         $this->PostsController->name = 'Posts';
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = 'Element';
+        $View->templatePath('Element');
         $pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
         $result = $View->getViewFileName('sub_dir/sub_element');
         $expected = $pluginPath . 'src' . DS . 'Template' . DS . 'Element' . DS . 'sub_dir' . DS . 'sub_element.ctp';
@@ -1320,7 +1320,7 @@ class ViewTest extends TestCase
         $Controller->helpers = ['Html'];
         $Controller->set('html', 'I am some test html');
         $View = $Controller->createView();
-        $View->viewPath = $Controller->name;
+        $View->templatePath($Controller->name);
         $result = $View->render('helper_overwrite', false);
 
         $this->assertRegExp('/I am some test html/', $result);
@@ -1335,7 +1335,7 @@ class ViewTest extends TestCase
     public function testViewFileName()
     {
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->viewPath = 'Posts';
+        $View->templatePath('Posts');
 
         $result = $View->getViewFileName('index');
         $this->assertRegExp('/Posts(\/|\\\)index.ctp/', $result);
@@ -1838,7 +1838,7 @@ TEXT;
         $this->ThemeController->name = 'Posts';
 
         $View = $this->ThemeController->createView();
-        $View->viewPath = 'Posts';
+        $View->templatePath('Posts');
         $View->layout = 'whatever';
         $View->theme = 'TestTheme';
         $View->element('test_element');

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1890,4 +1890,22 @@ TEXT;
         $result = $this->View->helpers();
         $this->assertSame($result, $this->View->helpers());
     }
+
+    /**
+     * Test magic getter and setter for removed properties.
+     *
+     * @return void
+     */
+    public function testMagicGetterSetter()
+    {
+        $View = $this->View;
+
+        $View->view = 'myview';
+        $this->assertEquals('myview', $View->template());
+        $this->assertEquals('myview', $View->view);
+
+        $View->viewPath = 'mypath';
+        $this->assertEquals('mypath', $View->templatePath());
+        $this->assertEquals('mypath', $View->templatePath);
+    }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -43,13 +43,6 @@ class ViewPostsController extends Controller
     public $name = 'Posts';
 
     /**
-     * uses property
-     *
-     * @var mixed
-     */
-    public $uses = null;
-
-    /**
      * index method
      *
      * @return void


### PR DESCRIPTION
Renamed `View::$view` and `View::$viewPath` to match the names used in `ViewBuilder`.

How to deal with `const TYPE_VIEW = 'view'` ?  We could add `const TYPE_TEMPLATE = 'view'` and mark `TYPE_VIEW` as deprecated. Removing it or changing value of `TYPE_VIEW` would break BC if someone is using it in their app.
