### PR TITLE
Use fewer mocks in the association tests

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -801,6 +801,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   When true records will be loaded and then deleted.
      * - conditions: array with a list of conditions to filter the join with
      * - sort: The order in which results for this association should be returned
+     * - saveStrategy: Either 'append' or 'replace'. When 'append' the current records
+     *   are appended to any records in the database. When 'replace' associated records
+     *   not in the current set will be removed. If the foreign key is a null able column
+     *   or if `dependent` is true records will be orphaned.
      * - strategy: The strategy to be used for selecting results Either 'select'
      *   or 'subquery'. If subquery is selected the query used to return results
      *   in the source table will be used as conditions for getting rows in the

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -39,13 +39,6 @@ class BelongsToTest extends TestCase
     public $fixtures = ['core.articles', 'core.authors', 'core.comments'];
 
     /**
-     * Don't autoload fixtures as most tests uses mocks.
-     *
-     * @var bool
-     */
-    public $autoFixture = false;
-
-    /**
      * Set up
      *
      * @return void
@@ -148,7 +141,6 @@ class BelongsToTest extends TestCase
      */
     public function testAttachTo()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
         $config = [
             'foreignKey' => 'company_id',
             'sourceTable' => $this->client,
@@ -156,22 +148,26 @@ class BelongsToTest extends TestCase
             'conditions' => ['Companies.is_active' => true]
         ];
         $association = new BelongsTo('Companies', $config);
-        $field = new IdentifierExpression('Clients.company_id');
-        $query->expects($this->once())->method('join')->with([
-            'Companies' => [
-                'conditions' => new QueryExpression([
-                    'Companies.is_active' => true,
-                    ['Companies.id' => $field]
-                ], $this->companiesTypeMap),
-                'table' => 'companies',
-                'type' => 'LEFT'
-            ]
-        ]);
-        $query->expects($this->once())->method('select')->with([
+        $query = $this->client->query();
+        $association->attachTo($query);
+
+        $expected = [
             'Companies__id' => 'Companies.id',
             'Companies__company_name' => 'Companies.company_name'
-        ]);
-        $association->attachTo($query);
+        ];
+        $this->assertEquals($expected, $query->clause('select'));
+        $expected = [
+            'Companies' => [
+                'alias' => 'Companies',
+                'table' => 'companies',
+                'type' => 'LEFT',
+                'conditions' => new QueryExpression([
+                    'Companies.is_active' => true,
+                    ['Companies.id' => new IdentifierExpression('Clients.company_id')]
+                ], $this->companiesTypeMap)
+            ]
+        ];
+        $this->assertEquals($expected, $query->clause('join'));
     }
 
     /**
@@ -181,26 +177,80 @@ class BelongsToTest extends TestCase
      */
     public function testAttachToNoFields()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
             'conditions' => ['Companies.is_active' => true]
         ];
+        $query = $this->client->query();
         $association = new BelongsTo('Companies', $config);
-        $field = new IdentifierExpression('Clients.company_id');
-        $query->expects($this->once())->method('join')->with([
+
+        $association->attachTo($query, ['includeFields' => false]);
+        $this->assertEmpty($query->clause('select'), 'no fields should be added.');
+    }
+
+    /**
+     * Tests that using belongsto with a table having a multi column primary
+     * key will work if the foreign key is passed
+     *
+     * @return void
+     */
+    public function testAttachToMultiPrimaryKey()
+    {
+        $this->company->primaryKey(['id', 'tenant_id']);
+        // $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $config = [
+            'foreignKey' => ['company_id', 'company_tenant_id'],
+            'sourceTable' => $this->client,
+            'targetTable' => $this->company,
+            'conditions' => ['Companies.is_active' => true]
+        ];
+        $association = new BelongsTo('Companies', $config);
+        $query = $this->client->query();
+        $association->attachTo($query);
+
+        $expected = [
+            'Companies__id' => 'Companies.id',
+            'Companies__company_name' => 'Companies.company_name'
+        ];
+        $this->assertEquals($expected, $query->clause('select'));
+
+        $field1 = new IdentifierExpression('Clients.company_id');
+        $field2 = new IdentifierExpression('Clients.company_tenant_id');
+        $expected = [
             'Companies' => [
                 'conditions' => new QueryExpression([
                     'Companies.is_active' => true,
-                    ['Companies.id' => $field]
+                    ['Companies.id' => $field1, 'Companies.tenant_id' => $field2]
                 ], $this->companiesTypeMap),
-                'type' => 'LEFT',
                 'table' => 'companies',
+                'type' => 'LEFT',
+                'alias' => 'Companies'
             ]
-        ]);
-        $query->expects($this->never())->method('select');
-        $association->attachTo($query, ['includeFields' => false]);
+        ];
+        $this->assertEquals($expected, $query->clause('join'));
+    }
+
+    /**
+     * Tests that using belongsto with a table having a multi column primary
+     * key will work if the foreign key is passed
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"
+     * @return void
+     */
+    public function testAttachToMultiPrimaryKeyMistmatch()
+    {
+        $this->company->primaryKey(['id', 'tenant_id']);
+        $query = $this->client->query();
+        $config = [
+            'foreignKey' => 'company_id',
+            'sourceTable' => $this->client,
+            'targetTable' => $this->company,
+            'conditions' => ['Companies.is_active' => true]
+        ];
+        $association = new BelongsTo('Companies', $config);
+        $association->attachTo($query);
     }
 
     /**
@@ -253,64 +303,6 @@ class BelongsToTest extends TestCase
     }
 
     /**
-     * Tests that using belongsto with a table having a multi column primary
-     * key will work if the foreign key is passed
-     *
-     * @return void
-     */
-    public function testAttachToMultiPrimaryKey()
-    {
-        $this->company->primaryKey(['id', 'tenant_id']);
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
-        $config = [
-            'foreignKey' => ['company_id', 'company_tenant_id'],
-            'sourceTable' => $this->client,
-            'targetTable' => $this->company,
-            'conditions' => ['Companies.is_active' => true]
-        ];
-        $association = new BelongsTo('Companies', $config);
-        $field1 = new IdentifierExpression('Clients.company_id');
-        $field2 = new IdentifierExpression('Clients.company_tenant_id');
-        $query->expects($this->once())->method('join')->with([
-            'Companies' => [
-                'conditions' => new QueryExpression([
-                    'Companies.is_active' => true,
-                    ['Companies.id' => $field1, 'Companies.tenant_id' => $field2]
-                ], $this->companiesTypeMap),
-                'table' => 'companies',
-                'type' => 'LEFT'
-            ]
-        ]);
-        $query->expects($this->once())->method('select')->with([
-            'Companies__id' => 'Companies.id',
-            'Companies__company_name' => 'Companies.company_name'
-        ]);
-        $association->attachTo($query);
-    }
-
-    /**
-     * Tests that using belongsto with a table having a multi column primary
-     * key will work if the foreign key is passed
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"
-     * @return void
-     */
-    public function testAttachToMultiPrimaryKeyMistmatch()
-    {
-        $this->company->primaryKey(['id', 'tenant_id']);
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
-        $config = [
-            'foreignKey' => 'company_id',
-            'sourceTable' => $this->client,
-            'targetTable' => $this->company,
-            'conditions' => ['Companies.is_active' => true]
-        ];
-        $association = new BelongsTo('Companies', $config);
-        $association->attachTo($query);
-    }
-
-    /**
      * Tests that property is being set using the constructor options.
      *
      * @return void
@@ -346,7 +338,6 @@ class BelongsToTest extends TestCase
      */
     public function testAttachToBeforeFind()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
         $config = [
             'foreignKey' => 'company_id',
             'sourceTable' => $this->client,
@@ -362,7 +353,7 @@ class BelongsToTest extends TestCase
                 $this->isInstanceOf('\ArrayObject'),
                 false
             );
-        $association->attachTo($query);
+        $association->attachTo($this->client->query());
     }
 
     /**
@@ -373,7 +364,6 @@ class BelongsToTest extends TestCase
      */
     public function testAttachToBeforeFindExtraOptions()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
         $config = [
             'foreignKey' => 'company_id',
             'sourceTable' => $this->client,
@@ -390,6 +380,7 @@ class BelongsToTest extends TestCase
                 $options,
                 false
             );
+        $query = $this->client->query();
         $association->attachTo($query, ['queryBuilder' => function ($q) {
             return $q->applyOptions(['something' => 'more']);
         }]);

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -198,7 +198,6 @@ class BelongsToTest extends TestCase
     public function testAttachToMultiPrimaryKey()
     {
         $this->company->primaryKey(['id', 'tenant_id']);
-        // $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
         $config = [
             'foreignKey' => ['company_id', 'company_tenant_id'],
             'sourceTable' => $this->client,

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -340,7 +340,7 @@ class HasManyTest extends TestCase
             ->will($this->returnValue($query));
 
         $queryBuilder = function ($query) {
-            return $query->select(['author_id'])->join('comments')->where(['Comments.id' => 1]);
+            return $query->select(['author_id'])->join('comments')->where(['comments.id' => 1]);
         };
         $association->eagerLoader(compact('keys', 'query', 'queryBuilder'));
 
@@ -361,7 +361,7 @@ class HasManyTest extends TestCase
 
         $expected = new QueryExpression([
                 'Articles.author_id IN' => $keys,
-                'Comments.id' => 1,
+                'comments.id' => 1,
             ],
             $query->typeMap()
         );

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -30,7 +30,6 @@ use Cake\TestSuite\TestCase;
  */
 class HasOneTest extends TestCase
 {
-
     /**
      * Set up
      *


### PR DESCRIPTION
Extensive mocking seemed useful in the association tests initially. However, over time I feel it has made it harder for contributors to add tests, and caused many tests that should go into the association test cases, to end up in `QueryRegressionTest` or `TableTest`. If people are comfortable with these changes I'd like to:
- Cleanup the BelongsToManyTest.
- Move tests out of QueryRegression and TableTest into more appropriate locations.
