### PR TITLE
Harden CORS origin handling.

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1390,9 +1390,9 @@ class Response
 
             $original = $preg = $domain;
             if (strpos($domain, '://') === false) {
-                $preg = ($requestIsSSL ? 'https://' : 'http://') . $domain;
+                $domain = ($requestIsSSL ? 'https://' : 'http://') . $domain;
             }
-            $preg = '@' . str_replace('*', '.*', $domain) . '@';
+            $preg = '@^' . str_replace('\*', '.*', preg_quote($domain, '@')) . '$@';
             $result[] = compact('original', 'preg');
         }
         return $result;

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1113,11 +1113,14 @@ class ResponseTest extends TestCase
     {
         $fooRequest = new Request();
 
-        $secureRequest = $this->getMock('Cake\Network\Request', ['is']);
-        $secureRequest->expects($this->any())
-            ->method('is')
-            ->with('ssl')
-            ->will($this->returnValue(true));
+        $secureRequest = function () {
+            $secureRequest = $this->getMock('Cake\Network\Request', ['is']);
+            $secureRequest->expects($this->any())
+                ->method('is')
+                ->with('ssl')
+                ->will($this->returnValue(true));
+            return $secureRequest;
+        };
 
         return [
             [$fooRequest, null, '*', '', '', false, false],
@@ -1129,9 +1132,15 @@ class ResponseTest extends TestCase
             [$fooRequest, 'http://www.foo.com', 'https://*.foo.com', '', '', false, false],
             [$fooRequest, 'http://www.foo.com', ['*.bar.com', '*.foo.com'], '', '', 'http://www.foo.com', false],
 
-            [$secureRequest, 'https://www.bar.com', 'www.bar.com', '', '', 'https://www.bar.com', false],
-            [$secureRequest, 'https://www.bar.com', 'http://www.bar.com', '', '', false, false],
-            [$secureRequest, 'https://www.bar.com', '*.bar.com', '', '', 'https://www.bar.com', false],
+            [$fooRequest, 'http://not-foo.com', '*.foo.com', '', '', false, false],
+            [$fooRequest, 'http://bad.academy', '*.acad.my', '', '', false, false],
+            [$fooRequest, 'http://www.foo.com.at.bad.com', '*.foo.com', '', '', false, false],
+            [$fooRequest, 'https://www.foo.com', '*.foo.com', '', '', false, false],
+
+            [$secureRequest(), 'https://www.bar.com', 'www.bar.com', '', '', 'https://www.bar.com', false],
+            [$secureRequest(), 'https://www.bar.com', 'http://www.bar.com', '', '', false, false],
+            [$secureRequest(), 'https://www.bar.com', '*.bar.com', '', '', 'https://www.bar.com', false],
+            [$secureRequest(), 'http://www.bar.com', '*.bar.com', '', '', false, false],
 
             [$fooRequest, 'http://www.foo.com', '*', 'GET', '', '*', 'GET'],
             [$fooRequest, 'http://www.foo.com', '*.foo.com', 'GET', '', 'http://www.foo.com', 'GET'],


### PR DESCRIPTION
While this is a security related problem, I figured that the impact is pretty low, given the general exploitability of CORS via any web client that doesn't put restrictions in place like default browsers do.

This also resurrects a dead line of code ( https://github.com/cakephp/cakephp/blob/3.1.5/src/Network/Response.php#L1393 ), which will cause consecutive tests that check `is('ssl')` to fail for some reason (it will return `null`, while each dataset on its own passes just fine). This seems to have something to do with reusing the mocked request object over multiple tests, and I'm not sure if there is any other way to fix this, other than creating separate mocks for each dataset!?
