### PR TITLE
FormContext: Cast Hash::get() value to force array.

### DIFF
--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -135,6 +135,6 @@ class FormContext implements ContextInterface
      */
     public function error($field)
     {
-        return array_values(Hash::get($this->_form->errors(), $field, []));
+        return array_values((array)Hash::get($this->_form->errors(), $field, []));
     }
 }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -196,9 +196,21 @@ class FormContextTest extends TestCase
         $this->assertEquals(['The provided value is invalid'], $context->error('email'));
         $this->assertEquals(['The provided value is invalid'], $context->error('name'));
         $this->assertEquals(['The provided value is invalid'], $context->error('pass.password'));
-
         $this->assertEquals([], $context->error('Alias.name'));
         $this->assertEquals([], $context->error('nope.nope'));
+
+        $mock = $this->getMock('Cake\Validation\Validator', ['errors']);
+        $mock->expects($this->once())
+            ->method('errors')
+            ->willReturn(['key' => 'should be an array, not a string']);
+        $form->validator($mock);
+        $form->validate([]);
+        $context = new FormContext($this->request, ['entity' => $form]);
+        $this->assertEquals(
+            ['should be an array, not a string'],
+            $context->error('key'),
+            'This test should not produce a PHP warning from array_values().'
+        );
     }
 
     /**


### PR DESCRIPTION
Corrects an error introduced in my previous PR, #7796. In some cases (I haven't been able to determine the exact cause) the value of a field's `$errors` may be a string instead of an array. When `Hash::get()` returns a string, it makes `array_values()` unhappy and produces PHP warnings like this:

```
Warning Error: array_values() expects parameter 1 to be array, string given in 
[ROOT/vendor/cakephp/cakephp/src/View/Form/FormContext.php, line 138]
```

This PR casts the returned value to an array to guarantee compatible input for `array_values()`.
