### PR TITLE
Fix MediaView extension handling as documented and expected.

### DIFF
--- a/lib/Cake/View/MediaView.php
+++ b/lib/Cake/View/MediaView.php
@@ -65,7 +65,7 @@ class MediaView extends View {
  * @return void
  */
 	public function render($view = null, $layout = null) {
-		$name = $download = $id = $modified = $path = $cache = $mimeType = $compress = null;
+		$name = $extension = $download = $id = $modified = $path = $cache = $mimeType = $compress = null;
 		extract($this->viewVars, EXTR_OVERWRITE);
 
 		$path = $path . $id;
@@ -86,7 +86,12 @@ class MediaView extends View {
 		}
 
 		if ($name !== null) {
-			$name .= '.' . pathinfo($id, PATHINFO_EXTENSION);
+			if (empty($extension)) {
+				$extension = pathinfo($id, PATHINFO_EXTENSION);
+			}
+			if (!empty($extension)) {
+				$name .= '.' . $extension;
+			}
 		}
 		$this->response->file($path, compact('name', 'download'));
 


### PR DESCRIPTION
Even thought its deprecated it is still used in 2.x and we should at least fix the broken behavior.
It is also documented to allow the extension setting.

This all makes it work as documented and expected.
See http://book.cakephp.org/2.0/en/views/media-view.html#settable-parameters

Note that the !empty() check is necessary in case the $id does not contain an extension if they are stored extension-less.

People on IRC tripped over it repeatedly, this way that should be resolved.
