### PR TITLE
Better handling of json_encode failure, especially in debug mode

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -184,7 +184,6 @@ class ExceptionRenderer
                 'format' => 'array',
                 'args' => false
             ]);
-            $viewVars['_serialize'][] = 'trace';
         }
         $this->controller->set($viewVars);
 

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1012,7 +1012,7 @@ class Email implements JsonSerializable, Serializable
             $className = App::className($config['className'], 'Network/Email', 'Transport');
             trigger_error(
                 'Transports in "Network/Email" are deprecated, use "Mailer/Transport" instead.',
-                E_USER_WARNING
+                E_USER_DEPRECATED
             );
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1020,7 +1020,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (isset($options['idField'])) {
             $options['keyField'] = $options['idField'];
             unset($options['idField']);
-            trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_WARNING);
+            trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_DEPRECATED);
         }
 
         if (!$query->clause('select') &&
@@ -1086,7 +1086,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (isset($options['idField'])) {
             $options['keyField'] = $options['idField'];
             unset($options['idField']);
-            trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_WARNING);
+            trigger_error('Option "idField" is deprecated, use "keyField" instead.', E_USER_DEPRECATED);
         }
 
         $options = $this->_setFieldMatchers($options, ['keyField', 'parentField']);

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -132,7 +132,7 @@ class JsonView extends SerializedView
      *
      * @param array|string|bool $serialize The name(s) of the view variable(s)
      *   that need(s) to be serialized. If true all available view variables.
-     * @return string The serialized data
+     * @return string|false The serialized data, or boolean false if not serializable.
      */
     protected function _serialize($serialize)
     {

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -88,16 +88,6 @@ class SerializedView extends View
         if ($serialize !== false) {
             $result = $this->_serialize($serialize);
             if ($result === false) {
-                if (Configure::read('debug') && in_array('trace', $serialize)) {
-                    $keys = array_keys($serialize, 'trace');
-                    foreach ($keys as $key) {
-                        unset($serialize[$key]);
-                    }
-                    $result = $this->_serialize($serialize);
-                    if ($result !== false) {
-                        return $result;
-                    }
-                }
                 throw new RuntimeException('Serialization of View data failed.');
             }
             return (string)$result;

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -17,6 +17,7 @@ namespace Cake\View;
 use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\Core\Configure;
 
 /**
  * Parent class for view classes generating serialized outputs like JsonView and XmlView.
@@ -84,8 +85,23 @@ class SerializedView extends View
         }
 
         if ($serialize !== false) {
-            return $this->_serialize($serialize);
-        } elseif ($view !== false && $this->_getViewFileName($view)) {
+            $result = $this->_serialize($serialize);
+            if ($result === false) {
+                if (Configure::read('debug') && in_array('trace', $serialize)) {
+                    $keys = array_keys($serialize, 'trace');
+                    foreach ($keys as $key) {
+                        unset($serialize[$key]);
+                    }
+                    $result = $this->_serialize($serialize);
+                    if ($result !== false) {
+                        return $result;
+                    }
+                }
+                trigger_error('Serialization of View data failed.');
+            }
+            return (string)$result;
+        }
+        if ($view !== false && $this->_getViewFileName($view)) {
             return parent::render($view, false);
         }
     }

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\View;
 
+use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
-use Cake\Core\Configure;
 use RuntimeException;
 
 /**

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -18,6 +18,7 @@ use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Core\Configure;
+use RuntimeException;
 
 /**
  * Parent class for view classes generating serialized outputs like JsonView and XmlView.
@@ -97,7 +98,7 @@ class SerializedView extends View
                         return $result;
                     }
                 }
-                trigger_error('Serialization of View data failed.');
+                throw new RuntimeException('Serialization of View data failed.');
             }
             return (string)$result;
         }


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/8130

Currently you get a white screen of death in debug mode and if json_encode doesnt like your stacktrace.
This removes the stacktrace and tries again.
As last resort at least a trigger_error() call gives the developer a hint what is going on.

I needed quite a while to track the issue down to the root cause, and luckily had a debugger to step through, otherwise it would have been close to impossible..
