### PR TITLE
Looping through themePaths by counting its own elements

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1249,7 +1249,7 @@ class View implements EventDispatcherInterface
             $themePaths = App::path('Template', Inflector::camelize($this->theme));
 
             if ($plugin) {
-                for ($i = 0, $count = count($templatePaths); $i < $count; $i++) {
+                for ($i = 0, $count = count($themePaths); $i < $count; $i++) {
                     array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DS . $plugin . DS);
                 }
             }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -519,6 +519,41 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test that multiple paths can be used in App.paths.templates.
+     *
+     * @return void
+     */
+    public function testMultipleAppPaths()
+    {
+        $viewOptions = ['plugin' => 'TestPlugin',
+            'name' => 'TestPlugin',
+            'viewPath' => 'Tests',
+            'view' => 'index',
+            'theme' => 'TestTheme'
+        ];
+
+        $paths = Configure::read('App.paths.templates');
+        $paths[] = Plugin::classPath('TestPlugin') . 'Template' . DS;
+        Configure::write('App.paths.templates', $paths);
+
+        $View = new TestView(null, null, null, $viewOptions);
+        $paths = $View->paths('TestPlugin');
+        $pluginPath = Plugin::path('TestPlugin');
+        $themePath = Plugin::path('TestTheme');
+        $expected = [
+            $themePath . 'src' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+            $themePath . 'src' . DS . 'Template' . DS,
+            TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+            $pluginPath . 'src' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+            $pluginPath . 'src' . DS . 'Template' . DS,
+            TEST_APP . 'TestApp' . DS . 'Template' . DS,
+            TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'src' . DS . 'Template' . DS,
+            CAKE . 'Template' . DS,
+        ];
+        $this->assertPathEquals($expected, $paths);
+    }
+
+    /**
      * Test that CamelCase'd plugins still find their view files.
      *
      * @return void


### PR DESCRIPTION
This loop would list the same path twice with crud-view which has a `count($themePaths)` of 2
