### PR TITLE
Flash Component was not handling plugin option

### DIFF
--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -38,6 +38,7 @@ class FlashComponent extends Component {
 		'key' => 'flash',
 		'element' => 'default',
 		'params' => array(),
+		'plugin' => '',
 	);
 
 /**
@@ -79,7 +80,11 @@ class FlashComponent extends Component {
 		list($plugin, $element) = pluginSplit($options['element']);
 
 		if ($plugin) {
-			$options['element'] = $plugin . '.Flash/' . $element;
+			$options['plugin'] = $plugin;
+		}
+
+		if (!empty($options['plugin'])) {
+			$options['element'] = $options['plugin'] . '.Flash/' . $element;
 		} else {
 			$options['element'] = 'Flash/' . $element;
 		}


### PR DESCRIPTION
In the documentation of Cakephp 2.x it says:

> If you are using the __call() magic method, the element option will always be replaced. In order to retrieve a specific element from a plugin, you should set the plugin parameter. For example:

So in the function below I can't see the plugin option to be handled and I tried it my self like this:

```
    $this->Flash->set('test', ['plugin' => 'MyPlugin']);
```

and it didn't work.

https://github.com/cakephp/cakephp/blob/2.8/lib/Cake/Controller/Component/FlashComponent.php#L71
