### PR TITLE
Making sure the database sessions adapter never returns false

### DIFF
--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -108,7 +108,13 @@ class DatabaseSession implements SessionHandlerInterface
             return $result['data'];
         }
 
-        return stream_get_contents($result['data']);
+        $session = stream_get_contents($result['data']);
+
+        if ($session === false) {
+            return '';
+        }
+        
+        return $session;
     }
 
     /**


### PR DESCRIPTION
We had a similar problem with a custom sessions adapter at work, and this change fixed it

Fixes #8785
