### PR TITLE
Fix use of $_connection in DboSource in 2.x

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -857,10 +857,14 @@ class DboSource extends DataSource {
  * @return bool True if the database is connected, else false
  */
 	public function isConnected() {
-		try {
-			$connected = $this->_connection->query('SELECT 1');
-		} catch (Exception $e) {
+		if (is_null($this->_connection)) {
 			$connected = false;
+		} else {
+			try {
+				$connected = $this->_connection->query('SELECT 1');
+			} catch (Exception $e) {
+				$connected = false;
+			}
 		}
 		$this->connected = ! empty($connected);
 		return $this->connected;

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -284,7 +284,7 @@ class DboSource extends DataSource {
 		if ($this->_result instanceof PDOStatement) {
 			$this->_result->closeCursor();
 		}
-		unset($this->_connection);
+		$this->_connection = null;
 		$this->connected = false;
 		return true;
 	}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -857,7 +857,7 @@ class DboSource extends DataSource {
  * @return bool True if the database is connected, else false
  */
 	public function isConnected() {
-		if (is_null($this->_connection)) {
+		if ($this->_connection === null) {
 			$connected = false;
 		} else {
 			try {


### PR DESCRIPTION
Stops a fatal error if calling isConnected() after disconnect() by first checking that $_connection exists before trying to use it.

Applies to CakePHP 2.7 and 2.8.

As discussion in #7426. Changed branch to 2.7, and implemented setting $_connection to null on disconnect.
