### PR TITLE
Optimizing a bit more the default type inference in the Query

### DIFF
--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -381,7 +381,7 @@ class Table
     }
 
     /**
-     * Returns an array where the kyes are the column names in the schema
+     * Returns an array where the keys are the column names in the schema
      * and the values the database type they have.
      *
      * @return array

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -47,6 +47,13 @@ class Table
     protected $_columns = [];
 
     /**
+     * A map with columns to types
+     *
+     * @var array
+     */
+    protected $_typeMap = [];
+
+    /**
      * Indexes in the table.
      *
      * @var array
@@ -297,6 +304,7 @@ class Table
         }
         $attrs = array_intersect_key($attrs, $valid);
         $this->_columns[$name] = $attrs + $valid;
+        $this->_typeMap[$name] = $this->_columns[$name]['type'];
         return $this;
     }
 
@@ -341,6 +349,7 @@ class Table
         }
         if ($type !== null) {
             $this->_columns[$name]['type'] = $type;
+            $this->_typeMap[$name] = $type;
         }
         return $this->_columns[$name]['type'];
     }
@@ -369,6 +378,17 @@ class Table
             $type = Type::build($type)->getBaseType();
         }
         return $this->_columns[$column]['baseType'] = $type;
+    }
+
+    /**
+     * Returns an array where the kyes are the column names in the schema
+     * and the values the database type they have.
+     *
+     * @return array
+     */
+    public function typeMap()
+    {
+        return $this->_typeMap;
     }
 
     /**

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -34,7 +34,7 @@ trait TypeMapTrait
      */
     public function typeMap($typeMap = null)
     {
-        if (!$this->_typeMap) {
+        if ($this->_typeMap === null) {
             $this->_typeMap = new TypeMap();
         }
         if ($typeMap === null) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -170,10 +170,10 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     public function addDefaultTypes(Table $table)
     {
         $alias = $table->alias();
-        $schema = $table->schema();
+        $map = $table->schema()->typeMap();
         $fields = [];
-        foreach ($schema->columns() as $f) {
-            $fields[$f] = $fields[$alias . '.' . $f] = $schema->columnType($f);
+        foreach ($map as $f => $type) {
+            $fields[$f] = $fields[$alias . '.' . $f] = $type;
         }
         $this->typeMap()->addDefaults($fields);
 


### PR DESCRIPTION
Found an easy way of shaving off around 20% more of the time spent in adding default types in the query, by calling less functions.
