### PR TITLE
Changes url to build in link helper doc

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -312,7 +312,7 @@ class HtmlHelper extends Helper
      *
      * If $url starts with "http://" this is treated as an external link. Else,
      * it is treated as a path to controller/action and parsed with the
-     * UrlHelper::url() method.
+     * UrlHelper::build() method.
      *
      * If the $url is empty, $title is used instead.
      *


### PR DESCRIPTION
Hello

Small typo in link helper doc block UrlHelper::url() to UrlHelper::build()
