### PR TITLE
Merging queryBuilders in contain. Fixes #6696

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -309,6 +309,15 @@ class EagerLoader
             }
 
             $pointer += [$table => []];
+
+            if (isset($options['queryBuilder']) && isset($pointer[$table]['queryBuilder'])) {
+                $first = $pointer[$table]['queryBuilder'];
+                $second = $options['queryBuilder'];
+                $options['queryBuilder'] = function ($query) use ($first, $second) {
+                    return $second($first($query));
+                };
+            }
+
             $pointer[$table] = $options + $pointer[$table];
         }
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -309,6 +309,31 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
+     * Tests that query builders are stacked
+     *
+     * @return void
+     */
+    public function testContainMergeBuilders()
+    {
+        $loader = new EagerLoader;
+        $loader->contain([
+            'clients' => function ($query) {
+                return $query->select(['a']);
+            }
+        ]);
+        $loader->contain([
+            'clients' => function ($query) {
+                return $query->select(['b']);
+            }
+        ]);
+        $builder = $loader->contain()['clients']['queryBuilder'];
+        $table = TableRegistry::get('foo');
+        $query = new Query($this->connection, $table);
+        $query = $builder($query);
+        $this->assertEquals(['a', 'b'], $query->clause('select'));
+    }
+
+    /**
      * Test that fields for contained models are aliased and added to the select clause
      *
      * @return void


### PR DESCRIPTION
This makes it a lot easir to break queries into multiple custom finders
where the same assocaition is used multiple times in contain. It also
brings the orm closer to the behavior in 2.x where you could appen to a contain
clause anywhere.
