### PR TITLE
Socket SSL Context options

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -74,7 +74,7 @@ class SmtpTransport extends AbstractTransport
         try {
             $this->disconnect();
         } catch (Exception $e) {
-// avoid fatal error on script termination
+            // avoid fatal error on script termination
         }
     }
 

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -177,8 +177,10 @@ class Socket
      * Configure the SSL context options.
      *
      * @param string $host The host name being connected to.
+     * @return void
      */
-    protected function _setSslContext($host) {
+    protected function _setSslContext($host)
+    {
         foreach ($this->_config as $key => $value) {
             if (substr($key, 0, 4) !== 'ssl_') {
                 continue;

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -204,7 +204,7 @@ class Socket
             }
         }
         if (empty($this->_config['context']['ssl']['cafile'])) {
-            $dir = dirname(__DIR__);
+            $dir = dirname(dirname(__DIR__));
             $this->_config['context']['ssl']['cafile'] = $dir . DIRECTORY_SEPARATOR .
                 'config' . DIRECTORY_SEPARATOR . 'cacert.pem';
         }

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -419,29 +419,30 @@ class SocketTest extends TestCase
      *
      * @return void
      */
-    public function testConfigContext() {
-       $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
-       $config = array(
-           'host' => 'smtp.gmail.com',
-           'port' => 465,
-           'timeout' => 5,
-           'ssl_verify_peer' => true,
-           'ssl_allow_self_signed' => false,
-           'ssl_verify_depth' => 5,
-           'ssl_verify_host' => true,
-       );
-       $socket = new Socket($config);
+    public function testConfigContext()
+    {
+        $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
+        $config = [
+            'host' => 'smtp.gmail.com',
+            'port' => 465,
+            'timeout' => 5,
+            'ssl_verify_peer' => true,
+            'ssl_allow_self_signed' => false,
+            'ssl_verify_depth' => 5,
+            'ssl_verify_host' => true,
+        ];
+        $socket = new Socket($config);
 
-       $socket->connect();
-       $result = $socket->context();
+        $socket->connect();
+        $result = $socket->context();
 
-       $this->assertTrue($result['ssl']['verify_peer']);
-       $this->assertFalse($result['ssl']['allow_self_signed']);
-       $this->assertEquals(5, $result['ssl']['verify_depth']);
-       $this->assertEquals('smtp.gmail.com', $result['ssl']['CN_match']);
-       $this->assertArrayNotHasKey('ssl_verify_peer', $socket->config());
-       $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->config());
-       $this->assertArrayNotHasKey('ssl_verify_host', $socket->config());
-       $this->assertArrayNotHasKey('ssl_verify_depth', $socket->config());
+        $this->assertTrue($result['ssl']['verify_peer']);
+        $this->assertFalse($result['ssl']['allow_self_signed']);
+        $this->assertEquals(5, $result['ssl']['verify_depth']);
+        $this->assertEquals('smtp.gmail.com', $result['ssl']['CN_match']);
+        $this->assertArrayNotHasKey('ssl_verify_peer', $socket->config());
+        $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->config());
+        $this->assertArrayNotHasKey('ssl_verify_host', $socket->config());
+        $this->assertArrayNotHasKey('ssl_verify_depth', $socket->config());
     }
 }

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -411,6 +411,37 @@ class SocketTest extends TestCase
             $this->markTestSkipped('No network, skipping test.');
         }
         $result = $this->Socket->context();
-        $this->assertEquals($config['context'], $result);
+        $this->assertTrue($result['ssl']['capture_peer']);
+    }
+
+    /**
+     * test configuring the context from the flat keys.
+     *
+     * @return void
+     */
+    public function testConfigContext() {
+       $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
+       $config = array(
+           'host' => 'smtp.gmail.com',
+           'port' => 465,
+           'timeout' => 5,
+           'ssl_verify_peer' => true,
+           'ssl_allow_self_signed' => false,
+           'ssl_verify_depth' => 5,
+           'ssl_verify_host' => true,
+       );
+       $socket = new Socket($config);
+
+       $socket->connect();
+       $result = $socket->context();
+
+       $this->assertTrue($result['ssl']['verify_peer']);
+       $this->assertFalse($result['ssl']['allow_self_signed']);
+       $this->assertEquals(5, $result['ssl']['verify_depth']);
+       $this->assertEquals('smtp.gmail.com', $result['ssl']['CN_match']);
+       $this->assertArrayNotHasKey('ssl_verify_peer', $socket->config());
+       $this->assertArrayNotHasKey('ssl_allow_self_signed', $socket->config());
+       $this->assertArrayNotHasKey('ssl_verify_host', $socket->config());
+       $this->assertArrayNotHasKey('ssl_verify_depth', $socket->config());
     }
 }


### PR DESCRIPTION
This ports #7496 to 3.x adding the ability to set ssl context options on any socket. This is most helpful with the SmtpTransport. I've not updated HttpClient as it does not use Network\Socket in the StreamAdapter.
