### PR TITLE
BaseAuth now pass the username to custom finder

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -153,6 +153,10 @@ abstract class BaseAuthenticate implements EventListenerInterface
             $finder = key($finder);
         }
 
+        if (!isset($options['username'])) {
+            $options['username'] = $username;
+        }
+
         $query = $table->find($finder, $options);
 
         return $query;

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -320,6 +320,43 @@ class FormAuthenticateTest extends TestCase
     }
 
     /**
+     * Test using custom finder
+     *
+     * @return void
+     */
+    public function testFinderOptions()
+    {
+        $request = new Request('posts/index');
+        $request->data = [
+            'username' => 'mariano',
+            'password' => 'password'
+        ];
+
+        $this->auth->config([
+            'userModel' => 'AuthUsers',
+            'finder' => 'username'
+        ]);
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $expected = [
+            'id' => 1,
+            'username' => 'mariano',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $this->auth->config([
+            'finder' => ['username' => ['username' => 'nate']]
+        ]);
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $expected = [
+            'id' => 5,
+            'username' => 'nate',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test password hasher settings
      *
      * @return void

--- a/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
@@ -12,6 +12,7 @@
  */
 namespace TestApp\Model\Table;
 
+use Cake\Core\Exception\Exception;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 
@@ -35,6 +36,26 @@ class AuthUsersTable extends Table
         if (!empty($options['return_created'])) {
             $query->select(['created']);
         }
+
+        return $query;
+    }
+
+    /**
+     * Custom finder
+     *
+     * @param \Cake\ORM\Query $query The query to find with
+     * @param array $options The options to find with
+     * @return \Cake\ORM\Query The query builder
+     */
+    public function findUsername(Query $query, array $options)
+    {
+        if (empty($options['username'])) {
+            throw new Exception(__('Username not defined'));
+        }
+
+        $query = $this->find()
+            ->where(['username' => $options['username']])
+            ->select(['id', 'username', 'password']);
 
         return $query;
     }


### PR DESCRIPTION
This commit adds the `$username` variable to the options of the custom finder. (if not defined in the config already)

It seems likely that a custom finder which is related to auth will require that value. One example would be to replicate a feature like the multi-column authentication from `friendsofcake\Authenticate` by using a custom finder.
