### PR TITLE
Added sorting by modified time in Folder Util.

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -213,10 +213,10 @@ class Folder
         }
 
         if ($sort || $this->sort) {
-            if ($sort === self::SORT_TIME or $this->sort === self::SORT_TIME) {
+            if ($sort === self::SORT_TIME || $this->sort === self::SORT_TIME) {
                 ksort($dirs);
                 ksort($files);
-            } else if ($sort === self::SORT_NAME or $this->sort === self::SORT_NAME) {
+            } elseif ($sort === self::SORT_NAME || $this->sort === self::SORT_NAME) {
                 sort($dirs);
                 sort($files);
             }

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -53,6 +53,16 @@ class Folder
     const SKIP = 'skip';
 
     /**
+     * Sort mode by name
+     */
+    const SORT_NAME = 'name';
+
+    /**
+     * Sort mode by time
+     */
+    const SORT_TIME = 'time';
+
+    /**
      * Path to Folder.
      *
      * @var string
@@ -165,7 +175,7 @@ class Folder
      * @param bool $fullPath True returns the full path
      * @return array Contents of current directory as an array, an empty array on failure
      */
-    public function read($sort = 'name', $exceptions = false, $fullPath = false)
+    public function read($sort = self::SORT_NAME, $exceptions = false, $fullPath = false)
     {
         $dirs = $files = [];
 
@@ -203,10 +213,10 @@ class Folder
         }
 
         if ($sort || $this->sort) {
-            if ($sort === 'time') {
+            if ($sort === self::SORT_TIME or $this->sort === self::SORT_TIME) {
                 ksort($dirs);
                 ksort($files);
-            } else {
+            } else if ($sort === self::SORT_NAME or $this->sort === self::SORT_NAME) {
                 sort($dirs);
                 sort($files);
             }

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -86,6 +86,14 @@ class Folder
     public $mode = 0755;
 
     /**
+     *
+     */
+    protected $_fsorts = [
+        self::SORT_NAME => 'getPathname',
+        self::SORT_TIME => 'getCTime'
+    ];
+
+    /**
      * Holds messages from last method.
      *
      * @var array
@@ -193,6 +201,12 @@ class Folder
             return [$dirs, $files];
         }
 
+        if (!is_bool($sort) && array_key_exists($sort, $this->_fsorts)) {
+            $methodName = $this->_fsorts[$sort];
+        } else {
+            $methodName = $this->_fsorts[self::SORT_NAME];
+        }
+
         foreach ($iterator as $item) {
             if ($item->isDot()) {
                 continue;
@@ -206,20 +220,15 @@ class Folder
             }
 
             if ($item->isDir()) {
-                $dirs[$item->getCTime()][] = $name;
+                $dirs[$item->{$methodName}()][] = $name;
             } else {
-                $files[$item->getCTime()][] = $name;
+                $files[$item->{$methodName}()][] = $name;
             }
         }
 
         if ($sort || $this->sort) {
-            if ($sort === self::SORT_TIME || $this->sort === self::SORT_TIME) {
-                ksort($dirs);
-                ksort($files);
-            } elseif ($sort === self::SORT_NAME || $this->sort === self::SORT_NAME) {
-                sort($dirs);
-                sort($files);
-            }
+            ksort($dirs);
+            ksort($files);
         }
 
         if (!empty($dirs)) {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -86,7 +86,7 @@ class Folder
     public $mode = 0755;
 
     /**
-     *
+     * Functions array to be called depending on the sort type chosen.
      */
     protected $_fsorts = [
         self::SORT_NAME => 'getPathname',
@@ -177,7 +177,7 @@ class Folder
      * Returns an array of the contents of the current directory.
      * The returned array holds two arrays: One of directories and one of files.
      *
-     * @param bool $sort Whether you want the results sorted, set this and the sort property
+     * @param string|bool $sort Whether you want the results sorted, set this and the sort property
      *   to false to get unsorted results.
      * @param array|bool $exceptions Either an array or boolean true will not grab dot files
      * @param bool $fullPath True returns the full path
@@ -201,7 +201,7 @@ class Folder
             return [$dirs, $files];
         }
 
-        if (!is_bool($sort) && array_key_exists($sort, $this->_fsorts)) {
+        if (!is_bool($sort) && isset($this->_fsorts[$sort])) {
             $methodName = $this->_fsorts[$sort];
         } else {
             $methodName = $this->_fsorts[self::SORT_NAME];
@@ -231,11 +231,11 @@ class Folder
             ksort($files);
         }
 
-        if (!empty($dirs)) {
+        if ($dirs) {
             $dirs = call_user_func_array('array_merge', $dirs);
         }
 
-        if (!empty($files)) {
+        if ($files) {
             $files = call_user_func_array('array_merge', $files);
         }
 

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -165,7 +165,7 @@ class Folder
      * @param bool $fullPath True returns the full path
      * @return array Contents of current directory as an array, an empty array on failure
      */
-    public function read($sort = true, $exceptions = false, $fullPath = false)
+    public function read($sort = 'name', $exceptions = false, $fullPath = false)
     {
         $dirs = $files = [];
 
@@ -194,16 +194,32 @@ class Folder
             if ($fullPath) {
                 $name = $item->getPathname();
             }
+
             if ($item->isDir()) {
-                $dirs[] = $name;
+                $dirs[$item->getCTime()][] = $name;
             } else {
-                $files[] = $name;
+                $files[$item->getCTime()][] = $name;
             }
         }
+
         if ($sort || $this->sort) {
-            sort($dirs);
-            sort($files);
+            if ($sort === 'time') {
+                ksort($dirs);
+                ksort($files);
+            } else {
+                sort($dirs);
+                sort($files);
+            }
         }
+
+        if (!empty($dirs)) {
+            $dirs = call_user_func_array('array_merge', $dirs);
+        }
+
+        if (!empty($files)) {
+            $files = call_user_func_array('array_merge', $files);
+        }
+
         return [$dirs, $files];
     }
 

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1271,4 +1271,31 @@ class FolderTest extends TestCase
 
         $this->assertSame(['file_2.tmp', 'file_1.tmp'], $results);
     }
+
+    /**
+     * testSortByTime2 method
+     *
+     * Verify that the order using modified time is correct.
+     *
+     * @return void
+     */
+    public function testSortByTime2()
+    {
+        $Folder = new Folder(TMP . 'tests', true);
+
+        $fileA = new File($Folder->pwd() . DS . 'a.txt');
+        $fileA->create();
+
+        $fileC = new File($Folder->pwd() . DS . 'c.txt');
+        $fileC->create();
+
+        sleep(1);
+
+        $fileB = new File($Folder->pwd() . DS . 'b.txt');
+        $fileB->create();
+
+        $results = $Folder->find('.*', Folder::SORT_TIME);
+
+        $this->assertSame(['a.txt', 'c.txt', 'b.txt'], $results);
+    }
 }

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1298,4 +1298,27 @@ class FolderTest extends TestCase
 
         $this->assertSame(['a.txt', 'c.txt', 'b.txt'], $results);
     }
+
+    /**
+     * Verify that the order using name is correct.
+     */
+    public function testSortByName()
+    {
+        $Folder = new Folder(TMP . 'tests', true);
+
+        $fileA = new File($Folder->pwd() . DS . 'a.txt');
+        $fileA->create();
+
+        $fileC = new File($Folder->pwd() . DS . 'c.txt');
+        $fileC->create();
+
+        sleep(1);
+
+        $fileB = new File($Folder->pwd() . DS . 'b.txt');
+        $fileB->create();
+
+        $results = $Folder->find('.*', Folder::SORT_NAME);
+
+        $this->assertSame(['a.txt', 'b.txt', 'c.txt'], $results);
+    }
 }

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1267,7 +1267,7 @@ class FolderTest extends TestCase
         $file1 = new File($Folder->pwd() . DS . 'file_1.tmp');
         $file1->create();
 
-        $results = $Folder->find('.*', 'time');
+        $results = $Folder->find('.*', Folder::SORT_TIME);
 
         $this->assertSame(['file_2.tmp', 'file_1.tmp'], $results);
     }

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1247,4 +1247,28 @@ class FolderTest extends TestCase
         $this->assertFalse(is_dir($folderTwo . '/folderA'));
         $this->assertFalse(file_exists($folderTwo . '/folderA/fileA.php'));
     }
+
+    /**
+     * testSortByTime method
+     *
+     * Verify that the order using modified time is correct.
+     *
+     * @return void
+     */
+    public function testSortByTime()
+    {
+        $Folder = new Folder(TMP . 'tests', true);
+
+        $file2 = new File($Folder->pwd() . DS . 'file_2.tmp');
+        $file2->create();
+
+        sleep(1);
+
+        $file1 = new File($Folder->pwd() . DS . 'file_1.tmp');
+        $file1->create();
+
+        $results = $Folder->find('.*', 'time');
+
+        $this->assertSame(['file_2.tmp', 'file_1.tmp'], $results);
+    }
 }


### PR DESCRIPTION
Initially Folder class does not allow to sort by Modified Time.
I added some logic to accomplish it. The PR is backwards with previous versions calls.

If someone is trying to sort with `$sort = true` it will sort by name.
If someone is trying to sort with `$sort = 'name'` it will sort by name.
If someone is trying to sort with `$sort = 'time'` it will sort by modified time.
If someone is trying to sort with `$sort = false` it will not sort.

Added method test in FolderTest.php
