### PR TITLE
Fixes #8054

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -186,10 +186,13 @@ class Plugin
             return;
         }
 
-        $vendorFile = dirname(dirname(dirname(dirname(__DIR__)))) . DS . 'cakephp-plugins.php';
+        $vendorFile = dirname(dirname(__DIR__)) . DS . 'cakephp-plugins.php';
         if (!file_exists($vendorFile)) {
-            Configure::write(['plugins' => []]);
-            return;
+            $vendorFile = dirname(dirname(dirname(dirname(__DIR__)))) . DS . 'cakephp-plugins.php';
+            if (!file_exists($vendorFile)) {
+                Configure::write(['plugins' => []]);
+                return;
+            }
         }
 
         $config = require $vendorFile;


### PR DESCRIPTION
Added a check first for the path to cakephp-plugins.php file will not go beyond the application in standalone one library.

The check for second one is made for framework.
