### PR TITLE
Add option to make CSRF Token HttpOnly & validate methods more safely.

### DIFF
--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -94,7 +94,7 @@ class CsrfComponent extends Component
         if ($request->is('get') && $cookieData === null) {
             $this->_setCookie($request, $response);
         }
-        if ($request->is(['patch', 'put', 'post', 'delete'])) {
+        if (!$request->is(['head', 'get', 'options'])) {
             $this->_validateToken($request);
             unset($request->data[$this->_config['field']]);
         }

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -46,6 +46,7 @@ class CsrfComponent extends Component
      *  - cookieName = The name of the cookie to send.
      *  - expiry = How long the CSRF token should last. Defaults to browser session.
      *  - secure = Whether or not the cookie will be set with the Secure flag. Defaults to false.
+     *  - httpOnly = Whether or not the cookie will be set with the HttpOnly flag. Defaults to false.
      *  - field = The form field to check. Changing this will also require configuring
      *    FormHelper.
      *
@@ -55,6 +56,7 @@ class CsrfComponent extends Component
         'cookieName' => 'csrfToken',
         'expiry' => 0,
         'secure' => false,
+        'httpOnly' => false,
         'field' => '_csrfToken',
     ];
 
@@ -132,6 +134,7 @@ class CsrfComponent extends Component
             'expire' => $expiry->format('U'),
             'path' => $request->webroot,
             'secure' => $this->_config['secure'],
+            'httpOnly' => $this->_config['httpOnly'],
         ]);
     }
 

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -265,7 +265,8 @@ class CsrfComponentTest extends TestCase
         $component = new CsrfComponent($this->registry, [
             'cookieName' => 'token',
             'expiry' => '+1 hour',
-            'secure' => true
+            'secure' => true,
+            'httpOnly' => true
         ]);
 
         $event = new Event('Controller.startup', $controller);
@@ -278,6 +279,7 @@ class CsrfComponentTest extends TestCase
         $this->assertWithinRange((new Time('+1 hour'))->format('U'), $cookie['expire'], 1, 'session duration.');
         $this->assertEquals('/dir/', $cookie['path'], 'session path.');
         $this->assertTrue($cookie['secure'], 'cookie security flag missing');
+        $this->assertTrue($cookie['httpOnly'], 'cookie httpOnly flag missing');
     }
 
     /**

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -85,6 +85,41 @@ class CsrfComponentTest extends TestCase
      *
      * @return void
      */
+    public static function safeHttpMethodProvider()
+    {
+        return [
+            ['GET'], ['OPTIONS'], ['HEAD']
+        ];
+    }
+
+    /**
+     * Test that the CSRF tokens are not required for idempotent operations
+     *
+     * @dataProvider safeHttpMethodProvider
+     * @return void
+     */
+    public function testSafeMethodNoCsrfRequired($method)
+    {
+        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => 'nope',
+            ],
+            'cookies' => ['csrfToken' => 'testing123']
+        ]);
+        $controller->response = new Response();
+
+        $event = new Event('Controller.startup', $controller);
+        $result = $this->component->startup($event);
+        $this->assertNull($result, 'No exception means valid.');
+    }
+
+    /**
+     * Data provider for HTTP method tests.
+     *
+     * @return void
+     */
     public static function httpMethodProvider()
     {
         return [

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -61,10 +61,11 @@ class CsrfComponentTest extends TestCase
      */
     public function testSettingCookie()
     {
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
-        $controller->request = new Request(['webroot' => '/dir/']);
+        $controller->request = new Request([
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+            'webroot' => '/dir/',
+        ]);
         $controller->response = new Response();
 
         $event = new Event('Controller.startup', $controller);
@@ -87,7 +88,7 @@ class CsrfComponentTest extends TestCase
     public static function httpMethodProvider()
     {
         return [
-            ['PATCH'], ['PUT'], ['POST'], ['DELETE']
+            ['PATCH'], ['PUT'], ['POST'], ['DELETE'], ['PURGE'], ['INVALIDMETHOD']
         ];
     }
 
@@ -100,11 +101,14 @@ class CsrfComponentTest extends TestCase
      */
     public function testValidTokenInHeader($method)
     {
-        $_SERVER['REQUEST_METHOD'] = $method;
-        $_SERVER['HTTP_X_CSRF_TOKEN'] = 'testing123';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
-        $controller->request = new Request(['cookies' => ['csrfToken' => 'testing123']]);
+        $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => 'testing123',
+            ],
+            'cookies' => ['csrfToken' => 'testing123']
+        ]);
         $controller->response = new Response();
 
         $event = new Event('Controller.startup', $controller);
@@ -122,11 +126,12 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenInHeader($method)
     {
-        $_SERVER['REQUEST_METHOD'] = $method;
-        $_SERVER['HTTP_X_CSRF_TOKEN'] = 'nope';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+                'HTTP_X_CSRF_TOKEN' => 'nope',
+            ],
             'cookies' => ['csrfToken' => 'testing123']
         ]);
         $controller->response = new Response();
@@ -144,10 +149,11 @@ class CsrfComponentTest extends TestCase
      */
     public function testValidTokenRequestData($method)
     {
-        $_SERVER['REQUEST_METHOD'] = $method;
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+            ],
             'post' => ['_csrfToken' => 'testing123'],
             'cookies' => ['csrfToken' => 'testing123']
         ]);
@@ -168,10 +174,11 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenRequestData($method)
     {
-        $_SERVER['REQUEST_METHOD'] = $method;
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => $method,
+            ],
             'post' => ['_csrfToken' => 'nope'],
             'cookies' => ['csrfToken' => 'testing123']
         ]);
@@ -189,10 +196,11 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenRequestDataMissing()
     {
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
             'post' => [],
             'cookies' => ['csrfToken' => 'testing123']
         ]);
@@ -211,10 +219,11 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenMissingCookie($method)
     {
-        $_SERVER['REQUEST_METHOD'] = $method;
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => [
+                'REQUEST_METHOD' => $method
+            ],
             'post' => ['_csrfToken' => 'could-be-valid'],
             'cookies' => []
         ]);
@@ -232,10 +241,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testCsrfValidationSkipsRequestAction()
     {
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => ['REQUEST_METHOD' => 'POST'],
             'params' => ['requested' => 1],
             'post' => ['_csrfToken' => 'nope'],
             'cookies' => ['csrfToken' => 'testing123']
@@ -256,10 +264,11 @@ class CsrfComponentTest extends TestCase
      */
     public function testConfigurationCookieCreate()
     {
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
-        $controller->request = new Request(['webroot' => '/dir/']);
+        $controller->request = new Request([
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+            'webroot' => '/dir/'
+        ]);
         $controller->response = new Response();
 
         $component = new CsrfComponent($this->registry, [
@@ -290,10 +299,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testConfigurationValidate()
     {
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-
         $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
         $controller->request = new Request([
+            'environment' => ['REQUEST_METHOD' => 'POST'],
             'cookies' => ['csrfToken' => 'nope', 'token' => 'yes'],
             'post' => ['_csrfToken' => 'no match', 'token' => 'yes'],
         ]);


### PR DESCRIPTION
Add option to make CSRF Token HttpOnly.

This option lets users opt-in to http only cookies for CSRF tokens, this is useful when you have no client-side scripting that needs a CSRF token.

Only allow GET, HEAD, OPTIONS to not have CSRF tokens. This covers cases where bad guys make up fake HTTP methods to trick CSRF validation.

Refs #7727
