### PR TITLE
[3.3] Add support for cross schema joins

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -694,6 +694,38 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Check if cross talk is supported between two connections
+     *
+     * @param ConnectionInterface $connection Connection to check cross talk with
+     *
+     * @return bool
+     */
+    public function supportsCrossWith(ConnectionInterface $target)
+    {
+        $sourceConfig = $this->config();
+        $targetConfig = $target->config();
+
+        // No need to do report cross support in case the same connection is being used
+        if ($sourceConfig['name'] ===  $targetConfig['name']) {
+            return false;
+        }
+
+        $configToCheck = [
+            'driver',
+            'host',
+            'port'
+        ];
+
+        foreach ($configToCheck as $config) {
+            if ((isset($sourceConfig[$config])) && ($sourceConfig[$config] !== $targetConfig[$config])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Returns a new statement object that will log the activity
      * for the passed original statement instance.
      *

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -265,6 +265,16 @@ abstract class Driver
     }
 
     /**
+     * Returns the schema name that's being used
+     *
+     * @return string
+     */
+    public function schema()
+    {
+        return $this->_config['schema'];
+    }
+
+    /**
      * Returns last id generated for a table or sequence in database
      *
      * @param string $table table name or sequence to get last insert value from

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -129,6 +129,14 @@ class Mysql extends Driver
     /**
      * {@inheritDoc}
      */
+    public function schema()
+    {
+        return $this->_config['database'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function supportsDynamicConstraints()
     {
         return true;

--- a/src/Database/Expression/CrossSchemaTableExpression.php
+++ b/src/Database/Expression/CrossSchemaTableExpression.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.1.4
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
+
+/**
+ * An expression object that represents a cross schema table name
+ *
+ * @internal
+ */
+class CrossSchemaTableExpression implements ExpressionInterface
+{
+
+    /**
+     * Name of the schema
+     *
+     * @var ExpressionInterface|string
+     */
+    protected $_schema;
+
+    /**
+     * Name of the table
+     *
+     * @var ExpressionInterface|string
+     */
+    protected $_table;
+
+    /**
+     * @inheritDoc
+     *
+     * @param string|ExpressionInterface $schema Name of the schema
+     * @param string|ExpressionInterface $table Name of the table
+     */
+    public function __construct($schema, $table)
+    {
+        $this->_schema = $schema;
+        $this->_table = $table;
+    }
+
+    /**
+     * Converts the Node into a SQL string fragment.
+     *
+     * @param \Cake\Database\ValueBinder $generator Placeholder generator object
+     * @return string
+     */
+    public function sql(ValueBinder $generator)
+    {
+        $schema = $this->_schema;
+        if ($schema instanceof ExpressionInterface) {
+            $schema = $schema->sql($generator);
+        }
+
+        $table = $this->_table;
+        if ($table instanceof ExpressionInterface) {
+            $table = $table->sql($generator);
+        }
+
+        return sprintf('%s.%s', $schema, $table);
+    }
+
+    /**
+     * Iterates over each part of the expression recursively for every
+     * level of the expressions tree and executes the $visitor callable
+     * passing as first parameter the instance of the expression currently
+     * being iterated.
+     *
+     * @param callable $visitor The callable to apply to all nodes.
+     * @return void
+     */
+    public function traverse(callable $visitor)
+    {
+        if ($this->_schema instanceof ExpressionInterface) {
+            $this->_schema->traverse($visitor);
+        }
+        if ($this->_table instanceof ExpressionInterface) {
+            $this->_table->traverse($visitor);
+        }
+    }
+}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -492,10 +492,11 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array|string|null $tables list of tables to be joined in the query
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset joins with passed list or not
+     * @param bool $subquery whether this is a subquery
      * @see \Cake\Database\Type
      * @return $this
      */
-    public function join($tables = null, $types = [], $overwrite = false)
+    public function join($tables = null, $types = [], $overwrite = false, $subquery = false)
     {
         if ($tables === null) {
             return $this->_parts['join'];
@@ -520,7 +521,7 @@ class Query implements ExpressionInterface, IteratorAggregate
                 $t['conditions'] = $this->newExpr()->add($t['conditions'], $types);
             }
             $alias = is_string($alias) ? $alias : null;
-            $joins[$alias ?: $i++] = $t + ['type' => 'INNER', 'alias' => $alias];
+            $joins[$alias ?: $i++] = $t + ['type' => 'INNER', 'alias' => $alias, 'subquery' => $subquery];
         }
 
         if ($overwrite) {
@@ -608,11 +609,12 @@ class Query implements ExpressionInterface, IteratorAggregate
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
      * values to the corresponding database representation.
+     * @param bool $subquery whether this is a subquery
      * @return $this
      */
-    public function innerJoin($table, $conditions = [], $types = [])
+    public function innerJoin($table, $conditions = [], $types = [], $subquery = false)
     {
-        return $this->join($this->_makeJoin($table, $conditions, 'INNER'), $types);
+        return $this->join($this->_makeJoin($table, $conditions, 'INNER'), $types, false, $subquery);
     }
 
     /**

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -212,8 +212,13 @@ class QueryCompiler
         $joins = '';
         foreach ($parts as $join) {
             if ($join['table'] instanceof ExpressionInterface) {
-                $join['table'] = '(' . $join['table']->sql($generator) . ')';
+                $join['table'] = $join['table']->sql($generator);
             }
+
+            if ($join['subquery']) {
+                $join['table'] = '(' . $join['table'] . ')';
+            }
+
             $joins .= sprintf(' %s JOIN %s %s', $join['type'], $join['table'], $join['alias']);
             if (isset($join['conditions']) && count($join['conditions'])) {
                 $joins .= sprintf(' ON %s', $join['conditions']->sql($generator));

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -15,6 +15,7 @@
 namespace Cake\ORM;
 
 use Cake\Core\ConventionsTrait;
+use Cake\Database\Expression\CrossSchemaTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetDecorator;
@@ -514,13 +515,21 @@ abstract class Association
     {
         $target = $this->target();
         $joinType = empty($options['joinType']) ? $this->joinType() : $options['joinType'];
+
+        $table = $target->table();
+        if ($this->source()->connection()->supportsCrossWith($target->connection())) {
+            $table = new CrossSchemaTableExpression(
+                $target->connection()->driver()->schema(), $table
+            );
+        }
+
         $options += [
             'includeFields' => true,
             'foreignKey' => $this->foreignKey(),
             'conditions' => [],
             'fields' => [],
             'type' => $joinType,
-            'table' => $target->table(),
+            'table' => $table,
             'finder' => $this->finder()
         ];
 

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -158,7 +158,9 @@ trait SelectableAssociationTrait
         $conditions = isset($conditions) ? $conditions : $query->newExpr([$key => $filter]);
         return $query->innerJoin(
             [$aliasedTable => $subquery],
-            $conditions
+            $conditions,
+            [],
+            true
         );
     }
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -859,7 +859,12 @@ class QueryTest extends TestCase
         $expected = new QueryExpression(['a > b'], $typeMap);
         $result = $query->clause('join');
         $this->assertEquals([
-            'table_a' => ['alias' => 'table_a', 'type' => 'INNER', 'conditions' => $expected]
+            'table_a' => [
+                'alias' => 'table_a',
+                'type' => 'INNER',
+                'conditions' => $expected,
+                'subquery' => false
+            ]
         ], $result);
 
         $expected = new OrderByExpression(['a' => 'ASC']);


### PR DESCRIPTION
This adds change adds support for cross database joins. I'll also try to add support for subquery support. I wanted to open the pull request already to see if it breaks anything for any of the drivers.

This will in the end make it easier to write applications that use multiple databases per customer for example.
