### PR TITLE
Allow filenames to be converted to slugs

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -733,12 +733,19 @@ class Inflector
      *
      * @param string $string the string you want to slug
      * @param string $replacement will replace keys in map
+     * @param string|bool $filename Whether the string is a filename
      * @return string
      * @link http://book.cakephp.org/3.0/en/core-libraries/inflector.html#creating-url-safe-strings
      */
-    public static function slug($string, $replacement = '-')
+    public static function slug($string, $replacement = '-', $filename = false)
     {
         $quotedReplacement = preg_quote($replacement, '/');
+
+				if ($filename == true) {
+					$string = explode('.', $string);
+					$extension = array_pop($string);
+					$string = implode('.', $string);
+				}
 
         $map = [
             '/[^\s\p{Zs}\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]/mu' => ' ',
@@ -751,6 +758,13 @@ class Inflector
             array_values(static::$_transliteration),
             $string
         );
-        return preg_replace(array_keys($map), array_values($map), $string);
+
+        $result = preg_replace(array_keys($map), array_values($map), $string);
+
+				if ($filename == true) {
+					$result .= '.'.$extension;
+				}
+
+				return $result;
     }
 }


### PR DESCRIPTION
This code adds the ability for the Inflector to create slugs from strings in such a way that preserves the last dot in the string and everything after it, to allow Inflector::slug() to be used on filenames, preserving their extensions.  For example, "image file.jpg" normally gets turned into "image-file-jpg".  This allows it to instead be turned into "image-file.jpg".  It's something I found useful, so I'd imagine others would too.  However, I'm not the best programmer, so it's quite possible that it can be implemented better.  It should work fine with CakePHP 2 and 3 alike.  Thank you for your time!
