### PR TITLE
[3.1] Convert type data earlier to allow expressions in types

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1362,8 +1362,20 @@ class Query implements ExpressionInterface, IteratorAggregate
             $this->_parts['set'] = $this->newExpr()->type(',');
         }
 
+        if (is_array($key)) {
+            foreach ($key as $field => &$value) {
+                $type = $this->typeMap()->type($field);
+                if (!$type) {
+                    continue;
+                }
+
+                $value = Type::build($type)->toDatabase($value, $this->connection()->driver());
+            }
+        }
+
         if (is_array($key) || $key instanceof ExpressionInterface) {
             $types = (array)$value;
+
             $this->_parts['set']->add($key, $types);
             return $this;
         }


### PR DESCRIPTION
This change makes it possible to return expressions from database types.

For example:

``` php
    /**
     * Convert point data into the database format.
     *
     * @param string|resource $value The value to convert.
     * @param Driver $driver The driver instance to convert with.
     * @return string|resource
     */
    public function toDatabase($value, Driver $driver)
    {
        if ($value === null || $value === '') {
            return null;
        }

        if (is_string($value)) {
            $coordinates = explode(',', $value);
            $x = (float) $coordinates[0];
            $y = (float) $coordinates[1];

            $value = new Point($x, $y);
        }

        if ($value instanceof Point) {
            return new FunctionExpression('POINT', [$value->x(), $value->y()]);
        }

        return new QueryExpression('GeomFromText(\'POINT(' . $value . ')\')');
    }
```
