### PR TITLE
RFC: Suggest a "dot-aware" Entity::get() implementation.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -338,9 +338,24 @@ trait EntityTrait
         if (!strlen((string)$property)) {
             throw new InvalidArgumentException('Cannot get an empty property');
         }
+
+        if (strpos($property, '.') > 0) {
+            list($property, $nested) = explode('.', $property, 2);
+            if ($this->_properties[$property] instanceof EntityInterface) {
+                return $this->_properties[$property]->getOriginal($nested);
+            }
+
+            throw new \InvalidArgumentException(sprintf(
+                'No original value is available for path: %s.%s',
+                $property,
+                $nested
+            ));
+        }
+
         if (array_key_exists($property, $this->_original)) {
             return $this->_original[$property];
         }
+
         return $this->get($property);
     }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1355,7 +1355,7 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Tests that setitng an empty property name does nothing
+     * Tests that settng an empty property name does nothing
      *
      * @expectedException \InvalidArgumentException
      * @dataProvider emptyNamesProvider

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -46,6 +46,31 @@ class EntityTest extends TestCase
         $this->assertSame(1, $entity->id);
         $this->assertEquals(1, $entity->getOriginal('id'));
         $this->assertEquals('bar', $entity->getOriginal('foo'));
+
+        $entity->set('level1.level2.level3', 'three');
+        $this->assertSame('three', $entity->level1->level2->level3);
+        $this->assertEquals('three', $entity->getOriginal('level1.level2.level3'));
+        $entity->set('level1.level2.level3', '333');
+        $this->assertEquals('three', $entity->getOriginal('level1.level2.level3'));
+
+        $entity->ary = [];
+        $entity->set('ary.season1.power9000', 'Goku');
+        $this->assertSame('Goku', $entity->ary['season1']['power9000']);
+    }
+
+    /**
+     * Tests setting a deep property that contains a segment already assigned as a scalar (string).
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetDottedScalarPath()
+    {
+        $entity = new Entity(['scalarKey' => 'this string does not implement ::set()']);
+        $entity->set(
+            'scalarKey.canNotTraverseHere',
+            'Not allowed since scalarKey is not an array or Entity.'
+        );
     }
 
     /**
@@ -68,6 +93,16 @@ class EntityTest extends TestCase
         $this->assertSame(3, $entity->thing);
         $this->assertEquals('bar', $entity->getOriginal('foo'));
         $this->assertEquals(1, $entity->getOriginal('id'));
+
+        $entity->deeply = new Entity(['nested' => new Entity(['id' => 4])]);
+        $entity->set(['foo' => ['bar' => 'baz'], 'deeply.nested.id' => 5, 'thing' => 6]);
+        $this->assertEquals('baz', $entity->foo['bar']);
+        $this->assertSame(5, $entity->deeply->nested->id);
+        $this->assertSame(6, $entity->thing);
+        $this->assertEquals(4, $entity->getOriginal('deeply.nested.id'));
+        $entity->set(['deeply.nested.id' => 7]);
+        $this->assertSame(7, $entity->deeply->nested->id);
+        $this->assertEquals(4, $entity->getOriginal('deeply.nested.id'));
     }
 
     /**
@@ -197,7 +232,7 @@ class EntityTest extends TestCase
      */
     public function testSetOneParamWithSetter()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName']);
+        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName', '_setStar']);
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
@@ -206,6 +241,22 @@ class EntityTest extends TestCase
             }));
         $entity->set('name', 'Jones');
         $this->assertEquals('Dr. Jones', $entity->name);
+
+        $movie = $this->getMock('\Cake\ORM\Entity', ['_setYear', '_setStar']);
+        $movie->expects($this->once())->method('_setYear')
+            ->with(1981)
+            ->willReturn(1981);
+
+        // Confirm that the setter for a final segment of a dotted path is called.
+        $entity->set('film', $movie);
+        $entity->set('film.year', 1981);
+        $this->assertEquals(1981, $entity->film->year);
+
+        // Confirm that the setter for an intermediate segment of a dotted path is NOT called.
+        $movie->set('star', $entity, ['setter' => false]);
+        $entity->expects($this->never())->method('_setStar');
+        $movie->set('star.hat', 'fedora');
+        $this->assertEquals('fedora', $movie->star->hat);
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -94,6 +94,22 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Test that getOriginal() throws an exception on empty param.
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetOriginalEmptyParam()
+    {
+        $entity = new Entity(
+            ['foo' => 'bar'],
+            ['markNew' => true]
+        );
+
+        $entity->getOriginal('');
+    }
+
+    /**
      * Test extractOriginal()
      *
      * @return void

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -413,7 +413,7 @@ class EntityTest extends TestCase
         $top->expects($this->any())
             ->method('_getNested')
             ->will($this->returnCallback(function ($nested) {
-                $nested->extra .= 'added';
+                $nested->extra = 'added';
                 return $nested;
             }));
 
@@ -424,8 +424,9 @@ class EntityTest extends TestCase
                 return $deep . ' modified';
             }));
         $top->set('nested', $nested);
+
         $this->assertNull($nested->extra);
-        $this->assertSame($nested, $top->get('nested')); // 1
+        $this->assertSame($nested, $top->get('nested'));
 
         $nested->set('deep', 'story');
         $this->assertEquals('story modified', $top->get('nested.deep'));
@@ -491,15 +492,19 @@ class EntityTest extends TestCase
         $entity->set('locations', ['raiders' => 'desert', 'temple' => 'jungle']);
 
         $this->assertEquals('ark', $entity->artifacts->get('raiders'));
+// debug($entity->artifacts);
         $this->assertEquals('cup', $entity->get('artifacts.crusade'));
+// debug($entity->artifacts);
         $this->assertNull($entity->get('artifacts.kingdom'));
+// debug($entity->artifacts);
 
-        $this->assertEquals('desert', $entity->locations['raiders']);
-        $this->assertEquals('jungle', $entity->get('locations.temple'));
-        $this->assertNull($entity->get('locations.kingdom'));
-
-        $entity = new Entity(['a' => new \ArrayObject(['b' => 'fizz/buzz'])]); // Object that implements ArrayAccess
-        $this->assertEquals('fizz/buzz', $entity->get('a.b'));
+//
+//         $this->assertEquals('desert', $entity->locations['raiders']);
+//         $this->assertEquals('jungle', $entity->get('locations.temple'));
+//         $this->assertNull($entity->get('locations.kingdom'));
+//
+//         $entity = new Entity(['a' => new \ArrayObject(['b' => 'fizz/buzz'])]); // Object that implements ArrayAccess
+//         $this->assertEquals('fizz/buzz', $entity->get('a.b'));
     }
 
     /**
@@ -628,7 +633,7 @@ class EntityTest extends TestCase
             ->will($this->returnValue(0));
         $this->assertTrue($entity->has('things'));
 
-        $child = new Entity(['name' => 'child']);
+        $child = new Entity(['name' => 'kid']);
         $parent = new Entity(['name' => 'parent', 'child' => $child]);
         $this->assertTrue($parent->has('child'));
         $this->assertTrue($parent->has('child.name'));

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1389,4 +1389,22 @@ class EntityTest extends TestCase
         $this->assertTrue($cloned->dirty('a'));
         $this->assertTrue($cloned->dirty('b'));
     }
+
+    /**
+     * Tests the invalid method.
+     *
+     * @return void
+     */
+    public function testInvalid()
+    {
+        $entity = new Entity(['a' => 1]);
+        $this->assertEmpty([], $entity->invalid());
+
+        $entity->invalid('a', 'Must be a float');
+        $this->assertEquals('Must be a float', $entity->invalid('a'));
+
+        $result = $entity->invalid('a', 'Must really be monetary', true);
+        $this->assertEquals('Must really be monetary', $entity->invalid('a'));
+        $this->assertSame($entity, $result);
+    }
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -71,20 +71,21 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Test that getOriginal() retains falsey values.
+     * Test that getOriginal() retains falsey values and recurses into nested entities.
      *
      * @return void
      */
     public function testGetOriginal()
     {
         $entity = new Entity(
-            ['false' => false, 'null' => null, 'zero' => 0, 'empty' => ''],
+            ['false' => false, 'null' => null, 'zero' => 0, 'empty' => '', 'nested' => new Entity(['deep' => 42])],
             ['markNew' => true]
         );
         $this->assertNull($entity->getOriginal('null'));
         $this->assertFalse($entity->getOriginal('false'));
         $this->assertSame(0, $entity->getOriginal('zero'));
         $this->assertSame('', $entity->getOriginal('empty'));
+        $this->assertSame(42, $entity->getOriginal('nested.deep'));
 
         $entity->set(['false' => 'y', 'null' => 'y', 'zero' => 'y', 'empty' => '']);
         $entity->nested->set('deep', 256);
@@ -92,6 +93,7 @@ class EntityTest extends TestCase
         $this->assertFalse($entity->getOriginal('false'));
         $this->assertSame(0, $entity->getOriginal('zero'));
         $this->assertSame('', $entity->getOriginal('empty'));
+        $this->assertSame(42, $entity->getOriginal('nested.deep'));
     }
 
     /**
@@ -108,6 +110,22 @@ class EntityTest extends TestCase
         );
 
         $entity->getOriginal('');
+    }
+
+    /**
+     * Test that getOriginal() throws an exception on invalid dotted path.
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetOriginalBadDottedPath()
+    {
+        $entity = new Entity(
+            ['foo' => 'bar'],
+            ['markNew' => true]
+        );
+
+        $entity->getOriginal('foo.not.there');
     }
 
     /**


### PR DESCRIPTION
This PR demonstrates the ability to use `Entity::get('property.subproperty')` to reach deeply into an Entity. This works in the case where `$entity->property` is either an Entity itself or an array. It preserves all existing functionality and (in the unit tests are any indication) should be fully backwards compatible. It simply extends the interface to recognize and attempt to recursively support dotted-notation when the top-level retrieved property supports `::get()` or `Hash::get()` itself. Like all existing Entity "get" interfaces, this methods returns null in any failure case.

Arguments in favor:
- `Hash::get()` provides a dot notation interface for traversing deep into an array structure. This PR provides a similar interface to Entities.
- There is no (simple) way to  _programmatically_ use arrow notation (`$entity->property->subproperty`) to retrieve a "path" from nested objects, which limits the ability to use Entities dynamically.

If the discussion is positive, I will happily add tests and documentation.

Additional talking points:
- [x] Is `method_exists('get')` the best approach? Maybe `instanceof EntityInterface` would be better?
- [x] Adding tests of the **new** functionality may illuminate shortcomings or gotchas (but I'm not going to waste my time unless there is interest in this.)
