### PR TITLE
Added `422 Unprocessable Entity` as suggested

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -71,6 +71,7 @@ class Response
         415 => 'Unsupported Media Type',
         416 => 'Requested range not satisfiable',
         417 => 'Expectation Failed',
+        422 => 'Unprocessable Entity',
         429 => 'Too Many Requests',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -550,7 +550,7 @@ abstract class IntegrationTestCase extends TestCase
      */
     public function assertResponseError()
     {
-        $this->_assertStatus(400, 417, 'Status code is not between 400 and 417');
+        $this->_assertStatus(400, 429, 'Status code is not between 400 and 429');
     }
 
     /**

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -448,7 +448,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response();
         $result = $response->httpCodes();
-        $this->assertEquals(41, count($result));
+        $this->assertEquals(42, count($result));
 
         $result = $response->httpCodes(100);
         $expected = [100 => 'Continue'];
@@ -461,7 +461,7 @@ class ResponseTest extends TestCase
 
         $result = $response->httpCodes($codes);
         $this->assertTrue($result);
-        $this->assertEquals(43, count($response->httpCodes()));
+        $this->assertEquals(44, count($response->httpCodes()));
 
         $result = $response->httpCodes(381);
         $expected = [381 => 'Unicorn Moved'];
@@ -470,7 +470,7 @@ class ResponseTest extends TestCase
         $codes = [404 => 'Sorry Bro'];
         $result = $response->httpCodes($codes);
         $this->assertTrue($result);
-        $this->assertEquals(43, count($response->httpCodes()));
+        $this->assertEquals(44, count($response->httpCodes()));
 
         $result = $response->httpCodes(404);
         $expected = [404 => 'Sorry Bro'];


### PR DESCRIPTION
>  The 412 (Precondition Failed) status code indicates that one or more
>    conditions given in the request header fields evaluated to false when
>    tested on the server.  This response code allows the client to place
>    preconditions on the current resource state (its current
>    representations and metadata) and, thus, prevent the request method
>    from being applied if the target resource is in an unexpected state.
> (http://tools.ietf.org/html/rfc7232#section-4.2)
> 
> The 422 (Unprocessable Entity) status code means the server
>    understands the content type of the request entity (hence a
>    415(Unsupported Media Type) status code is inappropriate), and the
>    syntax of the request entity is correct (thus a 400 (Bad Request)
>    status code is inappropriate) but was unable to process the contained
>    instructions.  For example, this error condition may occur if an XML
>    request body contains well-formed (i.e., syntactically correct), but
>    semantically erroneous, XML instructions.
> (http://tools.ietf.org/html/rfc4918#section-11.2)

This was all originally mentioned here: friendsofcake/crud#337
