### PR TITLE
Fix connection aliasing.

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -134,20 +134,20 @@ class ConnectionManager
      *
      * You can remove aliases with ConnectionManager::dropAlias().
      *
-     * @param string $from The connection to add an alias to.
-     * @param string $to The alias to create. $from should return when loaded with get().
+     * @param string $original The connection to add an alias to.
+     * @param string $target The alias to create. Fetching $original will return $target when loaded with get().
      * @return void
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When aliasing a
      * connection that does not exist.
      */
-    public static function alias($from, $to)
+    public static function alias($original, $target)
     {
-        if (empty(static::$_config[$to]) && empty(static::$_config[$from])) {
+        if (empty(static::$_config[$target]) && empty(static::$_config[$original])) {
             throw new MissingDatasourceConfigException(
-                sprintf('Cannot create alias of "%s" as it does not exist.', $from)
+                sprintf('Cannot create alias of "%s" as it does not exist.', $original)
             );
         }
-        static::$_aliasMap[$to] = $from;
+        static::$_aliasMap[$target] = $original;
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -133,7 +133,7 @@ class FixtureManager
                 continue;
             }
             if (strpos($connection, 'test_') === 0) {
-                $map[substr($connection, 5)] = $connection;
+                $map[$connection] = substr($connection, 5);
             } else {
                 $map['test_' . $connection] = $connection;
             }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -92,8 +92,8 @@ class TranslateBehaviorTest extends TestCase
         $i18n = $items->getByProperty('_i18n');
 
         $this->assertEquals('\TestApp\Model\Table\I18nTable', $i18n->name());
+        $this->assertInstanceOf('TestApp\Model\Table\I18nTable', $i18n->target());
         $this->assertEquals('custom_i18n_table', $i18n->target()->table());
-        $this->assertEquals('test_custom_i18n_datasource', $i18n->target()->connection()->configName());
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -24,9 +24,4 @@ class I18nTable extends Table
     {
         $this->table('custom_i18n_table');
     }
-
-    public static function defaultConnectionName()
-    {
-        return 'custom_i18n_datasource';
-    }
 }


### PR DESCRIPTION
Revert 1162121f1e8b8d0f1df0fb65ddf8ace5af8693d0 Which caused non-default connections to be incorrectly aliased.

I've also updated the alias() doc blocks to make the parameter names a bit clearer and hopefully reduce confusion later. The original FriendsOfCake/Crud issue sounded like the reporter was missing a `test_alpha` connection.

Refs #8319
