### PR TITLE
Always call counter function if present

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -729,13 +729,13 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * {@inheritDoc}
      *
-     * Returns the COUNT(*) for the query. If the query has not been
-     * modified, and the count has already been performed the cached
-     * value is returned
+     * Returns the COUNT(*) for the query. A cached value from a previous count
+     * is returned if no counter function is set and the query has not been
+     * modified.
      */
     public function count()
     {
-        if ($this->_resultsCount === null) {
+        if ($this->_resultsCount === null || $this->_counter) {
             $this->_resultsCount = $this->_performCount();
         }
 


### PR DESCRIPTION
The counter function passed to Query::counter() is expected to be called
on each count operation. From the docs:

> Registers a callable function that will be executed when the `count` method in
>      this query is called. The return value for the function will be set as the
>      return value of the `count` method.

This patch respects this and does not cache counter function results.

The counter function very well may cache itself. 
In my particular case I depend on the function always be called.
