### PR TITLE
Adds containsNonAlphaNumeric validation rule

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -308,6 +308,25 @@ class Validation
     }
 
     /**
+     * Checks if a string contains one or more non-alphanumeric characters.
+     *
+     * Returns true if string contains at least the specified number of non-alphanumeric characters
+     *
+     * @param string $check Value to check
+     * @param int $count Number of non-alphanumerics to check for
+     * @return bool Success
+     */
+    public static function containsNonAlphaNumeric($check, $count = 1)
+    {
+        if (!is_string($check)) {
+            return false;
+        }
+
+        $matches = preg_match_all('/[^a-zA-Z0-9]/', $check);
+        return $matches >= $count;
+    }
+
+    /**
      * Used when a custom regular expression is needed.
      *
      * @param string|array $check When used as a string, $regex must also be a valid regular expression.

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2529,6 +2529,60 @@ class ValidationTest extends TestCase
     }
 
     /**
+     * testContainsNonAlphaNumeric method
+     *
+     * @return void
+     */
+    public function testContainNonAlphaNumeric()
+    {
+        $this->assertFalse(Validation::containsNonAlphaNumeric('abcdefghijklmnopqrstuvwxyz'));
+        $this->assertFalse(Validation::containsNonAlphaNumeric('ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
+        $this->assertFalse(Validation::containsNonAlphaNumeric('0123456789'));
+        $this->assertFalse(Validation::containsNonAlphaNumeric('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'));
+
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#'));
+        $this->assertTrue(Validation::containsNonAlphaNumeric("0\n"));
+        $this->assertTrue(Validation::containsNonAlphaNumeric("\n"));
+        $this->assertTrue(Validation::containsNonAlphaNumeric("\t"));
+        $this->assertTrue(Validation::containsNonAlphaNumeric("\r"));
+        $this->assertTrue(Validation::containsNonAlphaNumeric(" "));
+
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abcdef'));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abc#def'));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abcdef#'));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abc def'));
+        $this->assertTrue(Validation::containsNonAlphaNumeric("abcdef\n"));
+
+        $this->assertTrue(Validation::containsNonAlphaNumeric('##abcdef', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abcdef##', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abcdef#', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abc#def', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abc#def#', 2));
+
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#♥abcdef', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abcdef#♥', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abcdef♥', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abc♥def', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abc#def♥', 2));
+
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#♥abcdef', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abcdef#♥', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abcdef♥', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abc♥def', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abc#def♥', 2));
+
+        $this->assertTrue(Validation::containsNonAlphaNumeric('###abcdef', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abc###def', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('abcdef###', 2));
+        $this->assertTrue(Validation::containsNonAlphaNumeric('#abc#def#', 2));
+
+        $this->assertFalse(Validation::containsNonAlphaNumeric('##abcdef', 3));
+        $this->assertFalse(Validation::containsNonAlphaNumeric('abcdef##', 3));
+        $this->assertFalse(Validation::containsNonAlphaNumeric('abc##def', 3));
+        $this->assertFalse(Validation::containsNonAlphaNumeric('ab#cd#ef', 3));
+    }
+
+    /**
      * Test the geoCoordinate method.
      *
      * @return void


### PR DESCRIPTION
Check for non-alphanumeric characters in a string, useful for e.g. password complexity requirements. As discussed in https://github.com/cakephp/cakephp/issues/7418.
