### PR TITLE
Make Http\Client\Request PSR7 compatible

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -421,7 +421,7 @@ class Client
     protected function _createRequest($method, $url, $data, $options)
     {
         $request = new Request();
-        $request->method($method)
+        $request = $request->withMethod($method)
             ->url($url)
             ->body($data);
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -336,6 +336,7 @@ class Client
             $data,
             $options
         );
+
         return $this->send($request, $options);
     }
 

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -145,8 +145,8 @@ class Stream
     protected function _buildHeaders(Request $request, $options)
     {
         $headers = [];
-        foreach ($request->headers() as $name => $value) {
-            $headers[] = "$name: $value";
+        foreach ($request->getHeaders() as $name => $values) {
+            $headers[] = sprintf('%s: %s', $name, implode(", ", $values));
         }
 
         $cookies = [];
@@ -171,23 +171,12 @@ class Stream
      */
     protected function _buildContent(Request $request, $options)
     {
-        $content = $request->body();
-        if (empty($content)) {
-            return;
+        $body = $request->getBody();
+        if (empty($body)) {
+            return $this->_contextOptions['content'] = '';
         }
-        if (is_string($content)) {
-            $this->_contextOptions['content'] = $content;
-            return;
-        }
-        if (is_array($content)) {
-            $formData = new FormData();
-            $formData->addMany($content);
-            $type = $formData->contentType();
-            $request->header('Content-Type', $type);
-            $this->_contextOptions['content'] = (string)$formData;
-            return;
-        }
-        $this->_contextOptions['content'] = $content;
+        $body->rewind();
+        $this->_contextOptions['content'] = $body->getContents();
     }
 
     /**

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -173,7 +173,8 @@ class Stream
     {
         $body = $request->getBody();
         if (empty($body)) {
-            return $this->_contextOptions['content'] = '';
+            $this->_contextOptions['content'] = '';
+            return;
         }
         $body->rewind();
         $this->_contextOptions['content'] = $body->getContents();

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -206,7 +206,9 @@ class Oauth
 
         $post = [];
         $body = $request->body();
-
+        if (is_string($body) && $request->getHeaderLine('content-type') === 'application/x-www-form-urlencoded') {
+            parse_str($body, $post);
+        }
         if (is_array($body)) {
             $post = $body;
         }

--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -142,13 +142,6 @@ class Message
     protected $_cookies = [];
 
     /**
-     * HTTP Version being used.
-     *
-     * @var string
-     */
-    protected $_version = '1.1';
-
-    /**
      * Normalize header names to Camel-Case form.
      *
      * @param string $name The header name to normalize.
@@ -191,7 +184,7 @@ class Message
      */
     public function version()
     {
-        return $this->_version;
+        return $this->protocol;
     }
 
     /**

--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -166,6 +166,7 @@ class Message
      * Get all headers
      *
      * @return array
+     * @deprecated 3.3.0 Use getHeaders() instead.
      */
     public function headers()
     {
@@ -186,6 +187,7 @@ class Message
      * Get the HTTP version used.
      *
      * @return string
+     * @deprecated 3.3.0 Use getProtocolVersion()
      */
     public function version()
     {

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -16,6 +16,7 @@ namespace Cake\Http\Client;
 use Cake\Core\Exception\Exception;
 use Psr\Http\Message\RequestInterface;
 use Zend\Diactoros\MessageTrait;
+use Zend\Diactoros\Stream;
 use Zend\Diactoros\RequestTrait;
 
 /**
@@ -28,13 +29,6 @@ class Request extends Message implements RequestInterface
 {
     use MessageTrait;
     use RequestTrait;
-
-    /**
-     * Request body to send.
-     *
-     * @var mixed
-     */
-    protected $_body;
 
     /**
      * Constructor
@@ -207,6 +201,28 @@ class Request extends Message implements RequestInterface
         }
 
         $this->protocol = $version;
+        return $this;
+    }
+
+    /**
+     * Get/set the body for the message.
+     *
+     * *Warning* This method mutates the request in-place for backwards
+     * compatibility reasons, and is not part of the PSR7 interface.
+     *
+     * @param string|null $body The body for the request. Leave null for get
+     * @return mixed Either $this or the body value.
+     * @deprecated 3.3.0 use getBody() and withBody() instead.
+     */
+    public function body($body = null)
+    {
+        if ($body === null) {
+            $body = $this->getBody();
+            return $body ? $body->__toString() : '';
+        }
+        $stream = new Stream('php://memory', 'rw');
+        $stream->write($body);
+        $this->stream = $stream;
         return $this;
     }
 }

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -14,6 +14,8 @@
 namespace Cake\Http\Client;
 
 use Cake\Core\Exception\Exception;
+use Zend\Diactoros\MessageTrait;
+use Zend\Diactoros\RequestTrait;
 
 /**
  * Implements methods for HTTP requests.
@@ -24,6 +26,8 @@ use Cake\Core\Exception\Exception;
  */
 class Request extends Message
 {
+    use MessageTrait;
+    use RequestTrait;
 
     /**
      * The HTTP method to use.
@@ -62,6 +66,7 @@ class Request extends Message
      * @param string|null $method The method for the request.
      * @return $this|string Either this or the current method.
      * @throws \Cake\Core\Exception\Exception On invalid methods.
+     * @deprecated 3.3.0 Use getMethod() and withMethod() instead.
      */
     public function method($method = null)
     {
@@ -178,8 +183,8 @@ class Request extends Message
      * Get/Set HTTP version.
      *
      * @param string|null $version The HTTP version.
-     *
      * @return $this|string Either $this or the HTTP version.
+     * @deprecated 3.3.0 Use getProtocolVersion() and withProtocolVersion() instead.
      */
     public function version($version = null)
     {

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -39,14 +39,10 @@ class Request extends Message implements RequestInterface
     {
         $this->method = static::METHOD_GET;
 
-        $this->headerNames = [
-            'connection' => 'Connection',
-            'user-agent' => 'User-Agent',
-        ];
-        $this->headers = [
+        $this->header([
             'Connection' => 'close',
             'User-Agent' => 'CakePHP'
-        ];
+        ]);
     }
 
     /**
@@ -205,20 +201,25 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Get/set the body for the message.
+     * Get/set the body/payload for the message.
      *
-     * *Warning* This method mutates the request in-place for backwards
-     * compatibility reasons, and is not part of the PSR7 interface.
+     * Array data will be serialized with Cake\Http\FormData,
+     * and the content-type will be set.
      *
      * @param string|null $body The body for the request. Leave null for get
      * @return mixed Either $this or the body value.
-     * @deprecated 3.3.0 use getBody() and withBody() instead.
      */
     public function body($body = null)
     {
         if ($body === null) {
             $body = $this->getBody();
             return $body ? $body->__toString() : '';
+        }
+        if (is_array($body)) {
+            $formData = new FormData();
+            $formData->addMany($body);
+            $this->header('Content-Type', $formData->contentType());
+            $body = (string)$formData;
         }
         $stream = new Stream('php://memory', 'rw');
         $stream->write($body);

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -206,7 +206,7 @@ class Request extends Message implements RequestInterface
      * Array data will be serialized with Cake\Http\FormData,
      * and the content-type will be set.
      *
-     * @param string|null $body The body for the request. Leave null for get
+     * @param string|array|null $body The body for the request. Leave null for get
      * @return mixed Either $this or the body value.
      */
     public function body($body = null)

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -16,8 +16,8 @@ namespace Cake\Http\Client;
 use Cake\Core\Exception\Exception;
 use Psr\Http\Message\RequestInterface;
 use Zend\Diactoros\MessageTrait;
-use Zend\Diactoros\Stream;
 use Zend\Diactoros\RequestTrait;
+use Zend\Diactoros\Stream;
 
 /**
  * Implements methods for HTTP requests.

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -59,7 +59,7 @@ class Request extends Message implements RequestInterface
      * Get/Set the HTTP method.
      *
      * *Warning* This method mutates the request in-place for backwards
-     * compatibility issues, and is not part of the PSR7 interface.
+     * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|null $method The method for the request.
      * @return $this|string Either this or the current method.
@@ -81,6 +81,9 @@ class Request extends Message implements RequestInterface
 
     /**
      * Get/Set the url for the request.
+     *
+     * *Warning* This method mutates the request in-place for backwards
+     * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|null $url The url for the request. Leave null for get
      * @return $this|string Either $this or the url value.
@@ -120,7 +123,7 @@ class Request extends Message implements RequestInterface
      * ```
      *
      * *Warning* This method mutates the request in-place for backwards
-     * compatibility issues, and is not part of the PSR7 interface.
+     * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|array|null $name The name to get, or array of multiple values to set.
      * @param string|null $value The value to set for the header.
@@ -191,7 +194,7 @@ class Request extends Message implements RequestInterface
      * Get/Set HTTP version.
      *
      * *Warning* This method mutates the request in-place for backwards
-     * compatibility issues, and is not part of the PSR7 interface.
+     * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|null $version The HTTP version.
      * @return $this|string Either $this or the HTTP version.

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -23,7 +23,6 @@ use Zend\Diactoros\RequestTrait;
  *
  * Used by Cake\Network\Http\Client to contain request information
  * for making requests.
- *
  */
 class Request extends Message implements RequestInterface
 {
@@ -36,13 +35,6 @@ class Request extends Message implements RequestInterface
      * @var mixed
      */
     protected $_body;
-
-    /**
-     * The URL to request.
-     *
-     * @var string
-     */
-    protected $_url;
 
     /**
      * Constructor
@@ -92,13 +84,14 @@ class Request extends Message implements RequestInterface
      *
      * @param string|null $url The url for the request. Leave null for get
      * @return $this|string Either $this or the url value.
+     * @deprecated 3.3.0 Use getUri() and withUri() instead.
      */
     public function url($url = null)
     {
         if ($url === null) {
-            return $this->_url;
+            return '' . $this->getUri();
         }
-        $this->_url = $url;
+        $this->uri = $this->createUri($url);
         return $this;
     }
 

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -89,6 +89,12 @@ use RuntimeException;
  */
 class Response extends Message
 {
+    /**
+     * This is temporary until the response is made PSR7 compliant as well.
+     *
+     * @var string
+     */
+    protected $protocol = '1.1';
 
     /**
      * The status code of the response.
@@ -187,7 +193,7 @@ class Response extends Message
         foreach ($headers as $key => $value) {
             if (substr($value, 0, 5) === 'HTTP/') {
                 preg_match('/HTTP\/([\d.]+) ([0-9]+)/i', $value, $matches);
-                $this->_version = $matches[1];
+                $this->protocol = $matches[1];
                 $this->_code = $matches[2];
                 continue;
             }

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -172,7 +172,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_method', Request::METHOD_GET),
+                $this->attributeEqualTo('method', Request::METHOD_GET),
                 $this->attributeEqualTo('_url', 'http://cakephp.org/test.html'),
                 $this->attributeEqualTo('_headers', $headers),
                 $this->attributeEqualTo('_cookies', $cookies)
@@ -201,7 +201,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_method', Request::METHOD_GET),
+                $this->attributeEqualTo('method', Request::METHOD_GET),
                 $this->attributeEqualTo('_url', 'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3')
             ))
             ->will($this->returnValue([$response]));
@@ -262,7 +262,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_method', Request::METHOD_GET),
+                $this->attributeEqualTo('method', Request::METHOD_GET),
                 $this->attributeEqualTo('_url', 'http://cakephp.org/search'),
                 $this->attributeEqualTo('_body', 'some data')
             ))
@@ -319,7 +319,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_method', Request::METHOD_GET),
+                $this->attributeEqualTo('method', Request::METHOD_GET),
                 $this->attributeEqualTo('_url', 'http://cakephp.org/'),
                 $this->attributeEqualTo('_headers', $headers)
             ))
@@ -368,7 +368,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_method', $method),
+                $this->attributeEqualTo('method', $method),
                 $this->attributeEqualTo('_url', 'http://cakephp.org/projects/add')
             ))
             ->will($this->returnValue([$response]));
@@ -417,7 +417,7 @@ class ClientTest extends TestCase
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
-                $this->attributeEqualTo('_method', Request::METHOD_POST),
+                $this->attributeEqualTo('method', Request::METHOD_POST),
                 $this->attributeEqualTo('_body', $data),
                 $this->attributeEqualTo('_headers', $headers)
             ))
@@ -538,7 +538,7 @@ class ClientTest extends TestCase
             ->method('send')
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_method', Request::METHOD_HEAD),
+                $this->attributeEqualTo('method', Request::METHOD_HEAD),
                 $this->attributeEqualTo('_url', 'http://cakephp.org/search?q=hi+there')
             ))
             ->will($this->returnValue([$response]));

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -17,6 +17,7 @@ use Cake\Network\Http\Client;
 use Cake\Network\Http\Request;
 use Cake\Network\Http\Response;
 use Cake\TestSuite\TestCase;
+use Zend\Diactoros\Uri;
 
 /**
  * HTTP client test.
@@ -369,7 +370,7 @@ class ClientTest extends TestCase
             ->with($this->logicalAnd(
                 $this->isInstanceOf('Cake\Network\Http\Request'),
                 $this->attributeEqualTo('method', $method),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/projects/add')
+                $this->attributeEqualTo('url', new Uri('http://cakephp.org/projects/add'))
             ))
             ->will($this->returnValue([$response]));
 

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -171,13 +171,15 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('method', Request::METHOD_GET),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/test.html'),
-                $this->attributeEqualTo('_headers', $headers),
-                $this->attributeEqualTo('_cookies', $cookies)
-            ))
+            ->with($this->callback(function ($request) use ($cookies, $headers) {
+                $this->assertInstanceOf('Cake\Network\Http\Request', $request);
+                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertEquals('http://cakephp.org/test.html', $request->getUri() . '');
+                $this->assertEquals($cookies, $request->cookies());
+                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
+                $this->assertEquals($headers['Connection'], $request->getHeaderLine('connection'));
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client(['adapter' => $mock]);
@@ -200,11 +202,14 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('method', Request::METHOD_GET),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3')
-            ))
+            ->with($this->callback(function ($request) {
+                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertEquals(
+                    'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
+                    $request->getUri() . ''
+                );
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -230,10 +235,13 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3')
-            ))
+            ->with($this->callback(function ($request) {
+                $this->assertEquals(
+                    'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
+                    $request->getUri() . ''
+                );
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -261,12 +269,12 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('method', Request::METHOD_GET),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/search'),
-                $this->attributeEqualTo('_body', 'some data')
-            ))
+            ->with($this->callback(function ($request) {
+                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertEquals('http://cakephp.org/search', '' . $request->getUri());
+                $this->assertEquals('some data', '' . $request->getBody());
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -311,19 +319,18 @@ class ClientTest extends TestCase
 
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $headers = [
-            'Connection' => 'close',
-            'User-Agent' => 'CakePHP',
             'Authorization' => 'Basic ' . base64_encode('mark:secret'),
             'Proxy-Authorization' => 'Basic ' . base64_encode('mark:pass'),
         ];
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('method', Request::METHOD_GET),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/'),
-                $this->attributeEqualTo('_headers', $headers)
-            ))
+            ->with($this->callback(function ($request) use ($headers) {
+                $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+                $this->assertEquals('http://cakephp.org/', '' . $request->getUri());
+                $this->assertEquals($headers['Authorization'], $request->getHeaderLine('Authorization'));
+                $this->assertEquals($headers['Proxy-Authorization'], $request->getHeaderLine('Proxy-Authorization'));
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -367,11 +374,12 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('method', $method),
-                $this->attributeEqualTo('url', new Uri('http://cakephp.org/projects/add'))
-            ))
+            ->with($this->callback(function ($request) use ($method) {
+                $this->assertInstanceOf('Cake\Network\Http\Request', $request);
+                $this->assertEquals($method, $request->getMethod());
+                $this->assertEquals('http://cakephp.org/projects/add', '' . $request->getUri());
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -408,8 +416,6 @@ class ClientTest extends TestCase
         $response = new Response();
         $data = 'some data';
         $headers = [
-            'Connection' => 'close',
-            'User-Agent' => 'CakePHP',
             'Content-Type' => $mime,
             'Accept' => $mime,
         ];
@@ -417,11 +423,12 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->attributeEqualTo('method', Request::METHOD_POST),
-                $this->attributeEqualTo('_body', $data),
-                $this->attributeEqualTo('_headers', $headers)
-            ))
+            ->with($this->callback(function ($request) use ($headers) {
+                $this->assertEquals(Request::METHOD_POST, $request->getMethod());
+                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
+                $this->assertEquals($headers['Accept'], $request->getHeaderLine('Accept'));
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -440,19 +447,15 @@ class ClientTest extends TestCase
     {
         $response = new Response();
         $data = 'some=value&more=data';
-        $headers = [
-            'Connection' => 'close',
-            'User-Agent' => 'CakePHP',
-            'Content-Type' => 'application/x-www-form-urlencoded',
-        ];
 
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->any())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->attributeEqualTo('_body', $data),
-                $this->attributeEqualTo('_headers', $headers)
-            ))
+            ->with($this->callback(function ($request) use ($data) {
+                $this->assertEquals($data, '' . $request->getBody());
+                $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([
@@ -537,11 +540,12 @@ class ClientTest extends TestCase
         $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
         $mock->expects($this->once())
             ->method('send')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf('Cake\Network\Http\Request'),
-                $this->attributeEqualTo('method', Request::METHOD_HEAD),
-                $this->attributeEqualTo('_url', 'http://cakephp.org/search?q=hi+there')
-            ))
+            ->with($this->callback(function ($request) {
+                $this->assertInstanceOf('Cake\Network\Http\Request', $request);
+                $this->assertEquals(Request::METHOD_HEAD, $request->getMethod());
+                $this->assertEquals('http://cakephp.org/search?q=hi+there', '' . $request->getUri());
+                return true;
+            }))
             ->will($this->returnValue([$response]));
 
         $http = new Client([

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -118,7 +118,14 @@ class RequestTest extends TestCase
      */
     public function testBodyInteroperability()
     {
-        $this->markTestIncomplete();
+        $request = new Request();
+        $this->assertSame('', $request->body());
+
+        $data = '{"json":"data"}';
+        $request = new Request();
+        $request->body($data);
+        $this->assertSame($data, $request->body());
+        $this->assertSame($data, '' . $request->getBody());
     }
 
     /**

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -112,6 +112,28 @@ class RequestTest extends TestCase
     }
 
     /**
+     * test body method with array payload
+     *
+     * @return void
+     */
+    public function testBodyArray()
+    {
+        $request = new Request();
+        $data = [
+            'a' => 'b',
+            'c' => 'd',
+            'e' => ['f', 'g']
+        ];
+        $request->body($data);
+        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));
+        $this->assertEquals(
+            'a=b&c=d&e%5B0%5D=f&e%5B1%5D=g',
+            $request->body(),
+            'Body should be serialized'
+        );
+    }
+
+    /**
      * Test that body() modifies the PSR7 stream
      *
      * @return void

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -49,6 +49,23 @@ class RequestTest extends TestCase
     }
 
     /**
+     * test method interop.
+     *
+     * @return void
+     */
+    public function testMethodInteroperability()
+    {
+        $request = new Request();
+        $this->assertSame($request, $request->method(Request::METHOD_GET));
+        $this->assertEquals(Request::METHOD_GET, $request->method());
+        $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+
+        $request = $request->withMethod(Request::METHOD_GET);
+        $this->assertEquals(Request::METHOD_GET, $request->method());
+        $this->assertEquals(Request::METHOD_GET, $request->getMethod());
+    }
+
+    /**
      * test invalid method.
      *
      * @expectedException \Cake\Core\Exception\Exception
@@ -104,6 +121,35 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test the default headers
+     *
+     * @return void
+     */
+    public function testDefaultHeaders()
+    {
+        $request = new Request();
+        $this->assertEquals('CakePHP', $request->getHeaderLine('User-Agent'));
+        $this->assertEquals('close', $request->getHeaderLine('Connection'));
+    }
+
+    /**
+     * Test that header() and PSR7 methods play nice.
+     *
+     * @return void
+     */
+    public function testHeaderMethodInteroperability()
+    {
+        $request = new Request();
+        $request->header('Content-Type', 'application/json');
+        $this->assertEquals('application/json', $request->header('Content-Type'), 'Old getter should work');
+
+        $this->assertEquals('application/json', $request->getHeaderLine('Content-Type'), 'getHeaderLine works');
+        $this->assertEquals('application/json', $request->getHeaderLine('content-type'), 'getHeaderLine works');
+        $this->assertEquals(['application/json'], $request->getHeader('Content-Type'), 'getHeader works');
+        $this->assertEquals(['application/json'], $request->getHeader('content-type'), 'getHeader works');
+    }
+
+    /**
      * test cookie method.
      *
      * @return void
@@ -132,5 +178,21 @@ class RequestTest extends TestCase
         $this->assertSame($request, $request, 'Should return self');
 
         $this->assertSame('1.0', $request->version());
+    }
+
+    /**
+     * test version interop.
+     *
+     * @return void
+     */
+    public function testVersionInteroperability()
+    {
+        $request = new Request();
+        $this->assertEquals('1.1', $request->version());
+        $this->assertEquals('1.1', $request->getProtocolVersion());
+
+        $request = $request->withProtocolVersion('1.0');
+        $this->assertEquals('1.0', $request->version());
+        $this->assertEquals('1.0', $request->getProtocolVersion());
     }
 }

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -15,6 +15,7 @@ namespace Cake\Test\TestCase\Network\Http;
 
 use Cake\Network\Http\Request;
 use Cake\TestSuite\TestCase;
+use Zend\Diactoros\Uri;
 
 /**
  * HTTP request test.
@@ -33,6 +34,25 @@ class RequestTest extends TestCase
         $this->assertSame($request, $request->url('http://example.com'));
 
         $this->assertEquals('http://example.com', $request->url());
+    }
+
+    /**
+     * Test that url() modifies the PSR7 stream
+     *
+     * @return void
+     */
+    public function testUrlInteroperability()
+    {
+        $request = new Request();
+        $request->url('http://example.com');
+        $this->assertSame('http://example.com', $request->url());
+        $this->assertSame('http://example.com', $request->getUri()->__toString());
+
+        $uri = 'http://example.com/test';
+        $request = new Request();
+        $request = $request->withUri(new Uri($uri));
+        $this->assertSame($uri, $request->url());
+        $this->assertSame($uri, $request->getUri()->__toString());
     }
 
     /**
@@ -89,6 +109,16 @@ class RequestTest extends TestCase
         $this->assertSame($request, $request->body($data));
 
         $this->assertEquals($data, $request->body());
+    }
+
+    /**
+     * Test that body() modifies the PSR7 stream
+     *
+     * @return void
+     */
+    public function testBodyInteroperability()
+    {
+        $this->markTestIncomplete();
     }
 
     /**


### PR DESCRIPTION
This makes the `Http\Client\Request` PSR7 compatible and maintains backwards compatibility in all but a few small places:
- Internal properties were renamed (this is ok by our backwards compatibility guidelines)
- `body()` now transforms array inputs into URL encoded data. The preservation of array data was previously not tested. I also think this change is acceptable as not many people will have extended this class.

There are still a few rough edges around `Message` and `Response`. I plan on updating the `Response` class next, and then updating all the internal calls in the `Client` to use the PSR7 methods, and not the deprecated ones where possible.

Refs #6960 
