### PR TITLE
Consistently use formatTemplate()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -428,7 +428,7 @@ class FormHelper extends Helper
         }
 
         $actionAttr = $templater->formatAttributes(['action' => $action, 'escape' => false]);
-        return $templater->format('formStart', [
+        return $this->formatTemplate('formStart', [
             'attrs' => $templater->formatAttributes($htmlAttributes) . $actionAttr
         ]) . $append;
     }
@@ -529,10 +529,9 @@ class FormHelper extends Helper
             $out .= $this->secure($this->fields, $secureAttributes);
             $this->fields = [];
         }
-        $templater = $this->templater();
-        $out .= $templater->format('formEnd', []);
+        $out .= $this->formatTemplate('formEnd', []);
 
-        $templater->pop();
+        $this->templater()->pop();
         $this->requestType = null;
         $this->_context = null;
         $this->_idPrefix = $this->config('idPrefix');
@@ -1057,7 +1056,7 @@ class FormHelper extends Helper
         if (!$this->templater()->get($groupTemplate)) {
             $groupTemplate = 'formGroup';
         }
-        return $this->templater()->format($groupTemplate, [
+        return $this->formatTemplate($groupTemplate, [
             'input' => $options['input'],
             'label' => $options['label'],
             'error' => $options['error'],
@@ -1078,7 +1077,7 @@ class FormHelper extends Helper
             $inputContainerTemplate = 'inputContainer' . $options['errorSuffix'];
         }
 
-        return $this->templater()->format($inputContainerTemplate, [
+        return $this->formatTemplate($inputContainerTemplate, [
             'content' => $options['content'],
             'error' => $options['error'],
             'required' => $options['options']['required'] ? ' required' : '',
@@ -1668,7 +1667,7 @@ class FormHelper extends Helper
             'escape' => false
         ]);
 
-        $out = $templater->format('formStart', [
+        $out = $this->formatTemplate('formStart', [
             'attrs' => $templater->formatAttributes($formOptions) . $action
         ]);
         $out .= $this->hidden('_method', ['value' => $requestMethod]);
@@ -1683,7 +1682,7 @@ class FormHelper extends Helper
             unset($options['data']);
         }
         $out .= $this->secure($fields);
-        $out .= $templater->format('formEnd', []);
+        $out .= $this->formatTemplate('formEnd', []);
 
         if ($options['block']) {
             if ($options['block'] === true) {


### PR DESCRIPTION
`formatTemplate()` is a method that can be overwritten by plugins. It is also a method that can be called by the user to manually build customized form elements (e.g. adding extra elements to a `submitContainer`).

Right now FormHelper inconsistently uses `formatTemplate()` or `$this->templater()->format()`. It should in all cases use `formatTemplate()` however, as to provide the same experience to the user in both cases (internal or external use).
Furthermore, overwriting `formatTemplate()` is a powerful tool for plugins, only if it is also consistently called internally.

An example where this is needed is https://github.com/Holt59/cakephp3-bootstrap-helpers/issues/73
