### PR TITLE
Don't use magic number for default error code.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -169,7 +169,7 @@ class ConsoleOptionParser
      *
      * @param string|null $command The command name this parser is for. The command name is used for generating help.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
-     * @return \Cake\Console\ConsoleOptionParser
+     * @return $this
      */
     public static function create($command, $defaultOptions = true)
     {
@@ -197,7 +197,7 @@ class ConsoleOptionParser
      *
      * @param array $spec The spec to build the OptionParser with.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
-     * @return \Cake\Console\ConsoleOptionParser
+     * @return $this
      */
     public static function buildFromArray($spec, $defaultOptions = true)
     {
@@ -371,7 +371,7 @@ class ConsoleOptionParser
      * Remove an option from the option parser.
      *
      * @param string $name The option name to remove.
-     * @return \Cake\Console\ConsoleOptionParser this
+     * @return $this
      */
     public function removeOption($name)
     {

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -169,7 +169,7 @@ class ConsoleOptionParser
      *
      * @param string|null $command The command name this parser is for. The command name is used for generating help.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
-     * @return ConsoleOptionParser
+     * @return \Cake\Console\ConsoleOptionParser
      */
     public static function create($command, $defaultOptions = true)
     {
@@ -197,7 +197,7 @@ class ConsoleOptionParser
      *
      * @param array $spec The spec to build the OptionParser with.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
-     * @return ConsoleOptionParser
+     * @return \Cake\Console\ConsoleOptionParser
      */
     public static function buildFromArray($spec, $defaultOptions = true)
     {
@@ -371,7 +371,7 @@ class ConsoleOptionParser
      * Remove an option from the option parser.
      *
      * @param string $name The option name to remove.
-     * @return ConsoleOptionParser this
+     * @return \Cake\Console\ConsoleOptionParser this
      */
     public function removeOption($name)
     {

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -41,6 +41,13 @@ class Shell
     use ModelAwareTrait;
 
     /**
+     * Default error code
+     *
+     * @var int
+     */
+    const CODE_ERROR = 1;
+
+    /**
      * Output constant making verbose shells.
      *
      * @var int
@@ -496,7 +503,7 @@ class Shell
      *
      * By overriding this method you can configure the ConsoleOptionParser before returning it.
      *
-     * @return ConsoleOptionParser
+     * @return \Cake\Console\ConsoleOptionParser
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
      */
     public function getOptionParser()
@@ -680,9 +687,9 @@ class Shell
         if (!empty($message)) {
             $this->_io->err($message);
         }
-        $this->_stop(1);
+        $this->_stop(self::CODE_ERROR);
 
-        return 1;
+        return self::CODE_ERROR;
     }
 
     /**


### PR DESCRIPTION
 Also fix up last wrong doc blocks.

The magic number one doesn't tell beginners that 1 means error.
They might confuse it with true.
I think we can all agree that a speaking constant would be a better fit to use in the code itself.
