### PR TITLE
Stateless auth

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -697,7 +697,7 @@ class AuthComponent extends Component
             $result = $auth->getUser($this->request);
             if (!empty($result) && is_array($result)) {
                 $this->_authenticationProvider = $auth;
-                $event = $this->dispatchEvent('Auth.afterIdentify', [$result]);
+                $event = $this->dispatchEvent('Auth.afterIdentify', [$result, $auth]);
                 if ($event->result !== null) {
                     $result = $event->result;
                 }
@@ -769,7 +769,7 @@ class AuthComponent extends Component
             $result = $auth->authenticate($this->request, $this->response);
             if (!empty($result) && is_array($result)) {
                 $this->_authenticationProvider = $auth;
-                $event = $this->dispatchEvent('Auth.afterIdentify', [$result]);
+                $event = $this->dispatchEvent('Auth.afterIdentify', [$result, $auth]);
                 if ($event->result !== null) {
                     return $event->result;
                 }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -696,6 +696,7 @@ class AuthComponent extends Component
         foreach ($this->_authenticateObjects as $auth) {
             $result = $auth->getUser($this->request);
             if (!empty($result) && is_array($result)) {
+                $this->_authenticationProvider = $auth;
                 $this->storage()->write($result);
                 return true;
             }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -697,6 +697,10 @@ class AuthComponent extends Component
             $result = $auth->getUser($this->request);
             if (!empty($result) && is_array($result)) {
                 $this->_authenticationProvider = $auth;
+                $event = $this->dispatchEvent('Auth.afterIdentify', [$result]);
+                if ($event->result !== null) {
+                    $result = $event->result;
+                }
                 $this->storage()->write($result);
                 return true;
             }

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1083,6 +1083,11 @@ class AuthComponentTest extends TestCase
         $result = $this->Auth->user();
         $this->assertEquals('mariano', $result['username']);
 
+        $this->assertInstanceOf(
+            'Cake\Auth\BasicAuthenticate',
+            $this->Auth->authenticationProvider()
+        );
+
         $result = $this->Auth->user('username');
         $this->assertEquals('mariano', $result);
         $this->assertFalse(isset($_SESSION));

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1156,6 +1156,10 @@ class AuthComponentTest extends TestCase
         $this->assertEquals($expected, $authObject->callStack);
         $expected = ['id' => 1, 'username' => 'admad'];
         $this->assertEquals($expected, $user);
+        $this->assertInstanceOf(
+            'TestApp\Auth\TestAuthenticate',
+            $authObject->authenticationProvider
+        );
 
         // Callback for Auth.afterIdentify returns a value
         $authObject->modifiedUser = true;

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -27,6 +27,8 @@ class TestAuthenticate extends BaseAuthenticate
 
     public $callStack = [];
 
+    public $authenticationProvider;
+
     public function implementedEvents()
     {
         return [
@@ -43,6 +45,7 @@ class TestAuthenticate extends BaseAuthenticate
     public function afterIdentify(Event $event, array $user)
     {
         $this->callStack[] = __FUNCTION__;
+        $this->authenticationProvider = $event->data[1];
 
         if (!empty($this->modifiedUser)) {
             return $user + ['extra' => 'foo'];


### PR DESCRIPTION
- Set authentication provider for stateless authentication too.
- Trigger Auth.afterIdentify even for stateless authentication.
- Include authentication provider instance in Auth.afterIdentify event data.
