### PR TITLE
Since return type of json_decode() is mixed, no need to check return …

### DIFF
--- a/src/Network/Http/Response.php
+++ b/src/Network/Http/Response.php
@@ -380,19 +380,14 @@ class Response extends Message
     /**
      * Get the response body as JSON decoded data.
      *
-     * @return null|array
+     * @return mixed
      */
     protected function _getJson()
     {
         if (!empty($this->_json)) {
             return $this->_json;
         }
-        $data = json_decode($this->_body, true);
-        if ($data) {
-            $this->_json = $data;
-            return $this->_json;
-        }
-        return null;
+        return $this->_json = json_decode($this->_body, true);
     }
 
     /**

--- a/tests/TestCase/Network/Http/ResponseTest.php
+++ b/tests/TestCase/Network/Http/ResponseTest.php
@@ -100,7 +100,23 @@ class ResponseTest extends TestCase
 
         $data = '';
         $response = new Response([], $data);
-        $this->assertFalse(isset($response->json));
+        $this->assertNull($response->json);
+
+        $data = json_encode([]);
+        $response = new Response([], $data);
+        $this->assertTrue(is_array($response->json));
+
+        $data = json_encode(null);
+        $response = new Response([], $data);
+        $this->assertNull($response->json);
+
+        $data = json_encode(false);
+        $response = new Response([], $data);
+        $this->assertFalse($response->json);
+
+        $data = json_encode('');
+        $response = new Response([], $data);
+        $this->assertSame('', $response->json);
     }
 
     /**


### PR DESCRIPTION
…type.

Closes #8610
