### PR TITLE
Fix inherited permissions when checking the '*' permission.

### DIFF
--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -107,10 +107,10 @@ class Permission extends AppModel {
 			return false;
 		}
 
-		$inherited = array();
 		$acoIDs = Hash::extract($acoPath, '{n}.' . $this->Aco->alias . '.id');
 
 		$count = count($aroPath);
+		$inherited = array();
 		for ($i = 0; $i < $count; $i++) {
 			$permAlias = $this->alias;
 
@@ -134,8 +134,8 @@ class Permission extends AppModel {
 						if (!empty($perm)) {
 							if ($perm[$key] == -1) {
 								return false;
-							} elseif ($perm[$key] == 1) {
-								$inherited[$key] = 1;
+							} elseif ($perm[$key] == 1 || $perm[$key] == 0) {
+								$inherited[$key] = $perm[$key];
 							}
 						}
 					}

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -129,7 +129,6 @@ class Permission extends AppModel {
 			$perms = Hash::extract($perms, '{n}.' . $this->alias);
 			foreach ($perms as $perm) {
 				if ($action === '*') {
-
 					foreach ($permKeys as $key) {
 						if (!empty($perm)) {
 							if ($perm[$key] == -1) {

--- a/lib/Cake/Test/Case/Console/Command/AclShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/AclShellTest.php
@@ -253,7 +253,7 @@ class AclShellTest extends CakeTestCase {
 		$this->Task->args = array('AuthUser.2', 'ROOT/Controller1', 'create');
 		$this->Task->check();
 
-		$this->Task->args = array('AuthUser.2', 'ROOT/Controller1', '*');
+		$this->Task->args = array('AuthUser.2', 'ROOT/Controller1', 'delete');
 		$this->Task->check();
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -429,15 +429,42 @@ class DbAclTest extends CakeTestCase {
  * @return void
  */
 	public function testInherit() {
-		//parent doesn't have access inherit should still deny
+		// parent doesn't have access inherit should still deny
 		$this->assertFalse($this->Acl->check('Milton', 'smash', 'delete'));
 		$this->Acl->inherit('Milton', 'smash', 'delete');
 		$this->assertFalse($this->Acl->check('Milton', 'smash', 'delete'));
 
-		//inherit parent
+		// inherit parent
 		$this->assertFalse($this->Acl->check('Milton', 'smash', 'read'));
 		$this->Acl->inherit('Milton', 'smash', 'read');
 		$this->assertTrue($this->Acl->check('Milton', 'smash', 'read'));
+	}
+
+/**
+ * test inherit from deny method
+ *
+ * @return void
+ */
+	public function testInheritParentDeny() {
+		$this->Acl->Aco->create(array('parent_id' => null, 'alias' => 'world'));
+		$this->Acl->Aco->save();
+
+		$this->Acl->Aco->create(array('parent_id' => $this->Acl->Aco->id, 'alias' => 'town'));
+		$this->Acl->Aco->save();
+
+		$this->Acl->Aro->create(array('parent_id' => null, 'alias' => 'Jane'));
+		$this->Acl->Aro->save();
+
+		// Setup deny on create for parent
+		$this->Acl->allow('Jane', 'world', '*');
+		$this->Acl->deny('Jane', 'world', 'create');
+
+		// Setup inherit and specify allow for create on child.
+		$this->Acl->inherit('Jane', 'town', '*');
+		$this->Acl->allow('Jane', 'town', 'create');
+
+		$this->assertTrue($this->Acl->check('Jane', 'town', 'create'), 'Should have access due to override');
+		$this->assertTrue($this->Acl->check('Jane', 'town', '*'), 'Should have access due to inherit');
 	}
 
 /**


### PR DESCRIPTION
When checking inherited permissions for '*' also copy inherited permissions onto the inherited list. By copying the inherited values, we get the union of explit allow and inherited permissions, which if all things go well will match the permission key list.

Refs #8114
