### PR TITLE
Fix that increment/decrement no longer work for XcacheEngine

### DIFF
--- a/src/Cache/Engine/XcacheEngine.php
+++ b/src/Cache/Engine/XcacheEngine.php
@@ -58,7 +58,7 @@ class XcacheEngine extends CacheEngine
      */
     public function init(array $config = [])
     {
-        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') || !extension_loaded('xcache')) {
+        if (!extension_loaded('xcache')) {
             return false;
         }
 

--- a/src/Cache/Engine/XcacheEngine.php
+++ b/src/Cache/Engine/XcacheEngine.php
@@ -77,10 +77,14 @@ class XcacheEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
+        if (!is_numeric($value)) {
+            $value = serialize($value);
+        }
+
         $duration = $this->_config['duration'];
         $expires = time() + $duration;
         xcache_set($key . '_expires', $expires, $duration);
-        return xcache_set($key, serialize($value), $duration);
+        return xcache_set($key, $value, $duration);
     }
 
     /**
@@ -100,7 +104,12 @@ class XcacheEngine extends CacheEngine
             if ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime) {
                 return false;
             }
-            return unserialize(xcache_get($key));
+
+            $value = xcache_get($key);
+            if (is_string($value) && !is_numeric($value)) {
+                $value = unserialize($value);
+            }
+            return $value;
         }
         return false;
     }

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -102,6 +102,7 @@ class XcacheEngineTest extends TestCase
         $expecting = '';
         $this->assertEquals($expecting, $result);
 
+        // String
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('test', $data, 'xcache');
         $this->assertTrue($result);
@@ -109,6 +110,23 @@ class XcacheEngineTest extends TestCase
         $result = Cache::read('test', 'xcache');
         $expecting = $data;
         $this->assertEquals($expecting, $result);
+
+        // Integer
+        $data = 100;
+        $result = Cache::write('test', 100, 'xcache');
+        $this->assertTrue($result);
+
+        $result = Cache::read('test', 'xcache');
+        $this->assertSame(100, $result);
+
+        // Object
+        $data = (object)['value' => 'an object'];
+        $result = Cache::write('test', $data, 'xcache');
+        $this->assertTrue($result);
+
+        $result = Cache::read('test', 'xcache');
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertEquals('an object', $result->value);
 
         Cache::delete('test', 'xcache');
     }

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -82,6 +82,7 @@ class XcacheEngineTest extends TestCase
             'prefix' => 'cake_',
             'duration' => 3600,
             'probability' => 100,
+            'groups' => [],
         ];
         $this->assertTrue(isset($config['PHP_AUTH_USER']));
         $this->assertTrue(isset($config['PHP_AUTH_PW']));
@@ -164,6 +165,9 @@ class XcacheEngineTest extends TestCase
      */
     public function testClearCache()
     {
+        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
+            $this->markTestSkipped('Xcache administration functions are not available for the CLI.');
+        }
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('clear_test_1', $data, 'xcache');
         $this->assertTrue($result);
@@ -171,7 +175,7 @@ class XcacheEngineTest extends TestCase
         $result = Cache::write('clear_test_2', $data, 'xcache');
         $this->assertTrue($result);
 
-        $result = Cache::clear();
+        $result = Cache::clear(false, 'xcache');
         $this->assertTrue($result);
     }
 
@@ -185,7 +189,7 @@ class XcacheEngineTest extends TestCase
         $result = Cache::write('test_decrement', 5, 'xcache');
         $this->assertTrue($result);
 
-        $result = Cache::decrement('test_decrement', 'xcache');
+        $result = Cache::decrement('test_decrement', 1, 'xcache');
         $this->assertEquals(4, $result);
 
         $result = Cache::read('test_decrement', 'xcache');
@@ -208,7 +212,7 @@ class XcacheEngineTest extends TestCase
         $result = Cache::write('test_increment', 5, 'xcache');
         $this->assertTrue($result);
 
-        $result = Cache::increment('test_increment', 'xcache');
+        $result = Cache::increment('test_increment', 1, 'xcache');
         $this->assertEquals(6, $result);
 
         $result = Cache::read('test_increment', 'xcache');

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -35,10 +35,7 @@ class XcacheEngineTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
-            $this->markTestSkipped('Xcache is not available for the CLI.');
-        }
-        if (!function_exists('xcache_set')) {
+        if (!extension_loaded('xcache')) {
             $this->markTestSkipped('Xcache is not installed or configured properly');
         }
         Cache::enable();


### PR DESCRIPTION
Fixed a bug in #8408. As travis seemed not to run any tests for XcacheEngine, I ran it on my local environments.

Before (commit: 6105714d77fb646a879576aef2af6a53c3bca351)
![xcache1](https://cloud.githubusercontent.com/assets/7399393/13728298/b47367ee-e956-11e5-99b5-aa12114ec2e1.png)

After (commit: 07bf6266ab358a58e4dd75e4a0f915df8e5001e2)
![xcache2](https://cloud.githubusercontent.com/assets/7399393/13728299/b97521d8-e956-11e5-9a46-a6f541ba9e8a.png)
