### PR TITLE
Fixes fatal error in DboSource::isConnected() in 2.x

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -857,10 +857,14 @@ class DboSource extends DataSource {
  * @return bool True if the database is connected, else false
  */
 	public function isConnected() {
-		try {
-			$connected = $this->_connection->query('SELECT 1');
-		} catch (Exception $e) {
+		if (empty($this->_connection)) {
 			$connected = false;
+		} else {
+			try {
+				$connected = $this->_connection->query('SELECT 1');
+			} catch (Exception $e) {
+				$connected = false;
+			}
 		}
 		$this->connected = ! empty($connected);
 		return $this->connected;


### PR DESCRIPTION
Stops a fatal error if calling isConnected() after disconnect() by first checking that $_connection exists before trying to use it.

Applies to CakePHP 2.7 and 2.8.
