### PR TITLE
Support for multiple pagination

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -203,7 +203,8 @@ class PaginatorComponent extends Component
             'direction' => current($order),
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
-            'directionDefault' => $directionDefault
+            'directionDefault' => $directionDefault,
+            'prefix' => Hash::get($options, 'prefix', null),
         ];
 
         if (!isset($request['paging'])) {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -18,6 +18,7 @@ use Cake\Controller\Component;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Network\Exception\NotFoundException;
+use Cake\Utility\Hash;
 
 /**
  * This component is used to handle automatic model data pagination. The primary way to use this
@@ -257,7 +258,12 @@ class PaginatorComponent extends Component
     {
         $defaults = $this->getDefaults($alias, $settings);
         $request = $this->_registry->getController()->request;
-        $request = array_intersect_key($request->query, array_flip($this->_config['whitelist']));
+        $prefix = Hash::get($settings, 'prefix', null);
+        $query = $request->query;
+        if ($prefix) {
+            $query = Hash::get($request->query, $prefix, []);
+        }
+        $request = array_intersect_key($query, array_flip($this->_config['whitelist']));
         return array_merge($defaults, $request);
     }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -660,11 +660,12 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @param \Cake\ORM\Table|string|\Cake\ORM\Query|null $object Table to paginate
      * (e.g: Table instance, 'TableName' or a Query object)
+     * @param array $settings The settings/configuration used for pagination.
      * @return \Cake\ORM\ResultSet Query results
      * @link http://book.cakephp.org/3.0/en/controllers.html#paginating-a-model
      * @throws \RuntimeException When no compatible table object can be found.
      */
-    public function paginate($object = null)
+    public function paginate($object = null, array $settings = [])
     {
         if (is_object($object)) {
             $table = $object;
@@ -685,7 +686,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if (empty($table)) {
             throw new RuntimeException('Unable to locate an object compatible with paginate.');
         }
-        return $this->Paginator->paginate($table, $this->paginate);
+        $settings = $settings + $this->paginate;
+        return $this->Paginator->paginate($table, $settings);
     }
 
     /**

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -417,8 +417,8 @@ class PaginatorHelper extends Helper
         $locked = isset($options['lock']) ? $options['lock'] : false;
         unset($options['lock']);
 
+        $sortKey = $this->sortKey($options['model']);
         $defaultModel = $this->defaultModel();
-        $incomingKey = $key;
         $model = Hash::get($options, 'model', $defaultModel);
         list($table, $field) = explode('.', $key . '.', 2);
         if (!$field) {
@@ -426,13 +426,10 @@ class PaginatorHelper extends Helper
             $table = $model;
         }
 
-        $incomingKey = $table . '.' . $field;
-
-        $sortKey = $this->sortKey($options['model']);
         $isSorted = (
-            $sortKey === $incomingKey ||
+            $sortKey === $table . '.' . $field ||
             $sortKey === $defaultModel . '.' . $key ||
-            $incomingKey === $defaultModel . '.' . $sortKey
+            $table . '.' . $field === $defaultModel . '.' . $sortKey
         );
 
         $template = 'sort';

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -420,7 +420,7 @@ class PaginatorHelper extends Helper
         $sortKey = $this->sortKey($options['model']);
         $defaultModel = $this->defaultModel();
         $model = Hash::get($options, 'model', $defaultModel);
-        list($table, $field) = explode('.', $key . '.', 2);
+        list($table, $field) = explode('.', $key . '.');
         if (!$field) {
             $field = $table;
             $table = $model;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -14,11 +14,11 @@
  */
 namespace Cake\View\Helper;
 
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
 use Cake\View\View;
-use Cake\Utility\Hash;
 
 /**
  * Pagination Helper class for easy generation of pagination links.

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -421,7 +421,7 @@ class PaginatorHelper extends Helper
         $incomingKey = $key;
         $model = Hash::get($options, 'model', $defaultModel);
         list($table, $field) = explode('.', $key . '.');
-        if (empty($field)) {
+        if (!$field) {
             $field = $table;
             $table = $model;
         }
@@ -574,7 +574,7 @@ class PaginatorHelper extends Helper
     /**
      * Gets or sets the default model of the paged sets
      *
-     * @param string $model Model name to set
+     * @param string|null $model Model name to set
      * @return string|null Model name or null if the pagination isn't initialized.
      */
     public function defaultModel($model = null)

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -480,14 +480,10 @@ class PaginatorHelper extends Helper
             'sort' => $paging['sort'],
             'direction' => $paging['direction'],
         ];
-        if (empty($paging['prefix'])) {
-            if (!empty($this->_config['options']['url'])) {
-                $url = array_merge($url, $this->_config['options']['url']);
-            }
-        } else {
-            if (!empty($this->_config['options']['url'][$paging['prefix']])) {
-                $url = array_merge($url, $this->_config['options']['url'][$paging['prefix']]);
-            }
+
+        if (!empty($this->_config['options']['url'])) {
+            $key = implode('.', array_filter(['options.url', $paging['prefix']]));
+            $url = array_merge($url, Hash::get($this->_config, $key, []));
         }
 
         $url = array_filter($url, function ($value) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -479,7 +479,7 @@ class PaginatorHelper extends Helper
         ];
 
         if (!empty($this->_config['options']['url'])) {
-            $key = implode('.', array_filter(['options.url', $paging['prefix']]));
+            $key = implode('.', array_filter(['options.url', Hash::get($paging, 'prefix', null)]));
             $url = array_merge($url, Hash::get($this->_config, $key, []));
         }
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -420,7 +420,7 @@ class PaginatorHelper extends Helper
         $defaultModel = $this->defaultModel();
         $incomingKey = $key;
         $model = Hash::get($options, 'model', $defaultModel);
-        list($table, $field) = explode('.', $key . '.');
+        list($table, $field) = explode('.', $key . '.', 2);
         if (!$field) {
             $field = $table;
             $table = $model;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -166,6 +166,12 @@ class PaginatorHelper extends Helper
             unset($options[$model]);
         }
         $this->_config['options'] = array_filter($options + $this->_config['options']);
+        if (empty($this->_config['options']['url'])) {
+            $this->_config['options']['url'] = [];
+        }
+        if (!empty($this->_config['options']['model'])) {
+            $this->defaultModel($this->_config['options']['model']);
+        }
     }
 
     /**
@@ -566,12 +572,16 @@ class PaginatorHelper extends Helper
     }
 
     /**
-     * Gets the default model of the paged sets
+     * Gets or sets the default model of the paged sets
      *
+     * @param string $model Model name to set
      * @return string|null Model name or null if the pagination isn't initialized.
      */
-    public function defaultModel()
+    public function defaultModel($model = null)
     {
+        if ($model !== null) {
+            $this->_defaultModel = $model;
+        }
         if ($this->_defaultModel) {
             return $this->_defaultModel;
         }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -18,6 +18,7 @@ use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
 use Cake\View\View;
+use Cake\Utility\Hash;
 
 /**
  * Pagination Helper class for easy generation of pagination links.
@@ -410,12 +411,22 @@ class PaginatorHelper extends Helper
         $locked = isset($options['lock']) ? $options['lock'] : false;
         unset($options['lock']);
 
-        $sortKey = $this->sortKey($options['model']);
         $defaultModel = $this->defaultModel();
+        $incomingKey = $key;
+        $model = Hash::get($options, 'model', $defaultModel);
+        list($table, $field) = explode('.', $key . '.');
+        if (empty($field)) {
+            $field = $table;
+            $table = $model;
+        }
+
+        $incomingKey = $table . '.' . $field;
+
+        $sortKey = $this->sortKey($options['model']);
         $isSorted = (
-            $sortKey === $key ||
+            $sortKey === $incomingKey ||
             $sortKey === $defaultModel . '.' . $key ||
-            $key === $defaultModel . '.' . $sortKey
+            $incomingKey === $defaultModel . '.' . $sortKey
         );
 
         $template = 'sort';

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -463,9 +463,14 @@ class PaginatorHelper extends Helper
             'sort' => $paging['sort'],
             'direction' => $paging['direction'],
         ];
-
-        if (!empty($this->_config['options']['url'])) {
-            $url = array_merge($url, $this->_config['options']['url']);
+        if (empty($paging['prefix'])) {
+            if (!empty($this->_config['options']['url'])) {
+                $url = array_merge($url, $this->_config['options']['url']);
+            }
+        } else {
+            if (!empty($this->_config['options']['url'][$paging['prefix']])) {
+                $url = array_merge($url, $this->_config['options']['url'][$paging['prefix']]);
+            }
         }
 
         $url = array_filter($url, function ($value) {
@@ -481,6 +486,12 @@ class PaginatorHelper extends Helper
             $url['direction'] === $paging['directionDefault']
         ) {
             $url['sort'] = $url['direction'] = null;
+        }
+        if (!empty($paging['prefix'])) {
+            $url = [$paging['prefix'] => $url] + $this->_config['options']['url'];
+            if (empty($url[$paging['prefix']]['page'])) {
+                unset($url[$paging['prefix']]['page']);
+            }
         }
         return $this->Url->build($url, $full);
     }


### PR DESCRIPTION
This change provides the initial support for multiple paginators on a given page.

To use it, you can do something like the following in your model layer:

``` php
$users = $this->paginate($this->Users->find(), ['prefix' => 'users']);
$categories = $this->paginate($this->Categories->find(), ['prefix' => 'categories']);

$this->set(compact('users', 'categories'));
```

The in your view layer, specify the `model` option whenever the `PaginatorHelper` allows you to set options.

Todo:
- [x] add prefix scoping support to PaginatorHelper
- [x] ensure sort links work
- [x] Allow setting the model via `$this->Paginator->options(['model' => 'ModelName'])` in the view
- [x] Allow setting the model via `$this->Paginator->defaultModel('ModelName')` in the view

Seems to work locally...

Refs #1731
