### PR TITLE
Move Http\Client into Http package.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -29,18 +29,6 @@ class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');
 class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');
 class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');
 
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');
-class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');
-class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');
-class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');
-class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');
-class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');
-class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');
-class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');
-class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');
-class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');
-class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');
 
 require CAKE . 'basics.php';
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -19,28 +19,28 @@ define('TIME_START', microtime(true));
 
 // @deprecated Backward compatibility with 2.x series
 if (PHP_VERSION_ID < 70000) {
-    class_alias('Cake\Utility\Text', 'Cake\Utility\String', false);
+    class_alias('Cake\Utility\Text', 'Cake\Utility\String');
 }
 
 // @deprecated Backward compatibility with 2.x, 3.0.x
-class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport', false);
-class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport', false);
-class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email', false);
-class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport', false);
-class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport', false);
+class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport');
+class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport');
+class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');
+class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');
+class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');
 
 // @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client', 'Cake\Network\Http\Client', false);
-class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection', false);
-class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData', false);
-class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message', false);
-class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request', false);
-class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response', false);
-class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream', false);
-class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic', false);
-class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest', false);
-class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth', false);
-class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part', false);
+class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');
+class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');
+class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');
+class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');
+class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');
+class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');
+class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');
+class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');
+class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');
+class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');
+class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');
 
 require CAKE . 'basics.php';
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -19,28 +19,28 @@ define('TIME_START', microtime(true));
 
 // @deprecated Backward compatibility with 2.x series
 if (PHP_VERSION_ID < 70000) {
-    class_alias('Cake\Utility\Text', 'Cake\Utility\String');
+    class_alias('Cake\Utility\Text', 'Cake\Utility\String', false);
 }
 
 // @deprecated Backward compatibility with 2.x, 3.0.x
-class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport');
-class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport');
-class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');
-class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');
-class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');
+class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport', false);
+class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport', false);
+class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email', false);
+class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport', false);
+class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport', false);
 
 // @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');
-class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');
-class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');
-class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');
-class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');
-class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');
-class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');
-class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');
-class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');
-class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');
-class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');
+class_alias('Cake\Http\Client', 'Cake\Network\Http\Client', false);
+class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection', false);
+class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData', false);
+class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message', false);
+class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request', false);
+class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response', false);
+class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream', false);
+class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic', false);
+class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest', false);
+class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth', false);
+class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part', false);
 
 require CAKE . 'basics.php';
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -29,6 +29,19 @@ class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');
 class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');
 class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');
 
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');
+class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');
+class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');
+class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');
+class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');
+class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');
+class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');
+class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');
+class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');
+class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');
+class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');
+
 require CAKE . 'basics.php';
 
 // Sets the initial router state so future reloads work.

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -11,11 +11,13 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http;
+namespace Cake\Http;
 
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Http\Client\CookieCollection;
+use Cake\Http\Client\Request;
 use Cake\Utility\Hash;
 
 /**
@@ -98,7 +100,7 @@ class Client
      * @var array
      */
     protected $_defaultConfig = [
-        'adapter' => 'Cake\Network\Http\Adapter\Stream',
+        'adapter' => 'Cake\Http\Client\Adapter\Stream',
         'host' => null,
         'port' => null,
         'scheme' => 'http',
@@ -116,7 +118,7 @@ class Client
      * Cookies are indexed by the cookie's domain or
      * request host name.
      *
-     * @var \Cake\Network\Http\CookieCollection
+     * @var \Cake\Http\Client\CookieCollection
      */
     protected $_cookies;
 
@@ -124,7 +126,7 @@ class Client
      * Adapter for sending requests. Defaults to
      * Cake\Network\Http\Adapter\Stream
      *
-     * @var \Cake\Network\Http\Adapter\Stream
+     * @var \Cake\Http\Client\Adapter\Stream
      */
     protected $_adapter;
 
@@ -175,7 +177,7 @@ class Client
      *
      * Returns an array of cookie data arrays.
      *
-     * @return \Cake\Network\Http\CookieCollection
+     * @return \Cake\Http\Client\CookieCollection
      */
     public function cookies()
     {
@@ -193,7 +195,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param array $data The query data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function get($url, $data = [], array $options = [])
     {
@@ -218,7 +220,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param mixed $data The post data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function post($url, $data = [], array $options = [])
     {
@@ -233,7 +235,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param mixed $data The request data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function put($url, $data = [], array $options = [])
     {
@@ -248,7 +250,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param mixed $data The request data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function patch($url, $data = [], array $options = [])
     {
@@ -263,7 +265,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param mixed $data The request data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function options($url, $data = [], array $options = [])
     {
@@ -278,7 +280,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param mixed $data The request data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function trace($url, $data = [], array $options = [])
     {
@@ -293,7 +295,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param mixed $data The request data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function delete($url, $data = [], array $options = [])
     {
@@ -308,7 +310,7 @@ class Client
      * @param string $url The url or path you want to request.
      * @param array $data The query string data you want to send.
      * @param array $options Additional options for the request.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function head($url, array $data = [], array $options = [])
     {
@@ -324,7 +326,7 @@ class Client
      * @param string $url URL to request.
      * @param mixed $data The request body.
      * @param array $options The options to use. Contains auth, proxy etc.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     protected function _doRequest($method, $url, $data, $options)
     {
@@ -354,9 +356,9 @@ class Client
      * Used internally by other methods, but can also be used to send
      * handcrafted Request objects.
      *
-     * @param \Cake\Network\Http\Request $request The request to send.
+     * @param \Cake\Http\Client\Request $request The request to send.
      * @param array $options Additional options to use.
-     * @return \Cake\Network\Http\Response
+     * @return \Cake\Http\Client\Response
      */
     public function send(Request $request, $options = [])
     {
@@ -414,7 +416,7 @@ class Client
      * @param string $url The url including query string.
      * @param mixed $data The request body.
      * @param array $options The options to use. Contains auth, proxy etc.
-     * @return \Cake\Network\Http\Request
+     * @return \Cake\Http\Client\Request
      */
     protected function _createRequest($method, $url, $data, $options)
     {
@@ -480,7 +482,7 @@ class Client
      * Uses the authentication type to choose the correct strategy
      * and use its methods to add headers.
      *
-     * @param \Cake\Network\Http\Request $request The request to modify.
+     * @param \Cake\Http\Client\Request $request The request to modify.
      * @param array $options Array of options containing the 'auth' key.
      * @return void
      */
@@ -497,7 +499,7 @@ class Client
      * Uses the authentication type to choose the correct strategy
      * and use its methods to add headers.
      *
-     * @param \Cake\Network\Http\Request $request The request to modify.
+     * @param \Cake\Http\Client\Request $request The request to modify.
      * @param array $options Array of options containing the 'proxy' key.
      * @return void
      */
@@ -525,7 +527,7 @@ class Client
             $auth['type'] = 'basic';
         }
         $name = ucfirst($auth['type']);
-        $class = App::className($name, 'Network/Http/Auth');
+        $class = App::className($name, 'Http/Client/Auth');
         if (!$class) {
             throw new Exception(
                 sprintf('Invalid authentication type %s', $name)

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -11,12 +11,12 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http\Adapter;
+namespace Cake\Http\Client\Adapter;
 
 use Cake\Core\Exception\Exception;
-use Cake\Network\Http\FormData;
-use Cake\Network\Http\Request;
-use Cake\Network\Http\Response;
+use Cake\Http\Client\FormData;
+use Cake\Http\Client\Request;
+use Cake\Http\Client\Response;
 
 /**
  * Implements sending Cake\Network\Http\Request
@@ -65,7 +65,7 @@ class Stream
     /**
      * Send a request and get a response back.
      *
-     * @param \Cake\Network\Http\Request $request The request object to send.
+     * @param \Cake\Http\Client\Request $request The request object to send.
      * @param array $options Array of options for the stream.
      * @return array Array of populated Response objects
      */

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http\Auth;
+namespace Cake\Http\Client\Auth;
 
 use Cake\Network\Http\Request;
 

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -11,10 +11,10 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http\Auth;
+namespace Cake\Http\Client\Auth;
 
-use Cake\Network\Http\Client;
-use Cake\Network\Http\Request;
+use Cake\Http\Client;
+use Cake\Http\Client\Request;
 
 /**
  * Digest authentication adapter for Cake\Network\Http\Client

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -11,10 +11,10 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http\Auth;
+namespace Cake\Http\Client\Auth;
 
 use Cake\Core\Exception\Exception;
-use Cake\Network\Http\Request;
+use Cake\Http\Client\Request;
 
 /**
  * Oauth 1 authentication strategy for Cake\Network\Http\Client

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -11,7 +11,9 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http;
+namespace Cake\Http\Client;
+
+use Cake\Http\Client\Response;
 
 /**
  * Container class for cookies used in Http\Client.

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -13,8 +13,6 @@
  */
 namespace Cake\Http\Client;
 
-use Cake\Http\Client\Response;
-
 /**
  * Container class for cookies used in Http\Client.
  *

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -11,9 +11,9 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http;
+namespace Cake\Http\Client;
 
-use Cake\Network\Http\FormData\Part;
+use Cake\Http\Client\FormDataPart;
 use Countable;
 use finfo;
 
@@ -23,7 +23,6 @@ use finfo;
  *
  * Used by Http\Client to upload POST/PUT data
  * and files.
- *
  */
 class FormData implements Countable
 {
@@ -75,11 +74,11 @@ class FormData implements Countable
      *
      * @param string $name The name of the part.
      * @param string $value The value to add.
-     * @return \Cake\Network\Http\FormData\Part
+     * @return \Cake\Network\Http\FormDataPart
      */
     public function newPart($name, $value)
     {
-        return new Part($name, $value);
+        return new FormDataPart($name, $value);
     }
 
     /**
@@ -109,7 +108,7 @@ class FormData implements Countable
                 E_USER_DEPRECATED
             );
             $this->_parts[] = $this->addFile($name, $value);
-        } elseif ($name instanceof Part && $value === null) {
+        } elseif ($name instanceof FormDataPart && $value === null) {
             $this->_hasComplexPart = true;
             $this->_parts[] = $name;
         } else {
@@ -140,7 +139,7 @@ class FormData implements Countable
      *
      * @param string $name The name to use.
      * @param mixed $value Either a string filename, or a filehandle.
-     * @return \Cake\Network\Http\FormData\Part
+     * @return \Cake\Network\Http\FormDataPart
      */
     public function addFile($name, $value)
     {

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -13,7 +13,6 @@
  */
 namespace Cake\Http\Client;
 
-use Cake\Http\Client\FormDataPart;
 use Countable;
 use finfo;
 

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http\FormData;
+namespace Cake\Http\Client;
 
 /**
  * Contains the data and behavior for a single
@@ -19,8 +19,10 @@ namespace Cake\Network\Http\FormData;
  *
  * Added to Cake\Network\Http\FormData when sending
  * data to a remote server.
+ *
+ * @internal
  */
-class Part
+class FormDataPart
 {
 
     /**

--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http;
+namespace Cake\Http\Client;
 
 /**
  * Base class for other HTTP requests/responses

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http;
+namespace Cake\Http\Client;
 
 use Cake\Core\Exception\Exception;
 
@@ -20,6 +20,7 @@ use Cake\Core\Exception\Exception;
  *
  * Used by Cake\Network\Http\Client to contain request information
  * for making requests.
+ *
  */
 class Request extends Message
 {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Network\Http;
+namespace Cake\Http\Client;
 
 use RuntimeException;
 

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');

--- a/src/Network/Http/Auth/Basic.php
+++ b/src/Network/Http/Auth/Basic.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');

--- a/src/Network/Http/Auth/Digest.php
+++ b/src/Network/Http/Auth/Digest.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');

--- a/src/Network/Http/CookieCollection.php
+++ b/src/Network/Http/CookieCollection.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');

--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');

--- a/src/Network/Http/FormData/Part.php
+++ b/src/Network/Http/FormData/Part.php
@@ -1,0 +1,2 @@
+<?php
+class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');

--- a/src/Network/Http/Message.php
+++ b/src/Network/Http/Message.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');

--- a/src/Network/Http/Response.php
+++ b/src/Network/Http/Response.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');


### PR DESCRIPTION
Move `Cake\Network\Http\Client` into the Http package. This change just moves the implementation and not the test cases. This shows that the correct class renames are in place. I wanted to move the implementation first to keep this change small and easy to review. I've renamed `FormData\Part` to `FormDataPart` as the extra directories were not necessary.

I also wanted get consensus on the renames before doing more work. After this, I'll be ensuring that the request and response object the client use implement the PSR7 interfaces.

Refs #6960 
