### PR TITLE
PHP requirement for CakePHP 2.8 should be at 5.4+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -37,7 +36,6 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi"
   - chmod -R 777 ./app/tmp
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]] ; then pecl install timezonedb ; fi
   - sh -c "if [ '$PHPCS' = '1' ]; then composer global require 'cakephp/cakephp-codesniffer:1.*'; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then ~/.composer/vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/cakephp/cakephp-codesniffer; fi"
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"source": "https://github.com/cakephp/cakephp"
 	},
 	"require": {
-		"php": ">=5.3.0",
+		"php": ">=5.4.0",
 		"ext-mcrypt": "*"
 	},
 	"require-dev": {


### PR DESCRIPTION
"2.8 will be an 2.x API compatible release of CakePHP"
This will still be true, we also don't have to change things like the array syntax just now.

But it seems somewhat pointless to extend PHP support to 7+ but still hold on to totally outdated and EOL PHP versions below 5.4.
Even EOL 5.4 was [4 months ago](http://php.net/eol.php), EOL 5.3 a total of 1 year and 4 months ago.

Everyone still actively upgrading CakePHP to the next minor release will also easily be able to take care of hosting.
Everyone still using PHP5.3 or less has some major hosting issues that cannot be the responsibility of any PHP framework. Or has to stick to the last minor framework version supporting this outdated plattform version IMO.
There is absolutely 0 reason these days to not use PHP5.5+ server envs.
It is even a security issue to continue to allow that IMO.

2.8 is basically the 3.2 equivalent for the 2.x series. 

Thoughts?
