### PR TITLE
skips ssl test if using a proxy

### DIFF
--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -441,6 +441,7 @@ class SocketTest extends TestCase
     public function testConfigContext()
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
+        $this->skipIf(!empty(getenv('http_proxy')) || !empty(getenv('https_proxy')), 'Proxy detected and cannot test SSL.');
         $config = [
             'host' => 'smtp.gmail.com',
             'port' => 465,


### PR DESCRIPTION
This is a low priority PR.

I found this test fails when the OS is using an internet proxy. So it will skip the test if HTTP_PROXY or HTTPS_PROXY is set as an environment variable.
