### PR TITLE
Correctly handle string timestamps.

### DIFF
--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -218,11 +218,11 @@ class DateTimeWidget implements WidgetInterface
             ];
         }
         try {
-            if (is_string($value)) {
+            if (is_string($value) && !is_numeric($value)) {
                 $date = new DateTime($value);
             } elseif (is_bool($value)) {
                 $date = new DateTime();
-            } elseif (is_int($value)) {
+            } elseif (is_int($value) || is_numeric($value)) {
                 $date = new DateTime('@' . $value);
             } elseif (is_array($value)) {
                 $dateArray = [

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -137,6 +137,7 @@ class DateTimeWidgetTest extends TestCase
         return [
             'DateTime' => [$date],
             'string' => [$date->format('Y-m-d H:i:s')],
+            'int string' => [$date->format('U')],
             'int' => [$date->getTimestamp()],
             'array' => [[
                 'year' => '2014', 'month' => '01', 'day' => '20',


### PR DESCRIPTION
Use is_numeric() to ensure that timestamps that are strings end up being handled like an integer.

Refs #7761
