### PR TITLE
Fix file:// paths being mishandled on windows.

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -286,7 +286,6 @@ class Folder
         if (empty($path)) {
             return false;
         }
-
         return $path[0] === '/' ||
             preg_match('/^[A-Z]:\\\\/i', $path) ||
             substr($path, 0, 2) === '\\\\' ||
@@ -827,13 +826,13 @@ class Folder
      */
     public function realpath($path)
     {
-        $path = str_replace('/', DIRECTORY_SEPARATOR, trim($path));
         if (strpos($path, '..') === false) {
             if (!Folder::isAbsolute($path)) {
                 $path = Folder::addPathElement($this->path, $path);
             }
             return $path;
         }
+        $path = str_replace('/', DIRECTORY_SEPARATOR, trim($path));
         $parts = explode(DIRECTORY_SEPARATOR, $path);
         $newparts = [];
         $newpath = '';

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * FileTest file
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -291,6 +289,24 @@ class FileTest extends TestCase
         $tmpFile = TMP . 'tests/cakephp.file.test.tmp';
         $File = new File($tmpFile, true, 0777);
         $this->assertTrue($File->exists());
+    }
+
+    /**
+     * Tests the exists() method.
+     *
+     * @return void
+     */
+    public function testExists()
+    {
+        $tmpFile = TMP . 'tests/cakephp.file.test.tmp';
+        $file = new File($tmpFile, true, 0777);
+        $this->assertTrue($file->exists(), 'absolute path should exist');
+
+        $file = new File('file://' . $tmpFile, false);
+        $this->assertTrue($file->exists(), 'file:// should exist.');
+
+        $file = new File('/something/bad', false);
+        $this->assertFalse($file->exists(), 'missing file should not exist.');
     }
 
     /**


### PR DESCRIPTION
While I don't think its feasible to fix all the cases reported in #7275 as certain paths have different meaning in windows, we can fix `file://` not working.

If people are happy with this, I'll backport to 2.x where it is also an issue.

Refs #7275
