### PR TITLE
Update ControllerFactoryFilter.php

### DIFF
--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -68,7 +68,11 @@ class ControllerFactoryFilter extends DispatcherFilter
             $controller = $request->params['controller'];
         }
         if (!empty($request->params['prefix'])) {
-            $namespace .= '/' . $request->params['prefix'];
+            $prefixes = array_map(
+                'Cake\Utility\Inflector::camelize',
+                explode('/', $request->params['prefix'])
+            );
+            $namespace .= '/' . implode('/', $prefixes);
         }
         $firstChar = substr($controller, 0, 1);
         if (strpos($controller, '\\') !== false ||


### PR DESCRIPTION
prefix Routing failed if file system is case sensitive (only on server, not in mamp or localhost),
class_exists is not case sensitive by checking an existing class,
but the used autoloader seems to be case sensitive.
I used prefix-Routing and the prefix is lowercase and the autoloader needs to get the CamelCased version of prefix.
