### PR TITLE
3.1 - Change how Auth.redirect is set.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -287,7 +287,12 @@ class AuthComponent extends Component
             return;
         }
 
+        $isLoginAction = $this->_isLoginAction($controller);
+
         if (!$this->_getUser()) {
+            if ($isLoginAction) {
+                return;
+            }
             $result = $this->_unauthenticated($controller);
             if ($result instanceof Response) {
                 $event->stopPropagation();
@@ -295,7 +300,7 @@ class AuthComponent extends Component
             return $result;
         }
 
-        if ($this->_isLoginAction($controller) ||
+        if ($isLoginAction ||
             empty($this->_config['authorize']) ||
             $this->isAuthorized($this->user())
         ) {
@@ -359,14 +364,8 @@ class AuthComponent extends Component
             return $result;
         }
 
-        if ($this->_isLoginAction($controller)) {
-            if (empty($controller->request->data) &&
-                !$this->storage()->redirectUrl() &&
-                $this->request->env('HTTP_REFERER')
-            ) {
-                $this->storage()->redirectUrl($controller->referer(null, true));
-            }
-            return;
+        if (!$this->storage()->redirectUrl()) {
+            $this->storage()->redirectUrl($this->request->here(false));
         }
 
         if (!$controller->request->is('ajax')) {

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -579,8 +579,7 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->session->write(
             'Auth',
-            [
-            'AuthUsers' => ['id' => '1', 'username' => 'nate']]
+            ['AuthUsers' => ['id' => '1', 'username' => 'nate']]
         );
         $this->Controller->testUrl = null;
         $this->Auth->request->addParams(Router::parse($url));
@@ -596,21 +595,7 @@ class AuthComponentTest extends TestCase
         $expected = Router::normalize('/auth_test/login');
         $this->assertEquals($expected, $this->Controller->testUrl);
 
-        $this->Auth->session->delete('Auth');
-        $this->Auth->session->write('Auth', [
-            'AuthUsers' => ['id' => '1', 'username' => 'nate']
-        ]);
-        $this->Auth->request->params['action'] = 'login';
-        $this->Auth->request->url = 'auth_test/login';
-        $this->Controller->request->env('HTTP_REFERER', Router::url('/admin', true));
-        $this->Auth->config('loginAction', 'auth_test/login');
-        $this->Auth->config('loginRedirect', false);
-        $event = new Event('Controller.startup', $this->Controller);
-        $this->Auth->startup($event);
-        $expected = Router::normalize('/admin');
-        $this->assertEquals($expected, $this->Auth->redirectUrl());
-
-        // Passed Arguments
+        // Auth.redirect gets set when accessing a protected action without being authenticated
         $this->Auth->session->delete('Auth');
         $url = '/posts/view/1';
         $this->Auth->request->addParams(Router::parse($url));
@@ -621,7 +606,7 @@ class AuthComponentTest extends TestCase
         $expected = Router::normalize('posts/view/1');
         $this->assertEquals($expected, $this->Auth->session->read('Auth.redirect'));
 
-        // QueryString parameters
+        // QueryString parameters are preserved when setting Auth.redirect
         $this->Auth->session->delete('Auth');
         $url = '/posts/view/29';
         $this->Auth->request->addParams(Router::parse($url));
@@ -676,19 +661,6 @@ class AuthComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $this->Auth->startup($event);
         $expected = Router::normalize('/posts/view/1');
-        $this->assertEquals($expected, $this->Auth->session->read('Auth.redirect'));
-
-        // External Direct Login Link
-        $this->Auth->session->delete('Auth');
-        $url = '/auth_test/login';
-        $this->Auth->request = $this->Controller->request = new Request($url);
-        $this->Auth->request->env('HTTP_REFERER', 'http://webmail.example.com/view/message');
-        $this->Auth->request->addParams(Router::parse($url));
-        $this->Auth->request->url = Router::normalize($url);
-        $this->Auth->config('loginAction', ['controller' => 'AuthTest', 'action' => 'login']);
-        $event = new Event('Controller.startup', $this->Controller);
-        $this->Auth->startup($event);
-        $expected = Router::normalize('/');
         $this->assertEquals($expected, $this->Auth->session->read('Auth.redirect'));
 
         $this->Auth->session->delete('Auth');


### PR DESCRIPTION
Auth.redirect is no longer set to referrer URL when accessing login action.
Instead it is only set to a protected URL when trying to access it without
authentication, before redirecting to login action.

Assuming `loginRedirect` is set to `/users/dashboard` this is how it works currently:
1. User accesses site root `/`.
2. He clicks login link and lands on `/users/login`.
3. After login he gets redirected to `/`.  (If `Auth::redirectUrl()` is used)

I don't think this behavior is intuitive. Most would expect to end up on `/users/dashboard` upon login, which is what happens after this patch.

Consider second scenario where a user directly access a protected action:
1. User accesses protected action `/users/profile`.
2. Auth component redirects user to `/users/login`.
3. After login user get redirected to `/users/profile`.   (If `Auth::redirectUrl()` is used)

This is intuitive behavior that happens currently too and remains unchanged.
