### PR TITLE
Recursive to json in entities

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -467,7 +467,7 @@ trait EntityTrait
      */
     public function jsonSerialize()
     {
-        return $this->toArray();
+        return $this->extract($this->visibleProperties());
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -646,6 +646,21 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Tests that jsonSerialize is called recursivily for contained entities
+     *
+     * @return void
+     */
+    public function testJsonSerializeRecursive()
+    {
+        $phone = $this->getMock(Entity::class, ['jsonSerialize']);
+        $phone->expects($this->once())->method('jsonSerialize')->will($this->returnValue('12345'));
+        $data = ['name' => 'James', 'age' => 20, 'phone' => $phone];
+        $entity = new Entity($data);
+        $expected = ['name' => 'James', 'age' => 20, 'phone' => '12345'];
+        $this->assertEquals(json_encode($expected), json_encode($entity));
+    }
+
+    /**
      * Tests the extract method
      *
      * @return void


### PR DESCRIPTION
I tend to override `jsonSerialize` in my entities, this allows me to have a better control of what I expose on  my API's, but currently it is not being called recursively for contained entities, which makes overriding it more difficult.

This PR makes `jsonSerialize` be called recursively in all entities
