### PR TITLE
Adds refilling get style forms with data from the requests query data.

### DIFF
--- a/src/View/Form/AbstractContext.php
+++ b/src/View/Form/AbstractContext.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Form;
+
+use Cake\Network\Request;
+
+/**
+ * Provides common functionality for ContextInterface implementations.
+ */
+abstract class AbstractContext implements ContextInterface
+{
+    /**
+     * The request object.
+     *
+     * @var \Cake\Network\Request
+     */
+    protected $_request;
+
+    /**
+     * The request type of the attached form.
+     *
+     * @var string
+     */
+    protected $_requestType;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\Network\Request $request The request object.
+     * @param string $requestType The type of request used by the form this context is attached to.
+     */
+    protected function __construct(Request $request, $requestType)
+    {
+        $this->_request = $request;
+        if ($requestType === null || $requestType === 'file') {
+            $this->_requestType = $this->isCreate() ? 'post' : 'put';
+        } else {
+            $this->_requestType = $requestType;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function val($field)
+    {
+        if ($this->_requestType === 'get') {
+            return $this->_request->query($field);
+        }
+        return $this->_request->data($field);
+    }
+}

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -57,15 +57,8 @@ use Cake\Utility\Hash;
  *  ];
  *  ```
  */
-class ArrayContext implements ContextInterface
+class ArrayContext extends AbstractContext
 {
-
-    /**
-     * The request object.
-     *
-     * @var \Cake\Network\Request
-     */
-    protected $_request;
 
     /**
      * Context data for this object.
@@ -79,10 +72,11 @@ class ArrayContext implements ContextInterface
      *
      * @param \Cake\Network\Request $request The request object.
      * @param array $context Context info.
+     * @param string $requestType The type of request used by the form this context is attached to.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(Request $request, array $context, $requestType)
     {
-        $this->_request = $request;
+        parent::__construct($request, $requestType);
         $context += [
             'schema' => [],
             'required' => [],
@@ -153,7 +147,7 @@ class ArrayContext implements ContextInterface
      */
     public function val($field)
     {
-        $val = $this->_request->data($field);
+        $val = parent::val($field);
         if ($val !== null) {
             return $val;
         }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -42,15 +42,8 @@ use Traversable;
  *   Defaults to 'default'. Can be an array of table alias=>validators when
  *   dealing with associated forms.
  */
-class EntityContext implements ContextInterface
+class EntityContext extends AbstractContext
 {
-
-    /**
-     * The request object.
-     *
-     * @var \Cake\Network\Request
-     */
-    protected $_request;
 
     /**
      * Context data for this object.
@@ -86,10 +79,11 @@ class EntityContext implements ContextInterface
      *
      * @param \Cake\Network\Request $request The request object.
      * @param array $context Context info.
+     * @param string $requestType The type of request used by the form this context is attached to.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(Request $request, array $context, $requestType)
     {
-        $this->_request = $request;
+        parent::__construct($request, $requestType);
         $context += [
             'entity' => null,
             'table' => null,
@@ -205,7 +199,7 @@ class EntityContext implements ContextInterface
      */
     public function val($field)
     {
-        $val = $this->_request->data($field);
+        $val = parent::val($field);
         if ($val !== null) {
             return $val;
         }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -23,25 +23,19 @@ use Cake\Utility\Hash;
  * This context provider simply fulfils the interface requirements
  * that FormHelper has and allows access to the request data.
  */
-class FormContext implements ContextInterface
+class FormContext extends AbstractContext
 {
-
-    /**
-     * The request object.
-     *
-     * @var \Cake\Network\Request
-     */
-    protected $_request;
 
     /**
      * Constructor.
      *
      * @param \Cake\Network\Request $request The request object.
      * @param array $context Context info.
+     * @param string $requestType The type of request used by the form this context is attached to.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(Request $request, array $context, $requestType)
     {
-        $this->_request = $request;
+        parent::__construct($request, $requestType);
         $context += [
             'entity' => null,
         ];
@@ -70,14 +64,6 @@ class FormContext implements ContextInterface
     public function isCreate()
     {
         return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function val($field)
-    {
-        return $this->_request->data($field);
     }
 
     /**

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -22,25 +22,19 @@ use Cake\Network\Request;
  * This context provider simply fulfils the interface requirements
  * that FormHelper has and allows access to the request data.
  */
-class NullContext implements ContextInterface
+class NullContext extends AbstractContext
 {
-
-    /**
-     * The request object.
-     *
-     * @var \Cake\Network\Request
-     */
-    protected $_request;
 
     /**
      * Constructor.
      *
      * @param \Cake\Network\Request $request The request object.
      * @param array $context Context info.
+     * @param string $requestType The type of request used by the form this context is attached to.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(Request $request, array $context, $requestType)
     {
-        $this->_request = $request;
+        parent::__construct($request, $requestType);
     }
 
     /**
@@ -65,14 +59,6 @@ class NullContext implements ContextInterface
     public function isCreate()
     {
         return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function val($field)
-    {
-        return $this->_request->data($field);
     }
 
     /**

--- a/tests/TestCase/View/Form/AbstractContextTest.php
+++ b/tests/TestCase/View/Form/AbstractContextTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Form;
+
+use Cake\Network\Request;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for AbstractContext
+ */
+class AbstractContextTest extends TestCase
+{
+    /**
+     * @dataProvider requestTypeInitializationDataProvider
+     */
+    public function testRequestTypeInitialization($requestType, $create, $expectedRequestType)
+    {
+        $context = new CustomContext(new Request(), $requestType, $create);
+        $this->assertEquals($expectedRequestType, $context->getRequestType());
+    }
+
+    public function requestTypeInitializationDataProvider()
+    {
+        return [
+            [null, false, 'put'],
+            [null, true, 'post'],
+            ['file', false, 'put'],
+            ['file', true, 'post'],
+            ['post', false, 'post'],
+            ['post', true, 'post'],
+            ['get', false, 'get'],
+            ['get', true, 'get']
+        ];
+    }
+
+    /**
+     * @dataProvider valDataProvider
+     */
+    public function testVal(array $data, array $query, $requestType, $expectedValue)
+    {
+        $request = new Request();
+        $request->data = $data;
+        $request->query = $query;
+        $context = new CustomContext($request, $requestType, false);
+        $this->assertEquals($expectedValue, $context->val('field'));
+    }
+
+    public function valDataProvider()
+    {
+        return [
+            [[], [], null, ''],
+            [[], [], 'post', ''],
+            [[], [], 'get', ''],
+            [[], ['field' => 'get'], null, ''],
+            [[], ['field' => 'get'], 'post', ''],
+            [[], ['field' => 'get'], 'get', 'get'],
+            [['field' => 'post'], [], null, 'post'],
+            [['field' => 'post'], [], 'post', 'post'],
+            [['field' => 'post'], [], 'get', ''],
+            [['field' => 'post'], ['field' => 'get'], null, 'post'],
+            [['field' => 'post'], ['field' => 'get'], 'post', 'post'],
+            [['field' => 'post'], ['field' => 'get'], 'get', 'get']
+        ];
+    }
+}

--- a/tests/TestCase/View/Form/CustomContext.php
+++ b/tests/TestCase/View/Form/CustomContext.php
@@ -1,0 +1,51 @@
+<?php
+namespace Cake\Test\TestCase\View\Form;
+
+use Cake\Network\Request;
+use Cake\View\Form\AbstractContext;
+
+class CustomContext extends AbstractContext
+{
+    private $create;
+
+    public function __construct(Request $request, $requestType, $create)
+    {
+        $this->create = $create;
+        parent::__construct($request, $requestType);
+    }
+
+    public function getRequestType()
+    {
+        return $this->_requestType;
+    }
+
+    public function isCreate()
+    {
+        return $this->create;
+    }
+
+    public function primaryKey()
+    {
+    }
+    public function isPrimaryKey($field)
+    {
+    }
+    public function isRequired($field)
+    {
+    }
+    public function fieldNames()
+    {
+    }
+    public function type($field)
+    {
+    }
+    public function hasError($field)
+    {
+    }
+    public function attributes($field)
+    {
+    }
+    public function error($field)
+    {
+    }
+}

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -44,7 +44,7 @@ class FormContextTest extends TestCase
      */
     public function testPrimaryKey()
     {
-        $context = new FormContext($this->request, ['entity' => new Form()]);
+        $context = new FormContext($this->request, ['entity' => new Form()], 'post');
         $this->assertEquals([], $context->primaryKey());
     }
 
@@ -55,7 +55,7 @@ class FormContextTest extends TestCase
      */
     public function testIsPrimaryKey()
     {
-        $context = new FormContext($this->request, ['entity' => new Form()]);
+        $context = new FormContext($this->request, ['entity' => new Form()], 'post');
         $this->assertFalse($context->isPrimaryKey('id'));
     }
 
@@ -66,7 +66,7 @@ class FormContextTest extends TestCase
      */
     public function testIsCreate()
     {
-        $context = new FormContext($this->request, ['entity' => new Form()]);
+        $context = new FormContext($this->request, ['entity' => new Form()], 'post');
         $this->assertTrue($context->isCreate());
     }
 
@@ -81,9 +81,32 @@ class FormContextTest extends TestCase
                 'body' => 'My copy',
             ]
         ];
-        $context = new FormContext($this->request, ['entity' => new Form()]);
+        $context = new FormContext($this->request, ['entity' => new Form()], 'post');
         $this->assertEquals('New title', $context->val('Articles.title'));
         $this->assertEquals('My copy', $context->val('Articles.body'));
+        $this->assertNull($context->val('Articles.nope'));
+    }
+
+    /**
+     * Test reading values from the query
+     */
+    public function testValFromQuery()
+    {
+        $this->request->data = [
+            'Articles' => [
+                'author' => 'Author'
+            ]
+        ];
+        $this->request->query = [
+            'Articles' => [
+                'title' => 'New title',
+                'body' => 'My copy'
+            ]
+        ];
+        $context = new FormContext($this->request, ['entity' => new Form()], 'get');
+        $this->assertEquals('New title', $context->val('Articles.title'));
+        $this->assertEquals('My copy', $context->val('Articles.body'));
+        $this->assertNull($context->val('Articles.author'));
         $this->assertNull($context->val('Articles.nope'));
     }
 
@@ -94,7 +117,7 @@ class FormContextTest extends TestCase
      */
     public function testValMissing()
     {
-        $context = new FormContext($this->request, ['entity' => new Form()]);
+        $context = new FormContext($this->request, ['entity' => new Form()], 'post');
         $this->assertNull($context->val('Comments.field'));
     }
 
@@ -112,7 +135,7 @@ class FormContextTest extends TestCase
 
         $context = new FormContext($this->request, [
             'entity' => $form
-        ]);
+        ], 'post');
         $this->assertTrue($context->isRequired('name'));
         $this->assertTrue($context->isRequired('email'));
         $this->assertFalse($context->isRequired('body'));
@@ -133,7 +156,7 @@ class FormContextTest extends TestCase
 
         $context = new FormContext($this->request, [
             'entity' => $form
-        ]);
+        ], 'post');
         $this->assertNull($context->type('undefined'));
         $this->assertEquals('integer', $context->type('user_id'));
         $this->assertEquals('string', $context->type('email'));
@@ -160,7 +183,7 @@ class FormContextTest extends TestCase
             ]);
         $context = new FormContext($this->request, [
             'entity' => $form
-        ]);
+        ], 'post');
         $this->assertEquals([], $context->attributes('id'));
         $this->assertEquals(['length' => 10, 'precision' => null], $context->attributes('email'));
         $this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('amount'));
@@ -191,7 +214,7 @@ class FormContextTest extends TestCase
             ],
         ]);
 
-        $context = new FormContext($this->request, ['entity' => $form]);
+        $context = new FormContext($this->request, ['entity' => $form], 'post');
         $this->assertEquals([], $context->error('empty'));
         $this->assertEquals(['The provided value is invalid'], $context->error('email'));
         $this->assertEquals(['The provided value is invalid'], $context->error('name'));
@@ -205,7 +228,7 @@ class FormContextTest extends TestCase
             ->willReturn(['key' => 'should be an array, not a string']);
         $form->validator($mock);
         $form->validate([]);
-        $context = new FormContext($this->request, ['entity' => $form]);
+        $context = new FormContext($this->request, ['entity' => $form], 'post');
         $this->assertEquals(
             ['should be an array, not a string'],
             $context->error('key'),
@@ -238,7 +261,7 @@ class FormContextTest extends TestCase
             ],
         ]);
 
-        $context = new FormContext($this->request, ['entity' => $form]);
+        $context = new FormContext($this->request, ['entity' => $form], 'post');
         $this->assertTrue($context->hasError('email'));
         $this->assertTrue($context->hasError('name'));
         $this->assertFalse($context->hasError('nope'));


### PR DESCRIPTION
In older versions of cake, where there was no differentiation between query and post data, data posted to forms having 'method' => 'get' set for their creation would show submitted data upon form reshow (e.g. after a validation error). In CakePHP 3.x however a form's input fields are only populated with the submitted data if it is present in the Request::$data property (not in the Request::$query property).
This PR adds settings the form's type on its context which is then able to correctly return an input field's data either from the requests query or post data.
What do you think about this?
