### PR TITLE
return the image path

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -800,7 +800,8 @@ class HtmlHelper extends Helper
      *   `$options['url']`.
      * - `fullBase` If true the src attribute will get a full address for the image file.
      * - `plugin` False value will prevent parsing path as a plugin
-     *
+     * - `pathImage` Returns the image path
+     * 
      * @param string $path Path to the image file, relative to the app/webroot/img/ directory.
      * @param array $options Array of HTML attributes. See above for special options.
      * @return string completed img tag
@@ -810,6 +811,10 @@ class HtmlHelper extends Helper
     {
         $path = $this->Url->assetUrl($path, $options + ['pathPrefix' => Configure::read('App.imageBaseUrl')]);
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
+
+        if (!empty($options['pathImage'])){
+            return $path;
+        }
 
         if (!isset($options['alt'])) {
             $options['alt'] = '';


### PR DESCRIPTION
Return the path of the image using the option pathImage => true

echo $this->Html->image("cake.icon.png", ['fullBase' => true, 'pathImage' => true]);
Example: http://localhost/test/img/cake.icon.png
