### PR TITLE
[WIP] 3.x - Add a database centric connection interface.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\ConnectionInterface;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\MissingDriverException;
 use Cake\Database\Exception\MissingExtensionException;
@@ -22,7 +23,6 @@ use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection as SchemaCollection;
-use Cake\Datasource\ConnectionInterface;
 use Exception;
 
 /**
@@ -141,16 +141,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Sets the driver instance. If a string is passed it will be treated
-     * as a class name and will be instantiated.
-     *
-     * If no params are passed it will return the current driver instance.
-     *
-     * @param \Cake\Database\Driver|string|null $driver The driver instance to use.
-     * @param array $config Either config for a new driver or null.
-     * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
-     * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
-     * @return \Cake\Database\Driver
+     * {@inheritDoc}
      */
     public function driver($driver = null, $config = [])
     {
@@ -170,10 +161,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Connects to the configured database.
-     *
-     * @throws \Cake\Database\Exception\MissingConnectionException if credentials are invalid
-     * @return bool true on success or false if already connected.
+     * {@inheritDoc}
      */
     public function connect()
     {
@@ -186,9 +174,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Disconnects from database server.
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function disconnect()
     {
@@ -196,9 +182,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Returns whether connection to database server was already established.
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function isConnected()
     {
@@ -206,10 +190,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Prepares a SQL statement to be executed.
-     *
-     * @param string|\Cake\Database\Query $sql The SQL to convert into a prepared statement.
-     * @return \Cake\Database\StatementInterface
+     * {@inheritDoc}
      */
     public function prepare($sql)
     {
@@ -223,13 +204,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Executes a query using $params for interpolating values and $types as a hint for each
-     * those params.
-     *
-     * @param string $query SQL to be executed and interpolated with $params
-     * @param array $params list or associative array of params to be interpolated in $query as values
-     * @param array $types list or associative array of types to be used for casting values in query
-     * @return \Cake\Database\StatementInterface executed statement
+     * {@inheritDoc}
      */
     public function execute($query, array $params = [], array $types = [])
     {
@@ -244,12 +219,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Compiles a Query object into a SQL string according to the dialect for this
-     * connection's driver
-     *
-     * @param \Cake\Database\Query $query The query to be compiled
-     * @param \Cake\Database\ValueBinder $generator The placeholder generator to use
-     * @return string
+     * {@inheritDoc}
      */
     public function compileQuery(Query $query, ValueBinder $generator)
     {
@@ -257,11 +227,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Executes the provided query after compiling it for the specific driver
-     * dialect and returns the executed Statement object.
-     *
-     * @param \Cake\Database\Query $query The query to be executed
-     * @return \Cake\Database\StatementInterface executed statement
+     * {@inheritDoc}
      */
     public function run(Query $query)
     {
@@ -273,10 +239,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Executes a SQL statement and returns the Statement object as result.
-     *
-     * @param string $sql The SQL query to execute.
-     * @return \Cake\Database\StatementInterface
+     * {@inheritDoc}
      */
     public function query($sql)
     {
@@ -286,9 +249,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Create a new Query instance for this connection.
-     *
-     * @return \Cake\Database\Query
+     * {@inheritDoc}
      */
     public function newQuery()
     {
@@ -296,10 +257,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Gets or sets a Schema\Collection object for this connection.
-     *
-     * @param \Cake\Database\Schema\Collection|null $collection The schema collection object
-     * @return \Cake\Database\Schema\Collection
+     * {@inheritDoc}
      */
     public function schemaCollection(SchemaCollection $collection = null)
     {
@@ -321,9 +279,9 @@ class Connection implements ConnectionInterface
     /**
      * Executes an INSERT query on the specified table.
      *
-     * @param string $table the table to insert values in
-     * @param array $data values to be inserted
-     * @param array $types list of associative array containing the types to be used for casting
+     * @param string $table The table to insert values in
+     * @param array $data Values to be inserted
+     * @param array $types List of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
     public function insert($table, array $data, array $types = [])
@@ -338,10 +296,10 @@ class Connection implements ConnectionInterface
     /**
      * Executes an UPDATE statement on the specified table.
      *
-     * @param string $table the table to update rows from
-     * @param array $data values to be updated
-     * @param array $conditions conditions to be set for update statement
-     * @param array $types list of associative array containing the types to be used for casting
+     * @param string $table The table to update rows from
+     * @param array $data Values to be updated
+     * @param array $conditions Conditions to be set for update statement
+     * @param array $types List of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
     public function update($table, array $data, array $conditions = [], $types = [])
@@ -355,9 +313,9 @@ class Connection implements ConnectionInterface
     /**
      * Executes a DELETE statement on the specified table.
      *
-     * @param string $table the table to delete rows from
-     * @param array $conditions conditions to be set for delete statement
-     * @param array $types list of associative array containing the types to be used for casting
+     * @param string $table The table to delete rows from
+     * @param array $conditions Conditions to be set for delete statement
+     * @param array $types List of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
     public function delete($table, $conditions = [], $types = [])
@@ -393,7 +351,7 @@ class Connection implements ConnectionInterface
     /**
      * Commits current transaction.
      *
-     * @return bool true on success, false otherwise
+     * @return bool `true` on success, `false` otherwise
      */
     public function commit()
     {
@@ -445,21 +403,13 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Returns whether this connection is using savepoints for nested transactions
-     * If a boolean is passed as argument it will enable/disable the usage of savepoints
-     * only if driver the allows it.
-     *
-     * If you are trying to enable this feature, make sure you check the return value of this
-     * function to verify it was enabled successfully.
+     * {@inheritDoc}
      *
      * ### Example:
      *
      * `$connection->useSavePoints(true)` Returns true if drivers supports save points, false otherwise
      * `$connection->useSavePoints(false)` Disables usage of savepoints and returns false
      * `$connection->useSavePoints()` Returns current status
-     *
-     * @param bool|null $enable Whether or not save points should be used.
-     * @return bool true if enabled, false otherwise
      */
     public function useSavePoints($enable = null)
     {
@@ -531,7 +481,7 @@ class Connection implements ConnectionInterface
      * Returns whether the driver supports adding or dropping constraints
      * to already created tables.
      *
-     * @return bool true if driver supports dynamic constraints
+     * @return bool `true` if driver supports dynamic constraints
      */
     public function supportsDynamicConstraints()
     {
@@ -596,9 +546,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Checks if a transaction is running.
-     *
-     * @return bool True if a transaction is running else false.
+     * {@inheritDoc}
      */
     public function inTransaction()
     {
@@ -606,11 +554,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Quotes value to be used safely in database query.
-     *
-     * @param mixed $value The value to quote.
-     * @param string $type Type to be used for determining kind of quoting to perform
-     * @return string Quoted value
+     * {@inheritDoc}
      */
     public function quote($value, $type = null)
     {
@@ -619,9 +563,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Checks if the driver supports quoting.
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function supportsQuoting()
     {
@@ -629,11 +571,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Quotes a database identifier (a column name, table name, etc..) to
-     * be used safely in queries without the risk of using reserved words.
-     *
-     * @param string $identifier The identifier to quote.
-     * @return string
+     * {@inheritDoc}
      */
     public function quoteIdentifier($identifier)
     {
@@ -641,13 +579,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Enables or disables metadata caching for this connection
-     *
-     * Changing this setting will not modify existing schema collections objects.
-     *
-     * @param bool|string $cache Either boolean false to disable meta dataing caching, or
-     *   true to use `_cake_model_` or the name of the cache config to use.
-     * @return void
+     * {@inheritDoc}
      */
     public function cacheMetadata($cache)
     {
@@ -683,7 +615,7 @@ class Connection implements ConnectionInterface
     /**
      * Logs a Query string using the configured logger object.
      *
-     * @param string $sql string to be logged
+     * @param string $sql String to be logged
      * @return void
      */
     public function log($sql)

--- a/src/Database/ConnectionInterface.php
+++ b/src/Database/ConnectionInterface.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database;
+
+use Cake\Database\Schema\Collection as SchemaCollection;
+use Cake\Datasource\ConnectionInterface as DatasourceConnectionInterface;
+
+/**
+ * This interface defines the methods you can depend on in
+ * a database connection.
+ */
+interface ConnectionInterface extends DatasourceConnectionInterface
+{
+    /**
+     * Sets the driver instance. If a string is passed it will be treated
+     * as a class name and will be instantiated.
+     *
+     * If no params are passed it will return the current driver instance.
+     *
+     * @param \Cake\Database\Driver|string|null $driver The driver instance to use.
+     * @param array $config Either config for a new driver or `null`.
+     * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
+     * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
+     * @return \Cake\Database\Driver
+     */
+    public function driver($driver = null, $config = []);
+
+    /**
+     * Prepares a SQL statement to be executed.
+     *
+     * @param string|\Cake\Database\Query $sql The SQL to convert into a prepared statement.
+     * @return \Cake\Database\StatementInterface
+     */
+    public function prepare($sql);
+
+    /**
+     * Executes a query using $params for interpolating values and $types as a hint for each
+     * those params.
+     *
+     * @param string $query SQL to be executed and interpolated with $params
+     * @param array $params List or associative array of params to be interpolated in `$query` as values
+     * @param array $types List or associative array of types to be used for casting values in query
+     * @return \Cake\Database\StatementInterface executed statement
+     */
+    public function execute($query, array $params = [], array $types = []);
+
+    /**
+     * Compiles a Query object into a SQL string according to the dialect for this
+     * connection's driver
+     *
+     * @param \Cake\Database\Query $query The query to be compiled
+     * @param \Cake\Database\ValueBinder $generator The placeholder generator to use
+     * @return string
+     */
+    public function compileQuery(Query $query, ValueBinder $generator);
+
+    /**
+     * Executes the provided query after compiling it for the specific driver
+     * dialect and returns the executed Statement object.
+     *
+     * @param \Cake\Database\Query $query The query to be executed
+     * @return \Cake\Database\StatementInterface executed statement
+     */
+    public function run(Query $query);
+
+    /**
+     * Executes a SQL statement and returns the Statement object as result.
+     *
+     * @param string $sql The SQL query to execute.
+     * @return \Cake\Database\StatementInterface
+     */
+    public function query($sql);
+
+    /**
+     * Create a new Query instance for this connection.
+     *
+     * @return \Cake\Database\Query
+     */
+    public function newQuery();
+
+    /**
+     * Gets or sets a Schema\Collection object for this connection.
+     *
+     * @param \Cake\Database\Schema\Collection|null $collection The schema collection object
+     * @return \Cake\Database\Schema\Collection
+     */
+    public function schemaCollection(SchemaCollection $collection = null);
+
+    /**
+     * Returns whether this connection is using savepoints for nested transactions
+     * If a boolean is passed as argument it will enable/disable the usage of savepoints
+     * only if driver the allows it.
+     *
+     * If you are trying to enable this feature, make sure you check the return value of this
+     * function to verify it was enabled successfully.
+     *
+     * @param bool|null $enable Whether or not save points should be used.
+     * @return bool `true` if enabled, `false` otherwise
+     */
+    public function useSavePoints($enable = null);
+
+    /**
+     * Checks if a transaction is running.
+     *
+     * @return bool `true` if a transaction is running else `false`.
+     */
+    public function inTransaction();
+
+    /**
+     * Quotes value to be used safely in database query.
+     *
+     * @param mixed $value The value to quote.
+     * @param string $type Type to be used for determining kind of quoting to perform
+     * @return string Quoted value
+     */
+    public function quote($value, $type = null);
+
+    /**
+     * Checks if the driver supports quoting.
+     *
+     * @return bool
+     */
+    public function supportsQuoting();
+
+    /**
+     * Quotes a database identifier (a column name, table name, etc..) to
+     * be used safely in queries without the risk of using reserved words.
+     *
+     * @param string $identifier The identifier to quote.
+     * @return string
+     */
+    public function quoteIdentifier($identifier);
+
+    /**
+     * Enables or disables metadata caching for this connection
+     *
+     * Changing this setting will not modify existing schema collections objects.
+     *
+     * @param bool|string $cache Either boolean `false` to disable metadata caching,
+     *   `true` to use `_cake_model_`, or the name of the cache config to use.
+     * @return void
+     */
+    public function cacheMetadata($cache);
+}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\ConnectionInterface;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
@@ -37,7 +38,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Connection instance to be used to execute this query.
      *
-     * @var \Cake\Datasource\ConnectionInterface
+     * @var \Cake\Database\ConnectionInterface
      */
     protected $_connection;
 
@@ -132,10 +133,10 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Constructor.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection
+     * @param \Cake\Database\ConnectionInterface $connection The connection
      * object to be used for transforming and executing this query
      */
-    public function __construct($connection)
+    public function __construct(ConnectionInterface $connection)
     {
         $this->connection($connection);
     }
@@ -144,10 +145,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Sets the connection instance to be used for executing and transforming this query
      * When called with a null argument, it will return the current connection instance.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection instance
-     * @return $this|\Cake\Datasource\ConnectionInterface
+     * @param \Cake\Database\ConnectionInterface $connection instance
+     * @return $this|\Cake\Database\ConnectionInterface
      */
-    public function connection($connection = null)
+    public function connection(ConnectionInterface $connection = null)
     {
         if ($connection === null) {
             return $this->_connection;

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -15,7 +15,7 @@
 namespace Cake\Database\Schema;
 
 use Cake\Cache\Cache;
-use Cake\Datasource\ConnectionInterface;
+use Cake\Database\ConnectionInterface;
 
 /**
  * Extends the schema collection class to provide caching
@@ -35,7 +35,7 @@ class CachedCollection extends Collection
     /**
      * Constructor.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection instance.
+     * @param \Cake\Database\ConnectionInterface $connection The connection instance.
      * @param string|bool $cacheKey The cache key or boolean false to disable caching.
      */
     public function __construct(ConnectionInterface $connection, $cacheKey = true)

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\ConnectionInterface;
 use Cake\Database\Exception;
-use Cake\Datasource\ConnectionInterface;
 use PDOException;
 
 /**
@@ -30,7 +30,7 @@ class Collection
     /**
      * Connection object
      *
-     * @var \Cake\Datasource\ConnectionInterface
+     * @var \Cake\Database\ConnectionInterface
      */
     protected $_connection;
 
@@ -44,7 +44,7 @@ class Collection
     /**
      * Constructor.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection instance.
+     * @param \Cake\Database\ConnectionInterface $connection The connection instance.
      */
     public function __construct(ConnectionInterface $connection)
     {

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\ConnectionInterface;
 use Cake\Database\Exception;
 use Cake\Database\Type;
-use Cake\Datasource\ConnectionInterface;
 
 /**
  * Represents a single table in a database schema.
@@ -697,7 +697,7 @@ class Table
      * Uses the connection to access the schema dialect
      * to generate platform specific SQL.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for
+     * @param \Cake\Database\ConnectionInterface $connection The connection to generate SQL for
      * @return array List of SQL statements to create the table and the
      *    required indexes.
      */
@@ -723,7 +723,7 @@ class Table
      * Uses the connection to access the schema dialect to generate platform
      * specific SQL.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\ConnectionInterface $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
     public function dropSql(ConnectionInterface $connection)
@@ -735,7 +735,7 @@ class Table
     /**
      * Generate the SQL statements to truncate a table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\ConnectionInterface $connection The connection to generate SQL for.
      * @return array SQL to truncate a table.
      */
     public function truncateSql(ConnectionInterface $connection)
@@ -747,7 +747,7 @@ class Table
     /**
      * Generate the SQL statements to add the constraints to the table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\ConnectionInterface $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
     public function addConstraintSql(ConnectionInterface $connection)
@@ -759,7 +759,7 @@ class Table
     /**
      * Generate the SQL statements to drop the constraints to the table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\ConnectionInterface $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
     public function dropConstraintSql(ConnectionInterface $connection)

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -35,6 +35,27 @@ interface ConnectionInterface
     public function config();
 
     /**
+     * Connects the datasource.
+     *
+     * @return bool true on success or false if already connected.
+     */
+    public function connect();
+
+    /**
+     * Disconnects the datasource
+     *
+     * @return void
+     */
+    public function disconnect();
+
+    /**
+     * Returns whether the datasource connection was already established.
+     *
+     * @return bool
+     */
+    public function isConnected();
+
+    /**
      * Executes a callable function inside a transaction, if any exception occurs
      * while executing the passed callable, the transaction will be rolled back
      * If the result of the callable function is `false`, the transaction will

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -16,6 +16,7 @@ namespace Cake\ORM;
 
 use ArrayObject;
 use Cake\Collection\CollectionInterface;
+use Cake\Database\ConnectionInterface;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\TypedResultInterface;
@@ -157,10 +158,10 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * Constructor
      *
-     * @param \Cake\Database\Connection $connection The connection object
+     * @param \Cake\Database\ConnectionInterface $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
-    public function __construct($connection, $table)
+    public function __construct(ConnectionInterface $connection, $table)
     {
         parent::__construct($connection);
         $this->repository($table);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -17,9 +17,9 @@ namespace Cake\ORM;
 use ArrayObject;
 use BadMethodCallException;
 use Cake\Core\App;
+use Cake\Database\ConnectionInterface;
 use Cake\Database\Schema\Table as Schema;
 use Cake\Database\Type;
-use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\RepositoryInterface;
@@ -161,7 +161,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Connection instance
      *
-     * @var \Cake\Datasource\ConnectionInterface
+     * @var \Cake\Database\ConnectionInterface
      */
     protected $_connection;
 
@@ -389,8 +389,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the connection instance or sets a new one
      *
-     * @param \Cake\Datasource\ConnectionInterface|null $conn The new connection instance
-     * @return \Cake\Datasource\ConnectionInterface
+     * @param \Cake\Database\ConnectionInterface|null $conn The new connection instance
+     * @return \Cake\Database\ConnectionInterface
      */
     public function connection(ConnectionInterface $conn = null)
     {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -219,7 +219,7 @@ class FixtureManager
      * Runs the drop and create commands on the fixtures if necessary.
      *
      * @param \Cake\TestSuite\Fixture\TestFixture $fixture the fixture object to create
-     * @param \Cake\Database\Connection $db The Connection object instance to use
+     * @param \Cake\Database\ConnectionInterface $db The Connection object instance to use
      * @param array $sources The existing tables in the datasource.
      * @param bool $drop whether drop the fixture if it is already created or not
      * @return void
@@ -383,7 +383,7 @@ class FixtureManager
      * Creates a single fixture table and loads data into it.
      *
      * @param string $name of the fixture
-     * @param \Cake\Datasource\ConnectionInterface $db Connection instance or leave null to get a Connection from the fixture
+     * @param \Cake\Database\ConnectionInterface $db Connection instance or leave null to get a Connection from the fixture
      * @param bool $dropTables Whether or not tables should be dropped and re-created.
      * @return void
      * @throws \UnexpectedValueException if $name is not a previously loaded class

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -184,7 +184,7 @@ class MysqlSchemaTest extends TestCase
     /**
      * Helper method for testing methods.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection
+     * @param \Cake\Database\ConnectionInterface $connection
      * @return void
      */
     protected function _createTables($connection)

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -41,7 +41,7 @@ class PostgresSchemaTest extends TestCase
     /**
      * Helper method for testing methods.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection
+     * @param \Cake\Database\ConnectionInterface $connection
      * @return void
      */
     protected function _createTables($connection)

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -58,11 +58,11 @@ class HasManyTest extends TestCase
                 ]
             ]
         ]);
-        $connection = ConnectionManager::get('test');
+        $this->connection = ConnectionManager::get('test');
         $this->article = $this->getMock(
             'Cake\ORM\Table',
             ['find', 'deleteAll', 'delete'],
-            [['alias' => 'Articles', 'table' => 'articles', 'connection' => $connection]]
+            [['alias' => 'Articles', 'table' => 'articles', 'connection' => $this->connection]]
         );
         $this->article->schema([
             'id' => ['type' => 'integer'],
@@ -84,7 +84,7 @@ class HasManyTest extends TestCase
             'Articles__title' => 'string',
             'Articles__author_id' => 'integer',
         ]);
-        $this->autoQuote = $connection->driver()->autoQuoting();
+        $this->autoQuote = $this->connection->driver()->autoQuoting();
     }
 
     /**
@@ -390,7 +390,7 @@ class HasManyTest extends TestCase
         $this->author->primaryKey(['id', 'site_id']);
         $association = new HasMany('Articles', $config);
         $keys = [[1, 10], [2, 20], [3, 30], [4, 40]];
-        $query = $this->getMock('Cake\ORM\Query', ['all', 'andWhere'], [null, null]);
+        $query = $this->getMock('Cake\ORM\Query', ['all', 'andWhere'], [$this->connection, null]);
         $this->article->method('find')
             ->with('all')
             ->will($this->returnValue($query));

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
+use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -38,6 +39,7 @@ class HasOneTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $this->connection = ConnectionManager::get('test');
         $this->user = TableRegistry::get('Users', [
             'schema' => [
                 'id' => ['type' => 'integer'],
@@ -100,7 +102,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachTo()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [$this->connection, null]);
         $config = [
             'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
@@ -134,7 +136,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToNoFields()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [$this->connection, null]);
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
@@ -164,7 +166,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToMultiPrimaryKey()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [$this->connection, null]);
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
@@ -199,7 +201,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToMultiPrimaryKeyMistmatch()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [$this->connection, null]);
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
@@ -273,7 +275,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToBeforeFind()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [$this->connection, null]);
         $config = [
             'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
@@ -300,7 +302,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToBeforeFindExtraOptions()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [$this->connection, null]);
         $config = [
             'foreignKey' => 'user_id',
             'sourceTable' => $this->user,

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Datasource\ConnectionManager;
 use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
@@ -293,7 +294,8 @@ class BehaviorRegistryTest extends TestCase
             ->getMock();
         $this->Behaviors->set('Sluggable', $mockedBehavior);
 
-        $query = $this->getMock('Cake\ORM\Query', [], [null, null]);
+        $connection = ConnectionManager::get('test');
+        $query = $this->getMock('Cake\ORM\Query', [], [$connection, null]);
         $mockedBehavior
             ->expects($this->once())
             ->method('findNoSlug')

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -591,7 +591,7 @@ class CompositeKeyTest extends TestCase
         $query = $this->getMock(
             '\Cake\ORM\Query',
             ['_addDefaultFields', 'execute'],
-            [null, $table]
+            [$this->connection, $table]
         );
 
         $items = new \Cake\Datasource\ResultSetDecorator([

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2308,7 +2308,7 @@ class TableTest extends TestCase
         $query = $this->getMock(
             '\Cake\ORM\Query',
             ['execute', 'addDefaultTypes'],
-            [null, $table]
+            [$this->connection, $table]
         );
         $statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
         $data = new \Cake\ORM\Entity([
@@ -2455,7 +2455,7 @@ class TableTest extends TestCase
         $query = $this->getMock(
             '\Cake\ORM\Query',
             ['execute', 'addDefaultTypes'],
-            [null, $table]
+            [$this->connection, $table]
         );
         $table->expects($this->any())->method('connection')
             ->will($this->returnValue($connection));
@@ -2498,7 +2498,7 @@ class TableTest extends TestCase
         $query = $this->getMock(
             '\Cake\ORM\Query',
             ['execute', 'addDefaultTypes'],
-            [null, $table]
+            [$this->connection, $table]
         );
 
         $table->expects($this->any())->method('connection')
@@ -2685,7 +2685,7 @@ class TableTest extends TestCase
         $query = $this->getMock(
             '\Cake\ORM\Query',
             ['execute', 'addDefaultTypes', 'set'],
-            [null, $table]
+            [$this->connection, $table]
         );
 
         $table->expects($this->once())->method('query')


### PR DESCRIPTION
Here we go, trying to make our beloved IDEs and code inspection tools a little more satisfied... I think we can all agree that all of us will be happier once we bow down to the machine overlords ![robot](https://cloud.githubusercontent.com/assets/5031606/12948242/11aa5d24-d001-11e5-8538-9af739a9763e.png)

Refs #8210
## Connections

I have replaced occourances of `\Cake\Datasource\ConnectionInterface` with `\Cake\Database\ConnectionInterface` where applicable, in most places it was already expected to actually receive instances of `\Cake\Database\Connection`.

I was a little unsure about what methods should be extracted into the interface, so I started with what I think would be a sane "minimal" set, and see what people think about it.

The following methods were moved into `Datasource\ConnectionInterface`:
- `connect`, `disconnect`, `isConnected`, as they feel kinda essential to any kind of connection (this might be a little controversial, considering that there might be connections whose state shouldn't be changable from the outside world).

The following methods aren't included (yet):
- `insert`, `update`, `delete`, as they are just convenience methods that can easily be used via `newQuery()`.
- `begin`, `commit`, `rollback`, `createSavePoint`, `releaseSavePoint`, `rollbackSavepoint`, as with the `transactional` method the need for them being exposed seems rather low.
- `supportsDynamicConstraints`, as it's just a proxy method.
- `disableForeignKeys`, `enableForeignKeys`, as with the `disableConstraints` method the need for them being exposed seems rather low.
- `log`, as it's merely more than a proxy method.

Let aside those methods that are used in the core and expected to be exposed on connections, the following methods are included:
- `useSavePoints` as it complements `transactional`.
- `query`, as it complements `execute`, and seems to me like it would be one of the more often used methods.
- `quote`, as custom processing depending on the connection implementation doesn't seem to be overly unlikely, and I'm also sure that people would easily forget about casting, even when it would be part of the interface.
- `supportsQuoting`, `quoteIdentifier` because when `quote` is exposed, it would feel kinda odd when these two were only to be found on the driver (not sure how good of an argument that is though).
- `cacheMetadata`, as it's part of the database source configuration options, and therefore kinda essential for database connections.
## Fixtures

And then there's also fixtures. I'm unsure about them, the current fixture interface lives in the `Datasource` namespace, but at least in the core it's only being used for database centric implementations, ie `Cake\TestSuite\Fixture\TestFixture` actually expects `\Cake\Database\Connection` instances, and isn't really satisified by the current fixture interface.

I'm not sure sure though how much sense two fixture interfaces would make, when one of them wouldn't be use in the core anymore.
