### PR TITLE
Solving issue #7313

### DIFF
--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -209,6 +209,9 @@ class Stream
         if (isset($options['redirect'])) {
             $this->_contextOptions['max_redirects'] = (int)$options['redirect'];
         }
+        if (isset($options['proxy']['proxy'])) {
+            $this->_contextOptions['proxy'] = $options['proxy']['proxy'];
+        }
     }
 
     /**

--- a/tests/TestCase/Network/Http/Adapter/StreamTest.php
+++ b/tests/TestCase/Network/Http/Adapter/StreamTest.php
@@ -74,7 +74,7 @@ class StreamTest extends TestCase
             ]);
 
         $options = [
-            'redirect' => 20
+            'redirect' => 20,
         ];
         $this->stream->send($request, $options);
         $result = $this->stream->contextOptions();
@@ -158,6 +158,9 @@ class StreamTest extends TestCase
             'ssl_verify_peer' => true,
             'ssl_verify_depth' => 9000,
             'ssl_allow_self_signed' => false,
+            'proxy' => [
+                'proxy' => '127.0.0.1:8080'
+            ]
         ];
 
         $this->stream->send($request, $options);
@@ -167,6 +170,7 @@ class StreamTest extends TestCase
             'verify_peer' => true,
             'verify_depth' => 9000,
             'allow_self_signed' => false,
+            'proxy' => '127.0.0.1:8080',
         ];
         foreach ($expected as $k => $v) {
             $this->assertEquals($v, $result[$k]);


### PR DESCRIPTION
The options array for http client requests has now a proxy parameter that is passed through stream context.
