### PR TITLE
Fix parsing empty header values.

### DIFF
--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -267,10 +267,19 @@ class HttpResponseTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $r);
 
-		$header = "Multi-Line: I am a \r\nmulti line\t\r\nfield value.\r\nSingle-Line: I am not\r\n";
+		$header = "Date:Sat, 07 Apr 2007 10:10:25 GMT\r\nLink: \r\nX-Total-Count: 19\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
 		$expected = array(
-			'Multi-Line' => "I am a\r\nmulti line\r\nfield value.",
+			'Date' => 'Sat, 07 Apr 2007 10:10:25 GMT',
+			'Link' => '',
+			'X-Total-Count' => '19',
+		);
+		$this->assertEquals($expected, $r);
+
+		$header = "Multi-Line: I am a\r\n multi line \r\n\tfield value.\r\nSingle-Line: I am not\r\n";
+		$r = $this->HttpResponse->parseHeader($header);
+		$expected = array(
+			'Multi-Line' => "I am a multi line field value.",
 			'Single-Line' => 'I am not'
 		);
 		$this->assertEquals($expected, $r);


### PR DESCRIPTION
Replace the complex and somewhat unfixable regexp based parser for a parser that handles each line individually. Normalize multi-line headers to replace multiple spaces with a single one. Section 4.2 of the
HTTP1.1 standard states

> Any LWS that occurs between field-content MAY be replaced with
> a single SP before interpreting the field value or forwarding the
> message downstream.

This makes me somewhat confident that we can safely normalize multi-line HTTP header values.

Refs #8330
