### PR TITLE
Remove superfluous Model.afterDelete from Table.delete doc-block

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1623,8 +1623,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   will be aborted. Receives the event, entity, and options.
      * - `Model.afterDelete` Fired after the delete has been successful. Receives
      *   the event, entity, and options.
-     * - `Model.afterDelete` Fired after the delete has been successful. Receives
-     *   the event, entity, and options.
      * - `Model.afterDeleteCommit` Fired after the transaction is committed for
      *   an atomic delete. Receives the event, entity, and options.
      *


### PR DESCRIPTION
I was reading the API and spotted the extra "afterDelete" event mentioned in the Table.delete doc-block.
