### PR TITLE
Make sure direction values are lowercased to be consistent.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -212,7 +212,7 @@ class PaginatorHelperTest extends CakeTestCase {
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
-		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'asc'));
+		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'ASC'));
 		$this->assertRegExp('/\/accounts\/index\/param\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -351,7 +351,7 @@ class PaginatorHelper extends AppHelper {
 
 			$title = __(Inflector::humanize(preg_replace('/_id$/', '', $title)));
 		}
-		$defaultDir = isset($options['direction']) ? $options['direction'] : 'asc';
+		$defaultDir = isset($options['direction']) ? strtolower($options['direction']) : 'asc';
 		unset($options['direction']);
 
 		$locked = isset($options['lock']) ? $options['lock'] : false;


### PR DESCRIPTION
Currently, using PaginatorHelper::sort() you can end up with uppercase letters in the URL:

```
...&direction=DESC
```

This should be always lowercase as the others are.
It is correct for sortDir() but has been forgotten to be applied inside sort() for dev input.

Note:
Might have to be ported to 3.x
