### PR TITLE
Allow --debug flag to enable fixture schema output.

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -50,6 +50,9 @@ class FixtureInjector implements PHPUnit_Framework_TestListener
      */
     public function __construct(FixtureManager $manager)
     {
+        if (isset($_SERVER['argv'])) {
+            $manager->setDebug(in_array('--debug', $_SERVER['argv']));
+        }
         $this->_fixtureManager = $manager;
         $this->_fixtureManager->shutdown();
     }

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -29,7 +29,7 @@ class FixtureManager
 {
 
     /**
-     * Was this class already initialized?
+     * Was this instance already initialized?
      *
      * @var bool
      */
@@ -62,6 +62,25 @@ class FixtureManager
      * @var array
      */
     protected $_processed = [];
+
+    /**
+     * Is the test runner being run with `--debug` enabled.
+     * When true, fixture SQL will also be logged.
+     *
+     * @var bool
+     */
+    protected $_debug = false;
+
+    /**
+     * Modify the debug mode.
+     *
+     * @param bool $debug Whether or not fixture debug mode is enabled.
+     * @retun void
+     */
+    public function setDebug($debug)
+    {
+        $this->_debug = $debug;
+    }
 
     /**
      * Inspects the test to look for unloaded fixtures and loads them
@@ -299,7 +318,7 @@ class FixtureManager
         foreach ($dbs as $connection => $fixtures) {
             $db = ConnectionManager::get($connection, false);
             $logQueries = $db->logQueries();
-            if ($logQueries) {
+            if ($logQueries && !$this->_debug) {
                 $db->logQueries(false);
             }
             $db->transactional(function ($db) use ($fixtures, $operation) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -75,7 +75,7 @@ class FixtureManager
      * Modify the debug mode.
      *
      * @param bool $debug Whether or not fixture debug mode is enabled.
-     * @retun void
+     * @return void
      */
     public function setDebug($debug)
     {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -240,7 +240,9 @@ class TestFixture implements FixtureInterface
         try {
             $queries = $this->_schema->createSql($db);
             foreach ($queries as $query) {
-                $db->execute($query)->closeCursor();
+                $stmt = $db->prepare($query);
+                $stmt->execute();
+                $stmt->closeCursor();
             }
         } catch (Exception $e) {
             $msg = sprintf(

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -228,9 +228,11 @@ class TestFixtureTest extends TestCase
             ->will($this->returnValue(['sql', 'sql']));
         $fixture->schema($table);
 
-        $statement = $this->getMock('\PDOStatement', ['closeCursor']);
+        $statement = $this->getMock('\PDOStatement', ['execute', 'closeCursor']);
         $statement->expects($this->atLeastOnce())->method('closeCursor');
-        $db->expects($this->exactly(2))->method('execute')
+        $statement->expects($this->atLeastOnce())->method('execute');
+        $db->expects($this->exactly(2))
+            ->method('prepare')
             ->will($this->returnValue($statement));
         $this->assertTrue($fixture->create($db));
     }


### PR DESCRIPTION
When PHPUnit's `--debug` flag is used and query logging is enabled, output the table creation schema. This helps developers figure out issues with their schema creation should it fail.

Refs #7606
