### PR TITLE
Fix TimeHelper using the incorrect timezone.

### DIFF
--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -334,7 +334,7 @@ class TimeHelper extends Helper
         }
 
         try {
-            $time = new Time($date, $timezone);
+            $time = new Time($date);
             return $time->i18nFormat($format, $timezone);
         } catch (Exception $e) {
             if ($invalid === false) {

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -434,16 +434,34 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * Test format() with a string.
+     *
+     * @return void
+     */
+    public function testFormatString()
+    {
+        $time = '2010-01-14 13:59:28';
+        $result = $this->Time->format($time);
+        $this->assertTimeFormat('1/14/10 1:59 PM', $result);
+
+        $result = $this->Time->format($time, 'HH:mm', null, 'America/New_York');
+        $this->assertTimeFormat('08:59', $result);
+    }
+
+    /**
      * Test format() with a Time instance.
      *
      * @return void
      */
     public function testFormatTimeInstance()
     {
+        $time = new Time('2010-01-14 13:59:28', 'America/New_York');
+        $result = $this->Time->format($time, 'HH:mm', null, 'America/New_York');
+        $this->assertTimeFormat('13:59', $result);
+
         $time = new Time('2010-01-14 13:59:28', 'UTC');
         $result = $this->Time->format($time, 'HH:mm', null, 'America/New_York');
-        $expected = '08:59';
-        $this->assertTimeFormat($expected, $result);
+        $this->assertTimeFormat('08:59', $result);
     }
 
     /**


### PR DESCRIPTION
When handling string datetimes, we should assume the datetimes are in the default system timezone, and not the user's timezone. The documentation implies that a timezone conversion will occur when the timezone parameter is provided. This change honours that intent.

Refs #7736
