### PR TITLE
Split the protocol out of the host name.

### DIFF
--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -128,8 +128,12 @@ class Socket
             $this->disconnect();
         }
 
+        $hasProtocol = strpos($this->_config['host'], '://') !== false;
+        if ($hasProtocol) {
+            list($this->_config['protocol'], $this->_config['host']) = explode('://', $this->_config['host']);
+        }
         $scheme = null;
-        if (!empty($this->_config['protocol']) && strpos($this->_config['host'], '://') === false) {
+        if (!empty($this->_config['protocol'])) {
             $scheme = $this->_config['protocol'] . '://';
         }
 

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -292,6 +292,25 @@ class SocketTest extends TestCase
     }
 
     /**
+     * Test that protocol in the host doesn't cause cert errors.
+     *
+     * @return void
+     */
+    public function testConnectProtocolInHost()
+    {
+        $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
+        $configSslTls = ['host' => 'ssl://smtp.gmail.com', 'port' => 465, 'timeout' => 5];
+        $socket = new Socket($configSslTls);
+        try {
+            $socket->connect();
+            $this->assertEquals('smtp.gmail.com', $socket->config('host'));
+            $this->assertEquals('ssl', $socket->config('protocol'));
+        } catch (SocketException $e) {
+            $this->markTestSkipped('Cannot test network, skipping.');
+        }
+    }
+
+    /**
      * _connectSocketToSslTls
      *
      * @return void


### PR DESCRIPTION
This avoids issues in PHP 5.6 where certificate validation fails when `ssl://smtp.gmail.com` is used as a host name.

Refs #7579
