### PR TITLE
Improve ExtractTask when CakePHP installed via Composer

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -151,7 +151,7 @@ class ExtractTask extends AppShell {
  */
 	public function execute() {
 		if (!empty($this->params['exclude'])) {
-			$this->_exclude = explode(',', $this->params['exclude']);
+			$this->_exclude = explode(',', str_replace('/', DS, $this->params['exclude']));
 		}
 		if (isset($this->params['files']) && !is_array($this->params['files'])) {
 			$this->_files = explode(',', $this->params['files']);
@@ -567,6 +567,11 @@ class ExtractTask extends AppShell {
 	protected function _buildFiles() {
 		$paths = $this->_paths;
 		$paths[] = realpath(APP) . DS;
+
+		usort($paths, function ($a, $b) {
+			return strlen($b) - strlen($a);
+		});
+
 		foreach ($this->_translations as $category => $domains) {
 			foreach ($domains as $domain => $translations) {
 				foreach ($translations as $msgid => $contexts) {
@@ -799,19 +804,17 @@ class ExtractTask extends AppShell {
 			}
 			$pattern = '/' . implode('|', $exclude) . '/';
 		}
-		foreach ($this->_paths as $path) {
-			$Folder = new Folder($path);
+		foreach ($this->_paths as $i => $path) {
+			$this->_paths[$i] = realpath($path) . DS;
+			$Folder = new Folder($this->_paths[$i]);
 			$files = $Folder->findRecursive('.*\.(php|ctp|thtml|inc|tpl)', true);
 			if (!empty($pattern)) {
-				foreach ($files as $i => $file) {
-					if (preg_match($pattern, $file)) {
-						unset($files[$i]);
-					}
-				}
+				$files = preg_grep($pattern, $files, PREG_GREP_INVERT);
 				$files = array_values($files);
 			}
 			$this->_files = array_merge($this->_files, $files);
 		}
+		$this->_files = array_unique($this->_files);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -135,23 +135,23 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->assertRegExp($pattern, $result);
 
 		// extract.ctp
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:15;6\n';
+		$pattern = '/\#: extract\.ctp:15;6\n';
 		$pattern .= 'msgid "You have %d new message."\nmsgid_plural "You have %d new messages."/';
 		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/msgid "You have %d new message."\nmsgstr ""/';
 		$this->assertNotRegExp($pattern, $result, 'No duplicate msgid');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:7\n';
+		$pattern = '/\#: extract\.ctp:7\n';
 		$pattern .= 'msgid "You deleted %d message."\nmsgid_plural "You deleted %d messages."/';
 		$this->assertRegExp($pattern, $result);
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:14\n';
-		$pattern .= '\#: (\\\\|\/)home\.ctp:68\n';
+		$pattern = '/\#: extract\.ctp:14\n';
+		$pattern .= '\#: home\.ctp:68\n';
 		$pattern .= 'msgid "Editing this Page"\nmsgstr ""/';
 		$this->assertRegExp($pattern, $result);
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:22\nmsgid "';
+		$pattern = '/\#: extract\.ctp:22\nmsgid "';
 		$pattern .= 'Hot features!';
 		$pattern .= '\\\n - No Configuration: Set-up the database and let the magic begin';
 		$pattern .= '\\\n - Extremely Simple: Just look at the name...It\'s Cake';
@@ -162,19 +162,19 @@ class ExtractTaskTest extends CakeTestCase {
 		$this->assertContains('msgid "double \\"quoted\\""', $result, 'Strings with quotes not handled correctly');
 		$this->assertContains("msgid \"single 'quoted'\"", $result, 'Strings with quotes not handled correctly');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:36\nmsgid "letter"/';
+		$pattern = '/\#: extract\.ctp:36\nmsgid "letter"/';
 		$this->assertRegExp($pattern, $result, 'Strings with context should not overwrite strings without context');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:37;39\nmsgctxt "A"\nmsgid "letter"/';
+		$pattern = '/\#: extract\.ctp:37;39\nmsgctxt "A"\nmsgid "letter"/';
 		$this->assertRegExp($pattern, $result, 'Should contain string with context "A"');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:38\nmsgctxt "B"\nmsgid "letter"/';
+		$pattern = '/\#: extract\.ctp:38\nmsgctxt "B"\nmsgid "letter"/';
 		$this->assertRegExp($pattern, $result, 'Should contain string with context "B"');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:40\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
+		$pattern = '/\#: extract\.ctp:40\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
 		$this->assertRegExp($pattern, $result, 'Plural strings with context should not overwrite strings without context');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:41\nmsgctxt "A"\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
+		$pattern = '/\#: extract\.ctp:41\nmsgctxt "A"\nmsgid "%d letter"\nmsgid_plural "%d letters"/';
 		$this->assertRegExp($pattern, $result, 'Should contain plural string with context "A"');
 
 		// extract.ctp - reading the domain.pot


### PR DESCRIPTION
When installed CakePHP via Composer, there are multiple issues with ExtractTask
-  `Console/cake i18n extract --extract-core=yes` scans core files twice.
  (Got `Invalid marker content in /full/path/app/Vendor/cakephp/cakephp/lib/Cake/...` twice).
  So improved to scan files once.
- Convert all relative paths to _realpath_ before scaning
- Source file headers are listed as `#: Vendor/cakephp/cakephp/lib/Cake/Controller/Scaffold.php`, so shortened to use `#: Controller/Scaffold.php` as in non Composer install:
  first resort paths longest to shortest, so that `/full/path/app/Vendor/cakephp/cakephp/lib/Cake/` would be replaced before `/full/path/app/`.
- Source file headers paths now never starts with / regardless if `--paths` ends with or without slash, so modified test cases.
- Simplify and speed up a bit by using `preg_grep` instead of `foreach` to filter out excludes.
- On Windows `--exclude=dir/subdir` didn't work, needed to use `dir\subdir`: convert / to DS, so you can use same command without modifications on both Windows and Linux.
