### PR TITLE
Add missing traverse call to UnaryExpression.

### DIFF
--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -100,6 +100,7 @@ class UnaryExpression implements ExpressionInterface
     {
         if ($this->_value instanceof ExpressionInterface) {
             $callable($this->_value);
+            $this->_value->traverse($callable);
         }
     }
 


### PR DESCRIPTION
Add missing traverse call to UnaryExpression such that the traverse function actually travers through the inheriting elements.

See #8398 
