### PR TITLE
`Xml::build()` can handle urls and json data

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -108,7 +108,17 @@ class Xml
             'readFile' => true
         ];
         $options += $defaults;
-
+        
+        if (!filter_var($input, FILTER_VALIDATE_URL) === false) {
+            $http = new Client();
+            $response = $http->get($input);
+            $input = $response->body();
+        }
+        
+        if (is_json($input)) {
+            $input = json_decode($input, TRUE);
+        }
+        
         if (is_array($input) || is_object($input)) {
             return static::fromArray($input, $options);
         }

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Utility;
 
+use Cake\Network\Http\Client;
 use Cake\Utility\Exception\XmlException;
 use DOMDocument;
 use DOMNode;


### PR DESCRIPTION
Why the `Xml` utility should not handle directly urls and json data?

Note: for now I have only entered the code in this PR, to know whether if you like it.  
We will need to update the method description and documentation, in the case.
