### PR TITLE
Allow camelBacked virtualProperties to be accessed.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -535,7 +535,9 @@ trait EntityTrait
             if ($method[0] !== '_' || ($prefix !== 'get' && $prefix !== 'set')) {
                 continue;
             }
-            $field = Inflector::underscore(substr($method, 4));
+            $field = lcfirst(substr($method, 4));
+            $snakeField = Inflector::underscore($field);
+            static::$_accessors[$class][$prefix][$snakeField] = $method;
             static::$_accessors[$class][$prefix][$field] = $method;
         }
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -418,6 +418,7 @@ class QueryTest extends TestCase
             ->where(['id' => 1, 'title' => 'First Article'])
             ->execute();
         $this->assertCount(1, $result);
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -426,6 +427,7 @@ class QueryTest extends TestCase
             ->where(['id' => 100], ['id' => 'integer'])
             ->execute();
         $this->assertCount(0, $result);
+        $result->closeCursor();
     }
 
     /**
@@ -437,12 +439,13 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection);
         $result = $query
-            ->select(['title'])
-            ->from('articles')
-            ->where(['id >' => 1])
+            ->select(['comment'])
+            ->from('comments')
+            ->where(['id >' => 4])
             ->execute();
         $this->assertCount(2, $result);
-        $this->assertEquals(['title' => 'Second Article'], $result->fetch('assoc'));
+        $this->assertEquals(['comment' => 'First Comment for Second Article'], $result->fetch('assoc'));
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -452,6 +455,7 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertCount(1, $result);
         $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -460,6 +464,7 @@ class QueryTest extends TestCase
             ->where(['id <=' => 2])
             ->execute();
         $this->assertCount(2, $result);
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -468,6 +473,7 @@ class QueryTest extends TestCase
             ->where(['id >=' => 1])
             ->execute();
         $this->assertCount(3, $result);
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -476,6 +482,7 @@ class QueryTest extends TestCase
             ->where(['id <=' => 1])
             ->execute();
         $this->assertCount(1, $result);
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -485,6 +492,7 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertCount(2, $result);
         $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -494,6 +502,7 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertCount(1, $result);
         $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -502,6 +511,7 @@ class QueryTest extends TestCase
             ->where(['title like' => '%Article%'])
             ->execute();
         $this->assertCount(3, $result);
+        $result->closeCursor();
 
         $query = new Query($this->connection);
         $result = $query
@@ -510,6 +520,7 @@ class QueryTest extends TestCase
             ->where(['title not like' => '%Article%'])
             ->execute();
         $this->assertCount(0, $result);
+        $result->closeCursor();
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -313,6 +313,23 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Test getting camelcased virtual fields.
+     *
+     * @return void
+     */
+    public function testGetCamelCasedProperties()
+    {
+        $entity = $this->getMock('\Cake\ORM\Entity', ['_getListIdName']);
+        $entity->expects($this->any())->method('_getListIdName')
+            ->will($this->returnCallback(function ($name) {
+                return 'A name';
+            }));
+        $entity->virtualProperties(['ListIdName']);
+        $this->assertSame('A name', $entity->list_id_name, 'underscored virtual field should be accessible');
+        $this->assertSame('A name', $entity->listIdName, 'Camelbacked virtual field should be accessible');
+    }
+
+    /**
      * Test magic property setting with no custom setter
      *
      * @return void


### PR DESCRIPTION
This fixes a regression introduced in while optimizing entity accessors.

Refs #8246
