### PR TITLE
Update HasMany to avoid ambiguous columns in replace mode.

### DIFF
--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -397,7 +397,7 @@ class HasMany extends Association
             function ($ent) use ($target) {
                 $fields = $ent->extract((array)$target->primaryKey());
                 foreach ($fields as $field => $value) {
-                    $fields[$table->aliasField($field)] = $value;
+                    $fields[$target->aliasField($field)] = $value;
                     unset($fields[$field]);
                 }
                 return $fields;

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -392,10 +392,11 @@ class HasMany extends Association
      */
     protected function _unlinkAssociated(array $properties, EntityInterface $entity, Table $target, array $remainingEntities = [], array $options = [])
     {
+        $primaryKey = (array)$target->primaryKey();
         $exclusions = new Collection($remainingEntities);
         $exclusions = $exclusions->map(
-            function ($ent) use ($target) {
-                $fields = $ent->extract((array)$target->primaryKey());
+            function ($ent) use ($target, $primaryKey) {
+                $fields = $ent->extract($primaryKey);
                 foreach ($fields as $field => $value) {
                     $fields[$target->aliasField($field)] = $value;
                     unset($fields[$field]);

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -392,11 +392,15 @@ class HasMany extends Association
      */
     protected function _unlinkAssociated(array $properties, EntityInterface $entity, Table $target, array $remainingEntities = [], array $options = [])
     {
-        $primaryKey = (array)$target->primaryKey();
         $exclusions = new Collection($remainingEntities);
         $exclusions = $exclusions->map(
-            function ($ent) use ($primaryKey) {
-                return $ent->extract($primaryKey);
+            function ($ent) use ($target) {
+                $fields = $ent->extract((array)$target->primaryKey());
+                foreach ($fields as $field => $value) {
+                    $fields[$table->aliasField($field)] = $value;
+                    unset($fields[$field]);
+                }
+                return $fields;
             }
         )
         ->filter(


### PR DESCRIPTION
I've updated the exclusions query in the_unlinkAssociations function such that the table alias is now added to the fields in the conditions, such that it's possible to have more tables with the same field names as the current table when executing this query.

See #8389 for more info.
