### PR TITLE
Changing the publish release step order.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,4 +179,4 @@ tag-component-%: component-% guard-VERSION guard-GITHUB_USER
 	git remote rm $*
 
 # Top level alias for doing a release.
-release: guard-VERSION guard-GITHUB_USER tag-release package publish components-tag
+release: guard-VERSION guard-GITHUB_USER tag-release components-tag package publish


### PR DESCRIPTION
Doing this step lasts helps packagist notice the change and
prevents us from publishing the previous branch
