### PR TITLE
Making debug functions return the same variable

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -130,10 +130,9 @@ if (!function_exists('pr')) {
      * This function returns the same variable that was passed.
      *
      * @param mixed $var Variable to print out.
-     * @return void
-     * @see debug()
-     * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pr
      * @return mixed the same $var that was passed to this function
+     * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pr
+     * @see debug()
      */
     function pr($var)
     {
@@ -158,10 +157,9 @@ if (!function_exists('pj')) {
      * This function returns the same variable that was passed.
      *
      * @param mixed $var Variable to print out.
-     * @return void
+     * @return mixed the same $var that was passed to this function
      * @see pr()
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pj
-     * @return mixed the same $var that was passed to this function
      */
     function pj($var)
     {

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -127,19 +127,23 @@ if (!function_exists('pr')) {
      * In terminals this will act similar to using print_r() directly, when not run on cli
      * print_r() will also wrap <pre> tags around the output of given variable. Similar to debug().
      *
+     * This function returns the same variable that was passed.
+     *
      * @param mixed $var Variable to print out.
      * @return void
      * @see debug()
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pr
+     * @return mixed the same $var that was passed to this function
      */
     function pr($var)
     {
         if (!Configure::read('debug')) {
-            return;
+            return $var;
         }
 
         $template = (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') ? '<pre class="pr">%s</pre>' : "\n%s\n\n";
         printf($template, trim(print_r($var, true)));
+        return $var;
     }
 
 }
@@ -151,19 +155,23 @@ if (!function_exists('pj')) {
      * In terminals this will act similar to using json_encode() with JSON_PRETTY_PRINT directly, when not run on cli
      * will also wrap <pre> tags around the output of given variable. Similar to pr().
      *
+     * This function returns the same variable that was passed.
+     *
      * @param mixed $var Variable to print out.
      * @return void
      * @see pr()
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#pj
+     * @return mixed the same $var that was passed to this function
      */
     function pj($var)
     {
         if (!Configure::read('debug')) {
-            return;
+            return $var;
         }
 
         $template = (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') ? '<pre class="pj">%s</pre>' : "\n%s\n\n";
         printf($template, trim(json_encode($var, JSON_PRETTY_PRINT)));
+        return $var;
     }
 
 }

--- a/src/basics.php
+++ b/src/basics.php
@@ -36,10 +36,9 @@ if (!function_exists('debug')) {
      * @param mixed $var Variable to show debug information for.
      * @param bool|null $showHtml If set to true, the method prints the debug data in a browser-friendly way.
      * @param bool $showFrom If set to true, the method prints from where the function was called.
-     * @return void
+     * @return mixed The same $var that was passed
      * @link http://book.cakephp.org/3.0/en/development/debugging.html#basic-debugging
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#debug
-     * @return mixed The same $var that was passed
      */
     function debug($var, $showHtml = null, $showFrom = true)
     {

--- a/src/basics.php
+++ b/src/basics.php
@@ -28,7 +28,8 @@ use Cake\Error\Debugger;
 
 if (!function_exists('debug')) {
     /**
-     * Prints out debug information about given variable.
+     * Prints out debug information about given variable and returns the
+     * variable that was passed.
      *
      * Only runs if debug level is greater than zero.
      *
@@ -38,13 +39,15 @@ if (!function_exists('debug')) {
      * @return void
      * @link http://book.cakephp.org/3.0/en/development/debugging.html#basic-debugging
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#debug
+     * @return mixed The same $var that was passed
      */
     function debug($var, $showHtml = null, $showFrom = true)
     {
         if (!Configure::read('debug')) {
-            return;
+            return $var;
         }
 
+        $originalVar = $var;
         $file = '';
         $line = '';
         $lineInfo = '';
@@ -91,6 +94,7 @@ TEXT;
             }
         }
         printf($template, $lineInfo, $var);
+        return $originalVar;
     }
 
 }
@@ -118,28 +122,6 @@ if (!function_exists('stackTrace')) {
         $options += ['start' => 0];
         $options['start']++;
         echo Debugger::trace($options);
-    }
-
-}
-
-if (!function_exists('json_last_error_msg')) {
-    /**
-     * Provides the fallback implementation of json_last_error_msg() available in PHP 5.5 and above.
-     *
-     * @return string Error message.
-     */
-    function json_last_error_msg()
-    {
-        static $errors = [
-            JSON_ERROR_NONE => '',
-            JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
-            JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
-            JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
-            JSON_ERROR_SYNTAX => 'Syntax error',
-            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
-        ];
-        $error = json_last_error();
-        return array_key_exists($error, $errors) ? $errors[$error] : "Unknown error ({$error})";
     }
 
 }

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -224,7 +224,7 @@ class BasicsTest extends TestCase
     public function testDebug()
     {
         ob_start();
-        debug('this-is-a-test', false);
+        $this->assertEquals('this-is-a-test', debug('this-is-a-test', false));
         $result = ob_get_clean();
         $expectedText = <<<EXPECTED
 %s (line %d)
@@ -238,7 +238,8 @@ EXPECTED;
         $this->assertEquals($expected, $result);
 
         ob_start();
-        debug('<div>this-is-a-test</div>', true);
+        $value = '<div>this-is-a-test</div>';
+        $this->assertSame($value, debug($value, true));
         $result = ob_get_clean();
         $expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
@@ -369,7 +370,7 @@ EXPECTED;
         $this->assertEquals($expected, $result);
 
         ob_start();
-        debug(false, false, false);
+        $this->assertFalse(debug(false, false, false));
         $result = ob_get_clean();
         $expected = <<<EXPECTED
 
@@ -390,25 +391,25 @@ EXPECTED;
     public function testPr()
     {
         ob_start();
-        pr(true);
+        $this->assertTrue(pr(true));
         $result = ob_get_clean();
         $expected = "\n1\n\n";
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pr(false);
+        $this->assertFalse(pr(false));
         $result = ob_get_clean();
         $expected = "\n\n\n";
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pr(null);
+        $this->assertNull(pr(null));
         $result = ob_get_clean();
         $expected = "\n\n\n";
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pr(123);
+        $this->assertSame(123, pr(123));
         $result = ob_get_clean();
         $expected = "\n123\n\n";
         $this->assertEquals($expected, $result);
@@ -440,25 +441,25 @@ EXPECTED;
     public function testPj()
     {
         ob_start();
-        pj(true);
+        $this->assertTrue(pj(true));
         $result = ob_get_clean();
         $expected = "\ntrue\n\n";
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pj(false);
+        $this->assertFalse(pj(false));
         $result = ob_get_clean();
         $expected = "\nfalse\n\n";
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pj(null);
+        $this->assertNull(pj(null));
         $result = ob_get_clean();
         $expected = "\nnull\n\n";
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pj(123);
+        $this->assertSame(123, pj(123));
         $result = ob_get_clean();
         $expected = "\n123\n\n";
         $this->assertEquals($expected, $result);
@@ -476,7 +477,8 @@ EXPECTED;
         $this->assertEquals($expected, $result);
 
         ob_start();
-        pj(['this' => 'is', 'a' => 'test', 123 => 456]);
+        $value = ['this' => 'is', 'a' => 'test', 123 => 456];
+        $this->assertSame($value, pj($value));
         $result = ob_get_clean();
         $expected = "\n{\n    \"this\": \"is\",\n    \"a\": \"test\",\n    \"123\": 456\n}\n\n";
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
After using the debugging functions in Elm, I came to realize a simple but life changing hack. I always have code like this

``` php
...
return my_func($var);
```

But then if I want to debug before returning, I have to assign to a variable:

``` php
$a = my_func($var);
debug($a);
return $a;
```

It is annoying, so this change makes the following possible:

``` php
...
return debug(my_func($var));
```

Additionally, removed the polyfill for `json_last_error_msg`
