### PR TITLE
Fix caching in camelize()

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -587,7 +587,7 @@ class Inflector
 
         if ($result === false) {
             $result = str_replace(' ', '', static::humanize($string, $delimiter));
-            static::_cache(__FUNCTION__, $string, $result);
+            static::_cache($cacheKey, $string, $result);
         }
 
         return $result;


### PR DESCRIPTION
Value was written to the wrong cache key.
This is especially important as camelize() is in heavy use by Cake ORM (e.g. EntityTrait::get())
