### PR TITLE
Add test for #7591

### DIFF
--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -944,6 +944,27 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Tests calling contain in a nested closure
+     *
+     * @see https://github.com/cakephp/cakephp/issues/7591
+     * @return void
+     */
+    public function testContainInNestedClosure()
+    {
+        $table = TableRegistry::get('Comments');
+        $table->belongsTo('Articles');
+        $table->Articles->belongsTo('Authors');
+        $table->Articles->Authors->belongsToMany('Tags');
+
+        $query = $table->find()->where(['Comments.id' => 5])->contain(['Articles' => function ($q) {
+            return $q->contain(['Authors' => function ($q) {
+                return $q->contain('Tags');
+            }]);
+        }]);
+        $this->assertCount(2, $query->first()->article->author->tags);
+    }
+
+    /**
      * Test that the typemaps used in function expressions
      * create the correct results.
      *


### PR DESCRIPTION
Sorry if this is not a correct way to contribute.
This commit contains a test case for #7591. This test case should pass but fail currently.

I investigated #7591 today. My guess is that this issue is related with `Cake\ORM\Association::_bindNewAssociations()`. Running this test, `$query->eagerLoader()` attempts to contain `$newContain` [at line 787 in src/ORM/Association.php](https://github.com/cakephp/cakephp/blob/935ac5024401688903bb50a84f4be6efaa4c400c/src/ORM/Association.php#L787). But then `$query->repository()->alias()` is `Comments` and `$newContain` is `['Authors.Tags' => []]`. So you would get an exception in the end: "Comments is not associated with Authors". It would work if `$query->repository()->alias()` were `Articles` or `$newContain` were `['Articles.Authors.Tags' => []]`.

As I couldn't come up with a nice fix, this commit doesn't contain the fix. I hope this will be a clue.
