### PR TITLE
Fixes failing unit tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
-#dist: trusty
 
 php:
   - 5.5
 #  - 5.6
 #  - 7.0
 
+dist: trusty
 sudo: required
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test'
 #    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
 #    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
 #  - 5.6
 #  - 7.0
 
-dist: trusty
+#dist: trusty
 sudo: required
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 #  - 5.6
 #  - 7.0
 
-sudo: false
+sudo: required
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+#dist: trusty
 
 php:
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: php
 
 php:
   - 5.5
-#  - 5.6
-#  - 7.0
+  - 5.6
+  - 7.0
 
-#dist: trusty
+dist: trusty
 sudo: required
 addons:
   apt:
@@ -17,14 +17,14 @@ addons:
 env:
   matrix:
     - DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test'
-#    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-#    - DB=sqlite db_dsn='sqlite:///:memory:'
+    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
 
-#services:
-#  - memcached
-#  - redis-server
+services:
+  - memcached
+  - redis-server
 
 cache:
   directories:
@@ -34,23 +34,23 @@ cache:
 matrix:
   fast_finish: true
 
-#  include:
-#    - php: 7.0
-#      env: CODECOVERAGE=1 DEFAULT=0
-#
-#    - php: 7.0
-#      env: PHPCS=1 DEFAULT=0
-#
-#    - php: hhvm
-#      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
-#
-#    - php: hhvm
-#      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-#
-#  allow_failures:
-#    - env: CODECOVERAGE=1 DEFAULT=0
-#
-#    - php: hhvm
+  include:
+    - php: 7.0
+      env: CODECOVERAGE=1 DEFAULT=0
+
+    - php: 7.0
+      env: PHPCS=1 DEFAULT=0
+
+    - php: hhvm
+      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
+
+    - php: hhvm
+      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+
+  allow_failures:
+    - env: CODECOVERAGE=1 DEFAULT=0
+
+    - php: hhvm
 
 before_install:
   - sh -c "if [ '$HHVM' != '1' ]; then phpenv config-rm xdebug.ini; fi"
@@ -84,11 +84,11 @@ before_script:
 script:
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit; fi"
 
-#  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-#
-#  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml || true; fi"
-#  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
-#  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then bash codecov.sh; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+
+  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml || true; fi"
+  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
+  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then bash codecov.sh; fi"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,31 @@
 language: php
+dist: trusty
 
 php:
   - 5.5
-  - 5.6
-  - 7.0
+#  - 5.6
+#  - 7.0
 
 sudo: false
+
+addons:
+  apt:
+    packages:
+    - mysql-server-5.6
+    - mysql-client-core-5.6
+    - mysql-client-5.6
 
 env:
   matrix:
     - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
+#    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+#    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
 
-services:
-  - memcached
-  - redis-server
+#services:
+#  - memcached
+#  - redis-server
 
 cache:
   directories:
@@ -27,32 +35,32 @@ cache:
 matrix:
   fast_finish: true
 
-  include:
-    - php: 7.0
-      env: CODECOVERAGE=1 DEFAULT=0
-
-    - php: 7.0
-      env: PHPCS=1 DEFAULT=0
-
-    - php: hhvm
-      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
-
-    - php: hhvm
-      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-
-  allow_failures:
-    - env: CODECOVERAGE=1 DEFAULT=0
-
-    - php: hhvm
+#  include:
+#    - php: 7.0
+#      env: CODECOVERAGE=1 DEFAULT=0
+#
+#    - php: 7.0
+#      env: PHPCS=1 DEFAULT=0
+#
+#    - php: hhvm
+#      env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
+#
+#    - php: hhvm
+#      env: HHVM=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+#
+#  allow_failures:
+#    - env: CODECOVERAGE=1 DEFAULT=0
+#
+#    - php: hhvm
 
 before_install:
   - sh -c "if [ '$HHVM' != '1' ]; then phpenv config-rm xdebug.ini; fi"
   - composer self-update
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
 
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test3;'; fi"
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi"
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test2;'; fi"
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test3;'; fi"
 
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi"
@@ -77,11 +85,11 @@ before_script:
 script:
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit; fi"
 
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-
-  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml || true; fi"
-  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
-  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then bash codecov.sh; fi"
+#  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+#
+#  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml || true; fi"
+#  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
+#  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then bash codecov.sh; fi"
 
 notifications:
   email: false


### PR DESCRIPTION
This PR fixes #8720 

Travis YAML has been updated to run Ubuntu 14.04 and MySQL 5.6.

This PR has all test passing without modifying any of the tests (based upon my upstream from yesterday).

Unit test failures were being caused by MySQL truncating fixture tables. The issue appears to be random but consistent when it happens. The work around was to load fixtures manually in the unit test.

I'm happy with this fix as it more closely matches production environments for CakePHP apps. I don't think the majority of people are going to be using Ubuntu 12 and MySQL 5.6 is also very common. I don't think there are any breaking changes between 5.5 and 5.6.
