### PR TITLE
Adding having clause as another complex condition

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -720,7 +720,7 @@ class Query extends DatabaseQuery implements JsonSerializable
         }
 
         $count = ['count' => $query->func()->count('*')];
-        $complex = count($query->clause('group')) || $query->clause('distinct');
+        $complex = count($query->clause('group')) || $query->clause('distinct') || $query->clause('having');
         $complex = $complex || count($query->clause('union'));
 
         if (!$complex) {


### PR DESCRIPTION
Added having clause as another condition to trigger the complex query.

I had subquery that got a current status, I wanted to filter on that current status, but was getting an error because a group clause was needed for the having to work. However, with a calculated column (subquery) in MySQL, if you want to perform some conditions on the calculated column you can't use a where clause and need to use the having clause. I was able to continue by adding a group clause for my primary key and everything worked fine. I was thinking this or a similar fix should solve the problem with paginate count errors and complex query where a subquery and a having clause were used. It might be worth mentioning something about this in the docs as well.   
