### PR TITLE
Making the integer marshaller accept negative numbers, fixes #7697

### DIFF
--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -85,15 +85,12 @@ class IntegerType extends Type
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_int($value)) {
-            return $value;
-        }
-        if (ctype_digit($value)) {
+        if (is_numeric($value) || ctype_digit($value)) {
             return (int)$value;
         }
         if (is_array($value)) {
             return 1;
         }
-        return $value;
+        return null;
     }
 }

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -55,6 +55,9 @@ class IntegerTypeTest extends TestCase
         $result = $this->type->toPHP('2 bears', $this->driver);
         $this->assertSame(2, $result);
 
+        $result = $this->type->toPHP('-2', $this->driver);
+        $this->assertSame(-2, $result);
+
         $result = $this->type->toPHP(['3', '4'], $this->driver);
         $this->assertSame(1, $result);
     }
@@ -95,7 +98,7 @@ class IntegerTypeTest extends TestCase
     public function testMarshal()
     {
         $result = $this->type->marshal('some data', $this->driver);
-        $this->assertSame('some data', $result);
+        $this->assertNull($result);
 
         $result = $this->type->marshal('', $this->driver);
         $this->assertNull($result);
@@ -109,11 +112,17 @@ class IntegerTypeTest extends TestCase
         $result = $this->type->marshal(105, $this->driver);
         $this->assertSame(105, $result);
 
+        $result = $this->type->marshal('-105', $this->driver);
+        $this->assertSame(-105, $result);
+
+        $result = $this->type->marshal(-105, $this->driver);
+        $this->assertSame(-105, $result);
+
         $result = $this->type->marshal('1.25', $this->driver);
-        $this->assertSame('1.25', $result);
+        $this->assertSame(1, $result);
 
         $result = $this->type->marshal('2 monkeys', $this->driver);
-        $this->assertSame('2 monkeys', $result);
+        $this->assertNull($result);
 
         $result = $this->type->marshal(['3', '4'], $this->driver);
         $this->assertSame(1, $result);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -264,7 +264,7 @@ class MarshallerTest extends TestCase
         $result = $marshall->one($data, []);
 
         $this->assertSame($data['title'], $result->title);
-        $this->assertSame($data['author_id'], $result->author_id, 'No cast on bad data.');
+        $this->assertNull($result->author_id, 'No cast on bad data.');
         $this->assertSame($data['created'], $result->created, 'No cast on bad data.');
     }
 


### PR DESCRIPTION
Also making the marshaller more strict on the passed data, in order
to align it with the rest of the other type classes, which will return
null in case of invalid arguments.
