### PR TITLE
3.2: Deprecate action in Form::create()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -317,7 +317,7 @@ class FormHelper extends Helper
      * - `type` Form method defaults to autodetecting based on the form context. If
      *   the form context's isCreate() method returns false, a PUT request will be done.
      * - `action` The controller action the form submits to, (optional). Use this option if you
-     *   don't need to change the controller from the current request's controller.
+     *   don't need to change the controller from the current request's controller. Deprecated since 3.2, use `url`.
      * - `url` The URL the form submits to. Can be a string or a URL array. If you use 'url'
      *    you should leave 'action' undefined.
      * - `encoding` Set the accept-charset encoding for the form. Defaults to `Configure::read('App.encoding')`
@@ -356,6 +356,10 @@ class FormHelper extends Helper
             'templates' => null,
             'idPrefix' => null,
         ];
+
+        if (isset($options['action'])) {
+            trigger_error('Using key `action` is deprecated, use `url` directly instead.', E_USER_DEPRECATED);
+        }
 
         if ($options['idPrefix'] !== null) {
             $this->_idPrefix = $options['idPrefix'];

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -727,7 +727,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->create(false, ['action' => false]);
+        $result = $this->Form->create(false, ['url' => ['action' => false]]);
         $this->assertHtml($expected, $result);
     }
 
@@ -783,7 +783,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->create(
             $this->article,
             [
-                'type' => 'post', 'action' => 'index', 'encoding' => 'iso-8859-1'
+                'type' => 'post', 'url' => ['action' => 'index'], 'encoding' => 'iso-8859-1'
             ]
         );
         $expected = [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -658,7 +658,7 @@ class FormHelperTest extends TestCase
         $this->article['defaults'] = ['id' => 1];
         $this->Form->request->here = '/articles/edit/1';
         $this->Form->request['action'] = 'delete';
-        $result = $this->Form->create($this->article, ['action' => 'edit']);
+        $result = $this->Form->create($this->article, ['url' => ['action' => 'edit']]);
         $expected = [
             'form' => [
                 'method' => 'post',
@@ -695,7 +695,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->request['controller'] = 'Pages';
-        $result = $this->Form->create($this->article, ['action' => 'signup']);
+        $result = $this->Form->create($this->article, ['url' => ['action' => 'signup']]);
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/Pages/signup/1',
@@ -743,7 +743,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->request['controller'] = 'users';
 
-        $result = $this->Form->create(false, ['action' => 'login']);
+        $result = $this->Form->create(false, ['url' => ['action' => 'login']]);
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/login',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -715,7 +715,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateNoUrl()
     {
-        $result = $this->Form->create(false, ['url' => false]);
+        $result = $this->Form->create(false, ['url' => ['action' => false]]);
         $expected = [
             'form' => [
                 'method' => 'post',
@@ -725,9 +725,6 @@ class FormHelperTest extends TestCase
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/div'
         ];
-        $this->assertHtml($expected, $result);
-
-        $result = $this->Form->create(false, ['url' => ['action' => false]]);
         $this->assertHtml($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -715,7 +715,7 @@ class FormHelperTest extends TestCase
      */
     public function testCreateNoUrl()
     {
-        $result = $this->Form->create(false, ['url' => ['action' => false]]);
+        $result = $this->Form->create(false, ['url' => false]);
         $expected = [
             'form' => [
                 'method' => 'post',


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/7885 as discussed.

We will also add it to the 3.2 change-log, of course. And also backport it to 2.8.
