### PR TITLE
Fix integration test case with form tampering.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -467,8 +467,10 @@ abstract class IntegrationTestCase extends TestCase
     protected function _addTokens($url, $data)
     {
         if ($this->_securityToken === true) {
-            $keys = Hash::flatten($data);
-            $tokenData = $this->_buildFieldToken($url, array_keys($keys));
+            $keys = array_map(function ($field) {
+                return preg_replace('/(\.\d+)+$/', '', $field);
+            }, array_keys(Hash::flatten($data)));
+            $tokenData = $this->_buildFieldToken($url, array_unique($keys));
             $data['_Token'] = $tokenData;
         }
 

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -240,7 +240,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
-     * Test posting to a secured form action action.
+     * Test posting to a secured form action.
      *
      * @return void
      */
@@ -250,6 +250,26 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $data = [
             'title' => 'Some title',
             'body' => 'Some text'
+        ];
+        $this->post('/posts/securePost', $data);
+        $this->assertResponseOk();
+        $this->assertResponseContains('Request was accepted');
+    }
+
+    /**
+     * Test posting to a secured form action with nested data.
+     *
+     * @return void
+     */
+    public function testPostSecuredFormNestedData()
+    {
+        $this->enableSecurityToken();
+        $data = [
+            'title' => 'New post',
+            'comments' => [
+                ['comment' => 'A new comment']
+            ],
+            'tags' => ['_ids' => [1, 2, 3, 4]]
         ];
         $this->post('/posts/securePost', $data);
         $this->assertResponseOk();


### PR DESCRIPTION
IntegrationTestCase form tamper token generation was not the same as FormHelpers, and had issues with nested fields always triggering a blackhole. This builds upon the work done in #7717 and fixes issues introduced there.
