### PR TITLE
Initial support of 'enum' types in MySQL

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -138,12 +138,12 @@ class MysqlSchema extends BaseSchema
                 'unsigned' => $unsigned
             ];
         }
-        if ($col == 'enum') {
+        if ($col === 'enum') {
             preg_match("(\(.*\))", $column, $members);
             if (empty($members)) {
                 throw new Exception(sprintf('Unable to parse members of enum column "%s"', $column));
             }
-            return['type' => $col, 'members' => $members[0]];
+            return ['type' => $col, 'members' => $members[0]];
         }
         return ['type' => 'text', 'length' => null];
     }

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -138,6 +138,13 @@ class MysqlSchema extends BaseSchema
                 'unsigned' => $unsigned
             ];
         }
+        if ($col == 'enum') {
+            preg_match("(\(.*\))", $column, $members);
+            if (empty($members)) {
+                throw new Exception(sprintf('Unable to parse members of enum column "%s"', $column));
+            }
+            return['type' => $col, 'members' => $members[0]];
+        }
         return ['type' => 'text', 'length' => null];
     }
 
@@ -296,12 +303,16 @@ class MysqlSchema extends BaseSchema
             'datetime' => ' DATETIME',
             'timestamp' => ' TIMESTAMP',
             'uuid' => ' CHAR(36)',
+            'enum' => ' ENUM',
         ];
         $specialMap = [
             'string' => true,
         ];
         if (isset($typeMap[$data['type']])) {
             $out .= $typeMap[$data['type']];
+        }
+        if ($data['type'] == 'enum') {
+            $out .= $data['members'];
         }
         if (isset($specialMap[$data['type']])) {
             switch ($data['type']) {

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -113,6 +113,9 @@ class Table
         'float' => [
             'unsigned' => null,
         ],
+        'enum' => [
+            'members' => null,
+        ],
     ];
 
     /**

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -54,6 +54,7 @@ class Type
     protected static $_basicTypes = [
         'string' => ['callback' => ['\Cake\Database\Type', 'strval']],
         'text' => ['callback' => ['\Cake\Database\Type', 'strval']],
+        'enum' => ['callback' => ['\Cake\Database\Type', 'strval']],
         'boolean' => [
             'callback' => ['\Cake\Database\Type', 'boolval'],
             'pdo' => PDO::PARAM_BOOL


### PR DESCRIPTION
Hi,

Here you have a small set of changes to support  `enum`  types in MySQL.

Don't know if these are enough, but at least my problem is solved: I was unable to create a Fixture with an `$import` from a table with `enum` columns. Now it's possible and all works fine.

Please let me know how can I test it in order to be integrated in the master branch (hope nothing is broken), or what additional requirements this patch should have. This is my first contribution, so I don't know very well your development-test-integration cycle. Thanks.

Hope it helps!
-- _Francesc_
