### PR TITLE
Fix a risky test

### DIFF
--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1518,7 +1518,6 @@ class ResponseTest extends TestCase
      */
     public function testGetFile()
     {
-        ob_start();
         $response = new Response();
         $this->assertNull($response->getFile(), 'No file to get');
 


### PR DESCRIPTION
I found a risky test (marked with R) in the travis log. 
https://travis-ci.org/cakephp/cakephp/jobs/116612791#L247

I confirmed the message in my local environment,

```
There was 1 risky test:

1) Cake\Test\TestCase\Network\ResponseTest::testGetFile
Test code or tested code did not (only) close its own output buffers
```

and removed `ob_start()` call.
