### PR TITLE
Make sure find() returning entities are not trying to further use Que…

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -634,9 +634,9 @@ abstract class Association
     {
         $type = $type ?: $this->finder();
         list($type, $opts) = $this->_extractFinder($type);
+        $options['conditions'] = $this->conditions();
         return $this->target()
-            ->find($type, $options + $opts)
-            ->where($this->conditions());
+            ->find($type, $options + $opts);
     }
 
     /**


### PR DESCRIPTION
…ry methods.

Currently using `$this->Primary->Secondary->find('first', ...)` fails with an exception:

```
Error: Call to undefined method Cake\ORM\Entity::where() 
File vendor\cakephp\cakephp\src\ORM\Association.php 
Line: 639
```

`$this->Primary->find('first', ...)` works.

In my case I shim find() to return an entity for find(first):

``` php
    /**
     * @param string $type
     * @param array $options
     * @return \Cake\ORM\Query
     */
    public function find($type = 'all', $options = []) {
        if ($type === 'first') {
            return parent::find('all', $options)->first();
        }
        if ($type === 'count') {
            return parent::find('all', $options)->count();
        }
        return parent::find($type, $options);
    }
```

find() in that case should use conditions array key instead of chaining to be on the safe side.
