### PR TITLE
Fix matching() on belongs to many associations with conditions

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -227,7 +227,8 @@ class BelongsToMany extends Association
                 'targetTable' => $source,
                 'foreignKey' => $this->targetForeignKey(),
                 'targetForeignKey' => $this->foreignKey(),
-                'through' => $junction
+                'through' => $junction,
+                'conditions' => $this->conditions(),
             ]);
         }
     }
@@ -322,6 +323,8 @@ class BelongsToMany extends Association
             $includeFields = $options['includeFields'];
         }
 
+        // TODO see if this can be removed and replaced with eagerly splitting
+        // up conditions when defining associations.
         $assoc = $this->_targetTable->association($junction->alias());
         $query->removeJoin($assoc->name());
 

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1032,7 +1032,7 @@ class BelongsToManyTest extends TestCase
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
             'associationForeignKey' => 'tag_id',
-            'conditions' => [new QueryExpression("Tags.name LIKE 'tag%'")],
+            'conditions' => [new QueryExpression("name LIKE 'tag%'")],
             'through' => 'SpecialTags'
         ]);
         $query = $table->find()->matching('Tags', function ($q) {

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
-use Cake\Database\Expression\TupleComparison;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Association\BelongsToMany;
@@ -1005,13 +1004,35 @@ class BelongsToManyTest extends TestCase
      *
      * @return void
      */
-    public function testBelongsToManyAssociationWithConditions()
+    public function testBelongsToManyAssociationWithArrayConditions()
     {
         $table = TableRegistry::get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
             'associationForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
+            'through' => 'SpecialTags'
+        ]);
+        $query = $table->find()->matching('Tags', function ($q) {
+            return $q->where(['Tags.name' => 'tag1']);
+        });
+        $results = $query->toArray();
+        $this->assertCount(1, $results);
+        $this->assertNotEmpty($results[0]->_matchingData);
+    }
+
+    /**
+     * Test that matching() works on belongsToMany associations.
+     *
+     * @return void
+     */
+    public function testBelongsToManyAssociationWithExpressionConditions()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'conditions' => [new QueryExpression('Tags.name LIKE "tag%"')],
             'through' => 'SpecialTags'
         ]);
         $query = $table->find()->matching('Tags', function ($q) {

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1032,7 +1032,7 @@ class BelongsToManyTest extends TestCase
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
             'associationForeignKey' => 'tag_id',
-            'conditions' => [new QueryExpression('Tags.name LIKE "tag%"')],
+            'conditions' => [new QueryExpression("Tags.name LIKE 'tag%'")],
             'through' => 'SpecialTags'
         ]);
         $query = $table->find()->matching('Tags', function ($q) {

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -121,6 +121,28 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Test that matching() works on belongsToMany associations.
+     *
+     * @return void
+     */
+    public function testMatchingOnBelongsToManyAssociationWithConditions()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'conditions' => ['SpecialTags.highlighted' => true],
+            'through' => 'SpecialTags'
+        ]);
+        $query = $table->find()->matching('Tags', function ($q) {
+            return $q->where(['Tags.name' => 'tag1']);
+        });
+        $results = $query->toArray();
+        $this->assertCount(1, $results);
+        $this->assertNotEmpty($results[0]->_matchingData);
+    }
+
+    /**
      * Test that association proxy find() with matching resolves joins correctly
      *
      * @return void

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -102,68 +102,6 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
-     * Test that association proxy find() applies joins when conditions are involved.
-     *
-     * @return void
-     */
-    public function testBelongsToManyAssociationProxyFindWithConditions()
-    {
-        $table = TableRegistry::get('Articles');
-        $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
-            'conditions' => ['SpecialTags.highlighted' => true],
-            'through' => 'SpecialTags'
-        ]);
-        $query = $table->Tags->find();
-        $result = $query->toArray();
-        $this->assertCount(1, $result);
-    }
-
-    /**
-     * Test that matching() works on belongsToMany associations.
-     *
-     * @return void
-     */
-    public function testMatchingOnBelongsToManyAssociationWithConditions()
-    {
-        $table = TableRegistry::get('Articles');
-        $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
-            'conditions' => ['SpecialTags.highlighted' => true],
-            'through' => 'SpecialTags'
-        ]);
-        $query = $table->find()->matching('Tags', function ($q) {
-            return $q->where(['Tags.name' => 'tag1']);
-        });
-        $results = $query->toArray();
-        $this->assertCount(1, $results);
-        $this->assertNotEmpty($results[0]->_matchingData);
-    }
-
-    /**
-     * Test that association proxy find() with matching resolves joins correctly
-     *
-     * @return void
-     */
-    public function testBelongsToManyAssociationProxyFindWithConditionsMatching()
-    {
-        $table = TableRegistry::get('Articles');
-        $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
-            'conditions' => ['SpecialTags.highlighted' => true],
-            'through' => 'SpecialTags'
-        ]);
-        $query = $table->Tags->find()->matching('Articles', function ($query) {
-            return $query->where(['Articles.id' => 1]);
-        });
-        // The inner join on special_tags excludes the results.
-        $this->assertEquals(0, $query->count());
-    }
-
-    /**
      * Tests that duplicate aliases in contain() can be used, even when they would
      * naturally be attached to the query instead of eagerly loaded. What should
      * happen here is that One of the duplicates will be changed to be loaded using


### PR DESCRIPTION
BelongsToMany associations with conditions failed when included in query->matching() because invalid SQL was emitted. When a belongstomany association contains conditions on the junction table, those conditions are emitted in the join to the target table creating SQL like:

```
SELECT * from articles
INNER JOIN tags ON (tags.name = 'php' and articles_tags.starred = 1)
INNER JOIN articles_tags ON (tags.id = articles_tags.id and articles.id = articles_tags.article_id)
```

This query will fail as the articles_tags.starred condition references a table that has not been joined on to the query. These changes split the conditions into target & junction conditions and apply those conditions to the appropriate joins. I've also moved some tests around to make BelongsToMany tests more comprehensive.

This addresses half of #7994. I still have to look into the issues with saving.
