### PR TITLE
Allow injection of types not just mapping

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -102,7 +102,11 @@ class Type
         if (!isset(static::$_types[$name])) {
             throw new InvalidArgumentException(sprintf('Unknown type "%s"', $name));
         }
-        return static::$_builtTypes[$name] = new static::$_types[$name]($name);
+        if (is_string(static::$_types[$name])) {
+            return static::$_builtTypes[$name] = new static::$_types[$name]($name);
+        }
+        
+        return static::$_builtTypes[$name] = static::$_types[$name];
     }
 
     /**
@@ -122,7 +126,7 @@ class Type
      * If called with no arguments it will return current types map array
      * If $className is omitted it will return mapped class for $type
      *
-     * @param string|array|null $type if string name of type to map, if array list of arrays to be mapped
+     * @param string|array|\Cake\Database\Type|null $type if string name of type to map, if array list of arrays to be mapped
      * @param string|null $className The classname to register.
      * @return array|string|null if $type is null then array with current map, if $className is null string
      * configured class name for give $type, null otherwise
@@ -132,7 +136,7 @@ class Type
         if ($type === null) {
             return self::$_types;
         }
-        if (!is_string($type)) {
+        if (is_array($type)) {
             self::$_types = $type;
             return null;
         }

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -142,8 +142,8 @@ class TypeTest extends TestCase
         $fooType = new FooType();
         Type::map('foo2', $fooType);
         $map = Type::map();
-        $this->assertEquals($fooType, $map['foo2']);
-        $this->assertEquals($fooType, Type::map('foo2'));
+        $this->assertSame($fooType, $map['foo2']);
+        $this->assertSame($fooType, Type::map('foo2'));
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -138,6 +138,12 @@ class TypeTest extends TestCase
         $this->assertInstanceOf($fooType, $type);
         $this->assertEquals('foo', $type->getName());
         $this->assertEquals('text', $type->getBaseType());
+
+        $fooType = new FooType();
+        Type::map('foo2', $fooType);
+        $map = Type::map();
+        $this->assertEquals($fooType, $map['foo2']);
+        $this->assertEquals($fooType, Type::map('foo2'));
     }
 
     /**


### PR DESCRIPTION
This would allow to have configurable types and be able to move some logic currently
done at the `Behavior` level instead but would fit the Type much more (i.e. data encryption)
