### PR TITLE
Clear model cache after schema update.

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -403,6 +403,9 @@ class SchemaShell extends AppShell {
 			$this->out();
 			$this->out(__d('cake_console', 'Updating Database...'));
 			$this->_run($contents, 'update', $Schema);
+
+			Configure::write('Cache.disable', false);
+			Cache::clear(false, '_cake_model_');
 		}
 
 		$this->out(__d('cake_console', 'End update.'));


### PR DESCRIPTION
After running `Console/cake schema update` it is useful to clean model cache.

If update added or dropped some field, it might create errors if cache is not outdated.
