### PR TITLE
Making CakePHP able to run inside a Phar file

### DIFF
--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -56,7 +56,7 @@ trait FileConfigTrait
 
         $file .= $this->_extension;
 
-        if ($checkExists && !is_file($file)) {
+        if ($checkExists && !is_file($file) && !is_file(realpath($file))) {
             throw new Exception(sprintf('Could not load configuration file: %s', $file));
         }
 

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -56,7 +56,7 @@ trait FileConfigTrait
 
         $file .= $this->_extension;
 
-        if ($checkExists && !is_file(realpath($file))) {
+        if ($checkExists && !is_file($file)) {
             throw new Exception(sprintf('Could not load configuration file: %s', $file));
         }
 


### PR DESCRIPTION
Using realpath() for configuration files breaks the lookup path for phar files,
we really don't need to resolve symbolic links in this specific case.
