### PR TITLE
Refactoring Travis build for CakePHP >= 3.2.x and PHP >= 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi
   - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi
-  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu_bc; fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu_bc; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then composer require lorenzo/multiple-iterator=~1.0; fi
 
   - phpenv rehash

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,8 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo yes | pecl install apcu; fi
+  - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then composer require lorenzo/multiple-iterator=~1.0; fi
 
   - phpenv rehash

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi
   - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi
   - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu_bc; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then composer require lorenzo/multiple-iterator=~1.0; fi
+  - if [[ $TRAVIS_PHP_VERSION = 'hhvm' ]] ; then composer require lorenzo/multiple-iterator=~1.0; fi
 
   - phpenv rehash
   - set +H

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
+  - 5.5
+  - 5.6
+  - 7.0
 
 sudo: false
 
@@ -21,7 +21,7 @@ services:
 
 cache:
   directories:
-    # - vendor
+    - vendor
     - $HOME/.composer/cache
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,14 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi"
+  
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then pecl channel-update pecl.php.net; fi;
 
-  - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
-  - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
-  - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = apc.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
-  - sh -c "if [ '$PHP' = '5.6' ]; then pecl install apc; fi"
-  - sh -c "if [ '$HHVM' = '1' ]; then composer require lorenzo/multiple-iterator=~1.0; fi"
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo yes | pecl install apcu; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then composer require lorenzo/multiple-iterator=~1.0; fi
 
   - phpenv rehash
   - set +H

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,22 +34,21 @@ matrix:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
-    # - php: hhvm
-    #   env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
+    - php: hhvm
+      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
 
-    # - php: hhvm
-    #   env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - php: hhvm
+      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
   allow_failures:
     - env: CODECOVERAGE=1 DEFAULT=0
 
-    # - php: hhvm
+    - php: hhvm
 
 before_install:
   - sh -c "if [ '$HHVM' != '1' ]; then phpenv config-rm xdebug.ini; fi"
   - composer self-update
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-  # - composer install --prefer-dist --no-interaction
 
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
+  - '5.5'
+  - '5.6'
+  - '7.0'
 
 sudo: false
 
@@ -21,7 +21,7 @@ services:
 
 cache:
   directories:
-    - vendor
+    # - vendor
     - $HOME/.composer/cache
 
 matrix:
@@ -34,22 +34,22 @@ matrix:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
-    - php: hhvm
-      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
+    # - php: hhvm
+    #   env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
 
-    - php: hhvm
-      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    # - php: hhvm
+    #   env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
   allow_failures:
     - env: CODECOVERAGE=1 DEFAULT=0
 
-    - php: hhvm
+    # - php: hhvm
 
-before_script:
+before_install:
   - sh -c "if [ '$HHVM' != '1' ]; then phpenv config-rm xdebug.ini; fi"
   - composer self-update
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-  - composer install --prefer-dist --no-interaction
+  # - composer install --prefer-dist --no-interaction
 
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"
@@ -71,6 +71,9 @@ before_script:
 
   - phpenv rehash
   - set +H
+
+before_script:
+  - composer install --prefer-dist --no-interaction
 
 script:
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi
   - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu_bc; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then composer require lorenzo/multiple-iterator=~1.0; fi
 
   - phpenv rehash

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
     >
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apcu.enable_cli" value="1"/>
+        <ini name="apc.enable_cli" value="1"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
     >
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
+        <ini name="apcu.enable_cli" value="1"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
Hi.

As CakePHP 3.2 requires minimum PHP 5.5.9, I thought that instead of installing/enabling APC to test with Travis, as that comes for >5.5 with OPCACHE enabled by default, we should test against APCu.

Also I refactored the .travis.yml file to check against the $TRAVIS_PHP_VERSION variable available.

I've switch in phpunit.xml.dist from apcu

Build log can be checked at https://travis-ci.org/16nsk/cakephp/builds/120096390

(#14.4 build fails identical like for the master branch, I would like to figure it out next).
