### PR TITLE
Make sure the line that will be overwritten in the CLI ProgressHelper does not have a new line feed

### DIFF
--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -69,6 +69,8 @@ class ProgressHelper extends Helper
         $this->init($args);
 
         $callback = $args['callback'];
+
+        $this->_io->out('', 0);
         while ($this->_progress < $this->_total) {
             $callback($this);
             $this->draw();

--- a/tests/TestCase/Shell/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Shell/Helper/ProgressHelperTest.php
@@ -61,6 +61,7 @@ class ProgressHelperTest extends TestCase
         }]);
         $expected = [
             '',
+            '',
             '==============>                                                              20%',
             '',
             '=============================>                                               40%',
@@ -90,6 +91,7 @@ class ProgressHelperTest extends TestCase
             }
         ]);
         $expected = [
+            '',
             '',
             '==>              20%',
             '',


### PR DESCRIPTION
I was able to reproduce issue #8076 using a Windows environment and connecting through Putty to a vagrant machine.

There was indeed a visual glitch (the progress bar started randomly in the middle of a line of the console window depending on the length I was giving to the progress bar), but only if I outputted lines before calling the helper.
The problem was that the IO was overwriting a line on which there was a new line feed at the end, which can apparently cause trouble, [according to the docblock of `ConsoleIo::overwrite()`](https://github.com/cakephp/cakephp/blob/master/src/Console/ConsoleIo.php#L180).

This fix is simple : it simply adds a new line without a new line feed at the end. This line will be the one that will be overwritten. It solved the problem on my setup.

Note : I was only able to do a real "app test" on 3.1.10 but there was no changes to the `ConsoleIo` or `ProgressHelper` classes for quite some time, so this should be good.

@jessicamarx : Can you test this and confirm it solves the problem on your setup too ?

Refs #8076 
