### PR TITLE
Don't display welcome message twice.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -447,7 +447,7 @@ class Shell
         if ($this->hasTask($command) && isset($subcommands[$command])) {
             $this->startup();
             array_shift($argv);
-            return $this->{$method}->runCommand($argv, false);
+            return $this->{$method}->runCommand($argv, false, ['requested' => true]);
         }
 
         if ($this->hasMethod('main')) {

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1066,7 +1066,7 @@ TEXT;
         $task->io($io);
         $task->expects($this->once())
             ->method('runCommand')
-            ->with(['one'], false);
+            ->with(['one'], false, ['requested' => true]);
 
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
@@ -1078,6 +1078,41 @@ TEXT;
 
         $shell->Slice = $task;
         $shell->runCommand(['slice', 'one']);
+    }
+
+    /**
+     * test that runCommand will invoke a task
+     *
+     * @return void
+     */
+    public function testRunCommandInvokeTask()
+    {
+        $parser = new ConsoleOptionParser('knife');
+        $parser->addSubcommand('slice');
+        $io = $this->getMock('Cake\Console\ConsoleIo');
+
+        $shell = $this->getMock('Cake\Console\Shell', ['hasTask', 'getOptionParser'], [$io]);
+        $task = $this->getMock('Cake\Console\Shell', ['main', '_welcome'], [$io]);
+
+        $shell->expects($this->once())
+            ->method('getOptionParser')
+            ->will($this->returnValue($parser));
+
+        $shell->expects($this->any())
+            ->method('hasTask')
+            ->will($this->returnValue(true));
+
+        $task->expects($this->never())
+            ->method('_welcome');
+
+        // One welcome message output.
+        $io->expects($this->at(2))
+            ->method('out')
+            ->with($this->stringContains('Welcome to CakePHP'));
+
+        $shell->Slice = $task;
+        $shell->runCommand(['slice', 'one']);
+        $this->assertTrue($task->params['requested'], 'Task is requested, no welcome.');
     }
 
     /**


### PR DESCRIPTION
Make the dispatched shell task as 'requested'. This disables the welcome message being output by the task. The containing shell will take care of emitting the welcome message.

Targeting `3.next` as this is a behavior change, that while backwards compatible (as no API signatures changed) could trip people up.

Refs #8600
