### PR TITLE
Contain the junction table when proxying finders.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -536,6 +536,22 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
+     * Remove a join if it has been defined.
+     *
+     * Useful when you are redefining joins or want to re-order
+     * the join clauses.
+     *
+     * @param string $name The alias/name of the join to remove.
+     * @return $this
+     */
+    public function removeJoin($name)
+    {
+        unset($this->_parts['join'][$name]);
+        $this->_dirty();
+        return $this;
+    }
+
+    /**
      * Adds a single LEFT JOIN clause to the query.
      *
      * This is a shorthand method for building joins via `join()`.

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -772,6 +772,29 @@ class BelongsToMany extends Association
     }
 
     /**
+     * Proxies the finding operation to the target table's find method
+     * and modifies the query accordingly based of this association
+     * configuration.
+     *
+     * If your association includes conditions, the junction table will be
+     * included in the query's contained associations.
+     *
+     * @param string|array $type the type of query to perform, if an array is passed,
+     *   it will be interpreted as the `$options` parameter
+     * @param array $options The options to for the find
+     * @see \Cake\ORM\Table::find()
+     * @return \Cake\ORM\Query
+     */
+    public function find($type = null, array $options = [])
+    {
+        $query = parent::find($type, $options);
+        if ($this->conditions()) {
+            $query->contain([$this->junction()->alias()]);
+        }
+        return $query;
+    }
+
+    /**
      * Replaces existing association links between the source entity and the target
      * with the ones passed. This method does a smart cleanup, links that are already
      * persisted and present in `$targetEntities` will not be deleted, new links will

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -799,8 +799,8 @@ class BelongsToMany extends Association
         $belongsTo = $junction->association($target->alias());
 
         $conditions = $belongsTo->_joinCondition([
-            'foreignKey' => $this->foreignKey()]
-        );
+            'foreignKey' => $this->foreignKey()
+        ]);
         $join = [
             'table' => $junction->table(),
             'conditions' => $conditions,

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3500,6 +3500,26 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test removeJoin().
+     *
+     * @return void
+     */
+    public function testRemoveJoin()
+    {
+        $query = new Query($this->connection);
+        $query->select(['id', 'title'])
+            ->from('articles')
+            ->join(['authors' => [
+                'type' => 'INNER',
+                'conditions' => ['articles.author_id = authors.id']
+            ]]);
+        $this->assertArrayHasKey('authors', $query->join());
+
+        $this->assertSame($query, $query->removeJoin('authors'));
+        $this->assertArrayNotHasKey('authors', $query->join());
+    }
+
+    /**
      * Assertion for comparing a table's contents with what is in it.
      *
      * @param string $table

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -855,36 +855,6 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
-     * Test that find() applies a contain() when the association uses conditions.
-     *
-     * @return void
-     */
-    public function testFindAppliesContainWithConditions()
-    {
-        $connection = ConnectionManager::get('test');
-        $this->article->belongsToMany('Tags', [
-            'targetTable' => $this->tag,
-            'conditions' => ['ArticlesTags.favorite' => true]
-        ]);
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            [],
-            [$connection, $this->article]
-        );
-        $query->expects($this->once())
-            ->method('where')
-            ->with(['ArticlesTags.favorite' => true])
-            ->will($this->returnSelf());
-        $query->expects($this->once())
-            ->method('contain')
-            ->with(['ArticlesTags'])
-            ->will($this->returnSelf());
-        $this->tag->method('find')->will($this->returnValue($query));
-
-        $this->article->Tags->find();
-    }
-
-    /**
      * Tests that replaceLinks() will contain() the target table when
      * there are conditions present on the association.
      *

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -854,6 +854,35 @@ class BelongsToManyTest extends TestCase
         $this->assertFalse($entity->dirty('tags'));
     }
 
+    /**
+     * Test that find() applies a contain() when the association uses conditions.
+     *
+     * @return void
+     */
+    public function testFindAppliesContainWithConditions()
+    {
+        $connection = ConnectionManager::get('test');
+        $this->article->belongsToMany('Tags', [
+            'targetTable' => $this->tag,
+            'conditions' => ['ArticlesTags.favorite' => true]
+        ]);
+        $query = $this->getMock(
+            '\Cake\ORM\Query',
+            [],
+            [$connection, $this->article]
+        );
+        $query->expects($this->once())
+            ->method('where')
+            ->with(['ArticlesTags.favorite' => true])
+            ->will($this->returnSelf());
+        $query->expects($this->once())
+            ->method('contain')
+            ->with(['ArticlesTags'])
+            ->will($this->returnSelf());
+        $this->tag->method('find')->will($this->returnValue($query));
+
+        $this->article->Tags->find();
+    }
 
     /**
      * Tests that replaceLinks() will contain() the target table when

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -102,6 +102,25 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Test that association proxy find() applies joins when conditions are involved.
+     *
+     * @return void
+     */
+    public function testBelongsToManyAssociationProxyFindWithConditions()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'conditions' => ['SpecialTags.highlighted' => true],
+            'through' => 'SpecialTags'
+        ]);
+        $query = $table->Tags->find();
+        $result = $query->toArray();
+        $this->assertCount(1, $result);
+    }
+
+    /**
      * Tests that duplicate aliases in contain() can be used, even when they would
      * naturally be attached to the query instead of eagerly loaded. What should
      * happen here is that One of the duplicates will be changed to be loaded using
@@ -221,11 +240,11 @@ class QueryRegressionTest extends TestCase
         $articles->belongsToMany('Tags');
         $tags->belongsToMany('Articles');
 
-        $sub = $articles->Tags->find()->select(['id'])->matching('Articles', function ($q) {
+        $sub = $articles->Tags->find()->select(['Tags.id'])->matching('Articles', function ($q) {
             return $q->where(['Articles.id' => 1]);
         });
 
-        $query = $articles->Tags->find()->where(['id NOT IN' => $sub]);
+        $query = $articles->Tags->find()->where(['Tags.id NOT IN' => $sub]);
         $this->assertEquals(1, $query->count());
     }
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -121,6 +121,27 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Test that association proxy find() with matching resolves joins correctly
+     *
+     * @return void
+     */
+    public function testBelongsToManyAssociationProxyFindWithConditionsMatching()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'conditions' => ['SpecialTags.highlighted' => true],
+            'through' => 'SpecialTags'
+        ]);
+        $query = $table->Tags->find()->matching('Articles', function ($query) {
+            return $query->where(['Articles.id' => 1]);
+        });
+        // The inner join on special_tags excludes the results.
+        $this->assertEquals(0, $query->count());
+    }
+
+    /**
      * Tests that duplicate aliases in contain() can be used, even when they would
      * naturally be attached to the query instead of eagerly loaded. What should
      * happen here is that One of the duplicates will be changed to be loaded using


### PR DESCRIPTION
When proxying finder methods from a belongstomany association, if that association has conditions we should contain the junction table as the conditions very likely use columns on that table.

Refs #7707
