### PR TITLE
Make return value of Controller:referer() consistent when returning local URLs.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -645,7 +645,18 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $referer = $this->request->referer($local);
         if ($referer === '/' && $default && $default !== $referer) {
-            return Router::url($default, !$local);
+            $url = Router::url($default, !$local);
+            if ($local
+                && $this->request->base
+                && strpos($url, $this->request->base) === 0
+            ) {
+                $url = substr($url, strlen($this->request->base));
+                if ($url[0] !== '/') {
+                    $url = '/' . $url;
+                }
+                return $url;
+            }
+            return $url;
         }
         return $referer;
     }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -626,7 +626,7 @@ class ControllerTest extends TestCase
 
         $controller = new Controller($request);
         $result = $controller->referer('/some/path', true);
-        $this->assertEquals('/base/some/path', $result);
+        $this->assertEquals('/some/path', $result);
     }
 
     /**


### PR DESCRIPTION
Before this fix if referrer is available the local URL returned does not have
base appended but if a referrer is not found the URL returned using the default
URL passed as argument gets returned with base appended. This inconsistency
makes it difficult to have usage like
return $this->redirect($this->referrer('/default')); when the app is in a
subfolder as the base get appended twice.

Targeting 3.3 as discussed in #8676
