### PR TITLE
Fix false != 0 in SelectBoxWidget

### DIFF
--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -287,6 +287,7 @@ class SelectBoxWidget extends BasicWidget
         }
         $isArray = is_array($selected);
         if (!$isArray) {
+            $selected = $selected === false ? '0' : $selected;
             return (string)$key === (string)$selected;
         }
         $strict = !is_numeric($key);

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -88,6 +88,28 @@ class SelectBoxWidgetTest extends TestCase
     }
 
     /**
+     * Test render boolean options
+     *
+     * @return void
+     */
+    public function testRenderBoolean()
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'id' => 'enabled',
+            'name' => 'enabled',
+            'options' => [0 => 'No', 1 => 'Yes'],
+            'val' => false
+        ];
+        $result = $select->render($data, $this->context);
+        $this->assertContains('<option value="0" selected="selected">No</option>', $result);
+
+        $data['value'] = [false, 2];
+        $result = $select->render($data, $this->context);
+        $this->assertContains('<option value="0" selected="selected">No</option>', $result);
+    }
+
+    /**
      * test simple iterator rendering
      *
      * @return void
@@ -734,10 +756,6 @@ class SelectBoxWidgetTest extends TestCase
             ['option' => ['value' => 'b']], 'Budgie', '/option',
             '/select'
         ];
-        $this->assertHtml($expected, $result);
-
-        $data['val'] = false;
-        $result = $select->render($data, $this->context);
         $this->assertHtml($expected, $result);
     }
 


### PR DESCRIPTION
This ports 745f3a33e6758f2b4332862f81312dd5e8533a4c to 3.x. Previously false was treated as ''/null. With this change boolean fields can now have select widgets created. I feel this is more useful than the
previous behavior.

Refs #8468 #8475
