### PR TITLE
Fix Text::truncate() on single words

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -570,13 +570,12 @@ class Text
             $default['ellipsis'] = "\xe2\x80\xa6";
         }
         $options += $default;
-        extract($options);
 
-        if ($html) {
+        if ($options['html']) {
             if (mb_strlen(preg_replace('/<.*?>/', '', $text)) <= $length) {
                 return $text;
             }
-            $totalLength = mb_strlen(strip_tags($ellipsis));
+            $totalLength = mb_strlen(strip_tags($options['ellipsis']));
             $openTags = [];
             $truncate = '';
 
@@ -623,11 +622,11 @@ class Text
             if (mb_strlen($text) <= $length) {
                 return $text;
             }
-            $truncate = mb_substr($text, 0, $length - mb_strlen($ellipsis));
+            $truncate = mb_substr($text, 0, $length - mb_strlen($options['ellipsis']));
         }
-        if (!$exact) {
+        if (!$options['exact']) {
             $spacepos = mb_strrpos($truncate, ' ');
-            if ($html) {
+            if ($options['html']) {
                 $truncateCheck = mb_substr($truncate, 0, $spacepos);
                 $lastOpenTag = mb_strrpos($truncateCheck, '<');
                 $lastCloseTag = mb_strrpos($truncateCheck, '>');
@@ -660,9 +659,9 @@ class Text
             }
         }
 
-        $truncate .= $ellipsis;
+        $truncate .= $options['ellipsis'];
 
-        if ($html) {
+        if ($options['html']) {
             foreach ($openTags as $tag) {
                 $truncate .= '</' . $tag . '>';
             }

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -556,7 +556,7 @@ TEXT;
         $this->assertSame($this->Text->truncate($text1, 15, ['html' => true]), "The quick brow\xe2\x80\xa6");
         $this->assertSame($this->Text->truncate($text1, 15, ['exact' => false, 'html' => true]), "The quick\xe2\x80\xa6");
         $this->assertSame($this->Text->truncate($text2, 10, ['html' => true]), "Heiz&ouml;lr&uuml;c\xe2\x80\xa6");
-        $this->assertSame($this->Text->truncate($text2, 10, ['exact' => false, 'html' => true]), "Heiz&ouml;\xe2\x80\xa6");
+        $this->assertSame($this->Text->truncate($text2, 10, ['exact' => false, 'html' => true]), "Heiz&ouml;lr&uuml;c\xe2\x80\xa6");
         $this->assertSame($this->Text->truncate($text3, 20, ['html' => true]), "<b>&copy; 2005-2007, Cake S\xe2\x80\xa6</b>");
         $this->assertSame($this->Text->truncate($text4, 15, ['html' => true]), "<img src=\"mypic.jpg\"> This image ta\xe2\x80\xa6");
         $this->assertSame($this->Text->truncate($text4, 45, ['html' => true]), "<img src=\"mypic.jpg\"> This image tag is not XHTML conform!<br><hr/><b>But the\xe2\x80\xa6</b>");
@@ -576,43 +576,31 @@ TEXT;
             'exact' => false,
             'html' => true
         ]);
-        $expected = '<p><span style="font-size: medium;"><a>...</a></span></p>';
+        $expected = '<p><span style="font-size: medium;"><a>Iamates...</a></span></p>';
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test truncate() method with both exact and html.
+     * @return void
+     */
+    public function testTruncateExactHtml()
+    {
+        $text = '<a href="http://example.org">hello</a> world';
+        $expected = '<a href="http://example.org">hell..</a>';
+        $result = Text::truncate($text, 6, array(
+            'ellipsis' => '..',
+            'exact' => true,
+            'html' => true
+        ));
         $this->assertEquals($expected, $result);
 
-        $text = '<p><span style="font-size: medium;">El biógrafo de Steve Jobs, Walter
-Isaacson, explica porqué Jobs le pidió que le hiciera su biografía en
-este artículo de El País.</span></p>
-<p><span style="font-size: medium;"><span style="font-size:
-large;">Por qué Steve era distinto.</span></span></p>
-<p><span style="font-size: medium;"><a href="http://www.elpais.com/
-articulo/primer/plano/Steve/era/distinto/elpepueconeg/
-20111009elpneglse_4/Tes">http://www.elpais.com/articulo/primer/plano/
-Steve/era/distinto/elpepueconeg/20111009elpneglse_4/Tes</a></span></p>
-<p><span style="font-size: medium;">Ya se ha publicado la biografía de
-Steve Jobs escrita por Walter Isaacson  "<strong>Steve Jobs by Walter
-Isaacson</strong>", aquí os dejamos la dirección de amazon donde
-podeís adquirirla.</span></p>
-<p><span style="font-size: medium;"><a>http://www.amazon.com/Steve-
-Jobs-Walter-Isaacson/dp/1451648537</a></span></p>';
-        $result = $this->Text->truncate($text, 500, [
-            'ellipsis' => '... ',
+        $expected = '<a href="http://example.org">hell..</a>';
+        $result = Text::truncate($text, 6, array(
+            'ellipsis' => '..',
             'exact' => false,
             'html' => true
-        ]);
-        $expected = '<p><span style="font-size: medium;">El biógrafo de Steve Jobs, Walter
-Isaacson, explica porqué Jobs le pidió que le hiciera su biografía en
-este artículo de El País.</span></p>
-<p><span style="font-size: medium;"><span style="font-size:
-large;">Por qué Steve era distinto.</span></span></p>
-<p><span style="font-size: medium;"><a href="http://www.elpais.com/
-articulo/primer/plano/Steve/era/distinto/elpepueconeg/
-20111009elpneglse_4/Tes">http://www.elpais.com/articulo/primer/plano/
-Steve/era/distinto/elpepueconeg/20111009elpneglse_4/Tes</a></span></p>
-<p><span style="font-size: medium;">Ya se ha publicado la biografía de
-Steve Jobs escrita por Walter Isaacson  "<strong>Steve Jobs by Walter
-Isaacson</strong>", aquí os dejamos la dirección de amazon donde
-podeís adquirirla.</span></p>
-<p><span style="font-size: medium;"><a>... </a></span></p>';
+        ));
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -588,19 +588,19 @@ TEXT;
     {
         $text = '<a href="http://example.org">hello</a> world';
         $expected = '<a href="http://example.org">hell..</a>';
-        $result = Text::truncate($text, 6, array(
+        $result = Text::truncate($text, 6, [
             'ellipsis' => '..',
             'exact' => true,
             'html' => true
-        ));
+        ]);
         $this->assertEquals($expected, $result);
 
         $expected = '<a href="http://example.org">hell..</a>';
-        $result = Text::truncate($text, 6, array(
+        $result = Text::truncate($text, 6, [
             'ellipsis' => '..',
             'exact' => false,
             'html' => true
-        ));
+        ]);
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
Fixing this issue required making a small behavior change around how single unbreakable words are handled. Instead of being entirely omitted as before, if a text fragment is not breakable, we do an exact slice. This favors including _some_ content over just the ellipsis. While this is a behavior change, I don't think its very intuitive that an inexact truncation will result in no text. This also changes how chains of entities work as shown in the modified test case.

This method is in pretty rough shape and at some point in the future, building a more robust HTML munger/tokenizer might be in order if we continue to get issues reported for how the HTML option works.

Refs #8673
