### PR TITLE
fixes unknown hash index errors when working with unique and overlapp…

### DIFF
--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -603,10 +603,12 @@ class Table
                     $attrs['columns']
                 ));
 
-                $this->_constraints[$name]['references'][1] = array_unique(array_merge(
-                    (array)$this->_constraints[$name]['references'][1],
-                    [$attrs['references'][1]]
-                ));
+                if (isset($this->_constraints[$name]['references'])) {
+                    $this->_constraints[$name]['references'][1] = array_unique(array_merge(
+                        (array)$this->_constraints[$name]['references'][1],
+                        [$attrs['references'][1]]
+                    ));
+                }
                 return $this;
             }
         } else {


### PR DESCRIPTION
cake bake error'ed out on this phinx migration without this fix:

``` php
<?php
use Migrations\AbstractMigration;

class CreateProfiles extends AbstractMigration
{
    /**
     * Change Method.
     *
     * More information on this method is available here:
     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
     * @return void
     */
    public function change()
    {
        $table = $this->table('profiles', [
            'id' => false,
            'primary_key' => [
                'project_id',
                'id',
        ]]);
        $table->addColumn('project_id', 'integer', [
            'default' => null,
            'limit' => 11,
            'null' => false,
        ]);
        $table->addColumn('id', 'integer', [
            'autoIncrement' => true,
            'limit' => 11
        ]);
        $table->addColumn('user_id', 'integer', [
            'default' => null,
            'limit' => 11,
            'null' => false,
        ]);
        $table->addColumn('nickname', 'string', [
            'default' => null,
            'null' => false,
        ]);
        $table->addForeignKey('project_id', 'projects', 'id', [
            'delete' => 'CASCADE',
            'update'=> 'NO_ACTION',
        ]);
        $table->addForeignKey(['project_id', 'user_id'], 'users', ['project_id', 'id'], [
            'delete' => 'CASCADE',
            'update'=> 'NO_ACTION',
        ]);
        $table->addIndex(['project_id', 'user_id'], ['unique' => true]);
        $table->create();
    }
}
```
