### PR TITLE
Fix __xn() and __dxn() so that plural forms are used.

### DIFF
--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -159,7 +159,7 @@ if (!function_exists('__xn')) {
 
         $arguments = func_num_args() === 5 ? (array)$args : array_slice(func_get_args(), 2);
         return I18n::translator()->translate(
-            $singular,
+            $plural,
             ['_count' => $count, '_singular' => $singular, '_context' => $context] + $arguments
         );
     }
@@ -218,7 +218,7 @@ if (!function_exists('__dxn')) {
 
         $arguments = func_num_args() === 6 ? (array)$args : array_slice(func_get_args(), 2);
         return I18n::translator($domain)->translate(
-            $singular,
+            $plural,
             ['_count' => $count, '_singular' => $singular, '_context' => $context] + $arguments
         );
     }

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -326,6 +326,12 @@ class I18nTest extends TestCase
             $package->setMessages([
                 'letter' => [
                     '_context' => [
+                        'character' => 'The letter {0}',
+                        'communication' => 'The letters {0} and {1}',
+                    ]
+                ],
+                'letters' => [
+                    '_context' => [
                         'character' => [
                             'The letter {0}',
                             'The letters {0} and {1}'
@@ -390,6 +396,12 @@ class I18nTest extends TestCase
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
+                    '_context' => [
+                        'character' => 'The letter {0}',
+                        'communication' => 'The letters {0} and {1}',
+                    ]
+                ],
+                'letters' => [
                     '_context' => [
                         'character' => [
                             'The letter {0}',

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -327,7 +327,7 @@ class I18nTest extends TestCase
                 'letter' => [
                     '_context' => [
                         'character' => 'The letter {0}',
-                        'communication' => 'The letters {0} and {1}',
+                        'communication' => 'She wrote a letter to {0}',
                     ]
                 ],
                 'letters' => [
@@ -398,7 +398,7 @@ class I18nTest extends TestCase
                 'letter' => [
                     '_context' => [
                         'character' => 'The letter {0}',
-                        'communication' => 'The letters {0} and {1}',
+                        'communication' => 'She wrote a letter to {0}',
                     ]
                 ],
                 'letters' => [


### PR DESCRIPTION
Fixes #8431

I fixed incorrectly formatted messages used in test cases too. PoFileParser returns different format actually.

``` po
msgctxt "character"
msgid "letter"
msgid_plural "letters"
msgstr[0] "The letter {0}"
msgstr[1] "The letters {0} and {1}"

msgctxt "communication"
msgid "letter"
msgid_plural "letters"
msgstr[0] "She wrote a letter to {0}"
msgstr[1] "She wrote a letter to {0} and {1}"
```

``` php
use Cake\I18n\Parser\PoFileParser;
$parser = new PoFileParser();
debug( $parser->parse(APP . '/Locale/de_DE/default.po') );
```

``` php
[
    'letter' => [
        '_context' => [
            'character' => 'The letter {0}',
            'communication' => 'She wrote a letter to {0}'
        ]
    ],
    'letters' => [
        '_context' => [
            'character' => [
                (int) 0 => 'The letter {0}',
                (int) 1 => 'The letters {0} and {1}'
            ],
            'communication' => [
                (int) 0 => 'She wrote a letter to {0}',
                (int) 1 => 'She wrote a letter to {0} and {1}'
            ]
        ]
    ]
]
```
