### PR TITLE
Change how a single view var is inferred with `'_serialize' => true`

### DIFF
--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -173,10 +173,6 @@ class JsonView extends SerializedView
                 return null;
             }
 
-            if (count($data) === 1) {
-                return current($data);
-            }
-
             return $data;
         }
 

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -119,6 +119,14 @@ class JsonViewTest extends TestCase
                 json_encode(['no' => 'nope', 'user' => 'fake', 'list' => ['item1', 'item2']])
             ],
 
+            // Test render with True in _serialize and single var
+            [
+                ['no' => 'nope'],
+                true,
+                null,
+                json_encode(['no' => 'nope'])
+            ],
+
             // Test render with empty string in _serialize.
             [
                 ['no' => 'nope', 'user' => 'fake', 'list' => ['item1', 'item2']],


### PR DESCRIPTION
Now if a single view var is set it's inferred as `'_serialize' => ['var']`
instead of `'_serialize' => 'var'`.

Closes #7482
