### PR TITLE
Removing legacy output buffer handling in Response::file().

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1453,7 +1453,6 @@ class Response
             $this->header('Content-Length', $fileSize);
         }
 
-        $this->_clearBuffer();
         $this->_file = $file;
     }
 
@@ -1520,6 +1519,8 @@ class Response
     protected function _sendFile($file, $range)
     {
         $compress = $this->outputCompressed();
+        ob_implicit_flush(true);
+
         $file->open('rb');
 
         $end = $start = false;
@@ -1546,9 +1547,6 @@ class Response
                 $bufferSize = $end - $offset + 1;
             }
             echo fread($file->handle, $bufferSize);
-            if (!$compress) {
-                $this->_flushBuffer();
-            }
         }
         $file->close();
         return true;
@@ -1568,6 +1566,7 @@ class Response
      * Clears the contents of the topmost output buffer and discards them
      *
      * @return bool
+     * @deprecated 3.2.4 This function is not needed anymore
      */
     protected function _clearBuffer()
     {
@@ -1580,6 +1579,7 @@ class Response
      * Flushes the contents of the output buffer
      *
      * @return void
+     * @deprecated 3.2.4 This function is not needed anymore
      */
     protected function _flushBuffer()
     {

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -888,7 +888,7 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
-     * Asserts that a file with the fiven name was sent in the response
+     * Asserts that a file with the given name was sent in the response
      *
      * @param string $expected The file name that should be sent in the response
      * @param string $message The failure message that will be appended to the generated message.

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -27,6 +27,7 @@ use Cake\Utility\Text;
 use Cake\View\Helper\SecureFieldTokenTrait;
 use Exception;
 use PHPUnit_Exception;
+use PHPUnit_Framework_Constraint_IsEqual;
 
 /**
  * A test case class intended to make integration tests of
@@ -878,11 +879,31 @@ abstract class IntegrationTestCase extends TestCase
     public function assertCookieEncrypted($expected, $name, $encrypt = 'aes', $key = null, $message = '')
     {
         if (empty($this->_response)) {
-            $this->fail('Not response set, cannot assert cookies.');
+            $this->fail('No response set, cannot assert cookies.');
         }
         $result = $this->_response->cookie($name);
         $this->_cookieEncriptionKey = $key;
         $result['value'] = $this->_decrypt($result['value'], $encrypt);
         $this->assertEquals($expected, $result['value'], 'Cookie data differs. ' . $message);
+    }
+
+    /**
+     * Asserts that a file with the fiven name was sent in the response
+     *
+     * @param string $expected The file name that should be sent in the response
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertFileResponse($expected, $message = '')
+    {
+        if ($this->_response === null) {
+            $this->fail('No response set, cannot assert file.');
+        }
+        $actual = isset($this->_response->getFile()->path) ? $this->_response->getFile()->path : null;
+
+        if ($actual === null) {
+            $this->fail('No file was sent in this response');
+        }
+        $this->assertEquals($expected, $actual, $message);
     }
 }

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1228,8 +1228,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->exactly(1))
@@ -1240,9 +1238,6 @@ class ResponseTest extends TestCase
         $response->expects($this->at(1))
             ->method('header')
             ->with('Accept-Ranges', 'bytes');
-
-        $response->expects($this->once())->method('_clearBuffer');
-        $response->expects($this->once())->method('_flushBuffer');
 
         $response->expects($this->exactly(1))
             ->method('_isActive')
@@ -1271,8 +1266,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->exactly(1))
@@ -1291,9 +1284,6 @@ class ResponseTest extends TestCase
         $response->expects($this->at(3))
             ->method('header')
             ->with('Accept-Ranges', 'bytes');
-
-        $response->expects($this->once())->method('_clearBuffer');
-        $response->expects($this->once())->method('_flushBuffer');
 
         $response->expects($this->exactly(1))
             ->method('_isActive')
@@ -1331,8 +1321,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->exactly(1))
@@ -1351,9 +1339,6 @@ class ResponseTest extends TestCase
         $response->expects($this->at(3))
             ->method('header')
             ->with('Accept-Ranges', 'bytes');
-
-        $response->expects($this->once())->method('_clearBuffer');
-        $response->expects($this->once())->method('_flushBuffer');
 
         $response->expects($this->exactly(1))
             ->method('_isActive')
@@ -1388,8 +1373,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->at(0))
@@ -1414,8 +1397,6 @@ class ResponseTest extends TestCase
             ->method('header')
             ->with('Accept-Ranges', 'bytes');
 
-        $response->expects($this->once())->method('_clearBuffer');
-        $response->expects($this->once())->method('_flushBuffer');
         $response->expects($this->exactly(1))
             ->method('_isActive')
             ->will($this->returnValue(true));
@@ -1449,8 +1430,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->at(0))
@@ -1475,8 +1454,6 @@ class ResponseTest extends TestCase
             ->method('header')
             ->with('Accept-Ranges', 'bytes');
 
-        $response->expects($this->once())->method('_clearBuffer');
-        $response->expects($this->once())->method('_flushBuffer');
         $response->expects($this->exactly(1))
             ->method('_isActive')
             ->will($this->returnValue(true));
@@ -1511,8 +1488,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->exactly(1))
@@ -1567,8 +1542,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->any())
@@ -1579,9 +1552,6 @@ class ResponseTest extends TestCase
         $response->expects($this->at(0))
             ->method('_isActive')
             ->will($this->returnValue(false));
-
-        $response->expects($this->once())->method('_clearBuffer');
-        $response->expects($this->never())->method('_flushBuffer');
 
         $response->file(TEST_APP . 'vendor/css/test_asset.css');
 
@@ -1603,8 +1573,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->any())
@@ -1633,8 +1601,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->any())
@@ -1688,8 +1654,6 @@ class ResponseTest extends TestCase
             'type',
             '_sendHeader',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->at(1))
@@ -1739,8 +1703,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->exactly(1))
@@ -1766,8 +1728,6 @@ class ResponseTest extends TestCase
                 'Content-Length' => 18,
                 'Content-Range' => 'bytes 8-25/38',
             ]);
-
-        $response->expects($this->once())->method('_clearBuffer');
 
         $response->expects($this->any())
             ->method('_isActive')
@@ -1800,8 +1760,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->at(1))
@@ -1845,8 +1803,6 @@ class ResponseTest extends TestCase
             'type',
             '_sendHeader',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->at(1))
@@ -1888,8 +1844,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->exactly(1))
@@ -1907,8 +1861,6 @@ class ResponseTest extends TestCase
                 'Content-Length' => 18,
                 'Content-Range' => 'bytes 8-25/38',
             ]);
-
-        $response->expects($this->once())->method('_clearBuffer');
 
         $response->expects($this->any())
             ->method('_isActive')
@@ -1941,8 +1893,6 @@ class ResponseTest extends TestCase
             '_sendHeader',
             '_setContentType',
             '_isActive',
-            '_clearBuffer',
-            '_flushBuffer'
         ]);
 
         $response->expects($this->at(1))

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -446,7 +446,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
 
         $this->assertHeader('Etag', 'abc123');
     }
-    
+
     /**
      * Test the header contains assertion.
      *
@@ -536,5 +536,41 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     public function testEventManagerReset2($prevEventManager)
     {
         $this->assertNotSame($prevEventManager, EventManager::instance());
+    }
+
+    /**
+     * Test sending file in requests.
+     *
+     * @return void
+     */
+    public function testSendFile()
+    {
+        $this->get('/posts/file');
+        $this->assertFileResponse(TEST_APP . 'TestApp' . DS . 'Controller' . DS . 'PostsController.php');
+    }
+
+    /**
+     * Test that assertFile requires a response
+     *
+     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage No response set, cannot assert file
+     * @return void
+     */
+    public function testAssertFileNoReponse()
+    {
+        $this->assertFileResponse('foo');
+    }
+
+    /**
+     * Test that assertFile requires a file
+     *
+     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage No file was sent in this response
+     * @return void
+     */
+    public function testAssertFileNoFile()
+    {
+        $this->get('/posts/get');
+        $this->assertFileResponse('foo');
     }
 }

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -81,4 +81,10 @@ class PostsController extends AppController
         $this->response->body('Request was accepted');
         return $this->response;
     }
+
+    public function file()
+    {
+        $this->response->file(__FILE__);
+        return $this->response;
+    }
 }


### PR DESCRIPTION
This made it possible to correctly test file sending in IntegrationTestCase.

Fixes #7974
