### PR TITLE
Fix duplicate pot files when extracting with merge=yes

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -482,9 +482,10 @@ class ExtractTask extends Shell
                         $sentence .= "msgstr[1] \"\"\n\n";
                     }
 
-                    $this->_store($domain, $header, $sentence);
                     if ($domain !== 'default' && $this->_merge) {
                         $this->_store('default', $header, $sentence);
+                    } else {
+                        $this->_store($domain, $header, $sentence);
                     }
                 }
             }

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -106,6 +106,15 @@ class ExtractTask extends Shell
     protected $_extractCore = false;
 
     /**
+     * No welcome message.
+     *
+     * @return void
+     */
+    protected function _welcome()
+    {
+    }
+
+    /**
      * Method to interact with the User and get path selections.
      *
      * @return void
@@ -182,10 +191,6 @@ class ExtractTask extends Shell
 
         if ($this->_extractCore) {
             $this->_paths[] = CAKE;
-            $this->_exclude = array_merge($this->_exclude, [
-                CAKE . 'Test',
-                CAKE . 'Console' . DS . 'Templates'
-            ]);
         }
 
         if (isset($this->params['output'])) {

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -69,11 +69,11 @@ class ExtractTaskTest extends TestCase
      */
     public function testExecute()
     {
-        $this->Task->interactive = false;
-
         $this->Task->params['paths'] = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages';
         $this->Task->params['output'] = $this->path . DS;
         $this->Task->params['extract-core'] = 'no';
+        $this->Task->params['merge'] = 'no';
+
         $this->Task->expects($this->never())->method('err');
         $this->Task->expects($this->any())->method('in')
             ->will($this->returnValue('y'));
@@ -130,6 +130,29 @@ class ExtractTaskTest extends TestCase
         $this->assertRegExp($pattern, $result);
         $pattern = '/msgid "You deleted %d message \(domain\)."\nmsgid_plural "You deleted %d messages \(domain\)."/';
         $this->assertRegExp($pattern, $result);
+    }
+
+    /**
+     * testExecute with merging on method
+     *
+     * @return void
+     */
+    public function testExecuteMerge()
+    {
+        $this->Task->params['paths'] = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages';
+        $this->Task->params['output'] = $this->path . DS;
+        $this->Task->params['extract-core'] = 'no';
+        $this->Task->params['merge'] = 'yes';
+
+        $this->Task->expects($this->never())->method('err');
+        $this->Task->expects($this->any())->method('in')
+            ->will($this->returnValue('y'));
+        $this->Task->expects($this->never())->method('_stop');
+
+        $this->Task->main();
+        $this->assertFileExists($this->path . DS . 'default.pot');
+        $this->assertFileNotExists($this->path . DS . 'cake.pot');
+        $this->assertFileNotExists($this->path . DS . 'domain.pot');
     }
 
     /**


### PR DESCRIPTION
Don't output both the merged and individual pot files when merge=yes. I've also removed the double welcome messages as they looked dumb.

Refs #7345
