### PR TITLE
When executing Shell 'main' method the current command name is set to…

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -444,6 +444,7 @@ class Shell
 
         if ($this->hasMethod('main')) {
             $this->startup();
+            $this->command = 'main';
             return call_user_func_array([$this, 'main'], $this->args);
         }
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -652,6 +652,7 @@ class ShellTest extends TestCase
             ->will($this->returnValue(true));
         $result = $shell->runCommand(['cakes', '--verbose']);
         $this->assertTrue($result);
+        $this->assertEquals('main', $shell->command);
     }
 
     /**
@@ -670,6 +671,7 @@ class ShellTest extends TestCase
             ->will($this->returnValue(true));
         $result = $shell->runCommand(['hit_me', 'cakes', '--verbose'], true);
         $this->assertTrue($result);
+        $this->assertEquals('hit_me', $shell->command);
     }
 
     /**


### PR DESCRIPTION
… 'main'

The previous behavior was that `$this->command` would be `null`.
