### PR TITLE
Fix isEmpty() consuming data.

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -607,7 +607,10 @@ trait CollectionTrait
      */
     public function isEmpty()
     {
-        return iterator_count($this->unwrap()) === 0;
+        foreach ($this->unwrap() as $el) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -607,7 +607,7 @@ trait CollectionTrait
      */
     public function isEmpty()
     {
-        return iterator_count($this->take(1)) === 0;
+        return iterator_count($this->unwrap()) === 0;
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1300,6 +1300,21 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Tests the isEmpty() method does not consume data
+     * from buffered iterators.
+     *
+     * @return void
+     */
+    public function testIsEmptyDoesNotConsume()
+    {
+        $array = new \ArrayIterator([1, 2, 3]);
+        $inner = new \Cake\Collection\Iterator\BufferedIterator($array);
+        $collection = new Collection($inner);
+        $this->assertFalse($collection->isEmpty());
+        $this->assertCount(3, $collection->toArray());
+    }
+
+    /**
      * Tests the zip() method
      *
      * @return void

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -368,4 +368,22 @@ class ResultSetTest extends TestCase
         $this->assertEquals('TestPlugin.Comments', $result->source());
         $this->assertEquals('TestPlugin.Authors', $result->_matchingData['Authors']->source());
     }
+
+    /**
+     * Ensure that isEmpty() on a ResultSet doesn't result in loss
+     * of records. This behavior is provided by CollectionTrait.
+     *
+     * @return void
+     */
+    public function testIsEmptyDoesNotConsumeData()
+    {
+        $table = TableRegistry::get('Comments');
+        $query = $table->find()
+            ->formatResults(function ($results) {
+                return $results;
+            });
+        $res = $query->all();
+        $res->isEmpty();
+        $this->assertCount(6, $res->toArray());
+    }
 }


### PR DESCRIPTION
When isEmpty() is used on a buffered iterator, that has not be iterated, the take(1) call combined with the new Collection's rewind() call would cause a row to be lost by creating the inner Collection. By not making a temporary Collection we don't consume data and saving some time as well.

Refs #7649
