### PR TITLE
[2.x] Extracts error trace in ErrorHandler to a helper function to allow customization

### DIFF
--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -203,7 +203,7 @@ class ErrorHandlerTest extends CakeTestCase {
 			$result[0]
 		);
 		$this->assertRegExp('/^Trace:/', $result[1]);
-		$this->assertRegExp('/^ErrorHandlerTest\:\:testHandleErrorLoggingTrace\(\)/', $result[2]);
+		$this->assertRegExp('/^ErrorHandlerTest\:\:testHandleErrorLoggingTrace\(\)/', $result[3]);
 		if (file_exists(LOGS . 'debug.log')) {
 			unlink(LOGS . 'debug.log');
 		}


### PR DESCRIPTION
I would like to be able to customize the error message which is logged by `CakeLog` without having to copy and paste code from `ErrorHandler` into my own version.

This pull request simply extracts the generation of the error trace to a helper function which can then be overridden in a custom error handler which extends the default.
