### PR TITLE
Set shell command 'main' before running startUp

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -443,8 +443,8 @@ class Shell
         }
 
         if ($this->hasMethod('main')) {
-            $this->startup();
             $this->command = 'main';
+            $this->startup();
             return call_user_func_array([$this, 'main'], $this->args);
         }
 


### PR DESCRIPTION
Consistent with calling any other method where `$this->command` is set before `startUp` is run.
