### PR TITLE
Fix complex conditions in BelongsToMany associations

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -853,7 +853,13 @@ class BelongsToMany extends Association
         }
         $alias = $this->_junctionAssociationName() . '.';
         foreach ($conditions as $field => $value) {
-            if (is_string($field) && strpos($field, $alias) === 0) {
+            $isString = is_string($field);
+            if ($isString && strpos($field, $alias) === 0) {
+                $matching[$field] = $value;
+            }
+            // Assume that operators contain junction conditions.
+            // Trying to munge complex conditions could result in incorrect queries.
+            if ($isString && in_array(strtoupper($field), ['OR', 'NOT', 'AND', 'XOR'])) {
                 $matching[$field] = $value;
             }
         }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1025,6 +1025,29 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Test that association proxy find() applies complex conditions
+     *
+     * @return void
+     */
+    public function testAssociationProxyFindWithComplexConditions()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->belongsToMany('Tags', [
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'tag_id',
+            'conditions' => [
+                'OR' => [
+                    'SpecialTags.highlighted' => true,
+                ]
+            ],
+            'through' => 'SpecialTags'
+        ]);
+        $query = $table->Tags->find();
+        $result = $query->toArray();
+        $this->assertCount(1, $result);
+    }
+
+    /**
      * Test that matching() works on belongsToMany associations.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -806,7 +806,12 @@ class TableTest extends TestCase
             'hasOne' => ['profiles'],
             'hasMany' => ['authors'],
             'belongsToMany' => [
-                'tags' => ['joinTable' => 'things_tags']
+                'tags' => [
+                    'joinTable' => 'things_tags',
+                    'conditions' => [
+                        'Tags.starred' => true
+                    ]
+                ]
             ]
         ];
 
@@ -834,6 +839,7 @@ class TableTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $belongsToMany);
         $this->assertEquals('tags', $belongsToMany->name());
         $this->assertSame('things_tags', $belongsToMany->junction()->table());
+        $this->assertSame(['Tags.starred' => true], $belongsToMany->conditions());
     }
 
     /**


### PR DESCRIPTION
While simple conditions worked fine, operator expressions matched neither the target alias, nor the junction table alias, and thus were excluded from both condition sets. Because munging complex conditions is pretty risky, I'm going to assume that all complex conditions are referencing junction fields.

Refs #8436
