### PR TITLE
allow appveyor tests to be run against 3.2 branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\projects\cakephp
 branches:
   only:
     - master
-    - 3.1
+    - 3.2
 environment:
   global:
     PHP: "C:/PHP"
@@ -34,6 +34,8 @@ install:
   - cd C:\projects\cakephp
   - php -r "readfile('https://getcomposer.org/installer');" | php
   - php composer.phar install --prefer-dist --no-interaction
+  - php -v
+  - php -i | grep "ICU version"
 before_test:
 # This script solves the "Database 'model' is being recovered. Waiting until recovery is finished."
 # This solution comes from https://gist.github.com/jonathanhickford/1cb0d6665adab8b9c664


### PR DESCRIPTION
It should allow us to enable the appveyor webhook after the next time master will been merged into 3.2
