### PR TITLE
Update DatabaseSession.php

### DIFF
--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -90,7 +90,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
  */
 	public function read($id) {
 		$row = $this->_model->find('first', array(
-			'conditions' => array($this->_model->primaryKey => $id)
+			'conditions' => array($this->_model->alias . '.' . $this->_model->primaryKey => $id)
 		));
 
 		if (empty($row[$this->_model->alias]['data'])) {


### PR DESCRIPTION
To prevent error: "Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous" when using a custom Session object in relationship with another object (belongsTo <-| hasMany)
