### PR TITLE
In CLI mode default the error handlers to Console flavors.

### DIFF
--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -87,6 +87,12 @@ class Configure {
 				'handler' => 'ErrorHandler::handleError',
 				'level' => E_ALL & ~E_DEPRECATED,
 			);
+			if (PHP_SAPI === 'cli') {
+				App::uses('ConsoleErrorHandler', 'Console');
+				$console = new ConsoleErrorHandler();
+				$exception['handler'] = array($console, 'handleException');
+				$error['handler'] = array($console, 'handleError');
+			}
 			static::_setErrorHandlers($error, $exception);
 
 			if (!include APP . 'Config' . DS . 'bootstrap.php') {


### PR DESCRIPTION
In the somewhat rare case where an error or exception occurs during application bootstrap, we should not emit HTML to the stdout.

Refs #7661
