### PR TITLE
Attempt to fix tests in 2.x

### DIFF
--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1843,7 +1843,6 @@ class HttpSocketTest extends CakeTestCase {
 		} catch (SocketException $e) {
 			$message = $e->getMessage();
 			$this->skipIf(strpos($message, 'Invalid HTTP') !== false, 'Invalid HTTP Response received, skipping.');
-			$this->assertContains('Peer certificate CN', $message);
 			$this->assertContains('Failed to enable crypto', $message);
 		}
 	}


### PR DESCRIPTION
Relying on tv.eurosport.com having a bad peer name is pretty fragile. However, we can more easily rely on their cert coming from a CA we no longer trust.
