### PR TITLE
2.next Add DboSource::flushQueryCache()

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3541,6 +3541,15 @@ class DboSource extends DataSource {
 	}
 
 /**
+ * Empties the query caches.
+ *
+ * @return void
+ */
+	public function flushQueryCache() {
+		$this->_queryCache = array();
+	}
+
+/**
  * Writes a new key for the in memory sql query cache
  *
  * @param string $sql SQL query

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1810,4 +1810,20 @@ class DboSourceTest extends CakeTestCase {
 		$User->Article = $Article;
 		$User->find('first', array('conditions' => array('User.id' => 1), 'recursive' => 2));
 	}
+
+/**
+ * Test that flushQueryCache works as expected
+ *
+ * @return void
+ */
+	public function testFlushQueryCache() {
+		$this->db->flushQueryCache();
+		$this->db->query('SELECT 1');
+		$this->db->query('SELECT 1');
+		$this->db->query('SELECT 2');
+		$this->assertAttributeCount(2, '_queryCache', $this->db);
+
+		$this->db->flushQueryCache();
+		$this->assertAttributeCount(0, '_queryCache', $this->db);
+	}
 }


### PR DESCRIPTION
Seems to be no way to flush query caches.
