### PR TITLE
Fix un-aliased query in Marshaller

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -380,9 +380,7 @@ class Marshaller
         $target = $assoc->target();
         $primaryKey = (array)$target->primaryKey();
         $multi = count($primaryKey) > 1;
-        $primaryKey = array_map(function ($key) use ($target) {
-            return $target->alias() . '.' . $key;
-        }, $primaryKey);
+        $primaryKey = array_map([$target, 'aliasField'], $primaryKey);
 
         if ($multi) {
             if (count(current($ids)) !== count($primaryKey)) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -591,7 +591,8 @@ class Marshaller
                 return count(array_filter($keys, 'strlen')) === count($primary);
             })
             ->reduce(function ($query, $keys) use ($primary) {
-                return $query->orWhere($query->newExpr()->and_(array_combine($primary, $keys)));
+                $fields = array_map([$this->_table, 'aliasField'], $primary);
+                return $query->orWhere($query->newExpr()->and_(array_combine($fields, $keys)));
             }, $this->_table->find());
 
         if (!empty($indexed) && count($maybeExistentQuery->clause('where'))) {

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -2151,6 +2151,30 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test mergeMany() with forced contain to ensure aliases are used in queries.
+     *
+     * @return void
+     */
+    public function testMergeManyExistingQueryAliases()
+    {
+        $entities = [
+            new OpenEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2], ['markClean' => true]),
+        ];
+
+        $data = [
+            ['id' => 1, 'comment' => 'Changed 1', 'user_id' => 1],
+            ['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
+        ];
+        $this->comments->eventManager()->on('Model.beforeFind', function ($event, $query) {
+            return $query->contain(['Articles']);
+        });
+        $marshall = new Marshaller($this->comments);
+        $result = $marshall->mergeMany($entities, $data);
+
+        $this->assertSame($entities[0], $result[0]);
+    }
+
+    /**
      * Test mergeMany() when the exist check returns nothing.
      *
      * @return void


### PR DESCRIPTION
The query used to find possibly existing entities should include the table alias to avoid ambiguous column names.

Refs #8463
