### PR TITLE
Add support for Self Signed certificates for email

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -410,6 +410,7 @@ class CakeSocket {
  * Accept Self-signed certificate on current stream socket
  *
  * @return bool True on success
+ * @link http://php.net/manual/en/context.ssl.php About the 'allow_self_signed' option.
  * @see stream_context_set_option
  */
 	public function enableSelfSigned() {

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -406,5 +406,19 @@ class CakeSocket {
 		throw new SocketException($errorMessage);
 	}
 
+/**
+ * Accept Self-signed certificate on current stream socket
+ *
+ * @return bool True on success
+ * @see stream_context_set_option
+ */
+	public function enableSelfSigned() {
+		$options['ssl'] = array(
+			'allow_self_signed' => true,
+			'verify_peer' => false,
+			'verify_peer_name' => false
+		);
+		return stream_context_set_option($this->connection, $options);
+	}
 }
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -413,12 +413,7 @@ class CakeSocket {
  * @see stream_context_set_option
  */
 	public function enableSelfSigned() {
-		$options['ssl'] = array(
-			'allow_self_signed' => true,
-			'verify_peer' => false,
-			'verify_peer_name' => false
-		);
-		return stream_context_set_option($this->connection, $options);
+		return stream_context_set_option($this->connection, 'ssl', 'allow_self_signed', true);
 	}
 }
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -413,7 +413,7 @@ class CakeSocket {
  * @link http://php.net/manual/en/context.ssl.php About the 'allow_self_signed' option.
  * @see stream_context_set_option
  */
-	public function enableSelfSigned() {
+	public function allowSelfSigned() {
 		return stream_context_set_option($this->connection, 'ssl', 'allow_self_signed', true);
 	}
 }

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -118,7 +118,8 @@ class SmtpTransport extends AbstractTransport {
 			'username' => null,
 			'password' => null,
 			'client' => null,
-			'tls' => false
+			'tls' => false,
+			'selfSigned' => false
 		);
 		$this->_config = array_merge($default, $this->_config, $config);
 		return $this->_config;
@@ -168,6 +169,9 @@ class SmtpTransport extends AbstractTransport {
 			$this->_smtpSend("EHLO {$host}", '250');
 			if ($this->_config['tls']) {
 				$this->_smtpSend("STARTTLS", '220');
+				if ($this->_config['selfSigned']) {
+					$this->_socket->enableSelfSigned();
+				}
 				$this->_socket->enableCrypto('tls');
 				$this->_smtpSend("EHLO {$host}", '250');
 			}

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -119,7 +119,7 @@ class SmtpTransport extends AbstractTransport {
 			'password' => null,
 			'client' => null,
 			'tls' => false,
-			'selfSigned' => false
+			'ssl_allow_self_signed' => false
 		);
 		$this->_config = array_merge($default, $this->_config, $config);
 		return $this->_config;
@@ -169,8 +169,8 @@ class SmtpTransport extends AbstractTransport {
 			$this->_smtpSend("EHLO {$host}", '250');
 			if ($this->_config['tls']) {
 				$this->_smtpSend("STARTTLS", '220');
-				if ($this->_config['selfSigned']) {
-					$this->_socket->enableSelfSigned();
+				if ($this->_config['ssl_allow_self_signed']) {
+					$this->_socket->allowSelfSigned();
 				}
 				$this->_socket->enableCrypto('tls');
 				$this->_smtpSend("EHLO {$host}", '250');

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -356,7 +356,7 @@ class CakeSocketTest extends CakeTestCase {
  */
 	public function testEnableCryptoSelfSigned() {
 		$this->_connectSocketToSslTls();
-		$this->assertTrue($this->Socket->enableSelfSigned());
+		$this->assertTrue($this->Socket->allowSelfSigned());
 		$this->assertTrue($this->Socket->enableCrypto('tls', 'client'));
 		$this->Socket->disconnect();
 	}

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -350,6 +350,18 @@ class CakeSocketTest extends CakeTestCase {
 	}
 
 /**
+ * testEnableCryptoSelfSigned
+ *
+ * @return void
+ */
+	public function testEnableCryptoSelfSigned() {
+		$this->_connectSocketToSslTls();
+		$this->assertTrue($this->Socket->enableSelfSigned());
+		$this->assertTrue($this->Socket->enableCrypto('tls', 'client'));
+		$this->Socket->disconnect();
+	}
+
+/**
  * test getting the context for a socket.
  *
  * @return void

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -946,7 +946,8 @@ class CakeEmailTest extends CakeTestCase {
 			'username' => null,
 			'password' => null,
 			'client' => null,
-			'tls' => false
+			'tls' => false,
+			'selfSigned' => false
 		);
 		$this->assertEquals($expected, $this->CakeEmail->transportClass()->config());
 

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -947,7 +947,7 @@ class CakeEmailTest extends CakeTestCase {
 			'password' => null,
 			'client' => null,
 			'tls' => false,
-			'selfSigned' => false
+			'ssl_allow_self_signed' => false
 		);
 		$this->assertEquals($expected, $this->CakeEmail->transportClass()->config());
 


### PR DESCRIPTION
Add option to accept self signed certificates when connecting to smtp with CakeSocket.

Refs #6511 
