### PR TITLE
Pin i18n standalone to Carbon v1.13

### DIFF
--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "cakephp/core": "~3.0",
         "ext-intl": "*",
-        "nesbot/Carbon": "~1.13",
+        "nesbot/Carbon": "1.13.*",
         "aura/intl": "1.1.*"
     },
     "suggest": {


### PR DESCRIPTION
As with the revert initiated in #7032, pin the i18n standalone library to Carbon version 1.13 to fix the compatibility issue between i18n's diffForHumans and Carbon's function of the same name.
