### PR TITLE
Correct DocBlock for HttpException

### DIFF
--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -53,14 +53,15 @@ class CakeBaseException extends RuntimeException {
 
 }
 
+if (!class_exists('HttpException', false)) {
 /**
  * Parent class for all of the HTTP related exceptions in CakePHP.
+ * 
  * All HTTP status/error related exceptions should extend this class so
  * catch blocks can be specifically typed.
  *
  * @package       Cake.Error
  */
-if (!class_exists('HttpException', false)) {
 	class HttpException extends CakeBaseException {
 	}
 }


### PR DESCRIPTION
http://api.cakephp.org/2.8/class-HttpException.html

> Class HttpException
> Base class that all Exceptions extend.

Which is actually the short description of  `CakeBaseException`.

http://api.cakephp.org/2.8/class-CakeBaseException.html

Probably because the DocBlock was placed before the if clause.
