### PR TITLE
Read content type in a more compatible way.

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -393,19 +393,19 @@ class CakeRequest implements ArrayAccess {
 			}
 		}
 	}
-        
+
 /**
  * Get the content type used in this request.
  * 
  * @return string
  */
-        public function contentType() {
-            $type = env('CONTENT_TYPE');
-            if ($type) {
-                return $type;
-            }
-            return env('HTTP_CONTENT_TYPE');
-        }
+	public function contentType() {
+		$type = env('CONTENT_TYPE');
+		if ($type) {
+			return $type;
+		}
+		return env('HTTP_CONTENT_TYPE');
+	}
 
 /**
  * Get the IP the client is using, or says they are using.

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -165,7 +165,7 @@ class CakeRequest implements ArrayAccess {
 		if ($_POST) {
 			$this->data = $_POST;
 		} elseif (($this->is('put') || $this->is('delete')) &&
-			strpos(env('CONTENT_TYPE'), 'application/x-www-form-urlencoded') === 0
+			strpos($this->contentType(), 'application/x-www-form-urlencoded') === 0
 		) {
 				$data = $this->_readInput();
 				parse_str($data, $this->data);
@@ -393,6 +393,19 @@ class CakeRequest implements ArrayAccess {
 			}
 		}
 	}
+        
+/**
+ * Get the content type used in this request.
+ * 
+ * @return string
+ */
+        public function contentType() {
+            $type = env('CONTENT_TYPE');
+            if ($type) {
+                return $type;
+            }
+            return env('HTTP_CONTENT_TYPE');
+        }
 
 /**
  * Get the IP the client is using, or says they are using.

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -153,11 +153,11 @@ class CakeRequestTest extends CakeTestCase {
  */
         public function testContentType() {
             $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
-            $request = Request::createFromGlobals();
+            $request = new CakeRequest('/', false);
             $this->assertEquals('application/json', $request->contentType());
 
             $_SERVER['CONTENT_TYPE'] = 'application/xml';
-            $request = Request::createFromGlobals();
+            $request = new CakeRequest('/', false);
             $this->assertEquals('application/xml', $request->contentType(), 'prefer non http header.');
         }
 

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -145,21 +145,21 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest(null, false);
 		$this->assertFalse(isset($request->query['one']));
 	}
-        
+
 /**
  * Test the content type method.
  * 
  * @return void
  */
-        public function testContentType() {
-            $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
-            $request = new CakeRequest('/', false);
-            $this->assertEquals('application/json', $request->contentType());
+	public function testContentType() {
+		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
+		$request = new CakeRequest('/', false);
+		$this->assertEquals('application/json', $request->contentType());
 
-            $_SERVER['CONTENT_TYPE'] = 'application/xml';
-            $request = new CakeRequest('/', false);
-            $this->assertEquals('application/xml', $request->contentType(), 'prefer non http header.');
-        }
+		$_SERVER['CONTENT_TYPE'] = 'application/xml';
+		$request = new CakeRequest('/', false);
+		$this->assertEquals('application/xml', $request->contentType(), 'prefer non http header.');
+	}
 
 /**
  * Test construction

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -145,6 +145,21 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest(null, false);
 		$this->assertFalse(isset($request->query['one']));
 	}
+        
+/**
+ * Test the content type method.
+ * 
+ * @return void
+ */
+        public function testContentType() {
+            $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
+            $request = Request::createFromGlobals();
+            $this->assertEquals('application/json', $request->contentType());
+
+            $_SERVER['CONTENT_TYPE'] = 'application/xml';
+            $request = Request::createFromGlobals();
+            $this->assertEquals('application/xml', $request->contentType(), 'prefer non http header.');
+        }
 
 /**
  * Test construction


### PR DESCRIPTION
Not all webservers set CONTENT_TYPE. The built-in PHP webserver for
example sets HTTP_CONTENT_TYPE instead. Add a public method to the
request object to smooth over this difference.

Refs #6051, #8267
