### PR TITLE
Find table from class

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -156,15 +156,27 @@ class TestFixture implements FixtureInterface
      */
     protected function _tableFromClass()
     {
+        $model = $this->_modelFromClass();
+
+        return Inflector::tableize($model);
+    }
+
+    /**
+     * Returns the model name using the fixture class
+     *
+     * @return string
+     */
+    protected function _modelFromClass()
+    {
         list(, $class) = namespaceSplit(get_class($this));
         preg_match('/^(.*)Fixture$/', $class, $matches);
-        $table = $class;
+        $model = $class;
 
         if (isset($matches[1])) {
-            $table = $matches[1];
+            $model = $matches[1];
         }
 
-        return Inflector::tableize($table);
+        return $model;
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -274,14 +274,15 @@ class TestFixtureTest extends TestCase
     }
 
     /**
-     * test schema reflection without $import or $fields will reflect the schema
+     * create the letters table
      *
      * @return void
      */
-    public function testInitNoImportNoFields()
+    protected function _createLettersTable()
     {
         $db = ConnectionManager::get('test');
         $collection = $db->schemaCollection();
+
         if (!in_array('letters', $collection->listTables())) {
             $table = new Table('letters', [
                 'id' => ['type' => 'integer'],
@@ -294,9 +295,20 @@ class TestFixtureTest extends TestCase
                 $db->execute($stmt);
             }
         }
+    }
 
+    /**
+     * test schema reflection without $import or $fields will reflect the schema
+     *
+     * @return void
+     */
+    public function testInitNoImportNoFields()
+    {
+        $this->_createLettersTable();
         $fixture = new LettersFixture();
+
         $fixture->init();
+
         $this->assertEquals(['id', 'letter'], $fixture->schema()->columns());
 
         $db = $this->getMock('Cake\Database\Connection', ['prepare', 'execute'], [], '', false);


### PR DESCRIPTION
## Explanation

When both $import and $fields are not specified in the Fixture class, the class name should be used instead of throwing an exception.
## _modelFromClass

I took the liberty of extracting the logic to get the Class name. It doesn't change anything but it give more flexibility to the developer.
