### PR TITLE
Set $idName correctly when using nested routes and dasherize

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -344,7 +344,7 @@ class RouteBuilder
         }
 
         if (is_callable($callback)) {
-            $idName = Inflector::singularize($urlName) . '_id';
+            $idName = Inflector::underscore(Inflector::singularize($name)) . '_id';
             $path = '/' . $urlName . '/:' . $idName;
             $this->scope($path, [], $callback);
         }


### PR DESCRIPTION
When using inflect = dasherize and Nested Resource Routes, `$idName` in `$path` is not being set correctly. For example, when `$name` was NetworkObjects, the resulting `$path` would be:

```
/network-objects/:network-object_id
```
