### PR TITLE
Php config short array syntax

### DIFF
--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -97,7 +97,7 @@ class PhpConfig implements ConfigEngineInterface
         $filename = $this->_getFilePath($key);
         return file_put_contents($filename, $contents) > 0;
     }
-
+    
     /**
      *
      * Converts an array $data into a string of PHP code using the Short Array Syntax.
@@ -121,6 +121,8 @@ class PhpConfig implements ConfigEngineInterface
 
             if (is_array($value)) {
                 $value = PHP_EOL . $this->shortArrayVarExport($value, $indent + 1);
+            } elseif (is_null($value)) {
+                $value = "null";
             } else {
                 $value = var_export($value, true);
             }

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -98,23 +98,22 @@ class PhpConfig implements ConfigEngineInterface
         return file_put_contents($filename, $contents) > 0;
     }
 
-    /** 
-    *
-    * Converts an array $data into a string of PHP code using the Short Array Syntax.
-    *
-    * Similar to var_export() except it uses the Short Array Syntax;
-    * 
-    * @param array $data Data to dump in Short Array Syntax
-    * @return string returns a parsable string representation of a short array syntax variable
-    */
+    /**
+     *
+     * Converts an array $data into a string of PHP code using the Short Array Syntax.
+     *
+     * Similar to var_export() except it uses the Short Array Syntax;
+     *
+     * @param array $data Data to dump in Short Array Syntax
+     * @return string returns a parsable string representation of a short array syntax variable
+     */
+    public function shortArrayVarExport($data)
+    {
+        $varExport = var_export($data, true);
+        $pattern = ['/array \(/', '/\)/'];
+        $replacements = ['[', ']'];
 
-    private function shortArrayVarExport($data){
-
-        $varExport      = var_export($data, TRUE);
-        $pattern        = array('/array \(/', '/\)/');
-        $replacements   = array('[', ']');
-
-        $shortArrayVarExport =  preg_replace(
+        $shortArrayVarExport = preg_replace(
             $pattern,
             $replacements,
             $varExport

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -104,24 +104,25 @@ class PhpConfig implements ConfigEngineInterface
      *
      * Similar to var_export() except it uses the Short Array Syntax;
      *
-     * @param array $data Data to dump in Short Array Syntax
+     * @param array $array Array to dump in Short Array Syntax
+     * @param int $indent Indentation Level
      * @return string A parsable string representation of a short array syntax variable
      */
     public function shortArrayVarExport($array, $indent)
     {
         $whiteSpace = "    "; // 4 Whitespace CakePHP Style
-        $indentation = str_repeat($whiteSpace, $indent);        
-        $opening =  $indentation . "[";
+        $indentation = str_repeat($whiteSpace, $indent);
+        $opening = $indentation . "[";
         $closing = PHP_EOL . $indentation . "]";
-
+        
         $vars = [];
-        foreach( $array as $key => $value ){
-            $key = (is_integer($key)) ? (int) $key : "'$key'";
+        foreach ($array as $key => $value) {
+            $key = (is_integer($key)) ? (int)$key : "'$key'";
 
-            if( is_array($value) ){
+            if (is_array($value)) {
                 $value = PHP_EOL . $this->shortArrayVarExport($value, $indent + 1);
             } else {
-                $value = var_export($value, TRUE);
+                $value = var_export($value, true);
             }
 
             $vars[] = PHP_EOL . str_repeat($whiteSpace, $indent + 1) . "$key => " . $value;

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -114,10 +114,10 @@ class PhpConfig implements ConfigEngineInterface
         $indentation = str_repeat($whiteSpace, $indent);
         $opening = $indentation . "[";
         $closing = PHP_EOL . $indentation . "]";
-        
+
         $vars = [];
         foreach ($array as $key => $value) {
-            $key = (is_integer($key)) ? (int)$key : "'$key'";
+            $key = (is_int($key)) ? (int)$key : "'$key'";
 
             if (is_array($value)) {
                 $value = PHP_EOL . $this->shortArrayVarExport($value, $indent + 1);

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -93,7 +93,6 @@ class PhpConfig implements ConfigEngineInterface
     public function dump($key, array $data)
     {
         $contents = '<?php' . "\n" . 'return ' . $this->shortArrayVarExport($data, 0) . ';';
-
         $filename = $this->_getFilePath($key);
         return file_put_contents($filename, $contents) > 0;
     }

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -105,7 +105,7 @@ class PhpConfig implements ConfigEngineInterface
      * Similar to var_export() except it uses the Short Array Syntax;
      *
      * @param array $data Data to dump in Short Array Syntax
-     * @return string returns a parsable string representation of a short array syntax variable
+     * @return string A parsable string representation of a short array syntax variable
      */
     public function shortArrayVarExport($data)
     {

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -110,8 +110,12 @@ class PhpConfig implements ConfigEngineInterface
     public function shortArrayVarExport($data)
     {
         $varExport = var_export($data, true);
-        $pattern = ['/array \(/', '/\)/'];
-        $replacements = ['[', ']'];
+        $pattern = [
+            '/array \(/', // Matches opening "array("
+            '/(\),)$/m', // Matches ending "),"
+            '/^\)$/m' // Matches last ) in file
+        ];
+        $replacements = ['[', '],', ']'];
 
         $shortArrayVarExport = preg_replace(
             $pattern,

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -92,9 +92,34 @@ class PhpConfig implements ConfigEngineInterface
      */
     public function dump($key, array $data)
     {
-        $contents = '<?php' . "\n" . 'return ' . var_export($data, true) . ';';
+        $contents = '<?php' . "\n" . 'return ' . $this->shortArrayVarExport($data) . ';';
 
         $filename = $this->_getFilePath($key);
         return file_put_contents($filename, $contents) > 0;
+    }
+
+    /** 
+    *
+    * Converts an array $data into a string of PHP code using the Short Array Syntax.
+    *
+    * Similar to var_export() except it uses the Short Array Syntax;
+    * 
+    * @param array $data Data to dump in Short Array Syntax
+    * @return string returns a parsable string representation of a short array syntax variable
+    */
+
+    private function shortArrayVarExport($data){
+
+        $varExport      = var_export($data, TRUE);
+        $pattern        = array('/array \(/', '/\)/');
+        $replacements   = array('[', ']');
+
+        $shortArrayVarExport =  preg_replace(
+            $pattern,
+            $replacements,
+            $varExport
+        );
+
+        return $shortArrayVarExport;
     }
 }

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -97,7 +97,7 @@ class PhpConfig implements ConfigEngineInterface
         $filename = $this->_getFilePath($key);
         return file_put_contents($filename, $contents) > 0;
     }
-    
+
     /**
      *
      * Converts an array $data into a string of PHP code using the Short Array Syntax.
@@ -110,7 +110,7 @@ class PhpConfig implements ConfigEngineInterface
      */
     public function shortArrayVarExport($array, $indent)
     {
-        $whiteSpace = "    "; // 4 Whitespace CakePHP Style
+        $whiteSpace = "    "; // 4 Whitespace
         $indentation = str_repeat($whiteSpace, $indent);
         $opening = $indentation . "[";
         $closing = PHP_EOL . $indentation . "]";

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -145,23 +145,23 @@ class PhpConfigTest extends TestCase
         $this->assertTrue($result > 0);
         $expected = <<<PHP
 <?php
-return array (
+return [
   'One' => 
-  array (
+  [
     'two' => 'value',
     'three' => 
-    array (
+    [
       'four' => 'value four',
-    ),
+    ],
     'is_null' => NULL,
     'bool_false' => false,
     'bool_true' => true,
-  ),
+  ],
   'Asset' => 
-  array (
+  [
     'timestamp' => 'force',
-  ),
-);
+  ],
+];
 PHP;
         $file = TMP . 'test.php';
         $contents = file_get_contents($file);

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -35,7 +35,7 @@ class PhpConfigTest extends TestCase
         'One' => [
             'two' => 'value',
             'three' => [
-                'four' => 'value four'
+                'four' => 'value four',
             ],
             'is_null' => null,
             'bool_false' => false,
@@ -45,7 +45,7 @@ class PhpConfigTest extends TestCase
             'timestamp' => 'force',
         ],
         ')',
-        '),'
+        '),',
     ];
 
     /**

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -148,28 +148,27 @@ class PhpConfigTest extends TestCase
         $expected = <<<PHP
 <?php
 return [
-  'One' => 
-  [
-    'two' => 'value',
-    'three' => 
+    'One' => 
     [
-      'four' => 'value four',
+        'two' => 'value',
+        'three' => 
+        [
+            'four' => 'value four'
+        ],
+        'is_null' => NULL,
+        'bool_false' => false,
+        'bool_true' => true
     ],
-    'is_null' => NULL,
-    'bool_false' => false,
-    'bool_true' => true,
-  ],
-  'Asset' => 
-  [
-    'timestamp' => 'force',
-  ],
-  0 => ')',
-  1 => '),',
+    'Asset' => 
+    [
+        'timestamp' => 'force'
+    ],
+    0 => ')',
+    1 => '),'
 ];
 PHP;
         $file = TMP . 'test.php';
         $contents = file_get_contents($file);
-
         unlink($file);
         $this->assertTextEquals($expected, $contents);
 

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -42,8 +42,10 @@ class PhpConfigTest extends TestCase
             'bool_true' => true,
         ],
         'Asset' => [
-            'timestamp' => 'force'
+            'timestamp' => 'force',
         ],
+        ')',
+        '),'
     ];
 
     /**
@@ -161,6 +163,8 @@ return [
   [
     'timestamp' => 'force',
   ],
+  0 => ')',
+  1 => '),',
 ];
 PHP;
         $file = TMP . 'test.php';

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -155,7 +155,7 @@ return [
         [
             'four' => 'value four'
         ],
-        'is_null' => NULL,
+        'is_null' => null,
         'bool_false' => false,
         'bool_true' => true
     ],


### PR DESCRIPTION
Changed PhpConfig::dump() to use the Short Array Syntax. Tests are included and passing. 

This for issue: #7804

It uses a new method in the PhpConfig.php file. It could be made to be more accessible by moving the method to "functions.php". However I'm not sure how beneficial that would be.
