### PR TITLE
Fix constraints in fixtures

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -528,6 +528,17 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Returns whether the driver supports adding or dropping constraints
+     * to already created tables.
+     *
+     * @return bool true if driver supports dynamic constraints
+     */
+    public function supportsDynamicConstraints()
+    {
+        return $this->_driver->supportsDynamicConstraints();
+    }
+
+    /**
      * {@inheritDoc}
      *
      * ### Example:

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -166,6 +166,14 @@ abstract class Driver
     abstract public function enableForeignKeySQL();
 
     /**
+     * Returns whether the driver supports adding or dropping constraints
+     * to already created tables.
+     *
+     * @return bool true if driver supports dynamic constraints
+     */
+    abstract public function supportsDynamicConstraints();
+
+    /**
      * Returns whether this driver supports save points for nested transactions
      *
      * @return bool true if save points are supported, false otherwise

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -125,4 +125,12 @@ class Mysql extends Driver
         }
         return $result;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsDynamicConstraints()
+    {
+        return true;
+    }
 }

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -118,4 +118,12 @@ class Postgres extends Driver
         $this->connect();
         $this->_connection->exec('SET search_path TO ' . $this->_connection->quote($schema));
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsDynamicConstraints()
+    {
+        return true;
+    }
 }

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -96,4 +96,12 @@ class Sqlite extends Driver
         }
         return $result;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsDynamicConstraints()
+    {
+        return false;
+    }
 }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -111,4 +111,12 @@ class Sqlserver extends Driver
         $statement = $this->_connection->prepare($isObject ? $query->sql() : $query, $options);
         return new SqlserverStatement($statement, $this);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsDynamicConstraints()
+    {
+        return true;
+    }
 }

--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -231,6 +231,22 @@ abstract class BaseSchema
     abstract public function columnSql(Table $table, $name);
 
     /**
+     * Generate the SQL queries needed to add foreign key constraints to the table
+     *
+     * @param \Cake\Database\Schema\Table $table The table instance the foreign key constraints are.
+     * @return array SQL fragment.
+     */
+    abstract public function addConstraintSql(Table $table);
+
+    /**
+     * Generate the SQL queries needed to drop foreign key constraints from the table
+     *
+     * @param \Cake\Database\Schema\Table $table The table instance the foreign key constraints are.
+     * @return array SQL fragment.
+     */
+    abstract public function dropConstraintSql(Table $table);
+
+    /**
      * Generate the SQL fragments for defining table constraints.
      *
      * @param \Cake\Database\Schema\Table $table The table instance the column is in.

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -394,13 +394,14 @@ class MysqlSchema extends BaseSchema
      */
     public function addConstraintSql(Table $table)
     {
-        $sqlPattern = 'ALTER TABLE %s ADD %s';
+        $sqlPattern = 'ALTER TABLE %s ADD %s;';
         $sql = [];
 
         foreach ($table->constraints() as $name) {
             $constraint = $table->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $sql[] = sprintf($sqlPattern, $table->name(), $this->constraintSql($table, $name));
+                $tableName = $this->_driver->quoteIdentifier($table->name());
+                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($table, $name));
             }
         }
 
@@ -412,13 +413,15 @@ class MysqlSchema extends BaseSchema
      */
     public function dropConstraintSql(Table $table)
     {
-        $sqlPattern = 'ALTER TABLE %s DROP FOREIGN KEY %s';
+        $sqlPattern = 'ALTER TABLE %s DROP FOREIGN KEY %s;';
         $sql = [];
 
         foreach ($table->constraints() as $name) {
             $constraint = $table->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $sql[] = sprintf($sqlPattern, $table->name(), $name);
+                $tableName = $this->_driver->quoteIdentifier($table->name());
+                $constraintName = $this->_driver->quoteIdentifier($name);
+                $sql[] = sprintf($sqlPattern, $tableName, $constraintName);
             }
         }
 

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -389,6 +389,36 @@ class MysqlSchema extends BaseSchema
         return $this->_keySql($out, $data);
     }
 
+    public function addConstraintSql(Table $table)
+    {
+        $sqlPattern = 'ALTER TABLE %s ADD %s';
+        $sql = [];
+
+        foreach ($table->constraints() as $name) {
+            $constraint = $table->constraint($name);
+            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
+                $sql[] = sprintf($sqlPattern, $table->name(), $this->constraintSql($table, $name));
+            }
+        }
+
+        return $sql;
+    }
+
+    public function dropConstraintSql(Table $table)
+    {
+        $sqlPattern = 'ALTER TABLE %s DROP FOREIGN KEY %s';
+        $sql = [];
+
+        foreach ($table->constraints() as $name) {
+            $constraint = $table->constraint($name);
+            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
+                $sql[] = sprintf($sqlPattern, $table->name(), $name);
+            }
+        }
+
+        return $sql;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -389,6 +389,9 @@ class MysqlSchema extends BaseSchema
         return $this->_keySql($out, $data);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function addConstraintSql(Table $table)
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s';
@@ -404,6 +407,9 @@ class MysqlSchema extends BaseSchema
         return $sql;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function dropConstraintSql(Table $table)
     {
         $sqlPattern = 'ALTER TABLE %s DROP FOREIGN KEY %s';

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -417,6 +417,37 @@ class PostgresSchema extends BaseSchema
         return $out;
     }
 
+
+    public function addConstraintSql(Table $table)
+    {
+        $sqlPattern = 'ALTER TABLE %s ADD %s';
+        $sql = [];
+
+        foreach ($table->constraints() as $name) {
+            $constraint = $table->constraint($name);
+            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
+                $sql[] = sprintf($sqlPattern, $table->name(), $this->constraintSql($table, $name));
+            }
+        }
+
+        return $sql;
+    }
+
+    public function dropConstraintSql(Table $table)
+    {
+        $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s';
+        $sql = [];
+
+        foreach ($table->constraints() as $name) {
+            $constraint = $table->constraint($name);
+            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
+                $sql[] = sprintf($sqlPattern, $table->name(), $name);
+            }
+        }
+
+        return $sql;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -422,13 +422,14 @@ class PostgresSchema extends BaseSchema
      */
     public function addConstraintSql(Table $table)
     {
-        $sqlPattern = 'ALTER TABLE %s ADD %s';
+        $sqlPattern = 'ALTER TABLE %s ADD %s;';
         $sql = [];
 
         foreach ($table->constraints() as $name) {
             $constraint = $table->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $sql[] = sprintf($sqlPattern, $table->name(), $this->constraintSql($table, $name));
+                $tableName = $this->_driver->quoteIdentifier($table->name());
+                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($table, $name));
             }
         }
 
@@ -440,13 +441,15 @@ class PostgresSchema extends BaseSchema
      */
     public function dropConstraintSql(Table $table)
     {
-        $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s';
+        $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s;';
         $sql = [];
 
         foreach ($table->constraints() as $name) {
             $constraint = $table->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $sql[] = sprintf($sqlPattern, $table->name(), $name);
+                $tableName = $this->_driver->quoteIdentifier($table->name());
+                $constraintName = $this->_driver->quoteIdentifier($name);
+                $sql[] = sprintf($sqlPattern, $tableName, $constraintName);
             }
         }
 

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -417,7 +417,9 @@ class PostgresSchema extends BaseSchema
         return $out;
     }
 
-
+    /**
+     * {@inheritDoc}
+     */
     public function addConstraintSql(Table $table)
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s';
@@ -433,6 +435,9 @@ class PostgresSchema extends BaseSchema
         return $sql;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function dropConstraintSql(Table $table)
     {
         $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s';

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -355,6 +355,100 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
+    public function addConstraintSql(Table $table)
+    {
+        $tmpTableName = $this->_driver->quoteIdentifier('tmp_' . $table->name());
+        $tableName = $this->_driver->quoteIdentifier($table->name());
+
+        $columns = $indexes = $constraints = [];
+        foreach ($table->columns() as $column) {
+            $columns[] = $this->columnSql($table, $column);
+        }
+
+        foreach ($table->constraints() as $constraint) {
+            $constraints[] = $this->constraintSql($table, $constraint);
+        }
+
+        foreach ($table->indexes() as $index) {
+            $indexes[] = $this->indexSql($table, $index);
+        }
+        $createSql = $this->createTableSql($table, $columns, $constraints, $indexes);
+
+        $columnsList = implode(', ', $table->columns());
+        $copySql = sprintf(
+            'INSERT INTO %s(%s) SELECT %s FROM %s',
+            $tableName,
+            $columnsList,
+            $columnsList,
+            $tmpTableName
+        );
+
+        $dropSql = sprintf('DROP TABLE IF EXISTS %s', $tmpTableName);
+
+        $sql = [
+            $dropSql,
+            sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName),
+            $createSql[0],
+            $copySql,
+            $dropSql
+        ];
+
+        return $sql;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function dropConstraintSql(Table $table)
+    {
+        $tmpTableName = $this->_driver->quoteIdentifier('tmp_' . $table->name());
+        $tableName = $this->_driver->quoteIdentifier($table->name());
+
+        $columns = [];
+        foreach ($table->columns() as $column) {
+            $columns[$column] = $this->columnSql($table, $column);
+        }
+
+        $indexes = [];
+        foreach ($table->indexes() as $index) {
+            $indexes[$index] = $this->indexSql($table, $index);
+        }
+
+        $constraints = [];
+        foreach ($table->constraints() as $constraint) {
+            $constraintDefinition = $table->constraint($constraint);
+            if ($constraintDefinition['type'] == Table::CONSTRAINT_FOREIGN) {
+                $table->dropConstraint($constraint);
+            } else {
+                $constraints[$constraint] = $this->constraintSql($table, $constraint);
+            }
+        }
+        $createSql = $this->createTableSql($table, $columns, $constraints, $indexes);
+
+        $columnsList = implode(', ', $table->columns());
+        $copySql = sprintf(
+            'INSERT INTO %s(%s) SELECT %s FROM %s',
+            $tableName,
+            $columnsList,
+            $columnsList,
+            $tmpTableName
+        );
+
+        $dropSql = sprintf('DROP TABLE IF EXISTS %s', $tmpTableName);
+        $sql = [
+            $dropSql,
+            sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName),
+            $createSql[0],
+            $copySql,
+            $dropSql
+        ];
+
+        return $sql;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function indexSql(Table $table, $name)
     {
         $data = $table->index($name);

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -14,7 +14,9 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Core\Configure;
 use Cake\Database\Exception;
+use RuntimeException;
 
 /**
  * Schema management/reflection features for Sqlite
@@ -354,96 +356,24 @@ class SqliteSchema extends BaseSchema
 
     /**
      * {@inheritDoc}
+     *
+     * SQLite can not properly handle adding a constraint to an existing table.
+     * This method is no-op
      */
     public function addConstraintSql(Table $table)
     {
-        $tmpTableName = $this->_driver->quoteIdentifier('tmp_' . $table->name());
-        $tableName = $this->_driver->quoteIdentifier($table->name());
-
-        $columns = $indexes = $constraints = [];
-        foreach ($table->columns() as $column) {
-            $columns[] = $this->columnSql($table, $column);
-        }
-
-        foreach ($table->constraints() as $constraint) {
-            $constraints[] = $this->constraintSql($table, $constraint);
-        }
-
-        foreach ($table->indexes() as $index) {
-            $indexes[] = $this->indexSql($table, $index);
-        }
-        $createSql = $this->createTableSql($table, $columns, $constraints, $indexes);
-
-        $columnsList = implode(', ', $table->columns());
-        $copySql = sprintf(
-            'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $tableName,
-            $columnsList,
-            $columnsList,
-            $tmpTableName
-        );
-
-        $dropSql = sprintf('DROP TABLE IF EXISTS %s', $tmpTableName);
-
-        $sql = [
-            $dropSql,
-            sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName),
-            $createSql[0],
-            $copySql,
-            $dropSql
-        ];
-
-        return $sql;
+        return [];
     }
 
     /**
      * {@inheritDoc}
+     *
+     * SQLite can not properly handle dropping a constraint to an existing table.
+     * This method is no-op
      */
     public function dropConstraintSql(Table $table)
     {
-        $tmpTableName = $this->_driver->quoteIdentifier('tmp_' . $table->name());
-        $tableName = $this->_driver->quoteIdentifier($table->name());
-
-        $columns = [];
-        foreach ($table->columns() as $column) {
-            $columns[$column] = $this->columnSql($table, $column);
-        }
-
-        $indexes = [];
-        foreach ($table->indexes() as $index) {
-            $indexes[$index] = $this->indexSql($table, $index);
-        }
-
-        $constraints = [];
-        foreach ($table->constraints() as $constraint) {
-            $constraintDefinition = $table->constraint($constraint);
-            if ($constraintDefinition['type'] == Table::CONSTRAINT_FOREIGN) {
-                $table->dropConstraint($constraint);
-            } else {
-                $constraints[$constraint] = $this->constraintSql($table, $constraint);
-            }
-        }
-        $createSql = $this->createTableSql($table, $columns, $constraints, $indexes);
-
-        $columnsList = implode(', ', $table->columns());
-        $copySql = sprintf(
-            'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $tableName,
-            $columnsList,
-            $columnsList,
-            $tmpTableName
-        );
-
-        $dropSql = sprintf('DROP TABLE IF EXISTS %s', $tmpTableName);
-        $sql = [
-            $dropSql,
-            sprintf('ALTER TABLE %s RENAME TO %s', $tableName, $tmpTableName),
-            $createSql[0],
-            $copySql,
-            $dropSql
-        ];
-
-        return $sql;
+        return [];
     }
 
     /**

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -365,6 +365,9 @@ class SqlserverSchema extends BaseSchema
         return $out;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function addConstraintSql(Table $table)
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s';
@@ -380,6 +383,9 @@ class SqlserverSchema extends BaseSchema
         return $sql;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function dropConstraintSql(Table $table)
     {
         $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s';

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -365,6 +365,36 @@ class SqlserverSchema extends BaseSchema
         return $out;
     }
 
+    public function addConstraintSql(Table $table)
+    {
+        $sqlPattern = 'ALTER TABLE %s ADD %s';
+        $sql = [];
+
+        foreach ($table->constraints() as $name) {
+            $constraint = $table->constraint($name);
+            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
+                $sql[] = sprintf($sqlPattern, $table->name(), $this->constraintSql($table, $name));
+            }
+        }
+
+        return $sql;
+    }
+
+    public function dropConstraintSql(Table $table)
+    {
+        $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s';
+        $sql = [];
+
+        foreach ($table->constraints() as $name) {
+            $constraint = $table->constraint($name);
+            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
+                $sql[] = sprintf($sqlPattern, $table->name(), $name);
+            }
+        }
+
+        return $sql;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -370,13 +370,14 @@ class SqlserverSchema extends BaseSchema
      */
     public function addConstraintSql(Table $table)
     {
-        $sqlPattern = 'ALTER TABLE %s ADD %s';
+        $sqlPattern = 'ALTER TABLE %s ADD %s;';
         $sql = [];
 
         foreach ($table->constraints() as $name) {
             $constraint = $table->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $sql[] = sprintf($sqlPattern, $table->name(), $this->constraintSql($table, $name));
+                $tableName = $this->_driver->quoteIdentifier($table->name());
+                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($table, $name));
             }
         }
 
@@ -388,13 +389,15 @@ class SqlserverSchema extends BaseSchema
      */
     public function dropConstraintSql(Table $table)
     {
-        $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s';
+        $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s;';
         $sql = [];
 
         foreach ($table->constraints() as $name) {
             $constraint = $table->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $sql[] = sprintf($sqlPattern, $table->name(), $name);
+                $tableName = $this->_driver->quoteIdentifier($table->name());
+                $constraintName = $this->_driver->quoteIdentifier($name);
+                $sql[] = sprintf($sqlPattern, $tableName, $constraintName);
             }
         }
 

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -718,13 +718,25 @@ class Table
         return $dialect->truncateTableSql($this);
     }
 
-    public function addConstraintSql(Connection $connection)
+    /**
+     * Generate the SQL statements to add the constraints to the table
+     *
+     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @return array SQL to drop a table.
+     */
+    public function addConstraintSql(ConnectionInterface $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
         return $dialect->addConstraintSql($this);
     }
 
-    public function dropConstraintSql(Connection $connection)
+    /**
+     * Generate the SQL statements to drop the constraints to the table
+     *
+     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @return array SQL to drop a table.
+     */
+    public function dropConstraintSql(ConnectionInterface $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
         return $dialect->dropConstraintSql($this);

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -565,6 +565,13 @@ class Table
         return $this;
     }
 
+    public function dropConstraint($name)
+    {
+        if (isset($this->_constraints[$name])) {
+            unset($this->_constraints[$name]);
+        }
+    }
+
     /**
      * Check whether or not a table has an autoIncrement column defined.
      *
@@ -709,5 +716,17 @@ class Table
     {
         $dialect = $connection->driver()->schemaDialect();
         return $dialect->truncateTableSql($this);
+    }
+
+    public function addConstraintSql(Connection $connection)
+    {
+        $dialect = $connection->driver()->schemaDialect();
+        return $dialect->addConstraintSql($this);
+    }
+
+    public function dropConstraintSql(Connection $connection)
+    {
+        $dialect = $connection->driver()->schemaDialect();
+        return $dialect->dropConstraintSql($this);
     }
 }

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -565,6 +565,12 @@ class Table
         return $this;
     }
 
+    /**
+     * Remove a constraint.
+     *
+     * @param string $name Name of the constraint to remove
+     * @return void
+     */
     public function dropConstraint($name)
     {
         if (isset($this->_constraints[$name])) {

--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -46,6 +46,24 @@ interface FixtureInterface
     public function insert(ConnectionInterface $db);
 
     /**
+     * Build and execute SQL queries necessary to create the constraints for the
+     * fixture
+     *
+     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database into which the constraints will be created
+     * @return bool on success or if there are no constraints to create, or false on failure
+     */
+    public function createConstraints(ConnectionInterface $db);
+
+    /**
+     * Build and execute SQL queries necessary to drop the constraints for the
+     * fixture
+     *
+     * @param \Cake\Datasource\ConnectionInterface $db An instance of the database into which the constraints will be dropped
+     * @return bool on success or if there are no constraints to drop, or false on failure
+     */
+    public function dropConstraints(ConnectionInterface $db);
+
+    /**
      * Truncates the current fixture.
      *
      * @param \Cake\Datasource\ConnectionInterface $db A reference to a db instance

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -344,6 +344,13 @@ class FixtureManager
         }
         $truncate = function ($db, $fixtures) {
             $configName = $db->configName();
+
+            foreach ($fixtures as $name => $fixture) {
+                if ($this->isFixtureSetup($configName, $fixture)) {
+                    $fixture->dropConstraints($db);
+                }
+            }
+
             foreach ($fixtures as $fixture) {
                 if ($this->isFixtureSetup($configName, $fixture)) {
                     $fixture->truncate($db);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -377,19 +377,17 @@ class FixtureManager
                 $db = ConnectionManager::get($fixture->connection());
             }
 
-            $fixture->dropConstraints($db);
-
             if (!$this->isFixtureSetup($db->configName(), $fixture)) {
                 $sources = $db->schemaCollection()->listTables();
                 $this->_setupTable($fixture, $db, $sources, $dropTables);
             }
 
-            $fixture->createConstraints($db);
-
             if (!$dropTables) {
                 $fixture->dropConstraints($db);
                 $fixture->truncate($db);
             }
+
+            $fixture->createConstraints($db);
             $fixture->insert($db);
         } else {
             throw new UnexpectedValueException(sprintf('Referenced fixture class %s not found', $name));

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -246,7 +246,6 @@ class FixtureManager
 
         try {
             $createTables = function ($db, $fixtures) use ($test) {
-                $db->enableForeignKeys();
                 $tables = $db->schemaCollection()->listTables();
                 $configName = $db->configName();
                 if (!isset($this->_insertionMap[$configName])) {
@@ -377,11 +376,17 @@ class FixtureManager
                 $db = ConnectionManager::get($fixture->connection());
             }
 
+            $fixture->dropConstraints($db);
+
             if (!$this->isFixtureSetup($db->configName(), $fixture)) {
                 $sources = $db->schemaCollection()->listTables();
                 $this->_setupTable($fixture, $db, $sources, $dropTables);
             }
+
+            $fixture->createConstraints($db);
+
             if (!$dropTables) {
+                $fixture->dropConstraints($db);
                 $fixture->truncate($db);
             }
             $fixture->insert($db);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -221,9 +221,10 @@ class FixtureManager
         } elseif (!$exists) {
             $fixture->create($db);
         } else {
-            $this->_insertionMap[$configName][] = $fixture;
             $fixture->truncate($db);
         }
+
+        $this->_insertionMap[$configName][] = $fixture;
     }
 
     /**

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -315,13 +315,10 @@ class TestFixture implements FixtureInterface
             return true;
         }
 
-        try {
-            foreach ($sql as $stmt) {
-                $db->execute($stmt)->closeCursor();
-            }
-        } catch (\Exception $e) {
-            return false;
+        foreach ($sql as $stmt) {
+            $db->execute($stmt)->closeCursor();
         }
+
         return true;
     }
 
@@ -340,13 +337,8 @@ class TestFixture implements FixtureInterface
             return true;
         }
 
-        try {
-            foreach ($sql as $stmt) {
-                $db->execute($stmt)->closeCursor();
-            }
-        } catch (\Exception $e) {
-            debug($e);
-            return false;
+        foreach ($sql as $stmt) {
+            $db->execute($stmt)->closeCursor();
         }
 
         foreach ($this->_constraints as $name => $data) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -166,7 +166,7 @@ class TestFixture implements FixtureInterface
         }
         if (!empty($this->fields['_constraints'])) {
             foreach ($this->fields['_constraints'] as $name => $data) {
-                if ($data['type'] !== 'foreign') {
+                if ($data['type'] !== Table::CONSTRAINT_FOREIGN) {
                     $this->_schema->addConstraint($name, $data);
                 } else {
                     $this->constraints[$name] = $data;

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -346,6 +346,7 @@ class TestFixture implements FixtureInterface
                 $db->execute($stmt)->closeCursor();
             }
         } catch (\Exception $e) {
+            debug($e);
             return false;
         }
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -14,6 +14,7 @@
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\Exception as CakeException;
+use Cake\Database\Driver\Sqlite;
 use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
@@ -157,6 +158,7 @@ class TestFixture implements FixtureInterface
      */
     protected function _schemaFromFields()
     {
+        $connection = ConnectionManager::get($this->connection());
         $this->_schema = new Table($this->table);
         foreach ($this->fields as $field => $data) {
             if ($field === '_constraints' || $field === '_indexes' || $field === '_options') {
@@ -166,7 +168,7 @@ class TestFixture implements FixtureInterface
         }
         if (!empty($this->fields['_constraints'])) {
             foreach ($this->fields['_constraints'] as $name => $data) {
-                if ($data['type'] !== Table::CONSTRAINT_FOREIGN) {
+                if (!$connection->supportsDynamicConstraints() || $data['type'] !== Table::CONSTRAINT_FOREIGN) {
                     $this->_schema->addConstraint($name, $data);
                 } else {
                     $this->_constraints[$name] = $data;
@@ -313,7 +315,6 @@ class TestFixture implements FixtureInterface
             return true;
         }
 
-        $db->disableForeignKeys();
         try {
             foreach ($sql as $stmt) {
                 $db->execute($stmt)->closeCursor();
@@ -339,7 +340,6 @@ class TestFixture implements FixtureInterface
             return true;
         }
 
-        $db->disableForeignKeys();
         try {
             foreach ($sql as $stmt) {
                 $db->execute($stmt)->closeCursor();

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -14,7 +14,6 @@
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\Exception as CakeException;
-use Cake\Database\Connection;
 use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
@@ -315,6 +314,7 @@ class TestFixture implements FixtureInterface
             return true;
         }
 
+        $db->disableForeignKeys();
         try {
             foreach ($sql as $stmt) {
                 $db->execute($stmt)->closeCursor();
@@ -340,6 +340,7 @@ class TestFixture implements FixtureInterface
             return true;
         }
 
+        $db->disableForeignKeys();
         try {
             foreach ($sql as $stmt) {
                 $db->execute($stmt)->closeCursor();

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -84,7 +84,7 @@ class TestFixture implements FixtureInterface
      *
      * @var array
      */
-    public $constraints = [];
+    protected $_constraints = [];
 
     /**
      * Instantiate the fixture.
@@ -169,7 +169,7 @@ class TestFixture implements FixtureInterface
                 if ($data['type'] !== Table::CONSTRAINT_FOREIGN) {
                     $this->_schema->addConstraint($name, $data);
                 } else {
-                    $this->constraints[$name] = $data;
+                    $this->_constraints[$name] = $data;
                 }
             }
         }
@@ -240,7 +240,6 @@ class TestFixture implements FixtureInterface
             foreach ($queries as $query) {
                 $db->execute($query)->closeCursor();
             }
-            $this->created[] = $db->configName();
         } catch (Exception $e) {
             $msg = sprintf(
                 'Fixture creation for "%s" failed "%s"',
@@ -300,11 +299,11 @@ class TestFixture implements FixtureInterface
      */
     public function createConstraints(ConnectionInterface $db)
     {
-        if (empty($this->constraints)) {
+        if (empty($this->_constraints)) {
             return true;
         }
 
-        foreach ($this->constraints as $name => $data) {
+        foreach ($this->_constraints as $name => $data) {
             $this->_schema->addConstraint($name, $data);
         }
 
@@ -330,7 +329,7 @@ class TestFixture implements FixtureInterface
      */
     public function dropConstraints(ConnectionInterface $db)
     {
-        if (empty($this->constraints)) {
+        if (empty($this->_constraints)) {
             return true;
         }
 
@@ -350,7 +349,7 @@ class TestFixture implements FixtureInterface
             return false;
         }
 
-        foreach ($this->constraints as $name => $data) {
+        foreach ($this->_constraints as $name => $data) {
             $this->_schema->dropConstraint($name);
         }
         return true;

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -297,13 +297,9 @@ class TestFixture implements FixtureInterface
     }
 
     /**
-     * Build and execute SQL queries necessary to create the constraints for the
-     * fixture
-     *
-     * @param \Cake\Database\Connection $db An instance of the database into which the constraints will be created
-     * @return bool on success or if there are no constraints to create, or false on failure
+     * {@inheritDoc}
      */
-    public function createConstraints(Connection $db)
+    public function createConstraints(ConnectionInterface $db)
     {
         if (empty($this->constraints)) {
             return true;
@@ -330,13 +326,9 @@ class TestFixture implements FixtureInterface
     }
 
     /**
-     * Build and execute SQL queries necessary to drop the constraints for the
-     * fixture
-     *
-     * @param \Cake\Database\Connection $db An instance of the database into which the constraints will be dropped
-     * @return bool on success or if there are no constraints to drop, or false on failure
+     * {@inheritDoc}
      */
-    public function dropConstraints(Connection $db)
+    public function dropConstraints(ConnectionInterface $db)
     {
         if (empty($this->constraints)) {
             return true;

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -47,7 +47,7 @@ class OrdersFixture extends TestFixture
             'primary' => [
                 'type' => 'primary', 'columns' => ['id']
             ],
-            'product_id_fk' => [
+            'product_category_fk' => [
                 'type' => 'foreign',
                 'columns' => ['product_category', 'product_id'],
                 'references' => ['products', ['category', 'id']],

--- a/tests/Fixture/OrdersFixture.php
+++ b/tests/Fixture/OrdersFixture.php
@@ -49,8 +49,8 @@ class OrdersFixture extends TestFixture
             ],
             'product_id_fk' => [
                 'type' => 'foreign',
-                'columns' => ['product_id', 'product_category'],
-                'references' => ['products', ['id', 'category']],
+                'columns' => ['product_category', 'product_id'],
+                'references' => ['products', ['category', 'id']],
                 'update' => 'cascade',
                 'delete' => 'cascade',
             ]

--- a/tests/Fixture/ProductsFixture.php
+++ b/tests/Fixture/ProductsFixture.php
@@ -37,7 +37,7 @@ class ProductsFixture extends TestFixture
         'category' => ['type' => 'integer', 'null' => false],
         'name' => ['type' => 'string', 'null' => false],
         'price' => ['type' => 'integer'],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'category']]]
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['category', 'id']]]
     ];
 
     /**

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -35,7 +35,7 @@ class BasicAuthenticateTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users', 'core.auth_users'];
+    public $fixtures = ['core.auth_users', 'core.users'];
 
     /**
      * setup

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -36,7 +36,7 @@ class DigestAuthenticateTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users', 'core.auth_users'];
+    public $fixtures = ['core.auth_users', 'core.users'];
 
     /**
      * setup

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -38,7 +38,7 @@ class FormAuthenticateTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users', 'core.auth_users'];
+    public $fixtures = ['core.auth_users', 'core.users'];
 
     /**
      * setup

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -128,13 +128,13 @@ class ShellTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.posts',
-        'core.comments',
         'core.articles',
-        'core.users',
-        'core.tags',
         'core.articles_tags',
-        'core.attachments'
+        'core.attachments',
+        'core.comments',
+        'core.posts',
+        'core.tags',
+        'core.users'
     ];
 
     /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -52,7 +52,7 @@ class AuthComponentTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users', 'core.auth_users'];
+    public $fixtures = ['core.auth_users', 'core.users'];
 
     /**
      * setUp method

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -239,8 +239,8 @@ class ControllerTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.posts',
-        'core.comments'
+        'core.comments',
+        'core.posts'
     ];
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -713,6 +713,120 @@ SQL;
     }
 
     /**
+     * Test the addConstraintSql method.
+     *
+     * @return void
+     */
+    public function testAddConstraintSql()
+    {
+        $driver = $this->_getMockedDriver();
+        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection->expects($this->any())->method('driver')
+            ->will($this->returnValue($driver));
+
+        $table = (new Table('posts'))
+            ->addColumn('author_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_name', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addConstraint('author_fk', [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE `posts` ADD CONSTRAINT `author_fk` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
+SQL;
+        $result = $table->addConstraintSql($connection);
+        $this->assertCount(1, $result);
+        $this->assertTextEquals($expected, $result[0]);
+
+        $table
+            ->addConstraint('category_fk', [
+                'type' => 'foreign',
+                'columns' => ['category_id', 'category_name'],
+                'references' => ['categories', ['id', 'name']],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE `posts` ADD CONSTRAINT `category_fk` FOREIGN KEY (`category_id`, `category_name`) REFERENCES `categories` (`id`, `name`) ON UPDATE CASCADE ON DELETE CASCADE;
+SQL;
+        $result = $table->addConstraintSql($connection);
+        $this->assertCount(2, $result);
+        $this->assertTextEquals($expected, $result[1]);
+    }
+
+    /**
+     * Test the dropConstraintSql method.
+     *
+     * @return void
+     */
+    public function testDropConstraintSql()
+    {
+        $driver = $this->_getMockedDriver();
+        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection->expects($this->any())->method('driver')
+            ->will($this->returnValue($driver));
+
+        $table = (new Table('posts'))
+            ->addColumn('author_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_name', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addConstraint('author_fk', [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE `posts` DROP FOREIGN KEY `author_fk`;
+SQL;
+        $result = $table->dropConstraintSql($connection);
+        $this->assertCount(1, $result);
+        $this->assertTextEquals($expected, $result[0]);
+
+        $table
+            ->addConstraint('category_fk', [
+                'type' => 'foreign',
+                'columns' => ['category_id', 'category_name'],
+                'references' => ['categories', ['id', 'name']],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE `posts` DROP FOREIGN KEY `category_fk`;
+SQL;
+        $result = $table->dropConstraintSql($connection);
+        $this->assertCount(2, $result);
+        $this->assertTextEquals($expected, $result[1]);
+    }
+
+    /**
      * Test generating a column that is a primary key.
      *
      * @return void

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -743,16 +743,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = <<<SQL
-ALTER TABLE `posts` ADD CONSTRAINT `author_fk` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;
-SQL;
-        $result = $table->addConstraintSql($connection);
-        $this->assertCount(1, $result);
-        $this->assertTextEquals($expected, $result[0]);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -761,12 +752,13 @@ SQL;
                 'delete' => 'cascade'
             ]);
 
-        $expected = <<<SQL
-ALTER TABLE `posts` ADD CONSTRAINT `category_fk` FOREIGN KEY (`category_id`, `category_name`) REFERENCES `categories` (`id`, `name`) ON UPDATE CASCADE ON DELETE CASCADE;
-SQL;
+        $expected = [
+            'ALTER TABLE `posts` ADD CONSTRAINT `author_fk` FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;',
+            'ALTER TABLE `posts` ADD CONSTRAINT `category_fk` FOREIGN KEY (`category_id`, `category_name`) REFERENCES `categories` (`id`, `name`) ON UPDATE CASCADE ON DELETE CASCADE;'
+        ];
         $result = $table->addConstraintSql($connection);
         $this->assertCount(2, $result);
-        $this->assertTextEquals($expected, $result[1]);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -800,16 +792,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = <<<SQL
-ALTER TABLE `posts` DROP FOREIGN KEY `author_fk`;
-SQL;
-        $result = $table->dropConstraintSql($connection);
-        $this->assertCount(1, $result);
-        $this->assertTextEquals($expected, $result[0]);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -818,12 +801,13 @@ SQL;
                 'delete' => 'cascade'
             ]);
 
-        $expected = <<<SQL
-ALTER TABLE `posts` DROP FOREIGN KEY `category_fk`;
-SQL;
+        $expected = [
+            'ALTER TABLE `posts` DROP FOREIGN KEY `author_fk`;',
+            'ALTER TABLE `posts` DROP FOREIGN KEY `category_fk`;'
+        ];
         $result = $table->dropConstraintSql($connection);
         $this->assertCount(2, $result);
-        $this->assertTextEquals($expected, $result[1]);
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -796,6 +796,120 @@ SQL;
     }
 
     /**
+     * Test the addConstraintSql method.
+     *
+     * @return void
+     */
+    public function testAddConstraintSql()
+    {
+        $driver = $this->_getMockedDriver();
+        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection->expects($this->any())->method('driver')
+            ->will($this->returnValue($driver));
+
+        $table = (new Table('posts'))
+            ->addColumn('author_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_name', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addConstraint('author_fk', [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE "posts" ADD CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+SQL;
+        $result = $table->addConstraintSql($connection);
+        $this->assertCount(1, $result);
+        $this->assertTextEquals($expected, $result[0]);
+
+        $table
+            ->addConstraint('category_fk', [
+                'type' => 'foreign',
+                'columns' => ['category_id', 'category_name'],
+                'references' => ['categories', ['id', 'name']],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE "posts" ADD CONSTRAINT "category_fk" FOREIGN KEY ("category_id", "category_name") REFERENCES "categories" ("id", "name") ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+SQL;
+        $result = $table->addConstraintSql($connection);
+        $this->assertCount(2, $result);
+        $this->assertTextEquals($expected, $result[1]);
+    }
+
+    /**
+     * Test the dropConstraintSql method.
+     *
+     * @return void
+     */
+    public function testDropConstraintSql()
+    {
+        $driver = $this->_getMockedDriver();
+        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection->expects($this->any())->method('driver')
+            ->will($this->returnValue($driver));
+
+        $table = (new Table('posts'))
+            ->addColumn('author_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_name', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addConstraint('author_fk', [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE "posts" DROP CONSTRAINT "author_fk";
+SQL;
+        $result = $table->dropConstraintSql($connection);
+        $this->assertCount(1, $result);
+        $this->assertTextEquals($expected, $result[0]);
+
+        $table
+            ->addConstraint('category_fk', [
+                'type' => 'foreign',
+                'columns' => ['category_id', 'category_name'],
+                'references' => ['categories', ['id', 'name']],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE "posts" DROP CONSTRAINT "category_fk";
+SQL;
+        $result = $table->dropConstraintSql($connection);
+        $this->assertCount(2, $result);
+        $this->assertTextEquals($expected, $result[1]);
+    }
+
+    /**
      * Integration test for converting a Schema\Table into MySQL table creates.
      *
      * @return void

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -826,16 +826,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = <<<SQL
-ALTER TABLE "posts" ADD CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
-SQL;
-        $result = $table->addConstraintSql($connection);
-        $this->assertCount(1, $result);
-        $this->assertTextEquals($expected, $result[0]);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -844,12 +835,13 @@ SQL;
                 'delete' => 'cascade'
             ]);
 
-        $expected = <<<SQL
-ALTER TABLE "posts" ADD CONSTRAINT "category_fk" FOREIGN KEY ("category_id", "category_name") REFERENCES "categories" ("id", "name") ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
-SQL;
+        $expected = [
+            'ALTER TABLE "posts" ADD CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;',
+            'ALTER TABLE "posts" ADD CONSTRAINT "category_fk" FOREIGN KEY ("category_id", "category_name") REFERENCES "categories" ("id", "name") ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;'
+        ];
         $result = $table->addConstraintSql($connection);
         $this->assertCount(2, $result);
-        $this->assertTextEquals($expected, $result[1]);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -883,16 +875,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = <<<SQL
-ALTER TABLE "posts" DROP CONSTRAINT "author_fk";
-SQL;
-        $result = $table->dropConstraintSql($connection);
-        $this->assertCount(1, $result);
-        $this->assertTextEquals($expected, $result[0]);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -901,12 +884,13 @@ SQL;
                 'delete' => 'cascade'
             ]);
 
-        $expected = <<<SQL
-ALTER TABLE "posts" DROP CONSTRAINT "category_fk";
-SQL;
+        $expected = [
+            'ALTER TABLE "posts" DROP CONSTRAINT "author_fk";',
+            'ALTER TABLE "posts" DROP CONSTRAINT "category_fk";'
+        ];
         $result = $table->dropConstraintSql($connection);
         $this->assertCount(2, $result);
-        $this->assertTextEquals($expected, $result[1]);
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -575,25 +575,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = [
-            'DROP TABLE IF EXISTS "tmp_posts"',
-            'ALTER TABLE "posts" RENAME TO "tmp_posts"',
-            'CREATE TABLE "posts" (
-"author_id" INTEGER NOT NULL,
-"category_id" INTEGER NOT NULL,
-"category_name" INTEGER NOT NULL,
-CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE
-)',
-            'INSERT INTO "posts"(author_id, category_id, category_name) SELECT author_id, category_id, category_name FROM "tmp_posts"',
-            'DROP TABLE IF EXISTS "tmp_posts"'
-        ];
-        $result = $table->addConstraintSql($connection);
-        $this->assertCount(5, $result);
-        $this->assertTextEquals($expected, $result);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -651,24 +633,7 @@ CONSTRAINT "category_fk" FOREIGN KEY ("category_id", "category_name") REFERENCES
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = [
-            'DROP TABLE IF EXISTS "tmp_posts"',
-            'ALTER TABLE "posts" RENAME TO "tmp_posts"',
-            'CREATE TABLE "posts" (
-"author_id" INTEGER NOT NULL,
-"category_id" INTEGER NOT NULL,
-"category_name" INTEGER NOT NULL
-)',
-            'INSERT INTO "posts"(author_id, category_id, category_name) SELECT author_id, category_id, category_name FROM "tmp_posts"',
-            'DROP TABLE IF EXISTS "tmp_posts"'
-        ];
-        $result = $table->dropConstraintSql($connection);
-        $this->assertCount(5, $result);
-        $this->assertTextEquals($expected, $result);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -556,50 +556,10 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
-            ->addColumn('author_id', [
-                'type' => 'integer',
-                'null' => false
-            ])
-            ->addColumn('category_id', [
-                'type' => 'integer',
-                'null' => false
-            ])
-            ->addColumn('category_name', [
-                'type' => 'integer',
-                'null' => false
-            ])
-            ->addConstraint('author_fk', [
-                'type' => 'foreign',
-                'columns' => ['author_id'],
-                'references' => ['authors', 'id'],
-                'update' => 'cascade',
-                'delete' => 'cascade'
-            ])
-            ->addConstraint('category_fk', [
-                'type' => 'foreign',
-                'columns' => ['category_id', 'category_name'],
-                'references' => ['categories', ['id', 'name']],
-                'update' => 'cascade',
-                'delete' => 'cascade'
-            ]);
+        $table = new Table('posts');
 
-        $expected = [
-            'DROP TABLE IF EXISTS "tmp_posts"',
-            'ALTER TABLE "posts" RENAME TO "tmp_posts"',
-            'CREATE TABLE "posts" (
-"author_id" INTEGER NOT NULL,
-"category_id" INTEGER NOT NULL,
-"category_name" INTEGER NOT NULL,
-CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
-CONSTRAINT "category_fk" FOREIGN KEY ("category_id", "category_name") REFERENCES "categories" ("id", "name") ON UPDATE CASCADE ON DELETE CASCADE
-)',
-            'INSERT INTO "posts"(author_id, category_id, category_name) SELECT author_id, category_id, category_name FROM "tmp_posts"',
-            'DROP TABLE IF EXISTS "tmp_posts"'
-        ];
         $result = $table->addConstraintSql($connection);
-        $this->assertCount(5, $result);
-        $this->assertTextEquals($expected, $result);
+        $this->assertEmpty($result);
     }
 
     /**
@@ -614,48 +574,9 @@ CONSTRAINT "category_fk" FOREIGN KEY ("category_id", "category_name") REFERENCES
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
-            ->addColumn('author_id', [
-                'type' => 'integer',
-                'null' => false
-            ])
-            ->addColumn('category_id', [
-                'type' => 'integer',
-                'null' => false
-            ])
-            ->addColumn('category_name', [
-                'type' => 'integer',
-                'null' => false
-            ])
-            ->addConstraint('author_fk', [
-                'type' => 'foreign',
-                'columns' => ['author_id'],
-                'references' => ['authors', 'id'],
-                'update' => 'cascade',
-                'delete' => 'cascade'
-            ])
-            ->addConstraint('category_fk', [
-                'type' => 'foreign',
-                'columns' => ['category_id', 'category_name'],
-                'references' => ['categories', ['id', 'name']],
-                'update' => 'cascade',
-                'delete' => 'cascade'
-            ]);
-
-        $expected = [
-            'DROP TABLE IF EXISTS "tmp_posts"',
-            'ALTER TABLE "posts" RENAME TO "tmp_posts"',
-            'CREATE TABLE "posts" (
-"author_id" INTEGER NOT NULL,
-"category_id" INTEGER NOT NULL,
-"category_name" INTEGER NOT NULL
-)',
-            'INSERT INTO "posts"(author_id, category_id, category_name) SELECT author_id, category_id, category_name FROM "tmp_posts"',
-            'DROP TABLE IF EXISTS "tmp_posts"'
-        ];
+        $table = new Table('posts');
         $result = $table->dropConstraintSql($connection);
-        $this->assertCount(5, $result);
-        $this->assertTextEquals($expected, $result);
+        $this->assertEmpty($result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -655,6 +655,120 @@ SQL;
     }
 
     /**
+     * Test the addConstraintSql method.
+     *
+     * @return void
+     */
+    public function testAddConstraintSql()
+    {
+        $driver = $this->_getMockedDriver();
+        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection->expects($this->any())->method('driver')
+            ->will($this->returnValue($driver));
+
+        $table = (new Table('posts'))
+            ->addColumn('author_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_name', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addConstraint('author_fk', [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE [posts] ADD CONSTRAINT [author_fk] FOREIGN KEY ([author_id]) REFERENCES [authors] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;
+SQL;
+        $result = $table->addConstraintSql($connection);
+        $this->assertCount(1, $result);
+        $this->assertTextEquals($expected, $result[0]);
+
+        $table
+            ->addConstraint('category_fk', [
+                'type' => 'foreign',
+                'columns' => ['category_id', 'category_name'],
+                'references' => ['categories', ['id', 'name']],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE [posts] ADD CONSTRAINT [category_fk] FOREIGN KEY (]category_id], [category_name]) REFERENCES [categories] ([id], [name]) ON UPDATE CASCADE ON DELETE CASCADE;
+SQL;
+        $result = $table->addConstraintSql($connection);
+        $this->assertCount(2, $result);
+        $this->assertTextEquals($expected, $result[1]);
+    }
+
+    /**
+     * Test the dropConstraintSql method.
+     *
+     * @return void
+     */
+    public function testDropConstraintSql()
+    {
+        $driver = $this->_getMockedDriver();
+        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection->expects($this->any())->method('driver')
+            ->will($this->returnValue($driver));
+
+        $table = (new Table('posts'))
+            ->addColumn('author_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_id', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addColumn('category_name', [
+                'type' => 'integer',
+                'null' => false
+            ])
+            ->addConstraint('author_fk', [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['authors', 'id'],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE [posts] DROP FOREIGN KEY [author_fk];
+SQL;
+        $result = $table->dropConstraintSql($connection);
+        $this->assertCount(1, $result);
+        $this->assertTextEquals($expected, $result[0]);
+
+        $table
+            ->addConstraint('category_fk', [
+                'type' => 'foreign',
+                'columns' => ['category_id', 'category_name'],
+                'references' => ['categories', ['id', 'name']],
+                'update' => 'cascade',
+                'delete' => 'cascade'
+            ]);
+
+        $expected = <<<SQL
+ALTER TABLE [posts] DROP FOREIGN KEY [category_fk];
+SQL;
+        $result = $table->dropConstraintSql($connection);
+        $this->assertCount(2, $result);
+        $this->assertTextEquals($expected, $result[1]);
+    }
+
+    /**
      * Integration test for converting a Schema\Table into MySQL table creates.
      *
      * @return void

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -685,16 +685,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = <<<SQL
-ALTER TABLE [posts] ADD CONSTRAINT [author_fk] FOREIGN KEY ([author_id]) REFERENCES [authors] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;
-SQL;
-        $result = $table->addConstraintSql($connection);
-        $this->assertCount(1, $result);
-        $this->assertTextEquals($expected, $result[0]);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -703,12 +694,13 @@ SQL;
                 'delete' => 'cascade'
             ]);
 
-        $expected = <<<SQL
-ALTER TABLE [posts] ADD CONSTRAINT [category_fk] FOREIGN KEY ([category_id], [category_name]) REFERENCES [categories] ([id], [name]) ON UPDATE CASCADE ON DELETE CASCADE;
-SQL;
+        $expected = [
+            'ALTER TABLE [posts] ADD CONSTRAINT [author_fk] FOREIGN KEY ([author_id]) REFERENCES [authors] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;',
+            'ALTER TABLE [posts] ADD CONSTRAINT [category_fk] FOREIGN KEY ([category_id], [category_name]) REFERENCES [categories] ([id], [name]) ON UPDATE CASCADE ON DELETE CASCADE;'
+        ];
         $result = $table->addConstraintSql($connection);
         $this->assertCount(2, $result);
-        $this->assertTextEquals($expected, $result[1]);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -742,16 +734,7 @@ SQL;
                 'references' => ['authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'cascade'
-            ]);
-
-        $expected = <<<SQL
-ALTER TABLE [posts] DROP CONSTRAINT [author_fk];
-SQL;
-        $result = $table->dropConstraintSql($connection);
-        $this->assertCount(1, $result);
-        $this->assertTextEquals($expected, $result[0]);
-
-        $table
+            ])
             ->addConstraint('category_fk', [
                 'type' => 'foreign',
                 'columns' => ['category_id', 'category_name'],
@@ -760,12 +743,13 @@ SQL;
                 'delete' => 'cascade'
             ]);
 
-        $expected = <<<SQL
-ALTER TABLE [posts] DROP CONSTRAINT [category_fk];
-SQL;
+        $expected = [
+            'ALTER TABLE [posts] DROP CONSTRAINT [author_fk];',
+            'ALTER TABLE [posts] DROP CONSTRAINT [category_fk];'
+        ];
         $result = $table->dropConstraintSql($connection);
         $this->assertCount(2, $result);
-        $this->assertTextEquals($expected, $result[1]);
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -704,7 +704,7 @@ SQL;
             ]);
 
         $expected = <<<SQL
-ALTER TABLE [posts] ADD CONSTRAINT [category_fk] FOREIGN KEY (]category_id], [category_name]) REFERENCES [categories] ([id], [name]) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE [posts] ADD CONSTRAINT [category_fk] FOREIGN KEY ([category_id], [category_name]) REFERENCES [categories] ([id], [name]) ON UPDATE CASCADE ON DELETE CASCADE;
 SQL;
         $result = $table->addConstraintSql($connection);
         $this->assertCount(2, $result);
@@ -745,7 +745,7 @@ SQL;
             ]);
 
         $expected = <<<SQL
-ALTER TABLE [posts] DROP FOREIGN KEY [author_fk];
+ALTER TABLE [posts] DROP CONSTRAINT [author_fk];
 SQL;
         $result = $table->dropConstraintSql($connection);
         $this->assertCount(1, $result);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -761,7 +761,7 @@ SQL;
             ]);
 
         $expected = <<<SQL
-ALTER TABLE [posts] DROP FOREIGN KEY [category_fk];
+ALTER TABLE [posts] DROP CONSTRAINT [category_fk];
 SQL;
         $result = $table->dropConstraintSql($connection);
         $this->assertCount(2, $result);

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -39,7 +39,7 @@ class FooType extends Type
 class TableTest extends TestCase
 {
 
-    public $fixtures = ['core.articles_tags', 'core.products', 'core.orders', 'core.tags'];
+    public $fixtures = ['core.articles_tags', 'core.orders', 'core.products', 'core.tags'];
 
     protected $_map;
 

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -510,12 +510,12 @@ class TableTest extends TestCase
         $expected = [
             'type' => 'foreign',
             'columns' => [
-                'product_id',
-                'product_category'
+                'product_category',
+                'product_id'
             ],
             'references' => [
                 'products',
-                ['id', 'category']
+                ['category', 'id']
             ],
             'update' => 'cascade',
             'delete' => 'cascade',
@@ -524,8 +524,8 @@ class TableTest extends TestCase
 
         $this->assertEquals($expected, $compositeConstraint);
 
-        $expectedSubstring = 'CONSTRAINT <product_id_fk> FOREIGN KEY \(<product_id>, <product_category>\)' .
-            ' REFERENCES <products> \(<id>, <category>\)';
+        $expectedSubstring = 'CONSTRAINT <product_id_fk> FOREIGN KEY \(<product_category>, <product_id>\)' .
+            ' REFERENCES <products> \(<category>, <id>\)';
 
         $this->assertQuotedQuery($expectedSubstring, $table->schema()->createSql(ConnectionManager::get('test'))[0]);
     }

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -506,7 +506,7 @@ class TableTest extends TestCase
     public function testConstraintForeignKeyTwoColumns()
     {
         $table = TableRegistry::get('Orders');
-        $compositeConstraint = $table->schema()->constraint('product_id_fk');
+        $compositeConstraint = $table->schema()->constraint('product_category_fk');
         $expected = [
             'type' => 'foreign',
             'columns' => [
@@ -524,7 +524,7 @@ class TableTest extends TestCase
 
         $this->assertEquals($expected, $compositeConstraint);
 
-        $expectedSubstring = 'CONSTRAINT <product_id_fk> FOREIGN KEY \(<product_category>, <product_id>\)' .
+        $expectedSubstring = 'CONSTRAINT <product_category_fk> FOREIGN KEY \(<product_category>, <product_id>\)' .
             ' REFERENCES <products> \(<category>, <id>\)';
 
         $this->assertQuotedQuery($expectedSubstring, $table->schema()->createSql(ConnectionManager::get('test'))[0]);

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -63,7 +63,7 @@ class SessionTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.sessions', 'core.cake_sessions'];
+    public $fixtures = ['core.cake_sessions', 'core.sessions'];
 
     /**
      * setup before class.

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -36,7 +36,7 @@ class BelongsToTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.comments', 'core.authors'];
+    public $fixtures = ['core.articles', 'core.authors', 'core.comments'];
 
     /**
      * Don't autoload fixtures as most tests uses mocks.

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -39,8 +39,8 @@ class BehaviorRegressionTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.translates',
         'core.number_trees',
+        'core.translates'
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -48,9 +48,9 @@ class CounterCacheBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.counter_cache_users',
-        'core.counter_cache_posts',
         'core.counter_cache_categories',
+        'core.counter_cache_posts',
+        'core.counter_cache_users'
     ];
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -44,10 +44,10 @@ class TranslateBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.translates',
         'core.articles',
+        'core.authors',
         'core.comments',
-        'core.authors'
+        'core.translates'
     ];
 
     public function tearDown()

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -33,8 +33,8 @@ class TreeBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.number_trees',
-        'core.menu_link_trees'
+        'core.menu_link_trees',
+        'core.number_trees'
     ];
 
     public function setUp()

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -29,9 +29,9 @@ class BindingKeyTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.users',
         'core.auth_users',
-        'core.site_authors'
+        'core.site_authors',
+        'core.users'
     ];
 
     /**

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -47,9 +47,9 @@ class CompositeKeyTest extends TestCase
     public $fixtures = [
         'core.composite_increments',
         'core.site_articles',
+        'core.site_articles_tags',
         'core.site_authors',
-        'core.site_tags',
-        'core.site_articles_tags'
+        'core.site_tags'
     ];
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -98,12 +98,12 @@ class MarshallerTest extends TestCase
 {
 
     public $fixtures = [
-        'core.tags',
-        'core.articles_tags',
         'core.articles',
-        'core.users',
+        'core.articles_tags',
         'core.comments',
-        'core.special_tags'
+        'core.special_tags',
+        'core.tags',
+        'core.users'
     ];
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -34,17 +34,17 @@ class QueryRegressionTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'core.users',
         'core.articles',
-        'core.comments',
-        'core.tags',
         'core.articles_tags',
         'core.authors',
-        'core.special_tags',
-        'core.translates',
         'core.authors_tags',
+        'core.comments',
         'core.featured_tags',
+        'core.special_tags',
+        'core.tags',
         'core.tags_translations',
+        'core.translates',
+        'core.users'
     ];
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -40,7 +40,7 @@ class QueryTest extends TestCase
         'core.articles',
         'core.articles_tags',
         'core.authors',
-        'core.comments'
+        'core.comments',
         'core.posts',
         'core.tags'
     ];

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -36,8 +36,14 @@ class QueryTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.authors', 'core.tags',
-        'core.comments', 'core.articles_tags', 'core.posts'];
+    public $fixtures = [
+        'core.articles',
+        'core.articles_tags',
+        'core.authors',
+        'core.comments'
+        'core.posts',
+        'core.tags'
+    ];
 
     /**
      * setUp method

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -30,7 +30,7 @@ use Cake\TestSuite\TestCase;
 class ResultSetTest extends TestCase
 {
 
-    public $fixtures = ['core.authors', 'core.articles', 'core.comments'];
+    public $fixtures = ['core.articles', 'core.authors', 'core.comments'];
 
     /**
      * setup

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -30,7 +30,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.authors', 'core.tags', 'core.articles_tags'];
+    public $fixtures = ['core.articles', 'core.articles_tags', 'core.authors', 'core.tags'];
 
     /**
      * Tear down

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -48,18 +48,18 @@ class TableTest extends TestCase
 {
 
     public $fixtures = [
-        'core.comments',
-        'core.users',
-        'core.categories',
         'core.articles',
-        'core.authors',
-        'core.tags',
         'core.articles_tags',
-        'core.site_articles',
-        'core.members',
+        'core.authors',
+        'core.categories',
+        'core.comments',
         'core.groups',
         'core.groups_members',
+        'core.members',
         'core.polymorphic_tagged',
+        'core.site_articles',
+        'core.tags',
+        'core.users'
     ];
 
     /**

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -33,7 +33,7 @@ class RequestActionTraitTest extends TestCase
      *
      * @var string
      */
-    public $fixtures = ['core.posts', 'core.test_plugin_comments', 'core.comments'];
+    public $fixtures = ['core.comments', 'core.posts', 'core.test_plugin_comments'];
 
     /**
      * Setup

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -15,7 +15,7 @@
 namespace Cake\Test\TestSuite;
 
 use Cake\Core\Plugin;
-use Cake\Database\ConnectionManager;
+use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
@@ -67,9 +67,6 @@ class FixtureManagerTest extends TestCase
 
         $table = TableRegistry::get('ArticlesTags');
         $schema = $table->schema();
-
-        $this->assertEquals(['primary', 'tag_id_fk'], $schema->constraints());
-
         $expectedConstraint = [
             'type' => 'foreign',
             'columns' => [
@@ -89,8 +86,6 @@ class FixtureManagerTest extends TestCase
         $this->manager->load($test);
         $table = TableRegistry::get('ArticlesTags');
         $schema = $table->schema();
-
-        $this->assertEquals(['primary', 'tag_id_fk'], $schema->constraints());
         $expectedConstraint = [
             'type' => 'foreign',
             'columns' => [

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -107,7 +107,6 @@ class FixtureManagerTest extends TestCase
         $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
 
         $this->manager->unload($test);
-        $this->manager->shutDown($test);
     }
 
     /**

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -156,4 +156,65 @@ class FixtureManagerTest extends TestCase
         $test->fixtures = ['derp.derp'];
         $this->manager->fixturize($test);
     }
+
+    /**
+     * Test loading fixtures using loadSingle()
+     *
+     * @return void
+     */
+    public function testLoadSingle()
+    {
+        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test->autoFixtures = false;
+        $test->fixtures = ['core.articles', 'core.articles_tags', 'core.tags'];
+        $this->manager->fixturize($test);
+        $this->manager->loadSingle('Articles');
+        $this->manager->loadSingle('Tags');
+        $this->manager->loadSingle('ArticlesTags');
+
+        $table = TableRegistry::get('ArticlesTags');
+        $results = $table->find('all')->toArray();
+        $schema = $table->schema();
+        $expectedConstraint = [
+            'type' => 'foreign',
+            'columns' => [
+                'tag_id'
+            ],
+            'references' => [
+                'tags',
+                'id'
+            ],
+            'update' => 'cascade',
+            'delete' => 'cascade',
+            'length' => []
+        ];
+        $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
+        $this->assertCount(4, $results);
+
+        $this->manager->unload($test);
+
+        $this->manager->loadSingle('Articles');
+        $this->manager->loadSingle('Tags');
+        $this->manager->loadSingle('ArticlesTags');
+
+        $table = TableRegistry::get('ArticlesTags');
+        $results = $table->find('all')->toArray();
+        $schema = $table->schema();
+        $expectedConstraint = [
+            'type' => 'foreign',
+            'columns' => [
+                'tag_id'
+            ],
+            'references' => [
+                'tags',
+                'id'
+            ],
+            'update' => 'cascade',
+            'delete' => 'cascade',
+            'length' => []
+        ];
+        $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
+        $this->assertCount(4, $results);
+        $this->manager->unload($test);
+    }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -282,7 +282,7 @@ class ViewTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users', 'core.posts'];
+    public $fixtures = ['core.posts', 'core.users'];
 
     /**
      * setUp method


### PR DESCRIPTION
Currently, when you load your fixtures, you have to carefully order them so constraints are dealt with correctly to avoid some db drivers complaining about constraint integrity violation.
This PR aims to correct that by allowing you to put your fixtures and whatever order.

The same idea than with the migration plugin was applied : first, all tables are created and only after that are constraints added. Same thing goes for a truncate or a drop : first constraints are dropped and then the truncate or drop is done.

Refs #6323 
