### PR TITLE
Wrappers for quiet() and verbose()

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -511,7 +511,7 @@ class Shell
      */
     public function verbose($message, $newlines = 1)
     {
-        return $this->io->verbose($message, $newlines);
+        return $this->_io->verbose($message, $newlines);
     }
 
     /**
@@ -523,7 +523,7 @@ class Shell
      */
     public function quiet($message, $newlines = 1)
     {
-        return $this->io->quiet($message, $newlines);
+        return $this->_io->quiet($message, $newlines);
     }
 
     /**

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -503,6 +503,30 @@ class Shell
     }
 
     /**
+     * Output at the verbose level.
+     *
+     * @param string|array $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @return int|bool Returns the number of bytes returned from writing to stdout.
+     */
+    public function verbose($message, $newlines = 1)
+    {
+        return $this->io->verbose($message, $newlines);
+    }
+
+    /**
+     * Output at all levels.
+     *
+     * @param string|array $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @return int|bool Returns the number of bytes returned from writing to stdout.
+     */
+    public function quiet($message, $newlines = 1)
+    {
+        return $this->io->quiet($message, $newlines);
+    }
+
+    /**
      * Outputs a single or multiple messages to stdout. If no parameters
      * are passed outputs just a newline.
      *

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -264,6 +264,34 @@ class ShellTest extends TestCase
     }
 
     /**
+     * testVerbose method
+     *
+     * @return void
+     */
+    public function testVerbose()
+    {
+        $this->io->expects($this->once())
+            ->method('verbose')
+            ->with('Just a test', 1);
+
+        $this->Shell->verbose('Just a test');
+    }
+
+    /**
+     * testQuiet method
+     *
+     * @return void
+     */
+    public function testQuiet()
+    {
+        $this->io->expects($this->once())
+            ->method('quiet')
+            ->with('Just a test', 1);
+
+        $this->Shell->quiet('Just a test');
+    }
+
+    /**
      * testOut method
      *
      * @return void


### PR DESCRIPTION
The [docs](http://book.cakephp.org/3.0/en/console-and-shells.html#console-output-levels) state the quiet() and verbose() level calls, but for some in IRC (and from a quick glance at the docs I can understand why) it was not clear that those have to be called from shells as

```
$this->_io->...()
```

So I think it makes sense to allow those wrappers to directly call

```
$this->...()
```

here as convenience shortcuts besides the existing `$this->out()`.

It also solves the issue with the newlines/level param order, as now there is no such order issue anymore using these wrappers.
