### PR TITLE
Handle both CHAR(36) and VARCHAR(36) as UUID under MySQL

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -106,7 +106,7 @@ class MysqlSchema extends BaseSchema
         if (in_array($col, ['int', 'integer', 'tinyint', 'smallint', 'mediumint'])) {
             return ['type' => 'integer', 'length' => $length, 'unsigned' => $unsigned];
         }
-        if ($col === 'char' && $length === 36) {
+        if (strpos($col, 'char') !== false && $length === 36) {
             return ['type' => 'uuid', 'length' => null];
         }
         if ($col === 'char') {


### PR DESCRIPTION
As of CakePHP 2.7.6, both VARCHAR(36) and CHAR(36) were handled as UUID in MySQL databases.
With CakePHP 3.x, VARCHAR(36) was left behind in favor of CHAR(36).
This patch simply restores the mapping for VARCHAR(36) fields to be handled as UUID and thus restore the ability for PK fields to have auto generated UUIDv4 value assigned to them upon entity creation.
