### PR TITLE
Allow invalid field data to be kept along with the error messages in the Entity

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -96,6 +96,13 @@ trait EntityTrait
     protected $_errors = [];
 
     /**
+     * List of invalid fields and their data for errors upon validation/patching
+     *
+     * @var array
+     */
+    protected $_invalid = [];
+
+    /**
      * Map of properties in this entity that can be safely assigned, each
      * property name points to a boolean indicating its status. An empty array
      * means no properties are accessible
@@ -600,7 +607,7 @@ trait EntityTrait
         }
 
         $this->_dirty[$property] = true;
-        unset($this->_errors[$property]);
+        unset($this->_errors[$property], $this->_invalid[$property]);
         return true;
     }
 
@@ -615,6 +622,7 @@ trait EntityTrait
     {
         $this->_dirty = [];
         $this->_errors = [];
+        $this->_invalid = [];
     }
 
     /**
@@ -780,6 +788,44 @@ trait EntityTrait
     }
 
     /**
+     * Sets a field as invalid and not patchable into the entity.
+     *
+     * This is useful for batch operations when one needs to get the original value for an error message after patching.
+     * This value could not be patched into the entity and is simply copied into the _invalid property for debugging purposes
+     * or to be able to log it away.
+     *
+     * @param string|array|null $field
+     * @param string|null $value
+     * @param bool $overwrite
+     * @return $this|mixed
+     */
+    public function invalid($field = null, $value = null, $overwrite = false)
+    {
+        if ($field === null) {
+            return $this->_invalid;
+        }
+
+        if (is_string($field) && $value === null) {
+            $value = isset($this->_invalid[$field]) ? $this->_invalid[$field] : null;
+            return $value;
+        }
+
+        if (!is_array($field)) {
+            $field = [$field => $value];
+        }
+
+        foreach ($field as $f => $value) {
+            if ($overwrite) {
+                $this->_invalid[$f] = $value;
+                continue;
+            }
+            $this->_invalid += [$f => $value];
+        }
+
+        return $this;
+    }
+
+    /**
      * Stores whether or not a property value can be changed or set in this entity.
      * The special property `*` can also be marked as accessible or protected, meaning
      * that any other property specified before will take its value. For example
@@ -881,6 +927,7 @@ trait EntityTrait
             '[original]' => $this->_original,
             '[virtual]' => $this->_virtual,
             '[errors]' => $this->_errors,
+            '[invalid]' => $this->_invalid,
             '[repository]' => $this->_registryAlias
         ];
     }

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -788,11 +788,14 @@ trait EntityTrait
     }
 
     /**
-     * Sets a field as invalid and not patchable into the entity.
+     * Sets the invalid value state for a field.
      *
-     * This is useful for batch operations when one needs to get the original value for an error message after patching.
-     * This value could not be patched into the entity and is simply copied into the _invalid property for debugging purposes
-     * or to be able to log it away.
+     * This can be used to track property values that failed validation.
+     * Adding values here will allow you to retain the invalid value without
+     * modifying the current state of the entity.
+     *
+     * This is useful for batch operations when one needs to get the
+     * original value when building an error message.
      *
      * @param string|array|null $field
      * @param string|null $value

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -327,6 +327,14 @@ class RulesChecker
                 $message = [$message];
             }
             $entity->errors($options['errorField'], $message);
+
+            if (method_exists($entity, 'invalid')) {
+                $invalid = null;
+                if (isset($entity->{$options['errorField']})) {
+                    $invalid = $entity->{$options['errorField']};
+                }
+                $entity->invalid($options['errorField'], $invalid);
+            }
             return $pass === true;
         };
     }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -128,6 +128,9 @@ class Marshaller
         $properties = [];
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {
+                if (method_exists($entity, 'invalid')) {
+                    $entity->invalid($key, $value);
+                }
                 continue;
             }
             $columnType = $schema->columnType($key);
@@ -463,6 +466,9 @@ class Marshaller
         $properties = $marshalledAssocs = [];
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {
+                if (method_exists($entity, 'invalid')) {
+                    $entity->invalid($key, $value);
+                }
                 continue;
             }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -126,9 +126,10 @@ class Marshaller
 
         $errors = $this->_validate($data, $options, true);
         $properties = [];
+        $setInvalidProperty = method_exists($entity, 'invalid');
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {
-                if (method_exists($entity, 'invalid')) {
+                if ($setInvalidProperty) {
                     $entity->invalid($key, $value);
                 }
                 continue;
@@ -464,9 +465,11 @@ class Marshaller
         $errors = $this->_validate($data + $keys, $options, $isNew);
         $schema = $this->_table->schema();
         $properties = $marshalledAssocs = [];
+
+        $setInvalidProperty = method_exists($entity, 'invalid');
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {
-                if (method_exists($entity, 'invalid')) {
+                if ($setInvalidProperty) {
                     $entity->invalid($key, $value);
                 }
                 continue;

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -2524,6 +2524,24 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Tests that invalid propery is being filled when data cannot be patched into an entity
+     *
+     * @return void
+     */
+    public function testValidationWithInvalidFilled() {
+        $data = [
+            'title' => 'foo',
+            'number' => 'bar',
+        ];
+        $validator = (new Validator)->add('number', 'numeric', ['rule' => 'numeric']);
+        $marshall = new Marshaller($this->articles);
+        $entity = $marshall->one($data, ['validate' => $validator]);
+        $this->assertNotEmpty($entity->errors('number'));
+        $this->assertNull($entity->number);
+        $this->assertSame(['number' => 'bar'], $entity->invalid());
+    }
+
+    /**
      * Test merge with validation error
      *
      * @return void
@@ -2541,6 +2559,8 @@ class MarshallerTest extends TestCase
             'body' => 'My Content',
             'author_id' => 1
         ]);
+        $this->assertEmpty($entity->invalid());
+
         $entity->accessible('*', true);
         $entity->isNew(false);
         $entity->clean();
@@ -2561,7 +2581,9 @@ class MarshallerTest extends TestCase
 
         $this->articles->validator()->requirePresence('thing', 'create');
         $result = $marshall->merge($entity, $data, []);
+
         $this->assertEmpty($result->errors('thing'));
+        $this->assertSame(['author_id' => 'foo'], $result->invalid());
     }
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -116,6 +116,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $this->assertNull($entity->article->get('author_id'));
         $this->assertFalse($entity->article->dirty('author_id'));
         $this->assertNotEmpty($entity->article->errors('title'));
+        $this->assertSame('A Title', $entity->article->invalid('title'));
     }
 
     /**


### PR DESCRIPTION
It would be nice if in 4.0 the errors would be objects containing both message and the data responsible for it.

But until then I propose this fully BC behavior here to have the data not just being thrown out the window.
This is especially useful and required when using the wrappers like

```
$entities = $this->Examples->newEntities($array);
```

Resolves https://github.com/cakephp/cakephp/issues/7615

Feel free to put any commit/changes on top you seem useful.
