### PR TITLE
Suggest methods that exist in deprecation warnings.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -355,12 +355,25 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function __set($name, $value)
     {
-        if (in_array($name, ['layout', 'view', 'theme', 'autoLayout', 'viewPath', 'layoutPath'], true)) {
+        $deprecated = [
+            'layout' => 'layout',
+            'view' => 'template',
+            'theme' => 'theme',
+            'autoLayout' => 'autoLayout',
+            'viewPath' => 'templatePath',
+            'layoutPath' => 'layoutPath',
+        ];
+        if (isset($deprecated[$name])) {
+            $method = $deprecated[$name];
             trigger_error(
-                sprintf('Controller::$%s is deprecated. Use $this->viewBuilder()->%s() instead.', $name, $name),
+                sprintf(
+                    'Controller::$%s is deprecated. Use $this->viewBuilder()->%s() instead.',
+                    $name,
+                    $method
+                ),
                 E_USER_DEPRECATED
             );
-            $this->viewBuilder()->{$name}($value);
+            $this->viewBuilder()->{$method}($value);
             return;
         }
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -88,14 +88,19 @@ class ViewBuilder implements JsonSerializable, Serializable
     protected $_name;
 
     /**
-     * The view variables to use
+     * The view class name to use.
+     * Can either use plugin notation, a short name
+     * or a fully namespaced classname.
      *
      * @var string
      */
     protected $_className;
 
     /**
-     * The view variables to use
+     * Additional options used when constructing the view.
+     *
+     * This options array lets you provide custom constructor
+     * arguments to application/plugin view classes.
      *
      * @var array
      */
@@ -249,6 +254,8 @@ class ViewBuilder implements JsonSerializable, Serializable
     /**
      * Set additional options for the view.
      *
+     * This lets you provide custom constructor arguments to application/plugin view classes.
+     *
      * @param array|null $options Either an array of options or null to get current options.
      * @param bool $merge Whether or not to merge existing data with the new data.
      * @return array|$this
@@ -281,7 +288,10 @@ class ViewBuilder implements JsonSerializable, Serializable
     }
 
     /**
-     * Get/set the view classname
+     * Get/set the view classname.
+     *
+     * Accepts either a short name (Ajax) a plugin name (MyPlugin.Ajax)
+     * or a fully namespaced name (App\View\AppView).
      *
      * @param string|null $name The class name for the view. Can
      *   be a plugin.class name reference, a short alias, or a fully

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -86,15 +86,22 @@ trait ViewVarsTrait
                 $viewOptions[$option] = $this->{$option};
             }
         }
-        $deprecatedOptions = ['layout', 'view', 'theme', 'autoLayout', 'viewPath', 'layoutPath'];
-        foreach ($deprecatedOptions as $option) {
-            if (property_exists($this, $option)) {
-                $method = $option === 'viewPath' ? 'templatePath' : $option;
-                $builder->{$method}($this->{$option});
+
+        $deprecatedOptions = [
+            'layout' => 'layout',
+            'view' => 'template',
+            'theme' => 'theme',
+            'autoLayout' => 'autoLayout',
+            'viewPath' => 'templatePath',
+            'layoutPath' => 'layoutPath',
+        ];
+        foreach ($deprecatedOptions as $old => $new) {
+            if (property_exists($this, $old)) {
+                $builder->{$new}($this->{$old});
                 trigger_error(sprintf(
                     'Property $%s is deprecated. Use $this->viewBuilder()->%s() instead in beforeRender().',
-                    $option,
-                    $method
+                    $old,
+                    $new
                 ), E_USER_DEPRECATED);
             }
         }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -987,6 +987,7 @@ class ControllerTest extends TestCase
 
     /**
      * Test declared deprecated properties like $theme are properly passed to view.
+     *
      * @return void
      */
     public function testDeclaredDeprecatedProperty()


### PR DESCRIPTION
Deprecation warnings should not tell developers to do a thing that will explode on them.

Refs #7468
