### PR TITLE
Disable stdout logging when --quiet is used.

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -353,21 +353,30 @@ class ConsoleIo
      * If you don't wish all log output in stdout or stderr
      * through Cake's Log class, call this function with `$enable=false`.
      *
-     * @param bool $enable Whether you want loggers on or off.
+     * @param int|bool $enable Use a boolean to enable/toggle all logging. Use
+     *   one of the verbosity constants (self::VERBOSE, self::QUIET, self::NORMAL)
+     *   to control logging levels. VERBOSE enables debug logs, NORMAL does not include debug logs,
+     *   QUIET disables notice, info and debug logs.
      * @return void
      */
     public function setLoggers($enable)
     {
         Log::drop('stdout');
         Log::drop('stderr');
-        if (!$enable) {
+        if ($enable === false) {
             return;
         }
-        $stdout = new ConsoleLog([
-            'types' => ['notice', 'info', 'debug'],
-            'stream' => $this->_out
-        ]);
-        Log::config('stdout', ['engine' => $stdout]);
+        $outLevels = ['notice', 'info'];
+        if ($enable === static::VERBOSE || $enable === true) {
+            $outLevels[] = 'debug';
+        }
+        if ($enable !== static::QUIET) {
+            $stdout = new ConsoleLog([
+                'types' => $outLevels,
+                'stream' => $this->_out
+            ]);
+            Log::config('stdout', ['engine' => $stdout]);
+        }
         $stderr = new ConsoleLog([
             'types' => ['emergency', 'alert', 'critical', 'error', 'warning'],
             'stream' => $this->_err,

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -163,11 +163,11 @@ class Shell
         $this->modelFactory('Table', [$locator, 'get']);
         $this->Tasks = new TaskRegistry($this);
 
-        $this->_io->setLoggers(true);
         $this->_mergeVars(
             ['tasks'],
             ['associative' => ['tasks']]
         );
+        $this->_io->setLoggers(true);
 
         if (isset($this->modelClass)) {
             $this->loadModel();
@@ -410,14 +410,7 @@ class Shell
         if (!empty($extra) && is_array($extra)) {
             $this->params = array_merge($this->params, $extra);
         }
-
-        if (!empty($this->params['quiet'])) {
-            $this->_io->level(ConsoleIo::QUIET);
-            $this->_io->setLoggers(false);
-        }
-        if (!empty($this->params['verbose'])) {
-            $this->_io->level(ConsoleIo::VERBOSE);
-        }
+        $this->_setOutputLevel();
         if (!empty($this->params['plugin'])) {
             Plugin::load($this->params['plugin']);
         }
@@ -454,6 +447,27 @@ class Shell
 
         $this->out($this->OptionParser->help($command));
         return false;
+    }
+
+    /**
+     * Set the output level based on the parameters.
+     *
+     * This reconfigures both the output level for out()
+     * and the configured stdout/stderr logging
+     *
+     * @return void
+     */
+    protected function _setOutputLevel()
+    {
+        $this->_io->setLoggers(ConsoleIo::NORMAL);
+        if (!empty($this->params['quiet'])) {
+            $this->_io->level(ConsoleIo::QUIET);
+            $this->_io->setLoggers(ConsoleIo::QUIET);
+        }
+        if (!empty($this->params['verbose'])) {
+            $this->_io->level(ConsoleIo::VERBOSE);
+            $this->_io->setLoggers(ConsoleIo::VERBOSE);
+        }
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -346,6 +346,36 @@ class ConsoleIoTest extends TestCase
     }
 
     /**
+     * Tests that setLoggers works properly with quiet
+     *
+     * @return void
+     */
+    public function testSetLoggersQuiet()
+    {
+        Log::drop('stdout');
+        Log::drop('stderr');
+        $this->io->setLoggers(ConsoleIo::QUIET);
+        $this->assertEmpty(Log::engine('stdout'));
+        $this->assertNotEmpty(Log::engine('stderr'));
+    }
+
+    /**
+     * Tests that setLoggers works properly with verbose
+     *
+     * @return void
+     */
+    public function testSetLoggersVerbose()
+    {
+        Log::drop('stdout');
+        Log::drop('stderr');
+        $this->io->setLoggers(ConsoleIo::VERBOSE);
+
+        $this->assertNotEmpty(Log::engine('stderr'));
+        $engine = Log::engine('stdout');
+        $this->assertEquals(['notice', 'info', 'debug'], $engine->config('levels'));
+    }
+
+    /**
      * Ensure that styles() just proxies to stdout.
      *
      * @return void


### PR DESCRIPTION
This changes stdout/stderr logging to better match the CLI flags being used. Now `--quiet` turns off all stdout logging, while `--verbose` enables debug logging.

I felt this setup took the spirit of #7417 and improved upon it. I'm targetting 3.1 as I don't see adjusting the logging levels of CLI tools as a breaking or notable change.
