### PR TITLE
Fix multiple typecasters being attached to queries

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -130,6 +130,13 @@ class Query implements ExpressionInterface, IteratorAggregate
     protected $_selectTypeMap;
 
     /**
+     * Tracking flag to ensure only one type caster is appended.
+     *
+     * @var bool
+     */
+    protected $_typeCastAttached = false;
+
+    /**
      * Constructor.
      *
      * @param \Cake\Datasource\ConnectionInterface $connection The connection
@@ -183,8 +190,9 @@ class Query implements ExpressionInterface, IteratorAggregate
         $driver = $this->_connection->driver();
         $typeMap = $this->selectTypeMap();
 
-        if ($typeMap->toArray()) {
+        if ($typeMap->toArray() && $this->_typeCastAttached === false) {
             $this->decorateResults(new FieldTypeConverter($typeMap, $driver));
+            $this->_typeCastAttached = true;
         }
 
         $this->_iterator = $this->_decorateStatement($statement);
@@ -1630,6 +1638,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     {
         if ($overwrite) {
             $this->_resultDecorators = [];
+            $this->_typeCastAttached = false;
         }
 
         if ($callback !== null) {

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -80,7 +80,7 @@ class DateType extends DateTimeType
      *
      * @param string $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
-     * @return \Carbon\Carbon
+     * @return \Cake\I18n\Date|\DateTime
      */
     public function toPHP($value, Driver $driver)
     {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3547,7 +3547,6 @@ class QueryTest extends TestCase
     public function testSelectTypeConversion()
     {
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:50:00');
         $query
             ->select(['id', 'comment', 'the_date' => 'created'])
             ->from('comments')

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -48,11 +48,19 @@ class DateTimeTypeTest extends TestCase
      *
      * @return void
      */
-    public function testToPHP()
+    public function testToPHPEmpty()
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertNull($this->type->toPHP('0000-00-00 00:00:00', $this->driver));
+    }
 
+    /**
+     * Test toPHP
+     *
+     * @return void
+     */
+    public function testToPHPString()
+    {
         $result = $this->type->toPHP('2001-01-04 12:13:14', $this->driver);
         $this->assertInstanceOf('Cake\I18n\Time', $result);
         $this->assertEquals('2001', $result->format('Y'));
@@ -260,10 +268,10 @@ class DateTimeTypeTest extends TestCase
     {
         $this->type->useImmutable();
         $this->assertInstanceOf('DateTimeImmutable', $this->type->marshal('2015-11-01 11:23:00'));
-        $this->assertInstanceOf('DateTimeImmutable', $this->type->toPhp('2015-11-01 11:23:00', $this->driver));
+        $this->assertInstanceOf('DateTimeImmutable', $this->type->toPHP('2015-11-01 11:23:00', $this->driver));
 
         $this->type->useMutable();
         $this->assertInstanceOf('DateTime', $this->type->marshal('2015-11-01 11:23:00'));
-        $this->assertInstanceOf('DateTime', $this->type->toPhp('2015-11-01 11:23:00', $this->driver));
+        $this->assertInstanceOf('DateTime', $this->type->toPHP('2015-11-01 11:23:00', $this->driver));
     }
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3197,4 +3197,25 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $results->first());
     }
+
+    /**
+     * Test that type conversion is only applied once.
+     *
+     * @return void
+     */
+    public function testAllNoDuplicateTypeCasting()
+    {
+        $table = TableRegistry::get('Comments');
+        $query = $table->find()
+            ->select(['id', 'comment', 'created']);
+
+        // Convert to an array and make the query dirty again.
+        $result = $query->all()->toArray();
+        $query->limit(99);
+
+        // Get results a second time.
+        $result2 = $query->all()->toArray();
+
+        $this->assertEquals(1, $query->__debugInfo()['decorators'], 'Only one typecaster should exist');
+    }
 }


### PR DESCRIPTION
When a query was executed multiple times, multiple type casters would be attached. This caused issues with non-english locales as datetime casting would fail when re-casting datetime objects.

Refs #8157
