### PR TITLE
Clear the router state after testAction().

### DIFF
--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -278,6 +278,10 @@ abstract class ControllerTestCase extends CakeTestCase {
 		$Dispatch->testController = $this->controller;
 		$Dispatch->response = $this->getMock('CakeResponse', array('send', '_clearBuffer'));
 		$this->result = $Dispatch->dispatch($request, $Dispatch->response, $params);
+
+		// Clear out any stored requests.
+		Router::reload();
+
 		$this->controller = $Dispatch->testController;
 		$this->vars = $this->controller->viewVars;
 		$this->contents = $this->controller->response->body();


### PR DESCRIPTION
When using array urls, internal state in the Router would cause requests to be incorrectly handled causing multiple testAction calls in a single test to fail. By reloading the router we start off with a clean slate each time.

Refs #8480
