### PR TITLE
Add the ability to get association by foreign key

### DIFF
--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -85,6 +85,22 @@ class AssociationCollection implements IteratorAggregate
     }
 
     /**
+     * Fetch an association by foreign key.
+     *
+     * @param string $fk The foreign key to find an association by.
+     * @return \Cake\ORM\Association|null Either the association or null.
+     */
+    public function getByForeignKey($fk)
+    {
+        foreach ($this->_items as $assoc) {
+            if ($assoc->foreignKey() === $fk) {
+                return $assoc;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Check for an attached association by name.
      *
      * @param string $alias The association alias to get.

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -104,6 +104,25 @@ class AssociationCollectionTest extends TestCase
     }
 
     /**
+     * Test getting associations by foreign key.
+     *
+     * @return void
+     */
+    public function testGetByForeignKey()
+    {
+        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table->schema([]);
+        $belongsTo = new BelongsTo('Users', [
+            'sourceTable' => $table
+        ]);
+        $this->assertEquals('user_id', $belongsTo->foreignKey());
+        $this->associations->add('Users', $belongsTo);
+        $this->assertNull($this->associations->get('user_id'));
+
+        $this->assertSame($belongsTo, $this->associations->getByForeignKey('user_id'));
+    }
+
+    /**
      * Test associations with plugin names.
      *
      * @return void


### PR DESCRIPTION
This function is useful when the database you're working with does not follow the CakePHP conventions about FK naming
