### PR TITLE
Honour templatePath set in Cell actions.

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -187,6 +187,8 @@ abstract class Cell
                 ));
             }
 
+            $builder = $this->viewBuilder();
+
             if ($template !== null &&
                 strpos($template, '/') === false &&
                 strpos($template, '.') === false
@@ -194,16 +196,16 @@ abstract class Cell
                 $template = Inflector::underscore($template);
             }
             if ($template === null) {
-                $template = $this->viewBuilder()->template() ?: $this->template;
+                $template = $builder->template() ?: $this->template;
             }
-
-            $builder = $this->viewBuilder();
-            $builder->layout(false);
-            $builder->template($template);
+            $builder->layout(false)
+                ->template($template);
 
             $className = substr(strrchr(get_class($this), "\\"), 1);
             $name = substr($className, 0, -4);
-            $builder->templatePath('Cell' . DS . $name);
+            if (!$builder->templatePath()) {
+                $builder->templatePath('Cell' . DS . $name);
+            }
 
             $this->View = $this->createView();
             try {

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -143,6 +143,20 @@ class CellTest extends TestCase
     }
 
     /**
+     * Tests that cell action setting the templatePath
+     *
+     * @return void
+     */
+    public function testSettingCellTemplatePathFromAction()
+    {
+        $appCell = $this->View->cell('Articles::customTemplatePath');
+
+        $this->assertContains('Articles subdir custom_template_path template', "{$appCell}");
+        $this->assertEquals('custom_template_path', $appCell->template);
+        $this->assertEquals('Cell/Articles/Subdir', $appCell->viewBuilder()->templatePath());
+    }
+
+    /**
      * Tests that cell action setting the template using the ViewBuilder renders the correct template
      *
      * @return void

--- a/tests/test_app/TestApp/Template/Cell/Articles/Subdir/custom_template_path.ctp
+++ b/tests/test_app/TestApp/Template/Cell/Articles/Subdir/custom_template_path.ctp
@@ -1,0 +1,1 @@
+Articles subdir custom_template_path template

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -83,6 +83,17 @@ class ArticlesCell extends \Cake\View\Cell
     }
 
     /**
+     * Renders a template in a custom templatePath
+     * The template is set using the ViewBuilder bound to the Cell
+     *
+     * @return void
+     */
+    public function customTemplatePath()
+    {
+        $this->viewBuilder()->templatePath('Cell/Articles/Subdir');
+    }
+
+    /**
      * Simple echo.
      *
      * @param string $msg1


### PR DESCRIPTION
When cells set their own templatePath we shouldn't muck about with that.

Refs #8271
