### PR TITLE
Fixed doc formatting on CakeResponse::cookie

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1191,9 +1191,6 @@ class CakeResponse {
  * If the method is called with an array as argument, it will set the cookie
  * configuration to the cookie container.
  *
- * @param array $options Either null to get all cookies, string for a specific cookie
- *  or array to set cookie.
- *
  * ### Options (when setting a configuration)
  *  - name: The Cookie name
  *  - value: Value of the cookie
@@ -1217,6 +1214,8 @@ class CakeResponse {
  *
  * `$this->cookie((array) $options)`
  *
+ * @param array $options Either null to get all cookies, string for a specific cookie
+ *  or array to set cookie.
  * @return mixed
  */
 	public function cookie($options = null) {


### PR DESCRIPTION
Fixed doc to show properly in the documentation. This change was already applied on master.

![image](https://cloud.githubusercontent.com/assets/26548/14416143/c36947bc-ff74-11e5-9dd8-e50d6d8245a5.png)
