### PR TITLE
Update Comparison.php

### DIFF
--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -192,10 +192,7 @@ class Comparison implements ExpressionInterface, FieldInterface
             // To avoid SQL errors when comparing a field to a list of empty values,
             // better just throw an exception here
             if ($value === '') {
-                $field = $this->_field instanceof ExpressionInterface ? $this->_field->sql($generator) : $this->_field;
-                throw new DatabaseException(
-                    "Impossible to generate condition with empty list of values for field ($field)"
-                );
+                return ['1 != 1', ''];
             }
         } else {
             $template .= '%s %s';


### PR DESCRIPTION
this solves issues with sub queries

```
$articlesWithComments = $this->Articles->find()
->select(['id'])
->where(['Articles.id IN' => $this->Articles->Comments->find()->select(['article_id'])]);
```

everything works find if the subquery returns at least one row - but otherwise it throws an exception: "Impossible to generate condition with empty list of values for field (Articles.id)"
It's a change which was made in 3.1.4 -> it breaks my existing code...
