### PR TITLE
Fix optgroup rendering with integer keys

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -233,7 +233,11 @@ class StringTemplate
         }
         $replace = [];
         foreach ($placeholders as $placeholder) {
-            $replace[] = isset($data[$placeholder]) ? $data[$placeholder] : null;
+            $replacement = isset($data[$placeholder]) ? $data[$placeholder] : null;
+            if (is_array($replacement)) {
+                $replacement = implode('', $replacement);
+            }
+            $replace[] = $replacement;
         }
         return vsprintf($template, $replace);
     }

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -228,7 +228,7 @@ class SelectBoxWidget extends BasicWidget
             // Option groups
             $arrayVal = (is_array($val) || $val instanceof Traversable);
             if ((!is_int($key) && $arrayVal) ||
-                (is_int($key) && $arrayVal && isset($val['options']))
+                (is_int($key) && $arrayVal && (isset($val['options']) || !isset($val['value'])))
             ) {
                 $out[] = $this->_renderOptgroup($key, $val, $disabled, $selected, $escape);
                 continue;
@@ -239,7 +239,7 @@ class SelectBoxWidget extends BasicWidget
                 'value' => $key,
                 'text' => $val,
             ];
-            if (is_array($val) && isset($optAttrs['text'], $optAttrs['value'])) {
+            if (is_array($val) && isset($val['text'], $val['value'])) {
                 $optAttrs = $val;
                 $key = $optAttrs['value'];
             }

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -104,6 +104,31 @@ class StringTemplateTest extends TestCase
     }
 
     /**
+     * Formatting array data should not trigger errors.
+     *
+     * @return void
+     */
+    public function testFormatArrayData()
+    {
+        $templates = [
+            'link' => '<a href="{{url}}">{{text}}</a>'
+        ];
+        $this->template->add($templates);
+
+        $result = $this->template->format('link', [
+            'url' => '/',
+            'text' => ['example', 'text']
+        ]);
+        $this->assertEquals('<a href="/">exampletext</a>', $result);
+
+        $result = $this->template->format('link', [
+            'url' => '/',
+            'text' => ['key' => 'example', 'text']
+        ]);
+        $this->assertEquals('<a href="/">exampletext</a>', $result);
+    }
+
+    /**
      * Test loading templates files in the app.
      *
      * @return void

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -353,6 +353,48 @@ class SelectBoxWidgetTest extends TestCase
     }
 
     /**
+     * test rendering with numeric option group keys
+     *
+     * @return void
+     */
+    public function testRenderOptionGroupsIntegerKeys()
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'name' => 'Year[key]',
+            'options' => [
+                2014 => [
+                    'key' => 'value'
+                ],
+                2013 => [
+                    'text' => '2013-text',
+                    'options' => [
+                        'key2' => 'value2'
+                    ]
+                ]
+            ]
+        ];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => [
+                'name' => 'Year[key]',
+            ],
+            ['optgroup' => ['label' => '2014']],
+            ['option' => ['value' => 'key']],
+            'value',
+            '/option',
+            '/optgroup',
+            ['optgroup' => ['label' => '2013-text']],
+            ['option' => ['value' => 'key2']],
+            'value2',
+            '/option',
+            '/optgroup',
+            '/select'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * test rendering with option groups and escaping
      *
      * @return void


### PR DESCRIPTION
This fixes a few issues related to optgroups
- Array values that sneak into StringTemplate are now imploded. This avoids some (but not all) issues where 'Array to string' errors would come from.
- Integer keys in optgroups are now handled correctly more frequently. There may be additional edge cases, but we'll worry about those as they come up.

Refs #7361
