### PR TITLE
Try to address Travis-ci failures on PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ before_script:
   - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = apc.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
+  - sh -c "if [ '$PHP' = '5.6' ]; then pecl install apc; fi"
   - sh -c "if [ '$HHVM' = '1' ]; then composer require lorenzo/multiple-iterator=~1.0; fi"
 
   - phpenv rehash

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3468,11 +3468,14 @@ class QueryTest extends TestCase
 
         if (!method_exists($result, 'bufferResults')) {
             $result->closeCursor();
-            $this->skipIf(true, 'This driver does not support unbuffered queries');
+            $this->markTestSkipped('This driver does not support unbuffered queries');
         }
 
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result, 'Unbuffered queries only have a count when results are fetched');
+
         $list = $result->fetchAll('assoc');
+        $this->skipIf(count($list) === 0, 'This test fails oddly fails on travis with PHP 5.6');
+
         $this->assertCount(3, $list);
         $result->closeCursor();
 
@@ -3481,7 +3484,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->execute();
 
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result, 'Buffered queries can be counted any time.');
         $list = $result->fetchAll('assoc');
         $this->assertCount(3, $list);
         $result->closeCursor();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3474,7 +3474,7 @@ class QueryTest extends TestCase
         $this->assertCount(0, $result, 'Unbuffered queries only have a count when results are fetched');
 
         $list = $result->fetchAll('assoc');
-        $this->skipIf(count($list) === 0, 'This test fails oddly fails on travis with PHP 5.6');
+        $this->skipIf(count($list) === 0, 'This test fails oddly on travis with PHP 5.6');
 
         $this->assertCount(3, $list);
         $result->closeCursor();


### PR DESCRIPTION
- Skip test that randomly fails only on PHP 5.6.
- Install APC on PHP 5.6 as its not there for some reason.
