### PR TITLE
Fix dashed route for vendored plugins

### DIFF
--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -35,6 +35,21 @@ class DashedRoute extends Route
     protected $_inflectedDefaults = false;
 
     /**
+     * Camelizes the previously dashed plugin route taking into account plugin vendors
+     *
+     * @param string $plugin Plugin name
+     * @return string
+     */
+    protected function _camelizePlugin($plugin) {
+        $plugin = str_replace('-', '_', $plugin);
+        if (strpos($plugin, '/') === false) {
+            return Inflector::camelize($plugin);
+        }
+        list($vendor, $plugin) = explode('/', $plugin, 1);
+        return Inflector::camelize($vendor) . '/' . Inflector::camelize($plugin);
+    }
+
+    /**
      * Parses a string URL into an array. If it matches, it will convert the
      * controller and plugin keys to their CamelCased form and action key to
      * camelBacked form.
@@ -56,11 +71,7 @@ class DashedRoute extends Route
             ));
         }
         if (!empty($params['plugin'])) {
-            $params['plugin'] = Inflector::camelize(str_replace(
-                '-',
-                '_',
-                $params['plugin']
-            ));
+            $params['plugin'] = $this->_camelizePlugin($params['plugin']);
         }
         if (!empty($params['action'])) {
             $params['action'] = Inflector::variable(str_replace(

--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -45,7 +45,7 @@ class DashedRoute extends Route
         if (strpos($plugin, '/') === false) {
             return Inflector::camelize($plugin);
         }
-        list($vendor, $plugin) = explode('/', $plugin, 1);
+        list($vendor, $plugin) = explode('/', $plugin, 2);
         return Inflector::camelize($vendor) . '/' . Inflector::camelize($plugin);
     }
 

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -192,4 +192,25 @@ class DashedRouteTest extends TestCase
         $this->assertEquals('searchIt', $result['action']);
         $this->assertEquals(['tv_shows'], $result['pass']);
     }
+
+    /**
+     * @return void
+     */
+    public function testMatchThenParse()
+    {
+        $route = new DashedRoute('/plugin/:controller/:action', [
+            'plugin' => 'Vendor/PluginName'
+        ]);
+        $url = $route->match([
+            'plugin' => 'Vendor/PluginName',
+            'controller' => 'ControllerName',
+            'action' => 'actionName'
+        ]);
+        $expected_url = '/plugin/controller-name/action-name';
+        $this->assertEquals($expected_url, $url);
+        $result = $route->parse($expected_url);
+        $this->assertEquals('ControllerName', $result['controller']);
+        $this->assertEquals('actionName', $result['action']);
+        $this->assertEquals('Vendor/PluginName', $result['plugin']);
+    }
 }


### PR DESCRIPTION
Due to the way the `DashedRoute` class works, if you use a vendored plugin (`VendorName/PluginName`), do a `match()` on a route and then `parse()` the url back the plugin name was inflected incorrectly to `VendorName/pluginName` (Note the lowercase _p_). This obviously broke dispatching.

This PR aims to fix that problem.
