### PR TITLE
Read schema defaults when generating field using EntityContext

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -152,7 +152,7 @@ class ArrayContext implements ContextInterface
      * @param array $options Options:
      *   - `default`: Default value to return if no value found in request
      *     data or context record.
-     *   - `schemaDefault`: Boolen indicating whether default value from
+     *   - `schemaDefault`: Boolean indicating whether default value from
      *      context's schema should be used if it's not explicitly provided.
      * @return mixed
      */

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -149,13 +149,26 @@ class ArrayContext implements ContextInterface
      *
      * @param string $field A dot separated path to the field a value
      *   is needed for.
+     * @param array $options Options:
+     *   - `default`: Default value to return if no value found in request
+     *     data or context record.
+     *   - `schemaDefault`: Boolen indicating whether default value from
+     *      context's schema should be used if it's not explicitly provided.
      * @return mixed
      */
-    public function val($field)
+    public function val($field, $options = [])
     {
+        $options += [
+            'default' => null,
+            'schemaDefault' => true
+        ];
+
         $val = $this->_request->data($field);
         if ($val !== null) {
             return $val;
+        }
+        if ($options['default'] !== null || !$options['schemaDefault']) {
+            return $options['default'];
         }
         if (empty($this->_context['defaults']) || !is_array($this->_context['defaults'])) {
             return null;

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -46,16 +46,19 @@ interface ContextInterface
     /**
      * Get the current value for a given field.
      *
-     * @param string $field A dot separated path to the field a value
-     *   is needed for.
-     * @param array $options Options:
+     * Classes implementing this method can optionally have a second argument
+     * `$options`. Valid key for `$options` array are:
+     *
      *   - `default`: Default value to return if no value found in request
      *     data or context record.
      *   - `schemaDefault`: Boolen indicating whether default value from
      *      context's schema should be used if it's not explicitly provided.
+     *
+     * @param string $field A dot separated path to the field a value
+     *   is needed for.
      * @return mixed
      */
-    public function val($field, $options = []);
+    public function val($field);
 
     /**
      * Check if a given field is 'required'.

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -48,9 +48,14 @@ interface ContextInterface
      *
      * @param string $field A dot separated path to the field a value
      *   is needed for.
+     * @param array $options Options:
+     *   - `default`: Default value to return if no value found in request
+     *     data or context record.
+     *   - `schemaDefault`: Boolen indicating whether default value from
+     *      context's schema should be used if it's not explicitly provided.
      * @return mixed
      */
-    public function val($field);
+    public function val($field, $options = []);
 
     /**
      * Check if a given field is 'required'.

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -201,16 +201,26 @@ class EntityContext implements ContextInterface
      * Traverses the entity data and finds the value for $path.
      *
      * @param string $field The dot separated path to the value.
+     * @param array $options Options:
+     *   - `default`: Default value to return if no value found in request
+     *     data or entity.
+     *   - `schemaDefault`: Boolen indicating whether default value from table
+     *     schema should be used if it's not explicitly provided.
      * @return mixed The value of the field or null on a miss.
      */
-    public function val($field)
+    public function val($field, $options = [])
     {
+        $options += [
+            'default' => null,
+            'schemaDefault' => true
+        ];
+
         $val = $this->_request->data($field);
         if ($val !== null) {
             return $val;
         }
         if (empty($this->_context['entity'])) {
-            return null;
+            return $options['default'];
         }
         $parts = explode('.', $field);
         $entity = $this->entity($parts);
@@ -220,13 +230,41 @@ class EntityContext implements ContextInterface
         }
 
         if ($entity instanceof EntityInterface) {
-            return $entity->get(array_pop($parts));
+            $part = array_pop($parts);
+            $val = $entity->get($part);
+            if ($val !== null) {
+                return $val;
+            }
+            if (!$options['schemaDefault']) {
+                return $options['default'];
+            }
+            return $this->_schemaDefault($part, $entity);
         }
         if (is_array($entity)) {
             $key = array_pop($parts);
             return isset($entity[$key]) ? $entity[$key] : null;
         }
         return null;
+    }
+
+    /**
+     * Get default value from table schema for given entity field.
+     *
+     * @param string $field Field name.
+     * @param \Cake\Datasource\EntityInterface $entity The entity.
+     * @return mixed
+     */
+    protected function _schemaDefault($field, $entity)
+    {
+        $table = $this->_getTable($entity);
+        if ($table === false) {
+            return null;
+        }
+        $defaults = $table->schema()->defaultValues();
+        if (!array_key_exists($field, $defaults)) {
+            return null;
+        }
+        return $defaults[$field];
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -235,7 +235,10 @@ class EntityContext implements ContextInterface
             if ($val !== null) {
                 return $val;
             }
-            if (!$options['schemaDefault']) {
+            if ($options['default'] !== null
+                || !$options['schemaDefault']
+                || !$entity->isNew()
+            ) {
                 return $options['default'];
             }
             return $this->_schemaDefault($part, $entity);

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -75,9 +75,18 @@ class FormContext implements ContextInterface
     /**
      * {@inheritDoc}
      */
-    public function val($field)
+    public function val($field, $options = [])
     {
-        return $this->_request->data($field);
+        $options += [
+            'default' => null,
+            'schemaDefault' => true
+        ];
+
+        $val = $this->_request->data($field);
+        if ($val !== null) {
+            return $val;
+        }
+        return $options['default'];
     }
 
     /**

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -70,7 +70,7 @@ class NullContext implements ContextInterface
     /**
      * {@inheritDoc}
      */
-    public function val($field)
+    public function val($field, $options = [])
     {
         return $this->_request->data($field);
     }

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -70,7 +70,7 @@ class NullContext implements ContextInterface
     /**
      * {@inheritDoc}
      */
-    public function val($field, $options = [])
+    public function val($field)
     {
         return $this->_request->data($field);
     }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2407,7 +2407,11 @@ class FormHelper extends Helper
             unset($options['value']);
         }
         if (!isset($options['val'])) {
-            $options['val'] = $context->val($field);
+            $valOptions = [
+                'default' => isset($options['default']) ? $options['default'] : null,
+                'schemaDefault' => isset($options['schemaDefault']) ? $options['schemaDefault'] : true,
+            ];
+            $options['val'] = $context->val($field, $valOptions);
         }
         if (!isset($options['val']) && isset($options['default'])) {
             $options['val'] = $options['default'];

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -167,6 +167,24 @@ class ArrayContextTest extends TestCase
     }
 
     /**
+     * Test getting default value
+     *
+     * @return void
+     */
+    public function testValDefault()
+    {
+        $context = new ArrayContext($this->request, [
+            'defaults' => [
+                'title' => 'Default value',
+            ]
+        ]);
+
+        $this->assertEquals('Default value', $context->val('title'));
+        $result = $context->val('title', ['default' => 'explicit default']);
+        $this->assertEquals('explicit default', $result);
+    }
+
+    /**
      * Test isRequired
      *
      * @return void

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -655,6 +655,26 @@ class EntityContextTest extends TestCase
     }
 
     /**
+     * Test getting default value from table schema.
+     *
+     * @return void
+     */
+    public function testValSchemaDefault()
+    {
+        $table = TableRegistry::get('Articles');
+        $column = $table->schema()->column('title');
+        $table->schema()->addColumn('title', ['default' => 'default title'] + $column);
+        $row = $table->newEntity();
+
+        $context = new EntityContext($this->request, [
+            'entity' => $row,
+            'table' => 'Articles',
+        ]);
+        $result = $context->val('title');
+        $this->assertEquals('default title', $result);
+    }
+
+    /**
      * Test validator for boolean fields.
      *
      * @return void

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -99,6 +99,19 @@ class FormContextTest extends TestCase
     }
 
     /**
+     * Test getting default value
+     *
+     * @return void
+     */
+    public function testValDefault()
+    {
+        $context = new FormContext($this->request, ['entity' => new Form()]);
+
+        $result = $context->val('title', ['default' => 'default default']);
+        $this->assertEquals('default default', $result);
+    }
+
+    /**
      * Test isRequired
      *
      * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4029,6 +4029,37 @@ class FormHelperTest extends TestCase
         $result = $this->Form->text('Model.field', ['default' => 'default value']);
         $expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'default value']];
         $this->assertHtml($expected, $result);
+
+        $Articles = TableRegistry::get('Articles');
+        $title = $Articles->schema()->column('title');
+        $Articles->schema()->addColumn(
+            'title',
+            ['default' => 'default title'] + $title
+        );
+
+        $entity = $Articles->newEntity();
+        $this->Form->create($entity);
+
+        // Get default value from schema
+        $result = $this->Form->text('title');
+        $expected = ['input' => ['type' => 'text', 'name' => 'title', 'value' => 'default title']];
+        $this->assertHtml($expected, $result);
+
+        // Don't get value from schema
+        $result = $this->Form->text('title', ['schemaDefault' => false]);
+        $expected = ['input' => ['type' => 'text', 'name' => 'title']];
+        $this->assertHtml($expected, $result);
+
+        // Custom default value overrides default value from schema
+        $result = $this->Form->text('title', ['default' => 'override default']);
+        $expected = ['input' => ['type' => 'text', 'name' => 'title', 'value' => 'override default']];
+        $this->assertHtml($expected, $result);
+
+        // Default value from schema is used only for new entities.
+        $entity->isNew(false);
+        $result = $this->Form->text('title');
+        $expected = ['input' => ['type' => 'text', 'name' => 'title']];
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -4233,6 +4264,37 @@ class FormHelperTest extends TestCase
             ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'female',
                 'id' => 'employee-gender-female', 'style' => 'width:20px']],
             'Female',
+            '/label',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test default value setting on radio() method
+     *
+     * @return void
+     */
+    public function testRadioDefaultValue()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $title = $Articles->schema()->column('title');
+        $Articles->schema()->addColumn(
+            'title',
+            ['default' => '1'] + $title
+        );
+
+        $this->Form->create($Articles->newEntity());
+
+        $result = $this->Form->radio('title', ['option A', 'option B']);
+        $expected = [
+            ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => '']],
+            ['label' => ['for' => 'title-0']],
+            ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
+            'option A',
+            '/label',
+            ['label' => ['for' => 'title-1']],
+            ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '1', 'id' => 'title-1', 'checked' => 'checked']],
+            'option B',
             '/label',
         ];
         $this->assertHtml($expected, $result);
@@ -5306,6 +5368,17 @@ class FormHelperTest extends TestCase
         unset($this->Form->request->data['Model']['field']);
         $result = $this->Form->checkbox('Model.field', ['default' => false, 'hiddenField' => false]);
         $expected = ['input' => ['type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1']];
+        $this->assertHtml($expected, $result);
+
+        $Articles = TableRegistry::get('Articles');
+        $Articles->schema()->addColumn(
+            'published',
+            ['type' => 'boolean', 'null' => false, 'default' => true]
+        );
+
+        $this->Form->create($Articles->newEntity());
+        $result = $this->Form->checkbox('published', ['hiddenField' => false]);
+        $expected = ['input' => ['type' => 'checkbox', 'name' => 'published', 'value' => '1', 'checked' => 'checked']];
         $this->assertHtml($expected, $result);
     }
 


### PR DESCRIPTION
In 2.x when creating an input if field value was not set in request data the default value available from table schema was set as field value (if an explicit default value was not provided).

This patch implements the same feature.

Refs #8733, Closes #5065
