### PR TITLE
Added identiferEquals method for expressions to use fields with quoting.

### DIFF
--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -130,6 +130,10 @@ class CaseExpression implements ExpressionInterface
                 $value = $keyValues[$k];
                 array_push($this->_values, $value);
                 continue;
+            } elseif ($value === 'identifier') {
+                $value = new IdentifierExpression($keyValues[$k]);
+                array_push($this->_values, $value);
+                continue;
             } elseif ($value instanceof ExpressionInterface) {
                 array_push($this->_values, $value);
                 continue;

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -102,6 +102,11 @@ class FunctionExpression extends QueryExpression
                 continue;
             }
 
+            if ($p === 'identifier') {
+                $put($this->_conditions, new IdentifierExpression($k));
+                continue;
+            }
+
             if ($p instanceof ExpressionInterface) {
                 $put($this->_conditions, $p);
                 continue;

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -393,6 +393,18 @@ class QueryExpression implements ExpressionInterface, Countable
     }
 
     /**
+     * Build join condition with identifier wrapping.
+     *
+     * @param string $left Left join condition field name.
+     * @param string $right Right join condition field name.
+     * @return $this
+     */
+    public function equalFields($left, $right)
+    {
+        return $this->eq(new IdentifierExpression($left), new IdentifierExpression($right));
+    }
+
+    /**
      * Returns the string representation of this object so that it can be used in a
      * SQL query. Note that values condition values are not included in the string,
      * in their place placeholders are put and can be replaced by the quoted values

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -194,7 +194,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->order(['title' => 'asc'])
             ->execute();
 
@@ -206,7 +206,7 @@ class QueryTest extends TestCase
         $this->assertCount(12, $result, 'Cross join results in 12 records');
 
         $result = $query->join([
-            ['table' => 'authors', 'type' => 'INNER', 'conditions' => 'author_id = authors.id']
+            ['table' => 'authors', 'type' => 'INNER', 'conditions' => $query->newExpr()->equalFields('author_id', 'authors.id')]
         ], [], true)->execute();
         $this->assertCount(3, $result);
         $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
@@ -224,14 +224,14 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => ['author_id = a.id']])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => [$query->newExpr()->equalFields('author_id ', 'a.id')]])
             ->order(['title' => 'asc'])
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
         $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $result->fetch('assoc'));
 
         $query = new Query($this->connection);
-        $conditions = $query->newExpr('author_id = a.id');
+        $conditions = $query->newExpr()->equalFields('author_id', 'a.id');
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
@@ -1294,7 +1294,7 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp, $q) {
-                $field = $q->newExpr('COALESCE(id, 1)');
+                $field = $q->func()->coalesce([new IdentifierExpression('id'), 1 => 'literal']);
                 return $exp->between($field, 5, 6, 'integer');
             })
             ->execute();
@@ -1558,7 +1558,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderAsc($query->func()->concat(['id' => 'literal', '3']));
+            ->orderAsc($query->func()->concat(['id' => 'identifier', '3']));
 
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1597,7 +1597,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderDesc($query->func()->concat(['id' => 'literal', '3']));
+            ->orderDesc($query->func()->concat(['id' => 'identifier', '3']));
 
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1765,7 +1765,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->having(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
             ->execute();
@@ -1797,7 +1797,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->orHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
@@ -1809,7 +1809,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->orHaving(['count(author_id) <=' => 2], ['count(author_id)' => 'integer'])
@@ -1821,7 +1821,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->orHaving(function ($e) {
@@ -1844,7 +1844,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
@@ -1855,7 +1855,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->having(['count(author_id)' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) >' => 1], ['count(author_id)' => 'integer'])
@@ -1867,7 +1867,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
             ->group('author_id')
             ->andHaving(function ($e) {
                 return $e->add('count(author_id) = 2 - 1');
@@ -2003,7 +2003,7 @@ class QueryTest extends TestCase
         $subquery = (new Query($this->connection))
             ->select('name')
             ->from(['b' => 'authors'])
-            ->where(['b.id = a.id']);
+            ->where([$query->newExpr()->equalFields('b.id', 'a.id')]);
         $result = $query
             ->select(['id', 'name' => $subquery])
             ->from(['a' => 'comments'])->execute();
@@ -2111,7 +2111,7 @@ class QueryTest extends TestCase
      *
      * @return void
      */
-    public function testSubqueyInJoin()
+    public function testSubqueryInJoin()
     {
         $subquery = (new Query($this->connection))->select('*')->from('authors');
 
@@ -2127,7 +2127,7 @@ class QueryTest extends TestCase
         $result = $query->execute();
         $this->assertCount(3, $result);
 
-        $query->join(['b' => ['table' => $subquery, 'conditions' => ['b.id = articles.id']]], [], true);
+        $query->join(['b' => ['table' => $subquery, 'conditions' => [$query->newExpr()->equalFields('b.id', 'articles.id')]]], [], true);
         $result = $query->execute();
         $this->assertCount(1, $result);
     }
@@ -2435,7 +2435,7 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection);
 
-        $expr = $query->newExpr('title = author_id');
+        $expr = $query->newExpr()->equalFields('title', 'author_id');
 
         $query->update('articles')
             ->set($expr)
@@ -2443,7 +2443,7 @@ class QueryTest extends TestCase
         $result = $query->sql();
 
         $this->assertQuotedQuery(
-            'UPDATE <articles> SET title = author_id WHERE <id> = :',
+            'UPDATE <articles> SET <title> = \(<author_id>\) WHERE <id> = :',
             $result,
             !$this->autoQuote
         );
@@ -2621,7 +2621,7 @@ class QueryTest extends TestCase
                 'published' => 'N',
             ]
         ];
-        $this->assertTable('articles', 1, $expected, ['id >= 4']);
+        $this->assertTable('articles', 1, $expected, ['id >=' => 4]);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -39,7 +39,13 @@ class FooType extends Type
 class TableTest extends TestCase
 {
 
-    public $fixtures = ['core.articles_tags', 'core.orders', 'core.products', 'core.tags'];
+    public $fixtures = [
+        'core.articles',
+        'core.tags',
+        'core.articles_tags',
+        'core.orders',
+        'core.products'
+    ];
 
     protected $_map;
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -35,13 +35,13 @@ class QueryRegressionTest extends TestCase
      */
     public $fixtures = [
         'core.articles',
+        'core.tags',
         'core.articles_tags',
         'core.authors',
         'core.authors_tags',
         'core.comments',
         'core.featured_tags',
         'core.special_tags',
-        'core.tags',
         'core.tags_translations',
         'core.translates',
         'core.users'
@@ -978,7 +978,7 @@ class QueryRegressionTest extends TestCase
         $query->select([
             'id',
             'coalesced' => $query->func()->coalesce(
-                ['published' => 'literal', -1],
+                ['published' => 'identifier', -1],
                 ['integer']
             )
         ]);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1522,7 +1522,7 @@ class QueryTest extends TestCase
         $query = $table->find();
         $query->select([
             'title' => $query->func()->concat(
-                ['title' => 'literal', 'test'],
+                ['title' => 'identifier', 'test'],
                 ['string']
             ),
         ]);
@@ -2183,7 +2183,7 @@ class QueryTest extends TestCase
      *
      * @return void
      */
-    public function testFormatDeepAssocationRecords()
+    public function testFormatDeepAssociationRecords()
     {
         $table = TableRegistry::get('ArticlesTags');
         $table->belongsTo('Articles');
@@ -2432,12 +2432,13 @@ class QueryTest extends TestCase
     public function testColumnsFromJoin()
     {
         $table = TableRegistry::get('articles');
-        $results = $table->find()
+        $query = $table->find();
+        $results = $query
             ->select(['title', 'person.name'])
             ->join([
                 'person' => [
                     'table' => 'authors',
-                    'conditions' => ['person.id = articles.author_id']
+                    'conditions' => [$query->newExpr()->equalFields('person.id', 'articles.author_id')]
                 ]
             ])
             ->order(['articles.id' => 'ASC'])

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -53,6 +53,7 @@ class TableTest extends TestCase
 
     public $fixtures = [
         'core.articles',
+        'core.tags',
         'core.articles_tags',
         'core.authors',
         'core.categories',
@@ -62,7 +63,6 @@ class TableTest extends TestCase
         'core.members',
         'core.polymorphic_tagged',
         'core.site_articles',
-        'core.tags',
         'core.users'
     ];
 


### PR DESCRIPTION
Added identiferEquals method for expressions to use fields with quoting in join conditions. 
Added identifier parameter for expressions.
