### PR TITLE
Removing Exception typehints in the error handling to account for PHP 7

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -15,11 +15,11 @@
 namespace Cake\Error;
 
 use Cake\Core\Configure;
+use Cake\Error\PHP7ErrorException;
 use Cake\Log\Log;
 use Cake\Routing\Router;
-use Exception;
 use Error;
-use Cake\Error\PHP7ErrorException;
+use Exception;
 
 /**
  * Base error handler that provides logic common to the CLI + web

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -18,6 +18,8 @@ use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Routing\Router;
 use Exception;
+use Error;
+use Cake\Error\PHP7ErrorException;
 
 /**
  * Base error handler that provides logic common to the CLI + web
@@ -65,7 +67,7 @@ abstract class BaseErrorHandler
         }
         error_reporting($level);
         set_error_handler([$this, 'handleError'], $level);
-        set_exception_handler([$this, 'handleException']);
+        set_exception_handler([$this, 'wrapAndHandleException']);
         register_shutdown_function(function () {
             if (PHP_SAPI === 'cli') {
                 return;
@@ -137,6 +139,22 @@ abstract class BaseErrorHandler
         $this->_displayError($data, $debug);
         $this->_logError($log, $data);
         return true;
+    }
+
+    /**
+     * Checks the passed exception type. If it is an instance of `Error`
+     * then, it wraps the passed object inside another Exception object
+     * for backwards compatibility purposes.
+     *
+     * @param Exception|Error $exception The exception to handle
+     * @return void
+     */
+    public function wrapAndHandleException($exception)
+    {
+        if ($exception instanceof Error) {
+            $exception = new PHP7ErrorException($exception);
+        }
+        $this->handleException($exception);
     }
 
     /**
@@ -231,13 +249,17 @@ abstract class BaseErrorHandler
     protected function _logException(Exception $exception)
     {
         $config = $this->_options;
+        $unwrapped = $exception instanceof PHP7ErrorException ?
+            $exception->getError() :
+            $exception;
+
         if (empty($config['log'])) {
             return false;
         }
 
         if (!empty($config['skipLog'])) {
             foreach ((array)$config['skipLog'] as $class) {
-                if ($exception instanceof $class) {
+                if ($unwrapped instanceof $class) {
                     return false;
                 }
             }
@@ -253,6 +275,9 @@ abstract class BaseErrorHandler
      */
     protected function _getMessage(Exception $exception)
     {
+        $exception = $exception instanceof PHP7ErrorException ?
+            $exception->getError() :
+            $exception;
         $config = $this->_options;
         $message = sprintf(
             "[%s] %s",

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.1.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error;
+
+use Exception;
+
+/**
+ * Wraps a PHP 7 Error object inside a normal Exception
+ * so it can be handled correctly by the rest of the
+ * error handling system
+ *
+ */
+class PHP7ErrorException extends Exception
+{
+
+    /**
+     * The wrapped error object
+     *
+     * @var Error
+     */
+    protected $_error;
+
+    /**
+     * Wraps the passed Error class
+     *
+     * @param Error $error the Error object
+     */
+    public function __construct($error)
+    {
+        $this->_error = $error;
+        $message = $error->getMessage();
+        $code = $error->getCode();
+        parent::__construct(sprintf('(%s) - %s', get_class($error), $message), $code);
+    }
+
+    /**
+     * Returns the wrapped error object
+     *
+     * @return Error
+     */
+    public function getError()
+    {
+        return $this->_error;
+    }
+}

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -21,6 +21,7 @@ use Cake\Core\Plugin;
 use Cake\Error;
 use Cake\Error\ErrorHandler;
 use Cake\Error\ExceptionRenderer;
+use Cake\Error\PHP7ErrorException;
 use Cake\Log\Log;
 use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Exception\NotFoundException;
@@ -29,6 +30,7 @@ use Cake\Network\Response;
 use Cake\Routing\Exception\MissingControllerException;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use ParseError;
 
 /**
  * Testing stub.
@@ -415,5 +417,20 @@ class ErrorHandlerTest extends TestCase
 
         $errorHandler = new TestErrorHandler(['log' => true]);
         $errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, __LINE__);
+    }
+
+    /**
+     * Tests Handling a PHP7 error
+     *
+     * @return void
+     */
+    public function testHandlePHP7Error()
+    {
+        $this->skipIf(!class_exists('Error'), 'Requires PHP7');
+        $error = new PHP7ErrorException(new ParseError('Unexpected variable foo'));
+        $errorHandler = new TestErrorHandler();
+
+        $errorHandler->handleException($error);
+        $this->assertContains('Unexpected variable foo', $errorHandler->response->body(), 'message missing.');
     }
 }


### PR DESCRIPTION
Since PHP 7 is around the corner, I think we should tho this sooner rather than later. This is probably controversial, and definitely BC breaking, but I can't think of a realistic better way.

Maybe we could offer some `sed` foo for people upgrading to the next version?
