### PR TITLE
Show warning if association property name is same as table field.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -439,7 +439,7 @@ abstract class Association
             $this->_propertyName = $this->_propertyName();
             if (in_array($this->_propertyName, $this->_sourceTable->schema()->columns())) {
                 $msg = 'Association property name "%s" clashes with field of same name of table "%s".' .
-                    "\n" . 'You should explicitly specify the "propertyName" option.';
+                    ' You should explicitly specify the "propertyName" option.';
                 trigger_error(
                     sprintf($msg, $this->_propertyName, $this->_sourceTable->table()),
                     E_USER_WARNING

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -438,6 +438,14 @@ abstract class Association
         if ($name === null && !$this->_propertyName) {
             list(, $name) = pluginSplit($this->_name);
             $this->_propertyName = Inflector::underscore($name);
+            if (in_array($this->_propertyName, $this->_sourceTable->schema()->columns())) {
+                $msg = 'Association property name "%s" clashes with field of same name of table "%s".' .
+                    "\n" . 'You should explicitly specify the "propertyName" option.';
+                trigger_error(
+                    sprintf($msg, $this->_propertyName, $this->_sourceTable->table()),
+                    E_USER_WARNING
+                );
+            }
         }
         return $this->_propertyName;
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -436,8 +436,7 @@ abstract class Association
             $this->_propertyName = $name;
         }
         if ($name === null && !$this->_propertyName) {
-            list(, $name) = pluginSplit($this->_name);
-            $this->_propertyName = Inflector::underscore($name);
+            $this->_propertyName = $this->_propertyName();
             if (in_array($this->_propertyName, $this->_sourceTable->schema()->columns())) {
                 $msg = 'Association property name "%s" clashes with field of same name of table "%s".' .
                     "\n" . 'You should explicitly specify the "propertyName" option.';
@@ -448,6 +447,17 @@ abstract class Association
             }
         }
         return $this->_propertyName;
+    }
+
+    /**
+     * Returns default property name based on association name.
+     *
+     * @return string
+     */
+    protected function _propertyName()
+    {
+        list(, $name) = pluginSplit($this->_name);
+        return Inflector::underscore($name);
     }
 
     /**

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -72,23 +72,14 @@ class BelongsTo extends Association
     }
 
     /**
-     * Sets the property name that should be filled with data from the target table
-     * in the source table record.
-     * If no arguments are passed, currently configured type is returned.
+     * Returns default property name based on association name.
      *
-     * @param string|null $name The property name, use null to read the current property.
      * @return string
      */
-    public function property($name = null)
+    protected function _propertyName()
     {
-        if ($name !== null) {
-            return parent::property($name);
-        }
-        if ($name === null && !$this->_propertyName) {
-            list(, $name) = pluginSplit($this->_name);
-            $this->_propertyName = Inflector::underscore(Inflector::singularize($name));
-        }
-        return $this->_propertyName;
+        list(, $name) = pluginSplit($this->_name);
+        return Inflector::underscore(Inflector::singularize($name));
     }
 
     /**

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -57,23 +57,14 @@ class HasOne extends Association
     }
 
     /**
-     * Sets the property name that should be filled with data from the target table
-     * in the source table record.
-     * If no arguments are passed, currently configured type is returned.
+     * Returns default property name based on association name.
      *
-     * @param string|null $name The name of the property. Pass null to read the current value.
      * @return string
      */
-    public function property($name = null)
+    protected function _propertyName()
     {
-        if ($name !== null) {
-            return parent::property($name);
-        }
-        if ($name === null && !$this->_propertyName) {
-            list(, $name) = pluginSplit($this->_name);
-            $this->_propertyName = Inflector::underscore(Inflector::singularize($name));
-        }
-        return $this->_propertyName;
+        list(, $name) = pluginSplit($this->_name);
+        return Inflector::underscore(Inflector::singularize($name));
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -700,10 +700,12 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedEmptySetSuccess($value)
     {
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $assoc = $this->getMock(
             '\Cake\ORM\Association\BelongsToMany',
             ['_saveTarget', 'replaceLinks'],
-            ['tags']
+            ['tags', ['sourceTable' => $table]]
         );
         $entity = new Entity([
             'id' => 1,
@@ -726,10 +728,12 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedEmptySetUpdateSuccess($value)
     {
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $assoc = $this->getMock(
             '\Cake\ORM\Association\BelongsToMany',
             ['_saveTarget', 'replaceLinks'],
-            ['tags']
+            ['tags', ['sourceTable' => $table]]
         );
         $entity = new Entity([
             'id' => 1,
@@ -755,10 +759,12 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedWithReplace()
     {
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $assoc = $this->getMock(
             '\Cake\ORM\Association\BelongsToMany',
             ['replaceLinks'],
-            ['tags']
+            ['tags', ['sourceTable' => $table]]
         );
         $entity = new Entity([
             'id' => 1,
@@ -782,10 +788,12 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedWithReplaceReturnFalse()
     {
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $assoc = $this->getMock(
             '\Cake\ORM\Association\BelongsToMany',
             ['replaceLinks'],
-            ['tags']
+            ['tags', ['sourceTable' => $table]]
         );
         $entity = new Entity([
             'id' => 1,

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -91,7 +91,11 @@ class AssociationCollectionTest extends TestCase
      */
     public function testGetByProperty()
     {
-        $belongsTo = new BelongsTo('Users', []);
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
+        $belongsTo = new BelongsTo('Users', [
+            'sourceTable' => $table
+        ]);
         $this->assertEquals('user', $belongsTo->property());
         $this->associations->add('Users', $belongsTo);
         $this->assertNull($this->associations->get('user'));
@@ -186,7 +190,8 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveParents()
     {
-        $table = $this->getMock('Cake\ORM\Table', [], [[]]);
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $mockOne = $this->getMock(
             'Cake\ORM\Association\BelongsTo',
             ['saveAssociated'],
@@ -235,7 +240,8 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveParentsFiltered()
     {
-        $table = $this->getMock('Cake\ORM\Table', [], [[]]);
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $mockOne = $this->getMock(
             'Cake\ORM\Association\BelongsTo',
             ['saveAssociated'],

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -284,7 +284,8 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveChildrenFiltered()
     {
-        $table = $this->getMock('Cake\ORM\Table', [], [[]]);
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
         $mockOne = $this->getMock(
             'Cake\ORM\Association\HasMany',
             ['saveAssociated'],

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -334,6 +334,7 @@ class AssociationTest extends TestCase
      *
      * @return void
      * @expectedException PHPUnit_Framework_Error_Warning
+     * @expectedExceptionMessageRegExp /^Association property name "foo" clashes with field of same name of table "test"/
      */
     public function testPropertyNameClash()
     {

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -330,6 +330,48 @@ class AssociationTest extends TestCase
     }
 
     /**
+     * Test that warning is shown if property name clashes with table field.
+     *
+     * @return void
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
+    public function testPropertyNameClash()
+    {
+        $this->source->schema(['foo' => ['type' => 'string']]);
+        $this->assertEquals('foo', $this->association->property());
+    }
+
+    /**
+     * Test that warning is not shown if "propertyName" option is explicitly specified.
+     *
+     * @return void
+     */
+    public function testPropertyNameExplicitySet()
+    {
+        $this->source->schema(['foo' => ['type' => 'string']]);
+
+        $config = [
+            'className' => '\Cake\Test\TestCase\ORM\TestTable',
+            'foreignKey' => 'a_key',
+            'conditions' => ['field' => 'value'],
+            'dependent' => true,
+            'sourceTable' => $this->source,
+            'joinType' => 'INNER',
+            'propertyName' => 'foo'
+        ];
+        $association = $this->getMock(
+            '\Cake\ORM\Association',
+            [
+                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+                'saveAssociated', 'eagerLoader', 'type'
+            ],
+            ['Foo', $config]
+        );
+
+        $this->assertEquals('foo', $association->property());
+    }
+
+    /**
      * Tests strategy method
      *
      * @return void


### PR DESCRIPTION
For e.g. if a table `Posts` has foreign key field `type` and you setup a belongs to association with table "Roles", for a `Post` entity `$post->type` will be entity of associated table rather than the foreign key field value. This at times is not easy to spot for new users.
