### PR TITLE
Missing beforeFilter and missleading initialize event

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -452,7 +452,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function implementedEvents()
     {
         return [
-            'Controller.initialize' => 'beforeFilter',
+            'Controller.beforeFilter' => 'beforeFilter',
             'Controller.beforeRender' => 'beforeRender',
             'Controller.beforeRedirect' => 'beforeRedirect',
             'Controller.shutdown' => 'afterFilter',
@@ -493,6 +493,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             return $event->result;
         }
         $event = $this->dispatchEvent('Controller.startup');
+        if ($event->result instanceof Response) {
+            return $event->result;
+        }
+        $event = $this->dispatchEvent('Controller.beforeFilter');
         if ($event->result instanceof Response) {
             return $event->result;
         }


### PR DESCRIPTION
There is no beforeFilter event available in the implementation, although there is a beforeFilter callback thats beeing called from an event called "initialize" which is missleading at best, as there is an initialize function (supposedly a callback) too!

Added a new event, supposedly beeing correctly named "beforeFilter", beeing called near the original "initialize" event.
No changes to the current initialize event for not breaking BC.

Here is a gist showing that the only proper way of setting up a beforeFilter event is in the initialize function in some cases, which _looks_ like not beeing able to work, because the initialize event gets attached in the initialize function - which is to late to get triggered.
https://gist.github.com/hmic/d09788322c86f3ec0fa9
