### PR TITLE
Move middleware into more relevant packages.

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -12,7 +12,7 @@
  * @since         3.3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Http\Middleware;
+namespace Cake\Error\Middleware;
 
 use Cake\Core\App;
 use Cake\Http\ResponseTransformer;

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -12,7 +12,7 @@
  * @since         3.3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Http\Middleware;
+namespace Cake\Routing\Middleware;
 
 use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\Router;

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -12,10 +12,10 @@
  * @since         3.3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Http\Middleware;
+namespace Cake\Test\TestCase\Error\Middleware;
 
 use Cake\Core\Configure;
-use Cake\Http\Middleware\ErrorHandlerMiddleware;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\ServerRequestFactory;
 use Cake\Network\Response as CakeResponse;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -12,9 +12,9 @@
  * @since         3.3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Http\Middleware;
+namespace Cake\Test\TestCase\Routing\Middleware;
 
-use Cake\Http\Middleware\RoutingMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Zend\Diactoros\Request;


### PR DESCRIPTION
Put middleware classes closer to the packages they interact with. This lets us reduce the number of inter-package dependencies we have. Both Error and Routing are not standalone packages yet, while I'd like cake/http to be standalone.

Refs #6960 
