### PR TITLE
Make spellcheck a standard attribute.

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -75,7 +75,6 @@ class StringTemplate
         'seamless' => true,
         'selected' => true,
         'sortable' => true,
-        'spellcheck' => true,
         'truespeed' => true,
         'typemustmatch' => true,
         'visible' => true,

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -208,10 +208,10 @@ class StringTemplateTest extends TestCase
      */
     public function testFormatAttributes()
     {
-        $attrs = ['name' => 'bruce', 'data-hero' => '<batman>'];
+        $attrs = ['name' => 'bruce', 'data-hero' => '<batman>', 'spellcheck' => 'true'];
         $result = $this->template->formatAttributes($attrs);
         $this->assertEquals(
-            ' name="bruce" data-hero="&lt;batman&gt;"',
+            ' name="bruce" data-hero="&lt;batman&gt;" spellcheck="true"',
             $result
         );
 


### PR DESCRIPTION
Unlike most HTML5 attributes, spellcheck requires 'true' and 'false' values, which means it cannot be a minimized attribute.

Refs #7708
