### PR TITLE
remove all reference to DS contant

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -251,7 +251,7 @@ abstract class CacheEngine
             $prefix = vsprintf($this->_groupPrefix, $this->groups());
         }
 
-        $key = preg_replace('/[\s]+/', '_', strtolower(trim(str_replace([DS, '/', '.'], '_', strval($key)))));
+        $key = preg_replace('/[\s]+/', '_', strtolower(trim(str_replace([DIRECTORY_SEPARATOR, '/', '.'], '_', strval($key)))));
         return $prefix . $key;
     }
 

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -91,16 +91,16 @@ class FileEngine extends CacheEngine
         parent::init($config);
 
         if ($this->_config['path'] === null) {
-            $this->_config['path'] = sys_get_temp_dir() . DS . 'cake_cache' . DS;
+            $this->_config['path'] = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cake_cache' . DIRECTORY_SEPARATOR;
         }
-        if (DS === '\\') {
+        if (DIRECTORY_SEPARATOR === '\\') {
             $this->_config['isWindows'] = true;
         }
-        if (substr($this->_config['path'], -1) !== DS) {
-            $this->_config['path'] .= DS;
+        if (substr($this->_config['path'], -1) !== DIRECTORY_SEPARATOR) {
+            $this->_config['path'] .= DIRECTORY_SEPARATOR;
         }
         if (!empty($this->_groupPrefix)) {
-            $this->_groupPrefix = str_replace('_', DS, $this->_groupPrefix);
+            $this->_groupPrefix = str_replace('_', DIRECTORY_SEPARATOR, $this->_groupPrefix);
         }
         return $this->_active();
     }
@@ -279,7 +279,7 @@ class FileEngine extends CacheEngine
                 continue;
             }
 
-            $path = $path->getRealPath() . DS;
+            $path = $path->getRealPath() . DIRECTORY_SEPARATOR;
             if (!in_array($path, $cleared)) {
                 $this->_clearDirectory($path, $now, $threshold);
                 $cleared[] = $path;
@@ -445,7 +445,7 @@ class FileEngine extends CacheEngine
         }
 
         $key = Inflector::underscore(str_replace(
-            [DS, '/', '.', '<', '>', '?', ':', '|', '*', '"'],
+            [DIRECTORY_SEPARATOR, '/', '.', '<', '>', '?', ':', '|', '*', '"'],
             '_',
             strval($key)
         ));
@@ -467,7 +467,7 @@ class FileEngine extends CacheEngine
             RecursiveIteratorIterator::CHILD_FIRST
         );
         foreach ($contents as $object) {
-            $containsGroup = strpos($object->getPathname(), DS . $group . DS) !== false;
+            $containsGroup = strpos($object->getPathname(), DIRECTORY_SEPARATOR . $group . DIRECTORY_SEPARATOR) !== false;
             $hasPrefix = true;
             if (strlen($this->_config['prefix']) !== 0) {
                 $hasPrefix = strpos($object->getBasename(), $this->_config['prefix']) === 0;

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -163,7 +163,7 @@ class ConsoleOutput
     {
         $this->_output = fopen($stream, 'w');
 
-        if ((DS === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
+        if ((DIRECTORY_SEPARATOR === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
             (function_exists('posix_isatty') && !posix_isatty($this->_output))
         ) {
             $this->_outputAs = self::PLAIN;

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -762,7 +762,7 @@ class Shell
     public function clear()
     {
         if (empty($this->params['noclear'])) {
-            if (DS === '/') {
+            if (DIRECTORY_SEPARATOR === '/') {
                 passthru('clear');
             } else {
                 passthru('cls');
@@ -780,7 +780,7 @@ class Shell
      */
     public function createFile($path, $contents)
     {
-        $path = str_replace(DS . DS, DS, $path);
+        $path = str_replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $path);
 
         $this->_io->out();
 
@@ -826,9 +826,9 @@ class Shell
     public function shortPath($file)
     {
         $shortPath = str_replace(ROOT, null, $file);
-        $shortPath = str_replace('..' . DS, '', $shortPath);
-        $shortPath = str_replace(DS, '/', $shortPath);
-        return str_replace('//', DS, $shortPath);
+        $shortPath = str_replace('..' . DIRECTORY_SEPARATOR, '', $shortPath);
+        $shortPath = str_replace(DIRECTORY_SEPARATOR, '/', $shortPath);
+        return str_replace('//', DIRECTORY_SEPARATOR, $shortPath);
     }
 
     /**

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -564,11 +564,11 @@ class RequestHandlerComponent extends Component
             $builder->className($viewClass);
         } else {
             if (empty($this->_renderType)) {
-                $builder->templatePath($builder->templatePath() . DS . $type);
+                $builder->templatePath($builder->templatePath() . DIRECTORY_SEPARATOR . $type);
             } else {
                 $builder->templatePath(preg_replace(
                     "/([\/\\\\]{$this->_renderType})$/",
-                    DS . $type,
+                    DIRECTORY_SEPARATOR . $type,
                     $builder->templatePath()
                 ));
             }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -625,7 +625,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
                 'Cake\Utility\Inflector::camelize',
                 explode('/', $this->request->params['prefix'])
             );
-            $viewPath = implode(DS, $prefixes) . DS . $viewPath;
+            $viewPath = implode(DIRECTORY_SEPARATOR, $prefixes) . DIRECTORY_SEPARATOR . $viewPath;
         }
         return $viewPath;
     }

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -186,9 +186,9 @@ class App
             return (array)Configure::read('App.paths.templates');
         }
         if (!empty($plugin)) {
-            return [Plugin::classPath($plugin) . $type . DS];
+            return [Plugin::classPath($plugin) . $type . DIRECTORY_SEPARATOR];
         }
-        return [APP . $type . DS];
+        return [APP . $type . DIRECTORY_SEPARATOR];
     }
 
     /**
@@ -207,6 +207,6 @@ class App
      */
     public static function core($type)
     {
-        return [CAKE . str_replace('/', DS, $type) . DS];
+        return [CAKE . str_replace('/', DIRECTORY_SEPARATOR, $type) . DIRECTORY_SEPARATOR];
     }
 }

--- a/src/Core/ClassLoader.php
+++ b/src/Core/ClassLoader.php
@@ -53,8 +53,8 @@ class ClassLoader
     {
         $prefix = trim($prefix, '\\') . '\\';
 
-        $baseDir = rtrim($baseDir, '/') . DS;
-        $baseDir = rtrim($baseDir, DS) . '/';
+        $baseDir = rtrim($baseDir, '/') . DIRECTORY_SEPARATOR;
+        $baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR) . '/';
 
         if (!isset($this->_prefixes[$prefix])) {
             $this->_prefixes[$prefix] = [];
@@ -108,7 +108,7 @@ class ClassLoader
         }
 
         foreach ($this->_prefixes[$prefix] as $baseDir) {
-            $file = $baseDir . str_replace('\\', DS, $relativeClass) . '.php';
+            $file = $baseDir . str_replace('\\', DIRECTORY_SEPARATOR, $relativeClass) . '.php';
 
             if ($this->_requireFile($file)) {
                 return $file;

--- a/src/Core/ConventionsTrait.php
+++ b/src/Core/ConventionsTrait.php
@@ -136,7 +136,7 @@ trait ConventionsTrait
         if (Plugin::loaded($pluginName)) {
             return Plugin::path($pluginName);
         }
-        return current(App::path('Plugin')) . $pluginName . DS;
+        return current(App::path('Plugin')) . $pluginName . DIRECTORY_SEPARATOR;
     }
 
     /**

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -135,10 +135,10 @@ class Plugin
 
         if (empty($config['path'])) {
             $paths = App::path('Plugin');
-            $pluginPath = str_replace('/', DS, $plugin);
+            $pluginPath = str_replace('/', DIRECTORY_SEPARATOR, $plugin);
             foreach ($paths as $path) {
                 if (is_dir($path . $pluginPath)) {
-                    $config['path'] = $path . $pluginPath . DS;
+                    $config['path'] = $path . $pluginPath . DIRECTORY_SEPARATOR;
                     break;
                 }
             }
@@ -148,9 +148,9 @@ class Plugin
             throw new MissingPluginException(['plugin' => $plugin]);
         }
 
-        $config['classPath'] = $config['path'] . $config['classBase'] . DS;
+        $config['classPath'] = $config['path'] . $config['classBase'] . DIRECTORY_SEPARATOR;
         if (!isset($config['configPath'])) {
-            $config['configPath'] = $config['path'] . 'config' . DS;
+            $config['configPath'] = $config['path'] . 'config' . DIRECTORY_SEPARATOR;
         }
 
         static::$_plugins[$plugin] = $config;
@@ -162,11 +162,11 @@ class Plugin
             }
             static::$_loader->addNamespace(
                 str_replace('/', '\\', $plugin),
-                $config['path'] . $config['classBase'] . DS
+                $config['path'] . $config['classBase'] . DIRECTORY_SEPARATOR
             );
             static::$_loader->addNamespace(
                 str_replace('/', '\\', $plugin) . '\Test',
-                $config['path'] . 'tests' . DS
+                $config['path'] . 'tests' . DIRECTORY_SEPARATOR
             );
         }
 
@@ -185,9 +185,9 @@ class Plugin
         if (Configure::check('plugins')) {
             return;
         }
-        $vendorFile = dirname(dirname(__DIR__)) . DS . 'cakephp-plugins.php';
+        $vendorFile = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
         if (!file_exists($vendorFile)) {
-            $vendorFile = dirname(dirname(dirname(dirname(__DIR__)))) . DS . 'cakephp-plugins.php';
+            $vendorFile = dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
             if (!file_exists($vendorFile)) {
                 Configure::write(['plugins' => []]);
                 return;

--- a/src/Filesystem/README.md
+++ b/src/Filesystem/README.md
@@ -20,7 +20,7 @@ Now you can loop through the files and read from or write/append to the contents
 
 ```php
 foreach ($files as $file) {
-    $file = new File($dir->pwd() . DS . $file);
+    $file = new File($dir->pwd() . DIRECTORY_SEPARATOR . $file);
     $contents = $file->read();
     // $file->write('I am overwriting the contents of this file');
     // $file->append('I am adding to the bottom of this file.');

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -160,20 +160,20 @@ class MessagesFileLoader
 
         $localePaths = App::path('Locale');
         if (empty($localePaths)) {
-            $localePaths[] = APP . 'Locale' . DS;
+            $localePaths[] = APP . 'Locale' . DIRECTORY_SEPARATOR;
         }
         foreach ($localePaths as $path) {
             foreach ($folders as $folder) {
-                $searchPaths[] = $path . $folder . DS;
+                $searchPaths[] = $path . $folder . DIRECTORY_SEPARATOR;
             }
         }
 
         // If space is not added after slash, the character after it remains lowercased
         $pluginName = Inflector::camelize(str_replace('/', '/ ', $this->_name));
         if (Plugin::loaded($pluginName)) {
-            $basePath = Plugin::classPath($pluginName) . 'Locale' . DS;
+            $basePath = Plugin::classPath($pluginName) . 'Locale' . DIRECTORY_SEPARATOR;
             foreach ($folders as $folder) {
-                $searchPaths[] = $basePath . $folder . DS;
+                $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR;
             }
         }
 

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -57,7 +57,7 @@ class ConsoleLog extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        if ((DS === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
+        if ((DIRECTORY_SEPARATOR === '\\' && !(bool)env('ANSICON') && env('ConEmuANSI') !== 'ON') ||
             (function_exists('posix_isatty') && !posix_isatty($this->_output))
         ) {
             $this->_defaultConfig['outputAs'] = ConsoleOutput::PLAIN;

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -232,7 +232,7 @@ class Stream
             'ssl_passphrase',
         ];
         if (empty($options['ssl_cafile'])) {
-            $options['ssl_cafile'] = CORE_PATH . 'config' . DS . 'cacert.pem';
+            $options['ssl_cafile'] = CORE_PATH . 'config' . DIRECTORY_SEPARATOR . 'cacert.pem';
         }
         if (!empty($options['ssl_verify_host'])) {
             $url = $request->url();

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -403,7 +403,7 @@ class Request implements ArrayAccess
                 $base = dirname($base);
             }
 
-            if ($base === DS || $base === '.') {
+            if ($base === DIRECTORY_SEPARATOR || $base === '.') {
                 $base = '';
             }
             $base = implode('/', array_map('rawurlencode', explode('/', $base)));
@@ -413,7 +413,7 @@ class Request implements ArrayAccess
         $file = '/' . basename($baseUrl);
         $base = dirname($baseUrl);
 
-        if ($base === DS || $base === '.') {
+        if ($base === DIRECTORY_SEPARATOR || $base === '.') {
             $base = '';
         }
         $webrootDir = $base . '/';

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -110,8 +110,8 @@ class AssetFilter extends DispatcherFilter
             $plugin = implode('/', $pluginPart);
             if ($plugin && Plugin::loaded($plugin)) {
                 $parts = array_slice($parts, $i + 1);
-                $fileFragment = implode(DS, $parts);
-                $pluginWebroot = Plugin::path($plugin) . 'webroot' . DS;
+                $fileFragment = implode(DIRECTORY_SEPARATOR, $parts);
+                $pluginWebroot = Plugin::path($plugin) . 'webroot' . DIRECTORY_SEPARATOR;
                 return $pluginWebroot . $fileFragment;
             }
         }

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -56,8 +56,8 @@ class CommandListShell extends Shell
         if (empty($this->params['xml'])) {
             $this->out("<info>Current Paths:</info>", 2);
             $this->out("* app:  " . APP_DIR);
-            $this->out("* root: " . rtrim(ROOT, DS));
-            $this->out("* core: " . rtrim(CORE_PATH, DS));
+            $this->out("* root: " . rtrim(ROOT, DIRECTORY_SEPARATOR));
+            $this->out("* core: " . rtrim(CORE_PATH, DIRECTORY_SEPARATOR));
             $this->out("");
 
             $this->out("<info>Available Shells:</info>", 2);

--- a/src/Shell/I18nShell.php
+++ b/src/Shell/I18nShell.php
@@ -89,9 +89,9 @@ class I18nShell extends Shell
             $this->_paths = [Plugin::classPath($plugin)];
         }
 
-        $response = $this->in('What folder?', null, rtrim($this->_paths[0], DS) . DS . 'Locale');
-        $sourceFolder = rtrim($response, DS) . DS;
-        $targetFolder = $sourceFolder . $language . DS;
+        $response = $this->in('What folder?', null, rtrim($this->_paths[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'Locale');
+        $sourceFolder = rtrim($response, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $targetFolder = $sourceFolder . $language . DIRECTORY_SEPARATOR;
         if (!is_dir($targetFolder)) {
             mkdir($targetFolder, 0775, true);
         }

--- a/src/Shell/ServerShell.php
+++ b/src/Shell/ServerShell.php
@@ -95,7 +95,7 @@ class ServerShell extends Shell
         }
 
         // For Windows
-        if (substr($this->_documentRoot, -1, 1) === DS) {
+        if (substr($this->_documentRoot, -1, 1) === DIRECTORY_SEPARATOR) {
             $this->_documentRoot = substr($this->_documentRoot, 0, strlen($this->_documentRoot) - 1);
         }
         if (preg_match("/^([a-z]:)[\\\]+(.+)$/i", $this->_documentRoot, $m)) {

--- a/src/Shell/Task/AssetsTask.php
+++ b/src/Shell/Task/AssetsTask.php
@@ -93,7 +93,7 @@ class AssetsTask extends Shell
                 $namespaced = true;
                 $parts = explode('/', $link);
                 $link = array_pop($parts);
-                $dir = WWW_ROOT . implode(DS, $parts) . DS;
+                $dir = WWW_ROOT . implode(DIRECTORY_SEPARATOR, $parts) . DIRECTORY_SEPARATOR;
             }
 
             $plugins[$plugin] = [

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -202,14 +202,14 @@ class ExtractTask extends Shell
         } else {
             $message = "What is the path you would like to output?\n[Q]uit";
             while (true) {
-                $response = $this->in($message, null, rtrim($this->_paths[0], DS) . DS . 'Locale');
+                $response = $this->in($message, null, rtrim($this->_paths[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'Locale');
                 if (strtoupper($response) === 'Q') {
                     $this->err('Extract Aborted');
                     $this->_stop();
                     return;
                 }
                 if ($this->_isPathUsable($response)) {
-                    $this->_output = $response . DS;
+                    $this->_output = $response . DIRECTORY_SEPARATOR;
                     break;
                 }
 
@@ -234,7 +234,7 @@ class ExtractTask extends Shell
             $this->_searchFiles();
         }
 
-        $this->_output = rtrim($this->_output, DS) . DS;
+        $this->_output = rtrim($this->_output, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         if (!$this->_isPathUsable($this->_output)) {
             $this->err(sprintf('The output directory %s was not found or writable.', $this->_output));
             $this->_stop();
@@ -464,7 +464,7 @@ class ExtractTask extends Shell
     protected function _buildFiles()
     {
         $paths = $this->_paths;
-        $paths[] = realpath(APP) . DS;
+        $paths[] = realpath(APP) . DIRECTORY_SEPARATOR;
 
         usort($paths, function ($a, $b) {
             return strlen($a) - strlen($b);
@@ -483,7 +483,7 @@ class ExtractTask extends Shell
                     $occurrences = implode("\n#: ", $occurrences);
                     $header = "";
                     if (!$this->param('no-location')) {
-                        $header = '#: ' . str_replace(DS, '/', str_replace($paths, '', $occurrences)) . "\n";
+                        $header = '#: ' . str_replace(DIRECTORY_SEPARATOR, '/', str_replace($paths, '', $occurrences)) . "\n";
                     }
 
                     $sentence = '';
@@ -694,15 +694,15 @@ class ExtractTask extends Shell
         if (!empty($this->_exclude)) {
             $exclude = [];
             foreach ($this->_exclude as $e) {
-                if (DS !== '\\' && $e[0] !== DS) {
-                    $e = DS . $e;
+                if (DIRECTORY_SEPARATOR !== '\\' && $e[0] !== DIRECTORY_SEPARATOR) {
+                    $e = DIRECTORY_SEPARATOR . $e;
                 }
                 $exclude[] = preg_quote($e, '/');
             }
             $pattern = '/' . implode('|', $exclude) . '/';
         }
         foreach ($this->_paths as $path) {
-            $path = realpath($path) . DS;
+            $path = realpath($path) . DIRECTORY_SEPARATOR;
             $Folder = new Folder($path);
             $files = $Folder->findRecursive('.*\.(php|ctp|thtml|inc|tpl)', true);
             if (!empty($pattern)) {

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -39,7 +39,7 @@ class LoadTask extends Shell
      */
     public function main($plugin = null)
     {
-        $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
+        $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
         if (empty($plugin)) {
             $this->err('<error>You must provide a plugin name in CamelCase format.</error>');

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -39,7 +39,7 @@ class UnloadTask extends Shell
      */
     public function main($plugin = null)
     {
-        $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
+        $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
         if (empty($plugin)) {
             $this->err('<error>You must provide a plugin name in CamelCase format.</error>');

--- a/src/Template/Element/plugin_class_error.ctp
+++ b/src/Template/Element/plugin_class_error.ctp
@@ -24,7 +24,7 @@ if (!Plugin::loaded($plugin)):
     echo sprintf('Make sure your plugin <em>%s</em> is in the %s directory and was loaded.', h($plugin), $pluginPath);
 else:
     echo sprintf('Make sure your plugin was loaded from %s and Composer is able to autoload its classes, see %s and %s',
-        '<em>config' . DS . 'bootstrap.php</em>',
+        '<em>config' . DIRECTORY_SEPARATOR . 'bootstrap.php</em>',
         '<a href="http://book.cakephp.org/3.0/en/plugins.html#loading-a-plugin">Loading a plugin</a>',
         '<a href="http://book.cakephp.org/3.0/en/plugins.html#autoloading-plugin-classes">Plugins - autoloading plugin classes</a>'
     );

--- a/src/Template/Error/missing_action.ctp
+++ b/src/Template/Error/missing_action.ctp
@@ -24,12 +24,12 @@ $prefixNs = '';
 if (!empty($prefix)) {
     $prefix = Inflector::camelize($prefix);
     $prefixNs = '\\' . $prefix;
-    $prefix .= DS;
+    $prefix .= DIRECTORY_SEPARATOR;
 }
 if (empty($plugin)) {
-    $path = APP_DIR . DS . 'Controller' . DS . $prefix . h($controller) . '.php' ;
+    $path = APP_DIR . DIRECTORY_SEPARATOR . 'Controller' . DIRECTORY_SEPARATOR . $prefix . h($controller) . '.php' ;
 } else {
-    $path = Plugin::classPath($plugin) . 'Controller' . DS . $prefix . h($controller) . '.php';
+    $path = Plugin::classPath($plugin) . 'Controller' . DIRECTORY_SEPARATOR . $prefix . h($controller) . '.php';
 }
 
 $this->layout = 'dev_error';

--- a/src/Template/Error/missing_behavior.ctp
+++ b/src/Template/Error/missing_behavior.ctp
@@ -24,13 +24,13 @@ $pluginPath = Configure::read('App.paths.plugins.0');
 
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 if (empty($plugin)) {
-    $filePath = APP_DIR . DS;
+    $filePath = APP_DIR . DIRECTORY_SEPARATOR;
 }
 if (!empty($plugin) && Plugin::loaded($plugin)) {
     $filePath = Plugin::classPath($plugin);
 }
 if (!empty($plugin) && !Plugin::loaded($plugin)) {
-    $filePath = $pluginPath . h($plugin) . DS . 'src' . DS;
+    $filePath = $pluginPath . h($plugin) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
 }
 
 $this->layout = 'dev_error';
@@ -48,7 +48,7 @@ $this->start('file');
 ?>
 <p class="error">
     <strong>Error: </strong>
-    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'Model' . DS . 'Behavior' . DS . h($class) . '.php'); ?>
+    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'Model' . DIRECTORY_SEPARATOR . 'Behavior' . DIRECTORY_SEPARATOR . h($class) . '.php'); ?>
 </p>
 
 <?php

--- a/src/Template/Error/missing_component.ctp
+++ b/src/Template/Error/missing_component.ctp
@@ -23,13 +23,13 @@ if (!empty($plugin)) {
 $pluginPath = Configure::read('App.paths.plugins.0');
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 if (empty($plugin)) {
-    $filePath = APP_DIR . DS;
+    $filePath = APP_DIR . DIRECTORY_SEPARATOR;
 }
 if (!empty($plugin) && Plugin::loaded($plugin)) {
     $filePath = Plugin::classPath($plugin);
 }
 if (!empty($plugin) && !Plugin::loaded($plugin)) {
-    $filePath = $pluginPath . h($plugin) . DS . 'src' . DS;
+    $filePath = $pluginPath . h($plugin) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
 }
 
 $this->layout = 'dev_error';
@@ -45,7 +45,7 @@ $this->start('file');
 ?>
 <p class="error">
     <strong>Error: </strong>
-    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'Controller' . DS . 'Component' . DS . h($class) . '.php'); ?>
+    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'Controller' . DIRECTORY_SEPARATOR . 'Component' . DIRECTORY_SEPARATOR . h($class) . '.php'); ?>
 </p>
 <?php
 $code = <<<PHP

--- a/src/Template/Error/missing_controller.ctp
+++ b/src/Template/Error/missing_controller.ctp
@@ -23,16 +23,16 @@ $prefixPath = '';
 if (!empty($prefix)) {
     $prefix = array_map('\Cake\Utility\Inflector::camelize', explode('/', $prefix));
     $prefixNs = '\\' . implode('\\', $prefix);
-    $prefixPath = implode(DS, $prefix) . DS;
+    $prefixPath = implode(DIRECTORY_SEPARATOR, $prefix) . DIRECTORY_SEPARATOR;
 }
 
 if (!empty($plugin)) {
     $namespace = str_replace('/', '\\', $plugin);
 }
 if (empty($plugin)) {
-    $path = APP_DIR . DS . 'Controller' . DS . $prefixPath . h($class) . 'Controller.php' ;
+    $path = APP_DIR . DIRECTORY_SEPARATOR . 'Controller' . DIRECTORY_SEPARATOR . $prefixPath . h($class) . 'Controller.php' ;
 } else {
-    $path = Plugin::classPath($plugin) . 'Controller' . DS . $prefixPath . h($class) . 'Controller.php';
+    $path = Plugin::classPath($plugin) . 'Controller' . DIRECTORY_SEPARATOR . $prefixPath . h($class) . 'Controller.php';
 }
 
 $this->layout = 'dev_error';

--- a/src/Template/Error/missing_datasource_config.ctp
+++ b/src/Template/Error/missing_datasource_config.ctp
@@ -22,7 +22,7 @@ $this->start('subheading');
 ?>
     <strong>Error: </strong>
     <?php if (isset($name)): ?>
-        The datasource configuration <em><?= h($name) ?></em> was not found in config<?= DS . 'app.php' ?>.
+        The datasource configuration <em><?= h($name) ?></em> was not found in config<?= DIRECTORY_SEPARATOR . 'app.php' ?>.
     <?php else: ?>
         <?= h($message) ?>
     <?php endif; ?>

--- a/src/Template/Error/missing_helper.ctp
+++ b/src/Template/Error/missing_helper.ctp
@@ -23,13 +23,13 @@ if (!empty($plugin)) {
 $pluginPath = Configure::read('App.paths.plugins.0');
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 if (empty($plugin)) {
-    $filePath = APP_DIR . DS;
+    $filePath = APP_DIR . DIRECTORY_SEPARATOR;
 }
 if (!empty($plugin) && Plugin::loaded($plugin)) {
     $filePath = Plugin::classPath($plugin);
 }
 if (!empty($plugin) && !Plugin::loaded($plugin)) {
-    $filePath = $pluginPath . h($plugin) . DS . 'src' . DS;
+    $filePath = $pluginPath . h($plugin) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
 }
 
 $this->layout = 'dev_error';
@@ -46,7 +46,7 @@ $this->start('subheading');
 <?php $this->start('file') ?>
 <p class="error">
     <strong>Error: </strong>
-    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'View' . DS . 'Helper' . DS . h($class) . '.php'); ?>
+    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'View' . DIRECTORY_SEPARATOR . 'Helper' . DIRECTORY_SEPARATOR . h($class) . '.php'); ?>
 </p>
 <?php
 $code = <<<PHP

--- a/src/Template/Error/missing_plugin.ctp
+++ b/src/Template/Error/missing_plugin.ctp
@@ -42,7 +42,7 @@ PHP;
 
 <p class="notice">
     <strong>Loading all plugins: </strong>
-    <?= sprintf('If you wish to load all plugins at once, use the following line in your %s file', 'config' . DS . 'bootstrap.php'); ?>
+    <?= sprintf('If you wish to load all plugins at once, use the following line in your %s file', 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php'); ?>
 </p>
 
 <?php

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -31,7 +31,7 @@ $this->start('subheading');
 
 <?php $this->start('file') ?>
 <p>None of the currently connected routes match the given URL or parameters.
-Add a matching route to <?= 'config' . DS . 'routes.php' ?></p>
+Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 
 <?php if (!empty($attributes['context'])): ?>
 <p>The passed context was:</p>

--- a/src/Template/Error/missing_view.ctp
+++ b/src/Template/Error/missing_view.ctp
@@ -20,14 +20,14 @@ $pluginPath = Configure::read('App.paths.plugins.0');
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 
 if (empty($plugin)) {
-    $filePath = APP_DIR . DS;
+    $filePath = APP_DIR . DIRECTORY_SEPARATOR;
     $namespace = str_replace('/', '\\', $plugin);
 }
 if (!empty($plugin) && Plugin::loaded($plugin)) {
     $filePath = Plugin::classPath($plugin);
 }
 if (!empty($plugin) && !Plugin::loaded($plugin)) {
-    $filePath = $pluginPath . h($plugin) . DS . 'src' . DS;
+    $filePath = $pluginPath . h($plugin) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
 }
 
 $this->layout = 'dev_error';
@@ -48,7 +48,7 @@ $this->start('subheading');
 <?php $this->start('file') ?>
 <p class="error">
     <strong>Error: </strong>
-    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'View' . DS . h($class) . '.php'); ?>
+    <?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'View' . DIRECTORY_SEPARATOR . h($class) . '.php'); ?>
 </p>
 <?php
 $code = <<<PHP

--- a/src/Template/Layout/dev_error.ctp
+++ b/src/Template/Layout/dev_error.ctp
@@ -227,7 +227,7 @@ use Cake\Error\Debugger;
         <?php if ($this->fetch('templateName')): ?>
         <p class="customize">
             If you want to customize this error message, create
-            <em><?= APP_DIR . DS . 'Template' . DS . 'Error' . DS . $this->fetch('templateName') ?></em>
+            <em><?= APP_DIR . DIRECTORY_SEPARATOR . 'Template' . DIRECTORY_SEPARATOR . 'Error' . DIRECTORY_SEPARATOR . $this->fetch('templateName') ?></em>
         </p>
         <?php endif; ?>
     </div>

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -509,11 +509,11 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      * Normalize a path for comparison.
      *
      * @param string $path Path separated by "/" slash.
-     * @return string Normalized path separated by DS.
+     * @return string Normalized path separated by DIRECTORY_SEPARATOR.
      */
     protected function _normalizePath($path)
     {
-        return str_replace('/', DS, $path);
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
 
 // @codingStandardsIgnoreStart
@@ -560,8 +560,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      */
     protected static function assertPathEquals($expected, $result, $message = '')
     {
-        $expected = str_replace(DS, '/', $expected);
-        $result = str_replace(DS, '/', $result);
+        $expected = str_replace(DIRECTORY_SEPARATOR, '/', $expected);
+        $result = str_replace(DIRECTORY_SEPARATOR, '/', $result);
         static::assertEquals($expected, $result, $message);
     }
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -204,7 +204,7 @@ abstract class Cell
             $className = substr(strrchr(get_class($this), "\\"), 1);
             $name = substr($className, 0, -4);
             if (!$builder->templatePath()) {
-                $builder->templatePath('Cell' . DS . $name);
+                $builder->templatePath('Cell' . DIRECTORY_SEPARATOR . $name);
             }
 
             $this->View = $this->createView();

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -119,7 +119,7 @@ class UrlHelper extends Helper
                 '',
                 urldecode($path)
             );
-            $webrootPath = WWW_ROOT . str_replace('/', DS, $filepath);
+            $webrootPath = WWW_ROOT . str_replace('/', DIRECTORY_SEPARATOR, $filepath);
             if (file_exists($webrootPath)) {
                 //@codingStandardsIgnoreStart
                 return $path . '?' . @filemtime($webrootPath);
@@ -129,7 +129,7 @@ class UrlHelper extends Helper
             $plugin = Inflector::camelize($segments[0]);
             if (Plugin::loaded($plugin)) {
                 unset($segments[0]);
-                $pluginPath = Plugin::path($plugin) . 'webroot' . DS . implode(DS, $segments);
+                $pluginPath = Plugin::path($plugin) . 'webroot' . DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $segments);
                 //@codingStandardsIgnoreStart
                 return $path . '?' . @filemtime($pluginPath);
                 //@codingStandardsIgnoreEnd
@@ -155,7 +155,7 @@ class UrlHelper extends Helper
             $file = trim($file, '/');
             $theme = $this->_inflectThemeName($this->theme) . '/';
 
-            if (DS === '\\') {
+            if (DIRECTORY_SEPARATOR === '\\') {
                 $file = str_replace('/', '\\', $file);
             }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -495,8 +495,8 @@ class View implements EventDispatcherInterface
 
         if (empty($options['ignoreMissing'])) {
             list ($plugin, $name) = pluginSplit($name, true);
-            $name = str_replace('/', DS, $name);
-            $file = $plugin . 'Element' . DS . $name . $this->_ext;
+            $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
+            $file = $plugin . 'Element' . DIRECTORY_SEPARATOR . $name . $this->_ext;
             throw new Exception\MissingElementException($file);
         }
     }
@@ -815,7 +815,7 @@ class View implements EventDispatcherInterface
                     if (!$parent) {
                         list($plugin, $name) = $this->pluginSplit($name);
                         $paths = $this->_paths($plugin);
-                        $defaultPath = $paths[0] . 'Element' . DS;
+                        $defaultPath = $paths[0] . 'Element' . DIRECTORY_SEPARATOR;
                         throw new LogicException(sprintf(
                             'You cannot extend an element which does not exist (%s).',
                             $defaultPath . $name . $this->_ext
@@ -1039,10 +1039,10 @@ class View implements EventDispatcherInterface
         $templatePath = $subDir = '';
 
         if ($this->subDir !== null) {
-            $subDir = $this->subDir . DS;
+            $subDir = $this->subDir . DIRECTORY_SEPARATOR;
         }
         if ($this->templatePath) {
-            $templatePath = $this->templatePath . DS;
+            $templatePath = $this->templatePath . DIRECTORY_SEPARATOR;
         }
 
         if ($name === null) {
@@ -1050,17 +1050,17 @@ class View implements EventDispatcherInterface
         }
 
         list($plugin, $name) = $this->pluginSplit($name);
-        $name = str_replace('/', DS, $name);
+        $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
 
-        if (strpos($name, DS) === false && $name[0] !== '.') {
+        if (strpos($name, DIRECTORY_SEPARATOR) === false && $name[0] !== '.') {
             $name = $templatePath . $subDir . $this->_inflectViewFileName($name);
-        } elseif (strpos($name, DS) !== false) {
-            if ($name[0] === DS || $name[1] === ':') {
-                $name = trim($name, DS);
+        } elseif (strpos($name, DIRECTORY_SEPARATOR) !== false) {
+            if ($name[0] === DIRECTORY_SEPARATOR || $name[1] === ':') {
+                $name = trim($name, DIRECTORY_SEPARATOR);
             } elseif (!$plugin || $this->templatePath !== $this->name) {
                 $name = $templatePath . $subDir . $name;
             } else {
-                $name = DS . $subDir . $name;
+                $name = DIRECTORY_SEPARATOR . $subDir . $name;
             }
         }
 
@@ -1147,11 +1147,11 @@ class View implements EventDispatcherInterface
         $subDir = null;
 
         if ($this->layoutPath) {
-            $subDir = $this->layoutPath . DS;
+            $subDir = $this->layoutPath . DIRECTORY_SEPARATOR;
         }
         list($plugin, $name) = $this->pluginSplit($name);
 
-        $layoutPaths = $this->_getSubPaths('Layout' . DS . $subDir);
+        $layoutPaths = $this->_getSubPaths('Layout' . DIRECTORY_SEPARATOR . $subDir);
 
         foreach ($this->_paths($plugin) as $path) {
             foreach ($layoutPaths as $layoutPath) {
@@ -1181,8 +1181,8 @@ class View implements EventDispatcherInterface
 
         foreach ($paths as $path) {
             foreach ($elementPaths as $elementPath) {
-                if (file_exists($path . $elementPath . DS . $name . $this->_ext)) {
-                    return $path . $elementPath . DS . $name . $this->_ext;
+                if (file_exists($path . $elementPath . DIRECTORY_SEPARATOR . $name . $this->_ext)) {
+                    return $path . $elementPath . DIRECTORY_SEPARATOR . $name . $this->_ext;
                 }
             }
         }
@@ -1207,7 +1207,7 @@ class View implements EventDispatcherInterface
             $prefixPath = explode('/', $this->request->params['prefix']);
             $path = '';
             foreach ($prefixPath as $prefixPart) {
-                $path .= Inflector::camelize($prefixPart) . DS;
+                $path .= Inflector::camelize($prefixPart) . DIRECTORY_SEPARATOR;
 
                 array_unshift(
                     $paths,
@@ -1240,7 +1240,7 @@ class View implements EventDispatcherInterface
         $pluginPaths = $themePaths = [];
         if (!empty($plugin)) {
             for ($i = 0, $count = count($templatePaths); $i < $count; $i++) {
-                $pluginPaths[] = $templatePaths[$i] . 'Plugin' . DS . $plugin . DS;
+                $pluginPaths[] = $templatePaths[$i] . 'Plugin' . DIRECTORY_SEPARATOR . $plugin . DIRECTORY_SEPARATOR;
             }
             $pluginPaths = array_merge($pluginPaths, App::path('Template', $plugin));
         }
@@ -1250,7 +1250,7 @@ class View implements EventDispatcherInterface
 
             if ($plugin) {
                 for ($i = 0, $count = count($themePaths); $i < $count; $i++) {
-                    array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DS . $plugin . DS);
+                    array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DIRECTORY_SEPARATOR . $plugin . DIRECTORY_SEPARATOR);
                 }
             }
         }
@@ -1259,7 +1259,7 @@ class View implements EventDispatcherInterface
             $themePaths,
             $pluginPaths,
             $templatePaths,
-            [dirname(__DIR__) . DS . 'Template' . DS]
+            [dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Template' . DIRECTORY_SEPARATOR]
         );
 
         if ($plugin !== null) {


### PR DESCRIPTION
ref comments in #8298 reagrding `DS` usage in the source code.

I intentionaly left [this definition](https://github.com/cakephp/cakephp/blob/master/src/Core/functions.php#L17-L23) to avoid to break things for people using cakephp/core in a standalone way but I'm open to if other thinks that it's a good idea.

Also I didn't remove it in the testsuite as it define in the [tests/bootstrap.php](https://github.com/cakephp/cakephp/blob/master/tests/bootstrap.php#L26-L28) but I could also remove it there and in the testsuite if you want to.
