### PR TITLE
Adds default value parameter to the env() function.

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -176,10 +176,11 @@ if (!function_exists('env')) {
      * environment information.
      *
      * @param string $key Environment variable name.
+     * @param string $default Specify a default value in case the environment variable is not defined.
      * @return string|null Environment variable setting.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#env
      */
-    function env($key)
+    function env($key, $default = null)
     {
         if ($key === 'HTTPS') {
             if (isset($_SERVER['HTTPS'])) {
@@ -228,7 +229,7 @@ if (!function_exists('env')) {
             case 'CGI_MODE':
                 return (PHP_SAPI === 'cgi');
         }
-        return null;
+        return $default;
     }
 
 }

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1227,10 +1227,12 @@ class Request implements ArrayAccess
      *
      * @param string $key The key you want to read/write from/to.
      * @param string|null $value Value to set. Default null.
+     * @param string|null $default Default value when trying to retrieve an environment
+     *   variable's value that does not exist. The value parameter must be null.
      * @return $this|string|null This instance if used as setter,
      *   if used as getter either the environment value, or null if the value doesn't exist.
      */
-    public function env($key, $value = null)
+    public function env($key, $value = null, $default = null)
     {
         if ($value !== null) {
             $this->_environment[$key] = $value;
@@ -1242,7 +1244,7 @@ class Request implements ArrayAccess
         if (!array_key_exists($key, $this->_environment)) {
             $this->_environment[$key] = env($key);
         }
-        return $this->_environment[$key];
+        return $this->_environment[$key] !== null ? $this->_environment[$key] : $default;
     }
 
     /**

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Core;
+
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test cases for functions in Core\functions.php
+ */
+class FunctionsTest extends TestCase
+{
+    /**
+     * Test cases for env()
+     */
+    public function testEnv()
+    {
+        $_ENV['DOES_NOT_EXIST'] = null;
+        $actual = env('DOES_NOT_EXIST');
+        $this->assertNull($actual);
+        $actual = env('DOES_NOT_EXIST', 'default');
+        $this->assertEquals('default', $actual);
+        $_ENV['DOES_EXIST'] = 'some value';
+        $actual = env('DOES_EXIST');
+        $this->assertEquals('some value', $actual);
+        $actual = env('DOES_EXIST', 'default');
+        $this->assertEquals('some value', $actual);
+        $_ENV['EMPTY_VALUE'] = '';
+        $actual = env('EMPTY_VALUE');
+        $this->assertEquals('', $actual);
+        $actuaal = env('EMPTY_VALUE', 'default');
+        $this->assertEquals('', $actual);
+        $_ENV['ZERO'] = '0';
+        $actual = env('ZERO');
+        $this->assertEquals('0', $actual);
+        $actual = env('ZERO', '1');
+        $this->assertEquals('0', $actual);
+    }
+}

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -500,6 +500,33 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Tests the env() method returning a default value in case the requested environment variable is not set.
+     */
+    public function testDefaultEnvValue()
+    {
+        $_ENV['DOES_NOT_EXIST'] = null;
+        $request = new Request();
+        $this->assertNull($request->env('DOES_NOT_EXIST'));
+        $request = new Request();
+        $this->assertEquals('default', $request->env('DOES_NOT_EXIST', null, 'default'));
+        $_ENV['DOES_EXIST'] = 'some value';
+        $request = new Request();
+        $this->assertEquals('some value', $request->env('DOES_EXIST'));
+        $request = new Request();
+        $this->assertEquals('some value', $request->env('DOES_EXIST', null, 'default'));
+        $_ENV['EMPTY_VALUE'] = '';
+        $request = new Request();
+        $this->assertEquals('', $request->env('EMPTY_VALUE'));
+        $request = new Request();
+        $this->assertEquals('', $request->env('EMPTY_VALUE', null, 'default'));
+        $_ENV['ZERO'] = '0';
+        $request = new Request();
+        $this->assertEquals('0', $request->env('ZERO'));
+        $request = new Request();
+        $this->assertEquals('0', $request->env('ZERO', null, 'default'));
+    }
+
+    /**
      * Test the clientIp method.
      *
      * @return void


### PR DESCRIPTION
This adds an additional parameter to the env() function that allows to provide a default value in case the requested environment variable is not defined.
So instead of writing

```
$setting = env('SETTING') != null ? env('SETTING') : 'default value';
```

one can now simply write

```
$setting = env('SETTING', 'default value');
```
