### PR TITLE
Fixed RssHelper 

### DIFF
--- a/src/View/Helper/RssHelper.php
+++ b/src/View/Helper/RssHelper.php
@@ -327,6 +327,9 @@ class RssHelper extends Helper
                 case 'atom':
                     $xml .= ' xmlns:atom="http://www.w3.org/2005/Atom"';
                     break;
+                default:
+                    $bareName = $name;
+                    break;
             }
         }
         if ($cdata && !empty($content)) {

--- a/src/View/Helper/RssHelper.php
+++ b/src/View/Helper/RssHelper.php
@@ -327,8 +327,8 @@ class RssHelper extends Helper
                 case 'atom':
                     $xml .= ' xmlns:atom="http://www.w3.org/2005/Atom"';
                     break;
-                default:
-                    $bareName = $name;
+                case 'media':
+                    $xml .= ' xmlns:media="http://search.yahoo.com/mrss/"';
                     break;
             }
         }

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -188,8 +188,8 @@ class RssHelperTest extends TestCase
                     'rel' => 'self',
                     'type' => 'application/rss+xml']
             ],
-            'media:content' =>[
-                'attrib'=>[
+            'media:content' => [
+                'attrib'=> [
                     'media'=>"video/mp4",
                 ]
             ]
@@ -213,7 +213,7 @@ class RssHelperTest extends TestCase
                     'rel' => "self",
                     'type' => "application/rss+xml"
                 ],
-                'media:content'=>[
+                'media:content'=> [
                     'media'=>"video/mp4",
                 ],
             'content-here',

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -187,6 +187,11 @@ class RssHelperTest extends TestCase
                     'href' => 'http://www.example.com/rss.xml',
                     'rel' => 'self',
                     'type' => 'application/rss+xml']
+            ],
+            'media:content' =>[
+                'attrib'=>[
+                    'media'=>"video/mp4",
+                ]
             ]
         ];
         $content = 'content-here';
@@ -207,6 +212,9 @@ class RssHelperTest extends TestCase
                     'href' => "http://www.example.com/rss.xml",
                     'rel' => "self",
                     'type' => "application/rss+xml"
+                ],
+                'media:content'=>[
+                    'media'=>"video/mp4",
                 ],
             'content-here',
             '/channel',

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -189,8 +189,8 @@ class RssHelperTest extends TestCase
                     'type' => 'application/rss+xml']
             ],
             'media:content' => [
-                'attrib'=> [
-                    'media'=>"video/mp4",
+                'attrib' => [
+                    'media' => "video/mp4",
                 ]
             ]
         ];

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -186,11 +186,12 @@ class RssHelperTest extends TestCase
                 'attrib' => [
                     'href' => 'http://www.example.com/rss.xml',
                     'rel' => 'self',
-                    'type' => 'application/rss+xml']
+                    'type' => 'application/rss+xml'
+                ]
             ],
             'media:content' => [
                 'attrib' => [
-                    'media' => "video/mp4",
+                    'media' => 'video/mp4'
                 ]
             ]
         ];
@@ -213,8 +214,9 @@ class RssHelperTest extends TestCase
                     'rel' => "self",
                     'type' => "application/rss+xml"
                 ],
-                'media:content'=> [
-                    'media'=>"video/mp4",
+                'media:content' => [
+                    'xmlns:media' => 'http://search.yahoo.com/mrss/',
+                    'media' => "video/mp4",
                 ],
             'content-here',
             '/channel',


### PR DESCRIPTION
#8331

Fix for this issue. It doesn't break the other tests.

Changed RssHelper so if it finds a colon and if it isn't atom, it won't
change the bareName. Updated test so it also tests for this.
