### PR TITLE
Added additional @methods to DocBlock of FlashComponent

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -24,6 +24,9 @@ use Exception;
  * The CakePHP FlashComponent provides a way for you to write a flash variable
  * to the session from your controllers, to be rendered in a view with the
  * FlashHelper.
+ *
+ * @method void success(string $message, array $options) Set a message using "success" element
+ * @method void error(string $message, array $options) Set a message using "error" element
  */
 class FlashComponent extends Component
 {


### PR DESCRIPTION
CakePHP provides a great way to deal with flash messages. However I'm really tired of having `$this->Flash->error()` or `$this->Flash->success()` flagged as wrong by my IDE.
![q2gyl1u](https://cloud.githubusercontent.com/assets/2865341/11156611/9429040e-8a55-11e5-8aeb-421dca8861ed.png)
So I went ahead and added those two methods to the DocBlock of the Flash Component.
I hope this will help everyone who is using IDEs that mark such usages as errors

P.S. I know that `__set()` can accept any element as method name. But we are not allowed to use wildcards in DocBlock and those two methods are most used ones (at least by me), so I decided to put only them
