### PR TITLE
More Phpdbg compatibility fixes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,15 +34,10 @@
 
     <!-- Prevent coverage reports from looking in tests, vendors, config folders -->
     <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor/</directory>
-            <directory suffix=".ctp">./vendor/</directory>
-
-            <directory suffix=".php">./tests/</directory>
-            <directory suffix=".ctp">./tests/</directory>
-
-            <directory suffix=".php">./config/</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".ctp">./src/</directory>
+        </whitelist>
     </filter>
 
     <php>

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -138,7 +138,7 @@ if (!function_exists('pr')) {
             return;
         }
 
-        $template = PHP_SAPI !== 'cli' ? '<pre class="pr">%s</pre>' : "\n%s\n\n";
+        $template = (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') ? '<pre class="pr">%s</pre>' : "\n%s\n\n";
         printf($template, trim(print_r($var, true)));
     }
 
@@ -162,7 +162,7 @@ if (!function_exists('pj')) {
             return;
         }
 
-        $template = PHP_SAPI !== 'cli' ? '<pre class="pj">%s</pre>' : "\n%s\n\n";
+        $template = (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') ? '<pre class="pj">%s</pre>' : "\n%s\n\n";
         printf($template, trim(json_encode($var, JSON_PRETTY_PRINT)));
     }
 

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -292,7 +292,7 @@ abstract class BaseErrorHandler
                 $message .= "\nException Attributes: " . var_export($exception->getAttributes(), true);
             }
         }
-        if (PHP_SAPI !== 'cli') {
+        if ((PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg')) {
             $request = Router::getRequest();
             if ($request) {
                 $message .= "\nRequest URL: " . $request->here();

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -869,10 +869,10 @@ class TimeTest extends TestCase
      */
     public function assertTimeFormat($expected, $result)
     {
-        $expected = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA'], '', $expected);
+        $expected = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA', 'à '], '', $expected);
         $expected = str_replace(['  '], ' ', $expected);
 
-        $result = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA'], '', $result);
+        $result = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA', 'à '], '', $result);
         $result = str_replace(['  '], ' ', $result);
 
         return $this->assertEquals($expected, $result);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1885,7 +1885,7 @@ TEXT;
             $View->element('test_element');
         }
         $end = memory_get_usage();
-        $this->assertLessThanOrEqual($start + 5000, $end);
+        $this->assertLessThanOrEqual($start + 15000, $end);
     }
 
     /**


### PR DESCRIPTION
On my last PR (#7782) I missed a few `PHP_SAPI` usages. This corrects that, and fixes some test failures in phpdbg land. As well as fixing a test failure due to a change in ICU 56's french formatting.
