### PR TITLE
Fix `driver` option lacking short classname/plugin syntax support.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Database;
 
+use Cake\Core\App;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\MissingDriverException;
 use Cake\Database\Exception\MissingExtensionException;
@@ -158,10 +159,11 @@ class Connection implements ConnectionInterface
             return $this->_driver;
         }
         if (is_string($driver)) {
-            if (!class_exists($driver)) {
+            $className = App::className($driver, 'Database/Driver');
+            if (!$className || !class_exists($className)) {
                 throw new MissingDriverException(['driver' => $driver]);
             }
-            $driver = new $driver($config);
+            $driver = new $className($config);
         }
         if (!$driver->enabled()) {
             throw new MissingExtensionException(['driver' => get_class($driver)]);

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -27,7 +27,7 @@ class ConnectionRegistry extends ObjectRegistry
 {
 
     /**
-     * Resolve a driver classname.
+     * Resolve a datasource classname.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
@@ -43,12 +43,12 @@ class ConnectionRegistry extends ObjectRegistry
     }
 
     /**
-     * Throws an exception when a driver is missing
+     * Throws an exception when a datasource is missing
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
      * @param string $class The classname that is missing.
-     * @param string $plugin The plugin the driver is missing in.
+     * @param string $plugin The plugin the datasource is missing in.
      * @return void
      * @throws \Cake\Datasource\Exception\MissingDatasourceException
      */
@@ -70,7 +70,7 @@ class ConnectionRegistry extends ObjectRegistry
      *
      * @param string|object|callable $class The classname or object to make.
      * @param string $alias The alias of the object.
-     * @param array $settings An array of settings to use for the driver.
+     * @param array $settings An array of settings to use for the datasource.
      * @return object A connection with the correct settings.
      */
     protected function _create($class, $alias, $settings)

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -29,8 +29,9 @@ class ConnectionTest extends TestCase
 
     public function setUp()
     {
-        $this->connection = ConnectionManager::get('test');
         parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+        Configure::write('App.namespace', 'TestApp');
     }
 
     public function tearDown()
@@ -113,6 +114,23 @@ class ConnectionTest extends TestCase
     {
         $mock = $this->getMock('\Cake\Database\Connection\Driver', ['enabled'], [], 'DriverMock');
         $connection = new Connection(['driver' => $mock]);
+    }
+
+    /**
+     * Tests that the `driver` option supports the short classname/plugin syntax.
+     *
+     * @return void
+     */
+    public function testDriverOptionClassNameSupport()
+    {
+        $connection = new Connection(['driver' => 'TestDriver']);
+        $this->assertInstanceOf('\TestApp\Database\Driver\TestDriver', $connection->driver());
+
+        $connection = new Connection(['driver' => 'TestPlugin.TestDriver']);
+        $this->assertInstanceOf('\TestPlugin\Database\Driver\TestDriver', $connection->driver());
+
+        $connection = new Connection(['driver' => 'Sqlite']);
+        $this->assertInstanceOf('\Cake\Database\Driver\Sqlite', $connection->driver());
     }
 
     /**

--- a/tests/test_app/Plugin/TestPlugin/src/Database/Driver/TestDriver.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Database/Driver/TestDriver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.7
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Database\Driver;
+
+use Cake\Database\Driver\Sqlite;
+
+class TestDriver extends Sqlite
+{
+}

--- a/tests/test_app/TestApp/Database/Driver/TestDriver.php
+++ b/tests/test_app/TestApp/Database/Driver/TestDriver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.7
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Database\Driver;
+
+use Cake\Database\Driver\Sqlite;
+
+class TestDriver extends Sqlite
+{
+}


### PR DESCRIPTION
While documented

> **driver**
> 
> > The class name of the driver used to implements all specificities for a database engine. This can either be a short classname using plugin syntax, a fully namespaced name, or a constructed driver instance. Examples of short classnames are Mysql, Sqlite, Postgres, and Sqlserver.

http://book.cakephp.org/3.0/en/orm/database-basics.html#configuration

the `driver` option didn't actually supported the short classname/plugin syntax.

I've kept the old behavior that supports throwing exceptions for missing classes when specifying fully qualified names. I wasn't sure whether removing this would be considered a breaking change, and if removing it would be a welcome change at all.

This seems a little inconistent in the core, in some places the return value of `App::className()` is only being checked for (non-)truthyness, other have an (additional) `class_exists()` check. Maybe it would be good to consolidate the behavior throughout the core, not sure.
