### PR TITLE
Backport paginator changes for string integers

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -2210,7 +2210,54 @@ class PaginatorHelperTest extends CakeTestCase {
 			array('span' => array()), array('a' => array('href' => '/index/page:4897')), '4897', '/a', '/span',
 		);
 		$this->assertTags($result, $expected);
+	}
 
+/**
+ * Test first/last options as strings.
+ *
+ * @return void
+ */
+	public function testNumbersStringFirstAndLast() {
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 10,
+				'current' => 3,
+				'count' => 30,
+				'prevPage' => false,
+				'nextPage' => 2,
+				'pageCount' => 15,
+				'options' => array(
+					'page' => 1,
+				),
+				'paramType' => 'named'
+			)
+		);
+
+		$result = $this->Paginator->numbers(array('first' => '1', 'last' => '1'));
+		$expected = array(
+			array('span' => array()), array('a' => array('href' => '/')), '1', '/a', '/span',
+			'...',
+			array('span' => array()), array('a' => array('href' => '/index/page:6')), '6', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:7')), '7', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:8')), '8', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:9')), '9', '/a', '/span',
+			' | ',
+			array('span' => array('class' => 'current')), '10', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:11')), '11', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:12')), '12', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:13')), '13', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:14')), '14', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:15')), '15', '/a', '/span',
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**
@@ -2240,6 +2287,9 @@ class PaginatorHelperTest extends CakeTestCase {
 			array('a' => array('href' => '/index/page:7')), '7', '/a',
 			'/li',
 		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->last('2', array('tag' => 'li', 'class' => 'last'));
 		$this->assertTags($result, $expected);
 	}
 
@@ -2390,6 +2440,10 @@ class PaginatorHelperTest extends CakeTestCase {
 			array('a' => array('href' => '/index/page:7')), '7', '/a',
 			'/span',
 		);
+		$this->assertTags($result, $expected);
+
+		// Test stringy number.
+		$result = $this->Paginator->last('2');
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->last(3);

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -1731,6 +1731,147 @@ class PaginatorHelperTest extends CakeTestCase {
 
 		$this->Paginator->request->params['paging'] = array(
 			'Client' => array(
+				'page' => 1,
+				'current' => 10,
+				'count' => 30,
+				'prevPage' => false,
+				'nextPage' => 2,
+				'pageCount' => 3,
+				'options' => array(
+					'page' => 1,
+				),
+				'paramType' => 'named'
+			)
+		);
+		$options = array('modulus' => 10);
+		$result = $this->Paginator->numbers($options);
+		$expected = array(
+			array('span' => array('class' => 'current')), '1', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:2')), '2', '/a', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/index/page:3')), '3', '/a', '/span',
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->numbers(array('modulus' => 3, 'currentTag' => 'span', 'tag' => 'li'));
+		$expected = array(
+			array('li' => array('class' => 'current')), array('span' => array()), '1', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index/page:2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index/page:3')), '3', '/a', '/li',
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 2,
+				'current' => 10,
+				'count' => 31,
+				'prevPage' => true,
+				'nextPage' => true,
+				'pageCount' => 4,
+				'options' => array(
+					'page' => 1,
+					'order' => array('Client.name' => 'DESC'),
+				),
+				'paramType' => 'named'
+			)
+		);
+		$result = $this->Paginator->numbers(array('class' => 'page-link'));
+		$expected = array(
+			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index/sort:Client.name/direction:DESC')), '1', '/a', '/span',
+			' | ',
+			array('span' => array('class' => 'current page-link')), '2', '/span',
+			' | ',
+			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index/page:3/sort:Client.name/direction:DESC')), '3', '/a', '/span',
+			' | ',
+			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index/page:4/sort:Client.name/direction:DESC')), '4', '/a', '/span',
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 2,
+				'current' => 2,
+				'count' => 30,
+				'prevPage' => false,
+				'nextPage' => 3,
+				'pageCount' => 3,
+				'options' => array(
+					'page' => 1,
+				),
+				'paramType' => 'named'
+			)
+		);
+
+		$request = new CakeRequest();
+		$request->addParams(array(
+			'controller' => 'clients', 'action' => 'index', 'plugin' => null, 'page' => 2
+		));
+		$request->base = '';
+		$request->here = '/clients/index/page:2';
+		$request->webroot = '/';
+
+		Router::setRequestInfo($request);
+
+		$result = $this->Paginator->numbers();
+		$expected = array(
+			array('span' => array()), array('a' => array('href' => '/clients')), '1', '/a', '/span',
+			' | ',
+			array('span' => array('class' => 'current')), '2', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/clients/index/page:3')), '3', '/a', '/span',
+
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 2,
+				'current' => 2,
+				'count' => 30,
+				'prevPage' => false,
+				'nextPage' => 3,
+				'pageCount' => 3,
+				'options' => array(
+					'page' => 1,
+				),
+				'paramType' => 'querystring'
+			)
+		);
+
+		$request = new CakeRequest();
+		$request->addParams(array(
+			'controller' => 'clients', 'action' => 'index', 'plugin' => null
+		));
+		$request->base = '';
+		$request->here = '/clients?page=2';
+		$request->webroot = '/';
+
+		Router::setRequestInfo($request);
+
+		$result = $this->Paginator->numbers();
+		$expected = array(
+			array('span' => array()), array('a' => array('href' => '/clients')), '1', '/a', '/span',
+			' | ',
+			array('span' => array('class' => 'current')), '2', '/span',
+			' | ',
+			array('span' => array()), array('a' => array('href' => '/clients?page=3')), '3', '/a', '/span',
+
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test that numbers() works with first and last options.
+ *
+ * @return void
+ */
+	public function testNumbersFirstAndLast() {
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
 				'page' => 10,
 				'current' => 3,
 				'count' => 30,
@@ -1849,68 +1990,6 @@ class PaginatorHelperTest extends CakeTestCase {
 			array('span' => array()), array('a' => array('href' => '/index/page:41')), '41', '/a', '/span',
 			' | ',
 			array('span' => array()), array('a' => array('href' => '/index/page:42')), '42', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 1,
-				'current' => 10,
-				'count' => 30,
-				'prevPage' => false,
-				'nextPage' => 2,
-				'pageCount' => 3,
-				'options' => array(
-					'page' => 1,
-				),
-				'paramType' => 'named'
-			)
-		);
-		$options = array('modulus' => 10);
-		$result = $this->Paginator->numbers($options);
-		$expected = array(
-			array('span' => array('class' => 'current')), '1', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index/page:2')), '2', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index/page:3')), '3', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->numbers(array('modulus' => 3, 'currentTag' => 'span', 'tag' => 'li'));
-		$expected = array(
-			array('li' => array('class' => 'current')), array('span' => array()), '1', '/span', '/li',
-			' | ',
-			array('li' => array()), array('a' => array('href' => '/index/page:2')), '2', '/a', '/li',
-			' | ',
-			array('li' => array()), array('a' => array('href' => '/index/page:3')), '3', '/a', '/li',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 2,
-				'current' => 10,
-				'count' => 31,
-				'prevPage' => true,
-				'nextPage' => true,
-				'pageCount' => 4,
-				'options' => array(
-					'page' => 1,
-					'order' => array('Client.name' => 'DESC'),
-				),
-				'paramType' => 'named'
-			)
-		);
-		$result = $this->Paginator->numbers(array('class' => 'page-link'));
-		$expected = array(
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index/sort:Client.name/direction:DESC')), '1', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'current page-link')), '2', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index/page:3/sort:Client.name/direction:DESC')), '3', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index/page:4/sort:Client.name/direction:DESC')), '4', '/a', '/span',
 		);
 		$this->assertTags($result, $expected);
 
@@ -2132,77 +2211,6 @@ class PaginatorHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 2,
-				'current' => 2,
-				'count' => 30,
-				'prevPage' => false,
-				'nextPage' => 3,
-				'pageCount' => 3,
-				'options' => array(
-					'page' => 1,
-				),
-				'paramType' => 'named'
-			)
-		);
-
-		$request = new CakeRequest();
-		$request->addParams(array(
-			'controller' => 'clients', 'action' => 'index', 'plugin' => null, 'page' => 2
-		));
-		$request->base = '';
-		$request->here = '/clients/index/page:2';
-		$request->webroot = '/';
-
-		Router::setRequestInfo($request);
-
-		$result = $this->Paginator->numbers();
-		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/clients')), '1', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'current')), '2', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/clients/index/page:3')), '3', '/a', '/span',
-
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 2,
-				'current' => 2,
-				'count' => 30,
-				'prevPage' => false,
-				'nextPage' => 3,
-				'pageCount' => 3,
-				'options' => array(
-					'page' => 1,
-				),
-				'paramType' => 'querystring'
-			)
-		);
-
-		$request = new CakeRequest();
-		$request->addParams(array(
-			'controller' => 'clients', 'action' => 'index', 'plugin' => null
-		));
-		$request->base = '';
-		$request->here = '/clients?page=2';
-		$request->webroot = '/';
-
-		Router::setRequestInfo($request);
-
-		$result = $this->Paginator->numbers();
-		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/clients')), '1', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'current')), '2', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/clients?page=3')), '3', '/a', '/span',
-
-		);
-		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -705,9 +705,11 @@ class PaginatorHelper extends AppHelper {
  * - `separator` Separator content defaults to ' | '
  * - `tag` The tag to wrap links in, defaults to 'span'
  * - `first` Whether you want first links generated, set to an integer to define the number of 'first'
- *    links to generate.
+ *    links to generate. If a string is set a link to the first page will be generated with the value
+ *    as the title.
  * - `last` Whether you want last links generated, set to an integer to define the number of 'last'
- *    links to generate.
+ *    links to generate. If a string is set a link to the last page will be generated with the value
+ *    as the title.
  * - `ellipsis` Ellipsis content, defaults to '...'
  * - `class` Class for wrapper tag
  * - `currentClass` Class for wrapper tag on current active page, defaults to 'current'
@@ -743,7 +745,6 @@ class PaginatorHelper extends AppHelper {
 			$options['modulus'], $options['separator'], $options['first'], $options['last'],
 			$options['ellipsis'], $options['class'], $options['currentClass'], $options['currentTag']
 		);
-
 		$out = '';
 
 		if ($modulus && $params['pageCount'] > $modulus) {
@@ -759,9 +760,10 @@ class PaginatorHelper extends AppHelper {
 				$end = $params['page'] + ($modulus - $params['page']) + 1;
 			}
 
+			$firstPage = is_int($first) ? $first : 0;
 			if ($first && $start > 1) {
-				$offset = ($start <= (int)$first) ? $start - 1 : $first;
-				if ($offset < $start - 1) {
+				$offset = ($start <= $firstPage) ? $start - 1 : $first;
+				if ($firstPage < $start - 1) {
 					$out .= $this->first($offset, compact('tag', 'separator', 'ellipsis', 'class'));
 				} else {
 					$out .= $this->first($offset, compact('tag', 'separator', 'class', 'ellipsis') + array('after' => $separator));
@@ -798,8 +800,9 @@ class PaginatorHelper extends AppHelper {
 			$out .= $after;
 
 			if ($last && $end < $params['pageCount']) {
-				$offset = ($params['pageCount'] < $end + (int)$last) ? $params['pageCount'] - $end : $last;
-				if ($offset <= $last && $params['pageCount'] - $end > $offset) {
+				$lastPage = is_int($last) ? $last : 0;
+				$offset = ($params['pageCount'] < $end + $lastPage) ? $params['pageCount'] - $end : $last;
+				if ($offset <= $lastPage && $params['pageCount'] - $end > $lastPage) {
 					$out .= $this->last($offset, compact('tag', 'separator', 'ellipsis', 'class'));
 				} else {
 					$out .= $this->last($offset, compact('tag', 'separator', 'class', 'ellipsis') + array('before' => $separator));
@@ -880,7 +883,7 @@ class PaginatorHelper extends AppHelper {
 
 		$out = '';
 
-		if (is_int($first) && $params['page'] >= $first) {
+		if ((is_int($first) || ctype_digit($first)) && $params['page'] >= $first) {
 			if ($after === null) {
 				$after = $ellipsis;
 			}
@@ -945,7 +948,7 @@ class PaginatorHelper extends AppHelper {
 		$out = '';
 		$lower = $params['pageCount'] - $last + 1;
 
-		if (is_int($last) && $params['page'] <= $lower) {
+		if ((is_int($last) || ctype_digit($last)) && $params['page'] <= $lower) {
 			if ($before === null) {
 				$before = $ellipsis;
 			}


### PR DESCRIPTION
Backport the intent of #7845 into 2.x. The implementation differs a bit from 3.x but paginator helper internals are pretty different in both branches.

Refs #7902
