### PR TITLE
Add a CORS builder

### DIFF
--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -58,18 +58,30 @@ class CorsBuilder
         return $result;
     }
 
-    public function allowMethods($methods)
+    public function allowMethods(array $methods)
     {
+        if (empty($this->_origin)) {
+            return $this;
+        }
+        $this->_response->header('Access-Control-Allow-Methods', implode(', ', $methods));
         return $this;
     }
 
     public function allowCredentials()
     {
+        if (empty($this->_origin)) {
+            return $this;
+        }
+        $this->_response->header('Access-Control-Allow-Credentials', 'true');
         return $this;
     }
 
-    public function allowHeaders($headers)
+    public function allowHeaders(array $headers)
     {
+        if (empty($this->_origin)) {
+            return $this;
+        }
+        $this->_response->header('Access-Control-Allow-Headers', implode(', ', $headers));
         return $this;
     }
 

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -27,7 +27,8 @@ class CorsBuilder
             if (!preg_match($domain['preg'], $this->_origin)) {
                 continue;
             }
-            $this->_response->header('Access-Control-Allow-Origin', $this->_origin);
+            $value = $domain['original'] === '*' ? '*' : $this->_origin;
+            $this->_response->header('Access-Control-Allow-Origin', $value);
             break;
         }
         return $this;

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -1,16 +1,70 @@
 <?php
-
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Network;
 
 use Cake\Network\Response;
 
+/**
+ * A builder object that assists in defining Cross Origin Request related
+ * headers.
+ *
+ * Each of the methods in this object provide a fluent interface. Once you've
+ * set all the headers you want to use, the `build()` method can be used to return
+ * a modified Response.
+ *
+ * It is most convenient to get this object via `Request::cors()`.
+ * 
+ * @see Cake\Network\Response::cors()
+ */
 class CorsBuilder
 {
+    /**
+     * The response object this builder is attached to.
+     *
+     * @var \Cake\Network\Response
+     */
     protected $_response;
+
+    /**
+     * The request's Origin header value
+     *
+     * @var string
+     */
     protected $_origin;
+
+    /**
+     * Whether or not the request was over SSL.
+     *
+     * @var bool
+     */
     protected $_isSsl;
+
+    /**
+     * The headers that have been queued so far.
+     *
+     * @var array
+     */
     protected $_headers = [];
 
+    /**
+     * Constructor.
+     *
+     * @param \Cake\Network\Response $response The response object to add headers onto.
+     * @param string $origin The request's Origin header.
+     * @param bool $isSsl Whether or not the request was over SSL.
+     */
     public function __construct(Response $response, $origin, $isSsl = false)
     {
         $this->_origin = $origin;
@@ -18,6 +72,14 @@ class CorsBuilder
         $this->_response = $response;
     }
 
+    /**
+     * Apply the queued headers to the response.
+     *
+     * If the builer has no Origin, or if there are no allowed domains,
+     * or if the allowed domains do not match the Origin header no headers will be applied.
+     *
+     * @return \Cake\Network\Response
+     */
     public function build()
     {
         if (empty($this->_origin)) {
@@ -29,6 +91,15 @@ class CorsBuilder
         return $this->_response;
     }
 
+    /**
+     * Set the list of allowed domains.
+     *
+     * Accepts a string or an array of domains that have CORS enabled.
+     * You can use `*.example.com` wildcards to accept subdomains, or `*` to allow all domains
+     *
+     * @param string|array $domain The allowed domains
+     * @return $this
+     */
     public function allowOrigin($domain)
     {
         $allowed = $this->_normalizeDomains((array)$domain);
@@ -68,30 +139,59 @@ class CorsBuilder
         return $result;
     }
 
+    /**
+     * Set the list of allowed HTTP Methods.
+     *
+     * @param array $domain The allowed HTTP methods
+     * @return $this
+     */
     public function allowMethods(array $methods)
     {
         $this->_headers['Access-Control-Allow-Methods'] = implode(', ', $methods);
         return $this;
     }
 
+    /**
+     * Enable cookies to be sent in CORS requests.
+     *
+     * @return $this
+     */
     public function allowCredentials()
     {
         $this->_headers['Access-Control-Allow-Credentials'] = 'true';
         return $this;
     }
 
+    /**
+     * Whitelist headers that can be sent in CORS requests.
+     *
+     * @param array $headers The list of headers to accept in CORS requests.
+     * @return $this
+     */
     public function allowHeaders(array $headers)
     {
         $this->_headers['Access-Control-Allow-Headers'] = implode(', ', $headers);
         return $this;
     }
 
+    /**
+     * Define the headers a client library/browser can expose to scripting
+     *
+     * @param array $headers The list of headers to expose CORS responses
+     * @return $this
+     */
     public function exposeHeaders(array $headers)
     {
         $this->_headers['Access-Control-Expose-Headers'] = implode(', ', $headers);
         return $this;
     }
 
+    /**
+     * Define the max-age preflight OPTIONS requests are valid for.
+     *
+     * @param int $age The max-age for OPTIONS requests in seconds
+     * @return $this
+     */
     public function maxAge($age)
     {
         $this->_headers['Access-Control-Max-Age'] = $age;

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -9,6 +9,7 @@ class CorsBuilder
     protected $_response;
     protected $_origin;
     protected $_isSsl;
+    protected $_headers = [];
 
     public function __construct(Response $response, $origin, $isSsl = false)
     {
@@ -17,18 +18,26 @@ class CorsBuilder
         $this->_response = $response;
     }
 
-    public function allowOrigin($domain)
+    public function build()
     {
         if (empty($this->_origin)) {
-            return $this;
+            return $this->_response;
         }
+        if (isset($this->_headers['Access-Control-Allow-Origin'])) {
+            $this->_response->header($this->_headers);
+        }
+        return $this->_response;
+    }
+
+    public function allowOrigin($domain)
+    {
         $allowed = $this->_normalizeDomains((array)$domain);
         foreach ($allowed as $domain) {
             if (!preg_match($domain['preg'], $this->_origin)) {
                 continue;
             }
             $value = $domain['original'] === '*' ? '*' : $this->_origin;
-            $this->_response->header('Access-Control-Allow-Origin', $value);
+            $this->_headers['Access-Control-Allow-Origin'] = $value;
             break;
         }
         return $this;
@@ -61,46 +70,31 @@ class CorsBuilder
 
     public function allowMethods(array $methods)
     {
-        if (empty($this->_origin)) {
-            return $this;
-        }
-        $this->_response->header('Access-Control-Allow-Methods', implode(', ', $methods));
+        $this->_headers['Access-Control-Allow-Methods'] = implode(', ', $methods);
         return $this;
     }
 
     public function allowCredentials()
     {
-        if (empty($this->_origin)) {
-            return $this;
-        }
-        $this->_response->header('Access-Control-Allow-Credentials', 'true');
+        $this->_headers['Access-Control-Allow-Credentials'] = 'true';
         return $this;
     }
 
     public function allowHeaders(array $headers)
     {
-        if (empty($this->_origin)) {
-            return $this;
-        }
-        $this->_response->header('Access-Control-Allow-Headers', implode(', ', $headers));
+        $this->_headers['Access-Control-Allow-Headers'] = implode(', ', $headers);
         return $this;
     }
 
     public function exposeHeaders(array $headers)
     {
-        if (empty($this->_origin)) {
-            return $this;
-        }
-        $this->_response->header('Access-Control-Expose-Headers', implode(', ', $headers));
+        $this->_headers['Access-Control-Expose-Headers'] = implode(', ', $headers);
         return $this;
     }
 
     public function maxAge($age)
     {
-        if (empty($this->_origin)) {
-            return $this;
-        }
-        $this->_response->header('Access-Control-Max-Age', $age);
+        $this->_headers['Access-Control-Max-Age'] = $age;
         return $this;
     }
 }

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -27,7 +27,7 @@ class CorsBuilder
             if (!preg_match($domain['preg'], $this->_origin)) {
                 continue;
             }
-            $this->_response->header('Access-Control-Origin', $this->_origin);
+            $this->_response->header('Access-Control-Allow-Origin', $this->_origin);
             break;
         }
         return $this;
@@ -85,13 +85,21 @@ class CorsBuilder
         return $this;
     }
 
-    public function exposeHeaders($headers)
+    public function exposeHeaders(array $headers)
     {
+        if (empty($this->_origin)) {
+            return $this;
+        }
+        $this->_response->header('Access-Control-Expose-Headers', implode(', ', $headers));
         return $this;
     }
 
-    public function maxAge($headers)
+    public function maxAge($age)
     {
+        if (empty($this->_origin)) {
+            return $this;
+        }
+        $this->_response->header('Access-Control-Max-Age', $age);
         return $this;
     }
 }

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -25,7 +25,7 @@ use Cake\Network\Response;
  * a modified Response.
  *
  * It is most convenient to get this object via `Request::cors()`.
- * 
+ *
  * @see Cake\Network\Response::cors()
  */
 class CorsBuilder
@@ -142,7 +142,7 @@ class CorsBuilder
     /**
      * Set the list of allowed HTTP Methods.
      *
-     * @param array $domain The allowed HTTP methods
+     * @param array $methods The allowed HTTP methods
      * @return $this
      */
     public function allowMethods(array $methods)

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Cake\Network;
+
+use Cake\Network\Response;
+
+class CorsBuilder
+{
+    protected $_response;
+    protected $_origin;
+    protected $_isSsl;
+
+    public function __construct(Response $response, $origin, $isSsl = false)
+    {
+        $this->_origin = $origin;
+        $this->_isSsl = $isSsl;
+        $this->_response = $response;
+    }
+
+    public function allowOrigin($domain)
+    {
+        if (empty($this->_origin)) {
+            return $this;
+        }
+        $allowed = $this->_normalizeDomains((array)$domain);
+        foreach ($allowed as $domain) {
+            if (!preg_match($domain['preg'], $this->_origin)) {
+                continue;
+            }
+            $this->_response->header('Access-Control-Origin', $this->_origin);
+            break;
+        }
+        return $this;
+    }
+
+    /**
+     * Normalize the origin to regular expressions and put in an array format
+     *
+     * @param array $domains Domain names to normalize.
+     * @return array
+     */
+    protected function _normalizeDomains($domains)
+    {
+        $result = [];
+        foreach ($domains as $domain) {
+            if ($domain === '*') {
+                $result[] = ['preg' => '@.@', 'original' => '*'];
+                continue;
+            }
+
+            $original = $preg = $domain;
+            if (strpos($domain, '://') === false) {
+                $preg = ($this->_isSsl ? 'https://' : 'http://') . $domain;
+            }
+            $preg = '@' . str_replace('*', '.*', $domain) . '@';
+            $result[] = compact('original', 'preg');
+        }
+        return $result;
+    }
+
+    public function allowMethods($methods)
+    {
+        return $this;
+    }
+
+    public function allowCredentials()
+    {
+        return $this;
+    }
+
+    public function allowHeaders($headers)
+    {
+        return $this;
+    }
+
+    public function exposeHeaders($headers)
+    {
+        return $this;
+    }
+
+    public function maxAge($headers)
+    {
+        return $this;
+    }
+}

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1351,51 +1351,25 @@ class Response
      * @param string|array $allowedDomains List of allowed domains, see method description for more details
      * @param string|array $allowedMethods List of HTTP verbs allowed
      * @param string|array $allowedHeaders List of HTTP headers allowed
-     * @return void
+     * @return \Cake\Network\CorsBuilder A builder object the provides a fluent interface for defining
+     *   additional CORS headers.
      */
     public function cors(Request $request, $allowedDomains, $allowedMethods = [], $allowedHeaders = [])
     {
         $origin = $request->header('Origin');
+        $ssl = $request->is('ssl');
+        $builder = new CorsBuilder($this, $origin, $ssl);
         if (!$origin) {
-            return;
+            return $builder;
         }
-
-        $allowedDomains = $this->_normalizeCorsDomains((array)$allowedDomains, $request->is('ssl'));
-        foreach ($allowedDomains as $domain) {
-            if (!preg_match($domain['preg'], $origin)) {
-                continue;
-            }
-            $this->header('Access-Control-Allow-Origin', $domain['original'] === '*' ? '*' : $origin);
-            $allowedMethods && $this->header('Access-Control-Allow-Methods', implode(', ', (array)$allowedMethods));
-            $allowedHeaders && $this->header('Access-Control-Allow-Headers', implode(', ', (array)$allowedHeaders));
-            break;
+        $builder->allowOrigin($allowedDomains);
+        if ($allowedMethods) {
+            $builder->allowMethods((array)$allowedMethods);
         }
-    }
-
-    /**
-     * Normalize the origin to regular expressions and put in an array format
-     *
-     * @param array $domains Domain names to normalize.
-     * @param bool $requestIsSSL Whether it's a SSL request.
-     * @return array
-     */
-    protected function _normalizeCorsDomains($domains, $requestIsSSL = false)
-    {
-        $result = [];
-        foreach ($domains as $domain) {
-            if ($domain === '*') {
-                $result[] = ['preg' => '@.@', 'original' => '*'];
-                continue;
-            }
-
-            $original = $preg = $domain;
-            if (strpos($domain, '://') === false) {
-                $preg = ($requestIsSSL ? 'https://' : 'http://') . $domain;
-            }
-            $preg = '@' . str_replace('*', '.*', $domain) . '@';
-            $result[] = compact('original', 'preg');
+        if ($allowedHeaders) {
+            $builder->allowHeaders((array)$allowedHeaders);
         }
-        return $result;
+        return $builder;
     }
 
     /**

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1365,15 +1365,14 @@ class Response
         if (!$origin) {
             return $builder;
         }
-        if ($allowedDomains) {
-            $builder->allowOrigin($allowedDomains);
+        if (empty($allowedDomains) && empty($allowedMethods) && empty($allowedHeaders)) {
+            return $builder;
         }
-        if ($allowedMethods) {
-            $builder->allowMethods((array)$allowedMethods);
-        }
-        if ($allowedHeaders) {
-            $builder->allowHeaders((array)$allowedHeaders);
-        }
+
+        $builder->allowOrigin($allowedDomains)
+            ->allowMethods((array)$allowedMethods)
+            ->allowHeaders((array)$allowedHeaders)
+            ->build();
         return $builder;
     }
 

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1347,6 +1347,9 @@ class Response
      * cors($request, ['http://www.cakephp.org', '*.google.com', 'https://myproject.github.io']);
      * ```
      *
+     * *Note* The `$allowedDomains`, `$allowedMethods`, `$allowedHeaders` parameters are deprectated.
+     * Instead the builder object should be used.
+     *
      * @param \Cake\Network\Request $request Request object
      * @param string|array $allowedDomains List of allowed domains, see method description for more details
      * @param string|array $allowedMethods List of HTTP verbs allowed
@@ -1354,7 +1357,7 @@ class Response
      * @return \Cake\Network\CorsBuilder A builder object the provides a fluent interface for defining
      *   additional CORS headers.
      */
-    public function cors(Request $request, $allowedDomains, $allowedMethods = [], $allowedHeaders = [])
+    public function cors(Request $request, $allowedDomains = [], $allowedMethods = [], $allowedHeaders = [])
     {
         $origin = $request->header('Origin');
         $ssl = $request->is('ssl');
@@ -1362,7 +1365,9 @@ class Response
         if (!$origin) {
             return $builder;
         }
-        $builder->allowOrigin($allowedDomains);
+        if ($allowedDomains) {
+            $builder->allowOrigin($allowedDomains);
+        }
         if ($allowedMethods) {
             $builder->allowMethods((array)$allowedMethods);
         }

--- a/tests/TestCase/Network/CorsBuilderTest.php
+++ b/tests/TestCase/Network/CorsBuilderTest.php
@@ -30,12 +30,12 @@ class CorsBuilderTest extends TestCase
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com');
         $this->assertSame($builder, $builder->allowOrigin(['*.example.com', '*.foo.com']));
-        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Allow-Origin');
 
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com');
         $this->assertSame($builder, $builder->allowOrigin('*.example.com'));
-        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Allow-Origin');
     }
 
     /**
@@ -48,17 +48,17 @@ class CorsBuilderTest extends TestCase
         $response = new Response();
         $builder = new CorsBuilder($response, 'https://www.example.com', true);
         $this->assertSame($builder, $builder->allowOrigin('http://example.com'));
-        $this->assertNoHeader($response, 'Access-Control-Origin');
+        $this->assertNoHeader($response, 'Access-Control-Allow-Origin');
 
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com', true);
         $this->assertSame($builder, $builder->allowOrigin('https://example.com'));
-        $this->assertNoHeader($response, 'Access-Control-Origin');
+        $this->assertNoHeader($response, 'Access-Control-Allow-Origin');
 
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com');
         $this->assertSame($builder, $builder->allowOrigin('https://example.com'));
-        $this->assertNoHeader($response, 'Access-Control-Origin');
+        $this->assertNoHeader($response, 'Access-Control-Allow-Origin');
     }
 
     public function testAllowMethodsNoOrigin()
@@ -107,6 +107,38 @@ class CorsBuilderTest extends TestCase
         $builder = new CorsBuilder($response, 'http://example.com');
         $this->assertSame($builder, $builder->allowHeaders(['Content-Type', 'Accept']));
         $this->assertHeader('Content-Type, Accept', $response, 'Access-Control-Allow-Headers');
+    }
+
+    public function testExposeHeadersNoOrigin()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, '');
+        $this->assertSame($builder, $builder->exposeHeaders(['X-THING']));
+        $this->assertNoHeader($response, 'Access-Control-Expose-Headers');
+    }
+
+    public function testExposeHeaders()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://example.com');
+        $this->assertSame($builder, $builder->exposeHeaders(['Content-Type', 'Accept']));
+        $this->assertHeader('Content-Type, Accept', $response, 'Access-Control-Expose-Headers');
+    }
+
+    public function testMaxAgeNoOrigin()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, '');
+        $this->assertSame($builder, $builder->maxAge(300));
+        $this->assertNoHeader($response, 'Access-Control-Max-Age');
+    }
+
+    public function testMaxAge()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://example.com');
+        $this->assertSame($builder, $builder->maxAge(300));
+        $this->assertHeader('300', $response, 'Access-Control-Max-Age');
     }
 
     /**

--- a/tests/TestCase/Network/CorsBuilderTest.php
+++ b/tests/TestCase/Network/CorsBuilderTest.php
@@ -12,12 +12,12 @@ class CorsBuilderTest extends TestCase
      *
      * @return void
      */
-    public function testAllowOriginArray()
+    public function testAllowOriginNoOrigin()
     {
         $response = new Response();
-        $builder = new CorsBuilder($response, 'http://www.example.com');
+        $builder = new CorsBuilder($response, '');
         $this->assertSame($builder, $builder->allowOrigin(['*.example.com', '*.foo.com']));
-        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+        $this->assertNoHeader($response, 'Access-Control-Origin');
     }
 
     /**
@@ -25,12 +25,88 @@ class CorsBuilderTest extends TestCase
      *
      * @return void
      */
-    public function testOriginString()
+    public function testAllowOrigin()
     {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://www.example.com');
+        $this->assertSame($builder, $builder->allowOrigin(['*.example.com', '*.foo.com']));
+        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com');
         $this->assertSame($builder, $builder->allowOrigin('*.example.com'));
         $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+    }
+
+    /**
+     * test allowOrigin() with SSL
+     *
+     * @return void
+     */
+    public function testAllowOriginSsl()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'https://www.example.com', true);
+        $this->assertSame($builder, $builder->allowOrigin('http://example.com'));
+        $this->assertNoHeader($response, 'Access-Control-Origin');
+
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://www.example.com', true);
+        $this->assertSame($builder, $builder->allowOrigin('https://example.com'));
+        $this->assertNoHeader($response, 'Access-Control-Origin');
+
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://www.example.com');
+        $this->assertSame($builder, $builder->allowOrigin('https://example.com'));
+        $this->assertNoHeader($response, 'Access-Control-Origin');
+    }
+
+    public function testAllowMethodsNoOrigin()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, '');
+        $this->assertSame($builder, $builder->allowMethods(['GET', 'POST']));
+        $this->assertNoHeader($response, 'Access-Control-Allow-Methods');
+    }
+
+    public function testAllowMethods()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://example.com');
+        $this->assertSame($builder, $builder->allowMethods(['GET', 'POST']));
+        $this->assertHeader('GET, POST', $response, 'Access-Control-Allow-Methods');
+    }
+
+    public function testAllowCredentialsNoOrigin()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, '');
+        $this->assertSame($builder, $builder->allowCredentials());
+        $this->assertNoHeader($response, 'Access-Control-Allow-Credentials');
+    }
+
+    public function testAllowCredentials()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://example.com');
+        $this->assertSame($builder, $builder->allowCredentials());
+        $this->assertHeader('true', $response, 'Access-Control-Allow-Credentials');
+    }
+
+    public function testAllowHeadersNoOrigin()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, '');
+        $this->assertSame($builder, $builder->allowHeaders(['X-THING']));
+        $this->assertNoHeader($response, 'Access-Control-Allow-Headers');
+    }
+
+    public function testAllowHeaders()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://example.com');
+        $this->assertSame($builder, $builder->allowHeaders(['Content-Type', 'Accept']));
+        $this->assertHeader('Content-Type, Accept', $response, 'Access-Control-Allow-Headers');
     }
 
     /**
@@ -45,5 +121,17 @@ class CorsBuilderTest extends TestCase
         $headers = $response->header();
         $this->assertArrayHasKey($header, $headers, 'Header key not found.');
         $this->assertEquals($expected, $headers[$header], 'Header value not found.');
+    }
+
+    /**
+     * Helper for checking header values.
+     *
+     * @param \Cake\Network\Response $response The Response object.
+     * @params string $header The header key to check
+     */
+    protected function assertNoHeader(Response $response, $header)
+    {
+        $headers = $response->header();
+        $this->assertArrayNotHasKey($header, $headers, 'Header key was found.');
     }
 }

--- a/tests/TestCase/Network/CorsBuilderTest.php
+++ b/tests/TestCase/Network/CorsBuilderTest.php
@@ -29,6 +29,11 @@ class CorsBuilderTest extends TestCase
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com');
+        $this->assertSame($builder, $builder->allowOrigin('*'));
+        $this->assertHeader('*', $response, 'Access-Control-Allow-Origin');
+
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://www.example.com');
         $this->assertSame($builder, $builder->allowOrigin(['*.example.com', '*.foo.com']));
         $this->assertHeader('http://www.example.com', $response, 'Access-Control-Allow-Origin');
 

--- a/tests/TestCase/Network/CorsBuilderTest.php
+++ b/tests/TestCase/Network/CorsBuilderTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Cake\Test\TestCase\Network;
+
+use Cake\Network\CorsBuilder;
+use Cake\Network\Response;
+use Cake\TestSuite\TestCase;
+
+class CorsBuilderTest extends TestCase
+{
+    /**
+     * test allowOrigin() setting allow-origin
+     *
+     * @return void
+     */
+    public function testAllowOriginArray()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://www.example.com');
+        $this->assertSame($builder, $builder->allowOrigin(['*.example.com', '*.foo.com']));
+        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+    }
+
+    /**
+     * test allowOrigin() setting allow-origin
+     *
+     * @return void
+     */
+    public function testOriginString()
+    {
+        $response = new Response();
+        $builder = new CorsBuilder($response, 'http://www.example.com');
+        $this->assertSame($builder, $builder->allowOrigin('*.example.com'));
+        $this->assertHeader('http://www.example.com', $response, 'Access-Control-Origin');
+    }
+
+    /**
+     * Helper for checking header values.
+     *
+     * @param string $expected The expected value
+     * @param \Cake\Network\Response $response The Response object.
+     * @params string $header The header key to check
+     */
+    protected function assertHeader($expected, Response $response, $header)
+    {
+        $headers = $response->header();
+        $this->assertArrayHasKey($header, $headers, 'Header key not found.');
+        $this->assertEquals($expected, $headers[$header], 'Header value not found.');
+    }
+}

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1082,25 +1082,24 @@ class ResponseTest extends TestCase
     public function testCors($request, $origin, $domains, $methods, $headers, $expectedOrigin, $expectedMethods = false, $expectedHeaders = false)
     {
         $request->env('HTTP_ORIGIN', $origin);
+        $response = new Response();
 
-        $response = $this->getMock('Cake\Network\Response', ['header']);
+        $result = $response->cors($request, $domains, $methods, $headers);
+        $this->assertInstanceOf('Cake\Network\CorsBuilder', $result);
 
-        $method = $response->expects(!$expectedOrigin ? $this->never() : $this->at(0))->method('header');
-        $expectedOrigin && $method->with('Access-Control-Allow-Origin', $expectedOrigin ? $expectedOrigin : $this->anything());
-
-        $i = 1;
+        $headers = $response->header();
+        if ($expectedOrigin) {
+            $this->assertArrayHasKey('Access-Control-Allow-Origin', $headers);
+            $this->assertEquals($expectedOrigin, $headers['Access-Control-Allow-Origin']);
+        }
         if ($expectedMethods) {
-            $response->expects($this->at($i++))
-                ->method('header')
-                ->with('Access-Control-Allow-Methods', $expectedMethods ? $expectedMethods : $this->anything());
+            $this->assertArrayHasKey('Access-Control-Allow-Methods', $headers);
+            $this->assertEquals($expectedMethods, $headers['Access-Control-Allow-Methods']);
         }
         if ($expectedHeaders) {
-            $response->expects($this->at($i++))
-                ->method('header')
-                ->with('Access-Control-Allow-Headers', $expectedHeaders ? $expectedHeaders : $this->anything());
+            $this->assertArrayHasKey('Access-Control-Allow-Headers', $headers);
+            $this->assertEquals($expectedHeaders, $headers['Access-Control-Allow-Headers']);
         }
-
-        $response->cors($request, $domains, $methods, $headers);
         unset($_SERVER['HTTP_ORIGIN']);
     }
 


### PR DESCRIPTION
This adds a CORS builder that can be used to set the various cors headers through a fluent interface. This was originally discussed in #7402 and #7405.

I've not finished the documentation, but I wanted to get feedback on these changes before writing all the documentation.
### Todo
- [x] Finish documentation.
- [ ] Update book docs.
