### PR TITLE
Use short widget names instead of FQCN.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -129,17 +129,17 @@ class FormHelper extends Helper
      * @var array
      */
     protected $_defaultWidgets = [
-        'button' => ['Cake\View\Widget\ButtonWidget'],
-        'checkbox' => ['Cake\View\Widget\CheckboxWidget'],
-        'file' => ['Cake\View\Widget\FileWidget'],
-        'label' => ['Cake\View\Widget\LabelWidget'],
-        'nestingLabel' => ['Cake\View\Widget\NestingLabelWidget'],
-        'multicheckbox' => ['Cake\View\Widget\MultiCheckboxWidget', 'nestingLabel'],
-        'radio' => ['Cake\View\Widget\RadioWidget', 'nestingLabel'],
-        'select' => ['Cake\View\Widget\SelectBoxWidget'],
-        'textarea' => ['Cake\View\Widget\TextareaWidget'],
-        'datetime' => ['Cake\View\Widget\DateTimeWidget', 'select'],
-        '_default' => ['Cake\View\Widget\BasicWidget'],
+        'button' => ['Button'],
+        'checkbox' => ['Checkbox'],
+        'file' => ['File'],
+        'label' => ['Label'],
+        'nestingLabel' => ['NestingLabel'],
+        'multicheckbox' => ['MultiCheckbox', 'nestingLabel'],
+        'radio' => ['Radio', 'nestingLabel'],
+        'select' => ['SelectBox'],
+        'textarea' => ['Textarea'],
+        'datetime' => ['DateTime', 'select'],
+        '_default' => ['Basic'],
     ];
 
     /**


### PR DESCRIPTION
This allows widget with same name under App namespace to be automatically used
without extra config.
