### PR TITLE
Suppress notice errors in PO file parsing.

### DIFF
--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -142,9 +142,10 @@ class PoFileParser
 
         $translation = stripcslashes($translation);
 
-        if ($context) {
+        if ($context && (!isset($messages[$singular]) || is_array($messages[$singular]))) {
             $messages[$singular]['_context'][$context] = $translation;
-        } else {
+        }
+        if ($context === null) {
             $messages[$singular] = $translation;
         }
 

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Test\TestCase\I18n\Parser;
 
+use Aura\Intl\Package;
+use Cake\I18n\I18n;
 use Cake\I18n\Parser\PoFileParser;
 use Cake\TestSuite\TestCase;
 
@@ -89,5 +91,29 @@ class PoFileParserTest extends TestCase
         $messages = $parser->parse($file);
 
         $this->assertTextEquals('this is a "quoted string" (translated)', $messages['this is a "quoted string"']);
+    }
+
+    /**
+     * Test parsing a file with message context on some msgid values.
+     *
+     * This behavior is not ideal, but more thorough solutions
+     * would break compatibility. Perhaps this is something we can
+     * reconsider in 4.x
+     *
+     * @return void
+     */
+    public function testParseContextOnSomeMessages()
+    {
+        $parser = new PoFileParser();
+        $file = APP . 'Locale' . DS . 'en' . DS . 'context.po';
+        $messages = $parser->parse($file);
+
+        I18n::translator('default', 'en_US', function () use ($messages) {
+            $package = new Package('default');
+            $package->setMessages($messages);
+            return $package;
+        });
+        $this->assertTextEquals('En cours', $messages['Pending']);
+        $this->assertTextEquals('En resolved', $messages['Resolved']);
     }
 }

--- a/tests/test_app/TestApp/Locale/en/context.po
+++ b/tests/test_app/TestApp/Locale/en/context.po
@@ -1,0 +1,15 @@
+#: Bare message first
+msgid "Pending"
+msgstr "En cours"
+
+msgctxt "Pay status"
+msgid "Pending"
+msgstr "En cours - context"
+
+#: Context message first
+msgctxt "Pay status"
+msgid "Resolved"
+msgstr "En resolved - context"
+
+msgid "Resolved"
+msgstr "En resolved"


### PR DESCRIPTION
Suppress the notice errors when PO files include duplicate msgid elements that have context and context-free variants. In these cases, the first definition 'wins'. 

Ideally we could add a '' context that is used by default. I tried this, but it broke a significant number of tests which made me concerned about backwards compatibility with userland message parsers.

Refs #8337
