### PR TITLE
Skip memory leak tests when coverage is on.

### DIFF
--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1204,8 +1204,9 @@ class QueryRegressionTest extends TestCase
      *
      * @return void
      */
-    public function testFormatResultsMemory()
+    public function testFormatResultsMemoryLeak()
     {
+        $this->skipIf(env('CODECOVERAGE') == 1, 'Running coverage this causes this tests to fail sometimes.');
         $table = TableRegistry::get('Articles');
         $table->belongsTo('Authors');
         $table->belongsToMany('Tags');
@@ -1221,7 +1222,7 @@ class QueryRegressionTest extends TestCase
         }
         gc_collect_cycles();
         $endMemory = memory_get_usage() / 1024 / 1024;
-        $this->assertWithinRange($endMemory, $memory, 1.50, 'Memory leak in ResultSet');
+        $this->assertWithinRange($endMemory, $memory, 1.25, 'Memory leak in ResultSet');
     }
 
     /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1921,6 +1921,7 @@ TEXT;
      */
     public function testMemoryLeakInPaths()
     {
+        $this->skipIf(env('CODECOVERAGE') == 1, 'Running coverage this causes this tests to fail sometimes.');
         $this->ThemeController->plugin = null;
         $this->ThemeController->name = 'Posts';
 
@@ -1935,7 +1936,7 @@ TEXT;
             $View->element('test_element');
         }
         $end = memory_get_usage();
-        $this->assertLessThanOrEqual($start + 25000, $end);
+        $this->assertLessThanOrEqual($start + 15000, $end);
     }
 
     /**


### PR DESCRIPTION
Despite fiddling with limits and boundaries these continue to fail sometimes. I feel that continuously bumping the threshold defeats the purpose of these tests and instead we can skip these tests when generating coverage.
