### PR TITLE
Cache accessor methods per-property

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -275,7 +275,7 @@ trait EntityTrait
         }
 
         $value = null;
-        $method = $this->_accessor($property);
+        $method = $this->_accessor($property, 'get');
 
         if (isset($this->_properties[$property])) {
             $value =& $this->_properties[$property];
@@ -506,7 +506,7 @@ trait EntityTrait
      * @param string $type the accessor type ('get' or 'set')
      * @return string method name or empty string (no method available)
      */
-    protected function _accessor($property, $type = 'get')
+    protected function _accessor($property, $type)
     {
         if (!isset(static::$_accessors[$this->_className][$type][$property])) {
             /* first time for this class: build all fields */

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -513,10 +513,11 @@ trait EntityTrait
             if (empty(static::$_accessors[$this->_className])) {
                 foreach (get_class_methods($this) as $m) {
                     $t = substr($m, 1, 3);
-                    if ($m[0] === '_' && in_array($t, ['get', 'set'])) {
-                        $p = Inflector::underscore(substr($m, 4));
-                        static::$_accessors[$this->_className][$t][$p] = $m;
+                    if ($m[0] !== '_' || !in_array($t, ['get', 'set'])) {
+                        continue;
                     }
+                    $p = Inflector::underscore(substr($m, 4));
+                    static::$_accessors[$this->_className][$t][$p] = $m;
                 }
             }
             /* if still not set, remember that the method indeed is not present */


### PR DESCRIPTION
Getting and setting are the most basic operations that the entity trait provides. They should do as less work as possible.
Currently, in _all_ get() or set() calls, method names are inflicted for potential getter/setter methods that don't even exist in most cases. Only afterwards, the inflicted method name is checked against a cache determining if the method exists.
In this patch, we cache the method names (or an empty string that indicates a method is not defined) per **property name**. Successive calls to get() and set() on the same property lead to only one isset() before either the inflicted method string or an empty string (no method defined) is returned.
