### PR TITLE
Completion shell enhancements

### DIFF
--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -186,7 +186,7 @@ class CommandTask extends Shell
             $pluginDot = '';
         }
 
-        if (!in_array($commandName, $this->commands())) {
+        if (!in_array($commandName, $this->commands()) && (empty($pluginDot) && !in_array($name, $this->commands()))) {
             return false;
         }
 

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -192,11 +192,14 @@ class CommandTask extends Shell
 
         if (empty($pluginDot)) {
             $shellList = $this->getShellList();
-            unset($shellList['CORE'], $shellList['app']);
-            foreach ($shellList as $plugin => $commands) {
-                if (in_array($commandName, $commands)) {
-                    $pluginDot = $plugin . '.';
-                    break;
+
+            if (!in_array($commandName, $shellList['app']) && !in_array($commandName, $shellList['CORE'])) {
+                unset($shellList['CORE'], $shellList['app']);
+                foreach ($shellList as $plugin => $commands) {
+                    if (in_array($commandName, $commands)) {
+                        $pluginDot = $plugin . '.';
+                        break;
+                    }
                 }
             }
         }

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -116,12 +116,16 @@ class CommandTask extends Shell
 
         $options = [];
         foreach ($shellList as $type => $commands) {
-            $prefix = '';
-            if (!in_array(strtolower($type), ['app', 'core']) && isset($duplicates[$type])) {
-                $prefix = $type . '.';
-            }
-
             foreach ($commands as $shell) {
+                $prefix = '';
+                if (
+                    !in_array(strtolower($type), ['app', 'core']) &&
+                    isset($duplicates[$type]) &&
+                    in_array($shell, $duplicates[$type])
+                ) {
+                    $prefix = $type . '.';
+                }
+
                 $options[] = $prefix . $shell;
             }
         }
@@ -192,6 +196,7 @@ class CommandTask extends Shell
             foreach ($shellList as $plugin => $commands) {
                 if (in_array($commandName, $commands)) {
                     $pluginDot = $plugin . '.';
+                    break;
                 }
             }
         }

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -81,7 +81,7 @@ class CommandListShellTest extends TestCase
         $expected = "/\[.*TestPlugin.*\] example/";
         $this->assertRegExp($expected, $output);
 
-        $expected = "/\[.*TestPluginTwo.*\] example, welcome/";
+        $expected = "/\[.*TestPluginTwo.*\] example, unique, welcome/";
         $this->assertRegExp($expected, $output);
 
         $expected = "/\[.*CORE.*\] i18n, orm_cache, plugin, routes, server/";

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -210,6 +210,20 @@ class CompletionShellTest extends TestCase
     }
 
     /**
+     * test that using the dot notation when not mandatory works to provide backward compatibility
+     *
+     * @return void
+     */
+    public function testSubCommandsPluginDotNotationBackwardCompatibility()
+    {
+        $this->Shell->runCommand(['subcommands', 'TestPluginTwo.welcome']);
+        $output = $this->out->output;
+
+        $expected = "say_hello\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
      * test that subCommands with an existing plugin command returns the proper sub commands
      *
      * @return void

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -119,7 +119,7 @@ class CompletionShellTest extends TestCase
         $this->Shell->runCommand(['commands']);
         $output = $this->out->output;
 
-        $expected = "TestPlugin.example TestPlugin.sample TestPluginTwo.example TestPluginTwo.welcome " .
+        $expected = "TestPlugin.example TestPlugin.sample TestPluginTwo.example unique welcome " .
             "i18n orm_cache plugin routes server i18m sample testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
@@ -195,13 +195,28 @@ class CompletionShellTest extends TestCase
     }
 
     /**
-     * test that subCommands with a existing plugin command returns the proper sub commands
+     * test that subCommands with an existing plugin command returns the proper sub commands
+     * when the Shell name is unique and the dot notation not mandatory
      *
      * @return void
      */
     public function testSubCommandsPlugin()
     {
-        $this->Shell->runCommand(['subcommands', 'TestPluginTwo.welcome']);
+        $this->Shell->runCommand(['subcommands', 'welcome']);
+        $output = $this->out->output;
+
+        $expected = "say_hello\n";
+        $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * test that subCommands with an existing plugin command returns the proper sub commands
+     *
+     * @return void
+     */
+    public function testSubCommandsPluginDotNotation()
+    {
+        $this->Shell->runCommand(['subcommands', 'TestPluginTwo.example']);
         $output = $this->out->output;
 
         $expected = "say_hello\n";

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -194,7 +194,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = "derp\n";
-        $this->assertEquals($expected, $output);
+        $this->assertTextEquals($expected, $output);
     }
 
     /**
@@ -252,7 +252,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = "derp\n";
-        $this->assertEquals($expected, $output);
+        $this->assertTextEquals($expected, $output);
     }
 
     /**
@@ -266,7 +266,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = "example\n";
-        $this->assertEquals($expected, $output);
+        $this->assertTextEquals($expected, $output);
     }
 
     /**

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Shell;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOutput;
 use Cake\Console\Shell;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Shell\CompletionShell;
 use Cake\Shell\Task\CommandTask;
@@ -51,6 +52,7 @@ class CompletionShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        Configure::write('App.namespace', 'TestApp');
         Plugin::load(['TestPlugin', 'TestPluginTwo']);
 
         $this->out = new TestCompletionStringOutput();
@@ -78,6 +80,7 @@ class CompletionShellTest extends TestCase
     {
         parent::tearDown();
         unset($this->Shell);
+        Configure::write('App.namespace', 'App');
         Plugin::unload();
     }
 
@@ -190,7 +193,7 @@ class CompletionShellTest extends TestCase
         $this->Shell->runCommand(['subcommands', 'app.sample']);
         $output = $this->out->output;
 
-        $expected = '';
+        $expected = "derp\n";
         $this->assertEquals($expected, $output);
     }
 
@@ -235,6 +238,35 @@ class CompletionShellTest extends TestCase
 
         $expected = "say_hello\n";
         $this->assertTextEquals($expected, $output);
+    }
+
+    /**
+     * test that subCommands with an app shell that is also defined in a plugin and without the prefix "app."
+     * returns proper sub commands
+     *
+     * @return void
+     */
+    public function testSubCommandsAppDuplicatePluginNoDot()
+    {
+        $this->Shell->runCommand(['subcommands', 'sample']);
+        $output = $this->out->output;
+
+        $expected = "derp\n";
+        $this->assertEquals($expected, $output);
+    }
+
+    /**
+     * test that subCommands with a plugin shell that is also defined in the returns proper sub commands
+     *
+     * @return void
+     */
+    public function testSubCommandsPluginDuplicateApp()
+    {
+        $this->Shell->runCommand(['subcommands', 'TestPlugin.sample']);
+        $output = $this->out->output;
+
+        $expected = "example\n";
+        $this->assertEquals($expected, $output);
     }
 
     /**

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
@@ -33,4 +33,14 @@ class SampleShell extends Shell
     {
         $this->out('This is the main method called from SampleShell');
     }
+
+    /**
+     * example method
+     *
+     * @return void
+     */
+    public function example()
+    {
+        $this->out('This is the example method called from TestPlugin.SampleShell');
+    }
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/ExampleShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/ExampleShell.php
@@ -34,7 +34,13 @@ class ExampleShell extends Shell
         $this->out('This is the main method called from TestPluginTwo.ExampleShell');
     }
 
-    public function say_hello() {
+    /**
+     * say_hello method
+     *
+     * @return void
+     */
+    public function say_hello()
+    {
     	$this->out('Hello from the TestPluginTwo.ExampleShell');
     }
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/UniqueShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/UniqueShell.php
@@ -14,14 +14,14 @@
  */
 
 /**
- * Class ExampleShell
+ * Class UniqueShell
  *
  */
 namespace TestPluginTwo\Shell;
 
 use Cake\Console\Shell;
 
-class ExampleShell extends Shell
+class UniqueShell extends Shell
 {
 
     /**
@@ -31,10 +31,6 @@ class ExampleShell extends Shell
      */
     public function main()
     {
-        $this->out('This is the main method called from TestPluginTwo.ExampleShell');
-    }
-
-    public function say_hello() {
-    	$this->out('Hello from the TestPluginTwo.ExampleShell');
+        $this->out('This is the main method called from TestPluginTwo.UniqueShell');
     }
 }

--- a/tests/test_app/TestApp/Shell/SampleShell.php
+++ b/tests/test_app/TestApp/Shell/SampleShell.php
@@ -35,4 +35,14 @@ class SampleShell extends Shell
     {
         $this->out('This is the main method called from SampleShell');
     }
+
+    /**
+     * derp method
+     *
+     * @return void
+     */
+    public function derp()
+    {
+        $this->out('This is the example method called from TestPlugin.SampleShell');
+    }
 }


### PR DESCRIPTION
While setting auto-completion with the CakePHP Shell, I noticed some things that could be improved.
For instance, with a basic app setup, I can use the `bake` and `migrations` shells without having to use the plugin dot notation.
However, currently, the `CompletionShell` suggests me to use the shells `Bake.bake` and `Migrations.migrations`. Since the plugin dot notation is not mandatory, I implemented a change that will suggest to use the "short" version if no shells have the same name accross the core, the app and the plugins.
If there are two shells with the same name, then the plugin dot notation is made mandatory.
If an app shell and a plugin shell shares the same name, the correct sub commands are returned for each on of them. (App shell should be called by its name while plugin shell by the plugin dot notation).

I've also implemented a backward compatibility change to make sure that `CommandTask::subCommands()` will return the correct sub commands if it is called with a plugin dot notation when it is not mandatory.

I can give you more explanations and examples if you need.
