### PR TITLE
Corrects return type of identify() method

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -751,7 +751,7 @@ class AuthComponent extends Component
      * Triggers `Auth.afterIdentify` event which the authenticate classes can listen
      * to.
      *
-     * @return array User record data, or false, if the user could not be identified.
+     * @return array|bool User record data, or false, if the user could not be identified.
      */
     public function identify()
     {


### PR DESCRIPTION
`\Cake\Controller\Component\AuthComponent::identify()` had what was (in my opinion) an incorrect return type, seeing as how `false` is not an array.  This PR corrects the docblock.
