### PR TITLE
Stop writing files with \r\n in windows.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -736,8 +736,7 @@ class Shell
 
         $File = new File($path, true);
         if ($File->exists() && $File->writable()) {
-            $data = $File->prepare($contents);
-            $File->write($data);
+            $File->write($contents);
             $this->_io->out(sprintf('<success>Wrote</success> `%s`', $path));
             return true;
         }


### PR DESCRIPTION
Output the line endings that were provided. If people want \r\n they can use those. This removes the chance of hard to debug issues around line endings being transparently switched on a user.

Refs #7751
