### PR TITLE
Use OPENSSL constants rather than a bool

### DIFF
--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -61,7 +61,7 @@ class OpenSsl
         $ivSize = openssl_cipher_iv_length($method);
 
         $iv = openssl_random_pseudo_bytes($ivSize);
-        return $iv . openssl_encrypt($plain, $method, $key, true, $iv);
+        return $iv . openssl_encrypt($plain, $method, $key, OPENSSL_RAW_DATA, $iv);
     }
 
     /**
@@ -80,6 +80,6 @@ class OpenSsl
         $iv = mb_substr($cipher, 0, $ivSize, '8bit');
 
         $cipher = mb_substr($cipher, $ivSize, null, '8bit');
-        return openssl_decrypt($cipher, $method, $key, true, $iv);
+        return openssl_decrypt($cipher, $method, $key, OPENSSL_RAW_DATA, $iv);
     }
 }


### PR DESCRIPTION
`OPENSSL_RAW_DATA` should be used rather than boolean `true` to specify the options for openssl_encrypt/openssl_decrypt.

Other options are `OPENSSL_ZERO_PADDING` (which has the value of 2), which can be useful to implement PKCS7 padding rather than the default null padding OpenSSL uses.

(If you want both, you need to provide the value of 3)
