### PR TITLE
Fix extracting POT files from vendor prefix plugins.

### DIFF
--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -547,7 +547,13 @@ class ExtractTask extends Shell
                 $output .= $header . $sentence;
             }
 
-            $filename = $domain . '.pot';
+            // Remove vendor prefix if present.
+            $slashPosition = strpos($domain, '/');
+            if ($slashPosition !== false) {
+                $domain = substr($domain, $slashPosition + 1);
+            }
+
+            $filename = str_replace('/', '_', $domain) . '.pot';
             $File = new File($this->_output . $filename);
             $response = '';
             while ($overwriteAll === false && $File->exists() && strtoupper($response) !== 'Y') {

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -263,7 +263,7 @@ class ExtractTaskTest extends TestCase
     }
 
     /**
-     * Test that is possible to extract messages form a single plugin
+     * Test that is possible to extract messages from a single plugin
      *
      * @return void
      */
@@ -285,6 +285,31 @@ class ExtractTaskTest extends TestCase
         $this->assertNotRegExp('#Pages#', $result);
         $this->assertRegExp('/translate\.ctp:\d+/', $result);
         $this->assertContains('This is a translatable string', $result);
+    }
+
+    /**
+     * Test that is possible to extract messages from a vendored plugin.
+     *
+     * @return void
+     */
+    public function testExtractVendoredPlugin()
+    {
+        Configure::write('App.namespace', 'TestApp');
+
+        $this->Task = $this->getMock(
+            'Cake\Shell\Task\ExtractTask',
+            ['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'],
+            [$this->io]
+        );
+
+        $this->Task->params['output'] = $this->path . DS;
+        $this->Task->params['plugin'] = 'Company/TestPluginThree';
+
+        $this->Task->main();
+        $result = file_get_contents($this->path . DS . 'test_plugin_three.pot');
+        $this->assertNotRegExp('#Pages#', $result);
+        $this->assertRegExp('/default\.ctp:\d+/', $result);
+        $this->assertContains('A vendor message', $result);
     }
 
     /**

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Template/Layout/default.ctp
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Template/Layout/default.ctp
@@ -1,2 +1,3 @@
 default test_three_theme layout
 <?= $this->fetch('content') ?>
+<?= __d('company/test_plugin_three', 'A vendor message') ?>


### PR DESCRIPTION
Correctly generate the output file name for vendor prefixed plugins. As per the convention defined in MessagesFileLoader, prefixed plugins only use the plugin name as the domain.po/pot file.

Refs #8316
