### PR TITLE
Accept , in datetime validation rules.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -447,7 +447,7 @@ class Validation
         }
         $parts = explode(' ', $check);
         if (!empty($parts) && count($parts) > 1) {
-            $date = array_shift($parts);
+            $date = rtrim(array_shift($parts), ',');
             $time = implode(' ', $parts);
             $valid = static::date($date, $dateFormat, $regex) && static::time($time);
         }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -1576,6 +1576,8 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::dateTime('12/04/2017 1:38 pm', ['dmy']));
         $this->assertTrue(Validation::dateTime('12/04/2017 1:38pm', ['dmy']));
         $this->assertTrue(Validation::dateTime('12/04/2017 1:38AM', ['dmy']));
+        $this->assertTrue(Validation::dateTime('12/04/2017, 1:38AM', ['dmy']));
+        $this->assertTrue(Validation::dateTime('28/10/2015, 3:21 PM', ['dmy']));
         $this->assertFalse(Validation::dateTime('12/04/2017 58:38AM', ['dmy']));
     }
 


### PR DESCRIPTION
The default en_US format outputs dates like 'd/m/y, H:i a' the comma should be accepted by the default dmy validator.

Refs cakephp/app#291
