### PR TITLE
Don't overwrite an entity's id when it was specified.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1487,7 +1487,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         $keys = array_fill(0, count($primary), null);
         $id = (array)$this->_newId($primary) + $keys;
+
+        // Generate primary keys preferring values in $data.
         $primary = array_combine($primary, $id);
+        $primary = array_intersect_key($data, $primary) + $primary;
+
         $filteredKeys = array_filter($primary, 'strlen');
         $data = $data + $filteredKeys;
 

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -97,6 +97,7 @@ class TableUuidTest extends TestCase
         ]);
         $table = TableRegistry::get('uuiditems');
         $this->assertSame($entity, $table->save($entity));
+        $this->assertSame($id, $entity->id);
 
         $row = $table->find('all')->where(['id' => $id])->first();
         $this->assertNotEmpty($row);


### PR DESCRIPTION
When an entity is persisted with a specific ID, we should not overwrite that value with the generated, but unused value.

Refs #7225
