### PR TITLE
Inflect Controller::$name when it is derived from request params.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -26,6 +26,7 @@ use Cake\Network\Response;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
+use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
 use Cake\View\ViewVarsTrait;
 use LogicException;
@@ -236,7 +237,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         if ($this->name === null && isset($request->params['controller'])) {
-            $this->name = $request->params['controller'];
+            $this->name = Inflector::camelize($request->params['controller']);
         }
 
         if ($this->name === null) {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -359,6 +359,12 @@ class ControllerTest extends TestCase
         $this->assertEquals('Posts', $controller->modelClass);
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
+        $request->params['controller'] = 'posts';
+        $controller = new \TestApp\Controller\PostsController($request, $response);
+        $this->assertEquals('Posts', $controller->modelClass);
+        $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
+        unset($request->params['controller']);
+
         $controller = new \TestApp\Controller\Admin\PostsController($request, $response);
         $this->assertEquals('Posts', $controller->modelClass);
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);


### PR DESCRIPTION
When the controller name is derived from the request parameters we need to inflect the controller name. This ensures that view paths and convention based modelClass names are correct.

Refs #8081
