### PR TITLE
Mismatched entity virtual fields cache names

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -517,6 +517,7 @@ trait EntityTrait
      */
     protected static function _accessor($property, $type)
     {
+        $property = Inflector::underscore($property);
         $class = static::class;
         if (isset(static::$_accessors[$class][$type][$property])) {
             return static::$_accessors[$class][$type][$property];


### PR DESCRIPTION
Fix of mismatched cache index name when using camel cased name of virtual field in entity.
