### PR TITLE
Merge data into existing belongsToMany associations.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -318,9 +318,7 @@ class Marshaller
             $query->andWhere(function ($exp) use ($conditions) {
                 return $exp->or_($conditions);
             });
-        }
 
-        if (isset($query)) {
             $keyFields = array_keys($primaryKey);
 
             $existing = [];
@@ -337,8 +335,10 @@ class Marshaller
                     }
                 }
                 $key = implode(';', $key);
+
+                // Update existing record and child associations
                 if (isset($existing[$key])) {
-                    $records[$i] = $existing[$key];
+                    $records[$i] = $this->merge($existing[$key], $data[$i], $options);
                 }
             }
         }
@@ -351,6 +351,7 @@ class Marshaller
         }
 
         foreach ($records as $i => $record) {
+            // Update junction table data in _joinData.
             if (isset($data[$i]['_joinData'])) {
                 $joinData = $jointMarshaller->one($data[$i]['_joinData'], $nested);
                 $record->set('_joinData', $joinData);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -714,15 +714,18 @@ class MarshallerTest extends TestCase
         $this->assertCount(1, $tag->articles);
         $this->assertInstanceOf('Cake\ORM\Entity', $tag->articles[0]);
         $this->assertSame('New tagged article', $tag->articles[0]->title);
+        $this->assertFalse($tag->articles[0]->isNew());
 
         $this->assertNotEmpty($tag->articles[0]->user);
         $this->assertInstanceOf('Cake\ORM\Entity', $tag->articles[0]->user);
         $this->assertSame('newuser', $tag->articles[0]->user->username);
+        $this->assertTrue($tag->articles[0]->user->isNew());
 
         $this->assertNotEmpty($tag->articles[0]->comments);
         $this->assertCount(2, $tag->articles[0]->comments);
         $this->assertInstanceOf('Cake\ORM\Entity', $tag->articles[0]->comments[0]);
-        $this->assertInstanceOf('Cake\ORM\Entity', $tag->articles[0]->comments[1]);
+        $this->assertTrue($tag->articles[0]->comments[0]->isNew());
+        $this->assertTrue($tag->articles[0]->comments[1]->isNew());
     }
 
     /**


### PR DESCRIPTION
When creating a new entity that is linked to existing belongsToMany records, we should merge request data into the existing entities. Failing to do so makes it hard to create a new record, link it to an existing record and update the existing record and its associations at the same time.

Refs #8082
