### PR TITLE
Make RedirectRoute use an exception instead of stopping the process.

### DIFF
--- a/src/Routing/Exception/RedirectException.php
+++ b/src/Routing/Exception/RedirectException.php
@@ -1,9 +1,31 @@
 <?php
-
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Routing\Exception;
 
 use RuntimeException;
 
+/**
+ * An exception subclass used by the routing layer to indicate
+ * that a route has resolved to a redirect.
+ *
+ * The URL and status code are provided as constructor arguments.
+ *
+ * ```
+ * throw new RedirectException('http://example.com/some/path', 301);
+ * ```
+ */
 class RedirectException extends RuntimeException
 {
 }

--- a/src/Routing/Exception/RedirectException.php
+++ b/src/Routing/Exception/RedirectException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Cake\Routing\Exception;
+
+use RuntimeException;
+
+class RedirectException extends RuntimeException
+{
+}

--- a/src/Routing/Filter/RoutingFilter.php
+++ b/src/Routing/Filter/RoutingFilter.php
@@ -16,6 +16,7 @@ namespace Cake\Routing\Filter;
 
 use Cake\Event\Event;
 use Cake\Routing\DispatcherFilter;
+use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\Router;
 
 /**
@@ -42,16 +43,23 @@ class RoutingFilter extends DispatcherFilter
      * If Routes have not been loaded they will be loaded, and config/routes.php will be run.
      *
      * @param \Cake\Event\Event $event containing the request, response and additional params
-     * @return void
+     * @return void|Cake\Network\Response A response will be returned when a redirect route is encountered.
      */
     public function beforeDispatch(Event $event)
     {
         $request = $event->data['request'];
         Router::setRequestInfo($request);
 
-        if (empty($request->params['controller'])) {
-            $params = Router::parse($request->url);
-            $request->addParams($params);
+        try {
+            if (empty($request->params['controller'])) {
+                $params = Router::parse($request->url);
+                $request->addParams($params);
+            }
+        } catch (RedirectException $e) {
+            $response = $event->data['response'];
+            $response->statusCode($e->getCode());
+            $response->header('Location', $e->getMessage());
+            return $response;
         }
     }
 }

--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -23,6 +23,8 @@ use Cake\Routing\Router;
  * are useful when you want to have Routing layer redirects occur in your
  * application, for when URLs move.
  *
+ * Redirection is signalled by an exception that halts route matching and
+ * defines the redirect URL and status code.
  */
 class RedirectRoute extends Route
 {
@@ -31,6 +33,7 @@ class RedirectRoute extends Route
      * A Response object
      *
      * @var \Cake\Network\Response
+     * @deprecated 3.2.0 This property is unused.
      */
     public $response = null;
 
@@ -62,16 +65,15 @@ class RedirectRoute extends Route
      * redirection.
      *
      * @param string $url The URL to parse.
-     * @return false|null False on failure, null otherwise.
+     * @return false|null False on failure. An exception is raised on a successful match.
+     * @throws \Cake\Routing\Exception\RedirectException An exception is raised on successful match.
+     *   This is used to halt route matching and signal to the middleware that a redirect should happen.
      */
     public function parse($url)
     {
         $params = parent::parse($url);
         if (!$params) {
             return false;
-        }
-        if (!$this->response) {
-            $this->response = new Response();
         }
         $redirect = $this->redirect;
         if (count($this->redirect) === 1 && !isset($this->redirect['controller'])) {

--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -15,6 +15,7 @@
 namespace Cake\Routing\Route;
 
 use Cake\Network\Response;
+use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\Router;
 
 /**
@@ -91,12 +92,7 @@ class RedirectRoute extends Route
         if (isset($this->options['status']) && ($this->options['status'] >= 300 && $this->options['status'] < 400)) {
             $status = $this->options['status'];
         }
-        $this->response->header([
-            'Location' => Router::url($redirect, true)
-        ]);
-        $this->response->statusCode($status);
-        $this->response->send();
-        $this->response->stop();
+        throw new RedirectException(Router::url($redirect, true), $status);
     }
 
     /**

--- a/tests/TestCase/Routing/Filter/RoutingFilterTest.php
+++ b/tests/TestCase/Routing/Filter/RoutingFilterTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\Routing\Filter;
 
 use Cake\Event\Event;
 use Cake\Network\Request;
+use Cake\Network\Response;
 use Cake\Routing\Filter\RoutingFilter;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -66,6 +67,27 @@ class RoutingFilterTest extends TestCase
         $this->assertSame($request->params['pass'][1], 'params2');
         $this->assertSame($request->params['pass'][2], 'params3');
         $this->assertFalse(!empty($request['form']));
+    }
+
+    /**
+     * test setting parameters in beforeDispatch method
+     *
+     * @return void
+     * @triggers __CLASS__ $this, compact(request)
+     */
+    public function testBeforeDispatchRedirectRoute()
+    {
+        Router::redirect('/home', ['controller' => 'articles']);
+        Router::connect('/:controller/:action/*');
+        $filter = new RoutingFilter();
+
+        $request = new Request("/home");
+        $response = new Response();
+        $event = new Event(__CLASS__, $this, compact('request', 'response'));
+        $response = $filter->beforeDispatch($event);
+        $this->assertInstanceOf('Cake\Network\Response', $response);
+        $this->assertSame('http://localhost/articles/index', $response->header()['Location']);
+        $this->assertSame(301, $response->statusCode());
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -43,6 +43,29 @@ class RedirectRouteTest extends TestCase
     }
 
     /**
+     * test match
+     *
+     * @return void
+     */
+    public function testMatch()
+    {
+        $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $this->assertFalse($route->match(['controller' => 'posts', 'action' => 'index']));
+    }
+
+    /**
+     * test parse failure
+     *
+     * @return void
+     */
+    public function testParseMiss()
+    {
+        $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $this->assertFalse($route->parse('/nope'));
+        $this->assertFalse($route->parse('/homes'));
+    }
+
+    /**
      * test the parsing of routes.
      *
      * @expectedException Cake\Routing\Exception\RedirectException
@@ -53,6 +76,20 @@ class RedirectRouteTest extends TestCase
     public function testParseSimple()
     {
         $route = new RedirectRoute('/home', ['controller' => 'posts']);
+        $route->parse('/home');
+    }
+
+    /**
+     * test the parsing of routes.
+     *
+     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedExceptionMessage http://localhost/posts
+     * @expectedExceptionCode 301
+     * @return void
+     */
+    public function testParseRedirectOption()
+    {
+        $route = new RedirectRoute('/home', ['redirect' => ['controller' => 'posts']]);
         $route->parse('/home');
     }
 


### PR DESCRIPTION
This will allow redirect routes to be testable in IntegrationTestCases. It also allows redirect routes to be processed by dispatch filters that further modify the response.

Targetting 3.2 as this could cause minor issues if people have subclassed the RedirectRoute, and I feel that something like this should be included in the migration guide.

Refs #8015
