### PR TITLE
Backport fix for Validation::uploadedFile to 2.x

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2505,4 +2505,20 @@ class ValidationTest extends CakeTestCase {
 		);
 		$this->assertFalse(Validation::uploadedFile($file, $options), 'File is required.');
 	}
+/**
+ * Test uploaded file validation.
+ *
+ * @return void
+ */
+	public function testUploadedFileWithDifferentFileParametersOrder() {
+		$file = array(
+			'name' => 'cake.power.gif',
+			'error' => UPLOAD_ERR_OK,
+			'tmp_name' => CORE_PATH . 'Cake' . DS . 'Test' . DS . 'test_app' . DS . 'webroot/img/cake.power.gif',
+			'type' => 'text/plain',
+			'size' => 201
+		);
+		$options = array();
+		$this->assertTrue(Validation::uploadedFile($file, $options), 'Wrong order');
+	}
 }

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -1016,7 +1016,8 @@ class Validation {
 		if (!is_array($file)) {
 			return false;
 		}
-		$keys = array('name', 'tmp_name', 'error', 'type', 'size');
+		$keys = array('error', 'name', 'size', 'tmp_name', 'type');
+		ksort($file);
 		if (array_keys($file) != $keys) {
 			return false;
 		}


### PR DESCRIPTION
Don't fail validation when the keys are not the expected order.

Refs #8201
