### PR TITLE
Make route patterns allow multibyte sub-patterns.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -199,9 +199,13 @@ class Route
             $parsed = preg_replace('#/\\\\\*$#', '(?:/(?P<_args_>.*))?', $parsed);
             $this->_greedy = true;
         }
+        $mode = '';
+        if (!empty($this->options['multibytePattern'])) {
+            $mode = 'u';
+        }
         krsort($routeParams);
         $parsed = str_replace(array_keys($routeParams), array_values($routeParams), $parsed);
-        $this->_compiledRoute = '#^' . $parsed . '[/]*$#u';
+        $this->_compiledRoute = '#^' . $parsed . '[/]*$#' . $mode;
         $this->keys = $names;
 
         // Remove defaults that are also keys. They can cause match failures

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -201,7 +201,7 @@ class Route
         }
         krsort($routeParams);
         $parsed = str_replace(array_keys($routeParams), array_values($routeParams), $parsed);
-        $this->_compiledRoute = '#^' . $parsed . '[/]*$#';
+        $this->_compiledRoute = '#^' . $parsed . '[/]*$#u';
         $this->keys = $names;
 
         // Remove defaults that are also keys. They can cause match failures

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -400,6 +400,8 @@ class RouteBuilder
      *   included when generating new URLs. You can override persistent parameters
      *   by redefining them in a URL or remove them by setting the parameter to `false`.
      *   Ex. `'persist' => ['lang']`
+     * - `multibytePattern` Set to true to enable multibyte pattern support in route
+     *   parameter patterns.
      * - `_name` is used to define a specific name for routes. This can be used to optimize
      *   reverse routing lookups. If undefined a name will be generated for each
      *   connected route.

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -207,6 +207,19 @@ class RouteTest extends TestCase
         $this->assertEquals(['url_title', 'id'], $route->keys);
     }
 
+    public function testRouteCompilingWithUnicodePatterns()
+    {
+        $route = new Route(
+            '/test/:slug',
+            ['controller' => 'Pages', 'action' => 'display'],
+            ['pass' => ['slug'], 'slug' => '[A-zА-я\-\ ]+']
+        );
+        $result = $route->compile();
+        $this->assertRegExp($result, '/test/abcDEF');
+        $this->assertRegExp($result, '/test/bla-blan-тест');
+        $this->assertNotRegExp($result, '/test/9999');
+    }
+
     /**
      * test more complex route compiling & parsing with mid route greedy stars
      * and optional routing parameters

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -212,12 +212,18 @@ class RouteTest extends TestCase
         $route = new Route(
             '/test/:slug',
             ['controller' => 'Pages', 'action' => 'display'],
-            ['pass' => ['slug'], 'slug' => '[A-zА-я\-\ ]+']
+            ['pass' => ['slug'], 'multibytePattern' => false, 'slug' => '[A-zА-я\-\ ]+']
         );
         $result = $route->compile();
-        $this->assertRegExp($result, '/test/abcDEF');
+        $this->assertNotRegExp($result, '/test/bla-blan-тест');
+
+        $route = new Route(
+            '/test/:slug',
+            ['controller' => 'Pages', 'action' => 'display'],
+            ['pass' => ['slug'], 'multibytePattern' => true, 'slug' => '[A-zА-я\-\ ]+']
+        );
+        $result = $route->compile();
         $this->assertRegExp($result, '/test/bla-blan-тест');
-        $this->assertNotRegExp($result, '/test/9999');
     }
 
     /**


### PR DESCRIPTION
This allows route parameter matching patterns to contain multibyte expressions which is useful for restricting parameters in non-ascii character sets.

Refs #8332
