### PR TITLE
Handle malformed Range headers without warnings.

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1478,11 +1478,16 @@ class Response
      */
     protected function _fileRange($file, $httpRange)
     {
-        list(, $range) = explode('=', $httpRange);
-        list($start, $end) = explode('-', $range);
-
         $fileSize = $file->size();
         $lastByte = $fileSize - 1;
+        $start = 0;
+        $end = $lastByte;
+
+        preg_match('/^bytes\s*=\s*(\d+)?\s*-\s*(\d+)?$/', $httpRange, $matches);
+        if ($matches) {
+            $start = $matches[1];
+            $end = isset($matches[2]) ? $matches[2] : '';
+        }
 
         if ($start === '') {
             $start = $fileSize - $end;


### PR DESCRIPTION
Don't emit warnings on malformed/invalid range headers. Also make parsing more robust and allow whitespace between significant tokens. I bumped into this while derping around with curl.
