### PR TITLE
Fix path traversal check for Windows based systems

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1337,7 +1337,7 @@ class CakeResponse {
 			'download' => null
 		);
 
-		if (strpos($path, '..' . DS) !== false) {
+		if (strpos($path, '../') !== false || strpos($path, '..\\') !== false) {
 			throw new NotFoundException(__d(
 				'cake_dev',
 				'The requested file contains `..` and will not be read.'

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -1167,15 +1167,27 @@ class CakeResponseTest extends CakeTestCase {
 	}
 
 /**
- * test file with ..
+ * test file with ../
  *
  * @expectedException NotFoundException
  * @expectedExceptionMessage The requested file contains `..` and will not be read.
  * @return void
  */
-	public function testFileWithPathTraversal() {
+	public function testFileWithForwardSlashPathTraversal() {
 		$response = new CakeResponse();
 		$response->file('my/../cat.gif');
+	}
+
+/**
+ * test file with ..\
+ *
+ * @expectedException NotFoundException
+ * @expectedExceptionMessage The requested file contains `..` and will not be read.
+ * @return void
+ */
+	public function testFileWithBackwardSlashPathTraversal() {
+		$response = new CakeResponse();
+		$response->file('my\..\cat.gif');
 	}
 
 /**


### PR DESCRIPTION
Just stumbled over this... @ADmad [had a good point](https://github.com/cakephp/cakephp/pull/5905#discussion_r24725766), the `DS` check allows for `../` on Windows based systems, thus letting path traversal attacks slip through.

When doing such checks at all, this method should assume that the value passed to it is non-normalized/sanitized user data, and thus check for all possible types of paths.

ps. generally this more specific, including path separator check should go in 3.x too, shouldn't it? Currently it only checks for `..` there.
