### PR TITLE
Set the `key` variable in the SessionHelper.

### DIFF
--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -156,6 +156,7 @@ class SessionHelper extends AppHelper {
 				}
 				$tmpVars = $flash['params'];
 				$tmpVars['message'] = $message;
+				$tmpVars['key'] = $key;
 				$out = $this->_View->element($flash['element'], $tmpVars, $options);
 			}
 		}


### PR DESCRIPTION
This fixes cross template compatibility between the Flash and Session helpers.

Refs #7365
