### PR TITLE
fixes Text::insert function example

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -138,7 +138,7 @@ class Text
      * corresponds to a variable placeholder name in $str.
      * Example:
      * ```
-     * Text::insert(':name is :age years old.', ['name' => 'Bob', '65']);
+     * Text::insert(':name is :age years old.', ['name' => 'Bob', 'age' => '65']);
      * ```
      * Returns: Bob is 65 years old.
      *


### PR DESCRIPTION
In the example of Text::insert, the 'age' key was omitted from the array of placeholders and values
