### PR TITLE
Slug transliterator

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -731,6 +731,7 @@ class Inflector
      * Returns a string with all spaces converted to dashes (by default), accented
      * characters converted to non-accented characters, and non word characters removed.
      *
+     * @deprecated 3.2.7 Use Text::slug() instead.
      * @param string $string the string you want to slug
      * @param string $replacement will replace keys in map
      * @return string

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -28,7 +28,7 @@ class Text
      *
      * @param string $defaultTransliteratorId Transliterator identifer string.
      */
-    public static $defaultTransliteratorId = 'Any-Latin; Latin-ASCII';
+    public static $defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
 
     /**
      * Generate a random UUID version 4

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -24,7 +24,7 @@ class Text
 {
 
     /**
-     * Default transliteration id.
+     * Default transliterator id string.
      *
      * @param string $defaultTransliteratorId Transliterator identifer string.
      */
@@ -867,6 +867,7 @@ class Text
      * @param string|null $transliteratorId Transliterator identifer. If null
      *   Text::$defaultTransliteratorId will be used.
      * @return string
+     * @see http://php.net/manual/en/transliterator.transliterate.php
      */
     public static function transliterate($string, $transliteratorId = null)
     {
@@ -875,11 +876,15 @@ class Text
     }
 
     /**
-     * Returns a string with all spaces converted to dashes (by default), accented
-     * characters converted to non-accented characters, and non word characters removed.
+     * Returns a string with all spaces converted to dashes (by default),
+     * characters transliterated to ASCII characters, and non word characters removed.
      *
      * @param string $string the string you want to slug
-     * @param array $options Options
+     * @param array $options Valid options:
+     *   - `replacement`: Replacement string. Default '-'.
+     *   - `transliteratorId`: A valid tranliteratorId string.
+     *     If default `null` Text::$defaultTransliteratorId to be used.
+     *     If `false` no transliteration will be done, only non words will be removed.
      * @return string
      */
     public static function slug($string, $options = [])

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -24,6 +24,13 @@ class Text
 {
 
     /**
+     * Default transliteration id.
+     *
+     * @param string $defaultTransliteratorId Transliterator identifer string.
+     */
+    public static $defaultTransliteratorId = 'Any-Latin; Latin-ASCII';
+
+    /**
      * Generate a random UUID version 4
      *
      * Warning: This method should not be used as a random seed for any cryptographic operations.
@@ -865,7 +872,7 @@ class Text
     {
         $options += [
             'replacement' => '-',
-            'transliteratorId' => 'Any-Latin; Latin-ASCII'
+            'transliteratorId' => static::$defaultTransliteratorId
         ];
 
         $quotedReplacement = preg_quote($options['replacement'], '/');

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -26,9 +26,9 @@ class Text
     /**
      * Default transliterator id string.
      *
-     * @param string $defaultTransliteratorId Transliterator identifer string.
+     * @param string $_defaultTransliteratorId Transliterator identifer string.
      */
-    public static $defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
+    protected static $_defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
 
     /**
      * Generate a random UUID version 4
@@ -861,17 +861,32 @@ class Text
     }
 
     /**
+     * Get/set defautl transliterator identifer string.
+     *
+     * @param string $transliteratorId Transliterator identifer.
+     * @return string|null
+     */
+    public static function defaultTransliteratorId($transliteratorId = null)
+    {
+        if ($transliteratorId === null) {
+            return static::$_defaultTransliteratorId;
+        }
+
+        static::$_defaultTransliteratorId = $transliteratorId;
+    }
+
+    /**
      * Transliterate string.
      *
      * @param string $string String to transliterate.
      * @param string|null $transliteratorId Transliterator identifer. If null
-     *   Text::$defaultTransliteratorId will be used.
+     *   Text::$_defaultTransliteratorId will be used.
      * @return string
      * @see http://php.net/manual/en/transliterator.transliterate.php
      */
     public static function transliterate($string, $transliteratorId = null)
     {
-        $transliteratorId = $transliteratorId ?: static::$defaultTransliteratorId;
+        $transliteratorId = $transliteratorId ?: static::$_defaultTransliteratorId;
         return transliterator_transliterate($transliteratorId, $string);
     }
 
@@ -883,7 +898,7 @@ class Text
      * @param array $options Valid options:
      *   - `replacement`: Replacement string. Default '-'.
      *   - `transliteratorId`: A valid tranliterator id string.
-     *     If default `null` Text::$defaultTransliteratorId to be used.
+     *     If default `null` Text::$_defaultTransliteratorId to be used.
      *     If `false` no transliteration will be done, only non words will be removed.
      *   - `preserve`: Specific non-word character to preserve. Default `null`.
      *     For e.g. this option can be set to '.' to generate clean file names.

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -852,4 +852,31 @@ class Text
         }
         throw new InvalidArgumentException('No unit type.');
     }
+
+    /**
+     * Returns a string with all spaces converted to dashes (by default), accented
+     * characters converted to non-accented characters, and non word characters removed.
+     *
+     * @param string $string the string you want to slug
+     * @param array $options Options
+     * @return string
+     */
+    public static function slug($string, $options = [])
+    {
+        $options += [
+            'replacement' => '-',
+            'transliteratorId' => 'Any-Latin; Latin-ASCII'
+        ];
+
+        $quotedReplacement = preg_quote($options['replacement'], '/');
+        $map = [
+            '/[^\s\p{Zs}\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]/mu' => ' ',
+            '/[\s\p{Zs}]+/mu' => $options['replacement'],
+            sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
+        ];
+
+        $string = preg_replace(array_keys($map), array_values($map), $string);
+
+        return transliterator_transliterate($options['transliteratorId'], $string);
+    }
 }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -875,15 +875,16 @@ class Text
             'transliteratorId' => static::$defaultTransliteratorId
         ];
 
+        $string = transliterator_transliterate($options['transliteratorId'], $string);
+
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [
-            '/[^\s\p{Zs}\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]/mu' => ' ',
-            '/[\s\p{Zs}]+/mu' => $options['replacement'],
+            '/[^\sa-zA-Z0-9]/mu' => ' ',
+            '/[\s]+/mu' => $options['replacement'],
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];
-
         $string = preg_replace(array_keys($map), array_values($map), $string);
 
-        return transliterator_transliterate($options['transliteratorId'], $string);
+        return $string;
     }
 }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -28,7 +28,7 @@ class Text
      *
      * @param string $defaultTransliteratorId Transliterator identifer string.
      */
-    public static $defaultTransliteratorId = 'Any-Latin; Latin-ASCII';
+    public static $defaultTransliteratorId = 'Latin-ASCII';
 
     /**
      * Generate a random UUID version 4
@@ -879,7 +879,7 @@ class Text
 
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [
-            '/[^\sa-zA-Z0-9]/mu' => ' ',
+            '/[^\s\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]/mu' => ' ',
             '/[\s]+/mu' => $options['replacement'],
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -861,6 +861,20 @@ class Text
     }
 
     /**
+     * Transliterate string.
+     *
+     * @param string $string String to transliterate.
+     * @param string|null $transliteratorId Transliterator identifer. If null
+     *   Text::$defaultTransliteratorId will be used.
+     * @return string
+     */
+    public static function transliterate($string, $transliteratorId = null)
+    {
+        $transliteratorId = $transliteratorId ?: static::$defaultTransliteratorId;
+        return transliterator_transliterate($transliteratorId, $string);
+    }
+
+    /**
      * Returns a string with all spaces converted to dashes (by default), accented
      * characters converted to non-accented characters, and non word characters removed.
      *
@@ -872,10 +886,10 @@ class Text
     {
         $options += [
             'replacement' => '-',
-            'transliteratorId' => static::$defaultTransliteratorId
+            'transliteratorId' => null
         ];
 
-        $string = transliterator_transliterate($options['transliteratorId'], $string);
+        $string = static::transliterate($string, $options['transliteratorId']);
 
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -900,18 +900,25 @@ class Text
      * Returns a string with all spaces converted to dashes (by default),
      * characters transliterated to ASCII characters, and non word characters removed.
      *
+     * ### Options:
+     *
+     * - `replacement`: Replacement string. Default '-'.
+     * - `transliteratorId`: A valid tranliterator id string.
+     *   If default `null` Text::$_defaultTransliteratorId to be used.
+     *   If `false` no transliteration will be done, only non words will be removed.
+     * - `preserve`: Specific non-word character to preserve. Default `null`.
+     *   For e.g. this option can be set to '.' to generate clean file names.
+     *
      * @param string $string the string you want to slug
-     * @param array $options Valid options:
-     *   - `replacement`: Replacement string. Default '-'.
-     *   - `transliteratorId`: A valid tranliterator id string.
-     *     If default `null` Text::$_defaultTransliteratorId to be used.
-     *     If `false` no transliteration will be done, only non words will be removed.
-     *   - `preserve`: Specific non-word character to preserve. Default `null`.
-     *     For e.g. this option can be set to '.' to generate clean file names.
+     * @param array $options If string it will be use as replacement character
+     *   or an array of options.
      * @return string
      */
     public static function slug($string, $options = [])
     {
+        if (is_string($options)) {
+            $options = ['replacement' => $options];
+        }
         $options += [
             'replacement' => '-',
             'transliteratorId' => null,

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -882,29 +882,36 @@ class Text
      * @param string $string the string you want to slug
      * @param array $options Valid options:
      *   - `replacement`: Replacement string. Default '-'.
-     *   - `transliteratorId`: A valid tranliteratorId string.
+     *   - `transliteratorId`: A valid tranliterator id string.
      *     If default `null` Text::$defaultTransliteratorId to be used.
      *     If `false` no transliteration will be done, only non words will be removed.
+     *   - `preserve`: Specific non-word character to preserve. Default `null`.
+     *     For e.g. this option can be set to '.' to generate clean file names.
      * @return string
      */
     public static function slug($string, $options = [])
     {
         $options += [
             'replacement' => '-',
-            'transliteratorId' => null
+            'transliteratorId' => null,
+            'preserve' => null
         ];
 
         if ($options['transliteratorId'] !== false) {
             $string = static::transliterate($string, $options['transliteratorId']);
         }
 
+        $regex = '^\s\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}';
+        if ($options['preserve']) {
+            $regex .= '(' . preg_quote($options['preserve'], '/') . ')';
+        }
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [
-            '/[^\s\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]/mu' => ' ',
+            '/[' . $regex . ']/mu' => ' ',
             '/[\s]+/mu' => $options['replacement'],
             sprintf('/^[%s]+|[%s]+$/', $quotedReplacement, $quotedReplacement) => '',
         ];
-        $string = preg_replace(array_keys($map), array_values($map), $string);
+        $string = preg_replace(array_keys($map), $map, $string);
 
         return $string;
     }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -861,10 +861,10 @@ class Text
     }
 
     /**
-     * Get/set defautl transliterator identifer string.
+     * Get/set default transliterator identifer string.
      *
-     * @param string $transliteratorId Transliterator identifer.
-     * @return string|null
+     * @param string|null $transliteratorId Transliterator identifer.
+     * @return string|void
      */
     public static function defaultTransliteratorId($transliteratorId = null)
     {

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -26,7 +26,7 @@ class Text
     /**
      * Default transliterator id string.
      *
-     * @param string $_defaultTransliteratorId Transliterator identifer string.
+     * @param string $_defaultTransliteratorId Transliterator identifier string.
      */
     protected static $_defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
 
@@ -861,9 +861,9 @@ class Text
     }
 
     /**
-     * Get default transliterator identifer string.
+     * Get default transliterator identifier string.
      *
-     * @return string Transliterator identifer.
+     * @return string Transliterator identifier.
      */
     public static function getTransliteratorId()
     {
@@ -871,9 +871,9 @@ class Text
     }
 
     /**
-     * Set default transliterator identifer string.
+     * Set default transliterator identifier string.
      *
-     * @param string $transliteratorId Transliterator identifer.
+     * @param string $transliteratorId Transliterator identifier.
      * @return void
      */
     public static function setTransliteratorId($transliteratorId)
@@ -885,7 +885,7 @@ class Text
      * Transliterate string.
      *
      * @param string $string String to transliterate.
-     * @param string|null $transliteratorId Transliterator identifer. If null
+     * @param string|null $transliteratorId Transliterator identifier. If null
      *   Text::$_defaultTransliteratorId will be used.
      * @return string
      * @see http://php.net/manual/en/transliterator.transliterate.php

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -28,7 +28,7 @@ class Text
      *
      * @param string $defaultTransliteratorId Transliterator identifer string.
      */
-    public static $defaultTransliteratorId = 'Latin-ASCII';
+    public static $defaultTransliteratorId = 'Any-Latin; Latin-ASCII';
 
     /**
      * Generate a random UUID version 4
@@ -889,7 +889,9 @@ class Text
             'transliteratorId' => null
         ];
 
-        $string = static::transliterate($string, $options['transliteratorId']);
+        if ($options['transliteratorId'] !== false) {
+            $string = static::transliterate($string, $options['transliteratorId']);
+        }
 
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -861,17 +861,23 @@ class Text
     }
 
     /**
-     * Get/set default transliterator identifer string.
+     * Get default transliterator identifer string.
      *
-     * @param string|null $transliteratorId Transliterator identifer.
-     * @return string|void
+     * @return string Transliterator identifer.
      */
-    public static function defaultTransliteratorId($transliteratorId = null)
+    public static function getTransliteratorId()
     {
-        if ($transliteratorId === null) {
-            return static::$_defaultTransliteratorId;
-        }
+        return static::$_defaultTransliteratorId;
+    }
 
+    /**
+     * Set default transliterator identifer string.
+     *
+     * @param string $transliteratorId Transliterator identifer.
+     * @return void
+     */
+    public static function setTransliteratorId($transliteratorId)
+    {
         static::$_defaultTransliteratorId = $transliteratorId;
     }
 

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "suggest": {
-      "ext-intl": "To use Text::slug()."
+      "ext-intl": "To use Text::transliterate() or Text::slug()"
     },
     "autoload": {
         "psr-4": {

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -4,10 +4,13 @@
     "license": "MIT",
     "authors": [
         {
-        "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
-    }
+            "name": "CakePHP Community",
+            "homepage": "http://cakephp.org"
+        }
     ],
+    "suggest": {
+      "ext-intl": "To use Text::slug()."
+    },
     "autoload": {
         "psr-4": {
             "Cake\\Utility\\": "."

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1588,4 +1588,85 @@ podeís adquirirla.</span></p>
             [['size' => '2VB', 'default' => 'Unknown type'], 'Unknown type']
         ];
     }
+
+    public function slugInputProvider()
+    {
+        return [
+            [
+                'Foo Bar: Not just for breakfast any-more', [],
+                'Foo-Bar-Not-just-for-breakfast-any-more'
+            ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['replacement' => '_'],
+                'Foo_Bar_Not_just_for_breakfast_any_more'
+            ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['replacement' => '+'],
+                'Foo+Bar+Not+just+for+breakfast+any+more'
+            ],
+            [
+                'Äpfel Über Öl grün ärgert groß öko', [],
+                'Aepfel-Ueber-Oel-gruen-aergert-gross-oeko'
+            ],
+            [
+                'The truth - and- more- news', [],
+                'The-truth-and-more-news'
+            ],
+            [
+                'The truth: and more news', [],
+                'The-truth-and-more-news'
+            ],
+            [
+                'La langue française est un attribut de souveraineté en France', [],
+                'La-langue-francaise-est-un-attribut-de-souverainete-en-France'
+            ],
+            [
+                '!@$#exciting stuff! - what !@-# was that?', [],
+                'exciting-stuff-what-was-that'
+            ],
+            [
+                '20% of profits went to me!', [],
+                '20-of-profits-went-to-me'
+            ],
+            [
+                '#this melts your face1#2#3', [],
+                'this-melts-your-face1-2-3'
+            ],
+            [
+                'controller/action/りんご/1', [],
+                'controller-action-りんご-1'
+            ],
+            [
+                'の話が出たので大丈夫かなあと', [],
+                'の話が出たので大丈夫かなあと'
+            ],
+            [
+                'posts/view/한국어/page:1/sort:asc', [],
+                'posts-view-한국어-page-1-sort-asc'
+            ],
+            [
+                "non\xc2\xa0breaking\xc2\xa0space", [],
+                'non-breaking-space'
+            ],
+            [
+                'Foo Bar: Not just for breakfast any-more', ['replacement' => ''],
+                'FooBarNotjustforbreakfastanymore'
+            ],
+        ];
+    }
+
+    /**
+     * testSlug method
+     *
+     * @param string $string String
+     * @param array $options Options
+     * @param String $expected Exepected string
+     * @return void
+     * @dataProvider slugInputProvider
+     */
+    public function testSlug($string, $options, $expected)
+    {
+        $result = Text::slug($string, $options);
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1671,6 +1671,10 @@ podeís adquirirla.</span></p>
                 'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-est-fi'
             ],
             [
+                'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', ['transliteratorId' => 'Latin-ASCII'],
+                'A-ae-Ubermensch-pa-hoyeste-niva-И-я-люблю-PHP-есть-fi'
+            ],
+            [
                 'Äpfel Über Öl grün ärgert groß öko', [],
                 'Apfel-Uber-Ol-grun-argert-gross-oko'
             ],

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1722,6 +1722,10 @@ podeís adquirirla.</span></p>
                 'Foo Bar: Not just for breakfast any-more', ['replacement' => ''],
                 'FooBarNotjustforbreakfastanymore'
             ],
+            [
+                'clean!_me.tar.gz', ['preserve' => '.'],
+                'clean-me.tar.gz'
+            ]
         ];
     }
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1605,6 +1605,10 @@ podeís adquirirla.</span></p>
                 'Foo+Bar+Not+just+for+breakfast+any+more'
             ],
             [
+                'A æ Übérmensch på høyeste nivå! И я люблю PHP! ﬁ', [],
+                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-fi'
+            ],
+            [
                 'Äpfel Über Öl grün ärgert groß öko', [],
                 'Aepfel-Ueber-Oel-gruen-aergert-gross-oeko'
             ],

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1603,7 +1603,7 @@ podeís adquirirla.</span></p>
             ],
             [
                 'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', null,
-                'A ae Ubermensch pa hoyeste niva! I a lublu PHP! estʹ. fi ¦'
+                'A ae Ubermensch pa hoyeste niva! I a lublu PHP! est. fi '
             ],
             [
                 'Äpfel Über Öl grün ärgert groß öko', null,
@@ -1668,7 +1668,7 @@ podeís adquirirla.</span></p>
             ],
             [
                 'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', [],
-                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-estʹ-fi'
+                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-est-fi'
             ],
             [
                 'Äpfel Über Öl grün ärgert groß öko', [],

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1589,6 +1589,18 @@ podeís adquirirla.</span></p>
         ];
     }
 
+    public function testDefaultTransliteratorId()
+    {
+        $expected = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
+        $this->assertEquals($expected, Text::defaultTransliteratorId());
+
+        $expected = 'Latin-ASCII; [\u0080-\u7fff] remove';
+        Text::defaultTransliteratorId($expected);
+        $this->assertEquals($expected, Text::defaultTransliteratorId());
+
+        Text::defaultTransliteratorId('Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove');
+    }
+
     /**
      * Data provider for testTransliterate()
      *

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1603,11 +1603,11 @@ podeís adquirirla.</span></p>
             ],
             [
                 'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', null,
-                'A ae Ubermensch pa hoyeste niva! И я люблю PHP! есть. fi ¦'
+                'A ae Ubermensch pa hoyeste niva! I a lublu PHP! estʹ. fi ¦'
             ],
             [
                 'Äpfel Über Öl grün ärgert groß öko', null,
-                'Aepfel Ueber Oel gruen aergert gross oeko'
+                'Apfel Uber Ol grun argert gross oko'
             ],
             [
                 'La langue française est un attribut de souveraineté en France', null,
@@ -1619,15 +1619,15 @@ podeís adquirirla.</span></p>
             ],
             [
                 'controller/action/りんご/1', null,
-                'controller/action/りんご/1'
+                'controller/action/ringo/1'
             ],
             [
                 'の話が出たので大丈夫かなあと', null,
-                'の話が出たので大丈夫かなあと'
+                'no huaga chutanode da zhang fukanaato'
             ],
             [
                 'posts/view/한국어/page:1/sort:asc', null,
-                'posts/view/한국어/page:1/sort:asc'
+                'posts/view/hangug-eo/page:1/sort:asc'
             ],
             [
                 "non\xc2\xa0breaking\xc2\xa0space", null,
@@ -1668,11 +1668,11 @@ podeís adquirirla.</span></p>
             ],
             [
                 'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', [],
-                'A-ae-Ubermensch-pa-hoyeste-niva-И-я-люблю-PHP-есть-fi'
+                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-estʹ-fi'
             ],
             [
                 'Äpfel Über Öl grün ärgert groß öko', [],
-                'Aepfel-Ueber-Oel-gruen-aergert-gross-oeko'
+                'Apfel-Uber-Ol-grun-argert-gross-oko'
             ],
             [
                 'The truth - and- more- news', [],
@@ -1699,15 +1699,15 @@ podeís adquirirla.</span></p>
                 'this-melts-your-face1-2-3'
             ],
             [
-                'controller/action/りんご/1', [],
+                'controller/action/りんご/1', ['transliteratorId' => false],
                 'controller-action-りんご-1'
             ],
             [
-                'の話が出たので大丈夫かなあと', [],
+                'の話が出たので大丈夫かなあと', ['transliteratorId' => false],
                 'の話が出たので大丈夫かなあと'
             ],
             [
-                'posts/view/한국어/page:1/sort:asc', [],
+                'posts/view/한국어/page:1/sort:asc', ['transliteratorId' => false],
                 'posts-view-한국어-page-1-sort-asc'
             ],
             [

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1606,7 +1606,7 @@ podeís adquirirla.</span></p>
             ],
             [
                 'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', [],
-                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-est-fi'
+                'A-ae-Ubermensch-pa-hoyeste-niva-И-я-люблю-PHP-есть-fi'
             ],
             [
                 'Äpfel Über Öl grün ärgert groß öko', [],

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1605,8 +1605,8 @@ podeís adquirirla.</span></p>
                 'Foo+Bar+Not+just+for+breakfast+any+more'
             ],
             [
-                'A æ Übérmensch på høyeste nivå! И я люблю PHP! ﬁ', [],
-                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-fi'
+                'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', [],
+                'A-ae-Ubermensch-pa-hoyeste-niva-I-a-lublu-PHP-est-fi'
             ],
             [
                 'Äpfel Über Öl grün ärgert groß öko', [],

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1589,6 +1589,68 @@ podeís adquirirla.</span></p>
         ];
     }
 
+    /**
+     * Data provider for testTransliterate()
+     *
+     * @return array
+     */
+    public function transliterateInputProvider()
+    {
+        return [
+            [
+                'Foo Bar: Not just for breakfast any-more', null,
+                'Foo Bar: Not just for breakfast any-more'
+            ],
+            [
+                'A æ Übérmensch på høyeste nivå! И я люблю PHP! есть. ﬁ ¦', null,
+                'A ae Ubermensch pa hoyeste niva! И я люблю PHP! есть. fi ¦'
+            ],
+            [
+                'Äpfel Über Öl grün ärgert groß öko', null,
+                'Aepfel Ueber Oel gruen aergert gross oeko'
+            ],
+            [
+                'La langue française est un attribut de souveraineté en France', null,
+                'La langue francaise est un attribut de souverainete en France'
+            ],
+            [
+                '!@$#exciting stuff! - what !@-# was that?', null,
+                '!@$#exciting stuff! - what !@-# was that?'
+            ],
+            [
+                'controller/action/りんご/1', null,
+                'controller/action/りんご/1'
+            ],
+            [
+                'の話が出たので大丈夫かなあと', null,
+                'の話が出たので大丈夫かなあと'
+            ],
+            [
+                'posts/view/한국어/page:1/sort:asc', null,
+                'posts/view/한국어/page:1/sort:asc'
+            ],
+            [
+                "non\xc2\xa0breaking\xc2\xa0space", null,
+                'non breaking space'
+            ]
+        ];
+    }
+
+    /**
+     * testTransliterate method
+     *
+     * @param string $string String
+     * @param string $transliteratorId Transliterator Id
+     * @param String $expected Exepected string
+     * @return void
+     * @dataProvider transliterateInputProvider
+     */
+    public function testTransliterate($string, $transliteratorId, $expected)
+    {
+        $result = Text::transliterate($string, $transliteratorId);
+        $this->assertEquals($expected, $result);
+    }
+
     public function slugInputProvider()
     {
         return [

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1589,16 +1589,21 @@ podeís adquirirla.</span></p>
         ];
     }
 
-    public function testDefaultTransliteratorId()
+    /**
+     * Test getting/setting default transliterator id.
+     *
+     * @return void
+     */
+    public function testGetSetTransliteratorId()
     {
-        $expected = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
-        $this->assertEquals($expected, Text::defaultTransliteratorId());
+        $defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
+        $this->assertEquals($defaultTransliteratorId, Text::getTransliteratorId());
 
         $expected = 'Latin-ASCII; [\u0080-\u7fff] remove';
-        Text::defaultTransliteratorId($expected);
-        $this->assertEquals($expected, Text::defaultTransliteratorId());
+        Text::setTransliteratorId($expected);
+        $this->assertEquals($expected, Text::getTransliteratorId());
 
-        Text::defaultTransliteratorId('Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove');
+        Text::setTransliteratorId($defaultTransliteratorId);
     }
 
     /**


### PR DESCRIPTION
- Adds 2 new methods `Text::transliterate()` and `Text::slug()`.
- Transliteration is done using [Transliterator::transliterate()](http://php.net/manual/en/transliterator.transliterate.php) provided by `intl`, which avoid us having to maintain replacements map. By changing the transliterator id string one can also control how transliterations are done.
- `Text::slug()` is more configurable than `Inflector::slug()`. Check options in docblock.

Refs #8441,  #8515
