### PR TITLE
RFC - Deprecate duplicate methods in Router

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -223,10 +223,6 @@ class Router
      */
     public static function redirect($route, $url, $options = [])
     {
-        trigger_error(
-            'Router::redirect() is deprecated. Use Router::scope() and $routes->redirect() instead.',
-            E_USER_DEPRECATED
-        );
         $options['routeClass'] = 'Cake\Routing\Route\RedirectRoute';
         if (is_string($url)) {
             $url = ['redirect' => $url];
@@ -289,10 +285,6 @@ class Router
      */
     public static function mapResources($controller, $options = [])
     {
-        trigger_error(
-            'Router::mapResources() is deprecated. Use Router::scope() and $routes->resources() instead.',
-            E_USER_DEPRECATED
-        );
         foreach ((array)$controller as $name) {
             list($plugin, $name) = pluginSplit($name);
 
@@ -812,10 +804,6 @@ class Router
      */
     public static function parseNamedParams(Request $request, array $options = [])
     {
-        trigger_error(
-            'Router::parseNamedParams() is deprecated and will be removed in 4.0.',
-            E_USER_DEPRECATED
-        );
         $options += ['separator' => ':'];
         if (empty($request->params['pass'])) {
             $request->params['named'] = [];

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -219,7 +219,7 @@ class Router
      *   shifted into the passed arguments. As well as supplying patterns for routing parameters.
      * @return void
      * @see \Cake\Routing\RouteBuilder::redirect()
-     * @deprected 3.3.0 Use Router::scope() and RouteBuilder::redirect() instead.
+     * @deprecated 3.3.0 Use Router::scope() and RouteBuilder::redirect() instead.
      */
     public static function redirect($route, $url, $options = [])
     {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -219,9 +219,14 @@ class Router
      *   shifted into the passed arguments. As well as supplying patterns for routing parameters.
      * @return void
      * @see \Cake\Routing\RouteBuilder::redirect()
+     * @deprected 3.3.0 Use Router::scope() and RouteBuilder::redirect() instead.
      */
     public static function redirect($route, $url, $options = [])
     {
+        trigger_error(
+            'Router::redirect() is deprecated. Use Router::scope() and $routes->redirect() instead.',
+            E_USER_DEPRECATED
+        );
         $options['routeClass'] = 'Cake\Routing\Route\RedirectRoute';
         if (is_string($url)) {
             $url = ['redirect' => $url];
@@ -279,10 +284,15 @@ class Router
      * @param string|array $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
      * @param array $options Options to use when generating REST routes
      * @see \Cake\Routing\RouteBuilder::resources()
+     * @deprecated 3.3.0 Use Router::scope() and RouteBuilder::resources() instead.
      * @return void
      */
     public static function mapResources($controller, $options = [])
     {
+        trigger_error(
+            'Router::mapResources() is deprecated. Use Router::scope() and $routes->resources() instead.',
+            E_USER_DEPRECATED
+        );
         foreach ((array)$controller as $name) {
             list($plugin, $name) = pluginSplit($name);
 
@@ -798,9 +808,14 @@ class Router
      * @param \Cake\Network\Request $request The request object to modify.
      * @param array $options The array of options.
      * @return \Cake\Network\Request The modified request
+     * @deprecated 3.3.0 Named parameter backwards compatibility will be removed in 4.0.
      */
     public static function parseNamedParams(Request $request, array $options = [])
     {
+        trigger_error(
+            'Router::parseNamedParams() is deprecated and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
         $options += ['separator' => ':'];
         if (empty($request->params['pass'])) {
             $request->params['named'] = [];

--- a/tests/TestCase/Routing/Filter/RoutingFilterTest.php
+++ b/tests/TestCase/Routing/Filter/RoutingFilterTest.php
@@ -77,8 +77,10 @@ class RoutingFilterTest extends TestCase
      */
     public function testBeforeDispatchRedirectRoute()
     {
-        Router::redirect('/home', ['controller' => 'articles']);
-        Router::connect('/:controller/:action/*');
+        Router::scope('/', function ($routes) {
+            $routes->redirect('/home', ['controller' => 'articles']);
+            $routes->connect('/:controller/:action/*');
+        });
         $filter = new RoutingFilter();
 
         $request = new Request("/home");
@@ -86,7 +88,7 @@ class RoutingFilterTest extends TestCase
         $event = new Event(__CLASS__, $this, compact('request', 'response'));
         $response = $filter->beforeDispatch($event);
         $this->assertInstanceOf('Cake\Network\Response', $response);
-        $this->assertSame('http://localhost/articles/index', $response->header()['Location']);
+        $this->assertSame('http://localhost/articles', $response->header()['Location']);
         $this->assertSame(301, $response->statusCode());
     }
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -134,7 +134,6 @@ class RouterTest extends TestCase
      */
     public function testMapResources()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('Posts');
 
         $expected = [
@@ -225,7 +224,6 @@ class RouterTest extends TestCase
         ];
         $result = Router::parse('/posts/name', 'PUT');
         $this->assertEquals($expected, $result);
-        error_reporting($restore);
     }
 
     /**
@@ -235,7 +233,6 @@ class RouterTest extends TestCase
      */
     public function testPluginMapResources()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('TestPlugin.TestPlugin');
 
         $result = Router::parse('/test_plugin/test_plugin', 'GET');
@@ -258,7 +255,6 @@ class RouterTest extends TestCase
             '_method' => 'GET',
         ];
         $this->assertEquals($expected, $result);
-        error_reporting($restore);
     }
 
     /**
@@ -268,7 +264,6 @@ class RouterTest extends TestCase
      */
     public function testMapResourcesWithPrefix()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('Posts', ['prefix' => 'api']);
 
         $result = Router::parse('/api/posts', 'GET');
@@ -282,7 +277,6 @@ class RouterTest extends TestCase
             '_method' => 'GET',
         ];
         $this->assertEquals($expected, $result);
-        error_reporting($restore);
     }
 
     /**
@@ -292,7 +286,6 @@ class RouterTest extends TestCase
      */
     public function testMapResourcesWithExtension()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::extensions(['json', 'xml'], false);
         Router::mapResources('Posts', ['_ext' => 'json']);
 
@@ -313,7 +306,6 @@ class RouterTest extends TestCase
 
         $result = Router::parse('/posts.xml', 'GET');
         $this->assertArrayNotHasKey('_method', $result, 'Not an extension/resource route.');
-        error_reporting($restore);
     }
 
     /**
@@ -321,7 +313,6 @@ class RouterTest extends TestCase
      */
     public function testMapResourcesConnectOptions()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Plugin::load('TestPlugin');
         Router::mapResources('Posts', [
             'connectOptions' => [
@@ -333,7 +324,6 @@ class RouterTest extends TestCase
         $route = $routes[0];
         $this->assertInstanceOf('TestPlugin\Routing\Route\TestRoute', $route);
         $this->assertEquals('^(bar)$', $route->options['foo']);
-        error_reporting($restore);
     }
 
     /**
@@ -343,7 +333,6 @@ class RouterTest extends TestCase
      */
     public function testPluginMapResourcesWithPrefix()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('TestPlugin.TestPlugin', ['prefix' => 'api']);
 
         $result = Router::parse('/api/test_plugin/test_plugin', 'GET');
@@ -369,7 +358,6 @@ class RouterTest extends TestCase
             'prefix' => 'api',
         ];
         $this->assertEquals($expected, $result);
-        error_reporting($restore);
     }
 
     /**
@@ -409,7 +397,6 @@ class RouterTest extends TestCase
      */
     public function testGenerateUrlResourceRoute()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('Posts');
 
         $result = Router::url([
@@ -444,7 +431,6 @@ class RouterTest extends TestCase
         $result = Router::url(['controller' => 'Posts', 'action' => 'edit', '_method' => 'PATCH', 'id' => 10]);
         $expected = '/posts/10';
         $this->assertEquals($expected, $result);
-        error_reporting($restore);
     }
 
     /**
@@ -2753,12 +2739,10 @@ class RouterTest extends TestCase
      */
     public function testRedirect()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::redirect('/mobile', '/', ['status' => 301]);
         $routes = Router::routes();
         $route = $routes[0];
         $this->assertInstanceOf('Cake\Routing\Route\RedirectRoute', $route);
-        error_reporting($restore);
     }
 
     /**
@@ -2768,8 +2752,6 @@ class RouterTest extends TestCase
      */
     public function testParseNamedParameters()
     {
-        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
-
         $request = new Request();
         $request->addParams([
             'controller' => 'posts',
@@ -2800,7 +2782,6 @@ class RouterTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $request->params);
-        error_reporting($restore);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -134,6 +134,7 @@ class RouterTest extends TestCase
      */
     public function testMapResources()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('Posts');
 
         $expected = [
@@ -224,6 +225,7 @@ class RouterTest extends TestCase
         ];
         $result = Router::parse('/posts/name', 'PUT');
         $this->assertEquals($expected, $result);
+        error_reporting($restore);
     }
 
     /**
@@ -233,6 +235,7 @@ class RouterTest extends TestCase
      */
     public function testPluginMapResources()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('TestPlugin.TestPlugin');
 
         $result = Router::parse('/test_plugin/test_plugin', 'GET');
@@ -255,6 +258,7 @@ class RouterTest extends TestCase
             '_method' => 'GET',
         ];
         $this->assertEquals($expected, $result);
+        error_reporting($restore);
     }
 
     /**
@@ -264,6 +268,7 @@ class RouterTest extends TestCase
      */
     public function testMapResourcesWithPrefix()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('Posts', ['prefix' => 'api']);
 
         $result = Router::parse('/api/posts', 'GET');
@@ -277,6 +282,7 @@ class RouterTest extends TestCase
             '_method' => 'GET',
         ];
         $this->assertEquals($expected, $result);
+        error_reporting($restore);
     }
 
     /**
@@ -286,6 +292,7 @@ class RouterTest extends TestCase
      */
     public function testMapResourcesWithExtension()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::extensions(['json', 'xml'], false);
         Router::mapResources('Posts', ['_ext' => 'json']);
 
@@ -306,6 +313,7 @@ class RouterTest extends TestCase
 
         $result = Router::parse('/posts.xml', 'GET');
         $this->assertArrayNotHasKey('_method', $result, 'Not an extension/resource route.');
+        error_reporting($restore);
     }
 
     /**
@@ -313,6 +321,7 @@ class RouterTest extends TestCase
      */
     public function testMapResourcesConnectOptions()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Plugin::load('TestPlugin');
         Router::mapResources('Posts', [
             'connectOptions' => [
@@ -324,6 +333,7 @@ class RouterTest extends TestCase
         $route = $routes[0];
         $this->assertInstanceOf('TestPlugin\Routing\Route\TestRoute', $route);
         $this->assertEquals('^(bar)$', $route->options['foo']);
+        error_reporting($restore);
     }
 
     /**
@@ -333,6 +343,7 @@ class RouterTest extends TestCase
      */
     public function testPluginMapResourcesWithPrefix()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('TestPlugin.TestPlugin', ['prefix' => 'api']);
 
         $result = Router::parse('/api/test_plugin/test_plugin', 'GET');
@@ -358,6 +369,7 @@ class RouterTest extends TestCase
             'prefix' => 'api',
         ];
         $this->assertEquals($expected, $result);
+        error_reporting($restore);
     }
 
     /**
@@ -397,6 +409,7 @@ class RouterTest extends TestCase
      */
     public function testGenerateUrlResourceRoute()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::mapResources('Posts');
 
         $result = Router::url([
@@ -431,6 +444,7 @@ class RouterTest extends TestCase
         $result = Router::url(['controller' => 'Posts', 'action' => 'edit', '_method' => 'PATCH', 'id' => 10]);
         $expected = '/posts/10';
         $this->assertEquals($expected, $result);
+        error_reporting($restore);
     }
 
     /**
@@ -2739,10 +2753,12 @@ class RouterTest extends TestCase
      */
     public function testRedirect()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
         Router::redirect('/mobile', '/', ['status' => 301]);
         $routes = Router::routes();
         $route = $routes[0];
         $this->assertInstanceOf('Cake\Routing\Route\RedirectRoute', $route);
+        error_reporting($restore);
     }
 
     /**
@@ -2752,6 +2768,8 @@ class RouterTest extends TestCase
      */
     public function testParseNamedParameters()
     {
+        $restore = error_reporting(E_ALL ^ E_USER_DEPRECATED);
+
         $request = new Request();
         $request->addParams([
             'controller' => 'posts',
@@ -2782,6 +2800,7 @@ class RouterTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $request->params);
+        error_reporting($restore);
     }
 
     /**


### PR DESCRIPTION
All of these methods have nicer/better cousins on `RouteBuilder`. By deprecating these methods we can remove them for 4.x. This is a possibly a contentious change as I suspect a few people are using these methods. I _really_ wanted to remove `Router::connect()` as well but I feel that might be too big of a change.

One of the reasons I want to remove these methods is they create broken use cases when combined with scopes. For example:

``` php
Router::scope('/api', function ($routes) {
  Router::mapResources('Articles');
});
```

Does not do what you want. There are many other ways to get into these bad states, and I'd prefer to not have them.
