### PR TITLE
Add a Cache::registry method

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -118,7 +118,7 @@ class Cache
      * Also allows for injecting of a new registry instance.
      *
      * @param \Cake\Core\ObjectRegistry $registry Injectable registry object.
-     * @return \Cake\Cache\CacheRegistry
+     * @return \Cake\Core\ObjectRegistry
      */
     public static function registry(ObjectRegistry $registry = null)
     {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -113,6 +113,20 @@ class Cache
     protected static $_registry;
 
     /**
+     * Returns the Cache Registry instance used for creating and using cache adapters.
+     *
+     * @return \Cake\Cache\CacheRegistry
+     */
+    public static function registry()
+    {
+        if (empty(static::$_registry)) {
+            static::$_registry = new CacheRegistry();
+        }
+
+        return static::$_registry;
+    }
+
+    /**
      * Finds and builds the instance of the required engine class.
      *
      * @param string $name Name of the config array that needs an engine instance built

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -135,9 +135,7 @@ class Cache
      */
     protected static function _buildEngine($name)
     {
-        if (empty(static::$_registry)) {
-            static::$_registry = new CacheRegistry();
-        }
+        $registry = static::registry();
 
         if (empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
@@ -146,7 +144,7 @@ class Cache
         }
 
         $config = static::$_config[$name];
-        static::$_registry->load($name, $config);
+        $registry->load($name, $config);
 
         if (!empty($config['groups'])) {
             foreach ($config['groups'] as $group) {
@@ -172,12 +170,14 @@ class Cache
             return new NullEngine();
         }
 
-        if (isset(static::$_registry->{$config})) {
-            return static::$_registry->{$config};
+        $registry = static::registry();
+
+        if (isset($registry->{$config})) {
+            return $registry->{$config};
         }
 
         static::_buildEngine($config);
-        return static::$_registry->{$config};
+        return $registry->{$config};
     }
 
     /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -15,6 +15,7 @@
 namespace Cake\Cache;
 
 use Cake\Cache\Engine\NullEngine;
+use Cake\Core\ObjectRegistry;
 use Cake\Core\StaticConfigTrait;
 use InvalidArgumentException;
 use RuntimeException;
@@ -114,11 +115,17 @@ class Cache
 
     /**
      * Returns the Cache Registry instance used for creating and using cache adapters.
+     * Also allows for injecting of a new registry instance.
      *
+     * @param \Cake\Core\ObjectRegistry $registry Injectable registry object.
      * @return \Cake\Cache\CacheRegistry
      */
-    public static function registry()
+    public static function registry(ObjectRegistry $registry = null)
     {
+        if ($registry) {
+            static::$_registry = $registry;
+        }
+        
         if (empty(static::$_registry)) {
             static::$_registry = new CacheRegistry();
         }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -559,4 +559,14 @@ class CacheTest extends TestCase
         $result = Cache::remember('test_key', $cacher, 'tests');
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * test registry method
+     *
+     * @return void
+     */
+    public function testRegistry()
+    {
+        $this->assertInstanceOf('\Cake\Cache\CacheRegistry', Cache::registry());
+    }
 }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -567,6 +567,6 @@ class CacheTest extends TestCase
      */
     public function testRegistry()
     {
-        $this->assertInstanceOf('\Cake\Cache\CacheRegistry', Cache::registry());
+        $this->assertInstanceOf('Cake\Cache\CacheRegistry', Cache::registry());
     }
 }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Cache;
 
 use Cake\Cache\Cache;
+use Cake\Cache\CacheRegistry;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -568,5 +569,18 @@ class CacheTest extends TestCase
     public function testRegistry()
     {
         $this->assertInstanceOf('Cake\Cache\CacheRegistry', Cache::registry());
+    }
+
+    /**
+     * test registry method setting
+     *
+     * @return void
+     */
+    public function testRegistrySet()
+    {
+        $registry = new CacheRegistry();
+        Cache::registry($registry);
+
+        $this->assertSame($registry, Cache::registry());
     }
 }


### PR DESCRIPTION
Useful method for injecting cache engine mocks for example.

``` php
$mock = $this->getMock('\Cake\Cache\Engine\NullEngine');
$mock->expects($this->once())->method('read')->willReturn(['value']);
Cache::registry()->set('default', $mock);
```

For example.
