### PR TITLE
Use mixed return type for AuthComponent::user()

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -655,7 +655,7 @@ class AuthComponent extends Component {
  * cookies + sessions will be used.
  *
  * @param string|null $key field to retrieve. Leave null to get entire User record
- * @return array|null User record. or null if no user is logged in.
+ * @return mixed|null User record. or null if no user is logged in.
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#accessing-the-logged-in-user
  */
 	public static function user($key = null) {


### PR DESCRIPTION
Merge 2.7 to 2.8 missed this change from my PR #8126.

I use this function in `string`/`int` context, so my IDE shows warnings again.
