### PR TITLE
Update FixtureInjector with addWarning

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -21,6 +21,8 @@ use PHPUnit_Framework_AssertionFailedError;
 use PHPUnit_Framework_Test;
 use PHPUnit_Framework_TestListener;
 use PHPUnit_Framework_TestSuite;
+use PHPUnit_Framework_Warning;
+
 
 /**
  * Test listener used to inject a fixture manager in all tests that
@@ -94,6 +96,18 @@ class FixtureInjector implements PHPUnit_Framework_TestListener
     {
     }
 
+    /**
+     * Not Implemented
+     *
+     * @param \PHPUnit_Framework_Test $test The test to add warnings from.
+     * @param \PHPUnit_Warning $e The warning
+     * @param float $time current time
+     * @return void
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
+    {
+    }
+    
     /**
      * Not Implemented
      *

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -23,7 +23,6 @@ use PHPUnit_Framework_TestListener;
 use PHPUnit_Framework_TestSuite;
 use PHPUnit_Framework_Warning;
 
-
 /**
  * Test listener used to inject a fixture manager in all tests that
  * are composed inside a Test Suite


### PR DESCRIPTION
PHPUnit has just added the `addWarning` signature to the `PHPUnit_Framework_TestListener` interface, which caused the CakePHP fixtures to fail with the latest PHPUnit.  

This patch implements a _Not Implemented_ version of the method signature to prevent the following error

```
PHP Fatal error:  Class Cake\TestSuite\Fixture\FixtureInjector contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (PHPUnit_Framework_TestListener::addWarning) in ./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php on line 174
```
