### PR TITLE
integration test case security token

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -425,7 +425,7 @@ abstract class IntegrationTestCase extends TestCase
     {
         if ($this->_securityToken === true) {
             $keys = Hash::flatten($data);
-            $tokenData = $this->_buildFieldToken($url, $keys);
+            $tokenData = $this->_buildFieldToken($url, array_keys($keys));
             $data['_Token'] = $tokenData;
         }
 


### PR DESCRIPTION
`_buildFieldToken` expects an array of keys not the request data as key value pairs.

Currently:

```
[
        'username' => 'my_username',
        'password' => 'my_password',
]
```

Expected:

```
[
        (int) 0 => 'username',
        (int) 1 => 'password',

]
```

Refs https://github.com/cakephp/cakephp/issues/7004
