### PR TITLE
Add warning when openssl doesn't have enough entropy.

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -104,7 +104,16 @@ class Security
             return random_bytes($length);
         }
         if (function_exists('openssl_random_pseudo_bytes')) {
-            return openssl_random_pseudo_bytes($length);
+            $bytes = openssl_random_pseudo_bytes($length, $strongSource);
+            if (!$strongSource) {
+                trigger_error(
+                    'openssl was unable to use a strong source of entropy. ' .
+                    'Consider updating your system libraries, or ensuring ' .
+                    'you have more available entropy.',
+                    E_USER_WARNING
+                );
+            }
+            return $bytes;
         }
         trigger_error(
             'You do not have a safe source of random data available. ' .


### PR DESCRIPTION
Add a warning when openssl is unable to get a strong source of random data. This was reported as a potential issue via the security mailing list by Paolo Cuffiani.
