### PR TITLE
Tree behaviour is currently broken for certain cases

### DIFF
--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -846,10 +846,10 @@ class TreeBehavior extends Behavior
     protected function _getMax()
     {
         $field = $this->_config['right'];
-        $leftField = $this->_config['leftField'];
+        $rightField = $this->_config['rightField'];
         $edge = $this->_scope($this->_table->find())
             ->select([$field])
-            ->orderDesc($leftField)
+            ->orderDesc($rightField)
             ->first();
 
         if (empty($edge->{$field})) {

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -853,6 +853,43 @@ class TreeBehaviorTest extends TestCase
     }
 
     /**
+     * Tests adding a root element to the tree when all other root elements have children
+     *
+     * @return void
+     */
+    public function testAddRoot()
+    {
+        $table = $this->table;
+
+        //First add a child to the empty root element
+        $alien = $table->find()->where(['name' => 'alien hardware'])->first();
+        $entity = new Entity(['name' => 'plasma rifle', 'parent_id' => $alien->id], ['markNew' => true]);
+        $table->save($entity);
+
+        $entity = new Entity(['name' => 'carpentry', 'parent_id' => null], ['markNew' => true]);
+        $this->assertSame($entity, $table->save($entity));
+        $this->assertEquals(25, $entity->lft);
+        $this->assertEquals(26, $entity->rght);
+
+        $expected = [
+            ' 1:20 -  1:electronics',
+            '_ 2: 9 -  2:televisions',
+            '__ 3: 4 -  3:tube',
+            '__ 5: 6 -  4:lcd',
+            '__ 7: 8 -  5:plasma',
+            '_10:19 -  6:portable',
+            '__11:14 -  7:mp3',
+            '___12:13 -  8:flash',
+            '__15:16 -  9:cd',
+            '__17:18 - 10:radios',
+            '21:24 - 11:alien hardware',
+            '_22:23 - 12:plasma rifle',
+            '25:26 - 13:carpentry',
+        ];
+        $this->assertMpttValues($expected, $this->table);
+    }
+
+    /**
      * Tests moving a subtree to the right
      *
      * @return void


### PR DESCRIPTION
https://github.com/cakephp/cakephp/commit/bbf407d525a67220d78536588a79ba4519305bcc broke the tree behaviour. When you create a new root element and all other root elements already have children the `lft` and `rght` fields are incorrectly assigned.

This correctly fixes the issue.
