### PR TITLE
ajaxLogin is available then why 403 statusCode

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -366,7 +366,6 @@ class AuthComponent extends Component {
 			return false;
 		}
 		if (!empty($this->ajaxLogin)) {
-			$controller->response->statusCode(403);
 			$controller->viewPath = 'Elements';
 			$response = $controller->render($this->ajaxLogin, $this->RequestHandler->ajaxLayout);
 			$response->send();


### PR DESCRIPTION
If ajaxLogin is available, then why 403 is sent.

```
$controller->response->statusCode(403);
```

Due to this the ajaxLogin view element is not rendered
