### PR TITLE
Fix doc block return statement in SmtpTransport

### DIFF
--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -369,7 +369,7 @@ class SmtpTransport extends AbstractTransport {
 				if ($code[2] === '-') {
 					continue;
 				}
-				return $code[1];
+				return;
 			}
 			throw new SocketException(__d('cake_dev', 'SMTP Error: %s', $response));
 		}

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -340,9 +340,9 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Protected method for sending data to SMTP connection
  *
- * @param string $data data to be sent to SMTP server
- * @param string|bool $checkCode code to check for in server response, false to skip
- * @return void
+ * @param string|null $data Data to be sent to SMTP server
+ * @param string|bool $checkCode Code to check for in server response, false to skip
+ * @return string Response code
  * @throws SocketException
  */
 	protected function _smtpSend($data, $checkCode = '250') {
@@ -369,7 +369,7 @@ class SmtpTransport extends AbstractTransport {
 				if ($code[2] === '-') {
 					continue;
 				}
-				return;
+				return $code[1];
 			}
 			throw new SocketException(__d('cake_dev', 'SMTP Error: %s', $response));
 		}


### PR DESCRIPTION
This void function should simply `return;`.
