### PR TITLE
Fix SSL via proxy

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -137,6 +137,9 @@ class CakeSocket {
 		if (!empty($this->config['protocol'])) {
 			$scheme = $this->config['protocol'] . '://';
 		}
+		if (!empty($this->config['proxy'])) {
+			$scheme = 'tcp://';
+		}
 
 		$host = $this->config['host'];
 		if (isset($this->config['request']['uri']['host'])) {


### PR DESCRIPTION
Commit 48dd778bd0eedcaaad57e81cebf74f7ebb76db9f broke SSL via a proxy because it sets the scheme to ssl:// which will break the proxy connection. This patch explicitly sets the scheme to tcp:// when a proxy is used to honor the fix for #7579 
