### PR TITLE
Allow to continue to use model to read table name for import.

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -59,11 +59,11 @@ class TestFixture implements FixtureInterface
     /**
      * Configuration for importing fixture schema
      *
-     * Accepts a `connection` and `table` key, to define
+     * Accepts a `connection` and `model` or `table` key, to define
      * which table and which connection contain the schema to be
      * imported.
      *
-     * @var array
+     * @var array|null
      */
     public $import = null;
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -20,6 +20,7 @@ use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\FixtureInterface;
 use Cake\Log\Log;
+use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Exception;
 
@@ -100,7 +101,7 @@ class TestFixture implements FixtureInterface
                 $message = sprintf(
                     'Invalid datasource name "%s" for "%s" fixture. Fixture datasource names must begin with "test".',
                     $connection,
-                    $this->name
+                    $this->table
                 );
                 throw new CakeException($message);
             }
@@ -196,16 +197,17 @@ class TestFixture implements FixtureInterface
         if (!is_array($this->import)) {
             return;
         }
-        $import = array_merge(
-            ['connection' => 'default', 'table' => null],
-            $this->import
-        );
+        $import = $this->import + ['connection' => 'default', 'table' => null, 'model' => null];
+
+        if (!empty($import['model'])) {
+            $import['table'] = TableRegistry::get($import['model'])->table();
+        }
 
         if (empty($import['table'])) {
             throw new CakeException('Cannot import from undefined table.');
-        } else {
-            $this->table = $import['table'];
         }
+
+        $this->table = $import['table'];
 
         $db = ConnectionManager::get($import['connection'], false);
         $schemaCollection = $db->schemaCollection();

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -200,6 +200,9 @@ class TestFixture implements FixtureInterface
         $import = $this->import + ['connection' => 'default', 'table' => null, 'model' => null];
 
         if (!empty($import['model'])) {
+            if (!empty($import['table'])) {
+                throw new CakeException('You cannot define both table and model.');
+            }
             $import['table'] = TableRegistry::get($import['model'])->table();
         }
 

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -213,6 +213,31 @@ class TestFixtureTest extends TestCase
     }
 
     /**
+     * test import fixture initialization
+     *
+     * @return void
+     */
+    public function testInitImportModel()
+    {
+        $fixture = new ImportsFixture();
+        $fixture->fields = $fixture->records = null;
+        $fixture->import = [
+            'model' => 'Posts',
+            'connection' => 'test',
+        ];
+        $fixture->init();
+
+        $expected = [
+            'id',
+            'author_id',
+            'title',
+            'body',
+            'published',
+        ];
+        $this->assertEquals($expected, $fixture->schema()->columns());
+    }
+
+    /**
      * test create method
      *
      * @return void


### PR DESCRIPTION
This used to work in 2.x.
I think it also makes sense to support in 3.x because often times, the Table classes contain

```
// FooTable
$this->alias('my_custom_foo');
```

This way, using

```
public $import = ['model' => 'Foo'];
```

in `FooFixture` is equivalent to

```
public $import = ['table' => 'my_custom_foo'];
```

We always get the correct table in a  DRY way. The concrete table is abstracted away in Table class and should not have to be known to the Fixture as well.

Fully BC.
Also fixed a naming bug (there is no $this->name).
