### PR TITLE
Make sure that the missing fields checks is done after the query is built

### DIFF
--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -119,7 +119,7 @@ trait SelectableAssociationTrait
      * has the foreignKey fields selected.
      * If the required fields are missing, throws an exception.
      *
-     * @param \Cake\ORM\Query The association fetching query
+     * @param \Cake\ORM\Query $fetchQuery The association fetching query
      * @param array $key The foreign key fields to check
      * @return void
      * @throws InvalidArgumentException
@@ -140,9 +140,11 @@ trait SelectableAssociationTrait
 
         if ($missingFields) {
             throw new InvalidArgumentException(
-                sprintf('You are required to select the "%s" field(s)',
-                implode(', ', (array)$key)
-            ));
+                sprintf(
+                    'You are required to select the "%s" field(s)',
+                    implode(', ', (array)$key)
+                )
+            );
         }
     }
 

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -126,7 +126,7 @@ trait SelectableAssociationTrait
      */
     protected function _assertFieldsPresent($fetchQuery, $key)
     {
-        $select = $fetchQuery->clause('select');
+        $select = $fetchQuery->aliasFields($fetchQuery->clause('select'));
         if (empty($select)) {
             return;
         }
@@ -134,8 +134,8 @@ trait SelectableAssociationTrait
 
         if ($missingFields) {
             $driver = $fetchQuery->connection()->driver();
-            $key = array_map([$driver, 'quoteIdentifier'], $key);
-            $missingFields = array_diff($key, $select) !== [];
+            $quoted = array_map([$driver, 'quoteIdentifier'], $key);
+            $missingFields = array_diff($quoted, $select) !== [];
         }
 
         if ($missingFields) {

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -267,7 +267,7 @@ class HasManyTest extends TestCase
             'conditions' => ['Articles.id !=' => 3],
             'sort' => ['title' => 'DESC'],
             'fields' => ['title', 'author_id'],
-            'contain' => ['Comments' => ['fields' => ['comment']]],
+            'contain' => ['Comments' => ['fields' => ['comment', 'article_id']]],
             'keys' => $keys,
             'query' => $query
         ]);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -87,7 +87,7 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that eagerloading belongsToMany with find list fails with a helpful message.
      *
-     * @expectedException \RuntimeException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testEagerLoadingBelongsToManyList()


### PR DESCRIPTION
After this changes, when using the query builder function for a HasMany or
BelongsToMany association, failing to select the foreignKey fields will
actually trigger the helpful exception for the user.

Fixes #6606
