### PR TITLE
added PDO-fetch-type FETCH_OBJ to PDOStatement

### DIFF
--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -97,6 +97,9 @@ class PDOStatement extends StatementDecorator
         if ($type === 'assoc') {
             return $this->_statement->fetch(PDO::FETCH_ASSOC);
         }
+        if ($type === 'obj') {
+            return $this->_statement->fetch(PDO::FETCH_OBJ);
+        }
         return $this->_statement->fetch($type);
     }
 
@@ -121,6 +124,9 @@ class PDOStatement extends StatementDecorator
         }
         if ($type === 'assoc') {
             return $this->_statement->fetchAll(PDO::FETCH_ASSOC);
+        }
+        if ($type === 'obj') {
+            return $this->_statement->fetchAll(PDO::FETCH_OBJ);
         }
         return $this->_statement->fetchAll($type);
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3675,4 +3675,31 @@ class QueryTest extends TestCase
         $pattern = str_replace('>', '[`"\]]' . $optional, $pattern);
         $this->assertRegExp('#' . $pattern . '#', $query);
     }
+
+    /**
+     * Tests that fetch returns an anonymous object when the string 'obj'
+     * is passed as an argument
+     *
+     * @return void
+     */
+    public function testSelectWithObjFetchType()
+    {
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('comments')
+            ->where(['id' => '1'])
+            ->execute();
+        $obj = (object)['id' => 1];
+        $this->assertEquals($obj, $result->fetch('obj'));
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('comments')
+            ->where(['id' => '1'])
+            ->execute();
+        $rows = $result->fetchAll('obj');
+        $this->assertEquals($obj, $rows[0]);
+    }
 }


### PR DESCRIPTION
This makes it possible to get database-results in the form of anonymous objects

```
$conn = ConnectionManager::get('default');
$r = $conn->query("SELECT id FROM things LIMIT 1");
$obj = $r->fetch('obj');
// id can be accessed with $obj->id instead of $obj['id']
```

Usecase: I need this fetch-type for a legacy-application which I am currently refactoring to work with cakephp-3. This application expects anonymous objects instead of arrays.
