### PR TITLE
2.7 fix PDO exception from Model::exists when useTable is false - #7229

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2895,6 +2895,10 @@ class Model extends Object implements CakeEventListener {
 			return false;
 		}
 
+		if ($this->useTable === false) {
+			return true;
+		}
+
 		return (bool)$this->find('count', array(
 			'conditions' => array(
 				$this->alias . '.' . $this->primaryKey => $id

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2896,7 +2896,7 @@ class Model extends Object implements CakeEventListener {
 		}
 
 		if ($this->useTable === false) {
-			return true;
+			return false;
 		}
 
 		return (bool)$this->find('count', array(

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -1334,7 +1334,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Article->useTable = false;
 		$Article->id = 1;
 		$result = $Article->exists();
-		$this->assertTrue($result);
+		$this->assertFalse($result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -555,6 +555,44 @@ class ModelValidationTest extends BaseModelTest {
 	}
 
 /**
+ * test that validates() still performs correctly when useTable = false on the mode.
+ *
+ * @return void
+ */
+	public function testValidatesWithNoTable() {
+		$TestModel = new TheVoid();
+		$TestModel->validate = array(
+			'title' => array(
+				'notEmpty' => array(
+					'rule' => array('notBlank'),
+					'required' => true,
+				),
+				'tooShort' => array(
+					'rule' => array('minLength', 10),
+				),
+			),
+		);
+		$data = array(
+			'TheVoid' => array(
+				'title' => 'too short',
+			),
+		);
+		$TestModel->create($data);
+		$result = $TestModel->validates();
+		$this->assertFalse($result);
+
+		$data = array(
+			'TheVoid' => array(
+				'id' => '1',
+				'title' => 'A good title',
+			),
+		);
+		$TestModel->create($data);
+		$result = $TestModel->validates();
+		$this->assertTrue($result);
+	}
+
+/**
  * test that validates() checks all the 'with' associations as well for validation
  * as this can cause partial/wrong data insertion.
  *

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -555,7 +555,7 @@ class ModelValidationTest extends BaseModelTest {
 	}
 
 /**
- * test that validates() still performs correctly when useTable = false on the mode.
+ * test that validates() still performs correctly when useTable = false on the model.
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -2787,7 +2787,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($TestModel->exists());
 
 		$TestModel->id = 5;
-		$this->assertTrue($TestModel->exists());
+		$this->assertFalse($TestModel->exists());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -2785,18 +2785,9 @@ class ModelWriteTest extends BaseModelTest {
 
 		$TestModel = new TheVoid();
 		$this->assertFalse($TestModel->exists());
-	}
 
-/**
- * testRecordExistsMissingTable method
- *
- * @expectedException PDOException
- * @return void
- */
-	public function testRecordExistsMissingTable() {
-		$TestModel = new TheVoid();
 		$TestModel->id = 5;
-		$TestModel->exists();
+		$this->assertTrue($TestModel->exists());
 	}
 
 /**


### PR DESCRIPTION
This is trying to resolve #7229 - Model::exists() will now skip the find call when `$useTable = false`
