### PR TITLE
Move aliases to compatibility shims.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,19 +17,6 @@ use Cake\Routing\Router;
 
 define('TIME_START', microtime(true));
 
-// @deprecated Backward compatibility with 2.x series
-if (PHP_VERSION_ID < 70000) {
-    class_alias('Cake\Utility\Text', 'Cake\Utility\String');
-}
-
-// @deprecated Backward compatibility with 2.x, 3.0.x
-class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport');
-class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport');
-class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');
-class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');
-class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');
-
-
 require CAKE . 'basics.php';
 
 // Sets the initial router state so future reloads work.

--- a/src/Network/Email/AbstractTransport.php
+++ b/src/Network/Email/AbstractTransport.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backward compatibility with 2.x, 3.0.x
+class_alias('Cake\Mailer\AbstractTransport', 'Cake\Network\Email\AbstractTransport');

--- a/src/Network/Email/DebugTransport.php
+++ b/src/Network/Email/DebugTransport.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backward compatibility with 2.x, 3.0.x
+class_alias('Cake\Mailer\Transport\DebugTransport', 'Cake\Network\Email\DebugTransport');

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backward compatibility with 2.x, 3.0.x
+class_alias('Cake\Mailer\Email', 'Cake\Network\Email\Email');

--- a/src/Network/Email/MailTransport.php
+++ b/src/Network/Email/MailTransport.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backward compatibility with 2.x, 3.0.x
+class_alias('Cake\Mailer\Transport\MailTransport', 'Cake\Network\Email\MailTransport');

--- a/src/Network/Email/SmtpTransport.php
+++ b/src/Network/Email/SmtpTransport.php
@@ -1,0 +1,3 @@
+<?php
+// @deprecated Backward compatibility with 2.x, 3.0.x
+class_alias('Cake\Mailer\Transport\SmtpTransport', 'Cake\Network\Email\SmtpTransport');

--- a/src/Utility/String.php
+++ b/src/Utility/String.php
@@ -1,0 +1,5 @@
+<?php
+// @deprecated Backward compatibility with 2.x series
+if (PHP_VERSION_ID < 70000) {
+    class_alias('Cake\Utility\Text', 'Cake\Utility\String');
+}


### PR DESCRIPTION
Move the backwards compatibility aliases out of the bootstrap and into stub files. By using stub files we don't force the aliased classes to be eagerly loaded on every request. Instead they are only loaded when they are used.
