### PR TITLE
Add config option to ignore specified files or folders when importing…

### DIFF
--- a/app/config/core.php
+++ b/app/config/core.php
@@ -248,6 +248,11 @@
 	//date_default_timezone_set('UTC');
 
 /**
+ * Add files or folders that should be ignored by CakePHP when scanning application folder.
+ */
+	//Configure::write('ignorePaths', array('.svn', '.git', 'CVS', 'tests', 'templates', 'node_modules'));
+
+/**
  *
  * Cache Engine Configuration
  * Default settings provided below

--- a/cake/libs/configure.php
+++ b/cake/libs/configure.php
@@ -1035,7 +1035,11 @@ class App extends Object {
 					require LIBS . 'folder.php';
 				}
 				$Folder =& new Folder();
-				$directories = $Folder->tree($path, array('.svn', '.git', 'CVS', 'tests', 'templates'), 'dir');
+				$ignorePaths = Configure::read('ignorePaths');
+				if(empty($ignorePaths)) {
+					$ignorePaths = array('.svn', '.git', 'CVS', 'tests', 'templates');
+				}
+				$directories = $Folder->tree($path, $ignorePaths, 'dir');
 				sort($directories);
 				$this->__paths[$path] = $directories;
 			}


### PR DESCRIPTION
Subfolders of the app folder containing a large number of files/folders causes Cake to time out in the folder.php __tree function that "list directories and files in each directory". This may e.g. occur during development when a plugin folder contains a node project where the "node_modules" folder consists of thousands of files/folders.
