### PR TITLE
Remove _configClass from Email

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -316,13 +316,6 @@ class Email implements JsonSerializable, Serializable
     protected $_emailPattern = self::EMAIL_PATTERN;
 
     /**
-     * The class name used for email configuration.
-     *
-     * @var string
-     */
-    protected $_configClass = 'EmailConfig';
-
-    /**
      * Constructor
      *
      * @param array|string|null $config Array of configs, or string to load configs from email.php


### PR DESCRIPTION
This property from CakePHP 2 is no longer in use. It should not break BC as its a protected property and doesn't do anything
