### PR TITLE
Fix BlowfishPasswordHasher::check() invalid argument

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
@@ -42,7 +42,7 @@ class BlowfishPasswordHasher extends AbstractPasswordHasher {
  * @return bool True if hashes match else false.
  */
 	public function check($password, $hashedPassword) {
-		return $hashedPassword === Security::hash($password, 'blowfish', $hashedPassword);
+		return $hashedPassword === Security::hash($password, 'blowfish', false);
 	}
 
 }


### PR DESCRIPTION
- BlowfishPasswordHasher::check() use Security::hash()
- Security::hash() 3rd argument must be '$salt'
- But BlowfishPasswordHasher::check() input '$hashedPassword' to 3rd argument
