### PR TITLE
Don't issue a count for cached queries

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -172,7 +172,9 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function execute()
     {
         $statement = $this->_connection->run($this);
-        return $this->_iterator = $this->_decorateStatement($statement);
+        $this->_iterator = $this->_decorateStatement($statement);
+        $this->_dirty = false;
+        return $this->_iterator;
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -108,6 +108,15 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     protected $_beforeFindFired = false;
 
     /**
+     * The COUNT(*) for the query.
+     *
+     * When set, count query execution will be bypassed.
+     *
+     * @var int
+     */
+    protected $_resultsCount;
+
+    /**
      * Constructor
      *
      * @param \Cake\Database\Connection $connection The connection object
@@ -685,6 +694,10 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function count()
     {
+        if (isset($this->_resultsCount)) {
+            return $this->_resultsCount;
+        }
+
         $query = $this->cleanCopy();
         $counter = $this->_counter;
         if ($counter) {
@@ -723,9 +736,10 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
                 ->execute();
         }
 
-        $result = $statement->fetch('assoc')['count'];
+        $this->_resultsCount = (int)$statement->fetch('assoc')['count'];
         $statement->closeCursor();
-        return (int)$result;
+
+        return $this->_resultsCount;
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -696,7 +696,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function count()
     {
-        if ($this->_dirty || $this->_resultsCount === null) {
+        if ($this->_resultsCount === null) {
             $this->_resultsCount = $this->_performCount();
         }
 
@@ -938,6 +938,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     protected function _dirty()
     {
         $this->_results = null;
+        $this->_resultsCount = null;
         parent::_dirty();
     }
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -694,7 +694,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function count()
     {
-        if (isset($this->_resultsCount)) {
+        if (!$this->_dirty && isset($this->_resultsCount)) {
             return $this->_resultsCount;
         }
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2107,20 +2107,16 @@ class QueryTest extends TestCase
             ->method('_performCount')
             ->will($this->returnValue(2));
 
-        $query->expects($this->at(2))
-            ->method('_performCount')
-            ->will($this->returnValue(3));
-
         $result = $query->count();
         $this->assertSame(1, $result, 'The result of the sql query should be returned');
 
         $query->where(['dirty' => 'cache']);
 
         $secondResult = $query->count();
-        $this->assertSame(2, $secondResult, 'The query is dirty, the cache should be ignored');
+        $this->assertSame(2, $secondResult, 'The query cache should be droppped with any modification');
 
         $thirdResult = $query->count();
-        $this->assertSame(3, $thirdResult, 'The query is still dirty, the cache should be ignored');
+        $this->assertSame(2, $thirdResult, 'The query has not been modified, the cached value is valid');
     }
 
     /**


### PR DESCRIPTION
I'm not sure about this but I noticed that a cached query, used in pagination, still issues a count query.

If the query was cached it's probably true that users wouldn't expect a query for the count to be issued either - so just count the results.

I can add some tests if I'm not missing something before merging.
