### PR TITLE
Make debugInfo methods more resilient.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -826,8 +826,8 @@ class Query extends DatabaseQuery implements JsonSerializable
             'buffered' => $this->_useBufferedResults,
             'formatters' => count($this->_formatters),
             'mapReducers' => count($this->_mapReduce),
-            'contain' => $eagerLoader->contain(),
-            'matching' => $eagerLoader->matching(),
+            'contain' => $eagerLoader ? $eagerLoader->contain() : [],
+            'matching' => $eagerLoader ? $eagerLoader->matching() : [],
             'extraOptions' => $this->_options,
             'repository' => $this->_repository
         ];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2203,13 +2203,15 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function __debugInfo()
     {
         $conn = $this->connection();
+        $associations = $this->_associations ?: false;
+        $behaviors = $this->_behaviors ?: false;
         return [
             'registryAlias' => $this->registryAlias(),
             'table' => $this->table(),
             'alias' => $this->alias(),
             'entityClass' => $this->entityClass(),
-            'associations' => $this->_associations->keys(),
-            'behaviors' => $this->_behaviors->loaded(),
+            'associations' => $associations ? $associations->keys() : false,
+            'behaviors' => $behaviors ? $behaviors->loaded() : false,
             'defaultConnection' => $this->defaultConnectionName(),
             'connectionName' => $conn ? $conn->configName() : null
         ];


### PR DESCRIPTION
Make the debugInfo methods for ORM\Table and ORM\Query not fail when they are used on partially complete objects.

Refs #7290
