### PR TITLE
Add 'staff' as uninflected

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1623,8 +1623,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   will be aborted. Receives the event, entity, and options.
      * - `Model.afterDelete` Fired after the delete has been successful. Receives
      *   the event, entity, and options.
-     * - `Model.afterDelete` Fired after the delete has been successful. Receives
-     *   the event, entity, and options.
      * - `Model.afterDeleteCommit` Fired after the transaction is committed for
      *   an atomic delete. Receives the event, entity, and options.
      *

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -156,7 +156,8 @@ class Inflector
         '.*pox', '.*sheep', 'people', 'feedback', 'stadia', '.*?media',
         'chassis', 'clippers', 'debris', 'diabetes', 'equipment', 'gallows',
         'graffiti', 'headquarters', 'information', 'innings', 'news', 'nexus',
-        'proceedings', 'research', 'sea[- ]bass', 'series', 'species', 'weather'
+        'proceedings', 'research', 'sea[- ]bass', 'series', 'species', 'staff',
+        'weather'
     ];
 
     /**

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -176,6 +176,7 @@ class InflectorTest extends TestCase
         $this->assertEquals('address', Inflector::singularize('addresses'));
         $this->assertEquals('sieve', Inflector::singularize('sieves'));
         $this->assertEquals('blue_octopus', Inflector::singularize('blue_octopuses'));
+        $this->assertEquals('staff', Inflector::singularize('staff'));
         $this->assertEquals('', Inflector::singularize(''));
     }
 
@@ -277,6 +278,7 @@ class InflectorTest extends TestCase
         $this->assertEquals('Addresses', Inflector::pluralize('Address'));
         $this->assertEquals('sieves', Inflector::pluralize('sieve'));
         $this->assertEquals('blue_octopuses', Inflector::pluralize('blue_octopus'));
+        $this->assertEquals('staff', Inflector::pluralize('staff'));
         $this->assertEquals('', Inflector::pluralize(''));
     }
 
@@ -668,5 +670,16 @@ class InflectorTest extends TestCase
         $this->assertEquals('Atlas', Inflector::pluralize('Atlas'));
         $this->assertEquals('Alcool', Inflector::singularize('Alcoois'));
         $this->assertEquals('Atlas', Inflector::singularize('Atlas'));
+    }
+
+    /**
+     * Test uninflected words.
+     *
+     * @return void
+     */
+    public function testUninflectedWords()
+    {
+        $this->assertEquals('staff', Inflector::pluralize('staff'));
+        $this->assertEquals('staff', Inflector::singularize('staff'));
     }
 }


### PR DESCRIPTION
Had a table named "staff" and I thought it was a good candidate for the uninflected category.

Please let me what you think.
