### PR TITLE
[3.2] Can encrypt with IntegrationTestCase::cookie()

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -211,10 +211,17 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @param string $name The cookie name to use.
      * @param mixed $value The value of the cookie.
+     * @param string|bool|null $encryption By default, the CookieComponent
+     *   isn't be used. If specified the encryption mode like 'aes' or false,
+     *   the CookieComponent is used to encrypt and json_encode if array.
      * @return void
      */
-    public function cookie($name, $value)
+    public function cookie($name, $value, $encryption = null)
     {
+        if ($encryption !== null) {
+            $CookieEncrypter = new TestCookieEncrypter();
+            $value = $CookieEncrypter->encrypt($value, $encryption);
+        }
         $this->_cookie[$name] = $value;
     }
 

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -8,7 +8,7 @@
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @since         3.0.0
+ * @since         3.2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\TestSuite;

--- a/src/TestSuite/TestCookieEncrypter.php
+++ b/src/TestSuite/TestCookieEncrypter.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Controller\Component\CookieComponent;
+use Cake\Controller\ComponentRegistry;
+
+class TestCookieEncrypter extends CookieComponent {
+    public function __construct() {
+        return parent::__construct(new ComponentRegistry());
+    }
+
+    public function encrypt($value, $encrypt)
+    {
+        return $this->_encrypt($value, $encrypt);
+    }
+}

--- a/src/TestSuite/TestCookieEncrypter.php
+++ b/src/TestSuite/TestCookieEncrypter.php
@@ -13,8 +13,8 @@
  */
 namespace Cake\TestSuite;
 
-use Cake\Controller\Component\CookieComponent;
 use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Component\CookieComponent;
 
 /**
  * Class TestCookieEncrypter
@@ -23,11 +23,13 @@ use Cake\Controller\ComponentRegistry;
  *
  * @package Cake\TestSuite
  */
-class TestCookieEncrypter extends CookieComponent {
+class TestCookieEncrypter extends CookieComponent
+{
     /**
      * TestCookieEncrypter constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         return parent::__construct(new ComponentRegistry());
     }
 

--- a/src/TestSuite/TestCookieEncrypter.php
+++ b/src/TestSuite/TestCookieEncrypter.php
@@ -16,11 +16,29 @@ namespace Cake\TestSuite;
 use Cake\Controller\Component\CookieComponent;
 use Cake\Controller\ComponentRegistry;
 
+/**
+ * Class TestCookieEncrypter
+ *
+ * This class is to encrypt a cookie value in the IntegrationTestCase as if CookieComponent would do.
+ *
+ * @package Cake\TestSuite
+ */
 class TestCookieEncrypter extends CookieComponent {
+    /**
+     * TestCookieEncrypter constructor.
+     */
     public function __construct() {
         return parent::__construct(new ComponentRegistry());
     }
 
+    /**
+     * Encrypt a cookie value as if CookieComponent would do.
+     *
+     * @param string $value Value to encrypt
+     * @param string|bool $encrypt Encryption mode to use. False
+     *   disabled encryption.
+     * @return string Encoded values
+     */
     public function encrypt($value, $encrypt)
     {
         return $this->_encrypt($value, $encrypt);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -21,6 +21,7 @@ use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\IntegrationTestCase;
 use Cake\Test\Fixture\AssertIntegrationTestCase;
+use Cake\Utility\Security;
 
 /**
  * Self test of the IntegrationTestCase
@@ -141,6 +142,25 @@ class IntegrationTestCaseTest extends IntegrationTestCase
 
         $this->assertEquals('/tasks/view?archived=yes', $request->here());
         $this->assertEquals('yes', $request->query('archived'));
+    }
+
+    public function testCookieWithNoEncription() {
+        $this->cookie('KeyOfCookie', 'CookieComponent is not used');
+        $request = $this->_buildRequest('/tasks/view', 'GET', []);
+        $this->assertEquals('CookieComponent is not used', $request->cookies['KeyOfCookie']);
+    }
+
+    public function testCookieWithEncriptionFalse() {
+        $this->cookie('KeyOfCookie', ['Array is', 'json-encoded', 'by CookieComponent'], false);
+        $request = $this->_buildRequest('/tasks/view', 'GET', []);
+        $this->assertEquals('["Array is","json-encoded","by CookieComponent"]', $request->cookies['KeyOfCookie']);
+    }
+
+    public function testCookieWithEncriptionAes() {
+        Security::salt('foo!foo!foo!foo!foo!foo!foo!foo!');
+        $this->cookie('KeyOfCookie', 'Encrypted by CookieComponent', 'aes');
+        $request = $this->_buildRequest('/tasks/view', 'GET', []);
+        $this->assertStringStartsWith('Q2FrZQ==.', $request->cookies['KeyOfCookie']);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -144,19 +144,22 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertEquals('yes', $request->query('archived'));
     }
 
-    public function testCookieWithNoEncription() {
+    public function testCookieWithNoEncription()
+    {
         $this->cookie('KeyOfCookie', 'CookieComponent is not used');
         $request = $this->_buildRequest('/tasks/view', 'GET', []);
         $this->assertEquals('CookieComponent is not used', $request->cookies['KeyOfCookie']);
     }
 
-    public function testCookieWithEncriptionFalse() {
+    public function testCookieWithEncriptionFalse()
+    {
         $this->cookie('KeyOfCookie', ['Array is', 'json-encoded', 'by CookieComponent'], false);
         $request = $this->_buildRequest('/tasks/view', 'GET', []);
         $this->assertEquals('["Array is","json-encoded","by CookieComponent"]', $request->cookies['KeyOfCookie']);
     }
 
-    public function testCookieWithEncriptionAes() {
+    public function testCookieWithEncriptionAes()
+    {
         Security::salt('foo!foo!foo!foo!foo!foo!foo!foo!');
         $this->cookie('KeyOfCookie', 'Encrypted by CookieComponent', 'aes');
         $request = $this->_buildRequest('/tasks/view', 'GET', []);

--- a/tests/TestCase/TestSuite/TestCookieEncrypterTest.php
+++ b/tests/TestCase/TestSuite/TestCookieEncrypterTest.php
@@ -24,7 +24,9 @@ class TestCookieEncrypterTest extends TestCase
 {
     public function testEncryptedAsSameSpecAsCookieComponent()
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|TestCookieEncrypter $TestCookieEncrypter */
+        /**
+         * @var \PHPUnit_Framework_MockObject_MockObject|TestCookieEncrypter $TestCookieEncrypter
+         */
         $TestCookieEncrypter = $this->getMock('Cake\\TestSuite\\TestCookieEncrypter', ['_encrypt']);
         $TestCookieEncrypter->expects($this->once())
             ->method('_encrypt')

--- a/tests/TestCase/TestSuite/TestCookieEncrypterTest.php
+++ b/tests/TestCase/TestSuite/TestCookieEncrypterTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\TestSuite\TestCase;
+use Cake\TestSuite\TestCookieEncrypter;
+
+/**
+ * Cookie encrypter test case
+ */
+class TestCookieEncrypterTest extends TestCase
+{
+    public function testEncryptedAsSameSpecAsCookieComponent()
+    {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|TestCookieEncrypter $TestCookieEncrypter */
+        $TestCookieEncrypter = $this->getMock('Cake\\TestSuite\\TestCookieEncrypter', ['_encrypt']);
+        $TestCookieEncrypter->expects($this->once())
+            ->method('_encrypt')
+            ->with('Arg1', 'Arg2')
+            ->will($this->returnValue('ReturnValue'));
+
+        $actual = $TestCookieEncrypter->encrypt('Arg1', 'Arg2');
+        $this->assertEquals('ReturnValue', $actual);
+    }
+}


### PR DESCRIPTION
Add the 3rd argument to IntegrationTestCase::cookie() to encrypt with the CookieComponent.
See: #7862
