### PR TITLE
Adding ids option support for hasMany/belongsToMany associations

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -86,16 +86,22 @@ class Marshaller
     /**
      * Hydrate one entity and its associated data.
      *
-     * When marshalling HasMany or BelongsToMany associations, `_ids` format can be used.
-     * `ids` option can also be used to determine whether the association must use the `_ids`
-     * format.
-     *
      * ### Options:
      *
      * * associated: Associations listed here will be marshalled as well.
      * * fieldList: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used.
      * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *
+     * The above options can be used in each nested `associated` array. In addition to the above
+     * options you can also use the `ids` option for HasMany and BelongsToMany associations.
+     * When true this option restricts the request data to only be read from `_ids`.
+     *
+     * ```
+     * $result = $marshaller->one($data, [
+     *   'associated' => ['Tags' => ['ids' => true]]
+     * ]);
+     * ```
      *
      * @param array $data The data to hydrate.
      * @param array $options List of options
@@ -415,6 +421,16 @@ class Marshaller
      * * fieldList: A whitelist of fields to be assigned to the entity. If not present
      *   the accessible fields list in the entity will be used.
      * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *
+     * The above options can be used in each nested `associated` array. In addition to the above
+     * options you can also use the `ids` option for HasMany and BelongsToMany associations.
+     * When true this option restricts the request data to only be read from `_ids`.
+     *
+     * ```
+     * $result = $marshaller->merge($entity, $data, [
+     *   'associated' => ['Tags' => ['ids' => true]]
+     * ]);
+     * ```
      *
      * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
      * data merged in

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -86,6 +86,10 @@ class Marshaller
     /**
      * Hydrate one entity and its associated data.
      *
+     * When marshalling HasMany or BelongsToMany associations, `_ids` format can be used.
+     * `ids` option can also be used to determine whether the association must use the `_ids`
+     * format.
+     *
      * ### Options:
      *
      * * associated: Associations listed here will be marshalled as well.
@@ -224,16 +228,16 @@ class Marshaller
             return $marshaller->one($value, (array)$options);
         }
         if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
-            $hasIds = array_key_exists('_ids', $data);
+            $hasIds = array_key_exists('_ids', $value);
             $idsOption = array_key_exists('ids', $options) && $options['ids'];
 
-            if ($hasIds && is_array($data['_ids'])) {
-                return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+            if ($hasIds && is_array($value['_ids'])) {
+                return $this->_loadAssociatedByIds($assoc, $value['_ids']);
             }
             if ($hasIds || $idsOption) {
                 return [];
             }
-        }        
+        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
         }
@@ -400,7 +404,8 @@ class Marshaller
      *
      * When merging HasMany or BelongsToMany associations, all the entities in the
      * `$data` array will appear, those that can be matched by primary key will get
-     * the data merged, but those that cannot, will be discarded.
+     * the data merged, but those that cannot, will be discarded. `ids` option can be used
+     * to determine whether the association must use the `_ids` format.
      *
      * ### Options:
      *
@@ -624,11 +629,11 @@ class Marshaller
     {
         $associated = isset($options['associated']) ? $options['associated'] : [];
 
-        $hasIds = array_key_exists('_ids', $data);
+        $hasIds = array_key_exists('_ids', $value);
         $idsOption = array_key_exists('ids', $options) && $options['ids'];
 
-        if ($hasIds && is_array($data['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+        if ($hasIds && is_array($value['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
         if ($hasIds || $idsOption) {
             return [];

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -223,19 +223,11 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->one($value, (array)$options);
         }
-        if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
-            $hasIds = array_key_exists('_ids', $data);
-            $idsOption = array_key_exists('ids', $options) && $options['ids'];
-
-            if ($hasIds && is_array($data['_ids'])) {
-                return $this->_loadAssociatedByIds($assoc, $data['_ids']);
-            }
-            if ($hasIds || $idsOption) {
-                return [];
-            }
-        }        
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
+        }
+        if ($assoc->type() === Association::ONE_TO_MANY && array_key_exists('_ids', $value) && is_array($value['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
         return $marshaller->many($value, (array)$options);
     }
@@ -280,8 +272,15 @@ class Marshaller
      */
     protected function _belongsToMany(Association $assoc, array $data, $options = [])
     {
+        // Accept _ids = [1, 2]
         $associated = isset($options['associated']) ? $options['associated'] : [];
-
+        $hasIds = array_key_exists('_ids', $data);
+        if ($hasIds && is_array($data['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+        }
+        if ($hasIds) {
+            return [];
+        }
         $data = array_values($data);
 
         $target = $assoc->target();
@@ -622,15 +621,14 @@ class Marshaller
      */
     protected function _mergeBelongsToMany($original, $assoc, $value, $options)
     {
+        $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
+        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
 
-        $hasIds = array_key_exists('_ids', $data);
-        $idsOption = array_key_exists('ids', $options) && $options['ids'];
-
-        if ($hasIds && is_array($data['_ids'])) {
-            return $this->_loadAssociatedByIds($assoc, $data['_ids']);
+        if ($hasIds && is_array($value['_ids'])) {
+            return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds || $idsOption) {
+        if ($hasIds || $_ids) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -623,10 +623,12 @@ class Marshaller
     {
         $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
+        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
+
         if ($hasIds && is_array($value['_ids'])) {
             return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds) {
+        if ($hasIds || $_ids) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -94,12 +94,12 @@ class Marshaller
      * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
      *
      * The above options can be used in each nested `associated` array. In addition to the above
-     * options you can also use the `ids` option for HasMany and BelongsToMany associations.
+     * options you can also use the `onlyIds` option for HasMany and BelongsToMany associations.
      * When true this option restricts the request data to only be read from `_ids`.
      *
      * ```
      * $result = $marshaller->one($data, [
-     *   'associated' => ['Tags' => ['ids' => true]]
+     *   'associated' => ['Tags' => ['onlyIds' => true]]
      * ]);
      * ```
      *
@@ -235,12 +235,12 @@ class Marshaller
         }
         if ($assoc->type() === Association::ONE_TO_MANY || $assoc->type() === Association::MANY_TO_MANY) {
             $hasIds = array_key_exists('_ids', $value);
-            $idsOption = array_key_exists('ids', $options) && $options['ids'];
+            $onlyIds = array_key_exists('onlyIds', $options) && $options['onlyIds'];
 
             if ($hasIds && is_array($value['_ids'])) {
                 return $this->_loadAssociatedByIds($assoc, $value['_ids']);
             }
-            if ($hasIds || $idsOption) {
+            if ($hasIds || $onlyIds) {
                 return [];
             }
         }
@@ -423,12 +423,12 @@ class Marshaller
      * * accessibleFields: A list of fields to allow or deny in entity accessible fields.
      *
      * The above options can be used in each nested `associated` array. In addition to the above
-     * options you can also use the `ids` option for HasMany and BelongsToMany associations.
+     * options you can also use the `onlyIds` option for HasMany and BelongsToMany associations.
      * When true this option restricts the request data to only be read from `_ids`.
      *
      * ```
      * $result = $marshaller->merge($entity, $data, [
-     *   'associated' => ['Tags' => ['ids' => true]]
+     *   'associated' => ['Tags' => ['onlyIds' => true]]
      * ]);
      * ```
      *
@@ -646,12 +646,12 @@ class Marshaller
         $associated = isset($options['associated']) ? $options['associated'] : [];
 
         $hasIds = array_key_exists('_ids', $value);
-        $idsOption = array_key_exists('ids', $options) && $options['ids'];
+        $onlyIds = array_key_exists('onlyIds', $options) && $options['onlyIds'];
 
         if ($hasIds && is_array($value['_ids'])) {
             return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds || $idsOption) {
+        if ($hasIds || $onlyIds) {
             return [];
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -223,9 +223,6 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->one($value, (array)$options);
         }
-        if($this->_isAssociatedByIdsInvalid($assoc, $value, (array)$options)){
-            return [];
-        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_belongsToMany($assoc, $value, (array)$options);
         }
@@ -379,13 +376,6 @@ class Marshaller
         }
 
         return $target->find()->where($filter)->toArray();
-    }
-
-    protected function _isAssociatedByIdsInvalid($assoc, $value, $options){
-        if($assoc->type() === Association::MANY_TO_MANY || $assoc->type() === Association::ONE_TO_MANY){
-            return array_key_exists('ids', $options) && $options['ids'] && !array_key_exists('_ids', $value);
-        }
-        return false;
     }
 
     /**
@@ -613,9 +603,6 @@ class Marshaller
         if (in_array($assoc->type(), $types)) {
             return $marshaller->merge($original, $value, (array)$options);
         }
-        if($this->_isAssociatedByIdsInvalid($assoc, $value, (array)$options)){
-            return [];
-        }
         if ($assoc->type() === Association::MANY_TO_MANY) {
             return $marshaller->_mergeBelongsToMany($original, $assoc, $value, (array)$options);
         }
@@ -636,11 +623,12 @@ class Marshaller
     {
         $hasIds = array_key_exists('_ids', $value);
         $associated = isset($options['associated']) ? $options['associated'] : [];
+        $_ids = array_key_exists('_ids', $options) && $options['_ids'];
 
         if ($hasIds && is_array($value['_ids'])) {
             return $this->_loadAssociatedByIds($assoc, $value['_ids']);
         }
-        if ($hasIds) {
+        if ($hasIds || $_ids) {
             return [];
         }
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -491,6 +491,52 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test that the ids option restricts to only accepting ids for belongs to many associations.
+     *
+     * @return void
+     */
+    public function testOneBelongsToManyOnlyIdsRejectArray()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'author_id' => 1,
+            'tags' => [
+                ['tag' => 'news'],
+                ['tag' => 'cakephp'],
+            ],
+        ];
+        $marshall = new Marshaller($this->articles);
+        $result = $marshall->one($data, [
+            'associated' => ['Tags' => ['ids' => true]]
+        ]);
+        $this->assertEmpty($result->tags, 'Only ids should be marshalled.');
+    }
+
+    /**
+     * Test that the ids option restricts to only accepting ids for belongs to many associations.
+     *
+     * @return void
+     */
+    public function testOneBelongsToManyOnlyIdsWithIds()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'author_id' => 1,
+            'tags' => [
+                '_ids' => [1, 2],
+                ['tag' => 'news'],
+            ],
+        ];
+        $marshall = new Marshaller($this->articles);
+        $result = $marshall->one($data, [
+            'associated' => ['Tags' => ['ids' => true]]
+        ]);
+        $this->assertCount(2, $result->tags, 'Ids should be marshalled.');
+    }
+
+    /**
      * Test marshalling nested associations on the _joinData structure.
      *
      * @return void
@@ -808,7 +854,7 @@ class MarshallerTest extends TestCase
      *
      * @return void
      */
-    public function testHasManyWithIds()
+    public function testOneHasManyWithIds()
     {
         $data = [
             'title' => 'article',
@@ -826,11 +872,57 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test that the ids option restricts to only accepting ids for hasmany associations.
+     *
+     * @return void
+     */
+    public function testOneHasManyOnlyIdsRejectArray()
+    {
+        $data = [
+            'title' => 'article',
+            'body' => 'some content',
+            'comments' => [
+                ['comment' => 'first comment'],
+                ['comment' => 'second comment'],
+            ]
+        ];
+
+        $marshaller = new Marshaller($this->articles);
+        $article = $marshaller->one($data, [
+            'associated' => ['Comments' => ['ids' => true]]
+        ]);
+        $this->assertEmpty($article->comments);
+    }
+
+    /**
+     * Test that the ids option restricts to only accepting ids for hasmany associations.
+     *
+     * @return void
+     */
+    public function testOneHasManyOnlyIdsWithIds()
+    {
+        $data = [
+            'title' => 'article',
+            'body' => 'some content',
+            'comments' => [
+                '_ids' => [1, 2],
+                ['comment' => 'first comment'],
+            ]
+        ];
+
+        $marshaller = new Marshaller($this->articles);
+        $article = $marshaller->one($data, [
+            'associated' => ['Comments' => ['ids' => true]]
+        ]);
+        $this->assertCount(2, $article->comments);
+    }
+
+    /**
      * Test HasMany association with invalid data
      *
      * @return void
      */
-    public function testHasManyInvalidData()
+    public function testOneHasManyInvalidData()
     {
         $data = [
             'title' => 'new title',
@@ -1503,6 +1595,68 @@ class MarshallerTest extends TestCase
         ];
         $result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
         $this->assertCount(0, $result->tags);
+    }
+
+    /**
+     * Test that the ids option restricts to only accepting ids for belongs to many associations.
+     *
+     * @return void
+     */
+    public function testMergeBelongsToManyOnlyIdsRejectArray()
+    {
+        $entity = new Entity([
+            'title' => 'Haz tags',
+            'body' => 'Some content here',
+            'tags' => [
+                new Entity(['id' => 1, 'name' => 'Cake']),
+                new Entity(['id' => 2, 'name' => 'PHP'])
+            ]
+        ]);
+
+        $data = [
+            'title' => 'Haz moar tags',
+            'tags' => [
+                ['name' => 'new'],
+                ['name' => 'awesome']
+            ]
+        ];
+        $entity->accessible('*', true);
+        $marshall = new Marshaller($this->articles);
+        $result = $marshall->merge($entity, $data, [
+            'associated' => ['Tags' => ['ids' => true]]
+        ]);
+        $this->assertCount(0, $result->tags);
+    }
+
+    /**
+     * Test that the ids option restricts to only accepting ids for belongs to many associations.
+     *
+     * @return void
+     */
+    public function testMergeBelongsToManyOnlyIdsWithIds()
+    {
+        $entity = new Entity([
+            'title' => 'Haz tags',
+            'body' => 'Some content here',
+            'tags' => [
+                new Entity(['id' => 1, 'name' => 'Cake']),
+                new Entity(['id' => 2, 'name' => 'PHP'])
+            ]
+        ]);
+
+        $data = [
+            'title' => 'Haz moar tags',
+            'tags' => [
+                '_ids' => [3]
+            ]
+        ];
+        $entity->accessible('*', true);
+        $marshall = new Marshaller($this->articles);
+        $result = $marshall->merge($entity, $data, [
+            'associated' => ['Tags' => ['ids' => true]]
+        ]);
+        $this->assertCount(1, $result->tags);
+        $this->assertEquals('tag3', $result->tags[0]->name);
     }
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -491,7 +491,7 @@ class MarshallerTest extends TestCase
     }
 
     /**
-     * Test that the ids option restricts to only accepting ids for belongs to many associations.
+     * Test that the onlyIds option restricts to only accepting ids for belongs to many associations.
      *
      * @return void
      */
@@ -508,13 +508,13 @@ class MarshallerTest extends TestCase
         ];
         $marshall = new Marshaller($this->articles);
         $result = $marshall->one($data, [
-            'associated' => ['Tags' => ['ids' => true]]
+            'associated' => ['Tags' => ['onlyIds' => true]]
         ]);
         $this->assertEmpty($result->tags, 'Only ids should be marshalled.');
     }
 
     /**
-     * Test that the ids option restricts to only accepting ids for belongs to many associations.
+     * Test that the onlyIds option restricts to only accepting ids for belongs to many associations.
      *
      * @return void
      */
@@ -531,7 +531,7 @@ class MarshallerTest extends TestCase
         ];
         $marshall = new Marshaller($this->articles);
         $result = $marshall->one($data, [
-            'associated' => ['Tags' => ['ids' => true]]
+            'associated' => ['Tags' => ['onlyIds' => true]]
         ]);
         $this->assertCount(2, $result->tags, 'Ids should be marshalled.');
     }
@@ -872,7 +872,7 @@ class MarshallerTest extends TestCase
     }
 
     /**
-     * Test that the ids option restricts to only accepting ids for hasmany associations.
+     * Test that the onlyIds option restricts to only accepting ids for hasmany associations.
      *
      * @return void
      */
@@ -889,13 +889,13 @@ class MarshallerTest extends TestCase
 
         $marshaller = new Marshaller($this->articles);
         $article = $marshaller->one($data, [
-            'associated' => ['Comments' => ['ids' => true]]
+            'associated' => ['Comments' => ['onlyIds' => true]]
         ]);
         $this->assertEmpty($article->comments);
     }
 
     /**
-     * Test that the ids option restricts to only accepting ids for hasmany associations.
+     * Test that the onlyIds option restricts to only accepting ids for hasmany associations.
      *
      * @return void
      */
@@ -912,7 +912,7 @@ class MarshallerTest extends TestCase
 
         $marshaller = new Marshaller($this->articles);
         $article = $marshaller->one($data, [
-            'associated' => ['Comments' => ['ids' => true]]
+            'associated' => ['Comments' => ['onlyIds' => true]]
         ]);
         $this->assertCount(2, $article->comments);
     }
@@ -1623,7 +1623,7 @@ class MarshallerTest extends TestCase
         $entity->accessible('*', true);
         $marshall = new Marshaller($this->articles);
         $result = $marshall->merge($entity, $data, [
-            'associated' => ['Tags' => ['ids' => true]]
+            'associated' => ['Tags' => ['onlyIds' => true]]
         ]);
         $this->assertCount(0, $result->tags);
     }


### PR DESCRIPTION
Complete changes started in #6846 to resolve #6835.

This set of changes adds an `ids` option. While, I'm not sold on the name, I can only think of:
- `onlyIds`
- `idsOnly`

Are the things I can think of. Any suggestions?
