### PR TITLE
Update postgres schema reflection query.

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -283,7 +283,7 @@ class PostgresSchema extends BaseSchema
         INNER JOIN pg_catalog.pg_attribute a ON (a.attrelid = cl.oid AND c.conrelid = a.attrelid AND a.attnum = ANY(c.conkey))
         INNER JOIN pg_catalog.pg_attribute ab ON (a.attrelid = cl.oid AND c.confrelid = ab.attrelid AND ab.attnum = ANY(c.confkey))
         WHERE n.nspname = ?
-        AND c.conrelid = ?::regclass
+        AND cl.relname = ?
         ORDER BY name, a.attnum, ab.attnum DESC";
 
         $schema = empty($config['schema']) ? 'public' : $config['schema'];


### PR DESCRIPTION
Use different conditions in foreign key reflection that match index reflection. This should solve issues around tables in non-default schemas failing to reflect correctly.

Refs #8503
