### PR TITLE
Add support for cells in sub-namespaces.

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -16,6 +16,7 @@ namespace Cake\View;
 
 use BadMethodCallException;
 use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
@@ -201,10 +202,12 @@ abstract class Cell
             $builder->layout(false)
                 ->template($template);
 
-            $className = substr(strrchr(get_class($this), "\\"), 1);
-            $name = substr($className, 0, -4);
+            $className = get_class($this);
+            $namePrefix = '\View\Cell\\';
+            $name = substr($className, strpos($className, $namePrefix) + strlen($namePrefix));
+            $name = substr($name, 0, -4);
             if (!$builder->templatePath()) {
-                $builder->templatePath('Cell' . DIRECTORY_SEPARATOR . $name);
+                $builder->templatePath('Cell' . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $name));
             }
 
             $this->View = $this->createView();

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -243,6 +243,28 @@ class CellTest extends TestCase
     }
 
     /**
+     * Tests that using namespaced cells works.
+     *
+     * @return void
+     */
+    public function testNamespacedCell()
+    {
+        $cell = $this->View->cell('Admin/Menu');
+        $this->assertContains('Admin Menu Cell', $cell->render());
+    }
+
+    /**
+     * Tests that using namespaced cells in plugins works
+     *
+     * @return void
+     */
+    public function testPluginNamespacedCell()
+    {
+        $cell = $this->View->cell('TestPlugin.Admin/Menu');
+        $this->assertContains('Test Plugin Admin Menu Cell', $cell->render());
+    }
+
+    /**
      * Test that plugin cells can render other view templates.
      *
      * @return void

--- a/tests/test_app/Plugin/TestPlugin/src/Template/Cell/Admin/Menu/display.ctp
+++ b/tests/test_app/Plugin/TestPlugin/src/Template/Cell/Admin/Menu/display.ctp
@@ -1,0 +1,1 @@
+Test Plugin Admin Menu Cell

--- a/tests/test_app/Plugin/TestPlugin/src/View/Cell/Admin/MenuCell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Cell/Admin/MenuCell.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.6
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\View\Cell\Admin;
+
+/**
+ * TestPlugin Admin Menu Cell
+ *
+ */
+class MenuCell extends \Cake\View\Cell
+{
+    /**
+     * Default cell action.
+     *
+     * @return void
+     */
+    public function display()
+    {
+    }
+}

--- a/tests/test_app/TestApp/Template/Cell/Admin/Menu/display.ctp
+++ b/tests/test_app/TestApp/Template/Cell/Admin/Menu/display.ctp
@@ -1,0 +1,1 @@
+Admin Menu Cell

--- a/tests/test_app/TestApp/View/Cell/Admin/MenuCell.php
+++ b/tests/test_app/TestApp/View/Cell/Admin/MenuCell.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.6
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\View\Cell\Admin;
+
+/**
+ * Admin Menu Cell
+ *
+ */
+class MenuCell extends \Cake\View\Cell
+{
+    /**
+     * Default cell action.
+     *
+     * @return void
+     */
+    public function display()
+    {
+    }
+}


### PR DESCRIPTION
Use more clever string slicing to extract the trailing part of the classname enabling cells to be located in sub-namespaces. This allows Cells to be structured like Elements and use subdirectories for more organization.

Refs #8520
