### PR TITLE
Fix HTTPS SNI via proxy

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -134,7 +134,7 @@ class CakeSocket {
 			$scheme = $this->config['protocol'] . '://';
 		}
 
-		$this->_setSslContext($this->config['host']);
+		$this->_setSslContext($this->config['request']['uri']['host']);
 		if (!empty($this->config['context'])) {
 			$context = stream_context_create($this->config['context']);
 		} else {


### PR DESCRIPTION
Commit cc3531d2886c96afb9c53e363cd4eaa04f92b2f3 broke HTTPS SNI via a proxy because config['host'] contains the hostname of the proxy. Using config['request']['uri']['host'] ensures the right hostname is always used.
