### PR TITLE
3.x - Handle negative numbers in Redis correctly.

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -153,11 +153,11 @@ class RedisEngine extends CacheEngine
         $key = $this->_key($key);
 
         $value = $this->_Redis->get($key);
-        if (ctype_digit($value)) {
-            $value = (int)$value;
+        if (preg_match('/^[-]?\d+$/', $value)) {
+            return (int)$value;
         }
         if ($value !== false && is_string($value)) {
-            $value = unserialize($value);
+            return unserialize($value);
         }
         return $value;
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -193,6 +193,23 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * test write numbers method
+     *
+     * @return void
+     */
+    public function testWriteNumbers()
+    {
+        $result = Cache::write('test-counter', 1, 'redis');
+        $this->assertSame(1, Cache::read('test-counter', 'redis'));
+
+        $result = Cache::write('test-counter', 0, 'redis');
+        $this->assertSame(0, Cache::read('test-counter', 'redis'));
+
+        $result = Cache::write('test-counter', -1, 'redis');
+        $this->assertSame(-1, Cache::read('test-counter', 'redis'));
+    }
+
+    /**
      * testReadAndWriteCache method
      *
      * @return void


### PR DESCRIPTION
Update number sniff to handle negative numbers. We need to do number sniffing so we can maintain compatibility between write() and increment()/decrement().

Refs #8364
