### PR TITLE
Make JsonConfig pretty print config files.

### DIFF
--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -93,6 +93,6 @@ class JsonConfig implements ConfigEngineInterface
     public function dump($key, array $data)
     {
         $filename = $this->_getFilePath($key);
-        return file_put_contents($filename, json_encode($data)) > 0;
+        return file_put_contents($filename, json_encode($data, JSON_PRETTY_PRINT)) > 0;
     }
 }

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -157,7 +157,20 @@ class JsonConfigTest extends TestCase
         $engine = new JsonConfig(TMP);
         $result = $engine->dump('test', $this->testData);
         $this->assertTrue($result > 0);
-        $expected = '{"One":{"two":"value","three":{"four":"value four"},"is_null":null,"bool_false":false,"bool_true":true},"Asset":{"timestamp":"force"}}';
+        $expected = '{
+    "One": {
+        "two": "value",
+        "three": {
+            "four": "value four"
+        },
+        "is_null": null,
+        "bool_false": false,
+        "bool_true": true
+    },
+    "Asset": {
+        "timestamp": "force"
+    }
+}';
         $file = TMP . 'test.json';
         $contents = file_get_contents($file);
 


### PR DESCRIPTION
This makes JSON config files slightly less horrible to work with as you can read them now.

Refs #8338
