### PR TITLE
Fix incorrect data types being returned in matching data

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -719,8 +719,8 @@ abstract class Association
 
         if (!empty($fields)) {
             $query->select($query->aliasFields($fields, $target->alias()));
-            $query->addDefaultTypes($target);
         }
+        $query->addDefaultTypes($target);
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -699,13 +699,13 @@ abstract class Association
      */
     protected function _appendFields($query, $surrogate, $options)
     {
-        $fields = $surrogate->clause('select') ?: $options['fields'];
-        $target = $this->_targetTable;
-        $autoFields = $surrogate->autoFields();
-
         if ($query->eagerLoader()->autoFields() === false) {
             return;
         }
+
+        $fields = $surrogate->clause('select') ?: $options['fields'];
+        $target = $this->_targetTable;
+        $autoFields = $surrogate->autoFields();
 
         if (empty($fields) && !$autoFields) {
             if ($options['includeFields'] && ($fields === null || $fields !== false)) {
@@ -719,6 +719,7 @@ abstract class Association
 
         if (!empty($fields)) {
             $query->select($query->aliasFields($fields, $target->alias()));
+            $query->addDefaultTypes($target);
         }
     }
 

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -170,6 +170,12 @@ class BelongsToTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $query->clause('join'));
+
+        $this->assertEquals(
+            'integer',
+            $query->typeMap()->type('Companies__id'),
+            'Associations should map types.'
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -125,6 +125,12 @@ class HasOneTest extends TestCase
             'Profiles__user_id' => 'Profiles.user_id'
         ]);
         $association->attachTo($query);
+
+        $this->assertEquals(
+            'string',
+            $query->typeMap()->type('Profiles__first_name'),
+            'Associations should map types.'
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -170,7 +170,7 @@ class EagerLoaderTest extends TestCase
                 'type' => 'LEFT',
                 'conditions' => new QueryExpression([
                     ['clients.id' => new IdentifierExpression('foo.client_id')],
-                ], $this->clientsTypeMap)
+                ], new TypeMap($this->clientsTypeMap->defaults()))
             ]])
             ->will($this->returnValue($query));
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
+use Cake\I18n\Time;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
@@ -655,28 +656,32 @@ class QueryTest extends TestCase
     public function testFilteringByHasManyNoHydration()
     {
         $query = new Query($this->connection, $this->table);
-        $table = TableRegistry::get('authors');
-        TableRegistry::get('articles');
-        $table->hasMany('articles');
+        $table = TableRegistry::get('Articles');
+        $table->hasMany('Comments');
 
         $results = $query->repository($table)
             ->select()
             ->hydrate(false)
-            ->matching('articles', function ($q) {
-                return $q->where(['articles.id' => 2]);
+            ->matching('Comments', function ($q) {
+                return $q->where(['Comments.user_id' => 4]);
             })
             ->toArray();
         $expected = [
             [
-                'id' => 3,
-                'name' => 'larry',
+                'id' => 1,
+                'title' => 'First Article',
+                'body' => 'First Article Body',
+                'author_id' => 1,
+                'published' => 'Y',
                 '_matchingData' => [
-                    'articles' => [
+                    'Comments' => [
                         'id' => 2,
-                        'title' => 'Second Article',
-                        'body' => 'Second Article Body',
-                        'author_id' => 3,
+                        'article_id' => 1,
+                        'user_id' => 4,
+                        'comment' => 'Second Comment for First Article',
                         'published' => 'Y',
+                        'created' => '2007-03-18 10:47:23',
+                        'updated' => '2007-03-18 10:49:31',
                     ]
                 ]
             ]


### PR DESCRIPTION
This fixes the incorrect datatypes being returned in `_matchingData` and other attached association data. This wasn't caught by the tests earlier, as the query tests don't use many datetimes, and furthermore rely on `assertEquals()` which does type coercion on scalars.

Refs #8147
