### PR TITLE
notBlank rule should not false positive on numeric input

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -83,7 +83,7 @@ class Validation
      */
     public static function notBlank($check)
     {
-        if (empty($check) && $check !== '0') {
+        if (empty($check) && $check !== '0' && $check !== 0) {
             return false;
         }
         return static::_check($check, '/[^\s]+/m');

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -481,7 +481,8 @@ class Validation
         if (empty($methods[$type])) {
             throw new \InvalidArgumentException('Unsupported parser type given.');
         }
-        return (Time::{$methods[$type]}($check, $format) !== null);
+        $method = $methods[$type];
+        return (Time::$method($check, $format) !== null);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -31,6 +31,16 @@ class ValidationTest extends TestCase
 {
 
     /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @var string
+     */
+    protected $_appEncoding;
+
+    /**
      * setUp method
      *
      * @return void
@@ -60,7 +70,7 @@ class ValidationTest extends TestCase
      *
      * @return void
      */
-    public function testNotEmpty()
+    public function testNotBlank()
     {
         $this->assertTrue(Validation::notBlank('abcdefg'));
         $this->assertTrue(Validation::notBlank('fasdf '));
@@ -69,6 +79,8 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::notBlank('José'));
         $this->assertTrue(Validation::notBlank('é'));
         $this->assertTrue(Validation::notBlank('π'));
+        $this->assertTrue(Validation::notBlank('0'));
+        $this->assertTrue(Validation::notBlank(0));
         $this->assertFalse(Validation::notBlank("\t "));
         $this->assertFalse(Validation::notBlank(""));
     }
@@ -78,7 +90,7 @@ class ValidationTest extends TestCase
      *
      * @return void
      */
-    public function testNotEmptyISO88591AppEncoding()
+    public function testNotBlankIso88591AppEncoding()
     {
         Configure::write('App.encoding', 'ISO-8859-1');
         $this->assertTrue(Validation::notBlank('abcdefg'));
@@ -1862,7 +1874,7 @@ class ValidationTest extends TestCase
      */
     public function testEmailDeep()
     {
-        $this->skipIf(gethostbynamel('example.abcd'), 'Your DNS service responds for non-existant domains, skipping deep email checks.');
+        $this->skipIf((bool)gethostbynamel('example.abcd'), 'Your DNS service responds for non-existant domains, skipping deep email checks.');
 
         $this->assertTrue(Validation::email('abc.efg@cakephp.org', true));
         $this->assertFalse(Validation::email('abc.efg@caphpkeinvalid.com', true));

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -33,7 +33,7 @@ class ValidationTest extends TestCase
     /**
      * @var string
      */
-    protected $locale;
+    public $locale;
 
     /**
      * @var string


### PR DESCRIPTION
Currently the rule `'notBlank'` works fine when working with submitting form input, due to the nature of string post values.
But as soon as you process them in beforeValidate() - e.g. numeric operations - they would be casted to int, as soon as you work with API or third party input or any input that might contain numeric `1` and `0` for this "count" field, the `notBlank` rule suddenly errors and prevents the totally valid entity from saving.
IMO notBlank should only error on actual empty input, thus for `''` (empty string) - or at least also allow numeric non-blank input as this fix allows.

We should also port this to 2.x ( https://github.com/cakephp/cakephp/blob/2.x/lib/Cake/Utility/Validation.php ) then.
