### PR TITLE
Table mixin added to Association

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -27,6 +27,7 @@ use RuntimeException;
  * An Association is a relationship established between two tables and is used
  * to configure and customize the way interconnected records are retrieved.
  *
+ * @mixin \Cake\ORM\Table
  */
 abstract class Association
 {


### PR DESCRIPTION
This fixes #8353.
A `@mixin \Cake\ORM\Table` has been added to `\Cake\ORM\Association`, this way, IDEs can see basic Table methods through associations.
