### PR TITLE
Fix setting the template from the action of a Cell

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -194,7 +194,7 @@ abstract class Cell
                 $template = Inflector::underscore($template);
             }
             if ($template === null) {
-                $template = $this->template;
+                $template = $this->viewBuilder()->template() ?: $this->template;
             }
 
             $builder = $this->viewBuilder();

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -176,6 +176,17 @@ abstract class Cell
         }
 
         $render = function () use ($template) {
+            try {
+                $reflect = new ReflectionMethod($this, $this->action);
+                $reflect->invokeArgs($this, $this->args);
+            } catch (ReflectionException $e) {
+                throw new BadMethodCallException(sprintf(
+                    'Class %s does not have a "%s" method.',
+                    get_class($this),
+                    $this->action
+                ));
+            }
+
             if ($template !== null &&
                 strpos($template, '/') === false &&
                 strpos($template, '.') === false
@@ -193,17 +204,6 @@ abstract class Cell
             $className = substr(strrchr(get_class($this), "\\"), 1);
             $name = substr($className, 0, -4);
             $builder->templatePath('Cell' . DS . $name);
-
-            try {
-                $reflect = new ReflectionMethod($this, $this->action);
-                $reflect->invokeArgs($this, $this->args);
-            } catch (ReflectionException $e) {
-                throw new BadMethodCallException(sprintf(
-                    'Class %s does not have a "%s" method.',
-                    get_class($this),
-                    $this->action
-                ));
-            }
 
             $this->View = $this->createView();
             try {

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -15,14 +15,9 @@
 namespace Cake\Test\TestCase\View;
 
 use Cake\Cache\Cache;
-use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Event\EventManager;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Cake\View\Cell;
-use Cake\View\CellTrait;
 use TestApp\View\CustomJsonView;
 
 /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -133,7 +133,7 @@ class CellTest extends TestCase
     }
 
     /**
-     * Tests that cell action setting the template renders the correct template
+     * Tests that cell action setting the template using the property renders the correct template
      *
      * @return void
      */
@@ -143,11 +143,31 @@ class CellTest extends TestCase
 
         $this->assertContains('This is the alternate template', "{$appCell}");
         $this->assertEquals('alternate_teaser_list', $appCell->template);
+        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->template());
 
         $appCell = $this->View->cell('Articles::customTemplate');
 
         $this->assertContains('This is the alternate template', $appCell->render());
         $this->assertEquals('alternate_teaser_list', $appCell->template);
+        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->template());
+    }
+
+    /**
+     * Tests that cell action setting the template using the ViewBuilder renders the correct template
+     *
+     * @return void
+     */
+    public function testSettingCellTemplateFromActionViewBuilder()
+    {
+        $appCell = $this->View->cell('Articles::customTemplateViewBuilder');
+
+        $this->assertContains('This is the alternate template', "{$appCell}");
+        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->template());
+
+        $appCell = $this->View->cell('Articles::customTemplateViewBuilder');
+
+        $this->assertContains('This is the alternate template', $appCell->render());
+        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->template());
     }
 
     /**
@@ -398,6 +418,30 @@ class CellTest extends TestCase
         Cache::config('default', $mock);
 
         $cell = $this->View->cell('Articles::customTemplate', [], ['cache' => true]);
+        $result = $cell->render();
+        $this->assertContains('This is the alternate template', $result);
+
+        Cache::drop('default');
+    }
+
+    /**
+     * Test cached render.
+     *
+     * @return void
+     */
+    public function testCachedRenderSimpleCustomTemplateViewBuilder()
+    {
+        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock->method('init')
+            ->will($this->returnValue(true));
+        $mock->method('read')
+            ->will($this->returnValue(false));
+        $mock->expects($this->once())
+            ->method('write')
+            ->with('cell_test_app_view_cell_articles_cell_customTemplateViewBuilder', "<h1>This is the alternate template</h1>\n");
+        Cache::config('default', $mock);
+
+        $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => true]);
         $result = $cell->render();
         $this->assertContains('This is the alternate template', $result);
 

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -133,6 +133,24 @@ class CellTest extends TestCase
     }
 
     /**
+     * Tests that cell action setting the template renders the correct template
+     *
+     * @return void
+     */
+    public function testSettingCellTemplateFromAction()
+    {
+        $appCell = $this->View->cell('Articles::customTemplate');
+
+        $this->assertContains('This is the alternate template', "{$appCell}");
+        $this->assertEquals('alternate_teaser_list', $appCell->template);
+
+        $appCell = $this->View->cell('Articles::customTemplate');
+
+        $this->assertContains('This is the alternate template', $appCell->render());
+        $this->assertEquals('alternate_teaser_list', $appCell->template);
+    }
+
+    /**
      * Tests manual render() invocation.
      *
      * @return void
@@ -360,5 +378,29 @@ class CellTest extends TestCase
         $result = $cell->render();
         $this->assertEquals("dummy\n", $result);
         Cache::drop('cell');
+    }
+
+    /**
+     * Test cached render.
+     *
+     * @return void
+     */
+    public function testCachedRenderSimpleCustomTemplate()
+    {
+        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock->method('init')
+            ->will($this->returnValue(true));
+        $mock->method('read')
+            ->will($this->returnValue(false));
+        $mock->expects($this->once())
+            ->method('write')
+            ->with('cell_test_app_view_cell_articles_cell_customTemplate', "<h1>This is the alternate template</h1>\n");
+        Cache::config('default', $mock);
+
+        $cell = $this->View->cell('Articles::customTemplate', [], ['cache' => true]);
+        $result = $cell->render();
+        $this->assertContains('This is the alternate template', $result);
+
+        Cache::drop('default');
     }
 }

--- a/tests/test_app/TestApp/Template/Cell/Articles/alternate_teaser_list.ctp
+++ b/tests/test_app/TestApp/Template/Cell/Articles/alternate_teaser_list.ctp
@@ -1,0 +1,1 @@
+<h1>This is the alternate template</h1>

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -28,6 +28,13 @@ class ArticlesCell extends \Cake\View\Cell
     protected $_validCellOptions = ['limit', 'page'];
 
     /**
+     * Counter used to test the cache cell feature
+     *
+     * @return void
+     */
+    public $counter = 0;
+
+    /**
      * Default cell action.
      *
      * @return void
@@ -71,6 +78,7 @@ class ArticlesCell extends \Cake\View\Cell
     public function customTemplateViewBuilder()
     {
         $this->template = 'derp';
+        $this->counter++;
         $this->viewBuilder()->template('alternate_teaser_list');
     }
 

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -52,6 +52,22 @@ class ArticlesCell extends \Cake\View\Cell
     }
 
     /**
+     * Renders articles in teaser view mode.
+     *
+     * @return void
+     */
+    public function customTemplate()
+    {
+        $this->template = 'alternate_teaser_list';
+        $this->set('articles', [
+            ['title' => 'Lorem ipsum', 'body' => 'dolorem sit amet'],
+            ['title' => 'Usectetur adipiscing eli', 'body' => 'tortor, in tincidunt sem dictum vel'],
+            ['title' => 'Topis semper blandit eu non', 'body' => 'alvinar diam convallis non. Nullam pu'],
+            ['title' => 'Suspendisse gravida neque', 'body' => 'pellentesque sed scelerisque libero'],
+        ]);
+    }
+
+    /**
      * Simple echo.
      *
      * @param string $msg1

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -52,19 +52,26 @@ class ArticlesCell extends \Cake\View\Cell
     }
 
     /**
-     * Renders articles in teaser view mode.
+     * Renders a view using a different template than the action name
+     * The template is set using the ``Cell::$template`` property
      *
      * @return void
      */
     public function customTemplate()
     {
         $this->template = 'alternate_teaser_list';
-        $this->set('articles', [
-            ['title' => 'Lorem ipsum', 'body' => 'dolorem sit amet'],
-            ['title' => 'Usectetur adipiscing eli', 'body' => 'tortor, in tincidunt sem dictum vel'],
-            ['title' => 'Topis semper blandit eu non', 'body' => 'alvinar diam convallis non. Nullam pu'],
-            ['title' => 'Suspendisse gravida neque', 'body' => 'pellentesque sed scelerisque libero'],
-        ]);
+    }
+
+    /**
+     * Renders a view using a different template than the action name
+     * The template is set using the ViewBuilder bound to the Cell
+     *
+     * @return void
+     */
+    public function customTemplateViewBuilder()
+    {
+        $this->template = 'derp';
+        $this->viewBuilder()->template('alternate_teaser_list');
     }
 
     /**


### PR DESCRIPTION
In previous releases, you could set the `Cell::$template` property directly from the action of a Cell to change the template with which the Cell was rendered.
A regression was introduced when the cache Cell feature was implemented, preventing this behavior from working : this PR fix this.

The PR also implements the ability to set the template rendered using the `ViewBuilder` instance bound to the cell.
When the template is set with the `ViewBuilder`, it takes priority over setting the template using directly the property.

Refs #8163 
