### PR TITLE
Mapping the json type to JSONB in postgres

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -345,7 +345,7 @@ class PostgresSchema extends BaseSchema
             'datetime' => ' TIMESTAMP',
             'timestamp' => ' TIMESTAMP',
             'uuid' => ' UUID',
-            'json' => ' JSON'
+            'json' => ' JSONB'
         ];
 
         if (isset($typeMap[$data['type']])) {

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -73,7 +73,7 @@ author_id INTEGER NOT NULL,
 published BOOLEAN DEFAULT false,
 views SMALLINT DEFAULT 0,
 readingtime TIME,
-data JSON,
+data JSONB,
 created TIMESTAMP,
 CONSTRAINT "content_idx" UNIQUE ("title", "body"),
 CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
@@ -203,6 +203,10 @@ SQL;
             ],
             [
                 'JSON',
+                ['type' => 'json', 'length' => null]
+            ],
+            [
+                'JSONB',
                 ['type' => 'json', 'length' => null]
             ],
         ];
@@ -988,7 +992,7 @@ CREATE TABLE "schema_articles" (
 "id" SERIAL,
 "title" VARCHAR NOT NULL,
 "body" TEXT,
-"data" JSON,
+"data" JSONB,
 "created" TIMESTAMP,
 PRIMARY KEY ("id")
 )


### PR DESCRIPTION
I made a mistake in my previous pull request by mapping the json
type to plain JSON in postgres, when it should have been JSONB.

JSONB has the advantage that values inside can be indexed and searched
very efficiently.
