### PR TITLE
Avoding errors when there is no translation for the given plural form

### DIFF
--- a/src/I18n/Formatter/IcuFormatter.php
+++ b/src/I18n/Formatter/IcuFormatter.php
@@ -65,7 +65,7 @@ class IcuFormatter implements FormatterInterface
             $count = isset($vars['_count']) ? $vars['_count'] : 0;
             unset($vars['_count'], $vars['_singular']);
             $form = PluralRules::calculate($locale, $count);
-            $message = $message[$form];
+            $message = isset($message[$form]) ? $message[$form] : end($message);
         }
 
         return $this->_formatMessage($locale, $message, $vars);

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\I18n;
 
 use Cake\I18n\FrozenTime;
+use Cake\I18n\I18n;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
 
@@ -55,6 +56,7 @@ class TimeTest extends TestCase
         FrozenTime::$defaultLocale = $this->locale;
         FrozenTime::resetToStringFormat();
         date_default_timezone_set('UTC');
+        I18n::locale(I18n::DEFAULT_LOCALE);
     }
 
     /**
@@ -805,6 +807,20 @@ class TimeTest extends TestCase
 
         $time = $class::parseTime('31c2:54');
         $this->assertNull($time);
+    }
+
+    /**
+     * Tests that timeAgoInWords when using a russian locale does not break things
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testRussianTimeAgoInWords($class)
+    {
+        I18n::locale('ru_RU');
+        $time = new $class('5 days ago');
+        $result = $time->timeAgoInWords();
+        $this->assertEquals('5 days ago', $result);
     }
 
     /**


### PR DESCRIPTION
Fixes #8373

While this avoids an annoying notice, it also hides problems in the translation
files. A more propper solution would be to use the ICU message selector syntax
instead of the magic __n() function, but it would require breaking the translation
files that already exist for the time class.

 Please enter the commit message for your changes. Lines starting
