### PR TITLE
Fix code markup for the DOCS

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -167,7 +167,9 @@ trait EntityTrait
      *
      * ### Example:
      *
-     * ``$entity->set('name', 'Andrew');``
+     * ```
+     * $entity->set('name', 'Andrew');
+     * ```
      *
      * It is also possible to mass-assign multiple properties to this entity
      * with one call by passing a hashed array as properties in the form of


### PR DESCRIPTION
Fix for markup in the CakePHP API docs.
