### PR TITLE
2.x - Handle negative numbers in Redis correctly.

### DIFF
--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -133,11 +133,11 @@ class RedisEngine extends CacheEngine {
  */
 	public function read($key) {
 		$value = $this->_Redis->get($key);
-		if (ctype_digit($value)) {
-			$value = (int)$value;
+		if (preg_match('/^[-]?\d+$/', $value)) {
+			return (int)$value;
 		}
 		if ($value !== false && is_string($value)) {
-			$value = unserialize($value);
+			return unserialize($value);
 		}
 		return $value;
 	}

--- a/lib/Cake/Test/Case/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/RedisEngineTest.php
@@ -145,6 +145,22 @@ class RedisEngineTest extends CakeTestCase {
 	}
 
 /**
+ * test write numbers method
+ *
+ * @return void
+ */
+	public function testWriteNumbers() {
+		$result = Cache::write('test-counter', 1, 'redis');
+		$this->assertSame(1, Cache::read('test-counter', 'redis'));
+
+		$result = Cache::write('test-counter', 0, 'redis');
+		$this->assertSame(0, Cache::read('test-counter', 'redis'));
+
+		$result = Cache::write('test-counter', -1, 'redis');
+		$this->assertSame(-1, Cache::read('test-counter', 'redis'));
+	}
+
+/**
  * testReadAndWriteCache method
  *
  * @return void


### PR DESCRIPTION
Update number sniff to handle negative numbers. We need to do number sniffing so we can maintain compatibility between write() and increment()/decrement().

Refs #8364
