### PR TITLE
Fix proxy authentication when SSL is used

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -189,6 +189,9 @@ class CakeSocket {
 					$this->config['request']['uri']['port'] . ' HTTP/1.1';
 				$req[] = 'Host: ' . $this->config['host'];
 				$req[] = 'User-Agent: php proxy';
+				if(!empty($this->config['proxyauth'])) {
+					$req[] = 'Proxy-Authorization: ' . $this->config['proxyauth'];
+				}
 
 				fwrite($this->connection, implode("\r\n", $req) . "\r\n\r\n");
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -189,7 +189,7 @@ class CakeSocket {
 					$this->config['request']['uri']['port'] . ' HTTP/1.1';
 				$req[] = 'Host: ' . $this->config['host'];
 				$req[] = 'User-Agent: php proxy';
-				if(!empty($this->config['proxyauth'])) {
+				if (!empty($this->config['proxyauth'])) {
 					$req[] = 'Proxy-Authorization: ' . $this->config['proxyauth'];
 				}
 

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -668,6 +668,13 @@ class HttpSocket extends CakeSocket {
 			throw new SocketException(__d('cake_dev', 'The %s does not support proxy authentication.', $authClass));
 		}
 		call_user_func_array("$authClass::proxyAuthentication", array($this, &$this->_proxy));
+
+		if (!empty($this->request['header']['Proxy-Authorization'])) {
+			$this->config['proxyauth'] = $this->request['header']['Proxy-Authorization'];
+			if ($this->request['uri']['scheme'] === 'https') {
+				$this->request['header'] = Hash::remove($this->request['header'], 'Proxy-Authorization');
+			}
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
@@ -20,6 +20,24 @@ App::uses('HttpSocket', 'Network/Http');
 App::uses('BasicAuthentication', 'Network/Http');
 
 /**
+ * class TestHttpSocket
+ *
+ * @package       Cake.Test.Case.Network.Http
+ */
+class TestHttpSocket extends HttpSocket {
+
+/**
+ * testSetProxy method
+ *
+ * @return void
+ */
+	public function testSetProxy($proxy = null) {
+		$this->_proxy=$proxy;
+		$this->_setProxy();
+	}
+}
+
+/**
  * BasicMethodTest class
  *
  * @package       Cake.Test.Case.Network.Http
@@ -58,6 +76,28 @@ class BasicAuthenticationTest extends CakeTestCase {
 
 		BasicAuthentication::proxyAuthentication($http, $proxy);
 		$this->assertEquals('Basic bWFyazpzZWNyZXQ=', $http->request['header']['Proxy-Authorization']);
+	}
+
+/**
+ * testProxyAuthenticationSsl method
+ *
+ * @return void
+ */
+	public function testProxyAuthenticationSsl() {
+		$http = new TestHttpSocket();
+		$http->request['uri']['scheme'] = 'https';
+		$proxy = array(
+			'host' => 'localhost',
+			'port' => 3128,
+			'method' => 'Basic',
+			'user' => 'mark',
+			'pass' => 'secret'
+		);
+
+		$http->testSetProxy($proxy);
+
+		$this->assertEquals('Basic bWFyazpzZWNyZXQ=', $http->config['proxyauth']);
+		$this->assertFalse(isset($http->request['header']['Proxy-Authorization']));
 	}
 
 }

--- a/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
@@ -20,11 +20,11 @@ App::uses('HttpSocket', 'Network/Http');
 App::uses('BasicAuthentication', 'Network/Http');
 
 /**
- * class TestHttpSocket
+ * class TestSslHttpSocket
  *
  * @package       Cake.Test.Case.Network.Http
  */
-class TestHttpSocket extends HttpSocket {
+class TestSslHttpSocket extends HttpSocket {
 
 /**
  * testSetProxy method
@@ -84,7 +84,7 @@ class BasicAuthenticationTest extends CakeTestCase {
  * @return void
  */
 	public function testProxyAuthenticationSsl() {
-		$http = new TestHttpSocket();
+		$http = new TestSslHttpSocket();
 		$http->request['uri']['scheme'] = 'https';
 		$proxy = array(
 			'host' => 'localhost',

--- a/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
@@ -32,9 +32,10 @@ class TestSslHttpSocket extends HttpSocket {
  * @return void
  */
 	public function testSetProxy($proxy = null) {
-		$this->_proxy=$proxy;
+		$this->_proxy = $proxy;
 		$this->_setProxy();
 	}
+
 }
 
 /**


### PR DESCRIPTION
When the request to the actual server uses SSL the proxy is unable to see the Proxy-Authorization so it needs to be copied to the CONNECT request. Also, because the actual request in encrypted the proxy cannot strip the Proxy-Authorization header from the request before forwarding it. We need to do this ourselves, otherwise proxy credentials will get leaked to the remote server.
