### PR TITLE
Corrects Type Var Name in AuthSecurityException

### DIFF
--- a/src/Controller/Exception/AuthSecurityException.php
+++ b/src/Controller/Exception/AuthSecurityException.php
@@ -21,5 +21,5 @@ class AuthSecurityException extends SecurityException
      * Security Exception type
      * @var string
      */
-    public $type = 'auth';
+    protected $_type = 'auth';
 }

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.6
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Controller\Exception;
+
+use Cake\Controller\Exception\AuthSecurityException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * AuthSecurityException Test class
+ *
+ */
+class AuthSecurityExceptionTest extends TestCase
+{
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->authSecurityException = new AuthSecurityException;
+    }
+
+    /**
+     * Test the getType() function.
+     *
+     * @return void
+     */
+    public function testGetType()
+    {
+        $this->assertEquals(
+            'auth',
+            $this->authSecurityException->getType(),
+            '::getType should always return the type of `auth`.'
+        );
+    }
+}

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.2.6
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Controller\Exception;
+
+use Cake\Controller\Exception\SecurityException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * SecurityException Test class
+ *
+ */
+class SecurityExceptionTest extends TestCase
+{
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->securityException = new SecurityException;
+    }
+
+    /**
+     * Test the getType() function.
+     *
+     * @return void
+     */
+    public function testGetType()
+    {
+        $this->assertEquals(
+            'secure',
+            $this->securityException->getType(),
+            '::getType should always return the type of `secure`.'
+        );
+    }
+
+    /**
+     * Test the setMessage() function.
+     *
+     * @return void
+     */
+    public function testSetMessage()
+    {
+        $sampleMessage = 'foo';
+        $this->securityException->setMessage($sampleMessage);
+        $this->assertEquals(
+            $sampleMessage,
+            $this->securityException->getMessage(),
+            '::getMessage should always return the message set.'
+        );
+    }
+
+    /**
+     * Test the setReason() and corresponding getReason() function.
+     *
+     * @return void
+     */
+    public function testSetGetReason()
+    {
+        $sampleReason = 'canary';
+        $this->securityException->setReason($sampleReason);
+        $this->assertEquals(
+            $sampleReason,
+            $this->securityException->getReason(),
+            '::getReason should always return the reason set.'
+        );
+    }
+}


### PR DESCRIPTION
Type Var in SubClass SecurityException is a protected $_type, updates the internal var to match.

SecurityException var type seen here: https://github.com/cakephp/cakephp/blob/master/src/Controller/Exception/SecurityException.php#L26
