### PR TITLE
add autoRequire to Validator class

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -344,6 +344,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
     /**
      * Adds automaticly requirePresence on each field added through add method
+     *
+     * @param bool $require whether auto require is on or off
+     * @return $this|object|string|null
      */
     public function autoRequire($require)
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -68,6 +68,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     protected $_useI18n = false;
 
     /**
+     * Whether or not to add requirePresence rule on each new rule
+     *
+     * @var bool
+     */
+    protected $_autoRequire = false;
+
+    /**
      * Contains the validation messages associated with checking the emptiness
      * for each corresponding field.
      *
@@ -306,7 +313,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function add($field, $name, $rule = [])
     {
-        $field = $this->field($field);
+        $ruleSet = $this->field($field);
 
         if (!is_array($name)) {
             $rules = [$name => $rule];
@@ -314,10 +321,33 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $rules = $name;
         }
 
+        if ($this->_autoRequire) {
+            $rules += [
+                '_requirePresence' => []
+            ];
+
+            $rules['_requirePresence'] += [
+                'mode' => true,
+                'message' => null
+            ];
+
+            $this->requirePresence($field, $rules['_requirePresence']['mode'], $rules['_requirePresence']['message']);
+        }
+        unset($rules['_requirePresence']);
+
         foreach ($rules as $name => $rule) {
-            $field->add($name, $rule);
+            $ruleSet->add($name, $rule);
         }
 
+        return $this;
+    }
+
+    /**
+     * Adds automaticly requirePresence on each field added through add method
+     */
+    public function autoRequire($require)
+    {
+        $this->_autoRequire = $require;
         return $this;
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -346,7 +346,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Adds automaticly requirePresence on each field added through add method
      *
      * @param bool $require whether auto require is on or off
-     * @return $this|object|string|null
+     * @return $this
      */
     public function autoRequire($require)
     {

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -237,52 +237,52 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->isPresenceRequired('title', false));
         $this->assertFalse($validator->isPresenceRequired('title', true));
     }
-	
-	/**
+
+    /**
      * Tests the autoRequire method
      *
      * @return void
      */
     public function testAutoRequire()
     {
-		$validator = new Validator;
-		$validator->autoRequire(true);
-		$validator->notBlank('title');
-		$this->assertTrue($validator->isPresenceRequired('title', true));
-		
-		$validator->add('comment', [
-			'notBlank' => [
-				'rule' => 'notBlank',
-				'message' => 'This field cannot be blank'
-			],
-			'_requirePresence' => [
-				'message' => 'This is test requirement'
-			]
-		]);
-		$data = [
-			'title' => 'Silly title'
-		];
-		$errors = $validator->errors($data);
-		$expected = [
+        $validator = new Validator;
+        $validator->autoRequire(true);
+        $validator->notBlank('title');
+        $this->assertTrue($validator->isPresenceRequired('title', true));
+
+        $validator->add('comment', [
+            'notBlank' => [
+                'rule' => 'notBlank',
+                'message' => 'This field cannot be blank'
+            ],
+            '_requirePresence' => [
+                'message' => 'This is test requirement'
+            ]
+        ]);
+        $data = [
+            'title' => 'Silly title'
+        ];
+        $errors = $validator->errors($data);
+        $expected = [
             'comment' => ['_required' => 'This is test requirement']
         ];
         $this->assertEquals($expected, $errors);
-		
-		$validator->autoRequire(false);
-		$validator->notBlank('username');
-		$this->assertFalse($validator->isPresenceRequired('username', true));
-		
-		$validator->notBlank('job_desc', 'This field cannot be blank');
-		$data = [
-			'job_desc' => 'Silly description'
-		];
-		$errors = $validator->errors($data);
-		$expected = [
-			'comment' => ['_required' => 'This is test requirement'],
-			'title' => ['_required' => 'This field is required'],
-		];
+
+        $validator->autoRequire(false);
+        $validator->notBlank('username');
+        $this->assertFalse($validator->isPresenceRequired('username', true));
+
+        $validator->notBlank('job_desc', 'This field cannot be blank');
+        $data = [
+            'job_desc' => 'Silly description'
+        ];
+        $errors = $validator->errors($data);
+        $expected = [
+            'comment' => ['_required' => 'This is test requirement'],
+            'title' => ['_required' => 'This field is required'],
+        ];
         $this->assertEquals($expected, $errors);
-	}
+    }
 
     /**
      * Tests errors generated when a field presence is required

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -237,6 +237,52 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->isPresenceRequired('title', false));
         $this->assertFalse($validator->isPresenceRequired('title', true));
     }
+	
+	/**
+     * Tests the autoRequire method
+     *
+     * @return void
+     */
+    public function testAutoRequire()
+    {
+		$validator = new Validator;
+		$validator->autoRequire(true);
+		$validator->notBlank('title');
+		$this->assertTrue($validator->isPresenceRequired('title', true));
+		
+		$validator->add('comment', [
+			'notBlank' => [
+				'rule' => 'notBlank',
+				'message' => 'This field cannot be blank'
+			],
+			'_requirePresence' => [
+				'message' => 'This is test requirement'
+			]
+		]);
+		$data = [
+			'title' => 'Silly title'
+		];
+		$errors = $validator->errors($data);
+		$expected = [
+            'comment' => ['_required' => 'This is test requirement']
+        ];
+        $this->assertEquals($expected, $errors);
+		
+		$validator->autoRequire(false);
+		$validator->notBlank('username');
+		$this->assertFalse($validator->isPresenceRequired('username', true));
+		
+		$validator->notBlank('job_desc', 'This field cannot be blank');
+		$data = [
+			'job_desc' => 'Silly description'
+		];
+		$errors = $validator->errors($data);
+		$expected = [
+			'comment' => ['_required' => 'This is test requirement'],
+			'title' => ['_required' => 'This field is required'],
+		];
+        $this->assertEquals($expected, $errors);
+	}
 
     /**
      * Tests errors generated when a field presence is required


### PR DESCRIPTION
add autoRequire to Validator class to skip all those `requirePresence` on each field in validation rules set, in most cases when i do validation i expect the field to exist but adding all those `requirePresence` is a bit annoying in long run

note:
`notEmpty` is different (also deprecated) and it doesnt use `add` so i didnt do anything to it but if you want its not a problem to change it also

PS
ill update docs if PR is merged
