### PR TITLE
Randomly generate a salt when the salt is '' or null.

### DIFF
--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -152,15 +152,35 @@ class SecurityTest extends CakeTestCase {
 	}
 
 /**
+ * Test that blowfish doesn't return '' when the salt is ''
+ *
+ * @return void
+ */
+	public function testHashBlowfishEmptySalt() {
+		$test = Security::hash('password', 'blowfish');
+		$this->skipIf(strpos($test, '$2a$') === false, 'Blowfish hashes are incorrect.');
+
+		$stored = '';
+		$hash = Security::hash('anything', 'blowfish', $stored);
+		$this->assertNotEquals($stored, $hash);
+
+		$hash = Security::hash('anything', 'blowfish', false);
+		$this->assertNotEquals($stored, $hash);
+
+		$hash = Security::hash('anything', 'blowfish', null);
+		$this->assertNotEquals($stored, $hash);
+	}
+
+/**
  * Test that hash() works with blowfish.
  *
  * @return void
  */
 	public function testHashBlowfish() {
-		Security::setCost(10);
 		$test = Security::hash('password', 'blowfish');
 		$this->skipIf(strpos($test, '$2a$') === false, 'Blowfish hashes are incorrect.');
 
+		Security::setCost(10);
 		$_hashType = Security::$hashType;
 
 		$key = 'someKey';

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -303,7 +303,7 @@ class Security {
  * @return string The hashed string or an empty string on error.
  */
 	protected static function _crypt($password, $salt = false) {
-		if ($salt === false) {
+		if ($salt === false || $salt === null || $salt === '') {
 			$salt = static::_salt(22);
 			$salt = vsprintf('$2a$%02d$%s', array(static::$hashCost, $salt));
 		}


### PR DESCRIPTION
To prevent an issue where any value is accepted as a password when '' is provided as the hashed password.

Refs #8650
