### PR TITLE
[3.3] Remove unused use statement from bootstrap

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -13,7 +13,6 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-use Cake\Datasource\FactoryLocator;
 use Cake\Routing\Router;
 
 define('TIME_START', microtime(true));


### PR DESCRIPTION
This removes a unused use statement from bootstrap that was a leftover from changes to #8713.
