### PR TITLE
It table exists but the fixture was not setup, we should reset the table

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -227,14 +227,15 @@ class FixtureManager
     protected function _setupTable($fixture, $db, array $sources, $drop = true)
     {
         $configName = $db->configName();
-        if ($this->isFixtureSetup($configName, $fixture)) {
+        $isFixtureSetup = $this->isFixtureSetup($configName, $fixture);
+        if ($isFixtureSetup) {
             return;
         }
 
         $table = $fixture->sourceName();
         $exists = in_array($table, $sources);
 
-        if ($drop && $exists) {
+        if (($drop && $exists) || ($exists && !$isFixtureSetup)) {
             $fixture->drop($db);
             $fixture->create($db);
         } elseif (!$exists) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -16,6 +16,7 @@ namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
+use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 use PDOException;
@@ -235,7 +236,9 @@ class FixtureManager
         $table = $fixture->sourceName();
         $exists = in_array($table, $sources);
 
-        if (($drop && $exists) || ($exists && !$isFixtureSetup)) {
+        if (($drop && $exists) ||
+            ($exists && !$isFixtureSetup && $fixture->schema() instanceof Table)
+        ) {
             $fixture->drop($db);
             $fixture->create($db);
         } elseif (!$exists) {


### PR DESCRIPTION
If you are running your tests and they stop because of an error, the database keeps the state it had prior to the error, which can lead to more problems when you start the test suite again.
This change will force the tables already in the database to be dropped and created again when you restart the test suite.

Refs #8187 
