### PR TITLE
Added Configure::readOrFail()

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -138,6 +138,31 @@ class Configure
     }
 
     /**
+     * Used to get information stored in Configure. It's not
+     * possible to store `null` values in Configure.
+     *
+     * Acts as a wrapper around Configure::read() and Configure::check().
+     * The configure value fetched via get is expected to exist. 
+     * In case it does not an exception will be thrown.
+     *
+     * Usage:
+     * ```
+     * Configure::get('Name'); will return all values for Name
+     * Configure::get('Name.key'); will return only the value of Configure::Name[key]
+     * ```
+     *
+     * @param string $var Variable to obtain. Use '.' to access array elements.
+     * @return mixed value stored in configure.
+     * @throws \Cake\Core\Exception\Exception if the requested configuration is not set.
+     */
+    public static function get($var) {
+        if (static::check($var) === false) {
+            throw new Exception(sprintf('Expected "%s" configuration.', $var));
+        }
+        return static::read($var);
+    }
+
+    /**
      * Used to delete a variable from Configure.
      *
      * Usage:

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -159,7 +159,7 @@ class Configure
      */
     public static function readOrFail($var) {
         if (static::check($var) === false) {
-            throw new RuntimeException(sprintf('Expected "%s" configuration.', $var));
+            throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
         }
         return static::read($var);
     }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -19,6 +19,7 @@ use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Exception\Exception;
 use Cake\Utility\Hash;
+use RuntimeException;
 
 /**
  * Configuration class. Used for managing runtime configuration information.
@@ -142,22 +143,23 @@ class Configure
      * possible to store `null` values in Configure.
      *
      * Acts as a wrapper around Configure::read() and Configure::check().
-     * The configure value fetched via this method is expected to exist. 
+     * The configure key/value pair fetched via this method is expected to exist. 
      * In case it does not an exception will be thrown.
      *
      * Usage:
      * ```
-     * Configure::get('Name'); will return all values for Name
-     * Configure::get('Name.key'); will return only the value of Configure::Name[key]
+     * Configure::readOrFail('Name'); will return all values for Name
+     * Configure::readOrFail('Name.key'); will return only the value of Configure::Name[key]
      * ```
      *
      * @param string $var Variable to obtain. Use '.' to access array elements.
      * @return mixed Value stored in configure.
-     * @throws \Cake\Core\Exception\Exception if the requested configuration is not set.
+     * @throws \RuntimeException if the requested configuration is not set.
+     * @link http://book.cakephp.org/3.0/en/development/configuration.html#reading-configuration-data
      */
-    public static function get($var) {
+    public static function readOrFail($var) {
         if (static::check($var) === false) {
-            throw new Exception(sprintf('Expected "%s" configuration.', $var));
+            throw new RuntimeException(sprintf('Expected "%s" configuration.', $var));
         }
         return static::read($var);
     }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -112,7 +112,7 @@ class Configure
      * ```
      *
      * @param string $var Variable to obtain. Use '.' to access array elements.
-     * @return mixed value stored in configure, or null.
+     * @return mixed Value stored in configure, or null.
      * @link http://book.cakephp.org/3.0/en/development/configuration.html#reading-configuration-data
      */
     public static function read($var = null)
@@ -142,7 +142,7 @@ class Configure
      * possible to store `null` values in Configure.
      *
      * Acts as a wrapper around Configure::read() and Configure::check().
-     * The configure value fetched via get is expected to exist. 
+     * The configure value fetched via this method is expected to exist. 
      * In case it does not an exception will be thrown.
      *
      * Usage:
@@ -152,7 +152,7 @@ class Configure
      * ```
      *
      * @param string $var Variable to obtain. Use '.' to access array elements.
-     * @return mixed value stored in configure.
+     * @return mixed Value stored in configure.
      * @throws \Cake\Core\Exception\Exception if the requested configuration is not set.
      */
     public static function get($var) {

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -69,6 +69,26 @@ class ConfigureTest extends TestCase
     }
 
     /**
+     * testGet method
+     *
+     * @return void
+     */
+    public function testGet()
+    {
+        $expected = 'ok';
+        Configure::write('This.Key.Exists', $expected);
+        $result = Configure::get('This.Key.Exists');
+        $this->assertEquals($expected, $result);
+
+        try {
+            $void = Configure::get('This.Key.Does.Not.exist');
+            $this->fail('Expected exception to be thrown.');
+        } catch (\Exception $e) {
+            $this->assertEquals('Expected "This.Key.Does.Not.exist" configuration.', $e->getMessage());
+        }
+    }
+
+    /**
      * testRead method
      *
      * @return void

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -84,17 +84,13 @@ class ConfigureTest extends TestCase
     /**
      * testReadOrFail method
      *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Expected "This.Key.Does.Not.exist" configuration
      * @return void
      */
     public function testReadOrFailThrowingException()
     {
-        try {
-            $void = Configure::readOrFail('This.Key.Does.Not.exist');
-            $this->fail('Expected exception to be thrown.');
-        } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \RuntimeException);
-            $this->assertEquals('Expected "This.Key.Does.Not.exist" configuration.', $e->getMessage());
-        }
+        Configure::readOrFail('This.Key.Does.Not.exist');
     }
 
     /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -69,21 +69,30 @@ class ConfigureTest extends TestCase
     }
 
     /**
-     * testGet method
+     * testReadOrFail method
      *
      * @return void
      */
-    public function testGet()
+    public function testReadOrFail()
     {
         $expected = 'ok';
         Configure::write('This.Key.Exists', $expected);
-        $result = Configure::get('This.Key.Exists');
+        $result = Configure::readOrFail('This.Key.Exists');
         $this->assertEquals($expected, $result);
+    }
 
+    /**
+     * testReadOrFail method
+     *
+     * @return void
+     */
+    public function testReadOrFailThrowingException()
+    {
         try {
-            $void = Configure::get('This.Key.Does.Not.exist');
+            $void = Configure::readOrFail('This.Key.Does.Not.exist');
             $this->fail('Expected exception to be thrown.');
         } catch (\Exception $e) {
+            $this->assertTrue($e instanceof \RuntimeException);
             $this->assertEquals('Expected "This.Key.Does.Not.exist" configuration.', $e->getMessage());
         }
     }

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -85,7 +85,7 @@ class ConfigureTest extends TestCase
      * testReadOrFail method
      *
      * @expectedException RuntimeException
-     * @expectedExceptionMessage Expected "This.Key.Does.Not.exist" configuration
+     * @expectedExceptionMessage Expected configuration key "This.Key.Does.Not.exist" not found
      * @return void
      */
     public function testReadOrFailThrowingException()


### PR DESCRIPTION
~~`Configure::get()`~~ `Configure::readOrFail()` reads mandatory values from Configure and throws an Exception if the configuration variable is not set.

Tests included.
