### PR TITLE
Fixing bug in BetweenExpression

### DIFF
--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -83,7 +83,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
         }
 
         foreach ($parts as $name => $part) {
-            if ($field instanceof ExpressionInterface) {
+            if ($part instanceof ExpressionInterface) {
                 $parts[$name] = $part->sql($generator);
                 continue;
             }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1299,6 +1299,33 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Tests that it is possible to use an expression object
+     * as any of the parts of the between expression
+     *
+     * @return void
+     */
+    public function testWhereWithBetweenWithExpressionParts()
+    {
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('comments')
+            ->where(function ($exp, $q) {
+                $from = $q->newExpr("'2007-03-18 10:51:00'");
+                $to = $q->newExpr("'2007-03-18 10:54:00'");
+                return $exp->between('created', $from, $to);
+            })
+            ->execute();
+
+        $this->assertCount(2, $result);
+        $first = $result->fetch('assoc');
+        $this->assertEquals(4, $first['id']);
+
+        $second = $result->fetch('assoc');
+        $this->assertEquals(5, $second['id']);
+    }
+
+    /**
      * Tests nesting query expressions both using arrays and closures
      *
      * @return void


### PR DESCRIPTION
The bug prevented the use of expression objects as parts of the between
