### PR TITLE
Add missing bracket in comment

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -497,7 +497,7 @@ trait EntityTrait
     }
 
     /**
-     * Implements unset($result[$offset);
+     * Implements unset($result[$offset]);
      *
      * @param mixed $offset The offset to remove.
      * @return void


### PR DESCRIPTION
Just a simple missing bracket in a method docblock
