### PR TITLE
Add Controller factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,12 @@
     "autoload-dev": {
         "psr-4": {
             "Cake\\Test\\": "tests",
-            "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests",
             "TestApp\\": "tests/test_app/TestApp",
             "TestPlugin\\": "tests/test_app/Plugin/TestPlugin/src",
             "TestPlugin\\Test\\": "tests/test_app/Plugin/TestPlugin/tests",
             "TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src",
+            "Company\\TestPluginThree\\": "tests/test_app/Plugin/Company/TestPluginThree/src",
+            "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests",
             "PluginJs\\": "tests/test_app/Plugin/PluginJs/src"
         }
     },

--- a/src/Http/ControllerFactory.php
+++ b/src/Http/ControllerFactory.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Cake\Core\App;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\Routing\Exception\MissingControllerException;
+use Cake\Utility\Inflector;
+use ReflectionClass;
+
+/**
+ * Factory method for building controllers from request/response pairs.
+ */
+class ControllerFactory
+{
+    /**
+     * Create a controller for a given request/response
+     *
+     * @param \Cake\Network\Request $request The request to build a controller for.
+     * @param \Cake\Network\Response $response The response to use.
+     * @return \Cake\Controller\Controller
+     */
+    public function create(Request $request, Response $response)
+    {
+        $pluginPath = $controller = null;
+        $namespace = 'Controller';
+        if (isset($request->params['plugin'])) {
+            $pluginPath = $request->params['plugin'] . '.';
+        }
+        if (isset($request->params['controller'])) {
+            $controller = $request->params['controller'];
+        }
+        if (isset($request->params['prefix'])) {
+            if (strpos($request->params['prefix'], '/') === false) {
+                $namespace .= '/' . Inflector::camelize($request->params['prefix']);
+            } else {
+                $prefixes = array_map(
+                    'Cake\Utility\Inflector::camelize',
+                    explode('/', $request->params['prefix'])
+                );
+                $namespace .= '/' . implode('/', $prefixes);
+            }
+        }
+        $firstChar = substr($controller, 0, 1);
+        if (strpos($controller, '\\') !== false ||
+            strpos($controller, '.') !== false ||
+            $firstChar === strtolower($firstChar)
+        ) {
+            return $this->missingController($request);
+        }
+        $className = false;
+        if ($pluginPath . $controller) {
+            $className = App::classname($pluginPath . $controller, $namespace, 'Controller');
+        }
+        if (!$className) {
+            return $this->missingController($request);
+        }
+        $reflection = new ReflectionClass($className);
+        if ($reflection->isAbstract() || $reflection->isInterface()) {
+            return $this->missingController($request);
+        }
+        return $reflection->newInstance($request, $response, $controller);
+    }
+
+    /**
+     * Throws an exception when a controller is missing.
+     *
+     * @param \Cake\Network\Request $request The request.
+     * @throws \Cake\Routing\Exception\MissingControllerException
+     * @return void
+     */
+    protected function missingController($request)
+    {
+        throw new MissingControllerException([
+            'class' => $request->param('controller'),
+            'plugin' => $request->param('plugin'),
+            'prefix' => $request->param('prefix'),
+            '_ext' => $request->param('_ext')
+        ]);
+    }
+}

--- a/src/Http/ControllerFactory.php
+++ b/src/Http/ControllerFactory.php
@@ -55,16 +55,19 @@ class ControllerFactory
             }
         }
         $firstChar = substr($controller, 0, 1);
+
+        // Disallow plugin short forms, / and \\ from
+        // controller names as they allow direct references to
+        // be created.
         if (strpos($controller, '\\') !== false ||
+            strpos($controller, '/') !== false ||
             strpos($controller, '.') !== false ||
             $firstChar === strtolower($firstChar)
         ) {
             return $this->missingController($request);
         }
-        $className = false;
-        if ($pluginPath . $controller) {
-            $className = App::classname($pluginPath . $controller, $namespace, 'Controller');
-        }
+
+        $className = App::classname($pluginPath . $controller, $namespace, 'Controller');
         if (!$className) {
             return $this->missingController($request);
         }

--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -16,6 +16,7 @@ namespace Cake\Routing\Filter;
 
 use Cake\Core\App;
 use Cake\Event\Event;
+use Cake\Http\ControllerFactory;
 use Cake\Routing\DispatcherFilter;
 use Cake\Utility\Inflector;
 use ReflectionClass;
@@ -56,47 +57,11 @@ class ControllerFactoryFilter extends DispatcherFilter
      *
      * @param \Cake\Network\Request $request Request object
      * @param \Cake\Network\Response $response Response for the controller.
-     * @return \Cake\Controller\Controller|false Object if loaded, boolean false otherwise.
+     * @return \Cake\Controller\Controller
      */
     protected function _getController($request, $response)
     {
-        $pluginPath = $controller = null;
-        $namespace = 'Controller';
-        if (!empty($request->params['plugin'])) {
-            $pluginPath = $request->params['plugin'] . '.';
-        }
-        if (!empty($request->params['controller'])) {
-            $controller = $request->params['controller'];
-        }
-        if (!empty($request->params['prefix'])) {
-            if (strpos($request->params['prefix'], '/') === false) {
-                $namespace .= '/' . Inflector::camelize($request->params['prefix']);
-            } else {
-                $prefixes = array_map(
-                    'Cake\Utility\Inflector::camelize',
-                    explode('/', $request->params['prefix'])
-                );
-                $namespace .= '/' . implode('/', $prefixes);
-            }
-        }
-        $firstChar = substr($controller, 0, 1);
-        if (strpos($controller, '\\') !== false ||
-            strpos($controller, '.') !== false ||
-            $firstChar === strtolower($firstChar)
-        ) {
-            return false;
-        }
-        $className = false;
-        if ($pluginPath . $controller) {
-            $className = App::classname($pluginPath . $controller, $namespace, 'Controller');
-        }
-        if (!$className) {
-            return false;
-        }
-        $reflection = new ReflectionClass($className);
-        if ($reflection->isAbstract() || $reflection->isInterface()) {
-            return false;
-        }
-        return $reflection->newInstance($request, $response, $controller);
+        $factory = new ControllerFactory();
+        return $factory->create($request, $response);
     }
 }

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -77,12 +77,12 @@ class PluginTest extends TestCase
      */
     public function testLoadSingleWithAutoload()
     {
-        $this->assertFalse(class_exists('Company\TestPluginThree\Utility\Hello'));
-        Plugin::load('Company/TestPluginThree', [
+        $this->assertFalse(class_exists('Company\TestPluginFive\Utility\Hello'));
+        Plugin::load('Company/TestPluginFive', [
             'autoload' => true,
         ]);
         $this->assertTrue(
-            class_exists('Company\TestPluginThree\Utility\Hello'),
+            class_exists('Company\TestPluginFive\Utility\Hello'),
             'Class should be loaded'
         );
     }
@@ -94,7 +94,6 @@ class PluginTest extends TestCase
      */
     public function testLoadSingleWithAutoloadAndBootstrap()
     {
-        $this->assertFalse(class_exists('Company\TestPluginFive\Utility\Hello'));
         Plugin::load(
             'Company/TestPluginFive',
             [

--- a/tests/TestCase/Http/ControllerFactoryTest.php
+++ b/tests/TestCase/Http/ControllerFactoryTest.php
@@ -232,6 +232,23 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class Admin/Posts could not be found.
+     * @return void
+     */
+    public function testSlashedControllerFailure()
+    {
+        $request = new Request([
+            'url' => 'admin/posts/index',
+            'params' => [
+                'controller' => 'Admin/Posts',
+                'action' => 'index',
+            ]
+        ]);
+        $this->factory->create($request, $this->response);
+    }
+
+    /**
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
      * @expectedExceptionMessage Controller class TestApp\Controller\CakesController could not be found.
      * @return void
      */

--- a/tests/TestCase/Http/ControllerFactoryTest.php
+++ b/tests/TestCase/Http/ControllerFactoryTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Core\Configure;
+use Cake\Http\ControllerFactory;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for ControllerFactory.
+ */
+class ControllerFactoryTest extends TestCase
+{
+    /**
+     * Setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        Configure::write('App.namespace', 'TestApp');
+        $this->factory = new ControllerFactory();
+        $this->response = $this->getMock('Cake\Network\Response');
+    }
+
+    /**
+     * Test building an application controller
+     *
+     * @return void
+     */
+    public function testApplicationController()
+    {
+        $request = new Request([
+            'url' => 'cakes/index',
+            'params' => [
+                'controller' => 'Cakes',
+                'action' => 'index',
+            ]
+        ]);
+        $result = $this->factory->create($request, $this->response);
+        $this->assertInstanceOf('TestApp\Controller\CakesController', $result);
+        $this->assertSame($request, $result->request);
+        $this->assertSame($this->response, $result->response);
+    }
+
+    /**
+     * Test building a prefixed app controller.
+     *
+     * @return void
+     */
+    public function testPrefixedAppController()
+    {
+        $request = new Request([
+            'url' => 'admin/posts/index',
+            'params' => [
+                'prefix' => 'admin',
+                'controller' => 'Posts',
+                'action' => 'index',
+            ]
+        ]);
+        $result = $this->factory->create($request, $this->response);
+        $this->assertInstanceOf(
+            'TestApp\Controller\Admin\PostsController',
+            $result
+        );
+        $this->assertSame($request, $result->request);
+        $this->assertSame($this->response, $result->response);
+    }
+
+    /**
+     * Test building a nested prefix app controller
+     *
+     * @return void
+     */
+    public function testNestedPrefixedAppController()
+    {
+        $request = new Request([
+            'url' => 'admin/sub/posts/index',
+            'params' => [
+                'prefix' => 'admin/sub',
+                'controller' => 'Posts',
+                'action' => 'index',
+            ]
+        ]);
+        $result = $this->factory->create($request, $this->response);
+        $this->assertInstanceOf(
+            'TestApp\Controller\Admin\Sub\PostsController',
+            $result
+        );
+        $this->assertSame($request, $result->request);
+        $this->assertSame($this->response, $result->response);
+    }
+
+    /**
+     * Test building a plugin controller
+     *
+     * @return void
+     */
+    public function testPluginController()
+    {
+        $request = new Request([
+            'url' => 'test_plugin/test_plugin/index',
+            'params' => [
+                'plugin' => 'TestPlugin',
+                'controller' => 'TestPlugin',
+                'action' => 'index',
+            ]
+        ]);
+        $result = $this->factory->create($request, $this->response);
+        $this->assertInstanceOf(
+            'TestPlugin\Controller\TestPluginController',
+            $result
+        );
+        $this->assertSame($request, $result->request);
+        $this->assertSame($this->response, $result->response);
+    }
+
+    /**
+     * Test building a vendored plugin controller.
+     *
+     * @return void
+     */
+    public function testVendorPluginController()
+    {
+        $request = new Request([
+            'url' => 'test_plugin_three/ovens/index',
+            'params' => [
+                'plugin' => 'Company/TestPluginThree',
+                'controller' => 'Ovens',
+                'action' => 'index',
+            ]
+        ]);
+        $result = $this->factory->create($request, $this->response);
+        $this->assertInstanceOf(
+            'Company\TestPluginThree\Controller\OvensController',
+            $result
+        );
+        $this->assertSame($request, $result->request);
+        $this->assertSame($this->response, $result->response);
+    }
+
+    /**
+     * Test building a prefixed plugin controller
+     *
+     * @return void
+     */
+    public function testPrefixedPluginController()
+    {
+        $request = new Request([
+            'url' => 'test_plugin/admin/comments',
+            'params' => [
+                'prefix' => 'admin',
+                'plugin' => 'TestPlugin',
+                'controller' => 'Comments',
+                'action' => 'index',
+            ]
+        ]);
+        $result = $this->factory->create($request, $this->response);
+        $this->assertInstanceOf(
+            'TestPlugin\Controller\Admin\CommentsController',
+            $result
+        );
+        $this->assertSame($request, $result->request);
+        $this->assertSame($this->response, $result->response);
+    }
+
+    /**
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class Abstract could not be found.
+     * @return void
+     */
+    public function testAbstractClassFailure()
+    {
+        $request = new Request([
+            'url' => 'abstract/index',
+            'params' => [
+                'controller' => 'Abstract',
+                'action' => 'index',
+            ]
+        ]);
+        $this->factory->create($request, $this->response);
+    }
+
+    /**
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class Interface could not be found.
+     * @return void
+     */
+    public function testInterfaceFailure()
+    {
+        $request = new Request([
+            'url' => 'interface/index',
+            'params' => [
+                'controller' => 'Interface',
+                'action' => 'index',
+            ]
+        ]);
+        $this->factory->create($request, $this->response);
+    }
+
+    /**
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class Invisible could not be found.
+     * @return void
+     */
+    public function testMissingClassFailure()
+    {
+        $request = new Request([
+            'url' => 'interface/index',
+            'params' => [
+                'controller' => 'Invisible',
+                'action' => 'index',
+            ]
+        ]);
+        $this->factory->create($request, $this->response);
+    }
+
+    /**
+     * @expectedException \Cake\Routing\Exception\MissingControllerException
+     * @expectedExceptionMessage Controller class TestApp\Controller\CakesController could not be found.
+     * @return void
+     */
+    public function testAbsoluteReferenceFailure()
+    {
+        $request = new Request([
+            'url' => 'interface/index',
+            'params' => [
+                'controller' => 'TestApp\Controller\CakesController',
+                'action' => 'index',
+            ]
+        ]);
+        $this->factory->create($request, $this->response);
+    }
+}

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -69,12 +69,6 @@ class MyPluginAppController extends Controller
 {
 }
 
-interface DispatcherTestInterfaceController
-{
-
-    public function index();
-}
-
 /**
  * MyPluginController class
  *
@@ -262,15 +256,15 @@ class DispatcherTest extends TestCase
      * testMissingControllerInterface method
      *
      * @expectedException \Cake\Routing\Exception\MissingControllerException
-     * @expectedExceptionMessage Controller class DispatcherTestInterface could not be found.
+     * @expectedExceptionMessage Controller class Interface could not be found.
      * @return void
      */
     public function testMissingControllerInterface()
     {
         $request = new Request([
-            'url' => 'dispatcher_test_interface/index',
+            'url' => 'interface/index',
             'params' => [
-                'controller' => 'DispatcherTestInterface',
+                'controller' => 'Interface',
                 'action' => 'index',
             ]
         ]);
@@ -530,7 +524,15 @@ class DispatcherTest extends TestCase
         $filter->expects($this->never())
             ->method('afterDispatch');
 
-        $request = new Request();
+        $request = new Request([
+            'url' => '/',
+            'params' => [
+                'controller' => 'Pages',
+                'action' => 'display',
+                'home',
+                'pass' => []
+            ]
+        ]);
         $res = new Response();
         $this->dispatcher->addFilter($filter);
         $this->dispatcher->dispatch($request, $res);

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/OvensController.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/OvensController.php
@@ -1,0 +1,12 @@
+<?php
+namespace Company\TestPluginThree\Controller;
+
+use Cake\Controller\Controller;
+
+class OvensController extends Controller
+{
+    public function index()
+    {
+        $this->autoRender = false;
+    }
+}

--- a/tests/test_app/TestApp/Controller/CakesController.php
+++ b/tests/test_app/TestApp/Controller/CakesController.php
@@ -1,0 +1,39 @@
+<?php
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Network\Exception\NotFoundException;
+
+/**
+ * CakesController class
+ */
+class CakesController extends Controller
+{
+    /**
+     * The default model to use.
+     *
+     * @var string
+     */
+    public $modelClass = 'Posts';
+
+    /**
+     * index method
+     *
+     * @return \Cake\Network\Response
+     */
+    public function index()
+    {
+        $this->response->body('Hello Jane');
+        return $this->response;
+    }
+
+    /**
+     * invalid method
+     *
+     * @return \Cake\Network\Response
+     */
+    public function invalid()
+    {
+        return 'Some string';
+    }
+}

--- a/tests/test_app/TestApp/Controller/InterfaceController.php
+++ b/tests/test_app/TestApp/Controller/InterfaceController.php
@@ -1,0 +1,8 @@
+<?php
+namespace TestApp\Controller;
+
+interface InterfaceController
+{
+
+    public function index();
+}


### PR DESCRIPTION
Having this logic out of the a dispatcher filter is necessary for PSR7 migration where the controller factory acts as part of the `ActionDispatcher`

Refs #6960 
