### PR TITLE
Issue #7091 Number Helper - Add Ordinal Number Suffix

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -15,6 +15,7 @@
 namespace Cake\I18n;
 
 use NumberFormatter;
+use Locale;
 
 /**
  * Number helper library.
@@ -312,4 +313,23 @@ class Number
 
         return $formatter;
     }
+
+    /**
+     * Returns a formatted integer as an ordinal number string (e.g. 1st, 2nd, 3rd, 4th, [...])
+     *
+     * ### Options
+     *
+     * - `locale` - The locale name to use for parsing the number, e.g. fr_FR
+     *
+     * @param string $value An integer or integer string.
+     * @param array $options An array with options.
+     * @return string
+     */
+    public static function ordinal($value, array $options = [])
+    {
+        $locale = isset($options['locale']) ? $options['locale'] : Locale::getDefault();
+        $formatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
+        return $formatter->format($value);
+    }
+
 }

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -325,9 +325,9 @@ class Number
      * @param array $options An array with options.
      * @return string
      */
-    public static function ordinal($value, array $options = [])
+    public static function ordinal($value)
     {
-        $locale = isset($options['locale']) ? $options['locale'] : Locale::getDefault();
+        $locale = Locale::getDefault();
         $formatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
         return $formatter->format($value);
     }

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -322,7 +322,7 @@ class Number
      */
     public static function ordinal($value)
     {
-        $locale = Locale::getDefault();
+        $locale = Locale::locale();
         $formatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
         return $formatter->format($value);
     }

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\I18n;
 
+use Cake\I18n\I18n;
 use Locale;
 use NumberFormatter;
 
@@ -322,7 +323,7 @@ class Number
      */
     public static function ordinal($value)
     {
-        $locale = Locale::locale();
+        $locale = I18n::locale();
         $formatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
         return $formatter->format($value);
     }

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\I18n;
 
-use Cake\I18n\I18n;
 use NumberFormatter;
 
 /**

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -317,12 +317,7 @@ class Number
     /**
      * Returns a formatted integer as an ordinal number string (e.g. 1st, 2nd, 3rd, 4th, [...])
      *
-     * ### Options
-     *
-     * - `locale` - The locale name to use for parsing the number, e.g. fr_FR
-     *
-     * @param string $value An integer or integer string.
-     * @param array $options An array with options.
+     * @param int|float $value An integer
      * @return string
      */
     public static function ordinal($value)

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\I18n;
 
-use NumberFormatter;
 use Locale;
+use NumberFormatter;
 
 /**
  * Number helper library.
@@ -326,5 +326,4 @@ class Number
         $formatter = new NumberFormatter($locale, NumberFormatter::ORDINAL);
         return $formatter->format($value);
     }
-
 }

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -15,7 +15,6 @@
 namespace Cake\I18n;
 
 use Cake\I18n\I18n;
-use Locale;
 use NumberFormatter;
 
 /**

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -234,7 +234,7 @@ class NumberHelper extends Helper
     /**
      * Formats a number into locale specific ordinal suffix.
      *
-     * @param integer|float $value An integer
+     * @param int|float $value An integer
      * @return string formatted number
      */
     public function ordinal($value)

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -231,6 +231,12 @@ class NumberHelper extends Helper
         return [];
     }
 
+    /**
+     * Formats a number into locale specific ordinal suffix.
+     *
+     * @param integer|float $value An integer
+     * @return string formatted number
+     */
     public function ordinal($value)
     {
         return $this->_engine->ordinal($value);

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -231,7 +231,7 @@ class NumberHelper extends Helper
         return [];
     }
 
-    public function ordinal($value, $options = [])
+    public function ordinal($value)
     {
         return $this->_engine->ordinal($value);
     }

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -230,4 +230,9 @@ class NumberHelper extends Helper
     {
         return [];
     }
+
+    public function ordinal($value, $options = [])
+    {
+        return $this->_engine->ordinal($value);
+    }
 }

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -538,4 +538,32 @@ class NumberTest extends TestCase
         $result = $this->Number->toReadableSize(512.05 * 1024 * 1024 * 1024);
         $this->assertEquals('512,05 GB', $result);
     }
+    
+    /**
+     * test ordinal() with locales
+     *
+     * @return void
+     */
+    public function testOrdinal()
+    {
+        I18n::locale('en_US');
+        $result = $this->Number->ordinal(1);
+        $this->assertEquals('1st', $result);
+
+        $result = $this->Number->toReadableSize(2);
+        $this->assertEquals('2nd', $result);
+
+        $result = $this->Number->toReadableSize(3);
+        $this->assertEquals('3rd', $result);
+
+        $result = $this->Number->toReadableSize(4);
+        $this->assertEquals('4th', $result);
+
+        I18n::locale('fr_FR');
+        $result = $this->Number->toReadableSize(1);
+        $this->assertEquals('1er', $result);
+
+        $result = $this->Number->toReadableSize(2);
+        $this->assertEquals('2e', $result);
+    }
 }

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -550,20 +550,20 @@ class NumberTest extends TestCase
         $result = $this->Number->ordinal(1);
         $this->assertEquals('1st', $result);
 
-        $result = $this->Number->toReadableSize(2);
+        $result = $this->Number->ordinal(2);
         $this->assertEquals('2nd', $result);
 
-        $result = $this->Number->toReadableSize(3);
+        $result = $this->Number->ordinal(3);
         $this->assertEquals('3rd', $result);
 
-        $result = $this->Number->toReadableSize(4);
+        $result = $this->Number->ordinal(4);
         $this->assertEquals('4th', $result);
 
         I18n::locale('fr_FR');
-        $result = $this->Number->toReadableSize(1);
+        $result = $this->Number->ordinal(1);
         $this->assertEquals('1er', $result);
 
-        $result = $this->Number->toReadableSize(2);
+        $result = $this->Number->ordinal(2);
         $this->assertEquals('2e', $result);
     }
 }


### PR DESCRIPTION
This is simple function to add English ordinal number suffix after normal number. Function takes number as a parameter and returns number with suffix, like:
1st, 2nd, 3rd, 4th, 5th, 6th…

Added a function `ordinal` in `NumberHelper`
