### PR TITLE
WIP: Read schema defaults when generating field using EntityContext.

### DIFF
--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -127,7 +127,7 @@ class SqliteSchema extends BaseSchema
         $field = $this->_convertColumn($row['type']);
         $field += [
             'null' => !$row['notnull'],
-            'default' => $row['dflt_value'] === null ? null : trim($row['dflt_value'], "'"),
+            'default' => $this->_defaultValue($row['dflt_value']),
         ];
         $primary = $table->constraint('primary');
 
@@ -151,6 +151,29 @@ class SqliteSchema extends BaseSchema
             $constraint['columns'] = array_merge($constraint['columns'], [$row['name']]);
             $table->addConstraint('primary', $constraint);
         }
+    }
+
+    /**
+     * Manipulate the default value.
+     *
+     * Sqlite includes quotes and bared NULLs in default values.
+     * We need to remove those.
+     *
+     * @param string|null $default The default value.
+     * @return string|null
+     */
+    protected function _defaultValue($default)
+    {
+        if ($default === 'NULL') {
+            return null;
+        }
+
+        // Remove quotes
+        if (preg_match("/^'(.*)'$/", $default, $matches)) {
+            return str_replace("''", "'", $matches[1]);
+        }
+
+        return $default;
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -201,16 +201,26 @@ class EntityContext implements ContextInterface
      * Traverses the entity data and finds the value for $path.
      *
      * @param string $field The dot separated path to the value.
+     * @param array $options Options:
+     *   - `default`: Default value to return if no value found in request
+     *     data or entity.
+     *   - `schemaDefault`: Boolen indicating whether default value from table
+     *     schema should be used if it's not explicitly provided.
      * @return mixed The value of the field or null on a miss.
      */
-    public function val($field)
+    public function val($field, $options = [])
     {
+        $options += [
+            'default' => null,
+            'schemaDefault' => true
+        ];
+
         $val = $this->_request->data($field);
         if ($val !== null) {
             return $val;
         }
         if (empty($this->_context['entity'])) {
-            return null;
+            return $options['default'];
         }
         $parts = explode('.', $field);
         $entity = $this->entity($parts);
@@ -220,13 +230,41 @@ class EntityContext implements ContextInterface
         }
 
         if ($entity instanceof EntityInterface) {
-            return $entity->get(array_pop($parts));
+            $part = array_pop($parts);
+            $val = $entity->get($part);
+            if ($val !== null) {
+                return $val;
+            }
+            if (!$options['schemaDefault']) {
+                return $options['default'];
+            }
+            return $this->_schemaDefault($part, $entity);
         }
         if (is_array($entity)) {
             $key = array_pop($parts);
             return isset($entity[$key]) ? $entity[$key] : null;
         }
         return null;
+    }
+
+    /**
+     * Get default value from table schema for given entity field.
+     *
+     * @param string $field Field name.
+     * @param \Cake\Datasource\EntityInterface $entity The entity.
+     * @return mixed
+     */
+    protected function _schemaDefault($field, $entity)
+    {
+        $table = $this->_getTable($entity);
+        if ($table === false) {
+            return null;
+        }
+        $defaults = $table->schema()->defaultValues();
+        if (!array_key_exists($field, $defaults)) {
+            return null;
+        }
+        return $defaults[$field];
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2407,7 +2407,11 @@ class FormHelper extends Helper
             unset($options['value']);
         }
         if (!isset($options['val'])) {
-            $options['val'] = $context->val($field);
+            $valOptions = [
+                'default' => isset($options['default']) ? $options['default'] : null,
+                'schemaDefault' => isset($options['schemaDefault']) ? $options['schemaDefault'] : true,
+            ];
+            $options['val'] = $context->val($field, $valOptions);
         }
         if (!isset($options['val']) && isset($options['default'])) {
             $options['val'] = $options['default'];

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -221,11 +221,13 @@ SQL;
         $table = <<<SQL
 CREATE TABLE schema_articles (
 id INTEGER PRIMARY KEY AUTOINCREMENT,
-title VARCHAR(20) DEFAULT 'testing',
+title VARCHAR(20) DEFAULT 'Let ''em eat cake',
 body TEXT,
 author_id INT(11) NOT NULL,
 published BOOLEAN DEFAULT 0,
 created DATETIME,
+field1 VARCHAR(10) DEFAULT NULL,
+field2 VARCHAR(10) DEFAULT 'NULL',
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
 CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
 );
@@ -288,7 +290,7 @@ SQL;
             'title' => [
                 'type' => 'string',
                 'null' => true,
-                'default' => 'testing',
+                'default' => 'Let \'em eat cake',
                 'length' => 20,
                 'precision' => null,
                 'fixed' => null,
@@ -326,6 +328,24 @@ SQL;
                 'default' => null,
                 'length' => null,
                 'precision' => null,
+                'comment' => null,
+            ],
+            'field1' => [
+                'type' => 'string',
+                'null' => true,
+                'default' => null,
+                'length' => 10,
+                'precision' => null,
+                'fixed' => null,
+                'comment' => null,
+            ],
+            'field2' => [
+                'type' => 'string',
+                'null' => true,
+                'default' => 'NULL',
+                'length' => 10,
+                'precision' => null,
+                'fixed' => null,
                 'comment' => null,
             ],
         ];

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -655,6 +655,26 @@ class EntityContextTest extends TestCase
     }
 
     /**
+     * Test getting default value from table schema.
+     *
+     * @return void
+     */
+    public function testValSchemaDefault()
+    {
+        $table = TableRegistry::get('Articles');
+        $column = $table->schema()->column('title');
+        $table->schema()->addColumn('title', ['default' => 'default title'] + $column);
+        $row = $table->newEntity();
+
+        $context = new EntityContext($this->request, [
+            'entity' => $row,
+            'table' => 'Articles',
+        ]);
+        $result = $context->val('title');
+        $this->assertEquals('default title', $result);
+    }
+
+    /**
      * Test validator for boolean fields.
      *
      * @return void


### PR DESCRIPTION
In 2.x when creating an input if field value was not set in request data the default value available from table schema was set as field value (if an explicit default value was not provided).

This patch implements the same feature.

I'll add more tests if the change is approved.
