### PR TITLE
#7794 Fix Redis DSN configuration.

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -83,7 +83,7 @@ class RedisEngine extends CacheEngine
         }
 
         if (!empty($config['host'])) {
-            $this->config('server', $config['host']);
+            $config['server'] = $config['host'];
         }
 
         parent::init($config);

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -82,6 +82,10 @@ class RedisEngine extends CacheEngine
             return false;
         }
 
+        if (!empty($config['host'])) {
+            $this->config('server', $config['host']);
+        }
+
         parent::init($config);
         return $this->_connect();
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -104,6 +104,38 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * testConfigDsn method
+     *
+     * @return void
+     */
+    public function testConfigDsn()
+    {
+        Cache::config('redis_dsn', [
+            'url' => 'redis://localhost:6379?database=1&prefix=redis_'
+        ]);
+
+        $config = Cache::engine('redis_dsn')->config();
+        $expecting = [
+            'prefix' => 'redis_',
+            'duration' => 3600,
+            'probability' => 100,
+            'groups' => [],
+            'server' => 'localhost',
+            'port' => 6379,
+            'timeout' => 0,
+            'persistent' => true,
+            'password' => false,
+            'database' => '1',
+            'unix_socket' => false,
+            'host' => 'localhost',
+            'scheme' => 'redis',
+        ];
+        $this->assertEquals($expecting, $config);
+
+        Cache::drop('redis_dsn');
+    }
+
+    /**
      * testConnect method
      *
      * @return void


### PR DESCRIPTION
Proposed fix for #7794. This patch differs from the solution proposed in my initial comment, and it should be more similar to the way DSN config is handled for the Memcached engine.
