### PR TITLE
Fix bound parameters in sub-queries not working.

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -103,7 +103,7 @@ class QueryCompiler
         if ($query->valueBinder() !== $generator) {
             foreach ($query->valueBinder()->bindings() as $binding) {
                 $placeholder = ':' . $binding['placeholder'];
-                if (strpos($sql, $placeholder) !== false) {
+                if (preg_match('/' . $placeholder . '(?:\W|$)/', $sql) > 0) {
                     $generator->bind($placeholder, $binding['value'], $binding['type']);
                 }
             }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -97,6 +97,13 @@ class QueryCompiler
             $this->_sqlCompiler($sql, $query, $generator),
             $this->{'_' . $type . 'Parts'}
         );
+
+        // Propagate bound parameters from sub-queries
+        if ($query->valueBinder() !== $generator) {
+            foreach ($query->valueBinder()->bindings() as $binding) {
+                $generator->bind(':' . $binding['placeholder'], $binding['value'], $binding['type']);
+            }
+        }
         return $sql;
     }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -98,10 +98,14 @@ class QueryCompiler
             $this->{'_' . $type . 'Parts'}
         );
 
-        // Propagate bound parameters from sub-queries
+        // Propagate bound parameters from sub-queries if the
+        // placeholders can be found in the SQL statement.
         if ($query->valueBinder() !== $generator) {
             foreach ($query->valueBinder()->bindings() as $binding) {
-                $generator->bind(':' . $binding['placeholder'], $binding['value'], $binding['type']);
+                $placeholder = ':' . $binding['placeholder'];
+                if (strpos($sql, $placeholder) !== false) {
+                    $generator->bind($placeholder, $binding['value'], $binding['type']);
+                }
             }
         }
         return $sql;

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -591,9 +591,9 @@ class QueryRegressionTest extends TestCase
         $table = TableRegistry::get('Articles');
         $query = $table
             ->find()
-            ->select(['Articles.title', 'Articles.id'])
-            ->where("Articles.title LIKE :val")
-            ->group('Articles.id')
+            ->select(['title', 'id'])
+            ->where("title LIKE :val")
+            ->group('id')
             ->bind(':val', '%Second%');
         $count = $query->count();
         $this->assertEquals(1, $count);
@@ -608,14 +608,14 @@ class QueryRegressionTest extends TestCase
     {
         $table = TableRegistry::get('Articles');
         $sub = $table->find()
-            ->select(['Articles.id'])
-            ->where("Articles.title LIKE :val")
+            ->select(['id'])
+            ->where("title LIKE :val")
             ->bind(':val', 'Second %');
 
         $query = $table
             ->find()
-            ->select(['Articles.title'])
-            ->where(["Articles.id NOT IN" => $sub]);
+            ->select(['title'])
+            ->where(["id NOT IN" => $sub]);
         $result = $query->toArray();
         $this->assertCount(2, $result);
         $this->assertEquals('First Article', $result[0]->title);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -593,7 +593,7 @@ class QueryRegressionTest extends TestCase
             ->find()
             ->select(['title', 'id'])
             ->where("title LIKE :val")
-            ->group('id')
+            ->group(['id', 'title'])
             ->bind(':val', '%Second%');
         $count = $query->count();
         $this->assertEquals(1, $count);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -581,6 +581,48 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Tests that getting the count of a query with bind is correct
+     *
+     * @see https://github.com/cakephp/cakephp/issues/8466
+     * @return void
+     */
+    public function testCountWithBind()
+    {
+        $table = TableRegistry::get('Articles');
+        $query = $table
+            ->find()
+            ->select(['Articles.title', 'Articles.id'])
+            ->where("Articles.title LIKE :val")
+            ->group('Articles.id')
+            ->bind(':val', '%Second%');
+        $count = $query->count();
+        $this->assertEquals(1, $count);
+    }
+
+    /**
+     * Tests that bind in subqueries works.
+     *
+     * @return void
+     */
+    public function testSubqueryBind()
+    {
+        $table = TableRegistry::get('Articles');
+        $sub = $table->find()
+            ->select(['Articles.id'])
+            ->where("Articles.title LIKE :val")
+            ->bind(':val', 'Second %');
+
+        $query = $table
+            ->find()
+            ->select(['Articles.title'])
+            ->where(["Articles.id NOT IN" => $sub]);
+        $result = $query->toArray();
+        $this->assertCount(2, $result);
+        $this->assertEquals('First Article', $result[0]->title);
+        $this->assertEquals('Third Article', $result[1]->title);
+    }
+
+    /**
      * Test that deep containments don't generate empty entities for
      * intermediary relations.
      *


### PR DESCRIPTION
By applying the bound parameters when the valueBinder is different than the current query's binder we can propagate bound variables from subqueries to the parent query. The caveat being that this only works seamlessly for named parameters. Numbered parameters still have a chance of overlapping.

Refs #8466
