### PR TITLE
Increase memory during shutdown for Fatal Error handling

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -67,6 +67,13 @@ abstract class BaseErrorHandler
         set_error_handler([$this, 'handleError'], $level);
         set_exception_handler([$this, 'handleException']);
         register_shutdown_function(function () {
+            $megabytes = Configure::read('Error.extraFatalErrorMemory');
+            if ($megabytes === null) {
+                $megabytes = 4;
+            }
+            if ($megabytes !== false && $megabytes > 0) {
+                static::increaseMemoryLimit($megabytes * 1024);
+            }
             if (PHP_SAPI === 'cli') {
                 return;
             }
@@ -192,6 +199,36 @@ abstract class BaseErrorHandler
 
         $this->handleException(new FatalErrorException($description, 500, $file, $line));
         return true;
+    }
+
+    /**
+     * Increases the PHP "memory_limit" ini setting by the specified amount
+     * in kilobytes
+     * 
+     * @param string $additionalKb Number in kilobytes
+     * @return void
+     */
+    public static function increaseMemoryLimit($additionalKb)
+    {
+        $limit = ini_get("memory_limit");
+        if (!is_string($limit) || !strlen($limit)) {
+            return;
+        }
+        $limit = trim($limit);
+        $units = strtoupper(substr($limit, -1));
+        $current = substr($limit, 0, strlen($limit) - 1);
+        if ($units === "M") {
+            $current = $current * 1024;
+            $units = "K";
+        }
+        if ($units === "G") {
+            $current = $current * 1024 * 1024;
+            $units = "K";
+        }
+
+        if ($units === "K") {
+            ini_set("memory_limit", ceil($current + $additionalKb) . "K");
+        }
     }
 
     /**


### PR DESCRIPTION
This is a port of the Cake 2.8 feature (PR #7224). When a fatal error occurs due to running out of memory, there is not enough memory left to load the error handler and log the error. This feature increases the memory limit by a small amount before the error handler is called to allow for logging of Out of Memory errors.
