### PR TITLE
Email log missing Subject and To headers when using MailTransport

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1184,7 +1184,7 @@ class CakeEmail {
 			}
 			CakeLog::write(
 				$config['level'],
-				PHP_EOL . $contents['headers'] . PHP_EOL . $contents['message'],
+				PHP_EOL . $contents['headers'] . PHP_EOL . PHP_EOL . $contents['message'],
 				$config['scope']
 			);
 		}

--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -49,6 +49,9 @@ class MailTransport extends AbstractTransport {
 
 		$params = isset($this->_config['additionalParameters']) ? $this->_config['additionalParameters'] : null;
 		$this->_mail($to, $subject, $message, $headers, $params);
+
+		$headers .= $eol . 'Subject: ' . $subject;
+		$headers .= $eol . 'To: ' . $to;
 		return array('headers' => $headers, 'message' => $message);
 	}
 

--- a/lib/Cake/Test/Case/Network/Email/MailTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/MailTransportTest.php
@@ -84,7 +84,10 @@ class MailTransportTest extends CakeTestCase {
 				'-f'
 			);
 
-		$this->MailTransport->send($email);
+		$result = $this->MailTransport->send($email);
+
+		$this->assertContains('Subject: ', $result['headers']);
+		$this->assertContains('To: ', $result['headers']);
 	}
 
 }


### PR DESCRIPTION
When using `CakeEmail` with `MailTransport` and email log enabled, log contains no `Subject:` and `To:` headers. These headers are most important.

Fixed to include these headers in log.

Also separate log headers and body with empty line.
