### PR TITLE
Make the session cacheLimiter a configuration option.

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -201,6 +201,8 @@
  *    to the ini array.
  * - `Session.autoRegenerate` - Enabling this setting, turns on automatic renewal of sessions, and
  *    sessionids that change frequently. See CakeSession::$requestCountdown.
+ * - `Session.cacheLimiter` - Configure the cache control headers used for the session cookie.
+ *   See http://php.net/session_cache_limiter for accepted values.
  * - `Session.ini` - An associative array of additional ini values to set.
  *
  * The built in defaults are:

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -541,6 +541,10 @@ class CakeSession {
 		if (!isset($sessionConfig['ini']['session.cookie_httponly'])) {
 			$sessionConfig['ini']['session.cookie_httponly'] = 1;
 		}
+		// For IE<=8
+		if (!isset($sessionConfig['cacheLimiter'])) {
+			$sessionConfig['cacheLimiter'] = 'must-revalidate';
+		}
 
 		if (empty($_SESSION)) {
 			if (!empty($sessionConfig['ini']) && is_array($sessionConfig['ini'])) {
@@ -696,8 +700,10 @@ class CakeSession {
 				$_SESSION = array();
 			}
 		} else {
-			// For IE<=8
-			session_cache_limiter("must-revalidate");
+			$limit = Configure::read('Session.cacheLimiter');
+			if (!empty($limit)) {
+				session_cache_limiter($limit);
+			}
 			session_start();
 		}
 		return true;

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -515,6 +515,22 @@ class CakeSessionTest extends CakeTestCase {
 	}
 
 /**
+ * Test te cacheLimiter settings.
+ *
+ * @return void
+ */
+	public function testCacheLimiter() {
+		Configure::write('Session.cacheLimiter', 'public');
+		TestCakeSession::start();
+		$this->assertSame('public', session_cache_limiter());
+
+		Configure::write('Session.cacheLimiter', 'private');
+		TestCakeSession::destroy();
+		TestCakeSession::start();
+		$this->assertSame('private', session_cache_limiter());
+	}
+
+/**
  * testCheckUserAgentFalse method
  *
  * @return void


### PR DESCRIPTION
Instead of hardcoding to must-revalidate, developers can use a more suitable option if they do not have to support IE8.

Refs #7096
