### PR TITLE
PaginatorHelper::meta() skips url parameters & disrespects defined routes

### DIFF
--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -988,17 +988,18 @@ class PaginatorHelper extends AppHelper {
 	public function meta($options = array()) {
 		$model = isset($options['model']) ? $options['model'] : null;
 		$params = $this->params($model);
+		$urlOptions = isset($this->options['url']) ? $this->options['url'] : array();
 		$links = array();
 		if ($this->hasPrev()) {
 			$links[] = $this->Html->meta(array(
 				'rel' => 'prev',
-				'link' => $this->url(array('page' => $params['page'] - 1), true)
+				'link' => $this->url(array_merge($urlOptions, array('page' => $params['page'] - 1)), true)
 			));
 		}
 		if ($this->hasNext()) {
 			$links[] = $this->Html->meta(array(
 				'rel' => 'next',
-				'link' => $this->url(array('page' => $params['page'] + 1), true)
+				'link' => $this->url(array_merge($urlOptions, array('page' => $params['page'] + 1)), true)
 			));
 		}
 		$out = implode($links);


### PR DESCRIPTION
PaginatorHelper::meta() skips url parameters (passed and named) which results in urls not respecting defined routes.
It means PaginatorHelper::meta() does not generate same urls as PaginatorHelper::prev() & PaginatorHelper::next().
