### PR TITLE
Added last option to Authorizer

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -492,8 +492,14 @@ class AuthComponent extends Component
         }
         foreach ($this->_authorizeObjects as $authorizer) {
             if ($authorizer->authorize($user, $request) === true) {
-                $this->_authorizationProvider = $authorizer;
-                return true;
+                if ($authorizer->config('last') !== true) {
+                    $this->_authorizationProvider = $authorizer;
+                    return true;
+                }
+            } else {
+                if ($authorizer->config('last') === true) {
+                    return false;
+                }
             }
         }
         return false;


### PR DESCRIPTION
With this option, you're able to set a `Authorizer` to `last`. This means, when it the `Authorizer` returns true, the search continues to another `Authorizer`, but when it returns false, we will stop searching for an new `Authorizer`.

On this way you're able to create an "god" or "master" `Authorizer`, which always has to be `true`. If not, the user is not authorized.
