### PR TITLE
Use CAKE constant to find the path of core templates

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1255,11 +1255,14 @@ class View implements EventDispatcherInterface
             }
         }
 
+        $class = new \ReflectionClass('\Cake\View\View');
+        $cake = dirname(dirname($class->getFilename()));
+
         $paths = array_merge(
             $themePaths,
             $pluginPaths,
             $templatePaths,
-            [dirname(__DIR__) . DS . 'Template' . DS]
+            [$cake . DIRECTORY_SEPARATOR . 'Template' . DIRECTORY_SEPARATOR]
         );
 
         if ($plugin !== null) {


### PR DESCRIPTION
This last path is used to find the templates provided by the core. Without this commit, the path is wrong when a child class overrides `_path()` and calls `parent::_paths()`.
