### PR TITLE
Point to the _new_ official CoC repo name.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ chance of keeping on top of things.
 
 ## Code of Conduct
 
-Help us keep CakePHP open and inclusive. Please read and follow our [Code of Conduct](https://github.com/cakephp/CoC/blob/master/CODE_OF_CONDUCT.md).
+Help us keep CakePHP open and inclusive. Please read and follow our [Code of Conduct](https://github.com/cakephp/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
 
 ## Getting Started
 


### PR DESCRIPTION
Corrects the link to the new code of conduct from #7725 to point to the renamed version of the repo (`cakephp/code-of-conduct` instead of `cakephp/CoC`.)
