### PR TITLE
Always update updated/modified columns when a fieldList is used.

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1835,7 +1835,12 @@ class Model extends Object implements CakeEventListener {
 		$now = time();
 
 		foreach ($dateFields as $updateCol) {
-			if (in_array($updateCol, $fields) || !$this->hasField($updateCol)) {
+			$fieldHasValue = in_array($updateCol, $fields);
+			$fieldInWhitelist = (
+				count($this->whitelist) === 0 ||
+				in_array($updateCol, $this->whitelist)
+			);
+			if (($fieldHasValue && $fieldInWhitelist) || !$this->hasField($updateCol)) {
 				continue;
 			}
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -388,6 +388,30 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
+ * Test that save() with a fieldList continues to write
+ * updated in all cases.
+ *
+ * @return void
+ */
+	public function testSaveUpdatedWithFieldList() {
+		$this->loadFixtures('Post', 'Author');
+		$model = ClassRegistry::init('Post');
+		$original = $model->find('first', ['conditions' => ['Post.id' => 1]]);
+		$data = array(
+			'Post' => array(
+				'id' => 1,
+				'title' => 'New title',
+				'updated' => '1999-01-01 00:00:00',
+			)
+		);
+		$model->save($data, array(
+			'fieldList' => ['title']
+		));
+		$new = $model->find('first', ['conditions' => ['Post.id' => 1]]);
+		$this->assertGreaterThan($original['Post']['updated'], $new['Post']['updated']);
+	}
+
+/**
  * Test save() resets the whitelist after afterSave
  *
  * @return void
@@ -1960,8 +1984,8 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'New Article With Tags and fieldList',
 				'body' => '',
 				'published' => 'N',
-				'created' => '',
-				'updated' => ''
+				'created' => static::date(),
+				'updated' => static::date(),
 			),
 			'Tag' => array(
 				0 => array(

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -396,7 +396,9 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveUpdatedWithFieldList() {
 		$this->loadFixtures('Post', 'Author');
 		$model = ClassRegistry::init('Post');
-		$original = $model->find('first', ['conditions' => ['Post.id' => 1]]);
+		$original = $model->find('first', array(
+			'conditions' => array('Post.id' => 1)
+		));
 		$data = array(
 			'Post' => array(
 				'id' => 1,
@@ -405,9 +407,11 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		);
 		$model->save($data, array(
-			'fieldList' => ['title']
+			'fieldList' => array('title')
 		));
-		$new = $model->find('first', ['conditions' => ['Post.id' => 1]]);
+		$new = $model->find('first', array(
+			'conditions' => array('Post.id' => 1)
+		));
 		$this->assertGreaterThan($original['Post']['updated'], $new['Post']['updated']);
 	}
 


### PR DESCRIPTION
When a fieldList is used, and updated is not in the fieldList, the column should continue to be updated even if the column has a value from the user. Because the field is not in the fieldList, we must assume that the intent is for the field to update automatically, as it would have if the updated column was not present in the save data.

Refs #7076
