### PR TITLE
Date and Time global toStringTimezone

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -226,7 +226,7 @@ trait DateFormatTrait
     }
 
     /**
-     * Sets the default timezone used when type converting instances ot this type to string
+     * Sets the default timezone used when type converting instances to this type to string
      *
      * @param string $timezone
      * @return void

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -55,6 +55,13 @@ trait DateFormatTrait
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH:mm:ssZ";
 
     /**
+     * The default timezone to be used for displaying formatted date strings.
+     *
+     * @var string
+     */
+    protected static $_toStringTimezone = 'UTC';
+
+    /**
      * Returns a nicely formatted date string for this object.
      *
      * The format to be used is stored in the static property `Time::niceFormat`.
@@ -124,12 +131,13 @@ trait DateFormatTrait
      */
     public function i18nFormat($format = null, $timezone = null, $locale = null)
     {
-        $time = $this;
+        // Handle the immutable and mutable object cases.
+        $time = clone $this;
 
         if ($timezone) {
-            // Handle the immutable and mutable object cases.
-            $time = clone $this;
             $time = $time->timezone($timezone);
+        } else {
+            $time = $time->timezone(self::$_toStringTimezone);
         }
 
         $format = $format !== null ? $format : static::$_toStringFormat;
@@ -215,6 +223,17 @@ trait DateFormatTrait
     public static function setToStringFormat($format)
     {
         static::$_toStringFormat = $format;
+    }
+
+    /**
+     * Sets the default timezone used when type converting instances ot this type to string
+     *
+     * @param string $timezone
+     * @return void
+     */
+    public static function setToStringTimezone($timezone)
+    {
+        static::$_toStringTimezone = $timezone;
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -112,6 +112,16 @@ class DateTest extends TestCase
 
         $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'es-ES');
         $this->assertContains('14 de enero de 2010', $result, 'Default locale should not be used');
+
+        $class->setToStringTimezone('Europe/Brussels');
+        $result = $time->i18nFormat('HH:mm:ss');
+        $expected = '14:59:28';
+        $this->assertEquals($expected, $result);
+
+        $class->setToStringTimezone('+02:00');
+        $result = $time->i18nFormat('HH:mm:ss');
+        $expected = '15:59:28';
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -113,12 +113,12 @@ class DateTest extends TestCase
         $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'es-ES');
         $this->assertContains('14 de enero de 2010', $result, 'Default locale should not be used');
 
-        $class->setToStringTimezone('Europe/Brussels');
+        $time->setToStringTimezone('Europe/Brussels');
         $result = $time->i18nFormat('HH:mm:ss');
         $expected = '14:59:28';
         $this->assertEquals($expected, $result);
 
-        $class->setToStringTimezone('+02:00');
+        $time->setToStringTimezone('+02:00');
         $result = $time->i18nFormat('HH:mm:ss');
         $expected = '15:59:28';
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Set a default timezone for printing times and dates.
Makes it easy to use different timezones in database and application front end.
