### PR TITLE
Add get/setDefaultLocale() to Time & Date objects

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -30,6 +30,7 @@ trait DateFormatTrait
      * The default locale to be used for displaying formatted date strings.
      *
      * @var string
+     * @deprecated 3.2.9 Use static::setDefaultLocale() and static::getDefaultLocale() instead.
      */
     public static $defaultLocale;
 
@@ -62,6 +63,27 @@ trait DateFormatTrait
      * @var boolean
      */
     protected static $_isDateInstance;
+
+    /**
+     * Gets the default locale.
+     *
+     * @return string|null The default locale string to be used or null.
+     */
+    public static function getDefaultLocale()
+    {
+        return static::$defaultLocale;
+    }
+
+    /**
+     * Sets the default locale.
+     *
+     * @param string|null $locale The default locale string to be used or null.
+     * @return void
+     */
+    public static function setDefaultLocale($locale = null)
+    {
+        static::$defaultLocale = $locale;
+    }
 
     /**
      * Returns a nicely formatted date string for this object.

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -39,7 +39,7 @@ class DateTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->locale = Date::$defaultLocale;
+        $this->locale = Date::getDefaultLocale();
     }
 
     /**
@@ -50,8 +50,8 @@ class DateTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Date::$defaultLocale = $this->locale;
-        FrozenDate::$defaultLocale = $this->locale;
+        Date::setDefaultLocale($this->locale);
+        FrozenDate::setDefaultLocale($this->locale);
         date_default_timezone_set('UTC');
     }
 
@@ -105,7 +105,7 @@ class DateTest extends TestCase
         $expected = '00:00:00';
         $this->assertEquals($expected, $result);
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $result = str_replace(' à', '', $result);
         $expected = 'jeudi 14 janvier 2010 00:00:00 UTC';
@@ -165,7 +165,7 @@ class DateTest extends TestCase
         $date = $class::parseDate('11/6/15');
         $this->assertEquals('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $date = $class::parseDate('13 10, 2015');
         $this->assertEquals('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }
@@ -181,7 +181,7 @@ class DateTest extends TestCase
         $date = $class::parseDate('11/6/15 12:33:12');
         $this->assertEquals('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $date = $class::parseDate('13 10, 2015 12:54:12');
         $this->assertEquals('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }
@@ -503,5 +503,38 @@ class DateTest extends TestCase
         date_default_timezone_set('Europe/Paris');
         $result = $class::parseDate('25-02-2016', 'd-M-y');
         $this->assertEquals('25-02-2016', $result->format('d-m-Y'));
+    }
+
+    /**
+     * Tests the default locale setter.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testGetSetDefaultLocale($class)
+    {
+        $class::setDefaultLocale('fr-FR');
+        $this->assertSame('fr-FR', $class::getDefaultLocale());
+    }
+
+    /**
+     * Tests the default locale setter.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testDefaultLocaleEffectsFormatting($class)
+    {
+        $result = $class::parseDate('12/03/2015');
+        $this->assertEquals('Dec 3, 2015', $result->nice());
+
+        $class::setDefaultLocale('fr-FR');
+
+        $result = $class::parseDate('12/03/2015');
+        $this->assertEquals('12 mars 2015', $result->nice());
+
+        $expected = 'Y-m-d';
+        $result = $class::parseDate('12/03/2015');
+        $this->assertEquals('2015-03-12', $result->format($expected));
     }
 }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -859,12 +859,12 @@ class TimeTest extends TestCase
     public function testDefaultLocaleEffectsFormatting($class)
     {
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('Dec 3, 2015, 12:00 AM', $result->nice());
+        $this->assertRegExp('/Dec 3, 2015[ ,]+12:00 AM/', $result->nice());
 
         $class::setDefaultLocale('fr-FR');
 
         $result = $class::parseDate('12/03/2015');
-        $this->assertEquals('12 mars 2015 à 00:00', $result->nice());
+        $this->assertRegexp('/12 mars 2015 (?:à )?00:00/', $result->nice());
 
         $expected = 'Y-m-d';
         $result = $class::parseDate('12/03/2015');

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -35,9 +35,9 @@ class TimeTest extends TestCase
         parent::setUp();
         $this->now = Time::getTestNow();
         $this->frozenNow = FrozenTime::getTestNow();
-        $this->locale = Time::$defaultLocale;
-        Time::$defaultLocale = 'en_US';
-        FrozenTime::$defaultLocale = 'en_US';
+        $this->locale = Time::getDefaultLocale();
+        Time::setDefaultLocale('en_US');
+        FrozenTime::setDefaultLocale('en_US');
     }
 
     /**
@@ -49,11 +49,11 @@ class TimeTest extends TestCase
     {
         parent::tearDown();
         Time::setTestNow($this->now);
-        Time::$defaultLocale = $this->locale;
+        Time::setDefaultLocale($this->locale);
         Time::resetToStringFormat();
 
         FrozenTime::setTestNow($this->frozenNow);
-        FrozenTime::$defaultLocale = $this->locale;
+        FrozenTime::setDefaultLocale($this->locale);
         FrozenTime::resetToStringFormat();
         date_default_timezone_set('UTC');
         I18n::locale(I18n::DEFAULT_LOCALE);
@@ -447,7 +447,7 @@ class TimeTest extends TestCase
         $expected = '00:59:28';
         $this->assertTimeFormat($expected, $result);
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'jeudi 14 janvier 2010 13:59:28 UTC';
         $this->assertTimeFormat($expected, $result);
@@ -562,7 +562,7 @@ class TimeTest extends TestCase
     public function testToString($class)
     {
         $time = new $class('2014-04-20 22:10');
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $class::setToStringFormat(\IntlDateFormatter::FULL);
         $this->assertTimeFormat('dimanche 20 avril 2014 22:10:00 UTC', (string)$time);
     }
@@ -750,7 +750,7 @@ class TimeTest extends TestCase
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:54', $time->format('Y-m-d H:i'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $time = $class::parseDateTime('13 10, 2013 12:54');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 12:54', $time->format('Y-m-d H:i'));
@@ -775,7 +775,7 @@ class TimeTest extends TestCase
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $time = $class::parseDate('13 10, 2013 12:54');
         $this->assertNotNull($time);
         $this->assertEquals('2013-10-13 00:00', $time->format('Y-m-d H:i'));
@@ -800,7 +800,7 @@ class TimeTest extends TestCase
         $this->assertNotNull($time);
         $this->assertEquals('00:54:00', $time->format('H:i:s'));
 
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $time = $class::parseTime('23:54');
         $this->assertNotNull($time);
         $this->assertEquals('23:54:00', $time->format('H:i:s'));
@@ -832,10 +832,43 @@ class TimeTest extends TestCase
     public function testParseDateDifferentTimezone($class)
     {
         date_default_timezone_set('Europe/Paris');
-        $class::$defaultLocale = 'fr-FR';
+        $class::setDefaultLocale('fr-FR');
         $result = $class::parseDate('12/03/2015');
         $this->assertEquals('2015-03-12', $result->format('Y-m-d'));
         $this->assertEquals(new \DateTimeZone('Europe/Paris'), $result->tz);
+    }
+
+    /**
+     * Tests the default locale setter.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testGetSetDefaultLocale($class)
+    {
+        $class::setDefaultLocale('fr-FR');
+        $this->assertSame('fr-FR', $class::getDefaultLocale());
+    }
+
+    /**
+     * Tests the default locale setter.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testDefaultLocaleEffectsFormatting($class)
+    {
+        $result = $class::parseDate('12/03/2015');
+        $this->assertEquals('Dec 3, 2015, 12:00 AM', $result->nice());
+
+        $class::setDefaultLocale('fr-FR');
+
+        $result = $class::parseDate('12/03/2015');
+        $this->assertEquals('12 mars 2015 à 00:00', $result->nice());
+
+        $expected = 'Y-m-d';
+        $result = $class::parseDate('12/03/2015');
+        $this->assertEquals('2015-03-12', $result->format($expected));
     }
 
     /**


### PR DESCRIPTION
These methods give a better alternative to the static property. This extracts the less tricky parts of #8588.
