### PR TITLE
Backport CODE_ERROR constant and return as per expectation.

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -31,6 +31,13 @@ App::uses('File', 'Utility');
 class Shell extends Object {
 
 /**
+ * Default error code
+ *
+ * @var int
+ */
+	const CODE_ERROR = 1;
+
+/**
  * Output constant making verbose shells.
  *
  * @var int
@@ -573,7 +580,8 @@ class Shell extends Object {
 		$result = $this->stdin->read();
 
 		if ($result === false) {
-			return $this->_stop(1);
+			$this->_stop(self::CODE_ERROR);
+			return self::CODE_ERROR;
 		}
 		$result = trim($result);
 
@@ -720,7 +728,8 @@ class Shell extends Object {
 		if (!empty($message)) {
 			$this->err($message);
 		}
-		return $this->_stop(1);
+		$this->_stop(self::CODE_ERROR);
+		return self::CODE_ERROR;
 	}
 
 /**
@@ -758,7 +767,8 @@ class Shell extends Object {
 
 			if (strtolower($key) === 'q') {
 				$this->out(__d('cake_console', '<error>Quitting</error>.'), 2);
-				return $this->_stop();
+				$this->_stop();
+				return true;
 			} elseif (strtolower($key) !== 'y') {
 				$this->out(__d('cake_console', 'Skip `%s`', $path), 2);
 				return false;


### PR DESCRIPTION
Backport from 3.x refactoring.

Using `1` magic number and `return 1` is not a good idea as it is very close to true (success) but means error.
Thus the constant.

Also, PHPStorm rightfully complains about returning void method result of _stop(), the return needs to be a separate code line or we would need to make _stop() return its input value.
