### PR TITLE
Missing templates should raise exceptions.

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -16,6 +16,7 @@ namespace Cake\View;
 
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\InstanceConfigTrait;
+use RuntimeException;
 
 /**
  * Provides an interface for registering and inserting
@@ -224,12 +225,9 @@ class StringTemplate
     public function format($name, array $data)
     {
         if (!isset($this->_compiled[$name])) {
-            return null;
+            throw new RuntimeException("Cannot find template named '$name'.");
         }
         list($template, $placeholders) = $this->_compiled[$name];
-        if ($template === null) {
-            return null;
-        }
 
         if (isset($data['templateVars'])) {
             $data += $data['templateVars'];

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -95,9 +95,6 @@ class StringTemplateTest extends TestCase
         ];
         $this->template->add($templates);
 
-        $result = $this->template->format('not there', []);
-        $this->assertNull($result);
-
         $result = $this->template->format('text', ['text' => '']);
         $this->assertSame('', $result);
 
@@ -140,6 +137,22 @@ class StringTemplateTest extends TestCase
             'text' => ['key' => 'example', 'text']
         ]);
         $this->assertEquals('<a href="/">exampletext</a>', $result);
+    }
+
+    /**
+     * Test formatting a missing template.
+     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Cannot find template named 'missing'
+     * @return void
+     */
+    public function testFormatMissingTemplate()
+    {
+        $templates = [
+            'text' => '{{text}}',
+        ];
+        $this->template->add($templates);
+        $this->template->format('missing', ['text' => 'missing']);
     }
 
     /**


### PR DESCRIPTION
Missing templates are a signal that a developer has made a mistake. We should help them find this error and an exception is the simplest way to signal an error to the developer.

Targeting this to `3.next` as it is a new error that I don't feel is appropriate at the bug-fix release level.

Refs #8554
