### PR TITLE
Update FormContext::errors() to handle nested errors.

### DIFF
--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -15,6 +15,7 @@
 namespace Cake\View\Form;
 
 use Cake\Network\Request;
+use Cake\Utility\Hash;
 
 /**
  * Provides a context provider for Cake\Form\Form instances.
@@ -134,10 +135,6 @@ class FormContext implements ContextInterface
      */
     public function error($field)
     {
-        $errors = $this->_form->errors();
-        if (isset($errors[$field])) {
-            return array_values($errors[$field]);
-        }
-        return [];
+        return array_values(Hash::get($this->_form->errors(), $field, []));
     }
 }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -208,13 +208,22 @@ class FormContextTest extends TestCase
      */
     public function testHasError()
     {
+        $nestedValidator = new Validator();
+        $nestedValidator
+            ->add('password', 'length', ['rule' => ['minLength', 8]])
+            ->add('confirm', 'length', ['rule' => ['minLength', 8]]);
         $form = new Form();
         $form->validator()
             ->add('email', 'format', ['rule' => 'email'])
-            ->add('name', 'length', ['rule' => ['minLength', 10]]);
+            ->add('name', 'length', ['rule' => ['minLength', 10]])
+            ->addNested('pass', $nestedValidator);
         $form->validate([
             'email' => 'derp',
-            'name' => 'derp'
+            'name' => 'derp',
+            'pass' => [
+                'password' => 'short',
+                'confirm' => 'long enough',
+            ],
         ]);
 
         $context = new FormContext($this->request, ['entity' => $form]);
@@ -222,5 +231,6 @@ class FormContextTest extends TestCase
         $this->assertTrue($context->hasError('name'));
         $this->assertFalse($context->hasError('nope'));
         $this->assertFalse($context->hasError('nope.nope'));
+        $this->assertTrue($context->hasError('pass.password'));
     }
 }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\View\Form;
 use Cake\Form\Form;
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
 use Cake\View\Form\FormContext;
 
 /**
@@ -172,19 +173,29 @@ class FormContextTest extends TestCase
      */
     public function testError()
     {
+        $nestedValidator = new Validator();
+        $nestedValidator
+            ->add('password', 'length', ['rule' => ['minLength', 8]])
+            ->add('confirm', 'length', ['rule' => ['minLength', 8]]);
         $form = new Form();
         $form->validator()
             ->add('email', 'format', ['rule' => 'email'])
-            ->add('name', 'length', ['rule' => ['minLength', 10]]);
+            ->add('name', 'length', ['rule' => ['minLength', 10]])
+            ->addNested('pass', $nestedValidator);
         $form->validate([
             'email' => 'derp',
-            'name' => 'derp'
+            'name' => 'derp',
+            'pass' => [
+                'password' => 'short',
+                'confirm' => 'long enough',
+            ],
         ]);
 
         $context = new FormContext($this->request, ['entity' => $form]);
         $this->assertEquals([], $context->error('empty'));
         $this->assertEquals(['The provided value is invalid'], $context->error('email'));
         $this->assertEquals(['The provided value is invalid'], $context->error('name'));
+        $this->assertEquals(['The provided value is invalid'], $context->error('pass.password'));
 
         $this->assertEquals([], $context->error('Alias.name'));
         $this->assertEquals([], $context->error('nope.nope'));


### PR DESCRIPTION
Adjust error collection to properly handle nested validators. Partially addresses #7532.
