### PR TITLE
Allows schema fixtures to be reflected directly from the datasource

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -150,6 +150,10 @@ class TestFixture implements FixtureInterface
         if (!empty($this->import)) {
             $this->_schemaFromImport();
         }
+
+        if (empty($this->import) && empty($this->fields)) {
+            $this->_schemaFromReflection();
+        }
     }
 
     /**
@@ -216,6 +220,31 @@ class TestFixture implements FixtureInterface
         $schemaCollection = $db->schemaCollection();
         $table = $schemaCollection->describe($import['table']);
         $this->_schema = $table;
+    }
+
+    /**
+     * Build fixture schema directly from the datasource
+     *
+     * @return void
+     * @throws \Cake\Core\Exception\Exception when trying to reflect a table that does not exist
+     */
+    protected function _schemaFromReflection()
+    {
+        $db = ConnectionManager::get($this->connection());
+        $schemaCollection = $db->schemaCollection();
+        $tables = $schemaCollection->listTables();
+
+        if (!in_array($this->table, $tables)) {
+            throw new CakeException(
+                sprintf(
+                    'Cannot describe schema for table `%s` for fixture `%s` : the table does not exist.',
+                    $this->table,
+                    get_class($this)
+                )
+            );
+        }
+
+        $this->_schema = $schema = $db->schemaCollection()->describe($this->table);
     }
 
     /**

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -244,7 +244,7 @@ class TestFixture implements FixtureInterface
             );
         }
 
-        $this->_schema = $schema = $db->schemaCollection()->describe($this->table);
+        $this->_schema = $schemaCollection->describe($this->table);
     }
 
     /**
@@ -269,6 +269,10 @@ class TestFixture implements FixtureInterface
     {
         if (empty($this->_schema)) {
             return false;
+        }
+
+        if (empty($this->import) && empty($this->fields)) {
+            return true;
         }
 
         try {
@@ -299,6 +303,11 @@ class TestFixture implements FixtureInterface
         if (empty($this->_schema)) {
             return false;
         }
+
+        if (empty($this->import) && empty($this->fields)) {
+            return true;
+        }
+
         try {
             $sql = $this->_schema->dropSql($db);
             foreach ($sql as $stmt) {

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -275,7 +275,7 @@ class TestFixtureTest extends TestCase
 
     /**
      * test schema reflection without $import or $fields will reflect the schema
-     *.
+     *
      * @return void
      */
     public function testInitNoImportNoFields()
@@ -285,7 +285,7 @@ class TestFixtureTest extends TestCase
         if (!in_array('letters', $collection->listTables())) {
             $table = new Table('letters', [
                 'id' => ['type' => 'integer'],
-                'letters' => ['type' => 'integer', 'null' => true]
+                'letter' => ['type' => 'string', 'length' => 1]
             ]);
             $table->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
             $sql = $table->createSql($db);
@@ -297,8 +297,15 @@ class TestFixtureTest extends TestCase
 
         $fixture = new LettersFixture();
         $fixture->init();
+        $this->assertEquals(['id', 'letter'], $fixture->schema()->columns());
 
-        $this->assertEquals(['id', 'letters'], $fixture->schema()->columns());
+        $db = $this->getMock('Cake\Database\Connection', ['prepare', 'execute'], [], '', false);
+        $db->expects($this->never())
+            ->method('prepare');
+        $db->expects($this->never())
+            ->method('execute');
+        $this->assertTrue($fixture->create($db));
+        $this->assertTrue($fixture->drop($db));
     }
 
     /**


### PR DESCRIPTION
When the properties `TestFixture::$import` or `TestFixture::$fields` are not defined, and if the table the fixture represents exists in the test datasource (or the specified one), the fixtures schema should be reflected using the datasource.

Since the table exists and the dev is doing this in purpose, we should not make any asumption and the `drop()` and `create()` methods should do nothing but returns that the table was correctly dropped / created.

Refs #8165 
