### PR TITLE
Fix RelativeTimeFormatter incorrectly formatting 'about a month ago'/…

### DIFF
--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -152,6 +152,7 @@ class RelativeTimeFormatter
                 'hour' => __d('cake', 'about an hour ago'),
                 'day' => __d('cake', 'about a day ago'),
                 'week' => __d('cake', 'about a week ago'),
+                'month' => __d('cake', 'about a month ago'),
                 'year' => __d('cake', 'about a year ago')
             ];
             return $relativeDate ? sprintf($options['relativeString'], $relativeDate) : $aboutAgo[$fWord];
@@ -167,6 +168,7 @@ class RelativeTimeFormatter
             'hour' => __d('cake', 'in about an hour'),
             'day' => __d('cake', 'in about a day'),
             'week' => __d('cake', 'in about a week'),
+            'month' => __d('cake', 'in about a month'),
             'year' => __d('cake', 'in about a year')
         ];
         return $aboutIn[$fWord];

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -310,6 +310,10 @@ class TimeTest extends TestCase
         ]);
         $expected = 'in about a day';
         $this->assertEquals($expected, $result);
+
+        $time = new $class('+20 days');
+        $result = $time->timeAgoInWords(['accuracy' => 'month']);
+        $this->assertEquals('in about a month', $result);
     }
 
     /**
@@ -390,6 +394,10 @@ class TimeTest extends TestCase
         $time = new $class('-23 hours');
         $result = $time->timeAgoInWords(['accuracy' => 'day']);
         $this->assertEquals('about a day ago', $result);
+
+        $time = new $class('-20 days');
+        $result = $time->timeAgoInWords(['accuracy' => 'month']);
+        $this->assertEquals('about a month ago', $result);
     }
 
     /**


### PR DESCRIPTION
Fixes #8377

The following code works now.

``` php
$time = new \Cake\I18n\Time('-20 days');
echo $time->timeAgoInWords(['accuracy' => 'month']);
// about a month ago
```
