### PR TITLE
Code of conduct (based on Contributor Covenant)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of  
+fostering an open and welcoming community, we pledge to respect all people who  
+contribute through reporting issues, posting feature requests, updating  
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free  
+experience for everyone, regardless of level of experience, gender, gender  
+identity and expression, sexual orientation, disability, personal appearance,  
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery  
+* Personal attacks  
+* Trolling or insulting/derogatory comments  
+* Public or private harassment  
+* Publishing other's private information, such as physical or electronic  
+  addresses, without explicit permission  
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or  
+reject comments, commits, code, wiki edits, issues, and other contributions  
+that are not aligned to this Code of Conduct, or to ban temporarily or  
+permanently any contributor for other behaviors that they deem inappropriate,  
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to  
+fairly and consistently applying these principles to every aspect of managing  
+this project. Project maintainers who do not follow or enforce the Code of  
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces  
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be  
+reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All  
+complaints will be reviewed and investigated and will result in a response that  
+is deemed necessary and appropriate to the circumstances. Maintainers are  
+obligated to maintain confidentiality with regard to the reporter of an  
+incident.  
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,7 +35,7 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be  
-reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All  
+reported by contacting a project maintainer at conduct@cakefoundation.org. All  
 complaints will be reviewed and investigated and will result in a response that  
 is deemed necessary and appropriate to the circumstances. Maintainers are  
 obligated to maintain confidentiality with regard to the reporter of an  

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,15 +10,14 @@ experience for everyone, regardless of level of experience, gender, gender
 identity and expression, sexual orientation, disability, personal appearance,  
 body size, race, ethnicity, age, religion, or nationality.
 
-Examples of unacceptable behavior by participants include:
+In essence: **Don't be Evil**, where...
 
-* The use of sexualized language or imagery  
-* Personal attacks  
-* Trolling or insulting/derogatory comments  
-* Public or private harassment  
-* Publishing other's private information, such as physical or electronic  
-  addresses, without explicit permission  
-* Other unethical or unprofessional conduct
+* 'Evil' is: Discriminating others because of their language, gender, religion or reputation. Don't do that.
+* 'Evil' is: Disregarding works of others because of their language, gender, religion or reputation. Don't do that.
+* 'Evil' is: Harassing individuals or groups on Github, google groups or public IRC chat. Don't do that.
+* 'Evil' is: Insulting others (limited amounts of swearing are tolerated, as long as the target are dead things, not beings). Don't do that.
+* 'Evil' is: Intimidation and threats of violence. Don't do that.
+* 'Evil' is: Being impatient and demanding. Don't do that.
 
 Project maintainers have the right and responsibility to remove, edit, or  
 reject comments, commits, code, wiki edits, issues, and other contributions  
@@ -42,7 +41,7 @@ obligated to maintain confidentiality with regard to the reporter of an
 incident.  
 
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+This Code of Conduct is losely based on the [Contributor Covenant][homepage],  
 version 1.3.0, available at
 [http://contributor-covenant.org/version/1/3/0/][version]
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ tests for CakePHP by doing the following:
 
 [CookBook "Contributing" Section](http://book.cakephp.org/3.0/en/contributing.html) - Details about contributing to the project.
 
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) - Code of conduct. All contributors are expected to abide by this.
+
 # Security
 
 If you’ve found a security issue in CakePHP, please use the following procedure instead of the normal bug reporting system. Instead of using the bug tracker, mailing list or IRC please send an email to security [at] cakephp.org. Emails sent to this address go to the CakePHP core team on a private mailing list.


### PR DESCRIPTION
**Explicit instead of Implicit rule set**
- An explicit instead of an implicit rule set because implicit rule sets allows for arbitrary application (far stretched up to ignored).
- Preliminary suggestion / PR (the list could be changed and/or extended).
- Note: Like the first CC based PR (#7725), this _also_ needs translation into well represented languages to take effect (else a CoC defeats itself).
- You can find the arguments for a specific list here: https://github.com/cakephp/cakephp/pull/7725#issuecomment-159018637, or here https://github.com/cakephp/cakephp/issues/7682#issuecomment-158915472 for instance.
