### PR TITLE
Update link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ tests for CakePHP by doing the following:
 
 ## Contributing
 
-[CONTRIBUTING.md](CONTRIBUTING.md) - Quick pointers for contributing to the CakePHP project.
+[CONTRIBUTING.md](.github/CONTRIBUTING.md) - Quick pointers for contributing to the CakePHP project.
 
 [CookBook "Contributing" Section](http://book.cakephp.org/3.0/en/contributing.html) - Details about contributing to the project.
 


### PR DESCRIPTION
CONTRIBUTING.md was moved to the .github folder 2 days ago. The link in README ought to be updated as well.
