### PR TITLE
Ensure a connection exists before using it.

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -82,6 +82,7 @@ trait SqlserverDialectTrait
      */
     public function _version()
     {
+        $this->connect();
         return $this->_connection->getAttribute(PDO::ATTR_SERVER_VERSION);
     }
 

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -139,12 +139,13 @@ trait PDODriverTrait
     }
 
     /**
-     * Rollsback a transaction
+     * Rollback a transaction
      *
      * @return bool true on success, false otherwise
      */
     public function rollbackTransaction()
     {
+        $this->connect();
         if (!$this->_connection->inTransaction()) {
             return false;
         }

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -141,4 +141,23 @@ class MysqlTest extends TestCase
         $connection->connect();
         $this->assertTrue($connection->isConnected(), 'Should be connected.');
     }
+
+    public function testRollbackTransactionAutoConnect()
+    {
+        $connection = ConnectionManager::get('test');
+        $connection->disconnect();
+
+        $driver = $connection->driver();
+        $this->assertFalse($driver->rollbackTransaction());
+        $this->assertTrue($driver->isConnected());
+    }
+
+    public function testCommitTransactionAutoConnect()
+    {
+        $connection = ConnectionManager::get('test');
+        $driver = $connection->driver();
+
+        $this->assertFalse($driver->commitTransaction());
+        $this->assertTrue($driver->isConnected());
+    }
 }


### PR DESCRIPTION
Fix up `SqlServer::_version` to ensure a connection exists before using it. Also fix similar issues I found in PDODriverTrait and add some test coverage.

Refs #8489
