### PR TITLE
remove extract function in the Validation::comparison without breaking compatibility.

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -954,6 +954,15 @@ class ValidationTest extends CakeTestCase {
 	}
 
 /**
+ * testComparisonCanNotOverwriteOperator rmethod
+ *
+ * @return void
+ */
+	public function testComparisonCanNotOverwriteOperator() {
+		$this->assertFalse(Validation::comparison(array('check1' => 2, 'operator' => '>', 'check2' => 1), '>', '10'));
+	}
+
+/**
  * testCustom method
  *
  * @return void

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -231,12 +231,10 @@ class Validation {
  * @return bool Success
  */
 	public static function comparison($check1, $operator = null, $check2 = null) {
-		if (is_array($check1) && !isset($operator) && !isset($check2)) {
-			if (isset($check1['check1']) && isset($check1['operator']) && isset($check1['check2'])) {
-				$operator = $check1['operator'];
-				$check2 = $check1['check2'];
-				$check1 = $check1['check1'];
-			}
+		if (is_null($operator) && is_null($check2) && isset($check1['check1']) && isset($check1['operator']) && isset($check1['check2'])) {
+			$operator = $check1['operator'];
+			$check2 = $check1['check2'];
+			$check1 = $check1['check1'];
 		}
 		if ((float)$check1 != $check1) {
 			return false;

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -231,7 +231,7 @@ class Validation {
  * @return bool Success
  */
 	public static function comparison($check1, $operator = null, $check2 = null) {
-		if (is_null($operator) && is_null($check2) && isset($check1['check1']) && isset($check1['operator']) && isset($check1['check2'])) {
+		if ($operator === null && $check2 === null && isset($check1['check1']) && isset($check1['operator']) && isset($check1['check2'])) {
 			$operator = $check1['operator'];
 			$check2 = $check1['check2'];
 			$check1 = $check1['check1'];

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -231,10 +231,13 @@ class Validation {
  * @return bool Success
  */
 	public static function comparison($check1, $operator = null, $check2 = null) {
-		if (is_array($check1)) {
-			extract($check1, EXTR_OVERWRITE);
+		if (is_array($check1) && !isset($operator) && !isset($check2)) {
+			if (isset($check1['check1']) && isset($check1['operator']) && isset($check1['check2'])) {
+				$operator = $check1['operator'];
+				$check2 = $check1['check2'];
+				$check1 = $check1['check1'];
+			}
 		}
-
 		if ((float)$check1 != $check1) {
 			return false;
 		}


### PR DESCRIPTION
This PR doesn't break compatibility. 
I've sent the pull request about same issue.
https://github.com/cakephp/cakephp/pull/7752
