### PR TITLE
Do not mix void with other return types

### DIFF
--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -155,7 +155,7 @@ class Component extends Object {
  * @param string|array $url Either the string or URL array that is being redirected to.
  * @param int $status The status code of the redirect
  * @param bool $exit Will the script exit.
- * @return array|void Either an array or null.
+ * @return array|null Either an array or null.
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::beforeRedirect
  */
 	public function beforeRedirect(Controller $controller, $url, $status = null, $exit = true) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3209,7 +3209,7 @@ class DboSource extends DataSource {
  *
  * @param string $table The name of the table to update.
  * @param string $column The column to use when resetting the sequence value.
- * @return bool|void success.
+ * @return bool Success.
  */
 	public function resetSequence($table, $column) {
 	}

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -207,8 +207,8 @@ class Router {
 /**
  * Set the default route class to use or return the current one
  *
- * @param string $routeClass to set as default
- * @return mixed void|string
+ * @param string $routeClass The route class to set as default.
+ * @return string|null The default route class.
  * @throws RouterException
  */
 	public static function defaultRouteClass($routeClass = null) {

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -980,10 +980,10 @@ class PaginatorHelper extends AppHelper {
  * ### Options:
  *
  * - `model` The model to use defaults to PaginatorHelper::defaultModel()
- * - `block` The block name to append the output to, or false/absenst to return as a string
+ * - `block` The block name to append the output to, or false/absent to return as a string
  *
- * @param array $options Array of options
- * @return string|void Meta links
+ * @param array $options Array of options.
+ * @return string|null Meta links.
  */
 	public function meta($options = array()) {
 		$model = isset($options['model']) ? $options['model'] : null;


### PR DESCRIPTION
Inspired by #7527 

Though I think `meta()` might have bigger issues, cause it behaves very differently depending on its parameters.

I'm looking into improving `beforeRedirect()` separately.
