### PR TITLE
Phpdoc fixes

### DIFF
--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -218,7 +218,7 @@ class ConsoleOptionParser {
  * Get or set the command name for shell/task.
  *
  * @param string $text The text to set, or null if you want to read
- * @return string|$this If reading, the value of the command. If setting $this will be returned.
+ * @return string|self If reading, the value of the command. If setting $this will be returned.
  */
 	public function command($text = null) {
 		if ($text !== null) {
@@ -233,7 +233,7 @@ class ConsoleOptionParser {
  *
  * @param string|array $text The text to set, or null if you want to read. If an array the
  *   text will be imploded with "\n"
- * @return string|$this If reading, the value of the description. If setting $this will be returned.
+ * @return string|self If reading, the value of the description. If setting $this will be returned.
  */
 	public function description($text = null) {
 		if ($text !== null) {
@@ -251,7 +251,7 @@ class ConsoleOptionParser {
  * the options and arguments listing when help is generated.
  *
  * @param string|array $text Text when setting or null when reading. If an array the text will be imploded with "\n"
- * @return string|$this If reading, the value of the epilog. If setting $this will be returned.
+ * @return string|self If reading, the value of the epilog. If setting $this will be returned.
  */
 	public function epilog($text = null) {
 		if ($text !== null) {
@@ -284,7 +284,7 @@ class ConsoleOptionParser {
  * @param ConsoleInputOption|string $name The long name you want to the value to be parsed out as when options are parsed.
  *   Will also accept an instance of ConsoleInputOption
  * @param array $options An array of parameters that define the behavior of the option
- * @return $this
+ * @return self
  */
 	public function addOption($name, $options = array()) {
 		if (is_object($name) && $name instanceof ConsoleInputOption) {
@@ -324,7 +324,7 @@ class ConsoleOptionParser {
  *
  * @param ConsoleInputArgument|string $name The name of the argument. Will also accept an instance of ConsoleInputArgument
  * @param array $params Parameters for the argument, see above.
- * @return $this
+ * @return self
  */
 	public function addArgument($name, $params = array()) {
 		if (is_object($name) && $name instanceof ConsoleInputArgument) {
@@ -354,7 +354,7 @@ class ConsoleOptionParser {
  *
  * @param array $args Array of arguments to add.
  * @see ConsoleOptionParser::addArgument()
- * @return $this
+ * @return self
  */
 	public function addArguments(array $args) {
 		foreach ($args as $name => $params) {
@@ -369,7 +369,7 @@ class ConsoleOptionParser {
  *
  * @param array $options Array of options to add.
  * @see ConsoleOptionParser::addOption()
- * @return $this
+ * @return self
  */
 	public function addOptions(array $options) {
 		foreach ($options as $name => $params) {
@@ -391,7 +391,7 @@ class ConsoleOptionParser {
  *
  * @param ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
  * @param array $options Array of params, see above.
- * @return $this
+ * @return self
  */
 	public function addSubcommand($name, $options = array()) {
 		if (is_object($name) && $name instanceof ConsoleInputSubcommand) {
@@ -414,7 +414,7 @@ class ConsoleOptionParser {
  * Remove a subcommand from the option parser.
  *
  * @param string $name The subcommand name to remove.
- * @return $this
+ * @return self
  */
 	public function removeSubcommand($name) {
 		unset($this->_subcommands[$name]);
@@ -425,7 +425,7 @@ class ConsoleOptionParser {
  * Add multiple subcommands at once.
  *
  * @param array $commands Array of subcommands.
- * @return $this
+ * @return self
  */
 	public function addSubcommands(array $commands) {
 		foreach ($commands as $name => $params) {
@@ -469,7 +469,7 @@ class ConsoleOptionParser {
  * @param array $argv Array of args (argv) to parse.
  * @param string $command The subcommand to use. If this parameter is a subcommand, that has a parser,
  *    That parser will be used to parse $argv instead.
- * @return Array array($params, $args)
+ * @return array array($params, $args)
  * @throws ConsoleException When an invalid parameter is encountered.
  */
 	public function parse($argv, $command = null) {

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -89,7 +89,7 @@ class AuthComponent extends Component {
 /**
  * Objects that will be used for authentication checks.
  *
- * @var array
+ * @var BaseAuthenticate[]
  */
 	protected $_authenticateObjects = array();
 
@@ -129,7 +129,7 @@ class AuthComponent extends Component {
 /**
  * Objects that will be used for authorization checks.
  *
- * @var array
+ * @var BaseAuthorize[]
  */
 	protected $_authorizeObjects = array();
 
@@ -653,7 +653,7 @@ class AuthComponent extends Component {
  * cookies + sessions will be used.
  *
  * @param string $key field to retrieve. Leave null to get entire User record
- * @return array|null User record. or null if no user is logged in.
+ * @return mixed|null User record. or null if no user is logged in.
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#accessing-the-logged-in-user
  */
 	public static function user($key = null) {

--- a/lib/Cake/Event/CakeEvent.php
+++ b/lib/Cake/Event/CakeEvent.php
@@ -102,7 +102,7 @@ class CakeEvent {
 /**
  * Returns the subject of this event
  *
- * @return string
+ * @return object
  */
 	public function subject() {
 		return $this->_subject;

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -363,7 +363,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * Sets the I18n domain for validation messages. This method is chainable.
  *
  * @param string $validationDomain [optional] The validation domain to be used.
- * @return $this
+ * @return self
  */
 	public function setValidationDomain($validationDomain = null) {
 		if (empty($validationDomain)) {
@@ -549,7 +549,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * @param string $field The name of the field where the rule is to be added
  * @param string|array|CakeValidationSet $name name of the rule to be added or list of rules for the field
  * @param array|CakeValidationRule $rule or list of rules to be added to the field's rule set
- * @return $this
+ * @return self
  */
 	public function add($field, $name, $rule = null) {
 		$this->_parseRules();
@@ -588,7 +588,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  *
  * @param string $field The name of the field from which the rule will be removed
  * @param string $rule the name of the rule to be removed
- * @return $this
+ * @return self
  */
 	public function remove($field, $rule = null) {
 		$this->_parseRules();

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -36,7 +36,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Holds the CakeValidationSet objects array
  *
- * @var array
+ * @var CakeValidationSet[]
  */
 	protected $_fields = array();
 
@@ -386,7 +386,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * Processes the passed fieldList and returns the list of fields to be validated
  *
  * @param array $fieldList list of fields to be used for validation
- * @return array List of validation rules to be applied
+ * @return CakeValidationSet[] List of validation rules to be applied
  */
 	protected function _validationList($fieldList = array()) {
 		if (empty($fieldList) || Hash::dimensions($fieldList) > 1) {

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -191,7 +191,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *
  * @param string $name The name under which the rule should be set
  * @param CakeValidationRule|array $rule The validation rule to be set
- * @return $this
+ * @return self
  */
 	public function setRule($name, $rule) {
 		if (!($rule instanceof CakeValidationRule)) {
@@ -213,7 +213,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * ```
  *
  * @param string $name The name under which the rule should be unset
- * @return $this
+ * @return self
  */
 	public function removeRule($name) {
 		unset($this->_rules[$name]);
@@ -234,7 +234,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *
  * @param array $rules The rules to be set
  * @param bool $mergeVars [optional] If true, merges vars instead of replace. Defaults to true.
- * @return $this
+ * @return self
  */
 	public function setRules($rules = array(), $mergeVars = true) {
 		if ($mergeVars === false) {

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -32,7 +32,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Holds the CakeValidationRule objects
  *
- * @var array
+ * @var CakeValidationRule[]
  */
 	protected $_rules = array();
 
@@ -172,7 +172,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Returns all rules for this validation set
  *
- * @return array
+ * @return CakeValidationRule[]
  */
 	public function getRules() {
 		return $this->_rules;

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -695,7 +695,7 @@ class CakeRequest implements ArrayAccess {
  * This modifies the parameters available through `$request->params`.
  *
  * @param array $params Array of parameters to merge in
- * @return $this
+ * @return self
  */
 	public function addParams($params) {
 		$this->params = array_merge($this->params, (array)$params);
@@ -707,7 +707,7 @@ class CakeRequest implements ArrayAccess {
  * Provides an easy way to modify, here, webroot and base.
  *
  * @param array $paths Array of paths to merge in
- * @return $this
+ * @return self
  */
 	public function addPaths($paths) {
 		foreach (array('webroot', 'here', 'base') as $element) {
@@ -948,7 +948,7 @@ class CakeRequest implements ArrayAccess {
  * will be created for you.
  *
  * @param string $name Dot separated name of the value to read/write, one or more args.
- * @return mixed|$this Either the value being read, or $this so you can chain consecutive writes.
+ * @return mixed|self Either the value being read, or $this so you can chain consecutive writes.
  */
 	public function data($name) {
 		$args = func_get_args();

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -339,7 +339,7 @@ class CakeEmail {
 /**
  * An instance of the EmailConfig class can be set here
  *
- * @var string
+ * @var EmailConfig
  */
 	protected $_configInstance;
 
@@ -1204,6 +1204,7 @@ class CakeEmail {
  */
 	public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'fast', $send = true) {
 		$class = __CLASS__;
+		/** @var CakeEmail $instance */
 		$instance = new $class($transportConfig);
 		if ($to !== null) {
 			$instance->to($to);
@@ -1673,6 +1674,7 @@ class CakeEmail {
 			App::uses($viewClass, $plugin . 'View');
 		}
 
+		/** @var View $View */
 		$View = new $viewClass(null);
 		$View->viewVars = $this->_viewVars;
 		$View->helpers = $this->_helpers;

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -457,7 +457,7 @@ class CakeEmail {
  * @param string|array $email Null to get, String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return array|CakeEmail
+ * @return array|self
  */
 	public function to($email = null, $name = null) {
 		if ($email === null) {
@@ -472,7 +472,7 @@ class CakeEmail {
  * @param string|array $email Null to get, String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return $this
+ * @return self
  */
 	public function addTo($email, $name = null) {
 		return $this->_addEmail('_to', $email, $name);
@@ -484,7 +484,7 @@ class CakeEmail {
  * @param string|array $email Null to get, String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return array|CakeEmail
+ * @return array|self
  */
 	public function cc($email = null, $name = null) {
 		if ($email === null) {
@@ -499,7 +499,7 @@ class CakeEmail {
  * @param string|array $email Null to get, String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return $this
+ * @return self
  */
 	public function addCc($email, $name = null) {
 		return $this->_addEmail('_cc', $email, $name);
@@ -511,7 +511,7 @@ class CakeEmail {
  * @param string|array $email Null to get, String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return array|CakeEmail
+ * @return array|self
  */
 	public function bcc($email = null, $name = null) {
 		if ($email === null) {
@@ -526,7 +526,7 @@ class CakeEmail {
  * @param string|array $email Null to get, String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return $this
+ * @return self
  */
 	public function addBcc($email, $name = null) {
 		return $this->_addEmail('_bcc', $email, $name);
@@ -568,7 +568,7 @@ class CakeEmail {
  * @param string|bool|null $regex The pattern to use for email address validation,
  *   null to unset the pattern and make use of filter_var() instead, false or
  *   nothing to return the current value
- * @return string|$this
+ * @return string|self
  */
 	public function emailPattern($regex = false) {
 		if ($regex === false) {
@@ -585,7 +585,7 @@ class CakeEmail {
  * @param string|array $email String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return $this
+ * @return self
  */
 	protected function _setEmail($varName, $email, $name) {
 		if (!is_array($email)) {
@@ -634,7 +634,7 @@ class CakeEmail {
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
  * @param string $throwMessage Exception message
- * @return $this
+ * @return self
  * @throws SocketException
  */
 	protected function _setEmailSingle($varName, $email, $name, $throwMessage) {
@@ -654,7 +654,7 @@ class CakeEmail {
  * @param string|array $email String with email,
  *   Array with email as key, name as value or email as value (without name)
  * @param string $name Name
- * @return $this
+ * @return self
  * @throws SocketException
  */
 	protected function _addEmail($varName, $email, $name) {
@@ -682,7 +682,7 @@ class CakeEmail {
  * Get/Set Subject.
  *
  * @param string $subject Subject string.
- * @return string|$this
+ * @return string|self
  */
 	public function subject($subject = null) {
 		if ($subject === null) {
@@ -696,7 +696,7 @@ class CakeEmail {
  * Sets headers for the message
  *
  * @param array $headers Associative array containing headers to be set.
- * @return $this
+ * @return self
  * @throws SocketException
  */
 	public function setHeaders($headers) {
@@ -711,7 +711,7 @@ class CakeEmail {
  * Add header for the message
  *
  * @param array $headers Headers to set.
- * @return $this
+ * @return self
  * @throws SocketException
  */
 	public function addHeaders($headers) {
@@ -844,7 +844,7 @@ class CakeEmail {
  *
  * @param bool|string $template Template name or null to not use
  * @param bool|string $layout Layout name or null to not use
- * @return array|$this
+ * @return array|self
  */
 	public function template($template = false, $layout = false) {
 		if ($template === false) {
@@ -864,7 +864,7 @@ class CakeEmail {
  * View class for render
  *
  * @param string $viewClass View class name.
- * @return string|$this
+ * @return string|self
  */
 	public function viewRender($viewClass = null) {
 		if ($viewClass === null) {
@@ -878,7 +878,7 @@ class CakeEmail {
  * Variables to be set on render
  *
  * @param array $viewVars Variables to set for view.
- * @return array|$this
+ * @return array|self
  */
 	public function viewVars($viewVars = null) {
 		if ($viewVars === null) {
@@ -892,7 +892,7 @@ class CakeEmail {
  * Theme to use when rendering
  *
  * @param string $theme Theme name.
- * @return string|$this
+ * @return string|self
  */
 	public function theme($theme = null) {
 		if ($theme === null) {
@@ -906,7 +906,7 @@ class CakeEmail {
  * Helpers to be used in render
  *
  * @param array $helpers Helpers list.
- * @return array|$this
+ * @return array|self
  */
 	public function helpers($helpers = null) {
 		if ($helpers === null) {
@@ -920,7 +920,7 @@ class CakeEmail {
  * Email format
  *
  * @param string $format Formatting string.
- * @return string|$this
+ * @return string|self
  * @throws SocketException
  */
 	public function emailFormat($format = null) {
@@ -938,7 +938,7 @@ class CakeEmail {
  * Transport name
  *
  * @param string $name Transport name.
- * @return string|$this
+ * @return string|self
  */
 	public function transport($name = null) {
 		if ($name === null) {
@@ -975,7 +975,7 @@ class CakeEmail {
  * Message-ID
  *
  * @param bool|string $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
- * @return bool|string|$this
+ * @return bool|string|self
  * @throws SocketException
  */
 	public function messageId($message = null) {
@@ -997,7 +997,7 @@ class CakeEmail {
  * Domain as top level (the part after @)
  *
  * @param string $domain Manually set the domain for CLI mailing
- * @return string|$this
+ * @return string|self
  */
 	public function domain($domain = null) {
 		if ($domain === null) {
@@ -1051,7 +1051,7 @@ class CakeEmail {
  * attachment compatibility with outlook email clients.
  *
  * @param string|array $attachments String with the filename or array with filenames
- * @return array|$this Either the array of attachments when getting or $this when setting.
+ * @return array|self Either the array of attachments when getting or $this when setting.
  * @throws SocketException
  */
 	public function attachments($attachments = null) {
@@ -1094,7 +1094,7 @@ class CakeEmail {
  * Add attachments
  *
  * @param string|array $attachments String with the filename or array with filenames
- * @return $this
+ * @return self
  * @throws SocketException
  * @see CakeEmail::attachments()
  */
@@ -1135,7 +1135,7 @@ class CakeEmail {
  * `$email->config(array('to' => 'bill@example.com'));`
  *
  * @param string|array $config String with configuration name (from email.php), array with config or null to return current config
- * @return string|array|$this
+ * @return string|array|self
  */
 	public function config($config = null) {
 		if ($config === null) {
@@ -1199,7 +1199,7 @@ class CakeEmail {
  * @param string|array $message String with message or array with variables to be used in render
  * @param string|array $transportConfig String to use config from EmailConfig or array with configs
  * @param bool $send Send the email or just return the instance pre-configured
- * @return CakeEmail Instance of CakeEmail
+ * @return self Instance of CakeEmail
  * @throws SocketException
  */
 	public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'fast', $send = true) {
@@ -1285,7 +1285,7 @@ class CakeEmail {
 /**
  * Reset all CakeEmail internal variables to be able to send out a new email.
  *
- * @return $this
+ * @return self
  */
 	public function reset() {
 		$this->_to = array();

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -174,7 +174,7 @@ class HtmlHelper extends AppHelper {
  * @param string $name Text for link
  * @param string $link URL for link (if empty it won't be a link)
  * @param string|array $options Link attributes e.g. array('id' => 'selected')
- * @return $this
+ * @return self
  * @see HtmlHelper::link() for details on $options that can be used.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */

--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -145,7 +145,7 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
  * Create javascript selector for a CSS rule
  *
  * @param string $selector The selector that is targeted
- * @return $this
+ * @return self
  */
 	public function get($selector) {
 		if ($selector === 'window' || $selector === 'document') {

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -285,7 +285,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
  * Create javascript selector for a CSS rule
  *
  * @param string $selector The selector that is targeted
- * @return JsBaseEngineHelper instance of $this. Allows chained methods.
+ * @return self instance of $this. Allows chained methods.
  */
 	abstract public function get($selector);
 

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -118,7 +118,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
  * Create javascript selector for a CSS rule
  *
  * @param string $selector The selector that is targeted
- * @return $this
+ * @return self
  */
 	public function get($selector) {
 		$this->_multipleSelection = false;

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -114,7 +114,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
  * Create javascript selector for a CSS rule
  *
  * @param string $selector The selector that is targeted
- * @return $this
+ * @return self
  */
 	public function get($selector) {
 		$this->_multiple = false;


### PR DESCRIPTION
Replace `@return $this` to `@return self` as recommended by PhpDoc. This fixes chained method calls in PHPStorm and possibly other IDEs.

Also update `array` to `ClassName[]` where possible, this also helps to autocomplete.

Update few incorrect datatypes.
