### PR TITLE
RFC: Add Request::toPath() and Request::toActionPath()

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -19,6 +19,7 @@ use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Network\Exception\MethodNotAllowedException;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.
@@ -1359,4 +1360,45 @@ class Request implements ArrayAccess
     {
         unset($this->params[$name]);
     }
+
+    /**
+     * Returns string representation of the current request in pluginDot syntax
+     *
+     * @params array $options Valid keys are `prefix`, `action`, `pass`, and `query`
+     * @return string Path
+     */
+    public function toPath($options = []) {
+        $prefix = $plugin = $controller = $action = $pass = $query = null;
+        if ($this->plugin) {
+            $plugin = $this->plugin . '.';
+        }
+        if ($prefix = $this->param('prefix')) {
+            $controller = Inflector::camelize($prefix) . '/';
+        }
+        $controller .= $this->param('controller') . 'Controller';
+
+        if (!empty($options['action'])) {
+            $action = '/' . $this->param('action');
+        }
+
+        if (!empty($options['pass']) && $passedArgs = $this->param('pass')) {
+            $pass = '/' . implode('/', $passedArgs);
+        }
+
+        if (!empty($options['query']) && $this->query) {
+            $query = '?' . http_build_query($this->query);
+        }
+
+        return $plugin . $controller . $action . $pass . $query;
+    }
+
+    /**
+     * Convenience method for toPath() that includes `action` of the current request
+     *
+     * @return string
+     */
+    public function toActionPath() {
+        return $this->toPath(['action' => true]);
+    }
+
 }


### PR DESCRIPTION
I find it useful to have a string representation (similar to our plugin dot syntax) of the current request.  If this is something that can be merged, please suggest a better method name for this.

And will add tests :)

Example:

Given the following request:

```
object(Cake\Network\Request) {
    params => [
        'plugin' => 'Croogo/Nodes',
        'controller' => 'Nodes',
        'action' => 'index',
        '_ext' => null,
        'pass' => [
            (int) 0 => 'foo',
            (int) 1 => 'bar'
        ],
        'prefix' => 'admin',
        'isAjax' => false,
    ]
    data => []
    query => [
        'spam' => 'eggs',
        'quz' => 'baz'
    ]
    url => 'admin/nodes/index/foo/bar'
    base => ''
    webroot => '/'
    here => '/admin/nodes/index/foo/bar'
```

I can transform it to a string representation with:
- `toActionPath()`: `Croogo/Nodes.Admin/NodesController/index`
- `toPath(['action' => true, 'pass' => true, 'query' => true])`: `Croogo/Nodes.Admin/NodesController/index/foo/bar?spam=eggs&quz=baz`

**Use case**: Storing a map of action paths with flags/options to enable/disable certain features.
