### PR TITLE
RFC: 3.2 Better CLI API around exiting

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -726,7 +726,7 @@ class Shell
      *
      * @param string $title Title of the error
      * @param string|null $message An optional error message
-     * @return void
+     * @return int Error code
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
      * @deprecated Since 3.2.0. Use Shell::abort() instead.
      */
@@ -738,6 +738,8 @@ class Shell
             $this->_io->err($message);
         }
         $this->_stop($exitCode);
+
+        return $exitCode;
     }
 
     /**

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -709,19 +709,35 @@ class Shell
      * Displays a formatted error message
      * and exits the application with status code 1
      *
+     * @param string|null $message Error message
+     * @param int $exitCode Exit code
+     * @return int Exit code
+     */
+    public function abort($message, $exitCode = 1) {
+        $this->_io->err('<error>' . $message . '</error>');
+        $this->_stop($exitCode);
+
+        return $exitCode;
+    }
+
+    /**
+     * Displays a formatted error message
+     * and exits the application with status code 1
+     *
      * @param string $title Title of the error
      * @param string|null $message An optional error message
      * @return void
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
+     * @deprecated Since 3.2.0. Use Shell::abort() instead.
      */
-    public function error($title, $message = null)
+    public function error($title, $message = null, $exitCode = 1)
     {
         $this->_io->err(sprintf('<error>Error:</error> %s', $title));
 
         if (!empty($message)) {
             $this->_io->err($message);
         }
-        $this->_stop(1);
+        $this->_stop($exitCode);
     }
 
     /**


### PR DESCRIPTION
Status quo: See discussion @ https://github.com/cakephp/docs/pull/3499

Basically, err() and error() is quite confusing, and with the latter one cannot customize the return code.
So with BC, we can use a new abort() method which itself is more clear in its intention.
It will not just output an error like the former method suggests, but also by default exit (and simulate it in test mode as always).

I first added an additional param to error(), but that might not be necessary when switching to abort() right away.

I removed the title/message thingy because from my experience you only use one of it, and you can always pre-format your text prior to passing it in the method.

Thoughts?

PS: I wanted to call the method `exit()`, but that is only allowed in PHP7+, so it had to be abort().
