### PR TITLE
Declare splits as stable.

### DIFF
--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -15,6 +15,5 @@
     },
     "require": {
         "cakephp/core": "~3.0"
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/Collection/composer.json
+++ b/src/Collection/composer.json
@@ -13,6 +13,5 @@
             "Cake\\Collection\\": "."
         },
         "files": ["functions.php"]
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -16,6 +16,5 @@
             "Cake\\Core\\": "."
         },
         "files": ["functions.php"]
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -20,6 +20,5 @@
         "psr-4": {
             "Cake\\Database\\": "."
         }
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -19,6 +19,5 @@
         "psr-4": {
             "Cake\\Datasource\\": "."
         }
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/Event/composer.json
+++ b/src/Event/composer.json
@@ -12,6 +12,5 @@
         "psr-4": {
             "Cake\\Event\\": "."
         }
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -22,6 +22,5 @@
     },
     "suggest": {
         "cakephp/cache": "Require this if you want automatic caching of translators"
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -16,6 +16,5 @@
     "require": {
         "cakephp/core": "~3.0",
         "psr/log": "1.0"
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -24,6 +24,5 @@
     },
     "suggest": {
         "cakephp/i18n": "~3.0"
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -13,6 +13,5 @@
             "Cake\\Utility\\": "."
         },
         "files": ["bootstrap.php"]
-    },
-    "minimum-stability": "beta"
+    }
 }

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -15,6 +15,5 @@
     },
     "require": {
         "cakephp/utility": "~3.0"
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Currently using the split offs as standalone sounds like an unsafe approach considering the beta/dev status.
This will hopefully make users looking into the split off libs more confident using them.

Any down-sides?
