### PR TITLE
Custom encryption key when using ConfigKey in CookieComponent

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -252,7 +252,7 @@ class CookieComponent extends Component
         $cookie = $this->request->cookies[$first];
         $config = $this->configKey($first);
         $this->_loaded[$first] = true;
-        $this->_values[$first] = $this->_decrypt($cookie, $config['encryption']);
+        $this->_values[$first] = $this->_decrypt($cookie, $config['encryption'], $config['key']);
     }
 
     /**
@@ -310,7 +310,7 @@ class CookieComponent extends Component
 
         $this->_response->cookie([
             'name' => $name,
-            'value' => $this->_encrypt($value, $config['encryption']),
+            'value' => $this->_encrypt($value, $config['encryption'], $config['key']),
             'expire' => $expires->format('U'),
             'path' => $config['path'],
             'domain' => $config['domain'],

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -46,7 +46,7 @@ trait CookieCryptTrait
      * @param string $value Value to encrypt
      * @param string|bool $encrypt Encryption mode to use. False
      *   disabled encryption.
-     * @param string|null $key Used as the security salt only in this time for tests if specified.
+     * @param string|null $key Used as the security salt if specified.
      * @return string Encoded values
      */
     protected function _encrypt($value, $encrypt, $key = null)
@@ -60,7 +60,7 @@ trait CookieCryptTrait
         $this->_checkCipher($encrypt);
         $prefix = "Q2FrZQ==.";
         $cipher = null;
-        if (!isset($key)) {
+        if ($key === null) {
             $key = $this->_getCookieEncryptionKey();
         }
         if ($encrypt === 'rijndael') {
@@ -95,6 +95,7 @@ trait CookieCryptTrait
      *
      * @param array $values Values to decrypt
      * @param string|bool $mode Encryption mode
+     * @param string|null $key Used as the security salt if specified.
      * @return string decrypted string
      */
     protected function _decrypt($values, $mode, $key = null)
@@ -115,6 +116,7 @@ trait CookieCryptTrait
      *
      * @param string $value The value to decode & decrypt.
      * @param string|false $encrypt The encryption cipher to use.
+     * @param string|null $key Used as the security salt if specified.
      * @return string Decoded value.
      */
     protected function _decode($value, $encrypt, $key)
@@ -125,7 +127,7 @@ trait CookieCryptTrait
         $this->_checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
         $value = base64_decode(substr($value, strlen($prefix)));
-        if (!isset($key)) {
+        if ($key === null) {
             $key = $this->_getCookieEncryptionKey();
         }
         if ($encrypt === 'rijndael') {

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -97,15 +97,15 @@ trait CookieCryptTrait
      * @param string|bool $mode Encryption mode
      * @return string decrypted string
      */
-    protected function _decrypt($values, $mode)
+    protected function _decrypt($values, $mode, $key = null)
     {
         if (is_string($values)) {
-            return $this->_decode($values, $mode);
+            return $this->_decode($values, $mode, $key);
         }
 
         $decrypted = [];
         foreach ($values as $name => $value) {
-            $decrypted[$name] = $this->_decode($value, $mode);
+            $decrypted[$name] = $this->_decode($value, $mode, $key);
         }
         return $decrypted;
     }
@@ -117,7 +117,7 @@ trait CookieCryptTrait
      * @param string|false $encrypt The encryption cipher to use.
      * @return string Decoded value.
      */
-    protected function _decode($value, $encrypt)
+    protected function _decode($value, $encrypt, $key)
     {
         if (!$encrypt) {
             return $this->_explode($value);
@@ -125,11 +125,14 @@ trait CookieCryptTrait
         $this->_checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
         $value = base64_decode(substr($value, strlen($prefix)));
+        if (!isset($key)) {
+            $key = $this->_getCookieEncryptionKey();
+        }
         if ($encrypt === 'rijndael') {
-            $value = Security::rijndael($value, $this->_getCookieEncryptionKey(), 'decrypt');
+            $value = Security::rijndael($value, $key, 'decrypt');
         }
         if ($encrypt === 'aes') {
-            $value = Security::decrypt($value, $this->_getCookieEncryptionKey());
+            $value = Security::decrypt($value, $key);
         }
         return $this->_explode($value);
     }

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -363,6 +363,45 @@ class CookieComponentTest extends TestCase
     }
 
     /**
+     * Test writing with a custom encryption key using ConfigKey
+     *
+     * @return void
+     */
+    public function testWriteConfigKeyWithCustomEncryptionKey()
+    {
+        $name = 'sampleCookieTest';
+        $value = 'some data';
+        $encryption = 'aes';
+        $prefix = "Q2FrZQ==.";
+        $key = 'justanotherencryptionkeyjustanotherencryptionkey';
+
+        $this->Cookie->configKey($name, compact('key', 'encryption'));
+        $this->Cookie->write($name, $value);
+
+        $cookie = $this->Controller->response->cookie($name);
+
+        $this->assertEquals($value, Security::decrypt(base64_decode(substr($cookie['value'], strlen($prefix))), $key));
+    }
+
+    /**
+     * Test reading with a custom encryption key using ConfigKey
+     *
+     * @return void
+     */
+    public function testReadConfigKeyWithCustomEncryptionKey()
+    {
+        $name = 'sampleCookieTest';
+        $value = 'some data';
+        $encryption = 'aes';
+        $key = 'justanotherencryptionkeyjustanotherencryptionkey';
+
+        $this->Cookie->configKey($name, compact('key', 'encryption'));
+        $this->Cookie->write($name, $value);
+
+        $this->assertEquals('some data', $this->Cookie->read($name));
+    }
+
+    /**
      * test delete with httpOnly
      *
      * @return void


### PR DESCRIPTION
When using configKey with a custom encryption key, this was ignored and the default key (app salt) is used.
