### PR TITLE
[3.1] Include _appCharset in serialisation process

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1906,7 +1906,7 @@ class Email implements JsonSerializable, Serializable
         $properties = [
             '_to', '_from', '_sender', '_replyTo', '_cc', '_bcc', '_subject',
             '_returnPath', '_readReceipt', '_emailFormat', '_emailPattern', '_domain',
-            '_attachments', '_messageId', '_headers', 'viewVars', 'charset', 'headerCharset'
+            '_attachments', '_messageId', '_headers', '_appCharset', 'viewVars', 'charset', 'headerCharset'
         ];
 
         $array = ['viewConfig' => $this->viewBuilder()->jsonSerialize()];

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2701,6 +2701,7 @@ XML;
             '_emailFormat' => 'text',
             '_messageId' => '<uuid@server.com>',
             '_domain' => 'foo.bar',
+            '_appCharset' => 'UTF-8',
             'charset' => 'utf-8',
             'headerCharset' => 'utf-8',
             'viewConfig' => [


### PR DESCRIPTION
Sending an email after serialisation causes the following error: `mb_convert_encoding(): Illegal character encoding specified in [CORE/src/Mailer/Email.php, line 1500]`.

This can be resolved by including the `_appCharset` in the serialised data.
