### PR TITLE
Fix 12PM not validating with string data.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1203,7 +1203,7 @@ class Validation
 
         if (isset($value['hour'])) {
             if (isset($value['meridian'])) {
-                if ($value['hour'] === 12) {
+                if ((int)$value['hour'] === 12) {
                     $value['hour'] = 0;
                 }
                 $value['hour'] = strtolower($value['meridian']) === 'am' ? $value['hour'] : $value['hour'] + 12;

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ValidationTest file
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -1470,6 +1468,17 @@ class ValidationTest extends TestCase
      */
     public function testDateTimeArray()
     {
+        $date = [
+            'year' => 2014,
+            'month' => '02',
+            'day' => '14',
+            'hour' => '12',
+            'minute' => '14',
+            'second' => '15',
+            'meridian' => 'pm'
+        ];
+        $this->assertTrue(Validation::datetime($date));
+
         $date = ['year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 13, 'minute' => 14, 'second' => 15];
         $this->assertTrue(Validation::datetime($date));
 


### PR DESCRIPTION
In 252267c4 strict equality was used which excludes string '12'.

Refs #7430
