### PR TITLE
Remove schema and prefix from 3.x's censor list

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -720,9 +720,7 @@ class Connection implements ConnectionInterface
             'username' => '*****',
             'host' => '*****',
             'database' => '*****',
-            'port' => '*****',
-            'prefix' => '*****',
-            'schema' => '*****'
+            'port' => '*****'
         ];
         $replace = array_intersect_key($secrets, $this->_config);
         $config = $replace + $this->_config;


### PR DESCRIPTION
Similar to PR #7555 - make 3.x match the censoring output. `schema` and `prefix`, even from the database connection info, isn't what I'd think of as secrets. Further, I'm actually unsure either of those keys exist in 3.x's database configuration anyway.
