### PR TITLE
solves issue #8197: Inflector::slug() to preserve space between non-ascii characters

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -741,8 +741,8 @@ class Inflector
         $quotedReplacement = preg_quote($replacement, '/');
 
         $map = [
-            '/[^\s\p{Zs}\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]/mu' => ' ',
             '/[\s\p{Zs}]+/mu' => $replacement,
+            '/[^\s\p{Zs}\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]+/mu' => $replacement,
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];
 


### PR DESCRIPTION
First of all replacing spaces with $replacement parameter and then other symbols.
