### PR TITLE
only encode data if it's not already encoded

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1133,7 +1133,7 @@ class Email implements JsonSerializable, Serializable
                 if (is_int($name)) {
                     throw new InvalidArgumentException('No filename specified.');
                 }
-                $fileInfo['data'] = chunk_split(base64_encode($fileInfo['data']), 76, "\r\n");
+                $fileInfo['data'] = base64_decode($fileInfo['data'], true) ? $fileInfo['data'] : chunk_split(base64_encode($fileInfo['data']), 76, "\r\n");
             } else {
                 $fileName = $fileInfo['file'];
                 $fileInfo['file'] = realpath($fileInfo['file']);


### PR DESCRIPTION
While creating a queue plugin which saves emails for sending later I found that this line was causing attachments to be double encoded.  I put a check in to see if it is already encoded before encoding it.   The other option I could think of was to put in some kind of bypass flag on either this line I just edited or some kind of bypass that would go around the _readFile() function on the first pass through, but this seemed the most non-invasive.  Please let me know your feedback and/or if you can release this with the next version. Else I'll have to make my own Email.php file I suppose.
