### PR TITLE
Cache/Engine/FileEngine.php: Optimize memory when saving large cache files

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -151,7 +151,7 @@ class FileEngine extends CacheEngine
 
         $duration = $this->_config['duration'];
         $expires = time() + $duration;
-        $contents = $expires . $lineBreak . $data . $lineBreak;
+        $contents = implode([$expires, $lineBreak, $data, $lineBreak]);
 
         if ($this->_config['lock']) {
             $this->_File->flock(LOCK_EX);


### PR DESCRIPTION
this commit fixes #8741
