### PR TITLE
Memcached can not connect using a socket

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -241,8 +241,9 @@ class MemcachedEngine extends CacheEngine
      */
     protected function _parseServerString($server)
     {
-        if (strpos($server, 'unix://') === 0) {
-            return [$server, 0];
+        $socketTransport = 'unix://';
+        if (strpos($server, $socketTransport) === 0) {
+            return [substr($server, strlen($socketTransport)), 0];
         }
         if (substr($server, 0, 1) === '[') {
             $position = strpos($server, ']:');

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -481,7 +481,7 @@ class MemcachedEngineTest extends TestCase
     {
         $Memcached = new TestMemcachedEngine();
         $result = $Memcached->parseServerString('unix:///path/to/memcachedd.sock');
-        $this->assertEquals(['unix:///path/to/memcachedd.sock', 0], $result);
+        $this->assertEquals(['/path/to/memcachedd.sock', 0], $result);
     }
 
     /**


### PR DESCRIPTION
In the `Memcache` client the socket path is prefixed by `unix://` in the `Memcached` client [it is not](http://php.net/manual/en/memcached.addserver.php#110661).
