### PR TITLE
Force ExistsIn rule in new Entity even with a not dirty field

### DIFF
--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -94,7 +94,7 @@ class ExistsIn
             return true;
         }
 
-        if (!$entity->extract($this->_fields, true)) {
+        if (!$entity->extract($this->_fields, true) && !$entity->isNew()) {
             return true;
         }
 

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -415,7 +415,7 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * ExistsIn uses the schema to verify that nullable fields are ok.
      *
-     * @return
+     * @return void
      */
     public function testExistsInNullValue()
     {
@@ -436,7 +436,7 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Test ExistsIn on not dirty field in new Entity
      *
-     * @return
+     * @return void
      */
     public function testExistsInNotNullValue()
     {
@@ -459,7 +459,7 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests exists in uses the bindingKey of the association
      *
-     * @return
+     * @return void
      */
     public function testExistsInWithBindingKey()
     {

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -29,7 +29,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.articles_tags', 'core.authors', 'core.tags'];
+    public $fixtures = ['core.articles', 'core.articles_tags', 'core.authors', 'core.tags', 'core.categories'];
 
     /**
      * Tear down
@@ -431,6 +431,29 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $this->assertEquals($entity, $table->save($entity));
         $this->assertEquals([], $entity->errors('author_id'));
+    }
+
+    /**
+     * Test ExistsIn on not dirty field in new Entity
+     *
+     * @return
+     */
+    public function testExistsInNotNullValue()
+    {
+        $entity = new Entity([
+            'name' => 'A Category',
+        ]);
+
+        $table = TableRegistry::get('Categories');
+        $table->belongsTo('Categories', [
+            'foreignKey' => 'parent_id',
+            'bindingKey' => 'id',
+        ]);
+        $rules = $table->rulesChecker();
+        $rules->add($rules->existsIn('parent_id', 'Categories'));
+
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['_existsIn' => 'This value does not exist'], $entity->errors('parent_id'));
     }
 
     /**


### PR DESCRIPTION
I found a bug with existsIn rule when testing that in my app (cake 3.2.8) with a Products, Sales and SaleDetails models, with SaleDetails belongsTo Products and Sales, allowed me to save a new Sale with new SaleDetails associated when sale_detail.product_id was null (not selected and the required attribute was missing in the browser).
An SQL exception was raised. The existsIn rule were not applied. Because the patchEntity did not touch the product_id, so it was not marked as dirty.

This pull request force the check of existIn on a newEntity even if the field were not set.

I don't know if the test is well written, I choose the Categories table because the other fixtures have nullable fields on relations, although I think the test would fail if the table was empty.
