### PR TITLE
Turning the code within Datasource\RulesChecker cleaner avoiding unecessary code repetition

### DIFF
--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -248,12 +248,7 @@ class RulesChecker
      */
     public function checkCreate(EntityInterface $entity, array $options = [])
     {
-        $success = true;
-        $options = $options + $this->_options;
-        foreach (array_merge($this->_rules, $this->_createRules) as $rule) {
-            $success = $rule($entity, $options) && $success;
-        }
-        return $success;
+        return $this->_checkRules($entity, $options, array_merge($this->_rules, $this->_createRules));
     }
 
     /**
@@ -266,12 +261,7 @@ class RulesChecker
      */
     public function checkUpdate(EntityInterface $entity, array $options = [])
     {
-        $success = true;
-        $options = $options + $this->_options;
-        foreach (array_merge($this->_rules, $this->_updateRules) as $rule) {
-            $success = $rule($entity, $options) && $success;
-        }
-        return $success;
+        return $this->_checkRules($entity, $options, array_merge($this->_rules, $this->_updateRules));
     }
 
     /**
@@ -284,9 +274,23 @@ class RulesChecker
      */
     public function checkDelete(EntityInterface $entity, array $options = [])
     {
+        return $this->_checkRules($entity, $options, $this->_deleteRules);
+    }
+
+    /**
+     * Used by top level functions checkDelete, checkCreate and checkUpdate, this function
+     * iterates an array containing the rules to be checked and check them all.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity to check for validity.
+     * @param array $options Extra options to pass to checker functions.
+     * @param array $rules the list of rules that must be checked
+     * @return bool
+     */
+    protected function _checkRules(EntityInterface $entity, array $options = [], array $rules = [])
+    {
         $success = true;
         $options = $options + $this->_options;
-        foreach ($this->_deleteRules as $rule) {
+        foreach ($rules as $rule) {
             $success = $rule($entity, $options) && $success;
         }
         return $success;


### PR DESCRIPTION
Created a new protected method to avoid code repetition.
