### PR TITLE
Make it easier to test csrf & security component protected actions.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -112,6 +112,14 @@ abstract class IntegrationTestCase extends TestCase
     protected $_securityToken = false;
 
     /**
+     * Boolean flag for whether or not the request should have
+     * a CSRF token added.
+     *
+     * @var bool
+     */
+    protected $_csrfToken = false;
+
+    /**
      * Clears the state used for requests.
      *
      * @return void
@@ -129,6 +137,7 @@ abstract class IntegrationTestCase extends TestCase
         $this->_layoutName = null;
         $this->_requestSession = null;
         $this->_securityToken = false;
+        $this->_csrfToken = false;
     }
 
     /**
@@ -141,6 +150,19 @@ abstract class IntegrationTestCase extends TestCase
     public function enableSecurityToken()
     {
         $this->_securityToken = true;
+    }
+
+    /**
+     * Calling this method will add a CSRF token to the request.
+     *
+     * Both the POST data and cookie will be populated when this option
+     * is enabled. The default parameter names will be used.
+     *
+     * @return void
+     */
+    public function enableCsrfToken()
+    {
+        $this->_csrfToken = true;
     }
 
     /**
@@ -371,7 +393,7 @@ abstract class IntegrationTestCase extends TestCase
 
         $props = [
             'url' => $url,
-            'post' => $this->_addTokens($url, $method, $data),
+            'post' => $this->_addTokens($url, $data),
             'cookies' => $this->_cookie,
             'session' => $session,
             'query' => $query
@@ -396,11 +418,10 @@ abstract class IntegrationTestCase extends TestCase
      * Add the CSRF and Security Component tokens if necessary.
      *
      * @param string $url The URL the form is being submitted on.
-     * @param string $method The HTTP method being used.
      * @param array $data The request body data.
      * @return array The request body with tokens added.
      */
-    protected function _addTokens($url, $method, $data)
+    protected function _addTokens($url, $data)
     {
         if ($this->_securityToken === true) {
             $keys = Hash::flatten($data);
@@ -408,12 +429,14 @@ abstract class IntegrationTestCase extends TestCase
             $data['_Token'] = $tokenData;
         }
 
-        $csrfToken = Text::uuid();
-        if ($method !== 'GET' && !isset($data['_csrfToken'])) {
-            $data['_csrfToken'] = $csrfToken;
-        }
-        if (!isset($this->_cookie['csrfToken'])) {
-            $this->_cookie['csrfToken'] = $csrfToken;
+        if ($this->_csrfToken === true) {
+            $csrfToken = Text::uuid();
+            if (!isset($data['_csrfToken'])) {
+                $data['_csrfToken'] = $csrfToken;
+            }
+            if (!isset($this->_cookie['csrfToken'])) {
+                $this->_cookie['csrfToken'] = $csrfToken;
+            }
         }
         return $data;
     }

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -21,6 +21,7 @@ use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\Stub\Response;
 use Cake\Utility\Hash;
+use Cake\Utility\Text;
 use Exception;
 use PHPUnit_Exception;
 
@@ -343,6 +344,14 @@ abstract class IntegrationTestCase extends TestCase
         ];
         $session = Session::create($sessionConfig);
         $session->write($this->_session);
+
+        $token = Text::uuid();
+        if ($method !== 'GET' && !isset($data['_csrfToken'])) {
+            $data['_csrfToken'] = $token;
+        }
+        if (!isset($this->_cookie['csrfToken'])) {
+            $this->_cookie['csrfToken'] = $token;
+        }
 
         list ($url, $query) = $this->_url($url);
         $props = [

--- a/src/View/Helper/SecureFieldTokenTrait.php
+++ b/src/View/Helper/SecureFieldTokenTrait.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.2
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Helper;
+
+use Cake\Utility\Security;
+
+/**
+ * Provides methods for building token data that is
+ * compatible with SecurityComponent.
+ */
+trait SecureFieldTokenTrait
+{
+    /**
+     * Generate the token data for the provided inputs.
+     *
+     * @param string $url The URL the form is being submitted to.
+     * @param array $fields If set specifies the list of fields to use when
+     *    generating the hash.
+     * @param array $unlockedFields The list of fields that are excluded from
+     *    field validation.
+     * @return array The token data.
+     */
+    protected function _buildFieldToken($url, $fields, $unlockedFields)
+    {
+        $locked = [];
+        foreach ($fields as $key => $value) {
+            if (is_numeric($value)) {
+                $value = (string)$value;
+            }
+            if (!is_int($key)) {
+                $locked[$key] = $value;
+                unset($fields[$key]);
+            }
+        }
+
+        sort($unlockedFields, SORT_STRING);
+        sort($fields, SORT_STRING);
+        ksort($locked, SORT_STRING);
+        $fields += $locked;
+
+        $locked = implode(array_keys($locked), '|');
+        $unlocked = implode($unlockedFields, '|');
+        $hashParts = [
+            $url,
+            serialize($fields),
+            $unlocked,
+            Security::salt()
+        ];
+        $fields = Security::hash(implode('', $hashParts), 'sha1');
+
+        return [
+            'fields' => urlencode($fields . ':' . $locked),
+            'unlocked' => urlencode($unlocked),
+        ];
+    }
+}

--- a/src/View/Helper/SecureFieldTokenTrait.php
+++ b/src/View/Helper/SecureFieldTokenTrait.php
@@ -32,7 +32,7 @@ trait SecureFieldTokenTrait
      *    field validation.
      * @return array The token data.
      */
-    protected function _buildFieldToken($url, $fields, $unlockedFields)
+    protected function _buildFieldToken($url, $fields, $unlockedFields = [])
     {
         $locked = [];
         foreach ($fields as $key => $value) {

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -80,6 +80,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
      */
     public function testRequestBuildingCsrfTokens()
     {
+        $this->enableCsrfToken();
         $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
 
         $this->assertArrayHasKey('csrfToken', $request->cookies);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -192,6 +192,38 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test posting to a secured form action action.
+     *
+     * @return void
+     */
+    public function testPostSecuredForm()
+    {
+        $this->enableSecurityToken();
+        $data = [
+            'title' => 'Some title',
+            'body' => 'Some text'
+        ];
+        $this->post('/posts/securePost', $data);
+        $this->assertResponseOk();
+        $this->assertResponseContains('Request was accepted');
+    }
+
+    /**
+     * Test posting to a secured form action action.
+     *
+     * @return void
+     */
+    public function testPostSecuredFormFailure()
+    {
+        $data = [
+            'title' => 'Some title',
+            'body' => 'Some text'
+        ];
+        $this->post('/posts/securePost', $data);
+        $this->assertResponseError();
+    }
+
+    /**
      * Test that exceptions being thrown are handled correctly.
      *
      * @return void

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -14,6 +14,7 @@
  */
 namespace TestApp\Controller;
 
+use Cake\Event\Event;
 use TestApp\Controller\AppController;
 
 /**
@@ -22,7 +23,6 @@ use TestApp\Controller\AppController;
  */
 class PostsController extends AppController
 {
-
     /**
      * Components array
      *
@@ -31,7 +31,20 @@ class PostsController extends AppController
     public $components = [
         'Flash',
         'RequestHandler',
+        'Security',
     ];
+
+    /**
+     * beforeFilter
+     *
+     * @return void
+     */
+    public function beforeFilter(Event $event)
+    {
+        if ($this->request->param('action') !== 'securePost') {
+            $this->eventManager()->off($this->Security);
+        }
+    }
 
     /**
      * Index method.
@@ -56,5 +69,16 @@ class PostsController extends AppController
     public function get()
     {
         // Do nothing.
+    }
+
+    /**
+     * Post endpoint for integration testing with security component.
+     *
+     * @return void
+     */
+    public function securePost()
+    {
+        $this->response->body('Request was accepted');
+        return $this->response;
     }
 }

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -23,13 +23,6 @@ class RequestActionController extends AppController
 {
 
     /**
-     * modelClass property
-     *
-     * @var string
-     */
-    public $modelClass = 'Posts';
-
-    /**
      * test_request_action method
      *
      * @return \Cake\Network\Response

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -23,6 +23,13 @@ class RequestActionController extends AppController
 {
 
     /**
+     * The default model to use.
+     *
+     * @var string
+     */
+    public $modelClass = 'Posts';
+
+    /**
      * test_request_action method
      *
      * @return \Cake\Network\Response


### PR DESCRIPTION
Make it much simpler for developers to use IntegrationTestCase with controllers protected by SecurityComponent and CsrfComponent.

I've made the `Token` data generation optional and require an explicit method call, as it adds some overhead, and the presence of that data could be unexpected by developers.

Refs #7004 
