### PR TITLE
Fix 0 being converted into 1 in CaseExpression

### DIFF
--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -119,13 +119,12 @@ class CaseExpression implements ExpressionInterface
             if ($numericKey && empty($c)) {
                 continue;
             }
-
             if (!$c instanceof ExpressionInterface) {
                 continue;
             }
             array_push($this->_conditions, $c);
 
-            $value = !empty($rawValues[$k]) ? $rawValues[$k] : 1;
+            $value = isset($rawValues[$k]) ? $rawValues[$k] : 1;
 
             if ($value === 'literal') {
                 $value = $keyValues[$k];

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -74,7 +74,7 @@ class SmtpTransport extends AbstractTransport
         try {
             $this->disconnect();
         } catch (Exception $e) {
-// avoid fatal error on script termination
+            // avoid fatal error on script termination
         }
     }
 

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -54,6 +54,26 @@ class CaseExpressionTest extends TestCase
     }
 
     /**
+     * Test sql generation with 0 case.
+     *
+     * @return void
+     */
+    public function testSqlOutputZero()
+    {
+        $expression = new QueryExpression();
+        $expression->add(['id' => 'test']);
+        $caseExpression = new CaseExpression([$expression], [0], ['integer']);
+        $expected = 'CASE WHEN id = :c0 THEN :c1 END';
+        $binder = new ValueBinder();
+        $this->assertSame($expected, $caseExpression->sql($binder));
+        $expected = [
+            ':c0' => ['value' => 'test', 'type' => null, 'placeholder' => 'c0'],
+            ':c1' => ['value' => 0, 'type' => 'integer', 'placeholder' => 'c1'],
+        ];
+        $this->assertEquals($expected, $binder->bindings());
+    }
+
+    /**
      * Tests that the expression is correctly traversed
      *
      * @return void


### PR DESCRIPTION
`empty()` continues to be sharp and pointy.

Refs #7529
