### PR TITLE
Allow array based URLs as parameter for Response::location()

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -16,6 +16,7 @@ namespace Cake\Network;
 
 use Cake\Core\Configure;
 use Cake\Filesystem\File;
+use Cake\Routing\Router;
 use Cake\Network\Exception\NotFoundException;
 use DateTime;
 use DateTimeZone;
@@ -631,6 +632,9 @@ class Response
         if ($url === null) {
             $headers = $this->header();
             return isset($headers['Location']) ? $headers['Location'] : null;
+        }
+        if (is_array($url)) {
+            $url = Router::url($url);
         }
         $this->header('Location', $url);
         return null;


### PR DESCRIPTION
Saves you from having to rewrite these redirects when changing routes.
