### PR TITLE
Adds sorting to the ConsoleOptionParser for shells.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -361,8 +361,10 @@ class ConsoleOptionParser
             $option = new ConsoleInputOption($options);
         }
         $this->_options[$name] = $option;
+        asort($this->_options);
         if ($option->short() !== null) {
             $this->_shortOptions[$option->short()] = $name;
+            asort($this->_shortOptions);
         }
         return $this;
     }
@@ -495,6 +497,7 @@ class ConsoleOptionParser
             $command = new ConsoleInputSubcommand($options);
         }
         $this->_subcommands[$name] = $command;
+        asort($this->_subcommands);
         return $this;
     }
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -591,12 +591,12 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->help('method');
         $expected = <<<TEXT
 <info>Usage:</info>
-cake mycommand method [-h] [--connection]
+cake mycommand method [--connection] [-h]
 
 <info>Options:</info>
 
---help, -h        Display this help.
 --connection      Db connection.
+--help, -h        Display this help.
 
 TEXT;
         $this->assertTextEquals($expected, $result, 'Help is not correct.');

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -47,7 +47,7 @@ This is fifteen This is
 fifteen This is fifteen
 
 <info>Usage:</info>
-cake test [subcommand] [-h] [--four] [<four>]
+cake test [subcommand] [--four] [-h] [<four>]
 
 <info>Subcommands:</info>
 
@@ -58,9 +58,9 @@ To see help on a subcommand use <info>`cake test [subcommand] --help`</info>
 
 <info>Options:</info>
 
---help, -h  Display this help.
 --four      this is help text
             this is help text
+--help, -h  Display this help.
 
 <info>Arguments:</info>
 
@@ -199,14 +199,14 @@ txt;
         $result = $formatter->text();
         $expected = <<<txt
 <info>Usage:</info>
-cake mycommand [-h] [--test] [-c default]
+cake mycommand [-c default] [-h] [--test]
 
 <info>Options:</info>
 
---help, -h        Display this help.
---test            A test option.
 --connection, -c  The connection to use. <comment>(default:
                   default)</comment>
+--help, -h        Display this help.
+--test            A test option.
 
 txt;
         $this->assertTextEquals($expected, $result, 'Help does not match');

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -161,7 +161,7 @@ class CompletionShellTest extends TestCase
         $this->Shell->runCommand(['options', 'orm_cache']);
         $output = $this->out->output;
 
-        $expected = "--help -h --verbose -v --quiet -q --connection -c\n";
+        $expected = "--connection -c --help -h --quiet -q --verbose -v\n";
         $this->assertTextEquals($expected, $output);
     }
 
@@ -175,7 +175,7 @@ class CompletionShellTest extends TestCase
         $this->Shell->runCommand(['options', 'sample', 'sample']);
         $output = $this->out->output;
 
-        $expected = "--help -h --verbose -v --quiet -q --sample -s\n";
+        $expected = "--help -h --quiet -q --sample -s --verbose -v\n";
         $this->assertTextEquals($expected, $output);
     }
 


### PR DESCRIPTION
`ConsoleOptionParser` was printing help messages in the order the parameters were add.

For most cases this is fine, but when there are a large number of parameters the help message is not in alphabetical order. It is kind of difficult to read this way.

This PR adds sorting to commands and parameters. The help messages are now in alphabetical order making it easier to read longer lists of options.
