### PR TITLE
Various improvements to the CakePHP lib files

### DIFF
--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -558,7 +558,7 @@ class AclShell extends AppShell {
  * or an array of properties to use in AcoNode::node()
  *
  * @param string $class Class type you want (Aro/Aco)
- * @param string|array $identifier A mixed identifier for finding the node.
+ * @param string|array|null $identifier A mixed identifier for finding the node, otherwise null.
  * @return int Integer of NodeId. Will trigger an error if nothing is found.
  */
 	protected function _getNodeId($class, $identifier) {
@@ -568,7 +568,7 @@ class AclShell extends AppShell {
 				$identifier = var_export($identifier, true);
 			}
 			$this->error(__d('cake_console', 'Could not find node using reference "%s"', $identifier));
-			return;
+			return null;
 		}
 		return Hash::get($node, "0.{$class}.id");
 	}

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -210,7 +210,7 @@ class FixtureTask extends BakeTask {
  * @param string $model Name of model to bake.
  * @param string $useTable Name of table to use.
  * @param array $importOptions Options for public $import
- * @return string Baked fixture content
+ * @return string|null Baked fixture content, otherwise null.
  */
 	public function bake($model, $useTable = false, $importOptions = array()) {
 		App::uses('CakeSchema', 'Model');
@@ -243,7 +243,7 @@ class FixtureTask extends BakeTask {
 		$data = $this->_Schema->read(array('models' => false, 'connection' => $this->connection));
 		if (!isset($data['tables'][$useTable])) {
 			$this->err("<warning>Warning:</warning> Could not find the '${useTable}' table for ${model}.");
-			return;
+			return null;
 		}
 
 		$tableInfo = $data['tables'][$useTable];

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -89,7 +89,7 @@ class ViewTask extends BakeTask {
 			$this->_interactive();
 		}
 		if (empty($this->args[0])) {
-			return;
+			return null;
 		}
 		if (!isset($this->connection)) {
 			$this->connection = 'default';

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -179,11 +179,11 @@ class TestShell extends Shell {
 /**
  * Parse the CLI options into an array CakeTestDispatcher can use.
  *
- * @return array Array of params for CakeTestDispatcher
+ * @return array|null Array of params for CakeTestDispatcher or null.
  */
 	protected function _parseArgs() {
 		if (empty($this->args)) {
-			return;
+			return null;
 		}
 		$params = array(
 			'core' => false,

--- a/lib/Cake/Console/Templates/default/classes/model.ctp
+++ b/lib/Cake/Console/Templates/default/classes/model.ctp
@@ -106,7 +106,7 @@ foreach ($associations as $assoc):
 	if (!empty($assoc)):
 ?>
 
-	//The Associations below have been created with all possible keys, those that are not needed can be removed
+	// The Associations below have been created with all possible keys, those that are not needed can be removed
 <?php
 		break;
 	endif;

--- a/lib/Cake/Console/Templates/default/views/view.ctp
+++ b/lib/Cake/Console/Templates/default/views/view.ctp
@@ -131,4 +131,5 @@ echo "\t<?php endforeach; ?>\n";
 		</ul>
 	</div>
 </div>
-<?php endforeach; ?>
+<?php
+endforeach;

--- a/lib/Cake/Console/Templates/default/views/view.ctp
+++ b/lib/Cake/Console/Templates/default/views/view.ctp
@@ -133,3 +133,4 @@ echo "\t<?php endforeach; ?>\n";
 </div>
 <?php
 endforeach;
+?>

--- a/lib/Cake/Controller/Component/Acl/DbAcl.php
+++ b/lib/Cake/Controller/Component/Acl/DbAcl.php
@@ -41,7 +41,6 @@ class DbAcl extends Object implements AclInterface {
 
 /**
  * Constructor
- *
  */
 	public function __construct() {
 		parent::__construct();

--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -196,7 +196,6 @@ class PhpAcl extends Object implements AclInterface {
 
 /**
  * Access Control Object
- *
  */
 class PhpAco {
 
@@ -361,7 +360,6 @@ class PhpAco {
 
 /**
  * Access Request Object
- *
  */
 class PhpAro {
 

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -79,7 +79,7 @@ class AclComponent extends Component {
  * Will call the initialize method on the adapter if setting a new one.
  *
  * @param AclInterface|string $adapter Instance of AclInterface or a string name of the class to use. (optional)
- * @return AclInterface|void either null, or the adapter implementation.
+ * @return AclInterface|null Either null, or the adapter implementation.
  * @throws CakeException when the given class is not an instance of AclInterface
  */
 	public function adapter($adapter = null) {
@@ -92,7 +92,7 @@ class AclComponent extends Component {
 			}
 			$this->_Instance = $adapter;
 			$this->_Instance->initialize($this);
-			return;
+			return null;
 		}
 		return $this->_Instance;
 	}

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -481,7 +481,7 @@ class AuthComponent extends Component {
  */
 	public function constructAuthorize() {
 		if (empty($this->authorize)) {
-			return;
+			return null;
 		}
 		$this->_authorizeObjects = array();
 		$config = Hash::normalize((array)$this->authorize);
@@ -772,12 +772,12 @@ class AuthComponent extends Component {
 /**
  * Loads the configured authentication objects.
  *
- * @return mixed either null on empty authenticate value, or an array of loaded objects.
+ * @return mixed Either null on empty authenticate value, or an array of loaded objects.
  * @throws CakeException
  */
 	public function constructAuthenticate() {
 		if (empty($this->authenticate)) {
-			return;
+			return null;
 		}
 		$this->_authenticateObjects = array();
 		$config = Hash::normalize((array)$this->authenticate);

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -27,7 +27,6 @@ App::uses('Hash', 'Utility');
  *
  * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html
- *
  */
 class CookieComponent extends Component {
 

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -32,7 +32,6 @@ App::uses('Xml', 'Utility');
  *
  * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/request-handling.html
- *
  */
 class RequestHandlerComponent extends Component {
 
@@ -280,7 +279,7 @@ class RequestHandlerComponent extends Component {
  * "304 Not Modified" header.
  *
  * @param Controller $controller Controller instance.
- * @return bool false if the render process should be aborted
+ * @return bool False if the render process should be aborted.
  */
 	public function beforeRender(Controller $controller) {
 		if ($this->settings['checkHttpCache'] && $this->response->checkNotModified($this->request)) {

--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -34,7 +34,7 @@ class SessionComponent extends Component {
  * Get / Set the userAgent
  *
  * @param string $userAgent Set the userAgent
- * @return void
+ * @return string Current user agent.
  */
 	public function userAgent($userAgent = null) {
 		return CakeSession::userAgent($userAgent);

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -31,7 +31,6 @@ class Object {
 
 /**
  * Constructor, no-op
- *
  */
 	public function __construct() {
 	}

--- a/lib/Cake/Event/CakeEvent.php
+++ b/lib/Cake/Event/CakeEvent.php
@@ -71,7 +71,6 @@ class CakeEvent {
  *	$event = new CakeEvent('Order.afterBuy', $this, array('buyer' => $userData));
  *	$event = new CakeEvent('User.afterRegister', $UserModel);
  * ```
- *
  */
 	public function __construct($name, $subject = null, $data = null) {
 		$this->_name = $name;

--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -172,10 +172,10 @@ class CakeEventManager {
 			foreach (array_keys($this->_listeners) as $eventKey) {
 				$this->detach($callable, $eventKey);
 			}
-			return;
+			return null;
 		}
 		if (empty($this->_listeners[$eventKey])) {
-			return;
+			return null;
 		}
 		foreach ($this->_listeners[$eventKey] as $priority => $callables) {
 			foreach ($callables as $k => $callback) {

--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -172,10 +172,10 @@ class CakeEventManager {
 			foreach (array_keys($this->_listeners) as $eventKey) {
 				$this->detach($callable, $eventKey);
 			}
-			return null;
+			return;
 		}
 		if (empty($this->_listeners[$eventKey])) {
-			return null;
+			return;
 		}
 		foreach ($this->_listeners[$eventKey] as $priority => $callables) {
 			foreach ($callables as $k => $callback) {

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -182,7 +182,7 @@ class FileLog extends BaseLog {
  * Also if `rotate` count is reached oldest file is removed.
  *
  * @param string $filename Log file name
- * @return mixed True if rotated successfully or false in case of error.
+ * @return mixed True if rotated successfully or false in case of error, otherwise null.
  *   Void if file doesn't need to be rotated.
  */
 	protected function _rotateFile($filename) {

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -196,7 +196,7 @@ class FileLog extends BaseLog {
 		if (!file_exists($filepath) ||
 			filesize($filepath) < $this->_size
 		) {
-			return;
+			return null;
 		}
 
 		if ($this->_config['rotate'] === 0) {

--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -39,7 +39,6 @@ class AclNode extends Model {
 
 /**
  * Constructor
- *
  */
 	public function __construct() {
 		$config = Configure::read('Acl.database');

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -357,7 +357,7 @@ class CakeSession {
  * Get / Set the user agent
  *
  * @param string|null $userAgent Set the user agent
- * @return string Current user agent
+ * @return string Current user agent.
  */
 	public static function userAgent($userAgent = null) {
 		if ($userAgent) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1258,7 +1258,7 @@ class DboSource extends DataSource {
 
 		$queryTemplate = $this->generateAssociationQuery($Model, $LinkModel, $type, $association, $assocData, $queryData, $external);
 		if (empty($queryTemplate)) {
-			return;
+			return null;
 		}
 
 		if (!is_array($resultSet)) {
@@ -1952,7 +1952,7 @@ class DboSource extends DataSource {
  *
  * @param string $type type of query being run. e.g select, create, update, delete, schema, alter.
  * @param array $data Array of data to insert into the query.
- * @return string Rendered SQL expression to be run.
+ * @return string|null Rendered SQL expression to be run, otherwise null.
  */
 	public function renderStatement($type, $data) {
 		extract($data);
@@ -1986,7 +1986,7 @@ class DboSource extends DataSource {
 				}
 				return "CREATE TABLE {$table} (\n{$columns}{$indexes}) {$tableParameters};";
 			case 'alter':
-				return;
+				return null;
 		}
 	}
 

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -43,7 +43,6 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Constructor. Looks at Session configuration information and
  * sets up the session model.
- *
  */
 	public function __construct() {
 		$modelName = Configure::read('Session.handler.model');

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1190,12 +1190,12 @@ class Model extends Object implements CakeEventListener {
  *
  * @param string|array|SimpleXmlElement|DomNode $one Array or string of data
  * @param string $two Value string for the alternative indata method
- * @return array Data with all of $one's keys and values
+ * @return array|null Data with all of $one's keys and values, otherwise null.
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html
  */
 	public function set($one, $two = null) {
 		if (!$one) {
-			return;
+			return null;
 		}
 
 		if (is_object($one)) {

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -452,7 +452,7 @@ class CakeResponse {
 
 /**
  * Formats the Content-Type header based on the configured contentType and charset
- * the charset will only be set in the header if the response is of type text/*
+ * the charset will only be set in the header if the response is of type text
  *
  * @return void
  */

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -216,7 +216,7 @@ class CakeSocket {
  */
 	public function context() {
 		if (!$this->connection) {
-			return;
+			return null;
 		}
 		return stream_context_get_options($this->connection);
 	}

--- a/lib/Cake/Routing/Dispatcher.php
+++ b/lib/Cake/Routing/Dispatcher.php
@@ -137,7 +137,7 @@ class Dispatcher implements CakeEventListener {
  * @param CakeRequest $request Request object to dispatch.
  * @param CakeResponse $response Response object to put the results of the dispatch into.
  * @param array $additionalParams Settings array ("bare", "return") which is melded with the GET and POST params
- * @return string|void if `$request['return']` is set then it returns response body, null otherwise
+ * @return string|null if `$request['return']` is set then it returns response body, null otherwise
  * @triggers Dispatcher.beforeDispatch $this, compact('request', 'response', 'additionalParams')
  * @triggers Dispatcher.afterDispatch $this, compact('request', 'response')
  * @throws MissingControllerException When the controller is missing.

--- a/lib/Cake/Routing/Dispatcher.php
+++ b/lib/Cake/Routing/Dispatcher.php
@@ -152,7 +152,7 @@ class Dispatcher implements CakeEventListener {
 				return $beforeEvent->result->body();
 			}
 			$beforeEvent->result->send();
-			return;
+			return null;
 		}
 
 		$controller = $this->_getController($request, $response);

--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -42,7 +42,7 @@ class AssetDispatcher extends DispatcherFilter {
 	public function beforeDispatch(CakeEvent $event) {
 		$url = urldecode($event->data['request']->url);
 		if (strpos($url, '..') !== false || strpos($url, '.') === false) {
-			return;
+			return null;
 		}
 
 		if ($result = $this->_filterAsset($event)) {

--- a/lib/Cake/Routing/Filter/CacheDispatcher.php
+++ b/lib/Cake/Routing/Filter/CacheDispatcher.php
@@ -39,7 +39,7 @@ class CacheDispatcher extends DispatcherFilter {
  */
 	public function beforeDispatch(CakeEvent $event) {
 		if (Configure::read('Cache.check') !== true) {
-			return;
+			return null;
 		}
 
 		$path = $event->data['request']->here();

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -91,7 +91,6 @@ class Debugger {
 
 /**
  * Constructor.
- *
  */
 	public function __construct() {
 		$docRef = ini_get('docref_root');
@@ -200,7 +199,7 @@ class Debugger {
  * @param string $file File on which error occurred
  * @param int $line Line that triggered the error
  * @param array $context Context
- * @return bool true if error was handled
+ * @return bool|null True if error was handled, otherwise null.
  * @deprecated 3.0.0 Will be removed in 3.0. This function is superseded by Debugger::outputError().
  */
 	public static function showError($code, $description, $file = null, $line = null, $context = null) {
@@ -217,7 +216,7 @@ class Debugger {
 		if (!in_array($info, $self->errors)) {
 			$self->errors[] = $info;
 		} else {
-			return;
+			return null;
 		}
 
 		switch ($code) {
@@ -247,7 +246,7 @@ class Debugger {
 				$level = LOG_NOTICE;
 				break;
 			default:
-				return;
+				return null;
 		}
 
 		$data = compact(

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -465,7 +465,7 @@ class Hash {
 		$count = count($paths);
 
 		if (!$count) {
-			return;
+			return null;
 		}
 
 		for ($i = 0; $i < $count; $i++) {

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -228,7 +228,7 @@ class Set {
  * @param array $data Source array from which to extract the data
  * @param string $format Format string into which values will be inserted, see sprintf()
  * @param array $keys An array containing one or more Set::extract()-style key paths
- * @return array An array of strings extracted from $keys and formatted with $format
+ * @return array|null An array of strings extracted from $keys and formatted with $format, otherwise null.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::format
  */
 	public static function format($data, $format, $keys) {
@@ -236,7 +236,7 @@ class Set {
 		$count = count($keys);
 
 		if (!$count) {
-			return;
+			return null;
 		}
 
 		for ($i = 0; $i < $count; $i++) {

--- a/lib/Cake/View/Errors/fatal_error.ctp
+++ b/lib/Cake/View/Errors/fatal_error.ctp
@@ -36,3 +36,4 @@
 if (extension_loaded('xdebug')) {
 	xdebug_print_function_stack();
 }
+?>

--- a/lib/Cake/View/Errors/fatal_error.ctp
+++ b/lib/Cake/View/Errors/fatal_error.ctp
@@ -36,4 +36,3 @@
 if (extension_loaded('xdebug')) {
 	xdebug_print_function_stack();
 }
-?>

--- a/lib/Cake/View/Errors/missing_action.ctp
+++ b/lib/Cake/View/Errors/missing_action.ctp
@@ -40,3 +40,4 @@ class <?php echo h($controller); ?> extends AppController {
 </p>
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_action.ctp
+++ b/lib/Cake/View/Errors/missing_action.ctp
@@ -38,4 +38,5 @@ class <?php echo h($controller); ?> extends AppController {
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_action.ctp'); ?>
 </p>
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_behavior.ctp
+++ b/lib/Cake/View/Errors/missing_behavior.ctp
@@ -36,4 +36,5 @@ class <?php echo h($class); ?> extends ModelBehavior {
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_behavior.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_behavior.ctp
+++ b/lib/Cake/View/Errors/missing_behavior.ctp
@@ -38,3 +38,4 @@ class <?php echo h($class); ?> extends ModelBehavior {
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_component.ctp
+++ b/lib/Cake/View/Errors/missing_component.ctp
@@ -36,4 +36,5 @@ class <?php echo h($class); ?> extends Component {
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_component.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_component.ctp
+++ b/lib/Cake/View/Errors/missing_component.ctp
@@ -38,3 +38,4 @@ class <?php echo h($class); ?> extends Component {
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_controller.ctp
+++ b/lib/Cake/View/Errors/missing_controller.ctp
@@ -38,3 +38,4 @@ class <?php echo h($class . ' extends ' . $plugin); ?>AppController {
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_controller.ctp
+++ b/lib/Cake/View/Errors/missing_controller.ctp
@@ -36,4 +36,5 @@ class <?php echo h($class . ' extends ' . $plugin); ?>AppController {
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_controller.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_database.ctp
+++ b/lib/Cake/View/Errors/missing_database.ctp
@@ -28,4 +28,5 @@
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_database.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_database.ctp
+++ b/lib/Cake/View/Errors/missing_database.ctp
@@ -30,3 +30,4 @@
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_datasource.ctp
+++ b/lib/Cake/View/Errors/missing_datasource.ctp
@@ -31,3 +31,4 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_datasource.ctp
+++ b/lib/Cake/View/Errors/missing_datasource.ctp
@@ -20,7 +20,7 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 <p class="error">
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
 	<?php echo __d('cake_dev', 'Datasource class %s could not be found.', '<em>' . h($pluginDot . $class) . '</em>'); ?>
-	<?php if (isset($message)):  ?>
+	<?php if (isset($message)): ?>
 		<?php echo h($message); ?>
 	<?php endif; ?>
 </p>
@@ -29,4 +29,5 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_datasource.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_datasource_config.ctp
+++ b/lib/Cake/View/Errors/missing_datasource_config.ctp
@@ -24,4 +24,5 @@
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_datasource_config.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_datasource_config.ctp
+++ b/lib/Cake/View/Errors/missing_datasource_config.ctp
@@ -26,3 +26,4 @@
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_helper.ctp
+++ b/lib/Cake/View/Errors/missing_helper.ctp
@@ -36,4 +36,5 @@ class <?php echo h($class); ?> extends AppHelper {
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_helper.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_helper.ctp
+++ b/lib/Cake/View/Errors/missing_helper.ctp
@@ -38,3 +38,4 @@ class <?php echo h($class); ?> extends AppHelper {
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -43,3 +43,4 @@
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -41,4 +41,5 @@
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_layout.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_plugin.ctp
+++ b/lib/Cake/View/Errors/missing_plugin.ctp
@@ -40,4 +40,5 @@ CakePlugin::loadAll();
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_plugin.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_plugin.ctp
+++ b/lib/Cake/View/Errors/missing_plugin.ctp
@@ -42,3 +42,4 @@ CakePlugin::loadAll();
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_table.ctp
+++ b/lib/Cake/View/Errors/missing_table.ctp
@@ -17,11 +17,12 @@
 <h2><?php echo __d('cake_dev', 'Missing Database Table'); ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
-	<?php echo __d('cake_dev', 'Table %1$s for model %2$s was not found in datasource %3$s.', '<em>' . h($table) . '</em>',  '<em>' . h($class) . '</em>', '<em>' . h($ds) . '</em>'); ?>
+	<?php echo __d('cake_dev', 'Table %1$s for model %2$s was not found in datasource %3$s.', '<em>' . h($table) . '</em>', '<em>' . h($class) . '</em>', '<em>' . h($ds) . '</em>'); ?>
 </p>
 <p class="notice">
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_table.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/missing_table.ctp
+++ b/lib/Cake/View/Errors/missing_table.ctp
@@ -26,3 +26,4 @@
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -43,3 +43,4 @@
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -41,4 +41,5 @@
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_view.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/pdo_error.ctp
+++ b/lib/Cake/View/Errors/pdo_error.ctp
@@ -35,3 +35,4 @@
 </p>
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/pdo_error.ctp
+++ b/lib/Cake/View/Errors/pdo_error.ctp
@@ -33,4 +33,5 @@
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'pdo_error.ctp'); ?>
 </p>
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/private_action.ctp
+++ b/lib/Cake/View/Errors/private_action.ctp
@@ -24,4 +24,5 @@
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'private_action.ctp'); ?>
 </p>
 
-<?php echo $this->element('exception_stack_trace'); ?>
+<?php
+echo $this->element('exception_stack_trace');

--- a/lib/Cake/View/Errors/private_action.ctp
+++ b/lib/Cake/View/Errors/private_action.ctp
@@ -26,3 +26,4 @@
 
 <?php
 echo $this->element('exception_stack_trace');
+?>

--- a/lib/Cake/View/Errors/scaffold_error.ctp
+++ b/lib/Cake/View/Errors/scaffold_error.ctp
@@ -35,3 +35,4 @@ function _scaffoldError() {<br />
 if (isset($error) && $error instanceof Exception) {
 	echo $this->element('exception_stack_trace');
 }
+?>

--- a/lib/Cake/View/Errors/scaffold_error.ctp
+++ b/lib/Cake/View/Errors/scaffold_error.ctp
@@ -33,6 +33,5 @@ function _scaffoldError() {<br />
 
 <?php
 if (isset($error) && $error instanceof Exception) {
-	echo $this->element('exception_stack_trace'); 
+	echo $this->element('exception_stack_trace');
 }
-?>

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -271,8 +271,8 @@ class CacheHelper extends AppHelper {
  *
  * @param string $content view content to write to a cache file.
  * @param string $timestamp Duration to set for cache file.
- * @param bool $useCallbacks Whether to include statements in cached file which
- *   run callbacks.
+ * @param bool|null $useCallbacks Whether to include statements in cached file which
+ *   run callbacks, otherwise null.
  * @return bool success of caching view.
  */
 	protected function _writeFile($content, $timestamp, $useCallbacks = false) {
@@ -294,7 +294,7 @@ class CacheHelper extends AppHelper {
 		$cache = strtolower(Inflector::slug($path));
 
 		if (empty($cache)) {
-			return;
+			return null;
 		}
 		$cache = $cache . '.php';
 		$file = '<!--cachetime:' . $cacheTime . '--><?php';

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -70,7 +70,7 @@ class FlashHelper extends AppHelper {
  */
 	public function render($key = 'flash', $options = array()) {
 		if (!CakeSession::check("Message.$key")) {
-			return;
+			return null;
 		}
 
 		$flash = CakeSession::read("Message.$key");

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -203,7 +203,7 @@ class FormHelper extends AppHelper {
 	protected function _introspectModel($model, $key, $field = null) {
 		$object = $this->_getModel($model);
 		if (!$object) {
-			return;
+			return null;
 		}
 
 		if ($key === 'key') {
@@ -561,12 +561,12 @@ class FormHelper extends AppHelper {
  *    generating the hash, else $this->fields is being used.
  * @param array $secureAttributes will be passed as html attributes into the hidden
  *    input elements generated for the Security Component.
- * @return string A hidden input field with a security hash
+ * @return string|null A hidden input field with a security hash, otherwise null.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::secure
  */
 	public function secure($fields = array(), $secureAttributes = array()) {
 		if (!isset($this->request['_Token']) || empty($this->request['_Token'])) {
-			return;
+			return null;
 		}
 		$locked = array();
 		$unlockedFields = $this->_unlockedFields;

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -446,7 +446,7 @@ class HtmlHelper extends AppHelper {
 			if (empty($options['block'])) {
 				return $out . "\n";
 			}
-			return;
+			return '';
 		}
 
 		if ($options['once'] && isset($this->_includedAssets[__METHOD__][$path])) {

--- a/lib/Cake/View/Scaffolds/form.ctp
+++ b/lib/Cake/View/Scaffolds/form.ctp
@@ -35,9 +35,9 @@
 		<li><?php echo $this->Html->link(__d('cake', 'List') . ' ' . $pluralHumanName, array('action' => 'index')); ?></li>
 <?php
 		$done = array();
-		foreach ($associations as $_type => $_data) {
-			foreach ($_data as $_alias => $_details) {
-				if ($_details['controller'] != $this->name && !in_array($_details['controller'], $done)) {
+		foreach ($associations as $_type => $_data):
+			foreach ($_data as $_alias => $_details):
+				if ($_details['controller'] != $this->name && !in_array($_details['controller'], $done)):
 					echo "\t\t<li>" . $this->Html->link(
 						__d('cake', 'List %s', Inflector::humanize($_details['controller'])),
 						array('plugin' => $_details['plugin'], 'controller' => $_details['controller'], 'action' => 'index')
@@ -47,9 +47,9 @@
 						array('plugin' => $_details['plugin'], 'controller' => $_details['controller'], 'action' => 'add')
 					) . "</li>\n";
 					$done[] = $_details['controller'];
-				}
-			}
-		}
+				endif;
+			endforeach;
+		endforeach;
 ?>
 	</ul>
 </div>

--- a/lib/Cake/View/Scaffolds/index.ctp
+++ b/lib/Cake/View/Scaffolds/index.ctp
@@ -26,21 +26,21 @@
 <?php
 foreach (${$pluralVar} as ${$singularVar}):
 	echo '<tr>';
-		foreach ($scaffoldFields as $_field) {
+		foreach ($scaffoldFields as $_field):
 			$isKey = false;
-			if (!empty($associations['belongsTo'])) {
-				foreach ($associations['belongsTo'] as $_alias => $_details) {
-					if ($_field === $_details['foreignKey']) {
+			if (!empty($associations['belongsTo'])):
+				foreach ($associations['belongsTo'] as $_alias => $_details):
+					if ($_field === $_details['foreignKey']):
 						$isKey = true;
 						echo '<td>' . $this->Html->link(${$singularVar}[$_alias][$_details['displayField']], array('controller' => $_details['controller'], 'action' => 'view', ${$singularVar}[$_alias][$_details['primaryKey']])) . '</td>';
 						break;
-					}
-				}
-			}
-			if ($isKey !== true) {
+					endif;
+				endforeach;
+			endif;
+			if ($isKey !== true):
 				echo '<td>' . h(${$singularVar}[$modelClass][$_field]) . '</td>';
-			}
-		}
+			endif;
+		endforeach;
 
 		echo '<td class="actions">';
 		echo $this->Html->link(__d('cake', 'View'), array('action' => 'view', ${$singularVar}[$modelClass][$primaryKey]));
@@ -67,7 +67,7 @@ endforeach;
 	<?php
 		echo $this->Paginator->prev('< ' . __d('cake', 'previous'), array(), null, array('class' => 'prev disabled'));
 		echo $this->Paginator->numbers(array('separator' => ''));
-		echo $this->Paginator->next(__d('cake', 'next') .' >', array(), null, array('class' => 'next disabled'));
+		echo $this->Paginator->next(__d('cake', 'next') . ' >', array(), null, array('class' => 'next disabled'));
 	?>
 	</div>
 </div>

--- a/lib/Cake/View/Scaffolds/view.ctp
+++ b/lib/Cake/View/Scaffolds/view.ctp
@@ -95,10 +95,10 @@ foreach ($associations['hasOne'] as $_alias => $_details): ?>
 	<dl>
 <?php
 		$otherFields = array_keys(${$singularVar}[$_alias]);
-		foreach ($otherFields as $_field) {
+		foreach ($otherFields as $_field):
 			echo "\t\t<dt>" . Inflector::humanize($_field) . "</dt>\n";
 			echo "\t\t<dd>\n\t" . ${$singularVar}[$_alias][$_field] . "\n&nbsp;</dd>\n";
-		}
+		endforeach;
 ?>
 	</dl>
 <?php endif; ?>

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -464,7 +464,7 @@ class View extends Object {
  */
 	public function render($view = null, $layout = null) {
 		if ($this->hasRendered) {
-			return;
+			return null;
 		}
 
 		if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -580,7 +580,7 @@ if (!function_exists('__')) {
  */
 	function __($singular, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 
 		App::uses('I18n', 'I18n');
@@ -600,13 +600,13 @@ if (!function_exists('__n')) {
  * @param string $singular Singular text to translate
  * @param string $plural Plural text
  * @param int $count Count
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return mixed plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__n
  */
 	function __n($singular, $plural, $count, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 
 		App::uses('I18n', 'I18n');
@@ -624,13 +624,13 @@ if (!function_exists('__d')) {
  *
  * @param string $domain Domain
  * @param string $msg String to translate
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__d
  */
 	function __d($domain, $msg, $args = null) {
 		if (!$msg) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($msg, null, $domain);
@@ -651,13 +651,13 @@ if (!function_exists('__dn')) {
  * @param string $singular Singular string to translate
  * @param string $plural Plural
  * @param int $count Count
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dn
  */
 	function __dn($domain, $singular, $plural, $count, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($singular, $plural, $domain, I18n::LC_MESSAGES, $count);
@@ -689,13 +689,13 @@ if (!function_exists('__dc')) {
  * @param string $domain Domain
  * @param string $msg Message to translate
  * @param int $category Category
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dc
  */
 	function __dc($domain, $msg, $category, $args = null) {
 		if (!$msg) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($msg, null, $domain, $category);
@@ -731,13 +731,13 @@ if (!function_exists('__dcn')) {
  * @param string $plural Plural
  * @param int $count Count
  * @param int $category Category
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dcn
  */
 	function __dcn($domain, $singular, $plural, $count, $category, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($singular, $plural, $domain, $category, $count);
@@ -765,13 +765,13 @@ if (!function_exists('__c')) {
  *
  * @param string $msg String to translate
  * @param int $category Category
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__c
  */
 	function __c($msg, $category, $args = null) {
 		if (!$msg) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($msg, null, null, $category);
@@ -788,13 +788,13 @@ if (!function_exists('__x')) {
  *
  * @param string $context Context of the text
  * @param string $singular Text to translate
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return mixed translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__
  */
 	function __x($context, $singular, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 
 		App::uses('I18n', 'I18n');
@@ -815,13 +815,13 @@ if (!function_exists('__xn')) {
  * @param string $singular Singular text to translate
  * @param string $plural Plural text
  * @param int $count Count
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return mixed plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__n
  */
 	function __xn($context, $singular, $plural, $count, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 
 		App::uses('I18n', 'I18n');
@@ -840,13 +840,13 @@ if (!function_exists('__dx')) {
  * @param string $domain Domain
  * @param string $context Context of the text
  * @param string $msg String to translate
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__d
  */
 	function __dx($domain, $context, $msg, $args = null) {
 		if (!$msg) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($msg, null, $domain, null, null, null, $context);
@@ -868,13 +868,13 @@ if (!function_exists('__dxn')) {
  * @param string $singular Singular string to translate
  * @param string $plural Plural
  * @param int $count Count
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dn
  */
 	function __dxn($domain, $context, $singular, $plural, $count, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($singular, $plural, $domain, I18n::LC_MESSAGES, $count, null, $context);
@@ -907,13 +907,13 @@ if (!function_exists('__dxc')) {
  * @param string $context Context of the text
  * @param string $msg Message to translate
  * @param int $category Category
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dc
  */
 	function __dxc($domain, $context, $msg, $category, $args = null) {
 		if (!$msg) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($msg, null, $domain, $category, null, null, $context);
@@ -950,13 +950,13 @@ if (!function_exists('__dxcn')) {
  * @param string $plural Plural
  * @param int $count Count
  * @param int $category Category
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string plural form of translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__dcn
  */
 	function __dxcn($domain, $context, $singular, $plural, $count, $category, $args = null) {
 		if (!$singular) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($singular, $plural, $domain, $category, $count, null, $context);
@@ -985,13 +985,13 @@ if (!function_exists('__xc')) {
  * @param string $context Context of the text
  * @param string $msg String to translate
  * @param int $category Category
- * @param mixed $args Array with arguments or multiple arguments in function
+ * @param mixed $args Array with arguments or multiple arguments in function, otherwise null.
  * @return string translated string
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__c
  */
 	function __xc($context, $msg, $category, $args = null) {
 		if (!$msg) {
-			return;
+			return null;
 		}
 		App::uses('I18n', 'I18n');
 		$translated = I18n::translate($msg, null, null, $category, null, null, $context);


### PR DESCRIPTION
Mostly CS, doc blocks and explicit returning nulls.

After adding cakephp/cakephp-codesniffer as dev dependency (see #7446 ), I did the mistake and checked if the checkstyle works on the library :crying_cat_face: 

I did not correct everything I found, though.
Many methods have "The function/method declared 'void' must not return a value" warnings.
I think not all of those methods should be daclared to return void.

Some view templates have redundant closing tags, wasn't sure if they are meant to be.
