### PR TITLE
Run sniffer to auto-fix default params into doc blocks.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -117,7 +117,7 @@ class Cache
      * Returns the Cache Registry instance used for creating and using cache adapters.
      * Also allows for injecting of a new registry instance.
      *
-     * @param \Cake\Core\ObjectRegistry $registry Injectable registry object.
+     * @param \Cake\Core\ObjectRegistry|null $registry Injectable registry object.
      * @return \Cake\Core\ObjectRegistry
      */
     public static function registry(ObjectRegistry $registry = null)

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -462,7 +462,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * // Total: 6
      * ```
      *
-     * @param string|callable $matcher The property name to sum or a function
+     * @param string|callable|null $matcher The property name to sum or a function
      * If no value is passed, an identity function will be used.
      * that will return the value of the property to sum.
      * @return float|int
@@ -840,7 +840,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * });
      * ```
      *
-     * @param callable $transformer A callable function that will receive each of
+     * @param callable|null $transformer A callable function that will receive each of
      * the items in the collection and should return an array or Traversable object
      * @return \Cake\Collection\CollectionInterface
      */

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -108,7 +108,7 @@ class MapReduce implements IteratorAggregate
      * @param callable $mapper the mapper callback. This function will receive 3 arguments.
      * The first one is the current value, second the current results key and third is
      * this class instance so you can call the result emitters.
-     * @param callable $reducer the reducer callback. This function will receive 3 arguments.
+     * @param callable|null $reducer the reducer callback. This function will receive 3 arguments.
      * The first one is the list of values inside a bucket, second one is the name
      * of the bucket that was created during the mapping phase and third one is an
      * instance of this class.
@@ -152,7 +152,7 @@ class MapReduce implements IteratorAggregate
      * for this record.
      *
      * @param mixed $value The value to be appended to the final list of results
-     * @param string $key and optional key to assign to the value
+     * @param string|null $key and optional key to assign to the value
      * @return void
      */
     public function emit($value, $key = null)

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -80,7 +80,7 @@ class TreeIterator extends RecursiveIteratorIterator
      *
      * @param string|callable $valuePath The property to extract or a callable to return
      * the display value
-     * @param string|callable $keyPath The property to use as iteration key or a
+     * @param string|callable|null $keyPath The property to use as iteration key or a
      * callable returning the key value.
      * @param string $spacer The string to use for prefixing the values according to
      * their depth in the tree

--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -67,7 +67,7 @@ class ZipIterator extends MultipleIterator implements CollectionInterface, Seria
      * iterators by their corresponding index.
      *
      * @param array $sets The list of array or iterators to be zipped.
-     * @param callable $callable The function to use for zipping the elements of each iterator.
+     * @param callable|null $callable The function to use for zipping the elements of each iterator.
      */
     public function __construct(array $sets, $callable = null)
     {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -181,7 +181,7 @@ class ConsoleIo
      *
      * @param array|string $message The message to output.
      * @param int $newlines Number of newlines to append.
-     * @param int $size The number of bytes to overwrite. Defaults to the
+     * @param int|null $size The number of bytes to overwrite. Defaults to the
      *    length of the last message output.
      * @return void
      */
@@ -269,7 +269,7 @@ class ConsoleIo
     /**
      * Add a new output style or get defined styles.
      *
-     * @param string $style The style to get or create.
+     * @param string|null $style The style to get or create.
      * @param array|bool|null $definition The array definition of the style to change or create a style
      *   or false to remove a style.
      * @return mixed If you are getting styles, the style or null will be returned. If you are creating/modifying

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -617,7 +617,7 @@ class ConsoleOptionParser
      * Generates help text based on the description, options, arguments, subcommands and epilog
      * in the parser.
      *
-     * @param string $subcommand If present and a valid subcommand that has a linked parser.
+     * @param string|null $subcommand If present and a valid subcommand that has a linked parser.
      *    That subcommands help will be shown instead.
      * @param string $format Define the output format, can be text or xml
      * @param int $width The width to format user content to. Defaults to 72

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -158,7 +158,7 @@ class Shell
     /**
      * Constructs this Shell instance.
      *
-     * @param \Cake\Console\ConsoleIo $io An io instance.
+     * @param \Cake\Console\ConsoleIo|null $io An io instance.
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#Shell
      */
     public function __construct(ConsoleIo $io = null)
@@ -187,7 +187,7 @@ class Shell
     /**
      * Get/Set the io object for this shell.
      *
-     * @param \Cake\Console\ConsoleIo $io The ConsoleIo object to use.
+     * @param \Cake\Console\ConsoleIo|null $io The ConsoleIo object to use.
      * @return \Cake\Console\ConsoleIo The current ConsoleIo object.
      */
     public function io(ConsoleIo $io = null)

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -567,7 +567,7 @@ class AuthComponent extends Component
      * $this->Auth->allow();
      * ```
      *
-     * @param string|array $actions Controller action name or array of actions
+     * @param string|array|null $actions Controller action name or array of actions
      * @return void
      * @link http://book.cakephp.org/3.0/en/controllers/components/authentication.html#making-actions-public
      */
@@ -596,7 +596,7 @@ class AuthComponent extends Component
      * ```
      * to remove all items from the allowed list
      *
-     * @param string|array $actions Controller action name or array of actions
+     * @param string|array|null $actions Controller action name or array of actions
      * @return void
      * @see \Cake\Controller\Component\AuthComponent::allow()
      * @link http://book.cakephp.org/3.0/en/controllers/components/authentication.html#making-actions-require-authorization
@@ -724,7 +724,7 @@ class AuthComponent extends Component
      *    `loginRedirect`, the `loginRedirect` value is returned.
      *  - If there is no session and no `loginRedirect`, / is returned.
      *
-     * @param string|array $url Optional URL to write as the login redirect URL.
+     * @param string|array|null $url Optional URL to write as the login redirect URL.
      * @return string Redirect URL
      */
     public function redirectUrl($url = null)

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -392,7 +392,7 @@ class RequestHandlerComponent extends Component
      *
      * Returns true if the client accepts xml.
      *
-     * @param string|array $type Can be null (or no parameter), a string type name, or an
+     * @param string|array|null $type Can be null (or no parameter), a string type name, or an
      *   array of types
      * @return mixed If null or no parameter is passed, returns an array of content
      *   types the client accepts. If a string is passed, returns true
@@ -426,7 +426,7 @@ class RequestHandlerComponent extends Component
     /**
      * Determines the content type of the data the client has sent (i.e. in a POST request)
      *
-     * @param string|array $type Can be null (or no parameter), a string type name, or an array of types
+     * @param string|array|null $type Can be null (or no parameter), a string type name, or an array of types
      * @return mixed If a single type is supplied a boolean will be returned. If no type is provided
      *   The mapped value of CONTENT_TYPE will be returned. If an array is supplied the first type
      *   in the request content type will be returned.
@@ -471,7 +471,7 @@ class RequestHandlerComponent extends Component
      * if provided, and secondarily by the list of content-types provided in
      * HTTP_ACCEPT.
      *
-     * @param string|array $type An optional array of 'friendly' content-type names, i.e.
+     * @param string|array|null $type An optional array of 'friendly' content-type names, i.e.
      *   'html', 'xml', 'js', etc.
      * @return mixed If $type is null or not provided, the first content-type in the
      *    list, based on preference, is returned. If a single type is provided

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -144,7 +144,7 @@ class SecurityComponent extends Component
     /**
      * Sets the actions that require a request that is SSL-secured, or empty for all actions
      *
-     * @param string|array $actions Actions list
+     * @param string|array|null $actions Actions list
      * @return void
      */
     public function requireSecure($actions = null)

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -40,7 +40,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     /**
      * Constructor.
      *
-     * @param \Cake\Controller\Controller $controller Controller instance.
+     * @param \Cake\Controller\Controller|null $controller Controller instance.
      */
     public function __construct(Controller $controller = null)
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -574,8 +574,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Instantiates the correct view class, hands it its data, and uses it to render the view output.
      *
-     * @param string $view View to use for rendering
-     * @param string $layout Layout to use
+     * @param string|null $view View to use for rendering
+     * @param string|null $layout Layout to use
      * @return \Cake\Network\Response A response object containing the rendered view.
      * @link http://book.cakephp.org/3.0/en/controllers.html#rendering-a-view
      */

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -170,7 +170,7 @@ class App
      * Will return the path for datasources under the 'MyPlugin' plugin.
      *
      * @param string $type type of path
-     * @param string $plugin name of plugin
+     * @param string|null $plugin name of plugin
      * @return array
      * @link http://book.cakephp.org/3.0/en/core-libraries/app.html#finding-paths-to-namespaces
      */

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -112,7 +112,7 @@ class Configure
      * Configure::read('Name.key'); will return only the value of Configure::Name[key]
      * ```
      *
-     * @param string $var Variable to obtain. Use '.' to access array elements.
+     * @param string|null $var Variable to obtain. Use '.' to access array elements.
      * @return mixed Value stored in configure, or null.
      * @link http://book.cakephp.org/3.0/en/development/configuration.html#reading-configuration-data
      */
@@ -385,7 +385,7 @@ class Configure
      *
      * @param string $name The storage name for the saved configuration.
      * @param string $cacheConfig The cache configuration to save into. Defaults to 'default'
-     * @param array $data Either an array of data to store, or leave empty to store all values.
+     * @param array|null $data Either an array of data to store, or leave empty to store all values.
      * @return bool Success
      */
     public static function store($name, $cacheConfig = 'default', $data = null)

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -52,7 +52,7 @@ class Exception extends RuntimeException
      * @param string|array $message Either the string of the error message, or an array of attributes
      *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
      * @param int $code The code of the error, is also the HTTP status code for the error.
-     * @param \Exception $previous the previous exception.
+     * @param \Exception|null $previous the previous exception.
      */
     public function __construct($message, $code = 500, $previous = null)
     {
@@ -81,7 +81,7 @@ class Exception extends RuntimeException
      * @param string|array|null $header An array of header strings or a single header string
      *  - an associative array of "header name" => "header value"
      *  - an array of string headers is also accepted
-     * @param string $value The header value.
+     * @param string|null $value The header value.
      * @return array
      */
     public function responseHeader($header = null, $value = null)

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -320,7 +320,7 @@ class Plugin
     /**
      * Loads the routes file for a plugin, or all plugins configured to load their respective routes file
      *
-     * @param string $plugin name of the plugin, if null will operate on all plugins having enabled the
+     * @param string|null $plugin name of the plugin, if null will operate on all plugins having enabled the
      * loading of routes files
      * @return bool
      */
@@ -346,7 +346,7 @@ class Plugin
      * Returns true if the plugin $plugin is already loaded
      * If plugin is null, it will return a list of all loaded plugins
      *
-     * @param string $plugin Plugin name.
+     * @param string|null $plugin Plugin name.
      * @return bool|array Boolean true if $plugin is already loaded.
      *   If $plugin is null, returns a list of plugins that have been loaded
      */
@@ -363,7 +363,7 @@ class Plugin
     /**
      * Forgets a loaded plugin or all of them if first parameter is null
      *
-     * @param string $plugin name of the plugin to forget
+     * @param string|null $plugin name of the plugin to forget
      * @return void
      */
     public static function unload($plugin = null)

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -73,7 +73,7 @@ trait StaticConfigTrait
      * ```
      *
      * @param string|array $key The name of the configuration, or an array of multiple configs.
-     * @param array $config An array of name => configuration data for adapter.
+     * @param array|null $config An array of name => configuration data for adapter.
      * @return array|null Null when adding configuration or an array of configuration data when reading.
      * @throws \BadMethodCallException When trying to modify an existing config.
      */

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -30,7 +30,7 @@ if (!function_exists('h')) {
      *    Arrays will be mapped and have all their elements escaped. Objects will be string cast if they
      *    implement a `__toString` method. Otherwise the class name will be used.
      * @param bool $double Encode existing html entities.
-     * @param string $charset Character set to use when escaping. Defaults to config value in `mb_internal_encoding()`
+     * @param string|null $charset Character set to use when escaping. Defaults to config value in `mb_internal_encoding()`
      * or 'UTF-8'.
      * @return string Wrapped text.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#h
@@ -82,7 +82,7 @@ if (!function_exists('pluginSplit')) {
      *
      * @param string $name The name you want to plugin split.
      * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
-     * @param string $plugin Optional default plugin to use if no plugin is found. Defaults to null.
+     * @param string|null $plugin Optional default plugin to use if no plugin is found. Defaults to null.
      * @return array Array with 2 indexes. 0 => plugin name, 1 => class name.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pluginSplit
      */
@@ -176,7 +176,7 @@ if (!function_exists('env')) {
      * environment information.
      *
      * @param string $key Environment variable name.
-     * @param string $default Specify a default value in case the environment variable is not defined.
+     * @param string|null $default Specify a default value in case the environment variable is not defined.
      * @return string|null Environment variable setting.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#env
      */

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -609,7 +609,7 @@ class Connection implements ConnectionInterface
      * Quotes value to be used safely in database query.
      *
      * @param mixed $value The value to quote.
-     * @param string $type Type to be used for determining kind of quoting to perform
+     * @param string|null $type Type to be used for determining kind of quoting to perform
      * @return string Quoted value
      */
     public function quote($value, $type = null)

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -267,8 +267,8 @@ abstract class Driver
     /**
      * Returns last id generated for a table or sequence in database
      *
-     * @param string $table table name or sequence to get last insert value from
-     * @param string $column the name of the column representing the primary key
+     * @param string|null $table table name or sequence to get last insert value from
+     * @param string|null $column the name of the column representing the primary key
      * @return string|int
      */
     public function lastInsertId($table = null, $column = null)
@@ -293,7 +293,7 @@ abstract class Driver
      * If called with a boolean argument, it will toggle the auto quoting setting
      * to the passed value
      *
-     * @param bool $enable whether to enable auto quoting
+     * @param bool|null $enable whether to enable auto quoting
      * @return bool
      */
     public function autoQuoting($enable = null)

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -54,7 +54,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
      * @param mixed $field The field name to compare for values in between the range.
      * @param mixed $from The initial value of the range.
      * @param mixed $to The ending value in the comparison range.
-     * @param string $type The data type name to bind the values with.
+     * @param string|null $type The data type name to bind the values with.
      */
     public function __construct($field, $from, $to, $type = null)
     {

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -150,7 +150,7 @@ class CaseExpression implements ExpressionInterface
      * Sets the default value
      *
      * @param \Cake\Database\ExpressionInterface|string|array|null $value Value to set
-     * @param string $type Type of value
+     * @param string|null $type Type of value
      *
      * @return void
      */

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -226,7 +226,7 @@ class Comparison implements ExpressionInterface, FieldInterface
      *
      * @param array|\Traversable $value the value to flatten
      * @param \Cake\Database\ValueBinder $generator The value binder to use
-     * @param string|array $type the type to cast values to
+     * @param string|array|null $type the type to cast values to
      * @return string
      */
     protected function _flattenValue($value, $generator, $type = null)

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -75,7 +75,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      * Sets the name of the SQL function to be invoke in this expression,
      * if no value is passed it will return current name
      *
-     * @param string $name The name of the function
+     * @param string|null $name The name of the function
      * @return string|$this
      */
     public function name($name = null)

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -143,7 +143,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * If it is suffixed with "[]" and the value is an array then multiple placeholders
      * will be created, one per each value in the array.
      * @return $this
@@ -161,7 +161,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * If it is suffixed with "[]" and the value is an array then multiple placeholders
      * will be created, one per each value in the array.
      * @return $this
@@ -179,7 +179,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function gt($field, $value, $type = null)
@@ -195,7 +195,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function lt($field, $value, $type = null)
@@ -211,7 +211,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function gte($field, $value, $type = null)
@@ -227,7 +227,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function lte($field, $value, $type = null)
@@ -273,7 +273,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function like($field, $value, $type = null)
@@ -289,7 +289,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function notLike($field, $value, $type = null)
@@ -306,7 +306,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param string|array $values the value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function in($field, $values, $type = null)
@@ -342,7 +342,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $field Database field to be compared against value
      * @param array $values the value to be bound to $field for comparison
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function notIn($field, $values, $type = null)
@@ -363,7 +363,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param mixed $field The field name to compare for values in between the range.
      * @param mixed $from The initial value of the range.
      * @param mixed $to The ending value in the comparison range.
-     * @param string $type the type name for $value as configured using the Type map.
+     * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
      */
     public function between($field, $from, $to, $type = null)

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -94,7 +94,7 @@ class ValuesExpression implements ExpressionInterface
      * Sets the columns to be inserted. If no params are passed, then it returns
      * the currently stored columns
      *
-     * @param array $cols arrays with columns to be inserted
+     * @param array|null $cols arrays with columns to be inserted
      * @return array|$this
      */
     public function columns($cols = null)
@@ -110,7 +110,7 @@ class ValuesExpression implements ExpressionInterface
      * Sets the values to be inserted. If no params are passed, then it returns
      * the currently stored values
      *
-     * @param array $values arrays with values to be inserted
+     * @param array|null $values arrays with values to be inserted
      * @return array|$this
      */
     public function values($values = null)
@@ -127,7 +127,7 @@ class ValuesExpression implements ExpressionInterface
      * to insert records in the table. If no params are passed, then it returns
      * the currently stored query
      *
-     * @param \Cake\Database\Query $query The query to set/get
+     * @param \Cake\Database\Query|null $query The query to set/get
      * @return \Cake\Database\Query
      */
     public function query(Query $query = null)

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -43,7 +43,7 @@ class LoggingStatement extends StatementDecorator
      * Wrapper for the execute function to calculate time spent
      * and log the query afterwards.
      *
-     * @param array $params List of values to be bound to query
+     * @param array|null $params List of values to be bound to query
      * @return bool True on success, false otherwise
      * @throws \Exception Re-throws any exception raised during query execution.
      */

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -150,7 +150,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Sets the connection instance to be used for executing and transforming this query
      * When called with a null argument, it will return the current connection instance.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection instance
+     * @param \Cake\Datasource\ConnectionInterface|null $connection instance
      * @return $this|\Cake\Datasource\ConnectionInterface
      */
     public function connection($connection = null)
@@ -211,7 +211,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * values when the query is executed, hence it is most suitable to use with
      * prepared statements.
      *
-     * @param \Cake\Database\ValueBinder $generator A placeholder object that will hold
+     * @param \Cake\Database\ValueBinder|null $generator A placeholder object that will hold
      * associated values for expressions
      * @return string
      */
@@ -1095,7 +1095,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * does. Please refer to its documentation for an insight on how to using each
      * parameter.
      *
-     * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions The having conditions.
+     * @param string|array|\Cake\Database\ExpressionInterface|callable|null $conditions The having conditions.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Query::where()
@@ -1154,7 +1154,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Pages should start at 1.
      *
      * @param int $num The page number you want.
-     * @param int $limit The number of rows you want in the page. If null
+     * @param int|null $limit The number of rows you want in the page. If null
      *  the current limit clause will be used.
      * @return $this
      */
@@ -1459,7 +1459,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Can be combined with from(), where() and other methods to
      * create delete queries with specific conditions.
      *
-     * @param string $table The table to use when deleting.
+     * @param string|null $table The table to use when deleting.
      * @return $this
      */
     public function delete($table = null)
@@ -1484,7 +1484,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *  ->epilog('RETURNING id');
      * ```
      *
-     * @param string|\Cake\Database\Expression\QueryExpression $expression The expression to be appended
+     * @param string|\Cake\Database\Expression\QueryExpression|null $expression The expression to be appended
      * @return $this
      */
     public function epilog($expression = null)
@@ -1709,7 +1709,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * associate values to those placeholders so that they can be passed correctly
      * statement object.
      *
-     * @param \Cake\Database\ValueBinder $binder new instance to be set. If no value is passed the
+     * @param \Cake\Database\ValueBinder|null $binder new instance to be set. If no value is passed the
      *   default one will be returned
      * @return $this|\Cake\Database\ValueBinder
      */

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -86,7 +86,7 @@ class CachedCollection extends Collection
      * disables it if false is passed.
      * If called with no arguments it returns the current configuration name.
      *
-     * @param bool $enable whether or not to enable caching
+     * @param bool|null $enable whether or not to enable caching
      * @return string|bool
      */
     public function cacheMetadata($enable = null)

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -339,7 +339,7 @@ class Table
      * if none is passed.
      *
      * @param string $name The column to get the type of.
-     * @param string $type The type to set the column to.
+     * @param string|null $type The type to set the column to.
      * @return string|null Either the column type or null.
      */
     public function columnType($name, $type = null)

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -88,7 +88,7 @@ interface StatementInterface
      * that binding parameters from this method will not perform any custom type conversion
      * as it would normally happen when calling `bindValue`
      *
-     * @param array $params list of values to be bound to query
+     * @param array|null $params list of values to be bound to query
      * @return bool true on success, false otherwise
      */
     public function execute($params = null);

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -80,7 +80,7 @@ class Type
     /**
      * Constructor
      *
-     * @param string $name The name identifying this type
+     * @param string|null $name The name identifying this type
      */
     public function __construct($name = null)
     {

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -66,7 +66,7 @@ class TypeMap
      *
      * This method will replace all the existing type maps with the ones provided.
      *
-     * @param array $defaults associative array where keys are field names and values
+     * @param array|null $defaults associative array where keys are field names and values
      * are the correspondent type.
      * @return $this|array
      */
@@ -105,7 +105,7 @@ class TypeMap
      *
      * This method will replace all the existing type maps with the ones provided.
      *
-     * @param array $types associative array where keys are field names and values
+     * @param array|null $types associative array where keys are field names and values
      * are the correspondent type.
      * @return $this|array
      */

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -29,7 +29,7 @@ trait TypeMapTrait
      * Creates a new TypeMap if $typeMap is an array, otherwise returns the existing type map
      * or exchanges it for the given one.
      *
-     * @param array|\Cake\Database\TypeMap $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
+     * @param array|\Cake\Database\TypeMap|null $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
      * @return $this|\Cake\Database\TypeMap
      */
     public function typeMap($typeMap = null)
@@ -47,7 +47,7 @@ trait TypeMapTrait
     /**
      * Allows setting default types when chaining query
      *
-     * @param array $types The array of types to set.
+     * @param array|null $types The array of types to set.
      * @return $this|array
      */
     public function defaultTypes(array $types = null)

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -65,7 +65,7 @@ interface ConnectionInterface
     /**
      * Enables or disables query logging for this connection.
      *
-     * @param bool $enable whether to turn logging on or disable it.
+     * @param bool|null $enable whether to turn logging on or disable it.
      *   Use null to read current value.
      * @return bool
      */
@@ -75,7 +75,7 @@ interface ConnectionInterface
      * Sets the logger object instance. When called with no arguments
      * it returns the currently setup logger instance.
      *
-     * @param object $instance logger object instance
+     * @param object|null $instance logger object instance
      * @return object logger instance
      */
     public function logger($instance = null);

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -66,7 +66,7 @@ class ConnectionManager
      * The connection will not be constructed until it is first used.
      *
      * @param string|array $key The name of the connection config, or an array of multiple configs.
-     * @param array $config An array of name => config data for adapter.
+     * @param array|null $config An array of name => config data for adapter.
      * @return array|null Null when adding configuration and an array of configuration data when reading.
      * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
      * @see \Cake\Core\StaticConfigTrait::config()

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -119,7 +119,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * When called with no arguments it will return whether or not there are any
      * dirty property in the entity
      *
-     * @param string $property the field to set or check status for
+     * @param string|null $property the field to set or check status for
      * @param null|bool $isDirty true means the property was changed, false means
      * it was not changed and null will make the function return current state
      * for that property
@@ -160,7 +160,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * When used as a setter, this method will return this entity instance for method
      * chaining.
      *
-     * @param string|array $field The field to get errors for.
+     * @param string|array|null $field The field to get errors for.
      * @param string|array|null $errors The errors to be set for $field
      * @param bool $overwrite Whether or not to overwrite pre-existing errors for $field
      * @return array|\Cake\Datasource\EntityInterface

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -616,7 +616,7 @@ trait EntityTrait
      * When called with no arguments it will return whether or not there are any
      * dirty property in the entity
      *
-     * @param string $property the field to set or check status for
+     * @param string|null $property the field to set or check status for
      * @param null|bool $isDirty true means the property was changed, false means
      * it was not changed and null will make the function return current state
      * for that property
@@ -799,7 +799,7 @@ trait EntityTrait
      * Read the error(s) from one or many objects.
      *
      * @param array|\Cake\Datasource\EntityTrait $object The object to read errors from.
-     * @param string $path The field name for errors.
+     * @param string|null $path The field name for errors.
      * @return array
      */
     protected function _readError($object, $path = null)
@@ -885,7 +885,7 @@ trait EntityTrait
      * ```
      *
      * @param string|array $property single or list of properties to change its accessibility
-     * @param bool $set true marks the property as accessible, false will
+     * @param bool|null $set true marks the property as accessible, false will
      * mark it as protected.
      * @return $this|bool
      */
@@ -920,7 +920,7 @@ trait EntityTrait
      * If called with no arguments, it returns the alias of the repository
      * this entity came from if it is known.
      *
-     * @param string $alias the alias of the repository
+     * @param string|null $alias the alias of the repository
      * @return string|$this
      */
     public function source($alias = null)

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -32,7 +32,7 @@ interface QueryInterface
      * If no $alias is passed, the default table for this query will be used.
      *
      * @param string $field The field to alias
-     * @param string $alias the alias used to prefix the field
+     * @param string|null $alias the alias used to prefix the field
      * @return array
      */
     public function aliasField($field, $alias = null);
@@ -237,7 +237,7 @@ interface QueryInterface
      * Pages should start at 1.
      *
      * @param int $num The page number you want.
-     * @param int $limit The number of rows you want in the page. If null
+     * @param int|null $limit The number of rows you want in the page. If null
      *  the current limit clause will be used.
      * @return $this
      */

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -202,7 +202,7 @@ trait QueryTrait
      * If no $alias is passed, the default table for this query will be used.
      *
      * @param string $field The field to alias
-     * @param string $alias the alias used to prefix the field
+     * @param string|null $alias the alias used to prefix the field
      * @return array
      */
     public function aliasField($field, $alias = null)

--- a/src/Datasource/RulesAwareTrait.php
+++ b/src/Datasource/RulesAwareTrait.php
@@ -43,7 +43,7 @@ trait RulesAwareTrait
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity to check for validity.
      * @param string $operation The operation being run. Either 'create', 'update' or 'delete'.
-     * @param \ArrayObject|array $options The options To be passed to the rules.
+     * @param \ArrayObject|array|null $options The options To be passed to the rules.
      * @return bool
      */
     public function checkRules(EntityInterface $entity, $operation = RulesChecker::CREATE, $options = null)

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -127,7 +127,7 @@ class RulesChecker
      *
      * @param callable $rule A callable function or object that will return whether
      * the entity is valid or not.
-     * @param string $name The alias for a rule.
+     * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
      * @return $this
@@ -151,7 +151,7 @@ class RulesChecker
      *
      * @param callable $rule A callable function or object that will return whether
      * the entity is valid or not.
-     * @param string $name The alias for a rule.
+     * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
      * @return $this
@@ -175,7 +175,7 @@ class RulesChecker
      *
      * @param callable $rule A callable function or object that will return whether
      * the entity is valid or not.
-     * @param string $name The alias for a rule.
+     * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
      * @return $this
@@ -199,7 +199,7 @@ class RulesChecker
      *
      * @param callable $rule A callable function or object that will return whether
      * the entity is valid or not.
-     * @param string $name The alias for a rule.
+     * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
      * @return $this

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -61,7 +61,7 @@ class EventManager
      *
      * If called with the first parameter, it will be set as the globally available instance
      *
-     * @param \Cake\Event\EventManager $manager Event manager instance.
+     * @param \Cake\Event\EventManager|null $manager Event manager instance.
      * @return \Cake\Event\EventManager the global event manager
      */
     public static function instance($manager = null)
@@ -85,7 +85,7 @@ class EventManager
      * method will be called on the object to register the declared events individually as methods to be managed by this class.
      * It is possible to define multiple event handlers per event name.
      *
-     * @param string $eventKey The event unique identifier name with which the callback will be associated. If $callable
+     * @param string|null $eventKey The event unique identifier name with which the callback will be associated. If $callable
      * is an instance of Cake\Event\EventListenerInterface this argument will be ignored
      *
      * @param array $options used to set the `priority` flag to the listener. In the future more options may be added.
@@ -133,7 +133,7 @@ class EventManager
      * $eventManager->on('Model.beforeSave', ['priority' => 90], $callable);
      * ```
      *
-     * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name
+     * @param string|\Cake\Event\EventListenerInterface|null $eventKey The event unique identifier name
      * with which the callback will be associated. If $eventKey is an instance of
      * Cake\Event\EventListenerInterface its events will be bound using the `implementedEvents` methods.
      *
@@ -142,7 +142,7 @@ class EventManager
      * Priorities are treated as queues. Lower values are called before higher ones, and multiple attachments
      * added to the same priority queue will be treated in the order of insertion.
      *
-     * @param callable $callable The callable function you want invoked.
+     * @param callable|null $callable The callable function you want invoked.
      *
      * @return void
      * @throws \InvalidArgumentException When event key is missing or callable is not an
@@ -264,7 +264,7 @@ class EventManager
      *
      * @param string|\Cake\Event\EventListenerInterface $eventKey The event unique identifier name
      *   with which the callback has been associated, or the $listener you want to remove.
-     * @param callable $callable The callback you want to detach.
+     * @param callable|null $callable The callback you want to detach.
      * @return void
      */
     public function off($eventKey, $callable = null)

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -517,7 +517,7 @@ class Folder
      * @param string $pathname The directory structure to create. Either an absolute or relative
      *   path. If the path is relative and exists in the process' cwd it will not be created.
      *   Otherwise relative paths will be prefixed with the current pwd().
-     * @param int $mode octal value 0755
+     * @param int|bool $mode octal value 0755
      * @return bool Returns TRUE on success, FALSE on failure
      */
     public function create($pathname, $mode = false)

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -64,7 +64,7 @@ class Form
      * is first built. This hook method lets you configure the
      * schema or load a pre-defined one.
      *
-     * @param \Cake\Form\Schema $schema The schema to set, or null.
+     * @param \Cake\Form\Schema|null $schema The schema to set, or null.
      * @return \Cake\Form\Schema the schema instance.
      */
     public function schema(Schema $schema = null)
@@ -100,7 +100,7 @@ class Form
      * is first built. This hook method lets you configure the
      * validator or load a pre-defined one.
      *
-     * @param \Cake\Validation\Validator $validator The validator to set, or null.
+     * @param \Cake\Validation\Validator|null $validator The validator to set, or null.
      * @return \Cake\Validation\Validator the validator instance.
      */
     public function validator(Validator $validator = null)

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -256,7 +256,7 @@ trait DateFormatTrait
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|array $format Any format accepted by IntlDateFormatter.
+     * @param string|array|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDateTime($time, $format = null)
@@ -314,7 +314,7 @@ trait DateFormatTrait
      * ```
      *
      * @param string $date The date string to parse.
-     * @param string|int $format Any format accepted by IntlDateFormatter.
+     * @param string|int|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseDate($date, $format = null)
@@ -343,7 +343,7 @@ trait DateFormatTrait
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|int $format Any format accepted by IntlDateFormatter.
+     * @param string|int|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
     public static function parseTime($time, $format = null)

--- a/src/I18n/FrozenTime.php
+++ b/src/I18n/FrozenTime.php
@@ -159,9 +159,9 @@ class FrozenTime extends Chronos implements JsonSerializable
     /**
      * Get list of timezone identifiers
      *
-     * @param int|string $filter A regex to filter identifier
+     * @param int|string|null $filter A regex to filter identifier
      *   Or one of DateTimeZone class constants
-     * @param string $country A two-letter ISO 3166-1 compatible country code.
+     * @param string|null $country A two-letter ISO 3166-1 compatible country code.
      *   This option is only used when $filter is set to DateTimeZone::PER_COUNTRY
      * @param bool|array $options If true (default value) groups the identifiers list by primary region.
      *   Otherwise, an array containing `group`, `abbr`, `before`, and `after`

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -239,9 +239,9 @@ class Time extends MutableDateTime implements JsonSerializable
     /**
      * Get list of timezone identifiers
      *
-     * @param int|string $filter A regex to filter identifier
+     * @param int|string|null $filter A regex to filter identifier
      *   Or one of DateTimeZone class constants
-     * @param string $country A two-letter ISO 3166-1 compatible country code.
+     * @param string|null $country A two-letter ISO 3166-1 compatible country code.
      *   This option is only used when $filter is set to DateTimeZone::PER_COUNTRY
      * @param bool|array $options If true (default value) groups the identifiers list by primary region.
      *   Otherwise, an array containing `group`, `abbr`, `before`, and `after`

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1336,9 +1336,9 @@ class Email implements JsonSerializable, Serializable
     /**
      * Static method to fast create an instance of \Cake\Mailer\Email
      *
-     * @param string|array $to Address to send (see Cake\Mailer\Email::to()). If null, will try to use 'to' from transport config
-     * @param string $subject String of subject or null to use 'subject' from transport config
-     * @param string|array $message String with message or array with variables to be used in render
+     * @param string|array|null $to Address to send (see Cake\Mailer\Email::to()). If null, will try to use 'to' from transport config
+     * @param string|null $subject String of subject or null to use 'subject' from transport config
+     * @param string|array|null $message String with message or array with variables to be used in render
      * @param string|array $transportConfig String to use config from EmailConfig or array with configs
      * @param bool $send Send the email or just return the instance pre-configured
      * @return \Cake\Mailer\Email Instance of Cake\Mailer\Email

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -390,7 +390,7 @@ class Socket
     /**
      * Resets the state of this Socket instance to it's initial state (before Object::__construct got executed)
      *
-     * @param array $state Array with key and values to reset
+     * @param array|null $state Array with key and values to reset
      * @return bool True on success
      */
     public function reset($state = null)

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -411,7 +411,7 @@ abstract class Association
      * Sets the type of join to be used when adding the association to a query.
      * If no arguments are passed, the currently configured type is returned.
      *
-     * @param string $type the join type to be used (e.g. INNER)
+     * @param string|null $type the join type to be used (e.g. INNER)
      * @return string
      */
     public function joinType($type = null)
@@ -653,7 +653,7 @@ abstract class Association
      * and modifies the query accordingly based of this association
      * configuration
      *
-     * @param string|array $type the type of query to perform, if an array is passed,
+     * @param string|array|null $type the type of query to perform, if an array is passed,
      *   it will be interpreted as the `$options` parameter
      * @param array $options The options to for the find
      * @see \Cake\ORM\Table::find()

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -868,7 +868,7 @@ class BelongsToMany extends Association
      * If your association includes conditions, the junction table will be
      * included in the query's contained associations.
      *
-     * @param string|array $type the type of query to perform, if an array is passed,
+     * @param string|array|null $type the type of query to perform, if an array is passed,
      *   it will be interpreted as the `$options` parameter
      * @param array $options The options to for the find
      * @see \Cake\ORM\Table::find()

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -130,7 +130,7 @@ class TimestampBehavior extends Behavior
      * If an explicit date time is passed, the config option `refreshTimestamp` is
      * automatically set to false.
      *
-     * @param \DateTime $ts Timestamp
+     * @param \DateTime|null $ts Timestamp
      * @param bool $refreshTimestamp If true timestamp is refreshed.
      * @return \Cake\I18n\Time
      */

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -161,7 +161,7 @@ class EagerLoader
     /**
      * Set whether or not contained associations will load fields automatically.
      *
-     * @param bool $value The value to set.
+     * @param bool|null $value The value to set.
      * @return bool The current value.
      */
     public function autoFields($value = null)

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -223,7 +223,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * and storing containments. If called with no arguments, it will return the
      * currently configured instance.
      *
-     * @param \Cake\ORM\EagerLoader $instance The eager loader to use. Pass null
+     * @param \Cake\ORM\EagerLoader|null $instance The eager loader to use. Pass null
      *   to get the current eagerloader.
      * @return \Cake\ORM\EagerLoader|$this
      */
@@ -328,7 +328,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * If called with an empty first argument and $override is set to true, the
      * previous list will be emptied.
      *
-     * @param array|string $associations list of table aliases to be queried
+     * @param array|string|null $associations list of table aliases to be queried
      * @param bool $override whether override previous list with the one passed
      * defaults to merging previous list with the new one.
      * @return array|$this
@@ -424,7 +424,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * add more complex clauses you can do it directly in the main query.
      *
      * @param string $assoc The association to filter by
-     * @param callable $builder a function that will receive a pre-made query object
+     * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
@@ -494,7 +494,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * add more complex clauses you can do it directly in the main query.
      *
      * @param string $assoc The association to join with
-     * @param callable $builder a function that will receive a pre-made query object
+     * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */
@@ -538,7 +538,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * will select no fields from the association.
      *
      * @param string $assoc The association to join with
-     * @param callable $builder a function that will receive a pre-made query object
+     * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      * @see \Cake\ORM\Query::matching()
@@ -599,7 +599,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * add more complex clauses you can do it directly in the main query.
      *
      * @param string $assoc The association to filter by
-     * @param callable $builder a function that will receive a pre-made query object
+     * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
      * @return $this
      */

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -39,7 +39,7 @@ class RulesChecker extends BaseRulesChecker
      * ```
      *
      * @param array $fields The list of fields to check for uniqueness.
-     * @param string $message The error message to show in case the rule does not pass.
+     * @param string|null $message The error message to show in case the rule does not pass.
      * @return callable
      */
     public function isUnique(array $fields, $message = null)
@@ -73,7 +73,7 @@ class RulesChecker extends BaseRulesChecker
      * @param string|array $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param object|string $table The table name where the fields existence will be checked.
-     * @param string $message The error message to show in case the rule does not pass.
+     * @param string|null $message The error message to show in case the rule does not pass.
      * @return callable
      */
     public function existsIn($field, $table, $message = null)

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -68,7 +68,7 @@ class TableRegistry
     /**
      * Sets and returns a singleton instance of LocatorInterface implementation.
      *
-     * @param \Cake\ORM\Locator\LocatorInterface $locator Instance of a locator to use.
+     * @param \Cake\ORM\Locator\LocatorInterface|null $locator Instance of a locator to use.
      * @return \Cake\ORM\Locator\LocatorInterface
      */
     public static function locator(LocatorInterface $locator = null)

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -532,7 +532,7 @@ class Router
      * - `_name` - Name of route. If you have setup named routes you can use this key
      *   to specify it.
      *
-     * @param string|array $url An array specifying any of the following:
+     * @param string|array|null $url An array specifying any of the following:
      *   'controller', 'action', 'plugin' additionally, you can provide routed
      *   elements or query string parameters. If string it can be name any valid url
      *   string.
@@ -760,7 +760,7 @@ class Router
      * A string or an array of valid extensions can be passed to this method.
      * If called without any parameters it will return current list of set extensions.
      *
-     * @param array|string $extensions List of extensions to be added.
+     * @param array|string|null $extensions List of extensions to be added.
      * @param bool $merge Whether to merge with or override existing extensions.
      *   Defaults to `true`.
      * @return array Array of extensions Router is configured to parse.
@@ -896,7 +896,7 @@ class Router
      * @param string $name The prefix name to use.
      * @param array|callable $params An array of routing defaults to add to each connected route.
      *   If you have no parameters, this argument can be a callable.
-     * @param callable $callback The callback to invoke that builds the prefixed routes.
+     * @param callable|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
      */
     public static function prefix($name, $params = [], $callback = null)

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -34,7 +34,7 @@ class LoadTask extends Shell
     /**
      * Execution method always used for tasks.
      *
-     * @param string $plugin The plugin name.
+     * @param string|null $plugin The plugin name.
      * @return bool
      */
     public function main($plugin = null)

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -34,7 +34,7 @@ class UnloadTask extends Shell
     /**
      * Execution method always used for tasks.
      *
-     * @param string $plugin The plugin name.
+     * @param string|null $plugin The plugin name.
      * @return bool if action passed.
      */
     public function main($plugin = null)

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -421,7 +421,7 @@ class FixtureManager
      * Creates a single fixture table and loads data into it.
      *
      * @param string $name of the fixture
-     * @param \Cake\Datasource\ConnectionInterface $db Connection instance or leave null to get a Connection from the fixture
+     * @param \Cake\Datasource\ConnectionInterface|null $db Connection instance or leave null to get a Connection from the fixture
      * @param bool $dropTables Whether or not tables should be dropped and re-created.
      * @return void
      * @throws \UnexpectedValueException if $name is not a previously loaded class

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -261,7 +261,7 @@ class TestFixture implements FixtureInterface
     /**
      * Get/Set the Cake\Database\Schema\Table instance used by this fixture.
      *
-     * @param \Cake\Database\Schema\Table $schema The table to set.
+     * @param \Cake\Database\Schema\Table|null $schema The table to set.
      * @return \Cake\Database\Schema\Table|null
      */
     public function schema(Table $schema = null)

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -474,7 +474,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      * @param array $assertions Assertions to run.
      * @param string $string The HTML string to check.
      * @param bool $fullDebug Whether or not more verbose output should be used.
-     * @param array $regex Full regexp from `assertHtml`
+     * @param array|string $regex Full regexp from `assertHtml`
      * @return string
      */
     protected function _assertAttributes($assertions, $string, $fullDebug = false, $regex = '')

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -609,7 +609,7 @@ class Hash
      * Recursively filters a data set.
      *
      * @param array $data Either an array to filter, or value when in callback
-     * @param callable $callback A function to filter the data with. Defaults to
+     * @param callable|array $callback A function to filter the data with. Defaults to
      *   `static::_filter()` Which strips out all non-zero empty values.
      * @return array Filtered array
      * @link http://book.cakephp.org/3.0/en/core-libraries/hash.html#Cake\Utility\Hash::filter

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -124,7 +124,7 @@ class Security
      *
      * You can use this method to forcibly decide between mcrypt/openssl/custom implementations.
      *
-     * @param object $instance The crypto instance to use.
+     * @param object|null $instance The crypto instance to use.
      * @return object Crypto instance.
      * @throws \InvalidArgumentException When no compatible crypto extension is available.
      */

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -713,7 +713,7 @@ class Text
      * Creates a comma separated list where the last two items are joined with 'and', forming natural language.
      *
      * @param array $list The list to be joined.
-     * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.
+     * @param string|null $and The word used to join the last and second last items together with. Defaults to 'and'.
      * @param string $separator The separator used to join all the other items together. Defaults to ', '.
      * @return string The glued together string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/string.html#converting-an-array-to-sentence-form

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -478,7 +478,7 @@ class Validation
      * - 1..N => Exactly that many number of decimal places. The '.' is required.
      *
      * @param float $check The value the test for decimal.
-     * @param int $places Decimal places.
+     * @param int|null $places Decimal places.
      * @param string|null $regex If a custom regular expression is used, this is the only validation that will occur.
      * @return bool Success
      */
@@ -526,7 +526,7 @@ class Validation
      *
      * @param string $check Value to check
      * @param bool $deep Perform a deeper validation (if true), by also checking availability of host
-     * @param string $regex Regex to use (if none it will use built in regex)
+     * @param string|null $regex Regex to use (if none it will use built in regex)
      * @return bool Success
      */
     public static function email($check, $deep = false, $regex = null)

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -512,7 +512,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * method called will take precedence.
      *
      * @param string $field the name of the field
-     * @param string $message The message to show if the field is not
+     * @param string|null $message The message to show if the field is not
      * @param bool|string|callable $when  Indicates when the field is not allowed
      * to be empty. Valid values are true (always), 'create', 'update'. If a
      * callable is passed then the field will allowed be empty only when
@@ -540,8 +540,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a notBlank rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::notBlank()
      * @return $this
@@ -558,8 +558,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add an alphanumeric rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::alphaNumeric()
      * @return $this
@@ -577,8 +577,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param array $range The inclusive minimum and maximum length you want permitted.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::alphaNumeric()
      * @return $this
@@ -600,8 +600,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $field The field you want to apply the rule to.
      * @param string $type The type of cards you want to allow. Defaults to 'all'.
      *   You can also supply an array of accepted card types. e.g `['mastercard', 'visa', 'amex']`
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::cc()
      * @return $this
@@ -619,8 +619,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int|float $value The value user data must be greater than.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
      * @return $this
@@ -638,8 +638,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int|float $value The value user data must be greater than or equal to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
      * @return $this
@@ -657,8 +657,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int|float $value The value user data must be less than.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
      * @return $this
@@ -676,8 +676,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int|float $value The value user data must be less than or equal to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
      * @return $this
@@ -695,8 +695,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int|float $value The value user data must be equal to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
      * @return $this
@@ -714,8 +714,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int|float $value The value user data must be not be equal to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
      * @return $this
@@ -735,8 +735,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param mixed $field The field you want to apply the rule to.
      * @param mixed $secondField The field you want to compare against.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::compareWith()
      * @return $this
@@ -754,8 +754,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int $limit The minimum number of non-alphanumeric fields required.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::containsNonAlphaNumeric()
      * @return $this
@@ -773,8 +773,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param array $formats A list of accepted date formats.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::date()
      * @return $this
@@ -792,8 +792,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param array $formats A list of accepted date formats.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::datetime()
      * @return $this
@@ -810,8 +810,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a time format validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::time()
      * @return $this
@@ -828,8 +828,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a boolean validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::boolean()
      * @return $this
@@ -846,9 +846,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a decimal validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param int $places The number of decimal places to require.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param int|null $places The number of decimal places to require.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::decimal()
      * @return $this
@@ -866,8 +866,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param bool $checkMX Whether or not to check the MX records.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::email()
      * @return $this
@@ -886,8 +886,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * This rule will accept both IPv4 and IPv6 addresses.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ip()
      * @return $this
@@ -904,8 +904,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add an IPv4 validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ip()
      * @return $this
@@ -922,8 +922,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add an IPv6 validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ip()
      * @return $this
@@ -941,8 +941,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int $min The minimum length required.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::minLength()
      * @return $this
@@ -960,8 +960,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param int $max The maximum length allowed.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::maxLength()
      * @return $this
@@ -978,8 +978,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a numeric value validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::numeric()
      * @return $this
@@ -996,8 +996,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a natural number validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::naturalNumber()
      * @return $this
@@ -1014,8 +1014,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure a field is a non negative integer.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::naturalNumber()
      * @return $this
@@ -1033,8 +1033,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param array $range The inclusive upper and lower bounds of the valid range.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::range()
      * @return $this
@@ -1056,8 +1056,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * This validator does not require a protocol.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::url()
      * @return $this
@@ -1076,8 +1076,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * This validator requires the URL to have a protocol.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::url()
      * @return $this
@@ -1095,8 +1095,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param array $list The list of valid options.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::inList()
      * @return $this
@@ -1113,8 +1113,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure the field is a UUID
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::uuid()
      * @return $this
@@ -1134,8 +1134,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The field you want to apply the rule to.
      * @param array $options An array of options.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::uploadedFile()
      * @return $this
@@ -1154,8 +1154,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * e.g. `<lat>, <lng>`
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::uuid()
      * @return $this
@@ -1172,8 +1172,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure the field is a latitude.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::latitude()
      * @return $this
@@ -1190,8 +1190,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure the field is a longitude.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::longitude()
      * @return $this
@@ -1208,8 +1208,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure a field contains only ascii bytes
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ascii()
      * @return $this
@@ -1226,8 +1226,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure a field contains only BMP utf8 bytes
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::utf8()
      * @return $this
@@ -1246,8 +1246,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * This rule will accept 3 and 4 byte UTF8 sequences, which are necessary for emoji.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::utf8()
      * @return $this
@@ -1264,8 +1264,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a validation rule to ensure a field is an integer value.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $message The error message when the rule fails.
-     * @param string|callable $when Either 'create' or 'update' or a callable that returns
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::isInteger()
      * @return $this

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -87,7 +87,7 @@ trait ValidatorAwareTrait
      * should you wish to have a validation set that applies in cases where no other
      * set is specified.
      *
-     * @param string $name the name of the validation set to return
+     * @param string|null $name the name of the validation set to return
      * @param \Cake\Validation\Validator|null $validator The validator instance to store,
      *   use null to get a validator.
      * @return \Cake\Validation\Validator

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -35,9 +35,9 @@ class AjaxView extends View
     /**
      * Constructor
      *
-     * @param \Cake\Network\Request $request The request object.
-     * @param \Cake\Network\Response $response The response object.
-     * @param \Cake\Event\EventManager $eventManager Event manager object.
+     * @param \Cake\Network\Request|null $request The request object.
+     * @param \Cake\Network\Response|null $response The response object.
+     * @param \Cake\Event\EventManager|null $eventManager Event manager object.
      * @param array $viewOptions View options.
      */
     public function __construct(

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -133,9 +133,9 @@ abstract class Cell
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request The request to use in the cell.
-     * @param \Cake\Network\Response $response The response to use in the cell.
-     * @param \Cake\Event\EventManager $eventManager The eventManager to bind events to.
+     * @param \Cake\Network\Request|null $request The request to use in the cell.
+     * @param \Cake\Network\Response|null $response The response to use in the cell.
+     * @param \Cake\Event\EventManager|null $eventManager The eventManager to bind events to.
      * @param array $cellOptions Cell options to apply.
      */
     public function __construct(

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -180,7 +180,7 @@ class Helper implements EventListenerInterface
      * Adds the given class to the element options
      *
      * @param array $options Array options/attributes to add a class to
-     * @param string $class The class name being added.
+     * @param string|null $class The class name being added.
      * @param string $key the key to use for class.
      * @return array Array of options with $key set.
      */

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -237,7 +237,7 @@ class FormHelper extends Helper
     /**
      * Set the widget registry the helper will use.
      *
-     * @param \Cake\View\Widget\WidgetRegistry $instance The registry instance to set.
+     * @param \Cake\View\Widget\WidgetRegistry|null $instance The registry instance to set.
      * @param array $widgets An array of widgets
      * @return \Cake\View\Widget\WidgetRegistry
      */
@@ -669,7 +669,7 @@ class FormHelper extends Helper
      * - `escape` boolean - Whether or not to html escape the contents of the error.
      *
      * @param string $field A field name, like "modelname.fieldname"
-     * @param string|array $text Error message as string or array of messages. If an array,
+     * @param string|array|null $text Error message as string or array of messages. If an array,
      *   it should be a hash of key names => messages.
      * @param array $options See above.
      * @return string Formatted errors or ''.
@@ -774,7 +774,7 @@ class FormHelper extends Helper
      * If you want to nest inputs in the labels, you will need to modify the default templates.
      *
      * @param string $fieldName This should be "modelname.fieldname"
-     * @param string $text Text that will appear in the label field. If
+     * @param string|null $text Text that will appear in the label field. If
      *   $text is left undefined the text will be inflected from the
      *   fieldName.
      * @param array $options An array of HTML attributes.
@@ -1631,7 +1631,7 @@ class FormHelper extends Helper
      * - The option `onclick` will be replaced.
      *
      * @param string $title The content to be wrapped by <a> tags.
-     * @param string|array $url Cake-relative URL or array of URL parameters, or
+     * @param string|array|null $url Cake-relative URL or array of URL parameters, or
      *   external URL (starts with http://)
      * @param array $options Array of HTML attributes.
      * @return string An `<a />` element.
@@ -1718,7 +1718,7 @@ class FormHelper extends Helper
      * - `templateVars` - Additional template variables for the input element and its container.
      * - Other attributes will be assigned to the input element.
      *
-     * @param string $caption The label appearing on the button OR if string contains :// or the
+     * @param string|null $caption The label appearing on the button OR if string contains :// or the
      *  extension .jpg, .jpe, .jpeg, .gif, .png use an image if the extension
      *  exists, AND the first character is /, image is relative to webroot,
      *  OR if the first character is not /, image is relative to webroot/img.
@@ -1967,7 +1967,7 @@ class FormHelper extends Helper
      *   that string is displayed as the empty element.
      * - `value` The selected value of the input.
      *
-     * @param string $fieldName Prefix name for the SELECT element
+     * @param string|null $fieldName Prefix name for the SELECT element
      * @param array $options Options & HTML attributes for the select element
      * @return string A generated day select box.
      * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#creating-day-inputs

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -945,7 +945,7 @@ class HtmlHelper extends Helper
      * - `escape` Whether or not the contents should be html_entity escaped.
      *
      * @param string $name Tag name.
-     * @param string $text String content that will appear inside the div element.
+     * @param string|null $text String content that will appear inside the div element.
      *   If null, only a start tag will be printed
      * @param array $options Additional HTML attributes of the DIV tag, see above.
      * @return string The formatted tag element
@@ -978,8 +978,8 @@ class HtmlHelper extends Helper
      *
      * - `escape` Whether or not the contents should be html_entity escaped.
      *
-     * @param string $class CSS class name of the div element.
-     * @param string $text String content that will appear inside the div element.
+     * @param string|null $class CSS class name of the div element.
+     * @param string|null $text String content that will appear inside the div element.
      *   If null, only a start tag will be printed
      * @param array $options Additional HTML attributes of the DIV tag
      * @return string The formatted DIV element

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -174,7 +174,7 @@ class NumberHelper extends Helper
      * - `escape` - Whether or not to escape html in resulting string
      *
      * @param float $number Value to format.
-     * @param string $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
+     * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array $options Options list.
      * @return string Number formatted as a currency.
      */

--- a/src/View/Helper/RssHelper.php
+++ b/src/View/Helper/RssHelper.php
@@ -286,7 +286,7 @@ class RssHelper extends Helper
      *
      * @param string $name The name of the XML element
      * @param array $attrib The attributes of the XML element
-     * @param string|array $content XML element content
+     * @param string|array|null $content XML element content
      * @param bool $endTag Whether the end tag of the element should be printed
      * @return string XML
      */

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -355,7 +355,7 @@ class TextHelper extends Helper
      * Creates a comma separated list where the last two items are joined with 'and', forming natural language.
      *
      * @param array $list The list to be joined.
-     * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.
+     * @param string|null $and The word used to join the last and second last items together with. Defaults to 'and'.
      * @param string $separator The separator used to join all the other items together. Defaults to ', '.
      * @return string The glued together string.
      * @see \Cake\Utility\Text::toList()

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -29,7 +29,7 @@ class UrlHelper extends Helper
     /**
      * Returns a URL based on provided parameters.
      *
-     * @param string|array $url Either a relative string url like `/products/view/23` or
+     * @param string|array|null $url Either a relative string url like `/products/view/23` or
      *    an array of URL parameters. Using an array for URLs will allow you to leverage
      *    the reverse routing features of CakePHP.
      * @param bool $full If true, the full base URL will be prepended to the result

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -35,9 +35,9 @@ class SerializedView extends View
     /**
      * Constructor
      *
-     * @param \Cake\Network\Request $request Request instance.
-     * @param \Cake\Network\Response $response Response instance.
-     * @param \Cake\Event\EventManager $eventManager EventManager instance.
+     * @param \Cake\Network\Request|null $request Request instance.
+     * @param \Cake\Network\Response|null $response Response instance.
+     * @param \Cake\Event\EventManager|null $eventManager EventManager instance.
      * @param array $viewOptions An array of view options
      */
     public function __construct(

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -362,7 +362,7 @@ class View implements EventDispatcherInterface
     /**
      * Get/set path for templates files.
      *
-     * @param string $path Path for template files. If null returns current path.
+     * @param string|null $path Path for template files. If null returns current path.
      * @return string|null
      */
     public function templatePath($path = null)
@@ -377,7 +377,7 @@ class View implements EventDispatcherInterface
     /**
      * Get/set path for layout files.
      *
-     * @param string $path Path for layout files. If null returns current path.
+     * @param string|null $path Path for layout files. If null returns current path.
      * @return string|null
      */
     public function layoutPath($path = null)
@@ -394,7 +394,7 @@ class View implements EventDispatcherInterface
      * On by default. Setting to off means that layouts will not be
      * automatically applied to rendered templates.
      *
-     * @param bool $autoLayout Boolean to turn on/off. If null returns current value.
+     * @param bool|null $autoLayout Boolean to turn on/off. If null returns current value.
      * @return bool|null
      */
     public function autoLayout($autoLayout = null)
@@ -409,7 +409,7 @@ class View implements EventDispatcherInterface
     /**
      * The view theme to use.
      *
-     * @param string $theme Theme name. If null returns current theme.
+     * @param string|null $theme Theme name. If null returns current theme.
      * @return string|null
      */
     public function theme($theme = null)
@@ -425,7 +425,7 @@ class View implements EventDispatcherInterface
      * Get/set the name of the template file to render. The name specified is the
      * filename in /src/Template/<SubFolder> without the .ctp extension.
      *
-     * @param string $name Template file name to set. If null returns current name.
+     * @param string|null $name Template file name to set. If null returns current name.
      * @return string|null
      */
     public function template($name = null)
@@ -442,7 +442,7 @@ class View implements EventDispatcherInterface
      * The name specified is the filename of the layout in /src/Template/Layout
      * without the .ctp extension.
      *
-     * @param string $name Layout file name to set. If null returns current name.
+     * @param string|null $name Layout file name to set. If null returns current name.
      * @return string|null
      */
     public function layout($name = null)

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -314,9 +314,9 @@ class ViewBuilder implements JsonSerializable, Serializable
      * If that class does not exist, then Cake\View\View will be used.
      *
      * @param array $vars The view variables/context to use.
-     * @param \Cake\Network\Request $request The request to use.
-     * @param \Cake\Network\Response $response The response to use.
-     * @param \Cake\Event\EventManager $events The event manager to use.
+     * @param \Cake\Network\Request|null $request The request to use.
+     * @param \Cake\Network\Response|null $response The response to use.
+     * @param \Cake\Event\EventManager|null $events The event manager to use.
      * @return \Cake\View\View
      * @throws \Cake\View\Exception\MissingViewException
      */


### PR DESCRIPTION
My new PSR2R sniffer for Doc Blocks found these issues with doc block param types missing.
