### PR TITLE
Return XML instead of DOMDocument object when using _serialize viewVar

### DIFF
--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -141,6 +141,9 @@ class XmlView extends SerializedView
             $options['pretty'] = true;
         }
 
+        if(isset($options['return']) && strtolower($options['return']) === 'domdocument') {
+            return Xml::fromArray($data, $options)->saveXML();
+        }
         return Xml::fromArray($data, $options)->asXML();
     }
 }


### PR DESCRIPTION
Fix for #7897
