### PR TITLE
3.x Allow for configurable output timezone defaults

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -30,8 +30,9 @@ trait DateFormatTrait
      * The default locale to be used for displaying formatted date strings.
      *
      * @var string
+     * @deprecated Use self::setDefaultLocale() and self::getDefaultLocale() instead.
      */
-    public static $defaultLocale;
+    public static $defaultLocale = null;
 
     /**
      * The default PHP \DateTimeZone or string representative for output.
@@ -39,7 +40,7 @@ trait DateFormatTrait
      *
      * @var string|\DateTimeZone
      */
-    public static $defaultOutputTimezone;
+    protected static $_defaultOutputTimezone = 'UTC';
 
     /**
      * In-memory cache of date formatters
@@ -72,6 +73,52 @@ trait DateFormatTrait
     protected static $_isDateInstance;
 
     /**
+     * Gets the default output timezone.
+     *
+     * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null.
+     */
+    public static function getDefaultOutputTimezone()
+    {
+        return static::$_defaultOutputTimezone;
+    }
+
+    /**
+     * Sets the default output timezone.
+     *
+     * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
+     * in which the date will be displayed.
+     * @return void
+     */
+    public static function setDefaultOutputTimezone($timezone)
+    {
+        if (is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+        static::$_defaultOutputTimezone = $timezone;
+    }
+
+    /**
+     * Gets the default locale.
+     *
+     * @return string|null The default locale string to be used or null.
+     */
+    public static function getDefaultLocale()
+    {
+        return static::$defaultLocale;
+    }
+
+    /**
+     * Sets the default locale.
+     *
+     * @param string|null $locale The default locale string to be used or null.
+     * @return void
+     */
+    public static function setDefaultLocale($locale = null)
+    {
+        static::$defaultLocale = $locale;
+    }
+
+    /**
      * Returns a nicely formatted date string for this object.
      *
      * The format to be used is stored in the static property `self::niceFormat`.
@@ -84,7 +131,7 @@ trait DateFormatTrait
      */
     public function nice($timezone = null, $locale = null)
     {
-        $timezone = $timezone ?: static::$defaultOutputTimezone;
+        $timezone = $timezone ?: static::getDefaultOutputTimezone();
         return $this->i18nFormat(static::$niceFormat, $timezone, $locale);
     }
 
@@ -106,11 +153,6 @@ trait DateFormatTrait
      * $time->i18nFormat([\IntlDateFormatter::FULL, \IntlDateFormatter::SHORT]); // Use full date but short time format
      * $time->i18nFormat('yyyy-MM-dd HH:mm:ss'); // outputs '2014-04-20 22:10'
      * ```
-     *
-     * If you wish to control the default format to be used for this method, you can alter
-     * the value of the static `self::$defaultLocale` variable and set it to one of the
-     * possible formats accepted by this function.
-     *
      * You can read about the available IntlDateFormatter constants at
      * http://www.php.net/manual/en/class.intldateformatter.php
      *
@@ -130,12 +172,12 @@ trait DateFormatTrait
      * $time->i18nFormat(null, new \DateTimeZone('Australia/Sydney'));
      * ```
      *
-     * You can control the default locale to be used by setting`static::$defaultLocale` to a
-     * valid locale string. If empty, the default will be taken from the `intl.default_locale`
+     * You can control the default locale to be used by calling `static::setDefaultLocale()`
+     * If null, the default will be taken from the `intl.default_locale`
      * ini config, see config/bootstrap.php.
      *
      * You can control the default timezone to be used for output formatting, by setting
-     * `static::$defaultOutputTimezone` to a valid locale string or \DateTimeZone object.
+     * calling `static::setDefaultOutputTimezone()`.
      * If empty, the default will be taken from `date_default_timezone_set()`, see config/bootstrap.php.
      *
      * @param string|int|null $format Format string.
@@ -149,7 +191,7 @@ trait DateFormatTrait
     {
         $time = $this;
 
-        $timezone = $timezone ?: static::$defaultOutputTimezone;
+        $timezone = $timezone ?: static::getDefaultOutputTimezone();
         if ($timezone) {
             // Handle the immutable and mutable object cases.
             $time = clone $this;
@@ -157,7 +199,7 @@ trait DateFormatTrait
         }
 
         $format = $format !== null ? $format : static::$_toStringFormat;
-        $locale = $locale ?: static::$defaultLocale;
+        $locale = $locale ?: static::getDefaultLocale();
         return $this->_formatObject($time, $format, $locale);
     }
 
@@ -296,7 +338,7 @@ trait DateFormatTrait
 
         $timezone = static::$_isDateInstance ? $timezone : date_default_timezone_get();
         $formatter = datefmt_create(
-            static::$defaultLocale,
+            static::getDefaultLocale(),
             $dateFormat,
             $timeFormat,
             $timezone,

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -30,7 +30,8 @@ trait DateFormatTrait
      * The default locale to be used for displaying formatted date strings.
      *
      * @var string
-     * @deprecated Use self::setDefaultLocale($locale) and self::getDefaultLocale() instead.
+     * @deprecated Public direct access deprecated.
+     *  use self::setDefaultLocale($locale) and self::getDefaultLocale() instead.
      */
     public static $defaultLocale = null;
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -93,7 +93,7 @@ trait DateFormatTrait
     {
         if ($timezone === null) {
             $timezone = new \DateTimeZone(date_default_timezone_get());
-        } else if (is_string($timezone)) {
+        } elseif (is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         }
         static::$_defaultOutputTimezone = $timezone;
@@ -340,7 +340,7 @@ trait DateFormatTrait
 
         if ($timezone === null) {
             $timezone = new \DateTimeZone('UTC');
-        } else if (is_string($timezone)) {
+        } elseif (is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         }
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -34,12 +34,12 @@ trait DateFormatTrait
     public static $defaultLocale;
 
     /**
-     * The default PHP \DateTimeZone or string representative.
+     * The default PHP \DateTimeZone or string representative for output formatting.
      * See http://php.net/manual/en/timezones.php.
      *
      * @var string|\DateTimeZone
      */
-    public static $defaultTimezone;
+    public static $defaultTimezoneFormat;
 
     /**
      * In-memory cache of date formatters
@@ -148,7 +148,7 @@ trait DateFormatTrait
     {
         $time = $this;
 
-        $timezone = $timezone ?: static::$defaultTimezone;
+        $timezone = $timezone ?: static::$defaultTimezoneFormat;
         if ($timezone) {
             // Handle the immutable and mutable object cases.
             $time = clone $this;
@@ -292,7 +292,7 @@ trait DateFormatTrait
                 is_subclass_of(static::class, MutableDate::class);
         }
 
-        $defaultTimezone = static::$_isDateInstance ? 'UTC' : date_default_timezone_get();
+        $defaultTimezone = static::$_isDateInstance ? 'UTC' : self::$defaultTimezoneFormat;
         $formatter = datefmt_create(
             static::$defaultLocale,
             $dateFormat,

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -34,12 +34,12 @@ trait DateFormatTrait
     public static $defaultLocale;
 
     /**
-     * The default PHP \DateTimeZone or string representative for output formatting.
+     * The default PHP \DateTimeZone or string representative for output.
      * See http://php.net/manual/en/timezones.php.
      *
      * @var string|\DateTimeZone
      */
-    public static $defaultTimezoneFormat;
+    public static $defaultOutputTimezone;
 
     /**
      * In-memory cache of date formatters
@@ -84,7 +84,7 @@ trait DateFormatTrait
      */
     public function nice($timezone = null, $locale = null)
     {
-        $timezone = $timezone ?: static::$defaultTimezoneFormat;
+        $timezone = $timezone ?: static::$defaultOutputTimezone;
         return $this->i18nFormat(static::$niceFormat, $timezone, $locale);
     }
 
@@ -134,9 +134,9 @@ trait DateFormatTrait
      * valid locale string. If empty, the default will be taken from the `intl.default_locale`
      * ini config, see config/bootstrap.php.
      *
-     * You can control the default timezone to be used by setting `static::$defaultLocale`
-     * to a valid locale string or \DateTimeZone object. If empty, the default will be taken from
-     * `date_default_timezone_set()`, see config/bootstrap.php.
+     * You can control the default timezone to be used for output formatting, by setting
+     * `static::$defaultOutputTimezone` to a valid locale string or \DateTimeZone object.
+     * If empty, the default will be taken from `date_default_timezone_set()`, see config/bootstrap.php.
      *
      * @param string|int|null $format Format string.
      * @param string|\DateTimeZone|null $timezone Timezone string or DateTimeZone object
@@ -149,7 +149,7 @@ trait DateFormatTrait
     {
         $time = $this;
 
-        $timezone = $timezone ?: static::$defaultTimezoneFormat;
+        $timezone = $timezone ?: static::$defaultOutputTimezone;
         if ($timezone) {
             // Handle the immutable and mutable object cases.
             $time = clone $this;
@@ -272,6 +272,7 @@ trait DateFormatTrait
      *
      * @param string $time The time string to parse.
      * @param string|array|null $format Any format accepted by IntlDateFormatter.
+     * @param string|\DateTimeZone|null $timezone Timezone string or DateTimeZone object
      * @return static|null
      */
     public static function parseDateTime($time, $format = null, $timezone = null)
@@ -293,7 +294,7 @@ trait DateFormatTrait
                 is_subclass_of(static::class, MutableDate::class);
         }
 
-        $timezone = $timezone ?: static::$defaultTimezoneFormat;
+        $timezone = $timezone ?: static::$defaultOutputTimezone;
         $timezone = static::$_isDateInstance ? date_default_timezone_get() : $timezone;
         $formatter = datefmt_create(
             static::$defaultLocale,

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -194,7 +194,9 @@ trait DateFormatTrait
     {
         $time = $this;
 
-        $timezone = $timezone ?: static::getDefaultOutputTimezone();
+        if ($time->getTimezone()->getName() === date_default_timezone_get()) {
+            $timezone = $timezone ?: static::getDefaultOutputTimezone();
+        }
         if ($timezone) {
             // Handle the immutable and mutable object cases.
             $time = clone $this;

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -30,7 +30,7 @@ trait DateFormatTrait
      * The default locale to be used for displaying formatted date strings.
      *
      * @var string
-     * @deprecated Use self::setDefaultLocale() and self::getDefaultLocale() instead.
+     * @deprecated Use self::setDefaultLocale($locale) and self::getDefaultLocale() instead.
      */
     public static $defaultLocale = null;
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -38,9 +38,9 @@ trait DateFormatTrait
      * The default PHP \DateTimeZone or string representative for output.
      * See http://php.net/manual/en/timezones.php.
      *
-     * @var string|\DateTimeZone
+     * @var \DateTimeZone|null
      */
-    protected static $_defaultOutputTimezone = 'UTC';
+    protected static $_defaultOutputTimezone = null;
 
     /**
      * In-memory cache of date formatters

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -84,6 +84,7 @@ trait DateFormatTrait
      */
     public function nice($timezone = null, $locale = null)
     {
+        $timezone = $timezone ?: static::$defaultTimezoneFormat;
         return $this->i18nFormat(static::$niceFormat, $timezone, $locale);
     }
 
@@ -273,7 +274,7 @@ trait DateFormatTrait
      * @param string|array|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
-    public static function parseDateTime($time, $format = null)
+    public static function parseDateTime($time, $format = null, $timezone = null)
     {
         $dateFormat = $format ?: static::$_toStringFormat;
         $timeFormat = $pattern = null;
@@ -292,19 +293,20 @@ trait DateFormatTrait
                 is_subclass_of(static::class, MutableDate::class);
         }
 
-        $defaultTimezone = static::$_isDateInstance ? 'UTC' : self::$defaultTimezoneFormat;
+        $timezone = $timezone ?: static::$defaultTimezoneFormat;
+        $timezone = static::$_isDateInstance ? date_default_timezone_get() : $timezone;
         $formatter = datefmt_create(
             static::$defaultLocale,
             $dateFormat,
             $timeFormat,
-            $defaultTimezone,
+            $timezone,
             null,
             $pattern
         );
         $time = $formatter->parse($time);
         if ($time !== false) {
             $result = new static('@' . $time);
-            return static::$_isDateInstance ? $result : $result->setTimezone($defaultTimezone);
+            return static::$_isDateInstance ? $result : $result->setTimezone($timezone);
         }
         return null;
     }

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -91,7 +91,9 @@ trait DateFormatTrait
      */
     public static function setDefaultOutputTimezone($timezone)
     {
-        if (is_string($timezone)) {
+        if ($timezone === null) {
+            $timezone = new \DateTimeZone(date_default_timezone_get());
+        } else if (is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         }
         static::$_defaultOutputTimezone = $timezone;
@@ -336,7 +338,13 @@ trait DateFormatTrait
                 is_subclass_of(static::class, MutableDate::class);
         }
 
-        $timezone = static::$_isDateInstance ? $timezone : date_default_timezone_get();
+        if ($timezone === null) {
+            $timezone = new \DateTimeZone('UTC');
+        } else if (is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+
+        $timezone = static::$_isDateInstance ? $timezone->getName() : date_default_timezone_get();
         $formatter = datefmt_create(
             static::getDefaultLocale(),
             $dateFormat,

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -294,8 +294,7 @@ trait DateFormatTrait
                 is_subclass_of(static::class, MutableDate::class);
         }
 
-        $timezone = $timezone ?: static::$defaultOutputTimezone;
-        $timezone = static::$_isDateInstance ? date_default_timezone_get() : $timezone;
+        $timezone = static::$_isDateInstance ? $timezone : date_default_timezone_get();
         $formatter = datefmt_create(
             static::$defaultLocale,
             $dateFormat,

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -35,7 +35,7 @@ trait DateFormatTrait
     public static $defaultLocale = null;
 
     /**
-     * The default PHP \DateTimeZone or string representative for output.
+     * The \DateTimeZone default output timezone.
      * See http://php.net/manual/en/timezones.php.
      *
      * @var \DateTimeZone|null

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -34,6 +34,14 @@ trait DateFormatTrait
     public static $defaultLocale;
 
     /**
+     * The default PHP \DateTimeZone or string representative.
+     * See http://php.net/manual/en/timezones.php.
+     *
+     * @var string|\DateTimeZone
+     */
+    public static $defaultTimezone;
+
+    /**
      * In-memory cache of date formatters
      *
      * @var array
@@ -52,7 +60,7 @@ trait DateFormatTrait
      * will be used to format the time part.
      *
      * @var string|array|int
-     * @see \Cake\I18n\Time::i18nFormat()
+     * @see self::i18nFormat()
      */
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH:mm:ssZ";
 
@@ -66,7 +74,7 @@ trait DateFormatTrait
     /**
      * Returns a nicely formatted date string for this object.
      *
-     * The format to be used is stored in the static property `Time::niceFormat`.
+     * The format to be used is stored in the static property `self::niceFormat`.
      *
      * @param string|\DateTimeZone|null $timezone Timezone string or DateTimeZone object
      * in which the date will be displayed. The timezone stored for this object will not
@@ -99,7 +107,7 @@ trait DateFormatTrait
      * ```
      *
      * If you wish to control the default format to be used for this method, you can alter
-     * the value of the static `Time::$defaultLocale` variable and set it to one of the
+     * the value of the static `self::$defaultLocale` variable and set it to one of the
      * possible formats accepted by this function.
      *
      * You can read about the available IntlDateFormatter constants at
@@ -118,11 +126,16 @@ trait DateFormatTrait
      * $time = new Time('2014-04-20 22:10');
      * $time->i18nFormat(null, null, 'de-DE');
      * $time->i18nFormat(\IntlDateFormatter::FULL, 'Europe/Berlin', 'de-DE');
+     * $time->i18nFormat(null, new \DateTimeZone('Australia/Sydney'));
      * ```
      *
-     * You can control the default locale to be used by setting the static variable
-     * `Time::$defaultLocale` to a  valid locale string. If empty, the default will be
-     * taken from the `intl.default_locale` ini config.
+     * You can control the default locale to be used by setting`static::$defaultLocale` to a
+     * valid locale string. If empty, the default will be taken from the `intl.default_locale`
+     * ini config, see config/bootstrap.php.
+     *
+     * You can control the default timezone to be used by setting `static::$defaultLocale`
+     * to a valid locale string or \DateTimeZone object. If empty, the default will be taken from
+     * `date_default_timezone_set()`, see config/bootstrap.php.
      *
      * @param string|int|null $format Format string.
      * @param string|\DateTimeZone|null $timezone Timezone string or DateTimeZone object
@@ -135,6 +148,7 @@ trait DateFormatTrait
     {
         $time = $this;
 
+        $timezone = $timezone ?: static::$defaultTimezone;
         if ($timezone) {
             // Handle the immutable and mutable object cases.
             $time = clone $this;

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -18,8 +18,13 @@ use Aura\Intl\FormatterLocator;
 use Aura\Intl\PackageLocator;
 use Aura\Intl\TranslatorFactory;
 use Cake\Cache\Cache;
+use Cake\I18n\Date;
 use Cake\I18n\Formatter\IcuFormatter;
 use Cake\I18n\Formatter\SprintfFormatter;
+use Cake\I18n\FrozenDate;
+use Cake\I18n\FrozenTime;
+use Cake\I18n\Time;
+use DateTimeZone;
 use Locale;
 
 /**
@@ -257,6 +262,29 @@ class I18n
     public static function defaultFormatter($name = null)
     {
         return static::translators()->defaultFormatter($name);
+    }
+
+    /**
+     * Sets the name of the default output timezone to use for future
+     * date and time operations.
+     *
+     * If called with no arguments, it will return the currently configured value.
+     *
+     * @param string|null $timezone The name of the output timezone to use.
+     * @return \DateTimezone|null The datetime zone.
+     */
+    public static function defaultOutputTimezone($timezone = null)
+    {
+        if (is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+        if ($timezone !== null) {
+            Time::setDefaultOutputTimezone($timezone);
+            Date::setDefaultOutputTimezone($timezone);
+            FrozenTime::setDefaultOutputTimezone($timezone);
+            FrozenDate::setDefaultOutputTimezone($timezone);
+        }
+        return $timezone;
     }
 
     /**

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -268,10 +268,11 @@ class I18n
      * Sets the name of the default output timezone to use for future
      * date and time operations.
      *
-     * If called with no arguments, it will return the currently configured value.
+     * If called with no arguments, it will return the currently configured value if it is
+     * the same for Time, Date, FrozenTime and FrozenDate. If not it will return false.
      *
      * @param string|null $timezone The name of the output timezone to use.
-     * @return \DateTimezone|null The datetime zone.
+     * @return \DateTimezone|null|false The default output datetime zone.
      */
     public static function defaultOutputTimezone($timezone = null)
     {
@@ -283,6 +284,16 @@ class I18n
             Date::setDefaultOutputTimezone($timezone);
             FrozenTime::setDefaultOutputTimezone($timezone);
             FrozenDate::setDefaultOutputTimezone($timezone);
+        } else if ($timezone === null) {
+            $t = Time::getDefaultOutputTimezone();
+            $d = Date::getDefaultOutputTimezone();
+            $ft = FrozenTime::getDefaultOutputTimezone();
+            $fd = FrozenDate::getDefaultOutputTimezone();
+            if ($t == $d && $d == $ft && $ft == $fd) {
+                return $t;
+            } else {
+                return false;
+            }
         }
         return $timezone;
     }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -65,6 +65,9 @@ class TimeHelper extends Helper
     public function __construct(View $View, array $config = [])
     {
         parent::__construct($View, $config);
+        if (isset($config['defaultLocale'])) {
+            $this->_defaultFormat = $config['defaultLocale'];
+        }
         if (isset($config['defaultFormat'])) {
             $this->_defaultFormat = $config['defaultFormat'];
         }
@@ -92,6 +95,9 @@ class TimeHelper extends Helper
      */
     public function setDefaultOutputTimezone($timezone)
     {
+        if ($timezone === null) {
+            $timezone = new \DateTimeZone(date_default_timezone_get());
+        }
         if (is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         }
@@ -437,7 +443,7 @@ class TimeHelper extends Helper
     public function format($date, $format = null, $invalid = false, $timezone = null)
     {
         $timezone = $timezone ?: $this->getDefaultOutputTimezone();
-        $format = $format ?: $this->getDefaultFormat();
+        $format = $format !== null ? $format : $this->getDefaultFormat();
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
 
@@ -456,7 +462,8 @@ class TimeHelper extends Helper
     public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
         $timezone = $timezone ?: $this->getDefaultOutputTimezone();
-        $format = $format ?: $this->getDefaultFormat();
+        $format = $format !== null ? $format : $this->getDefaultFormat();
+
         if (!isset($date)) {
             return $invalid;
         }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -52,7 +52,7 @@ class TimeHelper extends Helper
      * The default PHP \DateTimeZone or string representative.
      * See http://php.net/manual/en/timezones.php.
      *
-     * @var string|\DateTimeZone|null
+     * @var \DateTimeZone|null
      */
     protected $_defaultOutputTimezone = null;
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -34,119 +34,15 @@ class TimeHelper extends Helper
     use StringTemplateTrait;
 
     /**
-     * The default locale to be used for displaying formatted date strings.
+     * Default config for this class
      *
-     * @var string
-     * @deprecated Use self::setDefaultLocale() and self::getDefaultLocale() instead.
+     * @var array
      */
-    protected $_defaultLocale = null;
-
-    /**
-     * The default format to be used for displaying formatted date strings.
-     *
-     * @var string|null
-     */
-    protected $_defaultFormat = null;
-
-    /**
-     * The \DateTimeZone default output timezone.
-     * See http://php.net/manual/en/timezones.php.
-     *
-     * @var \DateTimeZone|null
-     */
-    protected $_defaultOutputTimezone = null;
-
-    /**
-     * Construct the TimeHelper
-     *
-     * @param \Cake\View\View $View The View this helper is being attached to
-     * @param array $config Configuration settings for the helper
-     */
-    public function __construct(View $View, array $config = [])
-    {
-        parent::__construct($View, $config);
-        if (isset($config['defaultLocale'])) {
-            $this->_defaultLocale = $config['defaultLocale'];
-        }
-        if (isset($config['defaultFormat'])) {
-            $this->_defaultFormat = $config['defaultFormat'];
-        }
-        if (isset($config['defaultOutputTimezone'])) {
-            $this->_defaultOutputTimezone = $config['defaultOutputTimezone'];
-        }
-    }
-
-    /**
-     * Gets the default output timezone
-     *
-     * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null
-     */
-    public function getDefaultOutputTimezone()
-    {
-        return $this->_defaultOutputTimezone;
-    }
-
-    /**
-     * Sets the default output timezone.
-     *
-     * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
-     *  in which the date will be displayed
-     * @return $this
-     */
-    public function setDefaultOutputTimezone($timezone)
-    {
-        if ($timezone === null) {
-            $timezone = new \DateTimeZone(date_default_timezone_get());
-        } elseif (is_string($timezone)) {
-            $timezone = new \DateTimeZone($timezone);
-        }
-        $this->_defaultOutputTimezone = $timezone;
-        return $this;
-    }
-
-    /**
-     * Gets the default format.
-     *
-     * @return string|null The default format string to be used or null
-     */
-    public function getDefaultFormat()
-    {
-        return $this->_defaultFormat;
-    }
-
-    /**
-     * Sets the default format.
-     *
-     * @param string|null $format The default format string to be used or null
-     * @return $this
-     */
-    public function setDefaultFormat($format = null)
-    {
-        $this->_defaultFormat = $format;
-        return $this;
-    }
-
-    /**
-     * Gets the default locale.
-     *
-     * @return string|null The default locale string to be used or null
-     */
-    public function getDefaultLocale()
-    {
-        return $this->_defaultLocale;
-    }
-
-    /**
-     * Sets the default locale.
-     *
-     * @param string|null $locale The default locale string to be used or null
-     * @return $this
-     */
-    public function setDefaultLocale($locale = null)
-    {
-        $this->_defaultLocale = $locale;
-        return $this;
-    }
+    protected $_defaultConfig = [
+        'defaultLocale' => null,
+        'defaultFormat' => null,
+        'defaultOutputTimezone' => null,
+    ];
 
     /**
      * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
@@ -157,7 +53,7 @@ class TimeHelper extends Helper
      */
     public function fromString($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString))->timezone($timezone);
     }
 
@@ -171,8 +67,8 @@ class TimeHelper extends Helper
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
-        $locale = $locale ?: $this->getDefaultLocale();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
+        $locale = $locale ?: $this->config('defaultLocale');
         return (new Time($dateString))->nice($timezone, $locale);
     }
 
@@ -185,7 +81,7 @@ class TimeHelper extends Helper
      */
     public function isToday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isToday();
     }
 
@@ -198,7 +94,7 @@ class TimeHelper extends Helper
      */
     public function isFuture($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isFuture();
     }
 
@@ -211,7 +107,7 @@ class TimeHelper extends Helper
      */
     public function isPast($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isPast();
     }
 
@@ -224,7 +120,7 @@ class TimeHelper extends Helper
      */
     public function isThisWeek($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isThisWeek();
     }
 
@@ -237,7 +133,7 @@ class TimeHelper extends Helper
      */
     public function isThisMonth($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isThisMonth();
     }
 
@@ -250,7 +146,7 @@ class TimeHelper extends Helper
      */
     public function isThisYear($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isThisYear();
     }
 
@@ -264,7 +160,7 @@ class TimeHelper extends Helper
      */
     public function wasYesterday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isYesterday();
     }
 
@@ -277,7 +173,7 @@ class TimeHelper extends Helper
      */
     public function isTomorrow($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isTomorrow();
     }
 
@@ -292,7 +188,7 @@ class TimeHelper extends Helper
      */
     public function toQuarter($dateString, $range = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->toQuarter($range);
     }
 
@@ -306,7 +202,7 @@ class TimeHelper extends Helper
      */
     public function toUnix($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->toUnixString();
     }
 
@@ -372,7 +268,7 @@ class TimeHelper extends Helper
             }
             unset($options['element']);
         }
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         $relativeDate = (new Time($dateTime, $timezone))->timeAgoInWords($options);
 
         if ($element) {
@@ -399,7 +295,7 @@ class TimeHelper extends Helper
      */
     public function wasWithinLast($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->wasWithinLast($timeInterval);
     }
 
@@ -415,7 +311,7 @@ class TimeHelper extends Helper
      */
     public function isWithinNext($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isWithinNext($timeInterval);
     }
 
@@ -428,7 +324,7 @@ class TimeHelper extends Helper
      */
     public function gmt($string = null)
     {
-        return (new Time($string, 'UTC'))->toUnixString();
+        return (new Time($string))->toUnixString();
     }
 
     /**
@@ -446,8 +342,8 @@ class TimeHelper extends Helper
      */
     public function format($date, $format = null, $invalid = false, $timezone = null)
     {
-        $format = $format !== null ? $format : $this->getDefaultFormat();
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $format = $format !== null ? $format : $this->config('defaultFormat');
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
 
@@ -465,8 +361,8 @@ class TimeHelper extends Helper
      */
     public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
-        $format = $format !== null ? $format : $this->getDefaultFormat();
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $format = $format !== null ? $format : $this->config('defaultFormat');
+        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
 
         if (!isset($date)) {
             return $invalid;

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -33,6 +33,21 @@ class TimeHelper extends Helper
     use StringTemplateTrait;
 
     /**
+     * The default format to be used for displaying formatted date strings.
+     *
+     * @var string
+     */
+    public $defaultFormat = null;
+
+    /**
+     * The default PHP \DateTimeZone or string representative.
+     * See http://php.net/manual/en/timezones.php.
+     *
+     * @var string|\DateTimeZone
+     */
+    public $defaultTimezone = null;
+
+    /**
      * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
      *
      * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
@@ -41,6 +56,7 @@ class TimeHelper extends Helper
      */
     public function fromString($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString))->timezone($timezone);
     }
 
@@ -54,6 +70,7 @@ class TimeHelper extends Helper
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString))->nice($timezone, $locale);
     }
 
@@ -66,6 +83,7 @@ class TimeHelper extends Helper
      */
     public function isToday($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isToday();
     }
 
@@ -78,6 +96,7 @@ class TimeHelper extends Helper
      */
     public function isFuture($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isFuture();
     }
 
@@ -90,6 +109,7 @@ class TimeHelper extends Helper
      */
     public function isPast($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isPast();
     }
 
@@ -102,6 +122,7 @@ class TimeHelper extends Helper
      */
     public function isThisWeek($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isThisWeek();
     }
 
@@ -114,6 +135,7 @@ class TimeHelper extends Helper
      */
     public function isThisMonth($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isThisMonth();
     }
 
@@ -126,6 +148,7 @@ class TimeHelper extends Helper
      */
     public function isThisYear($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isThisYear();
     }
 
@@ -139,6 +162,7 @@ class TimeHelper extends Helper
      */
     public function wasYesterday($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isYesterday();
     }
 
@@ -151,6 +175,7 @@ class TimeHelper extends Helper
      */
     public function isTomorrow($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isTomorrow();
     }
 
@@ -190,7 +215,7 @@ class TimeHelper extends Helper
      */
     public function toAtom($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: date_default_timezone_get();
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString))->timezone($timezone)->toAtomString();
     }
 
@@ -203,7 +228,7 @@ class TimeHelper extends Helper
      */
     public function toRss($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: date_default_timezone_get();
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString))->timezone($timezone)->toRssString();
     }
 
@@ -267,6 +292,7 @@ class TimeHelper extends Helper
      */
     public function wasWithinLast($timeInterval, $dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->wasWithinLast($timeInterval);
     }
 
@@ -282,6 +308,7 @@ class TimeHelper extends Helper
      */
     public function isWithinNext($timeInterval, $dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
         return (new Time($dateString, $timezone))->isWithinNext($timeInterval);
     }
 
@@ -312,6 +339,8 @@ class TimeHelper extends Helper
      */
     public function format($date, $format = null, $invalid = false, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
+        $format = $format ?: $this->defaultFormat;
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
 
@@ -329,6 +358,8 @@ class TimeHelper extends Helper
      */
     public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
+        $timezone = $timezone ?: $this->defaultTimezone;
+        $format = $format ?: $this->defaultFormat;
         if (!isset($date)) {
             return $invalid;
         }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -60,7 +60,7 @@ class TimeHelper extends Helper
             $this->defaultFormat = $config['defaultFormat'];
         }
         if (isset($config['defaultOutputTimezone'])) {
-            $this->defaultFormat = $config['defaultOutputTimezone'];
+            $this->defaultOutputTimezone = $config['defaultOutputTimezone'];
         }
     }
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -45,7 +45,7 @@ class TimeHelper extends Helper
      *
      * @var string|\DateTimeZone|null
      */
-    public $defaultTimezone = null;
+    public $defaultOutputTimezone = null;
 
     /**
      * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
@@ -56,7 +56,7 @@ class TimeHelper extends Helper
      */
     public function fromString($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString))->timezone($timezone);
     }
 
@@ -70,7 +70,7 @@ class TimeHelper extends Helper
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString))->nice($timezone, $locale);
     }
 
@@ -83,7 +83,7 @@ class TimeHelper extends Helper
      */
     public function isToday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isToday();
     }
 
@@ -96,7 +96,7 @@ class TimeHelper extends Helper
      */
     public function isFuture($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isFuture();
     }
 
@@ -109,7 +109,7 @@ class TimeHelper extends Helper
      */
     public function isPast($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isPast();
     }
 
@@ -122,7 +122,7 @@ class TimeHelper extends Helper
      */
     public function isThisWeek($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isThisWeek();
     }
 
@@ -135,7 +135,7 @@ class TimeHelper extends Helper
      */
     public function isThisMonth($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isThisMonth();
     }
 
@@ -148,7 +148,7 @@ class TimeHelper extends Helper
      */
     public function isThisYear($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isThisYear();
     }
 
@@ -162,7 +162,7 @@ class TimeHelper extends Helper
      */
     public function wasYesterday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isYesterday();
     }
 
@@ -175,7 +175,7 @@ class TimeHelper extends Helper
      */
     public function isTomorrow($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isTomorrow();
     }
 
@@ -215,7 +215,7 @@ class TimeHelper extends Helper
      */
     public function toAtom($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString))->timezone($timezone)->toAtomString();
     }
 
@@ -228,7 +228,7 @@ class TimeHelper extends Helper
      */
     public function toRss($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString))->timezone($timezone)->toRssString();
     }
 
@@ -292,7 +292,7 @@ class TimeHelper extends Helper
      */
     public function wasWithinLast($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->wasWithinLast($timeInterval);
     }
 
@@ -308,7 +308,7 @@ class TimeHelper extends Helper
      */
     public function isWithinNext($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         return (new Time($dateString, $timezone))->isWithinNext($timeInterval);
     }
 
@@ -339,7 +339,7 @@ class TimeHelper extends Helper
      */
     public function format($date, $format = null, $invalid = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         $format = $format ?: $this->defaultFormat;
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
@@ -358,7 +358,7 @@ class TimeHelper extends Helper
      */
     public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultTimezone;
+        $timezone = $timezone ?: $this->defaultOutputTimezone;
         $format = $format ?: $this->defaultFormat;
         if (!isset($date)) {
             return $invalid;

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -232,7 +232,7 @@ class TimeHelper extends Helper
      */
     public function toAtom($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: date_default_timezone_get();
         return (new Time($dateString))->timezone($timezone)->toAtomString();
     }
 
@@ -245,7 +245,7 @@ class TimeHelper extends Helper
      */
     public function toRss($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: date_default_timezone_get();
         return (new Time($dateString))->timezone($timezone)->toRssString();
     }
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -81,7 +81,6 @@ class TimeHelper extends Helper
      */
     public function isToday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isToday();
     }
 
@@ -94,7 +93,6 @@ class TimeHelper extends Helper
      */
     public function isFuture($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isFuture();
     }
 
@@ -107,7 +105,6 @@ class TimeHelper extends Helper
      */
     public function isPast($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isPast();
     }
 
@@ -120,7 +117,6 @@ class TimeHelper extends Helper
      */
     public function isThisWeek($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isThisWeek();
     }
 
@@ -133,7 +129,6 @@ class TimeHelper extends Helper
      */
     public function isThisMonth($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isThisMonth();
     }
 
@@ -146,7 +141,6 @@ class TimeHelper extends Helper
      */
     public function isThisYear($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isThisYear();
     }
 
@@ -160,7 +154,6 @@ class TimeHelper extends Helper
      */
     public function wasYesterday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isYesterday();
     }
 
@@ -295,7 +288,6 @@ class TimeHelper extends Helper
      */
     public function wasWithinLast($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->wasWithinLast($timeInterval);
     }
 
@@ -311,7 +303,6 @@ class TimeHelper extends Helper
      */
     public function isWithinNext($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isWithinNext($timeInterval);
     }
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -17,6 +17,7 @@ namespace Cake\View\Helper;
 use Cake\I18n\Time;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
+use Cake\View\View;
 use Exception;
 
 /**
@@ -33,11 +34,19 @@ class TimeHelper extends Helper
     use StringTemplateTrait;
 
     /**
+     * The default locale to be used for displaying formatted date strings.
+     *
+     * @var string
+     * @deprecated Use self::setDefaultLocale() and self::getDefaultLocale() instead.
+     */
+    protected $_defaultLocale = null;
+
+    /**
      * The default format to be used for displaying formatted date strings.
      *
      * @var string|null
      */
-    public $defaultFormat = null;
+    protected $_defaultFormat = null;
 
     /**
      * The default PHP \DateTimeZone or string representative.
@@ -45,7 +54,7 @@ class TimeHelper extends Helper
      *
      * @var string|\DateTimeZone|null
      */
-    public $defaultOutputTimezone = null;
+    protected $_defaultOutputTimezone = null;
 
     /**
      * Construct the TimeHelper
@@ -57,11 +66,81 @@ class TimeHelper extends Helper
     {
         parent::__construct($View, $config);
         if (isset($config['defaultFormat'])) {
-            $this->defaultFormat = $config['defaultFormat'];
+            $this->_defaultFormat = $config['defaultFormat'];
         }
         if (isset($config['defaultOutputTimezone'])) {
-            $this->defaultOutputTimezone = $config['defaultOutputTimezone'];
+            $this->_defaultOutputTimezone = $config['defaultOutputTimezone'];
         }
+    }
+
+    /**
+     * Gets the default output timezone.
+     *
+     * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null.
+     */
+    public function getDefaultOutputTimezone()
+    {
+        return $this->_defaultOutputTimezone;
+    }
+
+    /**
+     * Sets the default output timezone.
+     *
+     * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
+     * in which the date will be displayed.
+     * @return $this
+     */
+    public function setDefaultOutputTimezone($timezone)
+    {
+        if (is_string($timezone)) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+        $this->_defaultOutputTimezone = $timezone;
+        return $this;
+    }
+
+    /**
+     * Gets the default format.
+     *
+     * @return string|null The default format string to be used or null.
+     */
+    public function getDefaultFormat()
+    {
+        return $this->_defaultFormat;
+    }
+
+    /**
+     * Sets the default format.
+     *
+     * @param string|null $format The default format string to be used or null.
+     * @return $this
+     */
+    public function setDefaultFormat($format = null)
+    {
+        $this->_defaultFormat = $format;
+        return $this;
+    }
+
+    /**
+     * Gets the default locale.
+     *
+     * @return string|null The default locale string to be used or null.
+     */
+    public function getDefaultLocale()
+    {
+        return $this->_defaultLocale;
+    }
+
+    /**
+     * Sets the default locale.
+     *
+     * @param string|null $locale The default locale string to be used or null.
+     * @return $this
+     */
+    public function setDefaultLocale($locale = null)
+    {
+        $this->_defaultLocale = $locale;
+        return $this;
     }
 
     /**
@@ -73,7 +152,7 @@ class TimeHelper extends Helper
      */
     public function fromString($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString))->timezone($timezone);
     }
 
@@ -87,7 +166,8 @@ class TimeHelper extends Helper
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $locale = $locale ?: $this->getDefaultLocale();
         return (new Time($dateString))->nice($timezone, $locale);
     }
 
@@ -100,7 +180,7 @@ class TimeHelper extends Helper
      */
     public function isToday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isToday();
     }
 
@@ -113,7 +193,7 @@ class TimeHelper extends Helper
      */
     public function isFuture($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isFuture();
     }
 
@@ -126,7 +206,7 @@ class TimeHelper extends Helper
      */
     public function isPast($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isPast();
     }
 
@@ -139,7 +219,7 @@ class TimeHelper extends Helper
      */
     public function isThisWeek($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isThisWeek();
     }
 
@@ -152,7 +232,7 @@ class TimeHelper extends Helper
      */
     public function isThisMonth($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isThisMonth();
     }
 
@@ -165,7 +245,7 @@ class TimeHelper extends Helper
      */
     public function isThisYear($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isThisYear();
     }
 
@@ -179,7 +259,7 @@ class TimeHelper extends Helper
      */
     public function wasYesterday($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isYesterday();
     }
 
@@ -192,7 +272,7 @@ class TimeHelper extends Helper
      */
     public function isTomorrow($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isTomorrow();
     }
 
@@ -309,7 +389,7 @@ class TimeHelper extends Helper
      */
     public function wasWithinLast($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->wasWithinLast($timeInterval);
     }
 
@@ -325,7 +405,7 @@ class TimeHelper extends Helper
      */
     public function isWithinNext($timeInterval, $dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->isWithinNext($timeInterval);
     }
 
@@ -356,8 +436,8 @@ class TimeHelper extends Helper
      */
     public function format($date, $format = null, $invalid = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
-        $format = $format ?: $this->defaultFormat;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $format = $format ?: $this->getDefaultFormat();
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
 
@@ -375,8 +455,8 @@ class TimeHelper extends Helper
      */
     public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->defaultOutputTimezone;
-        $format = $format ?: $this->defaultFormat;
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $format = $format ?: $this->getDefaultFormat();
         if (!isset($date)) {
             return $invalid;
         }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -49,7 +49,7 @@ class TimeHelper extends Helper
     protected $_defaultFormat = null;
 
     /**
-     * The default PHP \DateTimeZone or string representative.
+     * The \DateTimeZone default output timezone.
      * See http://php.net/manual/en/timezones.php.
      *
      * @var \DateTimeZone|null

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -53,7 +53,6 @@ class TimeHelper extends Helper
      */
     public function fromString($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString))->timezone($timezone);
     }
 
@@ -166,7 +165,6 @@ class TimeHelper extends Helper
      */
     public function isTomorrow($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->isTomorrow();
     }
 
@@ -195,7 +193,6 @@ class TimeHelper extends Helper
      */
     public function toUnix($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
         return (new Time($dateString, $timezone))->toUnixString();
     }
 
@@ -239,11 +236,10 @@ class TimeHelper extends Helper
      *
      * @param int|string|\DateTime $dateTime UNIX timestamp, strtotime() valid string or DateTime object
      * @param array $options Default format if timestamp is used in $dateString
-     * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return string Relative time string.
      * @see \Cake\I18n\Time::timeAgoInWords()
      */
-    public function timeAgoInWords($dateTime, array $options = [], $timezone = null)
+    public function timeAgoInWords($dateTime, array $options = [])
     {
         $element = null;
 
@@ -261,8 +257,7 @@ class TimeHelper extends Helper
             }
             unset($options['element']);
         }
-        $timezone = $timezone ?: $this->config('defaultOutputTimezone');
-        $relativeDate = (new Time($dateTime, $timezone))->timeAgoInWords($options);
+        $relativeDate = (new Time($dateTime))->timeAgoInWords($options);
 
         if ($element) {
             $relativeDate = sprintf(

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -97,8 +97,7 @@ class TimeHelper extends Helper
     {
         if ($timezone === null) {
             $timezone = new \DateTimeZone(date_default_timezone_get());
-        }
-        if (is_string($timezone)) {
+        } elseif (is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
         }
         $this->_defaultOutputTimezone = $timezone;

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -48,6 +48,23 @@ class TimeHelper extends Helper
     public $defaultOutputTimezone = null;
 
     /**
+     * Construct the TimeHelper
+     *
+     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param array $config Configuration settings for the helper.
+     */
+    public function __construct(View $View, array $config = [])
+    {
+        parent::__construct($View, $config);
+        if (isset($config['defaultFormat'])) {
+            $this->defaultFormat = $config['defaultFormat'];
+        }
+        if (isset($config['defaultOutputTimezone'])) {
+            $this->defaultFormat = $config['defaultOutputTimezone'];
+        }
+    }
+
+    /**
      * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
      *
      * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -66,7 +66,7 @@ class TimeHelper extends Helper
     {
         parent::__construct($View, $config);
         if (isset($config['defaultLocale'])) {
-            $this->_defaultFormat = $config['defaultLocale'];
+            $this->_defaultLocale = $config['defaultLocale'];
         }
         if (isset($config['defaultFormat'])) {
             $this->_defaultFormat = $config['defaultFormat'];

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -35,7 +35,7 @@ class TimeHelper extends Helper
     /**
      * The default format to be used for displaying formatted date strings.
      *
-     * @var string
+     * @var string|null
      */
     public $defaultFormat = null;
 
@@ -43,7 +43,7 @@ class TimeHelper extends Helper
      * The default PHP \DateTimeZone or string representative.
      * See http://php.net/manual/en/timezones.php.
      *
-     * @var string|\DateTimeZone
+     * @var string|\DateTimeZone|null
      */
     public $defaultTimezone = null;
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -59,8 +59,8 @@ class TimeHelper extends Helper
     /**
      * Construct the TimeHelper
      *
-     * @param \Cake\View\View $View The View this helper is being attached to.
-     * @param array $config Configuration settings for the helper.
+     * @param \Cake\View\View $View The View this helper is being attached to
+     * @param array $config Configuration settings for the helper
      */
     public function __construct(View $View, array $config = [])
     {
@@ -77,9 +77,9 @@ class TimeHelper extends Helper
     }
 
     /**
-     * Gets the default output timezone.
+     * Gets the default output timezone
      *
-     * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null.
+     * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null
      */
     public function getDefaultOutputTimezone()
     {
@@ -90,7 +90,7 @@ class TimeHelper extends Helper
      * Sets the default output timezone.
      *
      * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
-     * in which the date will be displayed.
+     *  in which the date will be displayed
      * @return $this
      */
     public function setDefaultOutputTimezone($timezone)
@@ -107,7 +107,7 @@ class TimeHelper extends Helper
     /**
      * Gets the default format.
      *
-     * @return string|null The default format string to be used or null.
+     * @return string|null The default format string to be used or null
      */
     public function getDefaultFormat()
     {
@@ -117,7 +117,7 @@ class TimeHelper extends Helper
     /**
      * Sets the default format.
      *
-     * @param string|null $format The default format string to be used or null.
+     * @param string|null $format The default format string to be used or null
      * @return $this
      */
     public function setDefaultFormat($format = null)
@@ -129,7 +129,7 @@ class TimeHelper extends Helper
     /**
      * Gets the default locale.
      *
-     * @return string|null The default locale string to be used or null.
+     * @return string|null The default locale string to be used or null
      */
     public function getDefaultLocale()
     {
@@ -139,7 +139,7 @@ class TimeHelper extends Helper
     /**
      * Sets the default locale.
      *
-     * @param string|null $locale The default locale string to be used or null.
+     * @param string|null $locale The default locale string to be used or null
      * @return $this
      */
     public function setDefaultLocale($locale = null)
@@ -166,7 +166,7 @@ class TimeHelper extends Helper
      *
      * @param int|string|\DateTime|null $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
-     * @param string|null $locale Locale string.
+     * @param string|null $locale Locale string
      * @return string Formatted date string
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
@@ -286,12 +286,14 @@ class TimeHelper extends Helper
      *
      * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param bool $range if true returns a range in Y-m-d format
+     * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return int|array 1, 2, 3, or 4 quarter of year or array if $range true
      * @see \Cake\I18n\Time::toQuarter()
      */
-    public function toQuarter($dateString, $range = false)
+    public function toQuarter($dateString, $range = false, $timezone = null)
     {
-        return (new Time($dateString))->toQuarter($range);
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        return (new Time($dateString, $timezone))->toQuarter($range);
     }
 
     /**
@@ -304,6 +306,7 @@ class TimeHelper extends Helper
      */
     public function toUnix($dateString, $timezone = null)
     {
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return (new Time($dateString, $timezone))->toUnixString();
     }
 
@@ -347,10 +350,11 @@ class TimeHelper extends Helper
      *
      * @param int|string|\DateTime $dateTime UNIX timestamp, strtotime() valid string or DateTime object
      * @param array $options Default format if timestamp is used in $dateString
+     * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return string Relative time string.
      * @see \Cake\I18n\Time::timeAgoInWords()
      */
-    public function timeAgoInWords($dateTime, array $options = [])
+    public function timeAgoInWords($dateTime, array $options = [], $timezone = null)
     {
         $element = null;
 
@@ -368,7 +372,8 @@ class TimeHelper extends Helper
             }
             unset($options['element']);
         }
-        $relativeDate = (new Time($dateTime))->timeAgoInWords($options);
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
+        $relativeDate = (new Time($dateTime, $timezone))->timeAgoInWords($options);
 
         if ($element) {
             $relativeDate = sprintf(
@@ -423,7 +428,7 @@ class TimeHelper extends Helper
      */
     public function gmt($string = null)
     {
-        return (new Time($string))->toUnixString();
+        return (new Time($string, 'UTC'))->toUnixString();
     }
 
     /**
@@ -441,8 +446,8 @@ class TimeHelper extends Helper
      */
     public function format($date, $format = null, $invalid = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         $format = $format !== null ? $format : $this->getDefaultFormat();
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
 
@@ -451,7 +456,7 @@ class TimeHelper extends Helper
      * UNIX timestamp or a valid strtotime() date string.
      *
      * @param int|string|\DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
-     * @param string|null $format Intl compatible format string.
+     * @param string|null $format Intl compatible format string
      * @param bool|string $invalid Default value to display on invalid dates
      * @param string|\DateTimeZone|null $timezone User's timezone string or DateTimeZone object
      * @return string Formatted and translated date string
@@ -460,8 +465,8 @@ class TimeHelper extends Helper
      */
     public function i18nFormat($date, $format = null, $invalid = false, $timezone = null)
     {
-        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
         $format = $format !== null ? $format : $this->getDefaultFormat();
+        $timezone = $timezone ?: $this->getDefaultOutputTimezone();
 
         if (!isset($date)) {
             return $invalid;

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\I18n;
 
 use Cake\I18n\Date;
 use Cake\I18n\FrozenDate;
+use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use DateTimeZone;
 
@@ -25,11 +26,26 @@ use DateTimeZone;
 class DateTest extends TestCase
 {
     /**
-     * Backup the locale property
+     * Backup the defaultLocale property
      *
      * @var string
      */
-    protected $locale;
+    protected $defaultLocale;
+
+    /**
+     * Backup the defaultOutputTimezone property
+     *
+     * @var string
+     */
+    protected $defaultOutputTimezone = 'UTC';
+
+
+    /**
+     * Backup the serverTime
+     *
+     * @var string
+     */
+    protected $serverTime;
 
     /**
      * setup
@@ -39,7 +55,9 @@ class DateTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->locale = Date::$defaultLocale;
+        $this->serverTime = date_default_timezone_get();
+        $this->defaultLocale = Date::getDefaultLocale();
+        $this->defaultOutputTimezone = I18n::defaultOutputTimezone();
     }
 
     /**
@@ -50,9 +68,10 @@ class DateTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Date::$defaultLocale = $this->locale;
-        FrozenDate::$defaultLocale = $this->locale;
-        date_default_timezone_set('UTC');
+        date_default_timezone_set($this->serverTime);
+        Date::setDefaultLocale($this->defaultLocale);
+        FrozenDate::setDefaultLocale($this->defaultLocale);
+        I18n::defaultOutputTimezone($this->defaultOutputTimezone);
     }
 
     /**
@@ -105,7 +124,7 @@ class DateTest extends TestCase
         $expected = '00:00:00';
         $this->assertEquals($expected, $result);
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $result = str_replace(' à', '', $result);
         $expected = 'jeudi 14 janvier 2010 00:00:00 UTC';
@@ -165,7 +184,7 @@ class DateTest extends TestCase
         $date = $class::parseDate('11/6/15');
         $this->assertEquals('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $date = $class::parseDate('13 10, 2015');
         $this->assertEquals('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }
@@ -181,7 +200,7 @@ class DateTest extends TestCase
         $date = $class::parseDate('11/6/15 12:33:12');
         $this->assertEquals('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $date = $class::parseDate('13 10, 2015 12:54:12');
         $this->assertEquals('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -35,6 +35,13 @@ class I18nTest extends TestCase
     public $locale;
 
     /**
+     * Backup the defaultOutputTimezone property
+     *
+     * @var string
+     */
+    protected $defaultOutputTimezoneBackup = 'UTC';
+
+    /**
      * Set Up
      *
      * @return void

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -27,20 +27,6 @@ class TimeTest extends TestCase
 {
 
     /**
-     * Backup the defaultLocale property
-     *
-     * @var string
-     */
-    protected $defaultLocaleBackup;
-
-    /**
-     * Backup the defaultOutputTimezone property
-     *
-     * @var string
-     */
-    protected $defaultOutputTimezoneBackup = 'UTC';
-
-    /**
      * setUp method
      *
      * @return void
@@ -48,18 +34,14 @@ class TimeTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-
         date_default_timezone_set('UTC');
+        Time::setDefaultLocale('en_US');
+        FrozenTime::setDefaultLocale('en_US');
         Time::setDefaultOutputTimezone('UTC');
         FrozenTime::setDefaultOutputTimezone('UTC');
 
         $this->now = Time::getTestNow();
         $this->frozenNow = FrozenTime::getTestNow();
-
-        Time::setDefaultLocale('en_US');
-        FrozenTime::setDefaultLocale('en_US');
-
-        $this->defaultLocaleBackup = Time::getDefaultLocale();
     }
 
     /**
@@ -70,31 +52,19 @@ class TimeTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-
         date_default_timezone_set('UTC');
+        Time::setDefaultLocale('en_US');
+        FrozenTime::setDefaultLocale('en_US');
         Time::setDefaultOutputTimezone('UTC');
         FrozenTime::setDefaultOutputTimezone('UTC');
 
         Time::setTestNow($this->now);
         FrozenTime::setTestNow($this->frozenNow);
 
-        Time::setDefaultLocale($this->defaultLocaleBackup);
-        FrozenTime::setDefaultLocale($this->defaultLocaleBackup);
-
         Time::resetToStringFormat();
         FrozenTime::resetToStringFormat();
 
         I18n::locale(I18n::DEFAULT_LOCALE);
-    }
-
-    /**
-     * Restored the original system timezone
-     *
-     * @return void
-     */
-    protected function _restoreSystemTimezone()
-    {
-        date_default_timezone_set($this->_systemTimezoneIdentifier);
     }
 
     /**
@@ -570,7 +540,41 @@ class TimeTest extends TestCase
         $result = $time->i18nFormat(null, 'Europe/London');
         $expected = '14.01.10 13:59';
         $this->assertTimeFormat($expected, $result);
+    }
 
+    /**
+     * test unix string time
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToUnixString($class)
+    {
+        $time = new $class('Thu Jan 14 13:59:28 2010');
+        
+        $result = $time->toUnixString();
+        $expected = '1263477568';
+        $this->assertTimeFormat($expected, $result);
+
+        $class::setDefaultLocale('de-DE');
+        $class::setDefaultOutputTimezone('Europe/Berlin');
+
+        $result = $time->toUnixString();
+        $expected = '1263477568';
+        $this->assertTimeFormat($expected, $result);
+
+        $time = new $class('Thu Jan 1 00:00:00 1970');
+        
+        $result = $time->toUnixString();
+        $expected = '0';
+        $this->assertTimeFormat($expected, $result);
+
+        $class::setDefaultLocale('fr-FR');
+        $class::setDefaultOutputTimezone('Europe/Berlin');
+
+        $result = $time->toUnixString();
+        $expected = '0';
+        $this->assertTimeFormat($expected, $result);
     }
 
     /**
@@ -936,7 +940,8 @@ class TimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testSetDefaultLocale($class) {
+    public function testSetDefaultLocale($class)
+    {
         $result = $class::parseDate('12/03/2015');
         $this->assertEquals('Dec 3, 2015, 12:00 AM', $result->nice());
 
@@ -956,7 +961,8 @@ class TimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testGetDefaultLocale($class) {
+    public function testGetDefaultLocale($class)
+    {
         $this->testSetDefaultLocale($class);
     }
 
@@ -966,7 +972,8 @@ class TimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testSetDefaultOutputTimezone($class) {
+    public function testSetDefaultOutputTimezone($class)
+    {
         $expected = 'Europe/Berlin';
         $class::setDefaultOutputTimezone('Europe/Berlin');
         $result = $class::getDefaultOutputTimezone($expected);
@@ -980,7 +987,8 @@ class TimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testGetDefaultOutputTimezone($class) {
+    public function testGetDefaultOutputTimezone($class)
+    {
         $this->testSetDefaultOutputTimezone($class);
     }
 

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -556,22 +556,8 @@ class TimeTest extends TestCase
         $expected = '1263477568';
         $this->assertTimeFormat($expected, $result);
 
-        $class::setDefaultLocale('de-DE');
-        $class::setDefaultOutputTimezone('Europe/Berlin');
-
-        $result = $time->toUnixString();
-        $expected = '1263477568';
-        $this->assertTimeFormat($expected, $result);
-
         $time = new $class('Thu Jan 1 00:00:00 1970');
         
-        $result = $time->toUnixString();
-        $expected = '0';
-        $this->assertTimeFormat($expected, $result);
-
-        $class::setDefaultLocale('fr-FR');
-        $class::setDefaultOutputTimezone('Europe/Berlin');
-
         $result = $time->toUnixString();
         $expected = '0';
         $this->assertTimeFormat($expected, $result);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -40,7 +40,7 @@ class TimeHelperTest extends TestCase
         parent::setUp();
         $this->View = new View();
         $this->Time = new TimeHelper($this->View);
-        Time::$defaultLocale = 'en_US';
+        Time::setDefaultLocale('en_US');
         $this->locale = I18n::locale();
     }
 
@@ -52,7 +52,7 @@ class TimeHelperTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Time::$defaultLocale = 'en_US';
+        Time::setDefaultLocale('en_US');
         I18n::locale($this->locale);
     }
 
@@ -134,8 +134,12 @@ class TimeHelperTest extends TestCase
         $time = '2014-04-20 20:00';
         $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $this->Time->nice($time));
 
+        $time = '2015-11-06 01:00:00';
         $result = $this->Time->nice($time, 'America/New_York');
-        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
+        $this->assertTimeFormat('Nov 5, 2015, 8:00 PM', $result);
+        $this->Time->config('defaultOutputTimezone', 'Australia/Sydney');
+        $result = $this->Time->nice($time);
+        $this->assertTimeFormat('Nov 6, 2015, 12:00 PM', $result);
     }
 
     /**
@@ -445,7 +449,7 @@ class TimeHelperTest extends TestCase
         $this->assertEquals($expected, $result);
 
         I18n::locale('fr_FR');
-        Time::$defaultLocale = 'fr_FR';
+        Time::setDefaultLocale('fr_FR');
         $time = new \Cake\I18n\FrozenTime('Thu Jan 14 13:59:28 2010');
         $result = $this->Time->format($time, \IntlDateFormatter::FULL);
         $expected = 'jeudi 14 janvier 2010 13:59:28 UTC';
@@ -512,5 +516,22 @@ class TimeHelperTest extends TestCase
         $fallback = 'Date invalid or not set';
         $result = $this->Time->format(null, \IntlDateFormatter::FULL, $fallback);
         $this->assertEquals($fallback, $result);
+    }
+
+    /**
+     * Test config options
+     */
+    public function testConfigOptions()
+    {
+        $Time = new TimeHelper($this->View);
+        $this->assertEquals($Time->config('defaultLocale'), null);
+        $this->assertEquals($Time->config('defaultFormat'), null);
+        $this->assertEquals($Time->config('defaultOutputTimezone'), null);
+        $Time->config('defaultLocale', 'fr_FR');
+        $this->assertEquals($Time->config('defaultLocale'), 'fr_FR');
+        $Time = new TimeHelper($this->View, ['defaultOutputTimezone' => 'America/Vancouver']);
+        $this->assertEquals($Time->config('defaultOutputTimezone'), 'America/Vancouver');
+        $Time->config('defaultOutputTimezone', 'Europe/Berlin');
+        $this->assertEquals($Time->config('defaultOutputTimezone'), 'Europe/Berlin');
     }
 }

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -122,6 +122,9 @@ class TimeHelperTest extends TestCase
     {
         $this->assertEquals(4, $this->Time->toQuarter('2007-12-25'));
         $this->assertEquals(['2007-10-01', '2007-12-31'], $this->Time->toQuarter('2007-12-25', true));
+        $this->assertEquals(1, $this->Time->toQuarter('2016-03-31'));
+        $this->Time->config('defaultOutputTimezone', 'America/Vancouver');
+        $this->assertEquals(1, $this->Time->toQuarter('2016-04-01 01:00:00'));
     }
 
     /**


### PR DESCRIPTION
# Allow easy setting of default output time zones

This PR allows for easy changes of the default printed/formatted timezone. It keeps with the tradition of recommending UTC as the internal / server time zone.
## Examples for using this PR features
### Example in `AppController::beforeFilter()`:

``` php
use DateTimeZone;
use Cake\Controller\Controller;
use Cake\Event\Event;
use Cake\I18n;
use Cake\I18n\Date;
use Cake\I18n\FrozenTime;
use Cake\I18n\FrozenDate;
use Cake\I18n\Time;

class AppController extends Controller
{

    public function initialize()
    {
        parent::initialize();

        // Deprecated
        Time::$defaultLocale = 'de-DE';
        Date::$defaultLocale = 'de-DE';
        FrozenTime::$defaultLocale = 'de-DE';
        FrozenDate::$defaultLocale = 'de-DE';

        // Replacement for deprecated usage
        Time::setDefaultLocale('de-DE');
        Date::setDefaultLocale('de-DE');
        FrozenTime::setDefaultLocale('de-DE');
        FrozenDate::setDefaultLocale('de-DE');

        Time::setDefaultLocale(null);
        Date::setDefaultLocale(null);
        FrozenTime::setDefaultLocale(null);
        FrozenDate::setDefaultLocale(null);

        // New usage for timezones
        Time::setDefaultOutputTimezone('Europe/Berlin');
        Date::setDefaultOutputTimezone('Europe/Berlin');
        FrozenTime::setDefaultOutputTimezone('Europe/Berlin');
        FrozenDate::setDefaultOutputTimezone('Europe/Berlin');

        // Can also take PHP's \DateTimeZone
        Time::setDefaultOutputTimezone(new \DateTimeZone('UTC'));
        Date::setDefaultOutputTimezone(new \DateTimeZone('UTC'));
        FrozenTime::setDefaultOutputTimezone(new \DateTimeZone('UTC'));
        FrozenDate::setDefaultOutputTimezone(new \DateTimeZone('UTC'));

        // Can also take PHP's \DateTimeZone
        Time::setDefaultOutputTimezone(new \DateTimeZone('America/New_York'));
        Date::setDefaultOutputTimezone(new \DateTimeZone('America/New_York'));
        FrozenTime::setDefaultOutputTimezone(new \DateTimeZone('America/New_York'));
        FrozenDate::setDefaultOutputTimezone(new \DateTimeZone('America/New_York'));

        // DateTimeZone will throw exception
        Time::setDefaultOutputTimezone(new \DateTimeZone('Not/Existing_Exception_Please'));
        Date::setDefaultOutputTimezone(new \DateTimeZone('Not/Existing_Exception_Please'));
        FrozenTime::setDefaultOutputTimezone(new \DateTimeZone('Not/Existing_Exception_Please'));
        FrozenDate::setDefaultOutputTimezone(new \DateTimeZone('Not/Existing_Exception_Please'));

        // setDefaultOutputTimezone will create new \DateTimeZone and thus will throw exception
        Time::setDefaultOutputTimezone('Not/Existing_Exception_Please');
        Date::setDefaultOutputTimezone('Not/Existing_Exception_Please');
        FrozenTime::setDefaultOutputTimezone('Not/Existing_Exception_Please');
        FrozenDate::setDefaultOutputTimezone('Not/Existing_Exception_Please');

        // You can also be less explicit, set it for all at once:       
        I18n::defaultOutputTimezone('Australia/Sydney');

    }
```
## Example in some index.ctp view template:

``` php
$this->Time
    ->setDefaultFormat(\IntlDateFormatter::SHORT)
    ->setDefaultOutputTimezone(new \DateTimeZone('Europe/Berlin'))
echo h($article->created);
echo $this->Time->format($article->modified);
$this->Time
    ->setDefaultOutputTimezone('Australia/Sydney');
    ->setDefaultLocale('de-DE');
echo $this->Time->nice($article->published)
```
## EDIT # 1
- Having 2nd thoughts about the below because it will encourage people to use non-utc as internal server time. Better not have it at all.
## EDIT # 2
- Added setters/getters.

Ref: https://github.com/cakephp/cakephp/issues/8571
