### PR TITLE
Use variable and comment to be more clear on what the code does

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -166,7 +166,9 @@ class Helper implements EventListenerInterface
     {
         $message = json_encode($message);
         $confirm = "if (confirm({$message})) { {$okCode} } {$cancelCode}";
-        if (isset($options['escape']) && $options['escape'] === false) {
+        // We cannot change the key here in 3.x, but the behavior is inverted in this case
+        $escape = isset($options['escape']) && $options['escape'] === false;
+        if ($escape) {
             $confirm = h($confirm);
         }
         return $confirm;


### PR DESCRIPTION
Unfortunately, we cannot change the array key to noEscape in 3.x due to BC. 
Will have to wait for 4.0 to refactor this code smell.

Clears up future confusion around the inverted behavior mentioned in https://github.com/cakephp/cakephp/issues/8009
