### PR TITLE
Fixed the reading of the default email profile

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -346,7 +346,7 @@ class Email implements JsonSerializable, Serializable
             ->helpers(['Html']);
 
         if ($config === null) {
-            $config = Configure::read('Email.default');
+            $config = static::config('default');
         }
         if ($config) {
             $this->profile($config);

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -987,9 +987,11 @@ class EmailTest extends TestCase
     {
         $config = ['test' => 'ok', 'test2' => true];
         Configure::write('Email.default', $config);
+        Email::config(Configure::consume('Email'));
         $Email = new Email();
         $this->assertSame($Email->profile(), $config);
         Configure::delete('Email');
+        Email::drop('default');
     }
 
     /**


### PR DESCRIPTION
@ADmad and I discovered that once the config has been consumed it cannot be read. This change uses the config trait instead.
