### PR TITLE
Turn off log rotation by setting rotate to false

### DIFF
--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -124,7 +124,7 @@ class FileLog extends BaseLog
         $message = $this->_format($message, $context);
         $output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
         $filename = $this->_getFilename($level);
-        if (!empty($this->_size)) {
+        if (!empty($this->_size) && $this->_config['rotate'] !== false) {
             $this->_rotateFile($filename);
         }
 

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -208,6 +208,32 @@ class FileLogTest extends TestCase
         $this->assertEquals(0, count(glob($path . 'debug.log.*')));
     }
 
+    public function testNoRotation()
+    {
+        $path = TMP . 'tests' . DS;
+        $this->_deleteLogs($path);
+
+        file_put_contents($path . 'error.log', "this text is under 35 bytes\n");
+        $log = new FileLog([
+            'path' => $path,
+            'size' => 35,
+            'rotate' => false
+        ]);
+        $log->log('warning', 'Test warning one');
+        $this->assertTrue(file_exists($path . 'error.log'));
+
+        $result = file_get_contents($path . 'error.log');
+        $this->assertRegExp('/Warning: Test warning one/', $result);
+        $this->assertEquals(0, count(glob($path . 'error.log.*')));
+
+        clearstatcache();
+        $log->log('warning', 'Test warning second');
+
+        $result = file_get_contents($path . 'error.log');
+        $this->assertRegExp('/Warning: Test warning second/', $result);
+        $this->assertEquals(0, count(glob($path . 'error.log.*')));
+    }
+
     public function testMaskSetting()
     {
         if (DS === '\\') {


### PR DESCRIPTION
having log rotation build in is nice but I have my tools to do that and cake shouldn't get in the way of that. 
