### PR TITLE
Extract table from class logic to method

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -134,13 +134,7 @@ class TestFixture implements FixtureInterface
     public function init()
     {
         if ($this->table === null) {
-            list(, $class) = namespaceSplit(get_class($this));
-            preg_match('/^(.*)Fixture$/', $class, $matches);
-            $table = $class;
-            if (isset($matches[1])) {
-                $table = $matches[1];
-            }
-            $this->table = Inflector::tableize($table);
+            $this->table = $this->_tableFromClass();
         }
 
         if (empty($this->import) && !empty($this->fields)) {
@@ -154,6 +148,24 @@ class TestFixture implements FixtureInterface
         if (empty($this->import) && empty($this->fields)) {
             $this->_schemaFromReflection();
         }
+    }
+
+    /**
+     * Returns the table name using the fixture class
+     *
+     * @return string
+     */
+    protected function _tableFromClass()
+    {
+        list(, $class) = namespaceSplit(get_class($this));
+        preg_match('/^(.*)Fixture$/', $class, $matches);
+        $table = $class;
+
+        if (isset($matches[1])) {
+            $table = $matches[1];
+        }
+
+        return Inflector::tableize($table);
     }
 
     /**


### PR DESCRIPTION
## Context

When overriding the init method, there is no way to set the table from the class name before calling parent::init. Using my fix, the code would look like this:

```
class CustomFixture extends TestFixture
...
protected function init()
{
  $this->table = $this->_tableFromClass();
  //logic that requires the table name to be set
  parent::init();
}
```
## Explanation

One may ask why I would need the table name to be set before calling the init method. In my case, it's because I wish to load the fixtures from an external database before calling the init method. The problem is that querying a database requires that I set the table name and I need to call the init method in order to set the table name, hence the external method. This way I can set the table name and query the data from the database all before calling the init method from the parent. Unless there is something I am missing, this change should not change anything other than give more flexibility to developers.
## Version

I currently use cakephp ~3.0(so 3.2.1 at the time of writing) using composer so if you merge this in master, will it be merged back in the version I currently use? Or maybe I should make a pull request in 3.next?
