### PR TITLE
Clean up usage of _stop() and error().

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -670,7 +670,7 @@ class Shell
      *
      * @param string $title Title of the error
      * @param string|null $message An optional error message
-     * @return void
+     * @return int Error code
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
      */
     public function error($title, $message = null)
@@ -681,6 +681,8 @@ class Shell
             $this->_io->err($message);
         }
         $this->_stop(1);
+
+        return 1;
     }
 
     /**
@@ -720,7 +722,8 @@ class Shell
 
             if (strtolower($key) === 'q') {
                 $this->_io->out('<error>Quitting</error>.', 2);
-                return $this->_stop();
+                $this->_stop();
+                return false;
             }
             if (strtolower($key) === 'a') {
                 $this->params['force'] = true;


### PR DESCRIPTION
- _stop() is void and should not be used directly.
- Makes it possible to use `return $this->error()` in Shells, currently void requires 2 lines.

Fully BC because of void.

Example

``` php
/**
 * @return int|null
 */
public function run() {
    if ($check) {
        return $this->error(...);
    }
    ...
}
```

This will also mainly effect testing, where exit() would not be triggered, and as such the error code should probably be passed up.

We already got a few cases in the core, e.g.

```
// I18nShell::init()
if (strlen($language) < 2) {
    return $this->error('Invalid language code. Valid is `en`, `eng`, `en_US` etc.');
}
```
