### PR TITLE
Add deprecated notice to _className in EntityTrait

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -58,6 +58,15 @@ trait EntityTrait
     protected $_virtual = [];
 
     /**
+     * Holds the name of the class for the instance object
+     *
+     * @var string
+     *
+     * @deprecated 3.2 This field is no longer being used
+     */
+    protected $_className;
+
+    /**
      * Holds a list of the properties that were modified or added after this object
      * was originally created.
      *


### PR DESCRIPTION
This resolves a BC related issue with entity implementations that
are backwards compatible with 3.1.
