### PR TITLE
Finish fixing connection aliasing.

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -134,20 +134,27 @@ class ConnectionManager
      *
      * You can remove aliases with ConnectionManager::dropAlias().
      *
-     * @param string $original The connection to add an alias to.
-     * @param string $target The alias to create. Fetching $original will return $target when loaded with get().
+     * ### Usage
+     *
+     * ```
+     * // Make 'things' resolve to 'test_things' connection
+     * ConnectionManager::alias('test_things', 'things');
+     * ```
+     *
+     * @param string $alias The alias to add. Fetching $source will return $alias when loaded with get.
+     * @param string $source The connection to add an alias to.
      * @return void
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When aliasing a
      * connection that does not exist.
      */
-    public static function alias($original, $target)
+    public static function alias($alias, $source)
     {
-        if (empty(static::$_config[$target]) && empty(static::$_config[$original])) {
+        if (empty(static::$_config[$source]) && empty(static::$_config[$alias])) {
             throw new MissingDatasourceConfigException(
-                sprintf('Cannot create alias of "%s" as it does not exist.', $original)
+                sprintf('Cannot create alias of "%s" as it does not exist.', $alias)
             );
         }
-        static::$_aliasMap[$target] = $original;
+        static::$_aliasMap[$source] = $alias;
     }
 
     /**

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -138,8 +138,8 @@ class FixtureManager
                 $map['test_' . $connection] = $connection;
             }
         }
-        foreach ($map as $alias => $connection) {
-            ConnectionManager::alias($alias, $connection);
+        foreach ($map as $testConnection => $normal) {
+            ConnectionManager::alias($testConnection, $normal);
         }
     }
 

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -139,7 +139,7 @@ class FixtureManager
             }
         }
         foreach ($map as $alias => $connection) {
-            ConnectionManager::alias($connection, $alias);
+            ConnectionManager::alias($alias, $connection);
         }
     }
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -93,6 +93,7 @@ class TranslateBehaviorTest extends TestCase
 
         $this->assertEquals('\TestApp\Model\Table\I18nTable', $i18n->name());
         $this->assertInstanceOf('TestApp\Model\Table\I18nTable', $i18n->target());
+        $this->assertEquals('test_custom_i18n_datasource', $i18n->target()->connection()->configName());
         $this->assertEquals('custom_i18n_table', $i18n->target()->table());
     }
 

--- a/tests/test_app/TestApp/Model/Table/I18nTable.php
+++ b/tests/test_app/TestApp/Model/Table/I18nTable.php
@@ -24,4 +24,9 @@ class I18nTable extends Table
     {
         $this->table('custom_i18n_table');
     }
+
+    public static function defaultConnectionName()
+    {
+        return 'custom_i18n_datasource';
+    }
 }


### PR DESCRIPTION
The code in #8414 removed the defaultConnectionName from a test model. This shouldn't have been removed as it was exposing an issue in #8414.

Refs #8414
