### PR TITLE
assertSameAsFile - Make it easy to update test expectations

### DIFF
--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -52,7 +52,9 @@ trait StringCompareTrait
      */
     public function assertSameAsFile($path, $result)
     {
-        $path = $this->_compareBasePath . $path;
+        if (!file_exists($path)) {
+            $path = $this->_compareBasePath . $path;
+        }
 
         if ($this->_updateComparisons === null) {
             $this->_updateComparisons = env('UPDATE_TEST_COMPARISON_FILES');

--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\TestSuite;
 
+use Cake\Filesystem\File;
+
 /**
  * Compare a string to the contents of a file
  *
@@ -33,6 +35,15 @@ trait StringCompareTrait
     protected $_compareBasePath = '';
 
     /**
+     * Update comparisons to match test changes
+     *
+     * Initialized with the env variable UPDATE_TEST_COMPARISON_FILES
+     *
+     * @var bool
+     */
+    protected $_updateComparisons = null;
+
+    /**
      * Compare the result to the contents of the file
      *
      * @param string $path partial path to test comparison file
@@ -42,6 +53,15 @@ trait StringCompareTrait
     public function assertSameAsFile($path, $result)
     {
         $path = $this->_compareBasePath . $path;
+
+        if ($this->_updateComparisons === null) {
+            $this->_updateComparisons = env('UPDATE_TEST_COMPARISON_FILES');
+        }
+
+        if ($this->_updateComparisons) {
+            $file = new File($path, true);
+            $file->write($result);
+        }
 
         $expected = file_get_contents($path);
         $this->assertTextEquals($expected, $result);


### PR DESCRIPTION
This allows turning this:

![screenshot from 2016-02-03 10-13-37](https://cloud.githubusercontent.com/assets/33387/12777689/d09a0188-ca5e-11e5-9180-73454aba7596.png)

into this:

![screenshot from 2016-02-03 10-14-12](https://cloud.githubusercontent.com/assets/33387/12777703/e9e4b5de-ca5e-11e5-849e-8ddec8692a3d.png)
