### PR TITLE
Add support for tinyblob, mediumblob and longblob

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -121,6 +121,8 @@ class MysqlSchema extends BaseSchema
             return ['type' => 'text', 'length' => $length];
         }
         if (strpos($col, 'blob') !== false || $col === 'binary') {
+            $lengthName = substr($col, 0, -4);
+            $length = isset(Table::$columnLengths[$lengthName]) ? Table::$columnLengths[$lengthName] : null;
             return ['type' => 'binary', 'length' => $length];
         }
         if (strpos($col, 'float') !== false || strpos($col, 'double') !== false) {
@@ -288,7 +290,6 @@ class MysqlSchema extends BaseSchema
             'integer' => ' INTEGER',
             'biginteger' => ' BIGINT',
             'boolean' => ' BOOLEAN',
-            'binary' => ' LONGBLOB',
             'float' => ' FLOAT',
             'decimal' => ' DECIMAL',
             'date' => ' DATE',
@@ -300,6 +301,7 @@ class MysqlSchema extends BaseSchema
         $specialMap = [
             'string' => true,
             'text' => true,
+            'binary' => true,
         ];
         if (isset($typeMap[$data['type']])) {
             $out .= $typeMap[$data['type']];
@@ -322,6 +324,19 @@ class MysqlSchema extends BaseSchema
                     if ($isKnownLength) {
                         $length = array_search($data['length'], Table::$columnLengths);
                         $out .= ' ' . strtoupper($length) . 'TEXT';
+                    }
+
+                    break;
+                case 'binary':
+                    $isKnownLength = in_array($data['length'], Table::$columnLengths);
+                    if (empty($data['length']) || !$isKnownLength) {
+                        $out .= ' BLOB';
+                        break;
+                    }
+
+                    if ($isKnownLength) {
+                        $length = array_search($data['length'], Table::$columnLengths);
+                        $out .= ' ' . strtoupper($length) . 'BLOB';
                     }
 
                     break;

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -302,7 +302,6 @@ class SqlserverSchema extends BaseSchema
             'integer' => ' INTEGER',
             'biginteger' => ' BIGINT',
             'boolean' => ' BIT',
-            'binary' => ' VARBINARY(MAX)',
             'float' => ' FLOAT',
             'decimal' => ' DECIMAL',
             'date' => ' DATE',
@@ -325,6 +324,16 @@ class SqlserverSchema extends BaseSchema
 
         if ($data['type'] === 'text' && $data['length'] !== Table::LENGTH_TINY) {
             $out .= ' NVARCHAR(MAX)';
+        }
+
+        if ($data['type'] === 'binary') {
+            $out .= ' VARBINARY';
+
+            if ($data['length'] !== Table::LENGTH_TINY) {
+                $out .= '(MAX)';
+            } else {
+                $out .= sprintf('(%s)', Table::LENGTH_TINY);
+            }
         }
 
         if ($data['type'] === 'string' || ($data['type'] === 'text' && $data['length'] === Table::LENGTH_TINY)) {

--- a/tests/Fixture/SessionsFixture.php
+++ b/tests/Fixture/SessionsFixture.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\Fixture;
 
+use Cake\Database\Schema\Table;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
@@ -30,7 +31,7 @@ class SessionsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'string', 'length' => 128],
-        'data' => ['type' => 'binary', 'null' => true],
+        'data' => ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM, 'null' => true],
         'expires' => ['type' => 'integer', 'length' => 11, 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -99,6 +99,10 @@ class MysqlSchemaTest extends TestCase
                 ['type' => 'uuid', 'length' => null]
             ],
             [
+                'TEXT',
+                ['type' => 'text', 'length' => null]
+            ],
+            [
                 'TINYTEXT',
                 ['type' => 'text', 'length' => Table::LENGTH_TINY]
             ],
@@ -111,12 +115,20 @@ class MysqlSchemaTest extends TestCase
                 ['type' => 'text', 'length' => Table::LENGTH_LONG]
             ],
             [
+                'TINYBLOB',
+                ['type' => 'binary', 'length' => Table::LENGTH_TINY]
+            ],
+            [
                 'BLOB',
                 ['type' => 'binary', 'length' => null]
             ],
             [
                 'MEDIUMBLOB',
-                ['type' => 'binary', 'length' => null]
+                ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM]
+            ],
+            [
+                'LONGBLOB',
+                ['type' => 'binary', 'length' => Table::LENGTH_LONG]
             ],
             [
                 'FLOAT',
@@ -488,6 +500,27 @@ SQL;
                 'body',
                 ['type' => 'text', 'length' => Table::LENGTH_LONG, 'null' => false],
                 '`body` LONGTEXT NOT NULL'
+            ],
+            // Blob / binary
+            [
+                'body',
+                ['type' => 'binary', 'null' => false],
+                '`body` BLOB NOT NULL'
+            ],
+            [
+                'body',
+                ['type' => 'binary', 'length' => Table::LENGTH_TINY, 'null' => false],
+                '`body` TINYBLOB NOT NULL'
+            ],
+            [
+                'body',
+                ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM, 'null' => false],
+                '`body` MEDIUMBLOB NOT NULL'
+            ],
+            [
+                'body',
+                ['type' => 'binary', 'length' => Table::LENGTH_LONG, 'null' => false],
+                '`body` LONGBLOB NOT NULL'
             ],
             // Integers
             [

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -632,7 +632,7 @@ SQL;
             [
                 'body',
                 ['type' => 'text', 'length' => Table::LENGTH_TINY, 'null' => false],
-                '"body" VARCHAR(' . Table::LENGTH_TINY . ') NOT NULL'
+                sprintf('"body" VARCHAR(%s) NOT NULL', Table::LENGTH_TINY)
             ],
             [
                 'body',

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -490,7 +490,7 @@ SQL;
             [
                 'body',
                 ['type' => 'text', 'length' => Table::LENGTH_TINY, 'null' => false],
-                '[body] NVARCHAR(' . Table::LENGTH_TINY . ') NOT NULL'
+                sprintf('[body] NVARCHAR(%s) NOT NULL', Table::LENGTH_TINY)
             ],
             [
                 'body',
@@ -543,7 +543,22 @@ SQL;
             // Binary
             [
                 'img',
-                ['type' => 'binary'],
+                ['type' => 'binary', 'length' => null],
+                '[img] VARBINARY(MAX)'
+            ],
+            [
+                'img',
+                ['type' => 'binary', 'length' => Table::LENGTH_TINY],
+                sprintf('[img] VARBINARY(%s)', Table::LENGTH_TINY)
+            ],
+            [
+                'img',
+                ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM],
+                '[img] VARBINARY(MAX)'
+            ],
+            [
+                'img',
+                ['type' => 'binary', 'length' => Table::LENGTH_LONG],
                 '[img] VARBINARY(MAX)'
             ],
             // Boolean


### PR DESCRIPTION
Follow up to #8532 but for `blob` type this time. The same logic was applied.

I also replaced the concatenation from the tests file from #8532 with `sprintf` calls.

I did not take care of `int`, because they seem to be supported already ([see this](https://github.com/cakephp/cakephp/blob/master/tests/TestCase/Database/Schema/MysqlSchemaTest.php#L61-L87)).
