### PR TITLE
Allow multiple IMG tags to be formatted

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -840,9 +840,11 @@ class HtmlHelper extends Helper
     /**
      * Create multiple formatted image elements
      *
+     * ### Usage using glob:
      *
-     * ### Usage:
+     * echo $this->Html->images(glob("img/thumb/*.jpg"));
      *
+     * ### Usage using path and options:
      * $images = [
      *     [
      *         'path' => 'test-image-2.jpg',
@@ -856,12 +858,13 @@ class HtmlHelper extends Helper
      *
      * echo $this->Html->images($images);
      *
+     *
      * ### Multiple Images
      *
      * - `path` string Path to the image file, relative to the app/webroot/img/ directory.
      *   `options` Reference HtmlHelper::image - options
      *
-     * @param array $multipleImages Array of image Arrays. See above for special options.
+     * @param array $multipleImages Array of image paths or Array of path and options. See above for special options.
      * @return string of multiple image tags
      */
     public function images(array $multipleImages)
@@ -870,7 +873,7 @@ class HtmlHelper extends Helper
 
         if (!empty($multipleImages)) {
             foreach ($multipleImages as $image) {
-                if (isset($image['path'])) {
+                if (is_array($image) && isset($image['path'])) {
 
                     $path = $image['path'];
                     $options = [];
@@ -880,7 +883,8 @@ class HtmlHelper extends Helper
                     }
 
                     $images .= $this->image($path, $options);
-
+                } else {
+                    $images .= $this->image($image);
                 }
             }
         }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -864,7 +864,7 @@ class HtmlHelper extends Helper
      * - `path` string Path to the image file, relative to the app/webroot/img/ directory.
      *   `options` Reference HtmlHelper::image - options
      *
-     * @param array $multipleImages Array of image paths or Array of path and options. See above for special options.
+     * @param array $multipleImages Array of image paths or Array of path and options. See above for Multi Image structure.
      * @return string of multiple image tags
      */
     public function images(array $multipleImages)

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -838,6 +838,57 @@ class HtmlHelper extends Helper
     }
 
     /**
+     * Create multiple formatted image elements
+     *
+     *
+     * ### Usage:
+     *
+     * $images = [
+     *     [
+     *         'path' => 'test-image-2.jpg',
+     *         'options' => [] // optional
+     *     ],
+     *     [
+     *         'path' => 'test-image-3.jpg',
+     *         'options' => [] // optional
+     *     ]
+     * ];
+     *
+     * echo $this->Html->images($images);
+     *
+     * ### Multiple Images
+     *
+     * - `path` string Path to the image file, relative to the app/webroot/img/ directory.
+     *   `options` Reference HtmlHelper::image - options
+     *
+     * @param array $multipleImages Array of image Arrays. See above for special options.
+     * @return string of multiple image tags
+     */
+    public function images(array $multipleImages)
+    {
+        $images = '';
+
+        if (!empty($multipleImages)) {
+            foreach ($multipleImages as $image) {
+                if (isset($image['path'])) {
+
+                    $path = $image['path'];
+                    $options = [];
+
+                    if (isset($image['options'])) {
+                        $options = $image['options'];
+                    }
+
+                    $images .= $this->image($path, $options);
+
+                }
+            }
+        }
+
+        return $images;
+    }
+
+    /**
      * Returns a row of formatted and named TABLE headers.
      *
      * @param array $names Array of tablenames. Each tablename also can be a key that points to an array with a set

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -337,6 +337,52 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
+     * testImages method
+     *
+     * @return void
+     */
+    public function testImages()
+    {
+        Router::connect('/:controller', ['action' => 'index']);
+        Router::connect('/:controller/:action/*');
+
+        $this->Html->request->webroot = '';
+
+        $result = $this->Html->images([
+            'logo.gif'
+        ]);
+        $expected = ['img' => ['src' => 'img/logo.gif', 'alt' => '']];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->images([
+            'logo.gif',
+            'test.gif'
+        ]);
+        $expected = [
+            ['img' => ['src' => 'img/logo.gif', 'alt' => '']],
+            ['img' => ['src' => 'img/test.gif', 'alt' => '']]
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->images([
+            [
+                'path' => 'logo.gif',
+                'options' => [
+                    'alt' => 'hello',
+                    'width' => '100px'
+                ]
+            ],
+            'test.gif'
+        ]);
+        $expected = [
+            ['img' => ['src' => 'img/logo.gif', 'alt' => 'hello', 'width' => '100px']],
+            ['img' => ['src' => 'img/test.gif', 'alt' => '']]
+        ];
+        $this->assertHtml($expected, $result);
+
+    }
+
+    /**
      * Test image() with query strings.
      *
      * @return void


### PR DESCRIPTION
Allow multiple images to be formatted as IMG tags from one input array, this function calls HtmlHelper::image

Its basically to make things easier if you were using for example, glob() where an array could be passed straight in. Or if you did want for format options on each of them, then that also would be fine..
