### PR TITLE
Add assertArrayContentEquals

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -141,6 +141,17 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Assert array equality, ignoring the order of the content
+     * @param array $expected The expected array.
+     * @param array $actual The actual array.
+     * @param string $message The message to use for failure.
+     */
+    public function assertArrayContentEquals(array $expected, array $actual, $message = '')
+    {
+        $this->assertTrue($expected == $actual, $message);
+    }
+
+    /**
      * Assert text equality, ignoring differences in newlines.
      * Helpful for doing cross platform tests of blocks of text.
      *


### PR DESCRIPTION
I need to compare associative arrays a lot, and using assertEquals() will take the ordering of the array into account. Would it be useful to have something like this? It checks the equality of the contents of the arrays without taking their order into account. If there is a need for this, I could enhance it to work with === as well.
