### PR TITLE
2.x cake bake Controller: Only add Flash component when required

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -182,11 +182,11 @@ class ControllerTask extends BakeTask {
 				$components = $this->doComponents();
 
 				$wannaUseSession = $this->in(
-					__d('cake_console', "Would you like to use Session flash messages?"), array('y', 'n'), 'y'
+					__d('cake_console', "Would you like to use the FlashComponent to display flash messages?"), array('y', 'n'), 'y'
 				);
 
 				if (strtolower($wannaUseSession) === 'y') {
-					array_push($components, 'Session');
+					array_push($components, 'Session', 'Flash');
 				}
 				array_unique($components);
 			}
@@ -384,9 +384,9 @@ class ControllerTask extends BakeTask {
  * @return array Components the user wants to use.
  */
 	public function doComponents() {
-		$components = array('Paginator', 'Flash');
+		$components = array('Paginator');
 		return array_merge($components, $this->_doPropertyChoices(
-			__d('cake_console', "Would you like this controller to use other components\nbesides PaginatorComponent and FlashComponent?"),
+			__d('cake_console', "Would you like this controller to use other components\nbesides PaginatorComponent?"),
 			__d('cake_console', "Please provide a comma separated list of the component names you'd like to use.\nExample: 'Acl, Security, RequestHandler'")
 		));
 	}

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -222,7 +222,7 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testDoComponentsNo() {
 		$this->Task->expects($this->any())->method('in')->will($this->returnValue('n'));
 		$result = $this->Task->doComponents();
-		$this->assertSame(array('Paginator', 'Flash'), $result);
+		$this->assertSame(array('Paginator'), $result);
 	}
 
 /**
@@ -235,7 +235,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' RequestHandler, Security  '));
 
 		$result = $this->Task->doComponents();
-		$expected = array('Paginator', 'Flash', 'RequestHandler', 'Security');
+		$expected = array('Paginator', 'RequestHandler', 'Security');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -249,7 +249,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' RequestHandler, Security, , '));
 
 		$result = $this->Task->doComponents();
-		$expected = array('Paginator', 'Flash', 'RequestHandler', 'Security');
+		$expected = array('Paginator', 'RequestHandler', 'Security');
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
If a user selected no to the question "Would you like to use Session flash messages?" it would still load the Flash component, but not use it
