### PR TITLE
Fix Query::count() failing when fields have expressions.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -15,6 +15,7 @@
 namespace Cake\ORM;
 
 use ArrayObject;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\QueryTrait;
@@ -510,15 +511,27 @@ class Query extends DatabaseQuery implements JsonSerializable
     {
         $query = $this->cleanCopy();
         $counter = $this->_counter;
-
         if ($counter) {
             $query->counter(null);
             return (int)$counter($query);
         }
 
+        $complex = (
+            $query->clause('distinct') ||
+            count($query->clause('group')) ||
+            count($query->clause('union'))
+        );
+        if (!$complex) {
+            // Expression fields could have bound parameters.
+            foreach ($query->clause('select') as $field) {
+                if ($field instanceof ExpressionInterface) {
+                    $complex = true;
+                    break;
+                }
+            }
+        }
+
         $count = ['count' => $query->func()->count('*')];
-        $complex = count($query->clause('group')) || $query->clause('distinct');
-        $complex = $complex || count($query->clause('union'));
 
         if (!$complex) {
             $query->eagerLoader()->autoFields(false);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1473,8 +1473,10 @@ class QueryTest extends TestCase
         $counter->select([
                 'total' => $counter->func()->count('*')
             ])
-            ->where(['ArticlesTags.tag_id' => 1])
-            ->where(['ArticlesTags.article_id = Articles.id']);
+            ->where([
+                'ArticlesTags.tag_id' => 1,
+                'ArticlesTags.article_id' => new IdentifierExpression('Articles.id')
+            ]);
 
         $result = $table->find('all')
             ->select([
@@ -1498,12 +1500,12 @@ class QueryTest extends TestCase
         $table = TableRegistry::get('Articles');
         $query = $table->find();
         $query->select([
-            'admin' => $query->func()->concat(
-                ['Articles.title' => 'literal', 'test'],
+            'title' => $query->func()->concat(
+                ['title' => 'literal', 'test'],
                 ['string']
             ),
         ]);
-        $query->where(['Articles.id' => 1]);
+        $query->where(['id' => 1]);
         $this->assertCount(1, $query->all());
         $this->assertEquals(1, $query->count());
     }


### PR DESCRIPTION
Because we can't easily introspect and remove any bound parameters that will be unused, we must use a subselect query instead.

Also include additional test coverage for count() with subqueries, and matching().

Refs #7148
Refs #7272
