### PR TITLE
Preserve Translation data in result formatter.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -457,6 +457,9 @@ class TranslateBehavior extends Behavior
                 return $row;
             }
             $translations = (array)$row->get('_i18n');
+            if (empty($translations) && $row->get('_translations')) {
+                return $row;
+            }
             $grouped = new Collection($translations);
 
             $result = [];

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -138,6 +138,35 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
+     * Test that iterating in a formatResults() does not drop data.
+     *
+     * @return void
+     */
+    public function testFindTranslationsFormatResultsIteration()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $table->locale('eng');
+        $results = $table->find('translations')
+            ->limit(1)
+            ->formatResults(function ($results) {
+                foreach ($results as $res) {
+                    $res->first = 'val';
+                }
+                foreach ($results as $res) {
+                    $res->second = 'loop';
+                }
+                return $results;
+            })
+            ->toArray();
+        $this->assertCount(1, $results);
+        $this->assertSame('Title #1', $results[0]->title);
+        $this->assertSame('val', $results[0]->first);
+        $this->assertSame('loop', $results[0]->second);
+        $this->assertNotEmpty($results[0]->_translations);
+    }
+
+    /**
      * Tests that fields from a translated model use the I18n class locale
      * and that it propogates to associated models
      *


### PR DESCRIPTION
When results are iterated in a result formatter, the _translations property would get wiped as the groupTranslations formatter would be invoked each time the results were iterated.

Refs #8121
