### PR TITLE
Exclude NULLS clauses in schema reflection.

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -229,7 +229,7 @@ class PostgresSchema extends BaseSchema
         if ($row['indisunique'] && $type === Table::INDEX_INDEX) {
             $type = Table::CONSTRAINT_UNIQUE;
         }
-        preg_match('/\(([^\)]+)\)/', $row['statement'], $matches);
+        preg_match('/\(([^\)]+?)\s*(?:ASC|DESC)?(?:NULLS FIRST|LAST)?\)/', $row['statement'], $matches);
         $columns = $this->_convertColumnList($matches[1]);
         if ($type === Table::CONSTRAINT_PRIMARY || $type === Table::CONSTRAINT_UNIQUE) {
             $table->addConstraint($name, [

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -540,6 +540,50 @@ SQL;
     }
 
     /**
+     * Test describing a table with indexes with nulls first
+     *
+     * @return void
+     */
+    public function testDescribeTableIndexesNullsFirst()
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+        $connection->execute('DROP TABLE IF EXISTS schema_index');
+
+        $table = <<<SQL
+CREATE TABLE schema_index (
+  id serial NOT NULL,
+  user_id integer NOT NULL,
+  group_id integer NOT NULL,
+  grade double precision
+)
+WITH (
+  OIDS=FALSE
+)
+SQL;
+        $connection->execute($table);
+
+        $index = <<<SQL
+CREATE INDEX schema_index_nulls
+  ON schema_index
+  USING btree
+  (group_id, grade DESC NULLS FIRST);
+SQL;
+        $connection->execute($index);
+        $schema = new SchemaCollection($connection);
+
+        $result = $schema->describe('schema_index');
+        $this->assertCount(1, $result->indexes());
+        $expected = [
+            'type' => 'index',
+            'columns' => ['group_id', 'grade'],
+            'length' => []
+        ];
+        $this->assertEquals($expected, $result->index('schema_index_nulls'));
+        $connection->execute('DROP TABLE schema_index');
+    }
+
+    /**
      * Column provider for creating column sql
      *
      * @return array


### PR DESCRIPTION
Exclude `ASC|DESC NULLS FIRST|LAST` from column names as it not part of the column name. Sadly we have to muck around with regex as I can't find a way to get column metadata out of postgres.

Refs #7853
