### PR TITLE
Fix cookies not being passed for requested actions.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -271,7 +271,8 @@ class RequestHandlerComponent extends Component
             'environment' => [
                 'REQUEST_METHOD' => 'GET'
             ],
-            'query' => $query
+            'query' => $query,
+            'cookies' => $request->cookies
         ]));
         $response->statusCode(200);
         return $response;

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -139,6 +139,9 @@ trait RequestActionTrait
         if (isset($extra['query'])) {
             $params['query'] = $extra['query'];
         }
+        if (isset($extra['cookies'])) {
+            $params['cookies'] = $extra['cookies'];
+        }
         if (isset($extra['environment'])) {
             $params['environment'] = $extra['environment'] + $_SERVER + $_ENV;
         }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -942,6 +942,39 @@ class RequestHandlerComponentTest extends TestCase
     }
 
     /**
+     * Test that AJAX requests involving redirects handle cookie data
+     *
+     * @return void
+     * @triggers Controller.beforeRedirect $this->Controller
+     */
+    public function testAjaxRedirectAsRequestActionWithCookieData()
+    {
+        Configure::write('App.namespace', 'TestApp');
+        Router::connect('/:controller/:action');
+        $event = new Event('Controller.beforeRedirect', $this->Controller);
+
+        $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
+        $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->RequestHandler->request = $this->Controller->request;
+        $this->Controller->RequestHandler->response = $this->Controller->response;
+        $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
+
+        $cookies = [
+            'foo' => 'bar'
+        ];
+        $this->Controller->request->cookies = $cookies;
+
+        $response = $this->Controller->RequestHandler->beforeRedirect(
+            $event,
+            '/request_action/cookie_pass',
+            $this->Controller->response
+        );
+        $data = json_decode($response, true);
+        $this->assertEquals($cookies, $data);
+    }
+
+    /**
      * Tests that AJAX requests involving redirects don't let the status code bleed through.
      *
      * @return void

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -359,6 +359,24 @@ class RequestActionTraitTest extends TestCase
     }
 
     /**
+     * Test that requestAction handles cookies correctly.
+     *
+     * @return void
+     */
+    public function testRequestActionCookies()
+    {
+        $cookies = [
+            'foo' => 'bar'
+        ];
+        $result = $this->object->requestAction(
+            '/request_action/cookie_pass',
+            ['cookies' => $cookies]
+        );
+        $result = json_decode($result, true);
+        $this->assertEquals($cookies, $result);
+    }
+
+    /**
      * Test that environment overrides can be set.
      *
      * @return void

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -109,6 +109,17 @@ class RequestActionController extends AppController
     }
 
     /**
+     * cookie pass, testing cookie passing
+     *
+     * @return \Cake\Network\Response
+     */
+    public function cookie_pass()
+    {
+        $this->response->body(json_encode($this->request->cookies));
+        return $this->response;
+    }
+
+    /**
      * test param passing and parsing.
      *
      * @return \Cake\Network\Response


### PR DESCRIPTION
Contrary to its docs, `Controller::requestAction()` doesn't recognize the `cookies` option, leaving requested actions without cookies (at least those code parts that are using `Request::$cookies/cookie()` to access them).

This affects not only userland code that works with cookies, but also internals like the CSRF component, which won't set a token in that case, and ultimately mess up generated forms.

Also the request handler component doesn't pass cookies to the `Controller::requestAction()` call that is being used to simulate redirects on AJAX requests.

This PR attempts to fix both of these issues.
