### PR TITLE
3.x Ignore additional attributes in index column name

### DIFF
--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -459,8 +459,9 @@ class Table
             throw new Exception(sprintf('Index "%s" in table "%s" must have at least one column.', $name, $this->_table));
         }
         $attrs['columns'] = (array)$attrs['columns'];
-        foreach ($attrs['columns'] as $field) {
-            $field = explode(' ', $field)[0];
+        foreach ($attrs['columns'] as $parts) {
+            $parts = explode(' ', $parts);
+            $field = $parts[0];
             if (empty($this->_columns[$field])) {
                 $msg = sprintf(
                     'Columns used in index "%s" in table "%s" must be added to the Table schema first. ' .

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -460,6 +460,7 @@ class Table
         }
         $attrs['columns'] = (array)$attrs['columns'];
         foreach ($attrs['columns'] as $field) {
+            $field = explode(' ', $field)[0];
             if (empty($this->_columns[$field])) {
                 $msg = sprintf(
                     'Columns used in index "%s" in table "%s" must be added to the Table schema first. ' .

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -343,9 +343,12 @@ class TableTest extends TestCase
         $table->addColumn('title', [
             'type' => 'string'
         ]);
+	$table->addColumn('priority', [
+            'type' => 'integer'
+        ]);
         $result = $table->addIndex('faster', [
             'type' => 'index',
-            'columns' => ['title']
+            'columns' => ['title', 'priority DESC']
         ]);
         $this->assertSame($result, $table);
         $this->assertEquals(['faster'], $table->indexes());

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -343,7 +343,7 @@ class TableTest extends TestCase
         $table->addColumn('title', [
             'type' => 'string'
         ]);
-	$table->addColumn('priority', [
+        $table->addColumn('priority', [
             'type' => 'integer'
         ]);
         $result = $table->addIndex('faster', [


### PR DESCRIPTION
If I created manual index in the migration file like this (because migration plugin does not support DESC column indices):

``` PHP
$this->execute('CREATE INDEX articles_custom_index ON articles(published, created_at DESC)');
```

The following error was thrown by CakePHP:

```
[Cake\Database\Exception]                                                                                                                                                  
  Columns used in index "articles_custom_index" in table "articles" must be added to the Table schema first. The column "created_at DESC" was not found.
```

The reason is cake takes `created_at DESC` as the column name instead of only the first part (until the first space).

This should fix it. Can there be any other problem with this? For sure the `DESC` information will be lost but I'm not sure how to correctly update the code to work with these attributes. Similiar could apply to any other modifier SQL function such as `lower(email)` in the index.

For now this fixes only the `ASC/DESC` issue.
