### PR TITLE
Fix session regeneration on PHP 7

### DIFF
--- a/src/Network/Session/CacheSession.php
+++ b/src/Network/Session/CacheSession.php
@@ -78,11 +78,17 @@ class CacheSession implements SessionHandlerInterface
      * Method used to read from a cache session.
      *
      * @param string $id The key of the value to read
-     * @return mixed The value of the key or false if it does not exist
+     * @return string The value of the key or empty if it does not exist
      */
     public function read($id)
     {
-        return Cache::read($id, $this->_options['config']);
+        $value = Cache::read($id, $this->_options['config']);
+
+        if (empty($value)) {
+            return '';
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -89,7 +89,7 @@ class DatabaseSession implements SessionHandlerInterface
      * Method used to read from a database session.
      *
      * @param int|string $id The key of the value to read
-     * @return mixed The value of the key or false if it does not exist
+     * @return string The value of the key or empty if it does not exist
      */
     public function read($id)
     {
@@ -101,7 +101,7 @@ class DatabaseSession implements SessionHandlerInterface
             ->first();
 
         if (empty($result)) {
-            return false;
+            return '';
         }
 
         if (is_string($result['data'])) {

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -130,7 +130,7 @@ class DatabaseSessionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->storage->read('made up value');
-        $this->assertFalse($result);
+        $this->assertEmpty($result);
     }
 
     /**
@@ -143,7 +143,7 @@ class DatabaseSessionTest extends TestCase
         $this->storage->write('foo', 'Some value');
 
         $this->assertTrue($this->storage->destroy('foo'), 'Destroy failed');
-        $this->assertFalse($this->storage->read('foo'), 'Value still present.');
+        $this->assertEmpty($this->storage->read('foo'), 'Value still present.');
     }
 
     /**
@@ -161,7 +161,7 @@ class DatabaseSessionTest extends TestCase
 
         sleep(1);
         $storage->gc(0);
-        $this->assertFalse($storage->read('foo'));
+        $this->assertEmpty($storage->read('foo'));
     }
 
     /**


### PR DESCRIPTION
This fixes a bug mentioned by @Xety in #5988 where calling `session_regenerate_id()` under PHP 7 throws a fatal error when a session does not already exist.

[Due to a change in how PHP 7 handles the result of `SessionHandlerInterface::read()`](https://bugs.php.net/bug.php?id=70520) any result other than a string indicates a failure and an empty string is used to represent the lack of a session.

Tested `CacheSession` with PHP 7.0.0 using Memcached for storage. I have not tested the `DatabaseSession`.
