### PR TITLE
Adds an alias property for $id on EntityInterface

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -20,6 +20,8 @@ use JsonSerializable;
 /**
  * Describes the methods that any class representing a data storage should
  * comply with.
+ *
+ * @property mixed $id Alias for commonly used primary key.
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable
 {


### PR DESCRIPTION
This PR adds a `@property` alias for `ID` to the `EntityInterface`.

I keep running into cases where I know an entity has an `id` column but the IDE complains that the property does not exist. Here is a dumb example;

```
   function foo(EntityInterface $entity) {
         return $entity->id;   // <- id property does not exist
  }
```

The `id` property is accessed via magic. So to suppress the warning I often write this.

```
   function foo(EntityInterface $entity) {
         return $entity->get('id');
  }
```

I often thought it would be nice if the `EntityInterface` declared this property since it's part of the Cake table convention.

There is one **negative** side effect. This will force entity classes that do not have an `id` property to appear that they do in the IDE. An example would be entities that use compound keys. There would still be an `id` property showing in the auto complete list.

So the question is, does the frequent use of `id` justify it as a standard property for all entities. In the way that it assists developers with auto-complete, or are the edge cases of the few tables that do not have it require that we do not merge this PR.

I'll leave that decision to the community.
