### PR TITLE
[3.3] Add ability to define model factories globally

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -13,6 +13,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use Cake\Datasource\FactoryLocator;
 use Cake\Routing\Router;
 
 define('TIME_START', microtime(true));

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource;
+
+use Cake\ORM\TableRegistry;
+use InvalidArgumentException;
+
+class FactoryLocator
+{
+    /**
+     * A list of model factory functions.
+     *
+     * @var callable[]
+     */
+    protected static $_modelFactories = [];
+
+    /**
+     * Register a callable to generate repositories of a given type.
+     *
+     * @param string $type The name of the repository type the factory function is for.
+     * @param callable $factory The factory function used to create instances.
+     * @return void
+     */
+    public static function add($type, callable $factory)
+    {
+        static::$_modelFactories[$type] = $factory;
+    }
+
+    /**
+     * Drop a model factory.
+     *
+     * @param string $type The name of the repository type to drop the factory for.
+     * @return void
+     */
+    public static function drop($type)
+    {
+        unset(static::$_modelFactories[$type]);
+    }
+
+    /**
+     * Get the factory for the specified repository type.
+     *
+     * @param string $type The repository type to get the factory for.
+     * @throws InvalidArgumentException If the specified repository type has no factory.
+     * @return callable The factory for the repository type.
+     */
+    public static function get($type)
+    {
+        if (!isset(static::$_modelFactories['Table'])) {
+            static::$_modelFactories['Table'] = [TableRegistry::locator(), 'get'];
+        }
+
+        if (!isset(static::$_modelFactories[$type])) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown repository type "%s". Make sure you register a type before trying to use it.',
+                $type
+            ));
+        }
+
+        return static::$_modelFactories[$type];
+    }
+}

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -41,7 +41,7 @@ trait ModelAwareTrait
     public $modelClass;
 
     /**
-     * A list of model factory functions.
+     * A list of overridden model factory functions.
      *
      * @var array
      */
@@ -104,13 +104,12 @@ trait ModelAwareTrait
             return $this->{$alias};
         }
 
-        if (!isset($this->_modelFactories[$modelType])) {
-            throw new InvalidArgumentException(sprintf(
-                'Unknown repository type "%s". Make sure you register a type before trying to use it.',
-                $modelType
-            ));
+        if (isset($this->_modelFactories[$modelType])) {
+            $factory = $this->_modelFactories[$modelType];
         }
-        $factory = $this->_modelFactories[$modelType];
+        if (!isset($factory)) {
+            $factory = FactoryLocator::get($modelType);
+        }
         $this->{$alias} = $factory($modelClass);
         if (!$this->{$alias}) {
             throw new MissingModelException([$modelClass, $modelType]);
@@ -119,7 +118,7 @@ trait ModelAwareTrait
     }
 
     /**
-     * Register a callable to generate repositories of a given type.
+     * Override a existing callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
      * @param callable $factory The factory function used to create instances.

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -8,67 +8,69 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
+ * @since         3.3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\FactoryLocator;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\TestSuite\TestCase;
 
 /**
- * Testing stub.
+ * FactoryLocatorTest test case
  */
-class Stub
+class FactoryLocatorTest extends TestCase
 {
-
-    use ModelAwareTrait;
-
-    public function setProps($name)
-    {
-        $this->_setModelClass($name);
-    }
-}
-
-/**
- * ModelAwareTrait test case
- */
-class ModelAwareTraitTest extends TestCase
-{
-
     /**
-     * Test set modelClass
+     * Test get factory
      *
      * @return void
      */
-    public function testSetModelClass()
+    public function testGet()
     {
-        $stub = new Stub();
-        $this->assertNull($stub->modelClass);
-
-        $stub->setProps('StubArticles');
-        $this->assertEquals('StubArticles', $stub->modelClass);
+        $this->assertInternalType('callable', FactoryLocator::get('Table'));
     }
 
     /**
-     * test loadModel()
+     * Test get non existing factory
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown repository type "Test". Make sure you register a type before trying to use it.
+     */
+    public function testGetNonExisting()
+    {
+        FactoryLocator::get('Test');
+    }
+
+    /**
+     * test add()
      *
      * @return void
      */
-    public function testLoadModel()
+    public function testAdd()
     {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-        $stub->modelType('Table');
+        FactoryLocator::add('Test', function ($name) {
+            $mock = new \StdClass();
+            $mock->name = $name;
+            return $mock;
+        });
 
-        $result = $stub->loadModel();
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
+        $this->assertInternalType('callable', FactoryLocator::get('Test'));
+    }
 
-        $result = $stub->loadModel('Comments');
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
+    /**
+     * test drop()
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown repository type "Test". Make sure you register a type before trying to use it.
+     */
+    public function testDrop()
+    {
+        FactoryLocator::drop('Test');
+
+        FactoryLocator::get('Test');
     }
 
     /**


### PR DESCRIPTION
These changes make it possible to model factories statically for use across the application.

This way it becomes possible to replace https://github.com/cakephp/elastic-search/blob/master/config/bootstrap.php#L20-L49 with the following:

``` php
ModelFactory::add('Elastic', ['Cake\ElasticSearch\TypeRegistry', 'get']);
ModelFactory::add('ElasticSearch', ['Cake\ElasticSearch\TypeRegistry', 'get']);
```

It also makes it possible to actually load the models from the `initialize` method instead of `beforeFilter` in controllers and this way the factory becomes available for all classes that use `ModelAwareTrait` in general.
