### PR TITLE
CSRF and PDO improvements

### DIFF
--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -94,7 +94,7 @@ class CsrfComponent extends Component
         if ($request->is('get') && $cookieData === null) {
             $this->_setCookie($request, $response);
         }
-        if (!$request->is(['head', 'get', 'options'])) {
+        if ($request->is(['put', 'post', 'delete', 'patch']) || !empty($request->data)) {
             $this->_validateToken($request);
             unset($request->data[$this->_config['field']]);
         }

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -46,7 +46,7 @@ class CsrfComponent extends Component
      *  - cookieName = The name of the cookie to send.
      *  - expiry = How long the CSRF token should last. Defaults to browser session.
      *  - secure = Whether or not the cookie will be set with the Secure flag. Defaults to false.
-     *  - httpOnly = Whether or not the cookie will be set with the HttpOnly flag. Defaults to false.
+     *  - httpOnly = Whether or not the cookie will be set with the HttpOnly flag. Defaults to true.
      *  - field = The form field to check. Changing this will also require configuring
      *    FormHelper.
      *
@@ -56,7 +56,7 @@ class CsrfComponent extends Component
         'cookieName' => 'csrfToken',
         'expiry' => 0,
         'secure' => false,
-        'httpOnly' => false,
+        'httpOnly' => true,
         'field' => '_csrfToken',
     ];
 

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -46,7 +46,7 @@ class CsrfComponent extends Component
      *  - cookieName = The name of the cookie to send.
      *  - expiry = How long the CSRF token should last. Defaults to browser session.
      *  - secure = Whether or not the cookie will be set with the Secure flag. Defaults to false.
-     *  - httpOnly = Whether or not the cookie will be set with the HttpOnly flag. Defaults to true.
+     *  - httpOnly = Whether or not the cookie will be set with the HttpOnly flag. Defaults to false.
      *  - field = The form field to check. Changing this will also require configuring
      *    FormHelper.
      *
@@ -56,7 +56,7 @@ class CsrfComponent extends Component
         'cookieName' => 'csrfToken',
         'expiry' => 0,
         'secure' => false,
-        'httpOnly' => true,
+        'httpOnly' => false,
         'field' => '_csrfToken',
     ];
 

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -70,7 +70,7 @@ class Mysql extends Driver
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],
             PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
-            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
 
         if (!empty($config['ssl_key']) && !empty($config['ssl_cert'])) {

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -56,6 +56,7 @@ class Postgres extends Driver
         $config = $this->_config;
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
         if (empty($config['unix_socket'])) {

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -55,6 +55,7 @@ class Sqlite extends Driver
         $config = $this->_config;
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -60,6 +60,7 @@ class Sqlserver extends Driver
         $config = $this->_config;
         $config['flags'] += [
             PDO::ATTR_PERSISTENT => $config['persistent'],
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -83,12 +83,14 @@ class CsrfComponentTest extends TestCase
     /**
      * Data provider for HTTP method tests.
      *
+     * HEAD and GET do not populate $_POST or request->data.
+     *
      * @return void
      */
     public static function safeHttpMethodProvider()
     {
         return [
-            ['GET'], ['OPTIONS'], ['HEAD']
+            ['GET', 'HEAD']
         ];
     }
 
@@ -116,14 +118,14 @@ class CsrfComponentTest extends TestCase
     }
 
     /**
-     * Data provider for HTTP method tests.
+     * Data provider for HTTP methods that can contain request bodies.
      *
      * @return void
      */
     public static function httpMethodProvider()
     {
         return [
-            ['PATCH'], ['PUT'], ['POST'], ['DELETE'], ['PURGE'], ['INVALIDMETHOD']
+            ['OPTIONS'], ['PATCH'], ['PUT'], ['POST'], ['DELETE'], ['PURGE'], ['INVALIDMETHOD']
         ];
     }
 
@@ -142,6 +144,7 @@ class CsrfComponentTest extends TestCase
                 'REQUEST_METHOD' => $method,
                 'HTTP_X_CSRF_TOKEN' => 'testing123',
             ],
+            'post' => ['a' => 'b'],
             'cookies' => ['csrfToken' => 'testing123']
         ]);
         $controller->response = new Response();
@@ -167,6 +170,7 @@ class CsrfComponentTest extends TestCase
                 'REQUEST_METHOD' => $method,
                 'HTTP_X_CSRF_TOKEN' => 'nope',
             ],
+            'post' => ['a' => 'b'],
             'cookies' => ['csrfToken' => 'testing123']
         ]);
         $controller->response = new Response();

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -53,6 +53,7 @@ class PostgresTest extends TestCase
 
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => true,
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 
@@ -107,6 +108,7 @@ class PostgresTest extends TestCase
         $expected = $config;
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => false,
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -47,6 +47,7 @@ class SqliteTest extends TestCase
 
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => false,
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
         $driver->expects($this->once())->method('_connect')
@@ -80,6 +81,7 @@ class SqliteTest extends TestCase
         $expected += ['username' => null, 'password' => null];
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => true,
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -67,6 +67,7 @@ class SqlserverTest extends TestCase
         $expected = $config;
         $expected['flags'] += [
             PDO::ATTR_PERSISTENT => false,
+            PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::SQLSRV_ATTR_ENCODING => 'a-language'
         ];


### PR DESCRIPTION
@ionas Sent me an IRC log snippet from ##php where @bittarman had some good feedback for CakePHP.

Defaulting CSRF tokens to HttpOnly might cause upgrade issues, but I think its important for us to get new applications up and running in a safer mode. This change would be something highlighted in the migration guide for 3.2

I've enabled native prepares for the drivers that it seems to work on. I had very little luck in getting MySQL to use native prepares as there were issues preparing statements like `SELECT 1 + 1` which doesn't give me a ton of confidence.
