### PR TITLE
Unset CSRF token from request data after token validation.

### DIFF
--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -94,6 +94,7 @@ class CsrfComponent extends Component
         }
         if ($request->is(['patch', 'put', 'post', 'delete'])) {
             $this->_validateToken($request);
+            unset($request->data[$this->_config['field']]);
         }
     }
 

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -156,6 +156,7 @@ class CsrfComponentTest extends TestCase
         $event = new Event('Controller.startup', $controller);
         $result = $this->component->startup($event);
         $this->assertNull($result, 'No exception means valid.');
+        $this->assertFalse(isset($controller->request->data['_csrfToken']));
     }
 
     /**


### PR DESCRIPTION
This prevents the token being included in query string when using PRG pattern.
