### PR TITLE
Fixed the now() function expression when used in the where() clause

### DIFF
--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -139,4 +139,15 @@ class FunctionExpression extends QueryExpression
             $parts
         ));
     }
+
+    /**
+     * The name of the function is in itself an expression to generate, thus
+     * always adding 1 to the amount of expressions stored in this object.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return 1 + count($this->_conditions);
+    }
 }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1236,4 +1236,20 @@ class QueryRegressionTest extends TestCase
         // Not executing the query first, just getting the count
         $this->assertEquals(3, $query->count());
     }
+
+    /**
+     * Tests that the now() function expression can be used in the
+     * where clause of a query
+     *
+     * @see https://github.com/cakephp/cakephp/issues/7943
+     * @return void
+     */
+    public function testFunctionInWhereClause()
+    {
+        $table = TableRegistry::get('Comments');
+        $table->updateAll(['updated' => Time::tomorrow()], ['id' => 6]);
+        $query = $table->find();
+        $result = $query->where(['updated >' => $query->func()->now('datetime')])->first();
+        $this->assertSame(6, $result->id);
+    }
 }


### PR DESCRIPTION
Fixes #7943
