### PR TITLE
Lower PHP version requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/cakephp/cakephp"
     },
     "require": {
-        "php": ">=5.5.10",
+        "php": ">=5.5.9",
         "ext-intl": "*",
         "ext-mbstring": "*",
         "cakephp/chronos": "*",


### PR DESCRIPTION
As of date Ubuntu 14.04 LTS reports it's PHP version as "PHP 5.5.9-1ubuntu4.14" (although it's actually latest patched up 5.5) which prevents installation of CakePHP 3.2.
