### PR TITLE
Add Table::saveMany().

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1619,6 +1619,32 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
+     * Saves multiple records for a table.
+     *
+     * @param array $entities Entities to save.
+     * @param array $options Options used when calling Table::save() for each entity.
+     * @return bool|array False on failure, entities list on succcess.
+     */
+    public function saveMany($entities, $options = [])
+    {
+        $return = $this->connection()->transactional(
+            function () use ($entities, $options) {
+                foreach ($entities as $entity) {
+                    if ($this->save($entity, $options) === false) {
+                        return false;
+                    }
+                }
+            }
+        );
+
+        if ($return === false) {
+            return false;
+        }
+
+        return $entities;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * For HasMany and HasOne associations records will be removed based on

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1622,7 +1622,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Persists multiple entities of a table.
      *
      * The records will be saved in a transaction which will be rolled back if
-     * any one of the records fails to save due to failed validation or datbase
+     * any one of the records fails to save due to failed validation or database
      * error.
      *
      * @param array|\Cake\ORM\ResultSet $entities Entities to save.

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1619,10 +1619,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Saves multiple records for a table.
+     * Persists multiple entities of a table.
+     *
+     * The records will be saved in a transaction which will be rolled back if
+     * any one of the records fails to save due to failed validation or datbase
+     * error.
      *
      * @param array|\Cake\ORM\ResultSet $entities Entities to save.
-     * @param array $options Options used when calling Table::save() for each entity.
+     * @param array|\ArrayAccess $options Options used when calling Table::save() for each entity.
      * @return bool|array|\Cake\ORM\ResultSet False on failure, entities list on succcess.
      */
     public function saveMany($entities, $options = [])

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1621,9 +1621,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Saves multiple records for a table.
      *
-     * @param array $entities Entities to save.
+     * @param array|\Cake\ORM\ResultSet $entities Entities to save.
      * @param array $options Options used when calling Table::save() for each entity.
-     * @return bool|array False on failure, entities list on succcess.
+     * @return bool|array|\Cake\ORM\ResultSet False on failure, entities list on succcess.
      */
     public function saveMany($entities, $options = [])
     {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2796,6 +2796,25 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test saveMany() with ResultSet instance
+     *
+     * @return void
+     */
+    public function testSaveManyResultSet()
+    {
+        $table = TableRegistry::get('authors');
+
+        $entities = $table->find()->all();
+        $entities->first()->name = 'admad';
+
+        $result = $table->saveMany($entities);
+        $this->assertSame($entities, $result);
+
+        $first = $table->find()->first();
+        $this->assertSame('admad', $first->name);
+    }
+
+    /**
      * Test simple delete.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2778,6 +2778,24 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test saveMany() with entities array
+     *
+     * @return void
+     */
+    public function testSaveManyArray()
+    {
+        $entities = [
+            new Entity(['name' => 'admad']),
+            new Entity(['name' => 'dakota'])
+        ];
+
+        $table = TableRegistry::get('authors');
+        $result = $table->saveMany($entities);
+        $this->assertSame($entities, $result);
+        $this->assertTrue(isset($result[0]->id));
+    }
+
+    /**
      * Test simple delete.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2819,6 +2819,27 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test saveMany() with failed save
+     *
+     * @return void
+     */
+    public function testSaveManyFailed()
+    {
+        $table = TableRegistry::get('authors');
+        $entities = [
+            new Entity(['name' => 'mark']),
+            new Entity(['name' => 'jose'])
+        ];
+        $entities[1]->errors(['name' => ['message']]);
+        $result = $table->saveMany($entities);
+
+        $this->assertFalse($result);
+        foreach ($entities as $entity) {
+            $this->assertTrue($entity->isNew());
+        }
+    }
+
+    /**
      * Test simple delete.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2791,8 +2791,12 @@ class TableTest extends TestCase
 
         $table = TableRegistry::get('authors');
         $result = $table->saveMany($entities);
+
         $this->assertSame($entities, $result);
         $this->assertTrue(isset($result[0]->id));
+        foreach ($entities as $entity) {
+            $this->assertFalse($entity->isNew());
+        }
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2808,13 +2808,17 @@ class TableTest extends TestCase
     {
         $table = TableRegistry::get('authors');
 
-        $entities = $table->find()->all();
+        $entities = $table->find()
+            ->order(['id' => 'ASC'])
+            ->all();
         $entities->first()->name = 'admad';
 
         $result = $table->saveMany($entities);
         $this->assertSame($entities, $result);
 
-        $first = $table->find()->first();
+        $first = $table->find()
+            ->order(['id' => 'ASC'])
+            ->first();
         $this->assertSame('admad', $first->name);
     }
 


### PR DESCRIPTION
Allows saving multiple records in a transaction. This is a pretty common requirement and would be nice to have in core itself.

I'll add tests if people like the idea.
