### PR TITLE
RFC: Add convenience methods Shell::info|warn|success()

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -640,6 +640,47 @@ class Shell
     }
 
     /**
+     * Convenience method for out() that wraps message between <info /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @param int $level The message's output level, see above.
+     * @return int|bool Returns the number of bytes returned from writing to stdout.
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
+     */
+    public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
+    {
+        return $this->out('<info>' . $message . '</info>', $newlines, $level);
+    }
+
+    /**
+     * Convenience method for err() that wraps message between <warning /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @return void
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
+     */
+    public function warn($message = null, $newlines = 1)
+    {
+        return $this->err('<warning>' . $message . '</warning>', $newlines);
+    }
+
+    /**
+     * Convenience method for out() that wraps message between <success /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @param int $level The message's output level, see above.
+     * @return int|bool Returns the number of bytes returned from writing to stdout.
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
+     */
+    public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
+    {
+        return $this->out('<success>' . $message . '</success>', $newlines, $level);
+    }
+
+    /**
      * Returns a single or multiple linefeeds sequences.
      *
      * @param int $multiplier Number of times the linefeed sequence should be repeated

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -316,6 +316,48 @@ class ShellTest extends TestCase
     }
 
     /**
+     * testInfo method
+     *
+     * @return void
+     */
+    public function testInfo()
+    {
+        $this->io->expects($this->once())
+            ->method('out')
+            ->with('<info>Just a test</info>', 1);
+
+        $this->Shell->info('Just a test');
+    }
+
+    /**
+     * testWarn method
+     *
+     * @return void
+     */
+    public function testWarn()
+    {
+        $this->io->expects($this->once())
+            ->method('err')
+            ->with('<warning>Just a test</warning>', 1);
+
+        $this->Shell->warn('Just a test');
+    }
+
+    /**
+     * testSuccess method
+     *
+     * @return void
+     */
+    public function testSuccess()
+    {
+        $this->io->expects($this->once())
+            ->method('out')
+            ->with('<success>Just a test</success>', 1);
+
+        $this->Shell->success('Just a test');
+    }
+
+    /**
      * testNl
      *
      * @return void


### PR DESCRIPTION
I had this in my AppShell in 2.x, maybe useful for 3.x.
