### PR TITLE
Fix license for github license api match

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,28 +1,22 @@
-The MIT License
+The MIT License (MIT)
 
 CakePHP(tm) : The Rapid Development PHP Framework (http://cakephp.org)
-Copyright (c) 2005-2015, Cake Software Foundation, Inc.
+Copyright (c) 2005-2015, Cake Software Foundation, Inc. (http://cakefoundation.org)
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-Cake Software Foundation, Inc.
-1785 E. Sahara Avenue,
-Suite 490-204
-Las Vegas, Nevada 89104,
-United States of America.
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
As I was working with the GH API to automate some project monitoring, it came to my attention that we were scoring low when compared to the original MIT license. 

I discussed with @phpnut  and got approval to remove the address and make it more in-line with the expected result from choosealicense.com. It scores at 93.62% now.

**Before**

```
License file: LICENSE.txt
Attribution: Copyright (c) 2005-2015, Cake Software Foundation, Inc.
Unknown
```

**After**

```
License file: LICENSE.txt
Attribution: Copyright (c) 2005-2015, Cake Software Foundation, Inc. (http://cakefoundation.org)
License: MIT License
Confidence: 93.62084456424078%
Method: Licensee::LevenshteinMatcher
```

**Resources:**
https://developer.github.com/v3/licenses/
https://github.com/blog/1964-open-source-license-usage-on-github-com
https://github.com/benbalter/licensee
