### PR TITLE
Using APCu instead of APC

### DIFF
--- a/src/Cache/Engine/ApcEngine.php
+++ b/src/Cache/Engine/ApcEngine.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Cache\Engine;
 
-use APCIterator;
+use APCUIterator;
 use Cake\Cache\CacheEngine;
 
 /**
@@ -42,7 +42,7 @@ class ApcEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
-        if (!extension_loaded('apc')) {
+        if (!extension_loaded('apcu')) {
             return false;
         }
 
@@ -66,8 +66,8 @@ class ApcEngine extends CacheEngine
         if ($duration) {
             $expires = time() + $duration;
         }
-        apc_store($key . '_expires', $expires, $duration);
-        return apc_store($key, $value, $duration);
+        apcu_store($key . '_expires', $expires, $duration);
+        return apcu_store($key, $value, $duration);
     }
 
     /**
@@ -82,11 +82,11 @@ class ApcEngine extends CacheEngine
         $key = $this->_key($key);
 
         $time = time();
-        $cachetime = (int)apc_fetch($key . '_expires');
+        $cachetime = (int)apcu_fetch($key . '_expires');
         if ($cachetime !== 0 && ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime)) {
             return false;
         }
-        return apc_fetch($key);
+        return apcu_fetch($key);
     }
 
     /**
@@ -100,7 +100,7 @@ class ApcEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
-        return apc_inc($key, $offset);
+        return apcu_inc($key, $offset);
     }
 
     /**
@@ -114,7 +114,7 @@ class ApcEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
-        return apc_dec($key, $offset);
+        return apcu_dec($key, $offset);
     }
 
     /**
@@ -127,7 +127,7 @@ class ApcEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
-        return apc_delete($key);
+        return apcu_delete($key);
     }
 
     /**
@@ -142,21 +142,11 @@ class ApcEngine extends CacheEngine
         if ($check) {
             return true;
         }
-        if (class_exists('APCIterator', false)) {
-            $iterator = new APCIterator(
-                'user',
-                '/^' . preg_quote($this->_config['prefix'], '/') . '/',
-                APC_ITER_NONE
-            );
-            apc_delete($iterator);
-            return true;
-        }
-        $cache = apc_cache_info('user');
-        foreach ($cache['cache_list'] as $key) {
-            if (strpos($key['info'], $this->_config['prefix']) === 0) {
-                apc_delete($key['info']);
-            }
-        }
+        $iterator = new APCUIterator(
+            '/^' . preg_quote($this->_config['prefix'], '/') . '/',
+            APC_ITER_NONE
+        );
+        apcu_delete($iterator);
         return true;
     }
 
@@ -178,8 +168,8 @@ class ApcEngine extends CacheEngine
         if ($duration) {
             $expires = time() + $duration;
         }
-        apc_add($key . '_expires', $expires, $duration);
-        return apc_add($key, $value, $duration);
+        apcu_add($key . '_expires', $expires, $duration);
+        return apcu_add($key, $value, $duration);
     }
 
     /**
@@ -197,11 +187,11 @@ class ApcEngine extends CacheEngine
             }
         }
 
-        $groups = apc_fetch($this->_compiledGroupNames);
+        $groups = apcu_fetch($this->_compiledGroupNames);
         if (count($groups) !== count($this->_config['groups'])) {
             foreach ($this->_compiledGroupNames as $group) {
                 if (!isset($groups[$group])) {
-                    apc_store($group, 1);
+                    apcu_store($group, 1);
                     $groups[$group] = 1;
                 }
             }
@@ -225,7 +215,7 @@ class ApcEngine extends CacheEngine
      */
     public function clearGroup($group)
     {
-        apc_inc($this->_config['prefix'] . $group, 1, $success);
+        apcu_inc($this->_config['prefix'] . $group, 1, $success);
         return $success;
     }
 }

--- a/tests/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcEngineTest.php
@@ -34,7 +34,7 @@ class ApcEngineTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->skipIf(!function_exists('apcu_store'), 'Apc is not installed or configured properly.');
+        $this->skipIf(!function_exists('apcu_store'), 'APCu is not installed or configured properly.');
 
         if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
             $this->skipIf(!ini_get('apc.enable_cli'), 'APC is not enabled for the CLI.');

--- a/tests/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcEngineTest.php
@@ -34,7 +34,7 @@ class ApcEngineTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->skipIf(!function_exists('apc_store'), 'Apc is not installed or configured properly.');
+        $this->skipIf(!function_exists('apcu_store'), 'Apc is not installed or configured properly.');
 
         if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
             $this->skipIf(!ini_get('apc.enable_cli'), 'APC is not enabled for the CLI.');
@@ -155,8 +155,6 @@ class ApcEngineTest extends TestCase
      */
     public function testDecrement()
     {
-        $this->skipIf(!function_exists('apc_dec'), 'No apc_dec() function, cannot test decrement().');
-
         $result = Cache::write('test_decrement', 5, 'apc');
         $this->assertTrue($result);
 
@@ -180,8 +178,6 @@ class ApcEngineTest extends TestCase
      */
     public function testIncrement()
     {
-        $this->skipIf(!function_exists('apc_inc'), 'No apc_inc() function, cannot test increment().');
-
         $result = Cache::write('test_increment', 5, 'apc');
         $this->assertTrue($result);
 
@@ -205,14 +201,14 @@ class ApcEngineTest extends TestCase
      */
     public function testClear()
     {
-        apc_store('not_cake', 'survive');
+        apcu_store('not_cake', 'survive');
         Cache::write('some_value', 'value', 'apc');
 
         $result = Cache::clear(false, 'apc');
         $this->assertTrue($result);
         $this->assertFalse(Cache::read('some_value', 'apc'));
-        $this->assertEquals('survive', apc_fetch('not_cake'));
-        apc_delete('not_cake');
+        $this->assertEquals('survive', apcu_fetch('not_cake'));
+        apcu_delete('not_cake');
     }
 
     /**
@@ -233,12 +229,12 @@ class ApcEngineTest extends TestCase
         $this->assertTrue(Cache::write('test_groups', 'value', 'apc_groups'));
         $this->assertEquals('value', Cache::read('test_groups', 'apc_groups'));
 
-        apc_inc('test_group_a');
+        apcu_inc('test_group_a');
         $this->assertFalse(Cache::read('test_groups', 'apc_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value2', 'apc_groups'));
         $this->assertEquals('value2', Cache::read('test_groups', 'apc_groups'));
 
-        apc_inc('test_group_b');
+        apcu_inc('test_group_b');
         $this->assertFalse(Cache::read('test_groups', 'apc_groups'));
         $this->assertTrue(Cache::write('test_groups', 'value3', 'apc_groups'));
         $this->assertEquals('value3', Cache::read('test_groups', 'apc_groups'));


### PR DESCRIPTION
The APC extension is gone in PHP 5.5. Since we require this version now,
we need to adapt the engine so it is usable again
