### PR TITLE
Fix tests in mysql 5.7.3+

### DIFF
--- a/tests/Fixture/SiteArticlesFixture.php
+++ b/tests/Fixture/SiteArticlesFixture.php
@@ -27,7 +27,7 @@ class SiteArticlesFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer'],
         'author_id' => ['type' => 'integer', 'null' => true],
-        'site_id' => ['type' => 'integer', 'null' => true],
+        'site_id' => ['type' => 'integer', 'null' => false],
         'title' => ['type' => 'string', 'null' => true],
         'body' => 'text',
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'site_id']]]

--- a/tests/Fixture/SiteAuthorsFixture.php
+++ b/tests/Fixture/SiteAuthorsFixture.php
@@ -27,7 +27,7 @@ class SiteAuthorsFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer'],
         'name' => ['type' => 'string', 'default' => null],
-        'site_id' => ['type' => 'integer', 'null' => true],
+        'site_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'site_id']]]
     ];
 


### PR DESCRIPTION
TestFixtures `Cake\Test\Fixture\SiteAuthorsFixture` and `Cake\Test\Fixture\SiteArticlesFixture` both doesn't work on MySQL 5.7.3+. This can be traced down to the fact that they both contain a nullable field in their primary key, and which isn't allowed in MySQL, but from 5.7.3 and forward, this actually gives and error and the field isn't silently changed to NOT NULL.

Link to [MySQL 5.7.3 change log](http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-3.html):

> Columns in a PRIMARY KEY must be NOT NULL, but if declared explicitly as NULL produced no error. Now an error occurs. For example, a statement such as CREATE TABLE t (i INT NULL PRIMARY KEY) is rejected. The same occurs for similar ALTER TABLE statements. (Bug #13995622, Bug #66987, Bug #15967545, Bug #16545198)

This caused 

```
Fatal error: Uncaught exception 'Cake\Core\Exception\Exception' with message ' in /Users/jesper/code/cakephp/src/TestSuite/Fixture/FixtureManager.php on line 331

Cake\Core\Exception\Exception: Unable to insert fixture "Cake\Test\Fixture\SiteAuthorsFixture" in "Cake\Test\TestCase\ORM\BindingKeyTest" test case: 
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'test_content.site_authors' doesn't exist in /Users/jesper/code/cakephp/src/TestSuite/Fixture/FixtureManager.php on line 331
```

and

```
Fatal error: Uncaught exception 'Cake\Core\Exception\Exception' with message ' in /Users/jesper/code/cakephp/src/TestSuite/Fixture/FixtureManager.php on line 331

Cake\Core\Exception\Exception: Unable to insert fixture "Cake\Test\Fixture\SiteArticlesFixture" in "Cake\Test\TestCase\ORM\CompositeKeyTest" test case: 
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'test_content.site_articles' doesn't exist in /Users/jesper/code/cakephp/src/TestSuite/Fixture/FixtureManager.php on line 331
```

This PR changes both fixtures such that they are able to be converted to valid SQL again.
