### PR TITLE
Allow additional variables in inputSubmit and submitContainer templates

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1769,7 +1769,8 @@ class FormHelper extends Helper
 
         $input = $this->formatTemplate('inputSubmit', [
             'type' => $type,
-            'attrs' => $this->templater()->formatAttributes($options)
+            'attrs' => $this->templater()->formatAttributes($options),
+            'templateVars' => $options['templateVars']
         ]);
 
         return $this->formatTemplate('submitContainer', [

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1723,7 +1723,7 @@ class FormHelper extends Helper
             $caption = __d('cake', 'Submit');
         }
         $options += [
-            'type' => 'submit', 
+            'type' => 'submit',
             'secure' => false,
             'templateVars' => []
         ];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1707,6 +1707,7 @@ class FormHelper extends Helper
      * ### Options
      *
      * - `type` - Set to 'reset' for reset inputs. Defaults to 'submit'
+     * - `templateVars` - Additional template variables for the input element and its container.
      * - Other attributes will be assigned to the input element.
      *
      * @param string $caption The label appearing on the button OR if string contains :// or the

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1722,7 +1722,11 @@ class FormHelper extends Helper
         if (!is_string($caption) && empty($caption)) {
             $caption = __d('cake', 'Submit');
         }
-        $options += ['type' => 'submit', 'secure' => false];
+        $options += [
+            'type' => 'submit', 
+            'secure' => false,
+            'templateVars' => []
+        ];
 
         if (isset($options['name'])) {
             $this->_secure($options['secure'], $this->_secureFieldName($options['name']));
@@ -1765,11 +1769,12 @@ class FormHelper extends Helper
 
         $input = $this->formatTemplate('inputSubmit', [
             'type' => $type,
-            'attrs' => $this->templater()->formatAttributes($options),
+            'attrs' => $this->templater()->formatAttributes($options)
         ]);
 
         return $this->formatTemplate('submitContainer', [
-            'content' => $input
+            'content' => $input,
+            'templateVars' => $options['templateVars']
         ]);
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -581,6 +581,30 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
     }
+    
+    /**
+     * Test using template vars in submitContainer template.
+     *
+     * @return void
+     */
+    public function testSubmitTemplateVars()
+    {
+        $this->Form->templates([
+            'submitContainer' => '<div class="submit">{{content}}{{forcontainer}}</div>'
+        ]);
+        $result = $this->Form->submit('Submit', [
+            'templateVars' => [
+                'forcontainer' => 'in-container'
+            ]
+        ]);
+        $expected = [
+            'div' => ['class'],
+            'input' => ['type' => 'submit', 'value' => 'Submit'],
+            'in-container',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+    }
 
     /**
      * test the create() method

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -583,23 +583,25 @@ class FormHelperTest extends TestCase
     }
     
     /**
-     * Test using template vars in submitContainer template.
+     * Test using template vars in inputSubmit and submitContainer template.
      *
      * @return void
      */
     public function testSubmitTemplateVars()
     {
         $this->Form->templates([
+            'inputSubmit' => '<input custom="{{forinput}}" type="{{type}}"{{attrs}}/>',
             'submitContainer' => '<div class="submit">{{content}}{{forcontainer}}</div>'
         ]);
         $result = $this->Form->submit('Submit', [
             'templateVars' => [
+                'forinput' => 'in-input',
                 'forcontainer' => 'in-container'
             ]
         ]);
         $expected = [
             'div' => ['class'],
-            'input' => ['type' => 'submit', 'value' => 'Submit'],
+            'input' => ['custom' => 'in-input', 'type' => 'submit', 'value' => 'Submit'],
             'in-container',
             '/div',
         ];


### PR DESCRIPTION
Currently, it is possible to [add additional variables to templates](http://book.cakephp.org/3.0/en/views/helpers/form.html#adding-additional-template-variables-to-templates) for all inputs and input containers **except** hidden inputs and submit inputs due to [this conditional](https://github.com/cakephp/cakephp/blob/master/src/View/Helper/FormHelper.php#L1021) statement.

I am suggesting a patch to support additional variables for the `inputSubmit` and `submitContainer`  templates (PR opened after suggestion in [this issue](https://github.com/cakephp/cakephp/issues/7958#issuecomment-168629979)).
