### PR TITLE
Revert "Make find(list) not auto-null on a behavior of 2.x"

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1017,24 +1017,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function findList(Query $query, array $options)
     {
-        if (!isset($options['keyField']) && !isset($options['valueField'])) {
-            $select = $query->clause('select');
-            if ($select && count($select) <= 2) {
-                $keyField = array_shift($select);
-
-                $valueField = array_shift($select) ?: $keyField;
-                list($model, $keyField) = pluginSplit($keyField);
-                if (!$model || $model === $this->alias()) {
-                    $options['keyField'] = $keyField;
-                }
-
-                list($model, $valueField) = pluginSplit($valueField);
-                if (!$model || $model === $this->alias()) {
-                    $options['valueField'] = $valueField;
-                }
-            }
-        }
-
         $options += [
             'keyField' => $this->primaryKey(),
             'valueField' => $this->displayField(),

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1250,43 +1250,6 @@ class TableTest extends TestCase
     }
 
     /**
-     * Test that find('list') also works as it used to in 2.x.
-     *
-     * @return void
-     */
-    public function testFindListAutoSelectedFields()
-    {
-        $Users = new Table([
-            'table' => 'users',
-            'alias' => 'Users',
-            'connection' => $this->connection,
-        ]);
-        $Users->displayField('username');
-
-        $query = $Users->find('list', ['fields' => ['id', 'created']]);
-        $expected = ['id', 'created'];
-        $this->assertSame($expected, $query->clause('select'));
-
-        $query = $Users->find('list', ['fields' => ['id']]);
-        $expected = ['id'];
-        $this->assertSame($expected, $query->clause('select'));
-        $expected = [
-            1 => 1,
-            2 => 2,
-            3 => 3,
-            4 => 4
-        ];
-        $this->assertSame($expected, $query->toArray());
-
-        $query = $Users->find('list', ['fields' => ['Users.id', 'Users.created']]);
-        $expected = ['Users.id', 'Users.created'];
-        $this->assertSame($expected, $query->clause('select'));
-
-        $results = $query->toArray();
-        $this->assertInstanceOf('Cake\I18n\Time', array_shift($results));
-    }
-
-    /**
      * test that find('list') does not auto add fields to select if using virtual properties
      *
      * @return void


### PR DESCRIPTION
Reverts cakephp/cakephp#8098

This pull request caused a regression and the consensus in #8098 was that less magic is better. I don't think we can remove the 'older' magic as people clearly rely on it.
