### PR TITLE
Add ErrorHandling Middleware

### DIFF
--- a/src/Http/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Http/Middleware/ErrorHandlerMiddleware.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware;
+
+use Cake\Core\App;
+use Cake\Http\ResponseTransformer;
+use Exception;
+
+/**
+ * Error handling middleware.
+ *
+ * Traps exceptions and converts them into HTML or content-type appropriate
+ * error pages using the CakePHP ExceptionRenderer.
+ */
+class ErrorHandlerMiddleware
+{
+    /**
+     * Constructor
+     *
+     * @param string|callable $renderer The renderer or class name
+     *   to use or a callable factory.
+     */
+    public function __construct($renderer = null)
+    {
+        $this->renderer = $renderer ?: 'Cake\Error\ExceptionRenderer';
+    }
+
+    /**
+     * Wrap the remaining middleware with error handling.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next Callback to invoke the next middleware.
+     * @return \Psr\Http\Message\ResponseInterface A response
+     */
+    public function __invoke($request, $response, $next)
+    {
+        try {
+            return $next($request, $response);
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, $response);
+        }
+    }
+
+    /**
+     * Handle an exception and generate an error response
+     *
+     * @param \Exception $exception The exception to handle.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @return \Psr\Http\Message\ResponseInterface A response
+     */
+    public function handleException($exception, $request, $response)
+    {
+        $renderer = $this->getRenderer($exception);
+        try {
+            $response = $renderer->render();
+            return ResponseTransformer::toPsr($response);
+        } catch (Exception $e) {
+            $message = sprintf(
+                "[%s] %s\n%s", // Keeping same message format
+                get_class($e),
+                $e->getMessage(),
+                $e->getTraceAsString()
+            );
+            trigger_error($message, E_USER_ERROR);
+        }
+        return $response;
+    }
+
+    /**
+     * Get a renderer instance
+     *
+     * @param \Exception $exception The exception being rendered.
+     * @return \Cake\Error\BaseErrorHandler The exception renderer.
+     */
+    protected function getRenderer($exception)
+    {
+        if (is_string($this->renderer)) {
+            $class = App::className($this->renderer, 'Error');
+            if (!$class) {
+                throw new \Exception("The '{$this->renderer}' renderer class could not be found.");
+            }
+            return new $class($exception);
+        }
+        $factory = $this->renderer;
+        return $factory($exception);
+    }
+}

--- a/tests/TestCase/Http/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/ErrorHandlerMiddlewareTest.php
@@ -114,7 +114,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
     /**
      * Test handling an error and having rendering fail.
      *
-     * @expectedException PHPUnit_Framework_Error
      * @return void
      */
     public function testHandleExceptionRenderingFails()
@@ -135,6 +134,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $next = function ($req, $res) {
             throw new \Cake\Network\Exception\ServiceUnavailableException('whoops');
         };
-        $middleware($request, $response, $next);
+        $response = $middleware($request, $response, $next);
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('An Internal Server Error Occurred', '' . $response->getBody());
     }
 }

--- a/tests/TestCase/Http/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/ErrorHandlerMiddlewareTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\Middleware;
+
+use Cake\Core\Configure;
+use Cake\Http\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\ServerRequestFactory;
+use Cake\Network\Response as CakeResponse;
+use Cake\TestSuite\TestCase;
+use LogicException;
+use Zend\Diactoros\Request;
+use Zend\Diactoros\Response;
+
+/**
+ * Test for ErrorHandlerMiddleware
+ */
+class ErrorHandlerMiddlewareTest extends TestCase
+{
+    /**
+     * Test returning a response works ok.
+     *
+     * @return void
+     */
+    public function testNoErrorResponse()
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+
+        $middleware = new ErrorHandlerMiddleware();
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $result = $middleware($request, $response, $next);
+        $this->assertSame($result, $response);
+    }
+
+    /**
+     * Test an invalid rendering class.
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage The 'TotallyInvalid' renderer class could not be found
+     */
+    public function testInvalidRenderer()
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+
+        $middleware = new ErrorHandlerMiddleware('TotallyInvalid');
+        $next = function ($req, $res) {
+            throw new \Exception('Something bad');
+        };
+        $middleware($request, $response, $next);
+    }
+
+    /**
+     * Test using a factory method to make a renderer.
+     *
+     * @return void
+     */
+    public function testRendererFactory()
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+
+        $factory = function ($exception) {
+            $this->assertInstanceOf('LogicException', $exception);
+            $cakeResponse = new CakeResponse;
+            $mock = $this->getMock('StdClass', ['render']);
+            $mock->expects($this->once())
+                ->method('render')
+                ->will($this->returnValue($cakeResponse));
+            return $mock;
+        };
+        $middleware = new ErrorHandlerMiddleware($factory);
+        $next = function ($req, $res) {
+            throw new LogicException('Something bad');
+        };
+        $middleware($request, $response, $next);
+    }
+
+    /**
+     * Test rendering an error page
+     *
+     * @return void
+     */
+    public function testHandleException()
+    {
+        Configure::write('App.namespace', 'TestApp');
+
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+        $middleware = new ErrorHandlerMiddleware();
+        $next = function ($req, $res) {
+            throw new \Cake\Network\Exception\NotFoundException('whoops');
+        };
+        $result = $middleware($request, $response, $next);
+        $this->assertNotSame($result, $response);
+        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertContains("was not found", '' . $result->getBody());
+    }
+
+    /**
+     * Test handling an error and having rendering fail.
+     *
+     * @expectedException PHPUnit_Framework_Error
+     * @return void
+     */
+    public function testHandleExceptionRenderingFails()
+    {
+        Configure::write('App.namespace', 'TestApp');
+
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+
+        $factory = function ($exception) {
+            $mock = $this->getMock('StdClass', ['render']);
+            $mock->expects($this->once())
+                ->method('render')
+                ->will($this->throwException(new LogicException('Rendering failed')));
+            return $mock;
+        };
+        $middleware = new ErrorHandlerMiddleware($factory);
+        $next = function ($req, $res) {
+            throw new \Cake\Network\Exception\ServiceUnavailableException('whoops');
+        };
+        $middleware($request, $response, $next);
+    }
+}


### PR DESCRIPTION
Having middleware that can render errors reduces our reliance on global exception handlers and allows middleware to be wrapped around the error handling allowing things like CORS headers to be set on error pages.

Refs #6960 #7683
