### PR TITLE
Add Response::getFile()

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1458,6 +1458,16 @@ class Response
     }
 
     /**
+     * Get the current file if one exists.
+     *
+     * @return \Cake\Filesystem\File|null The file to use in the response or null
+     */
+    public function getFile()
+    {
+        return $this->_file;
+    }
+
+    /**
      * Apply a file range to a file and set the end offset.
      *
      * If an invalid range is requested a 416 Status code will be used

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1537,6 +1537,23 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * test getFile method
+     *
+     * @return void
+     */
+    public function testGetFile()
+    {
+        ob_start();
+        $response = new Response();
+        $this->assertNull($response->getFile(), 'No file to get');
+
+        $response->file(TEST_APP . 'vendor/css/test_asset.css');
+        $file = $response->getFile();
+        $this->assertInstanceOf('Cake\Filesystem\File', $file, 'Should get a file');
+        $this->assertSame(TEST_APP . 'vendor/css/test_asset.css', $file->path, 'Path should match');
+    }
+
+    /**
      * testConnectionAbortedOnBuffering method
      *
      * @return void

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1550,7 +1550,7 @@ class ResponseTest extends TestCase
         $response->file(TEST_APP . 'vendor/css/test_asset.css');
         $file = $response->getFile();
         $this->assertInstanceOf('Cake\Filesystem\File', $file, 'Should get a file');
-        $this->assertSame(TEST_APP . 'vendor/css/test_asset.css', $file->path, 'Path should match');
+        $this->assertPathEquals(TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css', $file->path);
     }
 
     /**


### PR DESCRIPTION
Right now if you need to get the file from inside the response, you have to use reflection tricks. Which makes me sad as I try to build out the PSR7 bridge for CakePHP. Having a method will be much nicer.
