### PR TITLE
Set the foreignKey of the (source hasMany junction) association.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -221,7 +221,10 @@ class BelongsToMany extends Association
         }
 
         if (!$source->association($table->alias())) {
-            $source->hasMany($junctionAlias)->target($table);
+			$source->hasMany($junctionAlias, [
+				'targetTable' => $table,
+				'foreignKey' => $this->foreignKey()
+			]);
         }
 
         return $this->_junctionTable = $table;


### PR DESCRIPTION
In application with complex associations, the foreignKey might be null in the (source hasMany junction) association (in a BelongsToMany association).
Then, a default foreignKey is generated using the table name, but it is not the correct key. It then leads to database error.
