### PR TITLE
fallback display fields should respect composite primary keys

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -525,7 +525,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($this->_displayField === null) {
             $schema = $this->schema();
             $primary = (array)$this->primaryKey();
-            $this->_displayField = array_shift($primary);
+            $this->_displayField = $primary;
             if ($schema->column('title')) {
                 $this->_displayField = 'title';
             }


### PR DESCRIPTION
This change allows bake et al. to render display fields that make sense in case there is no name/title found.
