### PR TITLE
Reject controller names that are not camel case.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -237,7 +237,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         if ($this->name === null && isset($request->params['controller'])) {
-            $this->name = Inflector::camelize($request->params['controller']);
+            $this->name = $request->params['controller'];
         }
 
         if ($this->name === null) {

--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -74,7 +74,12 @@ class ControllerFactoryFilter extends DispatcherFilter
             );
             $namespace .= '/' . implode('/', $prefixes);
         }
-        if (strpos($controller, '\\') !== false || strpos($controller, '.') !== false) {
+        $firstChar = substr($controller, 0, 1);
+        if (
+            strpos($controller, '\\') !== false ||
+            strpos($controller, '.') !== false ||
+            $firstChar === strtolower($firstChar)
+        ) {
             return false;
         }
         $className = false;

--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -75,8 +75,7 @@ class ControllerFactoryFilter extends DispatcherFilter
             $namespace .= '/' . implode('/', $prefixes);
         }
         $firstChar = substr($controller, 0, 1);
-        if (
-            strpos($controller, '\\') !== false ||
+        if (strpos($controller, '\\') !== false ||
             strpos($controller, '.') !== false ||
             $firstChar === strtolower($firstChar)
         ) {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -359,12 +359,6 @@ class ControllerTest extends TestCase
         $this->assertEquals('Posts', $controller->modelClass);
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
-        $request->params['controller'] = 'posts';
-        $controller = new \TestApp\Controller\PostsController($request, $response);
-        $this->assertEquals('Posts', $controller->modelClass);
-        $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
-        unset($request->params['controller']);
-
         $controller = new \TestApp\Controller\Admin\PostsController($request, $response);
         $this->assertEquals('Posts', $controller->modelClass);
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -303,6 +303,30 @@ class DispatcherTest extends TestCase
     }
 
     /**
+     * Test that lowercase controller names result in missing controller errors.
+     *
+     * In case-insensitive file systems, lowercase controller names will kind of work.
+     * This causes annoying deployment issues for lots of folks.
+     *
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class somepages could not be found.
+     * @return void
+     */
+    public function testMissingControllerLowercase()
+    {
+        $request = new Request([
+            'url' => 'pages/home',
+            'params' => [
+                'controller' => 'somepages',
+                'action' => 'display',
+                'pass' => ['home'],
+            ]
+        ]);
+        $response = $this->getMock('Cake\Network\Response');
+        $this->dispatcher->dispatch($request, $response, ['return' => 1]);
+    }
+
+    /**
      * testDispatch method
      *
      * @return void
@@ -477,7 +501,7 @@ class DispatcherTest extends TestCase
         $request = new Request([
             'url' => '/',
             'params' => [
-                'controller' => 'pages',
+                'controller' => 'Pages',
                 'action' => 'display',
                 'home',
                 'pass' => []


### PR DESCRIPTION
Controller names that are not CamelCase cause a few issues downstream:
1. They don't work on case-sensitive filesystems.
2. They cause Controller::$name and Controller::$modelClass to be wrong.

To help reduce these cryptic and environment sensitive issues we reject all controller names that start with a lower case letter.

Refs #8091
Refs #8085
