### PR TITLE
Fix fake AJAX redirects with query strings leading to malformed form URLs etc.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -259,13 +259,19 @@ class RequestHandlerComponent extends Component
         if (is_array($url)) {
             $url = Router::url($url + ['_base' => false]);
         }
+        $query = [];
+        if (strpos($url, '?') !== false) {
+            list($url, $querystr) = explode('?', $url);
+            parse_str($querystr, $query);
+        }
         $controller = $event->subject();
         $response->body($controller->requestAction($url, [
             'return',
             'bare' => false,
             'environment' => [
                 'REQUEST_METHOD' => 'GET'
-            ]
+            ],
+            'query' => $query
         ]));
         $response->statusCode(200);
         return $response;


### PR DESCRIPTION
For example, if one requested the "something" action with AJAX

``` php
// controller:
public function something()
{
    $this->redirect("/controller/someform?a=b&x=y");
}

```

the rendered Template for the "someform" action resulted in malformed URLs with repeated query strings:

``` php
// someform template:
echo $this->Form->create();

// rendered html:
<form action="/controller/someform?a=b&x=y?a=b&x=y">
```
