### PR TITLE
Disable colors in output form tests when run on Windows

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -226,6 +226,8 @@ class TestShell extends Shell {
 
 		if (!empty($params['no-colors'])) {
 			unset($params['no-colors'], $params['colors']);
+		} elseif (strtolower(substr(php_uname(), 0, 3)) === 'win') {
+			$params['colors'] = false;
 		} else {
 			$params['colors'] = true;
 		}


### PR DESCRIPTION
ANSI escape codes are not available in Windows Command Prompt. This PR disables colour output when running tests on Windows.
