### PR TITLE
Fix required state detection for booleans on associations.

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -348,12 +348,12 @@ class EntityContext implements ContextInterface
         }
 
         $validator = $this->_getValidator($parts);
-        $field = array_pop($parts);
-        if (!$validator->hasField($field)) {
+        $fieldName = array_pop($parts);
+        if (!$validator->hasField($fieldName)) {
             return false;
         }
         if ($this->type($field) !== 'boolean') {
-            return $validator->isEmptyAllowed($field, $isNew) === false;
+            return $validator->isEmptyAllowed($fieldName, $isNew) === false;
         }
         return false;
     }

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -740,6 +740,34 @@ class EntityContextTest extends TestCase
     }
 
     /**
+     * Test isRequired on associated entities with boolean fields
+     *
+     * @return void
+     */
+    public function testIsRequiredAssociatedHasManyBoolean()
+    {
+        $this->_setupTables();
+
+        $comments = TableRegistry::get('Comments');
+        $comments->schema()->addColumn('starred', 'boolean');
+        $comments->validator()->add('starred', 'valid', ['rule' => 'boolean']);
+
+        $row = new Article([
+            'title' => 'My title',
+            'comments' => [
+                new Entity(['comment' => 'First comment']),
+            ]
+        ]);
+        $context = new EntityContext($this->request, [
+            'entity' => $row,
+            'table' => 'Articles',
+            'validator' => 'default',
+        ]);
+
+        $this->assertFalse($context->isRequired('comments.0.starred'));
+    }
+
+    /**
      * Test isRequired on associated entities with custom validators.
      *
      * Ensures that missing associations use the correct entity class


### PR DESCRIPTION
The original value of $field was being replaced with the short name, this caused type() to get the wrong type data for association columns.

Refs #7349
