### PR TITLE
Add support for returning decoded subjects

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -695,12 +695,13 @@ class Email implements JsonSerializable, Serializable
      * Get/Set Subject.
      *
      * @param string|null $subject Subject string.
+     * @param bool $decode Whether to decode the subject.
      * @return string|$this
      */
-    public function subject($subject = null)
+    public function subject($subject = null, $decode = false)
     {
         if ($subject === null) {
-            return $this->_subject;
+            return ($decode) ? $this->_decode($this->_subject) : $this->_subject;
         }
         $this->_subject = $this->_encode((string)$subject);
         return $this;
@@ -1479,6 +1480,21 @@ class Email implements JsonSerializable, Serializable
             $this->headerCharset = $this->charset;
         }
         $return = mb_encode_mimeheader($text, $this->headerCharset, 'B');
+        mb_internal_encoding($restore);
+        return $return;
+    }
+
+    /**
+     * Decode the specified string
+     *
+     * @param string $text String to decode
+     * @return string Decoded string
+     */
+    protected function _decode($text)
+    {
+        $restore = mb_internal_encoding();
+        mb_internal_encoding($this->_appCharset);
+        $return = mb_decode_mimeheader($text);
         mb_internal_encoding($restore);
         return $return;
     }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -695,16 +695,25 @@ class Email implements JsonSerializable, Serializable
      * Get/Set Subject.
      *
      * @param string|null $subject Subject string.
-     * @param bool $decode Whether to decode the subject.
      * @return string|$this
      */
-    public function subject($subject = null, $decode = false)
+    public function subject($subject = null)
     {
         if ($subject === null) {
-            return ($decode) ? $this->_decode($this->_subject) : $this->_subject;
+            return $this->_subject;
         }
         $this->_subject = $this->_encode((string)$subject);
         return $this;
+    }
+
+    /**
+     * Get original subject without encoding
+     *
+     * @return string Original subject
+     */
+    public function getOriginalSubject()
+    {
+        return $this->_decode($this->_subject);
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -577,7 +577,7 @@ class EmailTest extends TestCase
         $this->CakeEmail->subject($input);
         $expected = '=?UTF-8?B?2YfYsNmHINix2LPYp9mE2Kkg2KjYudmG2YjYp9mGINi32YjZitmEINmF2LE=?=' . "\r\n" . ' =?UTF-8?B?2LPZhCDZhNmE2YXYs9iq2YTZhQ==?=';
         $this->assertSame($expected, $this->CakeEmail->subject());
-        $this->assertSame($input, $this->CakeEmail->subject(null, true));
+        $this->assertSame($input, $this->CakeEmail->getOriginalSubject());
     }
 
     /**

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -72,6 +72,16 @@ class TestEmail extends Email
     }
 
     /**
+     * Decode to protected method
+     *
+     * @return string
+     */
+    public function decode($text)
+    {
+        return $this->_decode($text);
+    }
+
+    /**
      * Render to protected method
      *
      * @return array
@@ -563,9 +573,11 @@ class EmailTest extends TestCase
         $this->CakeEmail->subject(1);
         $this->assertSame('1', $this->CakeEmail->subject());
 
-        $this->CakeEmail->subject('هذه رسالة بعنوان طويل مرسل للمستلم');
+        $input = 'هذه رسالة بعنوان طويل مرسل للمستلم';
+        $this->CakeEmail->subject($input);
         $expected = '=?UTF-8?B?2YfYsNmHINix2LPYp9mE2Kkg2KjYudmG2YjYp9mGINi32YjZitmEINmF2LE=?=' . "\r\n" . ' =?UTF-8?B?2LPZhCDZhNmE2YXYs9iq2YTZhQ==?=';
         $this->assertSame($expected, $this->CakeEmail->subject());
+        $this->assertSame($input, $this->CakeEmail->subject(null, true));
     }
 
     /**
@@ -2340,6 +2352,26 @@ class EmailTest extends TestCase
         $expected = "=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n" .
             " =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n" .
             " =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=";
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test CakeEmail::_decode function
+     *
+     * @return void
+     */
+    public function testDecode()
+    {
+        $this->CakeEmail->headerCharset = 'ISO-2022-JP';
+        $result = $this->CakeEmail->decode('=?ISO-2022-JP?B?GyRCRnxLXDhsGyhC?=');
+        $expected = '日本語';
+        $this->assertSame($expected, $result);
+
+        $this->CakeEmail->headerCharset = 'ISO-2022-JP';
+        $result = $this->CakeEmail->decode("=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n" .
+            " =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n" .
+            " =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=");
+        $expected = '長い長い長いSubjectの場合はfoldingするのが正しいんだけどいったいどうなるんだろう？';
         $this->assertSame($expected, $result);
     }
 


### PR DESCRIPTION
This change makes it possible to return the actual subject put into an email. This is useful when you want to for example pull the subject out of an email to log it.

This resolves the issue in cvo-technologies/cakephp-gearman#10
