### PR TITLE
Completing fix in FileConfigTrait to make phar files work

### DIFF
--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -57,7 +57,7 @@ trait FileConfigTrait
         $file .= $this->_extension;
 
         if (!$checkExists || is_file($file)) {
-            return $file
+            return $file;
         }
 
         if (is_file(realpath($file))) {

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -56,10 +56,14 @@ trait FileConfigTrait
 
         $file .= $this->_extension;
 
-        if ($checkExists && !is_file($file) && !is_file(realpath($file))) {
-            throw new Exception(sprintf('Could not load configuration file: %s', $file));
+        if (!$checkExists || is_file($file)) {
+            return $file
         }
 
-        return $file;
+        if (is_file(realpath($file))) {
+            return realpath($file);
+        }
+
+        throw new Exception(sprintf('Could not load configuration file: %s', $file));
     }
 }


### PR DESCRIPTION
We have to return the actual file that was found. Otherwise we risk including files that are not there.
