### PR TITLE
3.1 - Use default config when Email instance is constructed.

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -345,6 +345,9 @@ class Email implements JsonSerializable, Serializable
             ->layout('default')
             ->helpers(['Html']);
 
+        if ($config === null) {
+            $config = Configure::read('Email.default');
+        }
         if ($config) {
             $this->profile($config);
         }

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -979,6 +979,20 @@ class EmailTest extends TestCase
     }
 
     /**
+     * test that default profile is used by constructor if available.
+     *
+     * @return void
+     */
+    public function testDefaultProfile()
+    {
+        $config = ['test' => 'ok', 'test2' => true];
+        Configure::write('Email.default', $config);
+        $Email = new Email();
+        $this->assertSame($Email->profile(), $config);
+        Configure::delete('Email');
+    }
+
+    /**
      * Test that using an invalid profile fails.
      *
      * @expectedException \InvalidArgumentException


### PR DESCRIPTION
This is similar to what is done in 2.x.
