### PR TITLE
Instead of wiping the Router, just clear requests.

### DIFF
--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -280,7 +280,9 @@ abstract class ControllerTestCase extends CakeTestCase {
 		$this->result = $Dispatch->dispatch($request, $Dispatch->response, $params);
 
 		// Clear out any stored requests.
-		Router::reload();
+		while (Router::getRequest()) {
+			Router::popRequest();
+		}
 
 		$this->controller = $Dispatch->testController;
 		$this->vars = $this->controller->viewVars;


### PR DESCRIPTION
Clearing the router also removes routes which can cause assertions to fail. By just removing the stored requests we avoid the error reported in #8480 and not break as many tests.
