### PR TITLE
Use safer methods to read session configuration.

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -345,12 +345,13 @@ class CakeSession {
  * @return bool
  */
 	protected static function _validAgentAndTime() {
-		$config = static::read('Config');
+		$userAgent = static::read('Config.userAgent');
+		$time = static::read('Config.time');
 		$validAgent = (
 			Configure::read('Session.checkAgent') === false ||
-			isset($config['userAgent']) && static::$_userAgent === $config['userAgent']
+			isset($userAgent) && static::$_userAgent === $userAgent
 		);
-		return ($validAgent && static::$time <= $config['time']);
+		return ($validAgent && static::$time <= $time);
 	}
 
 /**


### PR DESCRIPTION
Avoid potential undefined index warnings by using read() to safely fetch data.

Refs #8101
