### PR TITLE
Fix double base directory in unauthorized redirects.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -405,6 +405,7 @@ class AuthComponent extends Component
             if (!empty($this->_config['loginRedirect'])) {
                 $default = $this->_config['loginRedirect'];
             }
+            $default['_base'] = false;
             $url = $controller->referer($default, true);
         } else {
             $url = $this->_config['unauthorizedRedirect'];


### PR DESCRIPTION
Turn off base path inclusion when the referrer is generated. In the case where there is no referrer header, we need to omit the base path as redirect() will add one in.

Including a base path causes apps in sub-directories to behave incorrectly.

Refs #7205
