### PR TITLE
Added i18n support to label

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -844,6 +844,8 @@ class FormHelper extends AppHelper {
 				$text = substr($text, 0, -3);
 			}
 			$text = __(Inflector::humanize(Inflector::underscore($text)));
+		} else {
+			$text = __($text);
 		}
 
 		if (is_string($options)) {


### PR DESCRIPTION
By default the label should use the same i18n translation as if the text wasn't supplied. This wasn't the case previously
