### PR TITLE
Swallow the "--quiet" shell parameter before calling PHPUnit.

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -222,6 +222,7 @@ class TestShell extends Shell {
 		$options = array();
 		$params = $this->params;
 		unset($params['help']);
+		unset($params['quiet']);
 
 		if (!empty($params['no-colors'])) {
 			unset($params['no-colors'], $params['colors']);

--- a/lib/Cake/Test/Case/Console/Command/TestShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/TestShellTest.php
@@ -341,4 +341,22 @@ class TestShellTest extends CakeTestCase {
 			);
 		$this->Shell->main();
 	}
+
+/**
+ * Tests that the 'quiet' parameter gets swallowed before calling PHPUnit
+ *
+ * @return void
+ */
+	public function testRunnerOptionsQuiet() {
+		$this->Shell->startup();
+		$this->Shell->args = array('core', 'Basics');
+		$this->Shell->params = array('quiet' => true);
+
+		$this->Shell->expects($this->once())->method('_run')
+			->with(
+				array('app' => false, 'plugin' => null, 'core' => true, 'output' => 'text', 'case' => 'Basics'),
+				array('--colors')
+			);
+		$this->Shell->main();
+	}
 }


### PR DESCRIPTION
PHPUnit does not provide a silent or quiet mode, so we cannot pass it along:
https://phpunit.de/manual/3.7/en/phpunit-book.html#textui.clioptions

Resolves #7432
