### PR TITLE
Only update autoFields() if it is undefined.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1215,7 +1215,6 @@ class BelongsToMany extends Association
             ->where($this->junctionConditions())
             ->select($query->aliasFields((array)$assoc->foreignKey(), $name));
 
-
         $assoc->attachTo($query);
         return $query;
     }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1204,12 +1204,17 @@ class BelongsToMany extends Association
         }
 
         $query = $this->_appendJunctionJoin($query, []);
+
+        if ($query->autoFields() === null) {
+            $query->autoFields($query->clause('select') === []);
+        }
+
         // Ensure that association conditions are applied
         // and that the required keys are in the selected columns.
         $query
             ->where($this->junctionConditions())
-            ->autoFields($query->clause('select') === [])
             ->select($query->aliasFields((array)$assoc->foreignKey(), $name));
+
 
         $assoc->attachTo($query);
         return $query;

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -981,6 +981,27 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that fetching belongsToMany association will retain autoFields(true) if it was used.
+     *
+     * @see https://github.com/cakephp/cakephp/issues/8052
+     * @return void
+     */
+    public function testEagerLoadingBelongsToManyLimitedFieldsWithAutoFields()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags');
+        $result = $table
+            ->find()
+            ->contain(['Tags' => function ($q) {
+                return $q->select(['two' => '1 + 1'])->autoFields(true);
+            }])
+            ->first();
+
+        $this->assertNotEmpty($result->tags[0]->two, 'Should have computed field');
+        $this->assertNotEmpty($result->tags[0]->name, 'Should have standard field');
+    }
+
+    /**
      * Test that association proxy find() applies joins when conditions are involved.
      *
      * @return void

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -993,7 +993,7 @@ class BelongsToManyTest extends TestCase
         $result = $table
             ->find()
             ->contain(['Tags' => function ($q) {
-                return $q->select(['two' => '1 + 1'])->autoFields(true);
+                return $q->select(['two' => $q->newExpr('1 + 1')])->autoFields(true);
             }])
             ->first();
 


### PR DESCRIPTION
If a query builder has enabled/disabled autoFields() we should preserve the developer's choice.

Refs #8052
