### PR TITLE
Save messages from failed rules with no errorField

### DIFF
--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -314,34 +314,29 @@ class RulesChecker
 
         return function ($entity, $scope) use ($rule, $name, $options) {
             $pass = $rule($entity, $options + $scope);
-            
+
             if ($pass === true) {
                 return true;
             }
 
-            $message = 'invalid';
-            $save = false;
+            $message = null;
             if (isset($options['message'])) {
                 $message = $options['message'];
-                $save = true;
             }
             if (is_string($pass)) {
                 $message = $pass;
-                $save = true;
             }
             if ($name) {
                 $message = [$name => $message];
             } else {
                 $message = [$message];
             }
-            
-            $errorField = '_rules';
-            if (isset($options['errorField'])) {
-                $errorField = $options['errorField'];
-                $save = true;
-            }
-            
-            if ($save) {
+
+            if ($message !== null) {
+                $errorField = '_rules';
+                if (isset($options['errorField'])) {
+                    $errorField = $options['errorField'];
+                }
                 $entity->errors($errorField, $message);
             }
             return false;

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -314,24 +314,37 @@ class RulesChecker
 
         return function ($entity, $scope) use ($rule, $name, $options) {
             $pass = $rule($entity, $options + $scope);
-            if ($pass === true || empty($options['errorField'])) {
-                return $pass === true;
+            
+            if ($pass === true) {
+                return true;
             }
 
             $message = 'invalid';
+            $save = false;
             if (isset($options['message'])) {
                 $message = $options['message'];
+                $save = true;
             }
             if (is_string($pass)) {
                 $message = $pass;
+                $save = true;
             }
             if ($name) {
                 $message = [$name => $message];
             } else {
                 $message = [$message];
             }
-            $entity->errors($options['errorField'], $message);
-            return $pass === true;
+            
+            $errorField = '_rules';
+            if (isset($options['errorField'])) {
+                $errorField = $options['errorField'];
+                $save = true;
+            }
+            
+            if ($save) {
+                $entity->errors($errorField, $message);
+            }
+            return false;
         };
     }
 }

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -199,4 +199,42 @@ class RulesCheckerTest extends TestCase
         $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
         $this->assertEmpty($entity->errors());
     }
+    
+    /**
+     * Test that messages with no errorField are stored in the virtual
+     * '_rules' field.
+     */
+    public function testMessageWithNoField()
+    {
+        $entity = new Entity([
+            'name' => 'larry'
+        ]);
+
+        $rules = new RulesChecker();
+        $rules->add(function () {
+            return false;
+        }, ['message' => 'that is bad']);
+
+        $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
+        $this->assertEquals(['that is bad'], $entity->errors('_rules'));
+    }
+    
+    /**
+     * Test that failed rules with no message are not stored in the
+     * '_rules' field.
+     */
+    public function testMessageWithNoFieldAndNoMessage()
+    {
+        $entity = new Entity([
+            'name' => 'larry'
+        ]);
+
+        $rules = new RulesChecker();
+        $rules->add(function () {
+            return false;
+        });
+
+        $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
+        $this->assertEmpty($entity->errors());
+    }
 }

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -800,7 +800,7 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
-     * Test adding rules with no errorField do not accept strings
+     * Test adding rules with no errorField will be placed in the "_rules" field.
      *
      * @group save
      * @return void
@@ -818,7 +818,7 @@ class RulesCheckerIntegrationTest extends TestCase
         });
 
         $this->assertFalse($table->save($entity));
-        $this->assertEmpty($entity->errors());
+        $this->assertEquals(['So much nope'], $entity->errors('_rules'));
     }
 
     /**


### PR DESCRIPTION
With the change in this PR the messages are stored in the "virtual" field `_rules`. Without this, all messages from rules are lost, when they have no associated field. I think it's not to uncommon to have a rule that you can't map directly to a field (like "this object is currently locked" or "you have selected an invalid set of options"). With this patch you can later retrieve this information and tell the user their error.

_Note_: This PR is mainly for discussing, I can add tests etc. if you like this idea.
