### PR TITLE
Add useful exception when ExistsIn is applied to an undefined association

### DIFF
--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -69,7 +69,8 @@ class ExistsIn
 
             if (empty($this->_repository)) {
                 throw new RuntimeException(sprintf(
-                    "ExistsIn rule for 'author_id' is invalid. The '%s' association is not defined.",
+                    "ExistsIn rule for '%s' is invalid. The '%s' association is not defined.",
+                    implode(', ', $this->_fields),
                     $alias
                 ));
             }
@@ -113,10 +114,10 @@ class ExistsIn
     }
 
     /**
-     * Check whether or not the entity fields are null and nullable.
+     * Check whether or not the entity fields nullable and null.
      *
      * @param \Cake\ORM\EntityInterface $entity The entity to check.
-     * @param \Cake\ORM\Table $table The table to use schema from.
+     * @param \Cake\ORM\Table $source The table to use schema from.
      * @return bool
      */
     protected function _fieldsAreNull($entity, $source)

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -461,6 +461,29 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
+     * Tests existsIn with invalid associations
+     *
+     * @group save
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage ExistsIn rule for 'author_id' is invalid. The 'NotValid' association is not defined.
+     * @return void
+     */
+    public function testExistsInInvalidAssociation()
+    {
+        $entity = new Entity([
+            'title' => 'An Article',
+            'author_id' => 500
+        ]);
+
+        $table = TableRegistry::get('Articles');
+        $table->belongsTo('Authors');
+        $rules = $table->rulesChecker();
+        $rules->add($rules->existsIn('author_id', 'NotValid'));
+
+        $table->save($entity);
+    }
+
+    /**
      * Tests the checkRules save option
      *
      * @group save


### PR DESCRIPTION
When an invalid association is used in an existsIn rule no fatal error should be raised.

Refs #7901 
