### PR TITLE
3.2 - Changes required for #4283

### DIFF
--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -103,12 +103,12 @@ trait PostgresDialectTrait
         switch ($expression->name()) {
             case 'CONCAT':
                 // CONCAT function is expressed as exp1 || exp2
-                $expression->name('')->type(' ||');
+                $expression->name('')->tieWith(' ||');
                 break;
             case 'DATEDIFF':
                 $expression
                     ->name('')
-                    ->type('-')
+                    ->tieWith('-')
                     ->iterateParts(function ($p) {
                         if (is_string($p)) {
                             $p = ['value' => [$p => 'literal'], 'type' => null];
@@ -121,11 +121,11 @@ trait PostgresDialectTrait
                 break;
             case 'CURRENT_DATE':
                 $time = new FunctionExpression('LOCALTIMESTAMP', [' 0 ' => 'literal']);
-                $expression->name('CAST')->type(' AS ')->add([$time, 'date' => 'literal']);
+                $expression->name('CAST')->tieWith(' AS ')->add([$time, 'date' => 'literal']);
                 break;
             case 'CURRENT_TIME':
                 $time = new FunctionExpression('LOCALTIMESTAMP', [' 0 ' => 'literal']);
-                $expression->name('CAST')->type(' AS ')->add([$time, 'time' => 'literal']);
+                $expression->name('CAST')->tieWith(' AS ')->add([$time, 'time' => 'literal']);
                 break;
             case 'NOW':
                 $expression->name('LOCALTIMESTAMP')->add([' 0 ' => 'literal']);
@@ -133,7 +133,7 @@ trait PostgresDialectTrait
             case 'DATE_ADD':
                 $expression
                     ->name('')
-                    ->type(' + INTERVAL')
+                    ->tieWith(' + INTERVAL')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 1) {
                             $p = sprintf("'%s'", $p);
@@ -144,7 +144,7 @@ trait PostgresDialectTrait
             case 'DAYOFWEEK':
                 $expression
                     ->name('EXTRACT')
-                    ->type(' ')
+                    ->tieWith(' ')
                     ->add(['DOW FROM' => 'literal'], [], true)
                     ->add([') + (1' => 'literal']); // Postgres starts on index 0 but Sunday should be 1
                 break;

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -95,12 +95,12 @@ trait SqliteDialectTrait
         switch ($expression->name()) {
             case 'CONCAT':
                 // CONCAT function is expressed as exp1 || exp2
-                $expression->name('')->type(' ||');
+                $expression->name('')->tieWith(' ||');
                 break;
             case 'DATEDIFF':
                 $expression
                     ->name('ROUND')
-                    ->type('-')
+                    ->tieWith('-')
                     ->iterateParts(function ($p) {
                         return new FunctionExpression('JULIANDAY', [$p['value']], [$p['type']]);
                     });
@@ -117,7 +117,7 @@ trait SqliteDialectTrait
             case 'EXTRACT':
                 $expression
                     ->name('STRFTIME')
-                    ->type(' ,')
+                    ->tieWith(' ,')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 0) {
                             $value = rtrim(strtolower($p), 's');
@@ -131,7 +131,7 @@ trait SqliteDialectTrait
             case 'DATE_ADD':
                 $expression
                     ->name('DATE')
-                    ->type(',')
+                    ->tieWith(',')
                     ->iterateParts(function ($p, $key) {
                         if ($key === 1) {
                             $p = ['value' => $p, 'type' => null];
@@ -142,7 +142,7 @@ trait SqliteDialectTrait
             case 'DAYOFWEEK':
                 $expression
                     ->name('STRFTIME')
-                    ->type(' ')
+                    ->tieWith(' ')
                     ->add(["'%w', " => 'literal'], [], true)
                     ->add([') + (1' => 'literal']); // Sqlite starts on index 0 but Sunday should be 1
                 break;

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -154,10 +154,10 @@ trait SqlserverDialectTrait
             ->select(function ($q) use ($distinct, $order) {
                 $over = $q->newExpr('ROW_NUMBER() OVER')
                     ->add('(PARTITION BY')
-                    ->add($q->newExpr()->add($distinct)->type(','))
+                    ->add($q->newExpr()->add($distinct)->tieWith(','))
                     ->add($order)
                     ->add(')')
-                    ->type(' ');
+                    ->tieWith(' ');
                 return [
                     '_cake_distinct_pivot_' => $over
                 ];
@@ -210,7 +210,7 @@ trait SqlserverDialectTrait
         switch ($expression->name()) {
             case 'CONCAT':
                 // CONCAT function is expressed as exp1 + exp2
-                $expression->name('')->type(' +');
+                $expression->name('')->tieWith(' +');
                 break;
             case 'DATEDIFF':
                 $hasDay = false;
@@ -238,7 +238,7 @@ trait SqlserverDialectTrait
                 $expression->name('GETUTCDATE');
                 break;
             case 'EXTRACT':
-                $expression->name('DATEPART')->type(' ,');
+                $expression->name('DATEPART')->tieWith(' ,');
                 break;
             case 'DATE_ADD':
                 $params = [];
@@ -258,7 +258,7 @@ trait SqlserverDialectTrait
 
                 $expression
                     ->name('DATEADD')
-                    ->type(',')
+                    ->tieWith(',')
                     ->iterateParts($visitor)
                     ->iterateParts($manipulator)
                     ->add([$params[2] => 'literal']);
@@ -266,7 +266,7 @@ trait SqlserverDialectTrait
             case 'DAYOFWEEK':
                 $expression
                     ->name('DATEPART')
-                    ->type(' ')
+                    ->tieWith(' ')
                     ->add(['weekday, ' => 'literal'], [], true);
                 break;
         }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -75,7 +75,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Changes the conjunction for the conditions at this level of the expression tree.
      * If called with no arguments it will return the currently configured value.
      *
-     * @param string $conjunction value to be used for joining conditions. If null it
+     * @param string|null $conjunction value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
      * @return string|$this
      */
@@ -92,7 +92,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Backwards compatible wrapper for tieWith()
      *
-     * @param string $conjunction value to be used for joining conditions. If null it
+     * @param string|null $conjunction value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
      * @return string|$this
      * @deprecated 3.2.0 Use tieWith() instead

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -65,7 +65,7 @@ class QueryExpression implements ExpressionInterface, Countable
     public function __construct($conditions = [], $types = [], $conjunction = 'AND')
     {
         $this->typeMap($types);
-        $this->type(strtoupper($conjunction));
+        $this->tieWith(strtoupper($conjunction));
         if (!empty($conditions)) {
             $this->add($conditions, $this->typeMap()->types());
         }
@@ -79,7 +79,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * will not set any value, but return the currently stored one
      * @return string|$this
      */
-    public function type($conjunction = null)
+    public function tieWith($conjunction = null)
     {
         if ($conjunction === null) {
             return $this->_conjunction;
@@ -87,6 +87,19 @@ class QueryExpression implements ExpressionInterface, Countable
 
         $this->_conjunction = strtoupper($conjunction);
         return $this;
+    }
+
+    /**
+     * Backwards compatible wrapper for tieWith()
+     *
+     * @param string $conjunction value to be used for joining conditions. If null it
+     * will not set any value, but return the currently stored one
+     * @return string|$this
+     * @deprecated 3.2.0 Use tieWith() instead
+     */
+    public function type($conjunction = null)
+    {
+        return $this->tieWith($conjunction);
     }
 
     /**

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\Type\OptionalConvertInterface;
+
 /**
  * A callable class to be used for processing each of the rows in a statement
  * result, so that the values are converted to the right PHP types.
@@ -48,6 +50,12 @@ class FieldTypeConverter
         $types = array_keys(Type::map());
         $types = array_map(['Cake\Database\Type', 'build'], array_combine($types, $types));
         $result = [];
+
+        foreach ($types as $k => $type) {
+            if ($type instanceof OptionalConvertInterface && !$type->requiresToPHPCast()) {
+                unset($types[$k]);
+            }
+        }
 
         foreach ($map as $field => $type) {
             if (isset($types[$type])) {

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -51,7 +51,7 @@ class FieldTypeConverter
         $result = [];
 
         foreach ($types as $k => $type) {
-            if ($type instanceof OptionalConvertInterface && !$type->requiresToPHPCast()) {
+            if ($type instanceof OptionalConvertInterface && !$type->requiresToPhpCast()) {
                 unset($types[$k]);
             }
         }

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -47,8 +47,7 @@ class FieldTypeConverter
     {
         $this->_driver = $driver;
         $map = $typeMap->toArray();
-        $types = array_keys(Type::map());
-        $types = array_map(['Cake\Database\Type', 'build'], array_combine($types, $types));
+        $types = Type::buildAll();
         $result = [];
 
         foreach ($types as $k => $type) {

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database;
+
+/**
+ * A callable class to be used for processing each of the rows in a statement
+ * result, so that the values are converted to the right PHP types.
+ */
+class FieldTypeConverter
+{
+    /**
+     * An array containing the name of the fields and the Type objects
+     * each should use when converting them.
+     *
+     * @var array
+     */
+    protected $_typeMap;
+
+    /**
+     * The driver object to be used in the type conversion
+     *
+     * @var \Cake\Database\Driver
+     */
+    protected $_driver;
+
+    /**
+     * Builds the type map
+     *
+     * @param \Cake\Database\TypeMap $typeMap Contains the types to use for converting results
+     * @param \Cake\Database\Driver $driver The driver to use for the type conversion
+     */
+    public function __construct(TypeMap $typeMap, Driver $driver)
+    {
+        $this->_driver = $driver;
+        $map = $typeMap->toArray();
+        $types = array_keys(Type::map());
+        $types = array_map(['Cake\Database\Type', 'build'], array_combine($types, $types));
+        $result = [];
+
+        foreach ($map as $field => $type) {
+            if (isset($types[$type])) {
+                $result[$field] = $types[$type];
+            }
+        }
+        $this->_typeMap = $result;
+    }
+
+    /**
+     * Converts each of the fields in the array that are present in the type map
+     * using the corresponding Type class.
+     *
+     * @param array $row The array with the fields to be casted
+     * @return array
+     */
+    public function __invoke($row)
+    {
+        foreach ($this->_typeMap as $field => $type) {
+            $row[$field] = $type->toPHP($row[$field], $this->_driver);
+        }
+        return $row;
+    }
+}

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -178,7 +178,7 @@ class FunctionsBuilder
     public function extract($part, $expression, $types = [])
     {
         $expression = $this->_literalArgumentFunction('EXTRACT', $expression, $types);
-        $expression->type(' FROM')->add([$part => 'literal'], [], true);
+        $expression->tieWith(' FROM')->add([$part => 'literal'], [], true);
         return $expression;
     }
 
@@ -198,7 +198,7 @@ class FunctionsBuilder
         }
         $interval = $value . ' ' . $unit;
         $expression = $this->_literalArgumentFunction('DATE_ADD', $expression, $types);
-        $expression->type(', INTERVAL')->add([$interval => 'literal']);
+        $expression->tieWith(', INTERVAL')->add([$interval => 'literal']);
         return $expression;
     }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1698,7 +1698,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * When called with no arguments, the current TypeMap object is returned.
      *
-     * @param \Cake\Database\TypeMap $typeMap The map object to use
+     * @param \Cake\Database\TypeMap|null $typeMap The map object to use
      * @return $this|\Cake\Database\TypeMap
      */
     public function selectTypeMap(TypeMap $typeMap = null)

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1790,8 +1790,11 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function __clone()
     {
         $this->_iterator = null;
-        if ($this->_valueBinder) {
+        if ($this->_valueBinder !== null) {
             $this->_valueBinder = clone $this->_valueBinder;
+        }
+        if ($this->_selectTypeMap !== null) {
+            $this->_selectTypeMap = clone $this->_selectTypeMap;
         }
         foreach ($this->_parts as $name => $part) {
             if (empty($part)) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -704,7 +704,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ### Using expressions objects:
      *
      * ```
-     *  $exp = $query->newExpr()->add(['id !=' => 100, 'author_id' != 1])->type('OR');
+     *  $exp = $query->newExpr()->add(['id !=' => 100, 'author_id' != 1])->tieWith('OR');
      *  $query->where(['published' => true], ['published' => 'boolean'])->where($exp);
      * ```
      *

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -106,6 +106,20 @@ class Type
     }
 
     /**
+     * Returns an arrays with all the mapped type objects, indexed by name
+     *
+     * @return array
+     */
+    public static function buildAll()
+    {
+        $result = [];
+        foreach (self::$_types as $name => $type) {
+            $result[$name] = isset(static::$_builtTypes[$name]) ? static::$_builtTypes[$name] : static::build($name);
+        }
+        return $result;
+    }
+
+    /**
      * Returns a Type object capable of converting a type identified by $name
      *
      * @param string $name The type identifier you want to set.

--- a/src/Database/Type/OptionalConvertInterface.php
+++ b/src/Database/Type/OptionalConvertInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Type;
+
+/**
+ * An interface used by Type objects to signal whether the casting
+ * is actually required.
+ */
+interface OptionalConvertInterface
+{
+
+    /**
+     * Returns whehter the cast to PHP is required to be invoked, since
+     * it is not a indentity function.
+     *
+     * @return boolean
+     */
+    public function requiresToPHPCast();
+}

--- a/src/Database/Type/OptionalConvertInterface.php
+++ b/src/Database/Type/OptionalConvertInterface.php
@@ -25,7 +25,7 @@ interface OptionalConvertInterface
      * Returns whehter the cast to PHP is required to be invoked, since
      * it is not a indentity function.
      *
-     * @return boolean
+     * @return bool
      */
     public function requiresToPHPCast();
 }

--- a/src/Database/Type/OptionalConvertInterface.php
+++ b/src/Database/Type/OptionalConvertInterface.php
@@ -27,5 +27,5 @@ interface OptionalConvertInterface
      *
      * @return boolean
      */
-    public function requiresToPHPCast();
+    public function requiresToPhpCast();
 }

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -24,7 +24,7 @@ use PDO;
  *
  * Use to convert string data between PHP and the database types.
  */
-class StringType extends Type
+class StringType extends Type implements OptionalConvertInterface
 {
 
     /**
@@ -93,5 +93,15 @@ class StringType extends Type
             return '';
         }
         return (string)$value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return boolean False as databse results are returned already as strings
+     */
+    public function requiresToPHPCast()
+    {
+        return false;
     }
 }

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -100,7 +100,7 @@ class StringType extends Type implements OptionalConvertInterface
      *
      * @return boolean False as databse results are returned already as strings
      */
-    public function requiresToPHPCast()
+    public function requiresToPhpCast()
     {
         return false;
     }

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -136,4 +136,14 @@ class TypeMap
         }
         return null;
     }
+
+    /**
+     * Returns an array of all types mapped types
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->_types + $this->_defaults;
+    }
 }

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -319,7 +319,7 @@ interface QueryInterface
      * ### Using expressions objects:
      *
      * ```
-     *  $exp = $query->newExpr()->add(['id !=' => 100, 'author_id' != 1])->type('OR');
+     *  $exp = $query->newExpr()->add(['id !=' => 100, 'author_id' != 1])->tieWith('OR');
      *  $query->where(['published' => true], ['published' => 'boolean'])->where($exp);
      * ```
      *

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -179,7 +179,6 @@ class ResultSet implements ResultSetInterface
         $this->_useBuffering = $query->bufferResults();
         $this->_defaultAlias = $this->_defaultTable->alias();
         $this->_calculateColumnMap();
-        $this->_calculateTypeMap();
 
         if ($this->_useBuffering) {
             $count = $this->count();
@@ -397,34 +396,11 @@ class ResultSet implements ResultSetInterface
      * Creates a map of Type converter classes for each of the columns that should
      * be fetched by this object.
      *
+     * @deprecated 3.2.0 Not used anymore. Type casting is done at the statement level
      * @return void
      */
     protected function _calculateTypeMap()
     {
-        if (isset($this->_map[$this->_defaultAlias])) {
-            $this->_types[$this->_defaultAlias] = $this->_getTypes(
-                $this->_defaultTable,
-                $this->_map[$this->_defaultAlias]
-            );
-        }
-
-        foreach ($this->_matchingMapColumns as $alias => $keys) {
-            $this->_types[$alias] = $this->_getTypes(
-                $this->_matchingMap[$alias]['instance']->target(),
-                $keys
-            );
-        }
-
-        foreach ($this->_containMap as $assoc) {
-            $alias = $assoc['alias'];
-            if (isset($this->_types[$alias]) || !$assoc['canBeJoined'] || !isset($this->_map[$alias])) {
-                continue;
-            }
-            $this->_types[$alias] = $this->_getTypes(
-                $assoc['instance']->target(),
-                $this->_map[$alias]
-            );
-        }
     }
 
     /**
@@ -499,12 +475,9 @@ class ResultSet implements ResultSetInterface
 
         foreach ($this->_matchingMapColumns as $alias => $keys) {
             $matching = $this->_matchingMap[$alias];
-            $results['_matchingData'][$alias] = $this->_castValues(
-                $alias,
-                array_combine(
-                    $keys,
-                    array_intersect_key($row, $keys)
-                )
+            $results['_matchingData'][$alias] = array_combine(
+                $keys,
+                array_intersect_key($row, $keys)
             );
             if ($this->_hydrate) {
                 $options['source'] = $matching['instance']->registryAlias();
@@ -519,12 +492,6 @@ class ResultSet implements ResultSetInterface
             $presentAliases[$table] = true;
         }
 
-        if (isset($presentAliases[$defaultAlias])) {
-            $results[$defaultAlias] = $this->_castValues(
-                $defaultAlias,
-                $results[$defaultAlias]
-            );
-        }
         unset($presentAliases[$defaultAlias]);
 
         foreach ($this->_containMap as $assoc) {
@@ -550,8 +517,6 @@ class ResultSet implements ResultSetInterface
             unset($presentAliases[$alias]);
 
             if ($assoc['canBeJoined']) {
-                $results[$alias] = $this->_castValues($assoc['alias'], $results[$alias]);
-
                 $hasData = false;
                 foreach ($results[$alias] as $v) {
                     if ($v !== null && $v !== []) {
@@ -602,14 +567,11 @@ class ResultSet implements ResultSetInterface
      *
      * @param string $alias The table object alias
      * @param array $values The values to cast
+     * @deprecated 3.2.0 Not used anymore. Type casting is done at the statement level
      * @return array
      */
     protected function _castValues($alias, $values)
     {
-        foreach ($this->_types[$alias] as $field => $type) {
-            $values[$field] = $type->toPHP($values[$field], $this->_driver);
-        }
-
         return $values;
     }
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Database;
 use Cake\Core\Configure;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Query;
+use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
@@ -3486,6 +3487,40 @@ class QueryTest extends TestCase
 
         $query->order(['Articles.title' => 'ASC']);
         $this->assertNotEquals($query->clause('order'), $dupe->clause('order'));
+    }
+
+    /**
+     * Tests the selectTypeMap method
+     *
+     * @return void
+     */
+    public function testSelectTypeMap()
+    {
+        $query = new Query($this->connection);
+        $typeMap = $query->selectTypeMap();
+        $this->assertInstanceOf(TypeMap::class, $typeMap);
+        $another = clone $typeMap;
+        $query->selectTypeMap($another);
+        $this->assertSame($another, $query->selectTypeMap());
+    }
+
+    /**
+     * Tests the automatic type conversion for the fields in the result
+     *
+     * @return void
+     */
+    public function testSelectTypeConversion()
+    {
+        $query = new Query($this->connection);
+        $time = new \DateTime('2007-03-18 10:50:00');
+        $query
+            ->select(['id', 'comment', 'the_date' => 'created'])
+            ->from('comments')
+            ->limit(1)
+            ->selectTypeMap()->types(['id' => 'integer', 'the_date' => 'datetime']);
+        $result = $query->execute()->fetchAll('assoc');
+        $this->assertInternalType('integer', $result[0]['id']);
+        $this->assertInstanceOf('DateTime', $result[0]['the_date']);
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3487,6 +3487,11 @@ class QueryTest extends TestCase
 
         $query->order(['Articles.title' => 'ASC']);
         $this->assertNotEquals($query->clause('order'), $dupe->clause('order'));
+
+        $this->assertNotSame(
+            $query->selectTypeMap(),
+            $dupe->selectTypeMap()
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -77,6 +77,8 @@ class BelongsToTest extends TestCase
             'id' => 'integer',
             'Companies.company_name' => 'string',
             'company_name' => 'string',
+            'Companies__id' => 'integer',
+            'Companies__company_name' => 'string'
         ]);
     }
 

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -65,6 +65,9 @@ class HasOneTest extends TestCase
             'first_name' => 'string',
             'Profiles.user_id' => 'integer',
             'user_id' => 'integer',
+            'Profiles__first_name' => 'string',
+            'Profiles__user_id' => 'integer',
+            'Profiles__id' => 'integer',
         ]);
     }
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -87,6 +87,9 @@ class EagerLoaderTest extends TestCase
             'name' => 'string',
             'clients.phone' => 'string',
             'phone' => 'string',
+            'clients__id' => 'integer',
+            'clients__name' => 'string',
+            'clients__phone' => 'string',
         ]);
         $this->ordersTypeMap = new TypeMap([
             'orders.id' => 'integer',
@@ -95,26 +98,34 @@ class EagerLoaderTest extends TestCase
             'total' => 'string',
             'orders.placed' => 'datetime',
             'placed' => 'datetime',
+            'orders__id' => 'integer',
+            'orders__total' => 'string',
+            'orders__placed' => 'datetime',
         ]);
         $this->orderTypesTypeMap = new TypeMap([
             'orderTypes.id' => 'integer',
             'id' => 'integer',
+            'orderTypes__id' => 'integer',
         ]);
         $this->stuffTypeMap = new TypeMap([
             'stuff.id' => 'integer',
             'id' => 'integer',
+            'stuff__id' => 'integer',
         ]);
         $this->stuffTypesTypeMap = new TypeMap([
             'stuffTypes.id' => 'integer',
             'id' => 'integer',
+            'stuffTypes__id' => 'integer',
         ]);
         $this->companiesTypeMap = new TypeMap([
             'companies.id' => 'integer',
             'id' => 'integer',
+            'companies__id' => 'integer',
         ]);
         $this->categoriesTypeMap = new TypeMap([
             'categories.id' => 'integer',
             'id' => 'integer',
+            'categories__id' => 'integer',
         ]);
     }
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -824,14 +824,20 @@ class QueryTest extends TestCase
         $typeMap = new TypeMap([
             'foo.id' => 'integer',
             'id' => 'integer',
+            'foo__id' => 'integer',
             'articles.id' => 'integer',
+            'articles__id' => 'integer',
             'articles.author_id' => 'integer',
+            'articles__author_id' => 'integer',
             'author_id' => 'integer',
             'articles.title' => 'string',
+            'articles__title' => 'string',
             'title' => 'string',
             'articles.body' => 'text',
+            'articles__body' => 'text',
             'body' => 'text',
             'articles.published' => 'string',
+            'articles__published' => 'string',
             'published' => 'string',
         ]);
 
@@ -2372,10 +2378,12 @@ class QueryTest extends TestCase
             'sql' => $query->sql(),
             'params' => $query->valueBinder()->bindings(),
             'defaultTypes' => [
+                'authors__id' => 'integer',
                 'authors.id' => 'integer',
                 'id' => 'integer',
+                'authors__name' => 'string',
                 'authors.name' => 'string',
-                'name' => 'string'
+                'name' => 'string',
             ],
             'decorators' => 0,
             'executed' => false,

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -82,25 +82,35 @@ class TableTest extends TestCase
         $this->usersTypeMap = new TypeMap([
             'Users.id' => 'integer',
             'id' => 'integer',
+            'Users__id' => 'integer',
             'Users.username' => 'string',
+            'Users__username' => 'string',
             'username' => 'string',
             'Users.password' => 'string',
+            'Users__password' => 'string',
             'password' => 'string',
             'Users.created' => 'timestamp',
+            'Users__created' => 'timestamp',
             'created' => 'timestamp',
             'Users.updated' => 'timestamp',
+            'Users__updated' => 'timestamp',
             'updated' => 'timestamp',
         ]);
         $this->articlesTypeMap = new TypeMap([
             'Articles.id' => 'integer',
+            'Articles__id' => 'integer',
             'id' => 'integer',
             'Articles.title' => 'string',
+            'Articles__title' => 'string',
             'title' => 'string',
             'Articles.author_id' => 'integer',
+            'Articles__author_id' => 'integer',
             'author_id' => 'integer',
             'Articles.body' => 'text',
+            'Articles__body' => 'text',
             'body' => 'text',
             'Articles.published' => 'string',
+            'Articles__published' => 'string',
             'published' => 'string',
         ]);
     }
@@ -1756,7 +1766,7 @@ class TableTest extends TestCase
                 'entityClass' => 'Cake\ORM\Entity',
             ]
         );
-        
+
         $authors->hasMany('Articles', ['saveStrategy' => 'replace']);
 
         $entity = $authors->newEntity([
@@ -1775,9 +1785,9 @@ class TableTest extends TestCase
         $articleId = $entity->articles[0]->id;
         unset($entity->articles[0]);
         $entity->dirty('articles', true);
-        
+
         $authors->save($entity, ['associated' => ['Articles']]);
-        
+
         $this->assertEquals($sizeArticles - 1, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
         $this->assertTrue($authors->Articles->exists(['id' => $articleId]));
     }
@@ -1798,7 +1808,7 @@ class TableTest extends TestCase
                 'entityClass' => 'Cake\ORM\Entity',
             ]
         );
-        
+
         $authors->hasMany('Articles', ['saveStrategy' => 'replace']);
 
         $entity = $authors->newEntity([
@@ -1815,9 +1825,9 @@ class TableTest extends TestCase
         $this->assertCount($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']]));
 
         $entity->set('articles', []);
-        
+
         $entity = $authors->save($entity, ['associated' => ['Articles']]);
-        
+
         $this->assertCount(0, $authors->Articles->find('all')->where(['author_id' => $entity['id']]));
     }
 
@@ -1852,13 +1862,13 @@ class TableTest extends TestCase
         $sizeArticles = count($entity->articles);
 
         $this->assertEquals($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
-        
+
         $articleId = $entity->articles[0]->id;
         unset($entity->articles[0]);
         $entity->dirty('articles', true);
-        
+
         $authors->save($entity, ['associated' => ['Articles']]);
-        
+
         $this->assertEquals($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
         $this->assertTrue($authors->Articles->exists(['id' => $articleId]));
     }
@@ -1916,9 +1926,9 @@ class TableTest extends TestCase
         $articleId = $entity->articles[0]->id;
         unset($entity->articles[0]);
         $entity->dirty('articles', true);
-        
+
         $authors->save($entity, ['associated' => ['Articles']]);
-        
+
         $this->assertEquals($sizeArticles - 1, $authors->Articles->find('all')->where(['author_id' => $entity['id']])->count());
         $this->assertFalse($authors->Articles->exists(['id' => $articleId]));
     }
@@ -1962,7 +1972,7 @@ class TableTest extends TestCase
 
         $this->assertEquals($sizeComments, $articles->Comments->find('all')->where(['article_id' => $article->id])->count());
         $this->assertTrue($articles->Comments->exists(['id' => $commentId]));
-        
+
         unset($article->comments[0]);
         $article->dirty('comments', true);
         $article = $articles->save($article, ['associated' => ['Comments']]);
@@ -2011,7 +2021,7 @@ class TableTest extends TestCase
 
         $this->assertEquals($sizeComments, $articles->Comments->find('all')->where(['article_id' => $article->id])->count());
         $this->assertTrue($articles->Comments->exists(['id' => $commentId]));
-        
+
         unset($article->comments[0]);
         $article->comments[] = $articles->Comments->newEntity([
             'user_id' => 1,
@@ -3351,18 +3361,7 @@ class TableTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Query', $result);
         $this->assertNull($result->clause('limit'));
         $expected = new QueryExpression();
-        $expected->typeMap()->defaults([
-            'Users.id' => 'integer',
-            'id' => 'integer',
-            'Users.username' => 'string',
-            'username' => 'string',
-            'Users.password' => 'string',
-            'password' => 'string',
-            'Users.created' => 'timestamp',
-            'created' => 'timestamp',
-            'Users.updated' => 'timestamp',
-            'updated' => 'timestamp',
-        ]);
+        $expected->typeMap()->defaults($this->usersTypeMap->toArray());
         $expected->add(
             ['or' => ['Users.author_id' => 1, 'Users.published' => 'Y']]
         );


### PR DESCRIPTION
Moving result type conversion to the statements layer and renaming some functions that could cause confusion in the short term.

This is part of the work needed for automatically converting SQL functions to their corresponding PHP types. It also cleans up quite a bit the ResultSet class
