### PR TITLE
2.x - Fix ApcEngine to work on PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ before_script:
   - sh -c "if [ '$PHPCS' = '1' ]; then composer global require 'cakephp/cakephp-codesniffer:1.*'; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then ~/.composer/vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/cakephp/cakephp-codesniffer; fi"
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]] ; then print "yes" | pecl install apcu-5.1.3; else print "yes" | pecl install apcu-4.0.11; fi
+  - echo -e "extension = apcu.so\napc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - phpenv rehash
   - set +H
   - echo "<?php


### PR DESCRIPTION
Currently Cake 2.8 is using only the `apc_*` functions, which doesn't work on PHP 7. The pecl `apcu` only support `apcu_*` functions on PHP 7+.

Since CakePHP 2.8 introduces the support to PHP 7, adding the support to both extensions.

The issue didn't show on CI before because apc wasn't being installed and the test case was skipping in this case.
