### PR TITLE
Allow NULL in boolean types.

### DIFF
--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -36,7 +36,7 @@ class BoolType extends Type
      */
     public function toDatabase($value, Driver $driver)
     {
-        if ($value === true || $value === false) {
+        if ($value === true || $value === false || $value === null) {
             return $value;
         }
 

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -272,6 +272,7 @@ class TypeTest extends TestCase
         $type = Type::build('boolean');
         $driver = $this->getMock('\Cake\Database\Driver');
 
+        $this->assertNull($type->toDatabase(null, $driver));
         $this->assertTrue($type->toDatabase(true, $driver));
         $this->assertFalse($type->toDatabase(false, $driver));
         $this->assertTrue($type->toDatabase(1, $driver));


### PR DESCRIPTION
BOOLEAN columns can be nullable, so we should allow that state.

Refs #7583
