### PR TITLE
Implement multiple paginators

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -18,6 +18,7 @@ use Cake\Controller\Component;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Network\Exception\NotFoundException;
+use Cake\Utility\Hash;
 
 /**
  * This component is used to handle automatic model data pagination. The primary way to use this
@@ -202,7 +203,8 @@ class PaginatorComponent extends Component
             'direction' => current($order),
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
-            'directionDefault' => $directionDefault
+            'directionDefault' => $directionDefault,
+            'prefix' => Hash::get($options, 'prefix', null),
         ];
 
         if (!isset($request['paging'])) {
@@ -257,7 +259,12 @@ class PaginatorComponent extends Component
     {
         $defaults = $this->getDefaults($alias, $settings);
         $request = $this->_registry->getController()->request;
-        $request = array_intersect_key($request->query, array_flip($this->_config['whitelist']));
+        $prefix = Hash::get($settings, 'prefix', null);
+        $query = $request->query;
+        if ($prefix) {
+            $query = Hash::get($request->query, $prefix, []);
+        }
+        $request = array_intersect_key($query, array_flip($this->_config['whitelist']));
         return array_merge($defaults, $request);
     }
 

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -142,6 +142,22 @@ class PaginatorComponent extends Component
      * $results = $paginator->paginate($query);
      * ```
      *
+     * ### Scoping Request parameters
+     *
+     * By using request parameter scopes you can paginate multiple queries in the same controller action:
+     *
+     * ```
+     * $articles = $paginator->paginate($articlesQuery, ['scope' => 'articles']);
+     * $tags = $paginator->paginate($tagsQuery, ['scope' => 'tags']);
+     * ```
+     *
+     * Each of the above queries will use different query string parameter sets
+     * for pagination data. An example URL paginating both results would be:
+     *
+     * ```
+     * /dashboard?articles[page]=1&tags[page]=2
+     * ```
+     *
      * @param \Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface $object The table or query to paginate.
      * @param array $settings The settings/configuration used for pagination.
      * @return \Cake\Datasource\ResultSetInterface Query results

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -159,7 +159,7 @@ class PaginatorComponent extends Component
         $options = $this->validateSort($object, $options);
         $options = $this->checkLimit($options);
 
-        $options += ['page' => 1, 'prefix' => null];
+        $options += ['page' => 1, 'scope' => null];
         $options['page'] = (int)$options['page'] < 1 ? 1 : (int)$options['page'];
         list($finder, $options) = $this->_extractFinder($options);
 
@@ -204,7 +204,7 @@ class PaginatorComponent extends Component
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,
-            'prefix' => $options['prefix'],
+            'scope' => $options['scope'],
         ];
 
         if (!isset($request['paging'])) {
@@ -259,10 +259,10 @@ class PaginatorComponent extends Component
     {
         $defaults = $this->getDefaults($alias, $settings);
         $request = $this->_registry->getController()->request;
-        $prefix = Hash::get($settings, 'prefix', null);
+        $scope = Hash::get($settings, 'scope', null);
         $query = $request->query;
-        if ($prefix) {
-            $query = Hash::get($request->query, $prefix, []);
+        if ($scope) {
+            $query = Hash::get($request->query, $scope, []);
         }
         $request = array_intersect_key($query, array_flip($this->_config['whitelist']));
         return array_merge($defaults, $request);

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -159,7 +159,7 @@ class PaginatorComponent extends Component
         $options = $this->validateSort($object, $options);
         $options = $this->checkLimit($options);
 
-        $options += ['page' => 1];
+        $options += ['page' => 1, 'prefix' => null];
         $options['page'] = (int)$options['page'] < 1 ? 1 : (int)$options['page'];
         list($finder, $options) = $this->_extractFinder($options);
 
@@ -204,7 +204,7 @@ class PaginatorComponent extends Component
             'limit' => $defaults['limit'] != $limit ? $limit : null,
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,
-            'prefix' => Hash::get($options, 'prefix', null),
+            'prefix' => $options['prefix'],
         ];
 
         if (!isset($request['paging'])) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -671,11 +671,12 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @param \Cake\ORM\Table|string|\Cake\ORM\Query|null $object Table to paginate
      * (e.g: Table instance, 'TableName' or a Query object)
+     * @param array $settings The settings/configuration used for pagination.
      * @return \Cake\ORM\ResultSet Query results
      * @link http://book.cakephp.org/3.0/en/controllers.html#paginating-a-model
      * @throws \RuntimeException When no compatible table object can be found.
      */
-    public function paginate($object = null)
+    public function paginate($object = null, array $settings = [])
     {
         if (is_object($object)) {
             $table = $object;
@@ -696,7 +697,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if (empty($table)) {
             throw new RuntimeException('Unable to locate an object compatible with paginate.');
         }
-        return $this->Paginator->paginate($table, $this->paginate);
+        $settings = $settings + $this->paginate;
+        return $this->Paginator->paginate($table, $settings);
     }
 
     /**

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -478,7 +478,7 @@ class PaginatorHelper extends Helper
         ];
 
         if (!empty($this->_config['options']['url'])) {
-            $key = implode('.', array_filter(['options.url', Hash::get($paging, 'prefix', null)]));
+            $key = implode('.', array_filter(['options.url', Hash::get($paging, 'scope', null)]));
             $url = array_merge($url, Hash::get($this->_config, $key, []));
         }
 
@@ -496,10 +496,10 @@ class PaginatorHelper extends Helper
         ) {
             $url['sort'] = $url['direction'] = null;
         }
-        if (!empty($paging['prefix'])) {
-            $url = [$paging['prefix'] => $url] + $this->_config['options']['url'];
-            if (empty($url[$paging['prefix']]['page'])) {
-                unset($url[$paging['prefix']]['page']);
+        if (!empty($paging['scope'])) {
+            $url = [$paging['scope'] => $url] + $this->_config['options']['url'];
+            if (empty($url[$paging['scope']]['page'])) {
+                unset($url[$paging['scope']]['page']);
             }
         }
         return $this->Url->build($url, $full);

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -419,7 +419,7 @@ class PaginatorHelper extends Helper
 
         $sortKey = $this->sortKey($options['model']);
         $defaultModel = $this->defaultModel();
-        $model = Hash::get($options, 'model', $defaultModel);
+        $model = $options['model'] ?: $defaultModel;
         list($table, $field) = explode('.', $key . '.');
         if (!$field) {
             $field = $table;

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -292,6 +292,76 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
+     * test mergeOptions with custom prefix
+     *
+     * @return void
+     */
+    public function testMergeOptionsCustomPrefix()
+    {
+        $this->request->query = [
+            'page' => 10,
+            'limit' => 10,
+            'prefix' => [
+                'page' => 2,
+                'limit' => 5,
+            ]
+        ];
+
+        $settings = [
+            'page' => 1,
+            'limit' => 20,
+            'maxLimit' => 100,
+            'finder' => 'myCustomFind',
+        ];
+        $result = $this->Paginator->mergeOptions('Post', $settings);
+        $expected = [
+            'page' => 10,
+            'limit' => 10,
+            'maxLimit' => 100,
+            'finder' => 'myCustomFind',
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+        ];
+        $this->assertEquals($expected, $result);
+
+        $settings = [
+            'page' => 1,
+            'limit' => 20,
+            'maxLimit' => 100,
+            'finder' => 'myCustomFind',
+            'prefix' => 'non-existent',
+        ];
+        $result = $this->Paginator->mergeOptions('Post', $settings);
+        $expected = [
+            'page' => 1,
+            'limit' => 20,
+            'maxLimit' => 100,
+            'finder' => 'myCustomFind',
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'prefix' => 'non-existent',
+        ];
+        $this->assertEquals($expected, $result);
+
+
+        $settings = [
+            'page' => 1,
+            'limit' => 20,
+            'maxLimit' => 100,
+            'finder' => 'myCustomFind',
+            'prefix' => 'prefix',
+        ];
+        $result = $this->Paginator->mergeOptions('Post', $settings);
+        $expected = [
+            'page' => 2,
+            'limit' => 5,
+            'maxLimit' => 100,
+            'finder' => 'myCustomFind',
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'prefix' => 'prefix',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test mergeOptions with customFind key
      *
      * @return void

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -144,7 +144,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
         $this->Paginator->paginate($table, $settings);
     }
@@ -228,7 +228,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
 
         $this->Paginator->paginate($table, $settings);
@@ -260,7 +260,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
 
         $this->Paginator->paginate($table, $settings);
@@ -295,16 +295,16 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
-     * test mergeOptions with custom prefix
+     * test mergeOptions with custom scope
      *
      * @return void
      */
-    public function testMergeOptionsCustomPrefix()
+    public function testMergeOptionsCustomScope()
     {
         $this->request->query = [
             'page' => 10,
             'limit' => 10,
-            'prefix' => [
+            'scope' => [
                 'page' => 2,
                 'limit' => 5,
             ]
@@ -331,7 +331,7 @@ class PaginatorComponentTest extends TestCase
             'limit' => 20,
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
-            'prefix' => 'non-existent',
+            'scope' => 'non-existent',
         ];
         $result = $this->Paginator->mergeOptions('Post', $settings);
         $expected = [
@@ -340,7 +340,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
-            'prefix' => 'non-existent',
+            'scope' => 'non-existent',
         ];
         $this->assertEquals($expected, $result);
 
@@ -350,7 +350,7 @@ class PaginatorComponentTest extends TestCase
             'limit' => 20,
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
-            'prefix' => 'prefix',
+            'scope' => 'scope',
         ];
         $result = $this->Paginator->mergeOptions('Post', $settings);
         $expected = [
@@ -359,7 +359,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
-            'prefix' => 'prefix',
+            'scope' => 'scope',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -522,7 +522,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
 
         $this->request->query = [
@@ -1031,7 +1031,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => [],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
         $this->Paginator->paginate($table, $settings);
     }
@@ -1065,7 +1065,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
         $this->Paginator->paginate($query, $settings);
     }
@@ -1125,7 +1125,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
-                'prefix' => null,
+                'scope' => null,
             ]);
         $this->Paginator->paginate($query, $settings);
     }

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -144,6 +144,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
             ]);
         $this->Paginator->paginate($table, $settings);
     }
@@ -227,6 +228,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
             ]);
 
         $this->Paginator->paginate($table, $settings);
@@ -258,6 +260,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
             ]);
 
         $this->Paginator->paginate($table, $settings);
@@ -519,6 +522,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
             ]);
 
         $this->request->query = [
@@ -1022,7 +1026,13 @@ class PaginatorComponentTest extends TestCase
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
-            ->with(['limit' => 2, 'page' => 1, 'order' => [], 'whitelist' => ['limit', 'sort', 'page', 'direction']]);
+            ->with([
+                'limit' => 2,
+                'page' => 1,
+                'order' => [],
+                'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
+            ]);
         $this->Paginator->paginate($table, $settings);
     }
 
@@ -1055,6 +1065,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
             ]);
         $this->Paginator->paginate($query, $settings);
     }
@@ -1114,6 +1125,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
+                'prefix' => null,
             ]);
         $this->Paginator->paginate($query, $settings);
     }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -726,7 +726,14 @@ class ControllerTest extends TestCase
             ->getMock();
 
         $Controller = new Controller($request, $response);
-        $Controller->request->query['url'] = [];
+        $Controller->request->query = [
+            'url' => [],
+            'prefix' => [
+                'page' => 2,
+                'limit' => 2,
+            ]
+        ];
+
         $this->assertEquals([], $Controller->paginate);
 
         $this->assertNotContains('Paginator', $Controller->helpers);
@@ -734,14 +741,26 @@ class ControllerTest extends TestCase
 
         $results = $Controller->paginate('Posts');
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+        $this->assertCount(3, $results);
 
         $results = $Controller->paginate(TableRegistry::get('Posts'));
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+        $this->assertCount(3, $results);
 
         $this->assertSame($Controller->request->params['paging']['Posts']['page'], 1);
         $this->assertSame($Controller->request->params['paging']['Posts']['pageCount'], 1);
         $this->assertSame($Controller->request->params['paging']['Posts']['prevPage'], false);
         $this->assertSame($Controller->request->params['paging']['Posts']['nextPage'], false);
+
+        $results = $Controller->paginate(TableRegistry::get('Posts'), ['prefix' => 'prefix']);
+        $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+        $this->assertCount(1, $results);
+
+        $this->assertSame($Controller->request->params['paging']['Posts']['page'], 2);
+        $this->assertSame($Controller->request->params['paging']['Posts']['pageCount'], 2);
+        $this->assertSame($Controller->request->params['paging']['Posts']['prevPage'], true);
+        $this->assertSame($Controller->request->params['paging']['Posts']['nextPage'], false);
+
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -728,7 +728,7 @@ class ControllerTest extends TestCase
         $Controller = new Controller($request, $response);
         $Controller->request->query = [
             'url' => [],
-            'prefix' => [
+            'posts' => [
                 'page' => 2,
                 'limit' => 2,
             ]
@@ -751,8 +751,9 @@ class ControllerTest extends TestCase
         $this->assertSame($Controller->request->params['paging']['Posts']['pageCount'], 1);
         $this->assertSame($Controller->request->params['paging']['Posts']['prevPage'], false);
         $this->assertSame($Controller->request->params['paging']['Posts']['nextPage'], false);
+        $this->assertNull($Controller->request->params['paging']['Posts']['scope']);
 
-        $results = $Controller->paginate(TableRegistry::get('Posts'), ['prefix' => 'prefix']);
+        $results = $Controller->paginate(TableRegistry::get('Posts'), ['scope' => 'posts']);
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
         $this->assertCount(1, $results);
 
@@ -760,6 +761,7 @@ class ControllerTest extends TestCase
         $this->assertSame($Controller->request->params['paging']['Posts']['pageCount'], 2);
         $this->assertSame($Controller->request->params['paging']['Posts']['prevPage'], true);
         $this->assertSame($Controller->request->params['paging']['Posts']['nextPage'], false);
+        $this->assertSame($Controller->request->params['paging']['Posts']['scope'], 'posts');
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -760,7 +760,6 @@ class ControllerTest extends TestCase
         $this->assertSame($Controller->request->params['paging']['Posts']['pageCount'], 2);
         $this->assertSame($Controller->request->params['paging']['Posts']['prevPage'], true);
         $this->assertSame($Controller->request->params['paging']['Posts']['nextPage'], false);
-
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2253,6 +2253,12 @@ class PaginatorHelperTest extends TestCase
     {
         $this->Paginator->request = new Request();
         $this->assertNull($this->Paginator->defaultModel());
+
+        $this->Paginator->defaultModel('Article');
+        $this->assertEquals('Article', $this->Paginator->defaultModel());
+
+        $this->Paginator->options(['model' => 'Client']);
+        $this->assertEquals('Client', $this->Paginator->defaultModel());
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -424,6 +424,42 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * test multiple pagination sort links
+     *
+     * @return void
+     */
+    public function testSortLinksMultiplePagination()
+    {
+        Router::setRequestInfo([
+            ['plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => [], 'url' => ['url' => 'accounts/']],
+            ['base' => '', 'here' => '/accounts/', 'webroot' => '/']
+        ]);
+
+        $this->Paginator->options(['model' => 'Articles']);
+        $this->Paginator->request['paging'] = [
+            'Articles' => [
+                'current' => 9,
+                'count' => 62,
+                'prevPage' => false,
+                'nextPage' => true,
+                'pageCount' => 7,
+                'sort' => 'date',
+                'direction' => 'asc',
+                'page' => 1,
+                'prefix' => 'article',
+            ]
+        ];
+
+        $result = $this->Paginator->sort('title');
+        $expected = [
+            'a' => ['href' => '/accounts/index?article%5Bsort%5D=title&amp;article%5Bdirection%5D=asc'],
+            'Title',
+            '/a'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * Test creating paging links for missing models.
      *
      * @return void
@@ -677,7 +713,7 @@ class PaginatorHelperTest extends TestCase
      *
      * @return void
      */
-    public function testUrlGenerationWithPrefixes()
+    public function testGenerateUrlWithPrefixes()
     {
         Configure::write('Routing.prefixes', ['members']);
         Router::reload();
@@ -733,6 +769,60 @@ class PaginatorHelperTest extends TestCase
         $options = ['controller' => 'posts', 'sort' => 'Article.name', 'direction' => 'desc'];
         $result = $this->Paginator->generateUrl($options);
         $expected = '/posts/index?page=2&amp;sort=Article.name&amp;direction=desc';
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * test generateUrl with multiple pagination
+     *
+     * @return void
+     */
+    public function testGenerateUrlMultiplePagination()
+    {
+        Router::setRequestInfo([
+            ['controller' => 'posts', 'action' => 'index', 'plugin' => null],
+            ['base' => '', 'here' => 'posts/index', 'webroot' => '/']
+        ]);
+
+        $this->Paginator->request->params['paging']['Article']['prefix'] = 'article';
+        $this->Paginator->request->params['paging']['Article']['page'] = 3;
+        $this->Paginator->request->params['paging']['Article']['prevPage'] = true;
+        $this->Paginator->options(['model' => 'Article']);
+
+        $result = $this->Paginator->generateUrl([]);
+        $expected = '/posts/index?article%5Bpage%5D=3';
+        $this->assertEquals($expected, $result);
+
+        $result = $this->Paginator->sort('name');
+        $expected = [
+            'a' => ['href' => '/posts/index?article%5Bpage%5D=3&amp;article%5Bsort%5D=name&amp;article%5Bdirection%5D=asc'],
+            'Name',
+            '/a'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->next('next');
+        $expected = [
+            'li' => ['class' => 'next'],
+            'a' => ['href' => '/posts/index?article%5Bpage%5D=4', 'rel' => 'next'],
+            'next',
+            '/a',
+            '/li'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->prev('prev');
+        $expected = [
+            'li' => ['class' => 'prev'],
+            'a' => ['href' => '/posts/index?article%5Bpage%5D=2', 'rel' => 'prev'],
+            'prev',
+            '/a',
+            '/li'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->generateUrl(['sort' => 'name']);
+        $expected = '/posts/index?article%5Bpage%5D=3&amp;article%5Bsort%5D=name';
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -446,7 +446,7 @@ class PaginatorHelperTest extends TestCase
                 'sort' => 'date',
                 'direction' => 'asc',
                 'page' => 1,
-                'prefix' => 'article',
+                'scope' => 'article',
             ]
         ];
 
@@ -784,7 +784,7 @@ class PaginatorHelperTest extends TestCase
             ['base' => '', 'here' => 'posts/index', 'webroot' => '/']
         ]);
 
-        $this->Paginator->request->params['paging']['Article']['prefix'] = 'article';
+        $this->Paginator->request->params['paging']['Article']['scope'] = 'article';
         $this->Paginator->request->params['paging']['Article']['page'] = 3;
         $this->Paginator->request->params['paging']['Article']['prevPage'] = true;
         $this->Paginator->options(['model' => 'Article']);


### PR DESCRIPTION
This change provides the initial support for multiple paginators on a given page.

To use it, you can do something like the following in your controller layer:

``` php
$users = $this->paginate($this->Users->find(), ['prefix' => 'users']);
$categories = $this->paginate($this->Categories->find(), ['prefix' => 'categories']);

$this->set(compact('users', 'categories'));
```

The in your view layer, specify the model option whenever the `PaginatorHelper` allows you to set options.

Closes #1731
