### PR TITLE
Native Json type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ cache:
     - vendor
     - $HOME/.composer/cache
 
+addons:
+  postgresql: "9.4.1"
+
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ cache:
     - vendor
     - $HOME/.composer/cache
 
-addons:
-  postgresql: "9.4.1"
-
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ env:
 services:
   - memcached
   - redis-server
+  - postgresql
+
+addons:
+  postgresql: "9.4"
 
 cache:
   directories:

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -45,6 +45,20 @@ class Mysql extends Driver
     ];
 
     /**
+     * The server version
+     *
+     * @var string
+     */
+    protected $_version;
+
+    /**
+     * Whether or not the server supports native JSON
+     *
+     * @var bool
+     */
+    protected $_supportsNativeJson;
+
+    /**
      * Establishes a connection to the database server
      *
      * @return bool true on success
@@ -140,5 +154,23 @@ class Mysql extends Driver
     public function supportsDynamicConstraints()
     {
         return true;
+    }
+
+    /**
+     * Returns true if the server supports native JSON columns
+     *
+     * @return bool
+     */
+    public function supportsNativeJson()
+    {
+        if ($this->_supportsNativeJson !== null) {
+            return $this->_supportsNativeJson;
+        }
+
+        if ($this->_version === null) {
+            $this->_version = $this->_connection->getAttribute(PDO::ATTR_SERVER_VERSION);
+        }
+
+        return $this->_supportsNativeJson = version_compare($this->_version, '5.7.0', '>=');
     }
 }

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -287,6 +287,8 @@ class MysqlSchema extends BaseSchema
     {
         $data = $table->column($name);
         $out = $this->_driver->quoteIdentifier($name);
+        $nativeJson = $this->_driver->supportsNativeJson();
+
         $typeMap = [
             'integer' => ' INTEGER',
             'biginteger' => ' BIGINT',
@@ -300,6 +302,7 @@ class MysqlSchema extends BaseSchema
             'datetime' => ' DATETIME',
             'timestamp' => ' TIMESTAMP',
             'uuid' => ' CHAR(36)',
+            'json' => $nativeJson ? ' JSON' : ' LONGTEXT'
         ];
         $specialMap = [
             'string' => true,

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -137,6 +137,11 @@ class MysqlSchema extends BaseSchema
                 'unsigned' => $unsigned
             ];
         }
+
+        if (strpos($col, 'json') !== false) {
+            return ['type' => 'json', 'length' => null];
+        }
+
         return ['type' => 'text', 'length' => null];
     }
 

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -129,6 +129,11 @@ class PostgresSchema extends BaseSchema
         ) {
             return ['type' => 'decimal', 'length' => null];
         }
+
+        if (strpos($col, 'json') !== false) {
+            return ['type' => 'json', 'length' => null];
+        }
+
         return ['type' => 'text', 'length' => null];
     }
 

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -345,6 +345,7 @@ class PostgresSchema extends BaseSchema
             'datetime' => ' TIMESTAMP',
             'timestamp' => ' TIMESTAMP',
             'uuid' => ' UUID',
+            'json' => ' JSON'
         ];
 
         if (isset($typeMap[$data['type']])) {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -257,6 +257,7 @@ class SqliteSchema extends BaseSchema
             'time' => ' TIME',
             'datetime' => ' DATETIME',
             'timestamp' => ' TIMESTAMP',
+            'json' => ' TEXT'
         ];
         if (!isset($typeMap[$data['type']])) {
             throw new Exception(sprintf('Unknown column type for "%s"', $name));

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -310,7 +310,8 @@ class SqlserverSchema extends BaseSchema
             'time' => ' TIME',
             'datetime' => ' DATETIME',
             'timestamp' => ' DATETIME',
-            'uuid' => ' UNIQUEIDENTIFIER'
+            'uuid' => ' UNIQUEIDENTIFIER',
+            'json' => ' NVARCHAR(MAX)',
         ];
 
         if (isset($typeMap[$data['type']])) {

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -40,6 +40,7 @@ class Type
         'decimal' => 'Cake\Database\Type\FloatType',
         'float' => 'Cake\Database\Type\FloatType',
         'integer' => 'Cake\Database\Type\IntegerType',
+        'json' => 'Cake\Database\Type\JsonType',
         'string' => 'Cake\Database\Type\StringType',
         'text' => 'Cake\Database\Type\StringType',
         'time' => 'Cake\Database\Type\TimeType',

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -29,7 +29,7 @@ class JsonType extends Type
 {
 
     /**
-     * Convert a value data into a json string
+     * Convert a value data into a JSON string
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
@@ -45,7 +45,7 @@ class JsonType extends Type
     }
 
     /**
-     * Convert string values to PHP strings.
+     * Convert string values to PHP arrays.
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
@@ -69,7 +69,7 @@ class JsonType extends Type
     }
 
     /**
-     * Marshalls request data into PHP strings.
+     * Marshalls request data into a JSON compatible structure.
      *
      * @param mixed $value The value to convert.
      * @return mixed Converted value.

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type;
+use InvalidArgumentException;
+use JsonSerializable;
+use PDO;
+
+/**
+ * Json type converter.
+ *
+ * Use to convert json data between PHP and the database types.
+ */
+class JsonType extends Type
+{
+
+    /**
+     * Convert a value data into a json string
+     *
+     * @param mixed $value The value to convert.
+     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @return string|null
+     */
+    public function toDatabase($value, Driver $driver)
+    {
+        if (is_resource($value)) {
+            throw new InvalidArgumentException('Cannot convert a resource value to JSON');
+        }
+
+        return json_encode($value);
+    }
+
+    /**
+     * Convert string values to PHP strings.
+     *
+     * @param mixed $value The value to convert.
+     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @return string|null|array
+     */
+    public function toPHP($value, Driver $driver)
+    {
+        return json_decode($value, true);
+    }
+
+    /**
+     * Get the correct PDO binding type for string data.
+     *
+     * @param mixed $value The value being bound.
+     * @param \Cake\Database\Driver $driver The driver.
+     * @return int
+     */
+    public function toStatement($value, Driver $driver)
+    {
+        return PDO::PARAM_STR;
+    }
+
+    /**
+     * Marshalls request data into PHP strings.
+     *
+     * @param mixed $value The value to convert.
+     * @return mixed Converted value.
+     */
+    public function marshal($value)
+    {
+        return $value;
+    }
+}

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3604,7 +3604,7 @@ class QueryTest extends TestCase
     public function testSymetricJsonType()
     {
         $query = new Query($this->connection);
-        $id = $query
+        $insert = $query
             ->insert(['comment', 'article_id', 'user_id'], ['comment' => 'json'])
             ->into('comments')
             ->values([
@@ -3612,8 +3612,10 @@ class QueryTest extends TestCase
                 'article_id' => 1,
                 'user_id' => 1
             ])
-            ->execute()
-            ->lastInsertId('id');
+            ->execute();
+
+        $id = $insert->lastInsertId('comments', 'id');
+        $insert->closeCursor();
 
         $query = new Query($this->connection);
         $query
@@ -3622,8 +3624,10 @@ class QueryTest extends TestCase
             ->where(['id' => $id])
             ->selectTypeMap()->types(['comment' => 'json']);
 
-        $result = $query->execute()->fetchAll('assoc')[0]['comment'];
-        $this->assertSame(['a' => 'b', 'c' => true], $result);
+        $result = $query->execute();
+        $comment = $result->fetchAll('assoc')[0]['comment'];
+        $result->closeCursor();
+        $this->assertSame(['a' => 'b', 'c' => true], $comment);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -146,6 +146,10 @@ class MysqlSchemaTest extends TestCase
                 'DOUBLE(10,4) UNSIGNED',
                 ['type' => 'float', 'length' => 10, 'precision' => 4, 'unsigned' => true]
             ],
+            [
+                'JSON',
+                ['type' => 'json', 'length' => null]
+            ],
         ];
     }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1124,7 +1124,7 @@ SQL;
         $this->assertEquals(
             $expected,
             $result->column('data'),
-            'Field definition does not match for'
+            'Field definition does not match for data'
         );
     }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -972,6 +972,7 @@ SQL;
                 'comment' => 'This is the title',
             ])
             ->addColumn('body', ['type' => 'text'])
+            ->addColumn('data', ['type' => 'json'])
             ->addColumn('created', 'datetime')
             ->addConstraint('primary', [
                 'type' => 'primary',
@@ -987,6 +988,7 @@ CREATE TABLE "schema_articles" (
 "id" SERIAL,
 "title" VARCHAR NOT NULL,
 "body" TEXT,
+"data" JSON,
 "created" TIMESTAMP,
 PRIMARY KEY ("id")
 )

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -200,6 +200,10 @@ SQL;
                 'DOUBLE PRECISION',
                 ['type' => 'float', 'length' => null]
             ],
+            [
+                'JSON',
+                ['type' => 'json', 'length' => null]
+            ],
         ];
     }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -73,6 +73,7 @@ author_id INTEGER NOT NULL,
 published BOOLEAN DEFAULT false,
 views SMALLINT DEFAULT 0,
 readingtime TIME,
+data JSON,
 created TIMESTAMP,
 CONSTRAINT "content_idx" UNIQUE ("title", "body"),
 CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
@@ -341,6 +342,14 @@ SQL;
             ],
             'readingtime' => [
                 'type' => 'time',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => null,
+                'comment' => null,
+            ],
+            'data' => [
+                'type' => 'json',
                 'null' => true,
                 'default' => null,
                 'length' => null,

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -776,6 +776,7 @@ SQL;
                 'null' => false,
             ])
             ->addColumn('body', ['type' => 'text'])
+            ->addColumn('data', ['type' => 'json'])
             ->addColumn('created', 'datetime')
             ->addConstraint('primary', [
                 'type' => 'primary',
@@ -791,6 +792,7 @@ CREATE TABLE "articles" (
 "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
 "title" VARCHAR NOT NULL,
 "body" TEXT,
+"data" TEXT,
 "created" DATETIME
 )
 SQL;

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -773,6 +773,7 @@ SQL;
                 'null' => false,
             ])
             ->addColumn('body', ['type' => 'text'])
+            ->addColumn('data', ['type' => 'json'])
             ->addColumn('created', 'datetime')
             ->addConstraint('primary', [
                 'type' => 'primary',
@@ -788,6 +789,7 @@ CREATE TABLE [schema_articles] (
 [id] INTEGER IDENTITY(1, 1),
 [title] NVARCHAR(255) NOT NULL,
 [body] NVARCHAR(MAX),
+[data] NVARCHAR(MAX),
 [created] DATETIME,
 PRIMARY KEY ([id])
 )

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Type;
+
+use Cake\Database\Type;
+use Cake\TestSuite\TestCase;
+use PDO;
+
+/**
+ * Test for the String type.
+ */
+class JsonTypeTest extends TestCase
+{
+
+    /**
+     * Setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->type = Type::build('json');
+        $this->driver = $this->getMock('Cake\Database\Driver');
+    }
+
+    /**
+     * Test toPHP
+     *
+     * @return void
+     */
+    public function testToPHP()
+    {
+        $this->assertNull($this->type->toPHP(null, $this->driver));
+        $this->assertSame('word', $this->type->toPHP(json_encode('word'), $this->driver));
+        $this->assertSame(2.123, $this->type->toPHP(json_encode(2.123), $this->driver));
+    }
+
+    /**
+     * Test converting to database format
+     *
+     * @return void
+     */
+    public function testToDatabase()
+    {
+        $this->assertSame('null', $this->type->toDatabase(null, $this->driver));
+        $this->assertSame(json_encode('word'), $this->type->toDatabase('word', $this->driver));
+        $this->assertSame(json_encode(2.123), $this->type->toDatabase(2.123, $this->driver));
+        $this->assertSame(json_encode(['a' => 'b']), $this->type->toDatabase(['a' => 'b'], $this->driver));
+    }
+
+    /**
+     * Tests that passing an invalid value will throw an exception
+     *
+     * @expectedException InvalidArgumentException
+     * @return void
+     */
+    public function testToDatabaseInvalid()
+    {
+        $value = fopen(__FILE__, 'r');
+        $this->type->toDatabase($value, $this->driver);
+    }
+
+    /**
+     * Test marshalling
+     *
+     * @return void
+     */
+    public function testMarshal()
+    {
+        $this->assertNull($this->type->marshal(null));
+        $this->assertSame('word', $this->type->marshal('word'));
+        $this->assertSame(2.123, $this->type->marshal(2.123));
+        $this->assertSame([1, 2, 3], $this->type->marshal([1, 2, 3]));
+        $this->assertSame(['a' => 1, 2, 3], $this->type->marshal(['a' => 1, 2, 3]));
+    }
+
+    /**
+     * Test that the PDO binding type is correct.
+     *
+     * @return void
+     */
+    public function testToStatement()
+    {
+        $this->assertEquals(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
+    }
+}
+

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -97,4 +97,3 @@ class JsonTypeTest extends TestCase
         $this->assertEquals(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
     }
 }
-


### PR DESCRIPTION
Both Postgres and mysql can support natively JSON column; and SQL Server 2016 already promises support for it. The good news is that JSON columns still are just strings, this means it is safe for the ORM to offer support for the native type, as there will not be a big incompatibility between the other database servers.

This adds support for using the native json types and automatically converting back and forth the json data.
