### PR TITLE
Return empty array instead of null when response is an empty array

### DIFF
--- a/src/Network/Http/Response.php
+++ b/src/Network/Http/Response.php
@@ -388,7 +388,7 @@ class Response extends Message
             return $this->_json;
         }
         $data = json_decode($this->_body, true);
-        if ($data) {
+        if (is_array($data)) {
             $this->_json = $data;
             return $this->_json;
         }

--- a/tests/TestCase/Network/Http/ResponseTest.php
+++ b/tests/TestCase/Network/Http/ResponseTest.php
@@ -101,6 +101,10 @@ class ResponseTest extends TestCase
         $data = '';
         $response = new Response([], $data);
         $this->assertFalse(isset($response->json));
+
+        $data = json_encode([]);
+        $response = new Response([], $data);
+        $this->assertEquals([], $response->json);
     }
 
     /**


### PR DESCRIPTION
Response should return an empty array when the response is an empty array. Right now it's returning null in that case.

Fixed + added tests
