### PR TITLE
Use import options when generating fixtures

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -178,9 +178,13 @@ class FixtureTask extends BakeTask {
  */
 	public function importOptions($modelName) {
 		$options = array();
+		$plugin = '';
+		if (isset($this->params['plugin'])) {
+			$plugin = $this->params['plugin'] . '.';
+		}
 
 		if (!empty($this->params['schema'])) {
-			$options['schema'] = $modelName;
+			$options['schema'] = $plugin . $modelName;
 		} elseif ($this->interactive) {
 			$doSchema = $this->in(__d('cake_console', 'Would you like to import schema for this fixture?'), array('y', 'n'), 'n');
 			if ($doSchema === 'y') {

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -125,7 +125,8 @@ class FixtureTask extends BakeTask {
 				return $this->all();
 			}
 			$model = $this->_modelName($this->args[0]);
-			$this->bake($model);
+			$importOptions = $this->importOptions($model);
+			$this->bake($model, false, $importOptions);
 		}
 	}
 
@@ -180,21 +181,22 @@ class FixtureTask extends BakeTask {
 
 		if (!empty($this->params['schema'])) {
 			$options['schema'] = $modelName;
-		} else {
+		} elseif ($this->interactive) {
 			$doSchema = $this->in(__d('cake_console', 'Would you like to import schema for this fixture?'), array('y', 'n'), 'n');
 			if ($doSchema === 'y') {
 				$options['schema'] = $modelName;
 			}
 		}
+
 		if (!empty($this->params['records'])) {
-			$doRecords = 'y';
-		} else {
+			$options['fromTable'] = true;
+		} elseif ($this->interactive) {
 			$doRecords = $this->in(__d('cake_console', 'Would you like to use record importing for this fixture?'), array('y', 'n'), 'n');
+			if ($doRecords === 'y') {
+				$options['records'] = true;
+			}
 		}
-		if ($doRecords === 'y') {
-			$options['records'] = true;
-		}
-		if ($doRecords === 'n') {
+		if (!isset($options['records']) && $this->interactive) {
 			$prompt = __d('cake_console', "Would you like to build this fixture with data from %s's table?", $modelName);
 			$fromTable = $this->in($prompt, array('y', 'n'), 'n');
 			if (strtolower($fromTable) === 'y') {

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -137,6 +137,19 @@ class FixtureTaskTest extends CakeTestCase {
 	}
 
 /**
+ * test importOptions with overwriting CLI options
+ *
+ * @return void
+ */
+	public function testImportOptionsWithCommandLineOptionsPlugin() {
+		$this->Task->params = array('schema' => true, 'records' => true, 'plugin' => 'TestPlugin');
+
+		$result = $this->Task->importOptions('Article');
+		$expected = array('schema' => 'TestPlugin.Article', 'fromTable' => true);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * test importOptions with schema.
  *
  * @return void

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -98,6 +98,7 @@ class FixtureTaskTest extends CakeTestCase {
  * @return void
  */
 	public function testImportOptionsSchemaRecords() {
+		$this->Task->interactive = true;
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('y'));
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue('y'));
 
@@ -112,6 +113,7 @@ class FixtureTaskTest extends CakeTestCase {
  * @return void
  */
 	public function testImportOptionsNothing() {
+		$this->Task->interactive = true;
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('n'));
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue('n'));
 		$this->Task->expects($this->at(2))->method('in')->will($this->returnValue('n'));
@@ -130,7 +132,7 @@ class FixtureTaskTest extends CakeTestCase {
 		$this->Task->params = array('schema' => true, 'records' => true);
 
 		$result = $this->Task->importOptions('Article');
-		$expected = array('schema' => 'Article', 'records' => true);
+		$expected = array('schema' => 'Article', 'fromTable' => true);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -140,6 +142,7 @@ class FixtureTaskTest extends CakeTestCase {
  * @return void
  */
 	public function testImportOptionsWithSchema() {
+		$this->Task->interactive = true;
 		$this->Task->params = array('schema' => true);
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('n'));
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue('n'));
@@ -155,11 +158,12 @@ class FixtureTaskTest extends CakeTestCase {
  * @return void
  */
 	public function testImportOptionsWithRecords() {
+		$this->Task->interactive = true;
 		$this->Task->params = array('records' => true);
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('n'));
 
 		$result = $this->Task->importOptions('Article');
-		$expected = array('records' => true);
+		$expected = array('fromTable' => true);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -169,6 +173,7 @@ class FixtureTaskTest extends CakeTestCase {
  * @return void
  */
 	public function testImportOptionsTable() {
+		$this->Task->interactive = true;
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('n'));
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue('n'));
 		$this->Task->expects($this->at(2))->method('in')->will($this->returnValue('y'));
@@ -242,6 +247,62 @@ class FixtureTaskTest extends CakeTestCase {
 			'records' => false
 		));
 		$this->assertContains("'body' => 'Body \"value\"'", $result, 'Data has bad escaping');
+	}
+
+/**
+ * test that execute includes import options
+ *
+ * @return void
+ */
+	public function testExecuteWithImportSchema() {
+		$this->Task->connection = 'test';
+		$this->Task->path = '/my/path/';
+		$this->Task->args = array('article');
+		$this->Task->params = array(
+			'schema' => true,
+			'records' => false,
+		);
+		$filename = '/my/path/ArticleFixture.php';
+
+		$this->Task->expects($this->never())
+			->method('in');
+
+		$this->Task->expects($this->at(0))
+			->method('createFile')
+			->with($filename, $this->logicalAnd(
+				$this->stringContains('class ArticleFixture'),
+				$this->stringContains("\$import = array('model' => 'Article'")
+			));
+
+		$this->Task->execute();
+	}
+
+/**
+ * test that execute includes import options
+ *
+ * @return void
+ */
+	public function testExecuteWithImportRecords() {
+		$this->Task->connection = 'test';
+		$this->Task->path = '/my/path/';
+		$this->Task->args = array('article');
+		$this->Task->params = array(
+			'schema' => true,
+			'records' => true,
+		);
+		$filename = '/my/path/ArticleFixture.php';
+
+		$this->Task->expects($this->never())
+			->method('in');
+
+		$this->Task->expects($this->at(0))
+			->method('createFile')
+			->with($filename, $this->logicalAnd(
+				$this->stringContains('class ArticleFixture'),
+				$this->stringContains("\$import = array('model' => 'Article', 'connection' => 'test')")
+			));
+
+		$this->Task->execute();
 	}
 
 /**


### PR DESCRIPTION
The `records` and `schema` options should work when using execute(). Previously they were not working. Furthermore, the records option did a non-sensical thing where it both set import=>records and generated static records from the live table. The `records` option now enables the generation of static data from a live table, as I think this is a more common scenario.

I've also pulled in the plugin fixes from #8694

Refs #8693 #8694 
