### PR TITLE
Correct method to fluent interface.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -582,7 +582,7 @@ trait EntityTrait
      * @param null|bool $isDirty true means the property was changed, false means
      * it was not changed and null will make the function return current state
      * for that property
-     * @return bool whether the property was changed or not
+     * @return bool Whether the property was changed or not
      */
     public function dirty($property = null, $isDirty = null)
     {
@@ -844,7 +844,7 @@ trait EntityTrait
      * this entity came from if it is known.
      *
      * @param string $alias the alias of the repository
-     * @return string
+     * @return string|$this
      */
     public function source($alias = null)
     {
@@ -852,6 +852,8 @@ trait EntityTrait
             return $this->_registryAlias;
         }
         $this->_registryAlias = $alias;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/7587#discussion_r42614590

Consistently use fluent interface as the other methods do (hiddenProperties, virtualProperties, errors).

The alternative would be to correct the doc block to `@return string|null`.
But that would make it the only setter/getter this way.
