### PR TITLE
Fix database composer.json

### DIFF
--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "cakephp/core": "~3.0"
+        "cakephp/core": "~3.0",
+        "cakephp/datasource": "~3.0"
     },
     "suggest": {
         "cakephp/log": "Require this if you want to use the built-in query logger",


### PR DESCRIPTION
- `Cake\Database\Connection` depends `Cake\Datasource\ConnectionInterface`
  - ref. https://github.com/cakephp/database/commit/57a54c6862e99b912876d2ee08fd1e41c7eddb7a#diff-eba180ff89e23df156c82c995be952df
  
  ```
  class Connection implements ConnectionInterface
  ```
- Updated `Database/composer.json`.
