### PR TITLE
Expand path before is_file check

### DIFF
--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -56,7 +56,7 @@ trait FileConfigTrait
 
         $file .= $this->_extension;
 
-        if ($checkExists && !is_file($file)) {
+        if ($checkExists && !is_file(realpath($file))) {
             throw new Exception(sprintf('Could not load configuration file: %s', $file));
         }
 


### PR DESCRIPTION
To allow symlinks to config files

Fixes #8181
