### PR TITLE
Fix BelongsToMany saving incorrectly when _joinData is used.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -622,11 +622,13 @@ class BelongsToMany extends Association
         $junctionAlias = $junction->alias();
 
         foreach ($targetEntities as $e) {
-            $joint = $e->get($jointProperty);
+            $joint = $jointVal = $e->get($jointProperty);
             if (!$joint || !($joint instanceof EntityInterface)) {
                 $joint = new $entityClass([], ['markNew' => true, 'source' => $junctionAlias]);
+                if (is_array($jointVal)) {
+                    $joint->set($jointVal);
+                }
             }
-
             $sourceKeys = array_combine($foreignKey, $sourceEntity->extract($bindingKey));
             $targetKeys = array_combine($assocForeignKey, $e->extract($targetPrimaryKey));
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -622,12 +622,9 @@ class BelongsToMany extends Association
         $junctionAlias = $junction->alias();
 
         foreach ($targetEntities as $e) {
-            $joint = $jointVal = $e->get($jointProperty);
+            $joint = $e->get($jointProperty);
             if (!$joint || !($joint instanceof EntityInterface)) {
                 $joint = new $entityClass([], ['markNew' => true, 'source' => $junctionAlias]);
-                if (is_array($jointVal)) {
-                    $joint->set($jointVal);
-                }
             }
             $sourceKeys = array_combine($foreignKey, $sourceEntity->extract($bindingKey));
             $targetKeys = array_combine($assocForeignKey, $e->extract($targetPrimaryKey));

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -657,7 +657,7 @@ class Marshaller
             return [];
         }
 
-        if (!in_array('_joinData', $associated) && !isset($associated['_joinData'])) {
+        if (!empty($associated) && !in_array('_joinData', $associated) && !isset($associated['_joinData'])) {
             return $this->mergeMany($original, $value, $options);
         }
 

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -657,38 +657,6 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
-     * Tests that replaceLinks will apply _joinData when it has not been converted
-     * to an entity if that data is an array.
-     *
-     * @return void
-     */
-    public function testReplaceLinkJoinDataHandling()
-    {
-        $joint = TableRegistry::get('SpecialTags');
-        $articles = TableRegistry::get('Articles');
-
-        $assoc = $articles->belongsToMany('Tags', [
-            'through' => 'SpecialTags',
-            'conditions' => ['SpecialTags.highlighted' => true]
-        ]);
-        $id = 2;
-        $entity = $articles->get($id, ['contain' => 'Tags']);
-
-        // New tag
-        $tagData = [
-            new Entity(['id' => 2, '_joinData' => ['highlighted' => true]]),
-        ];
-
-        $assoc->replaceLinks($entity, $tagData);
-        $this->assertSame($tagData, $entity->tags, 'Tags should match replaced objects');
-        $this->assertFalse($entity->dirty('tags'), 'Should be clean');
-
-        $jointRecords = $joint->find()->where(['article_id' => $id])->toArray();
-        $this->assertCount(1, $jointRecords);
-        $this->assertTrue($jointRecords[0]->highlighted, 'joinData should be set.');
-    }
-
-    /**
      * Provider for empty values
      *
      * @return array


### PR DESCRIPTION
When the `_joinData` has not been fully marshalled, BelongsToMany associations will not save the joinData correctly. This can cause data to go 'missing' when associations with conditions are involved.

Refs #7808
