### PR TITLE
Fix for 'Uninitialized string offset: 0' when using Request's `referer` under PHP 7

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -547,6 +547,9 @@ class Request implements ArrayAccess
         if (!empty($ref) && !empty($base)) {
             if ($local && strpos($ref, $base) === 0) {
                 $ref = substr($ref, strlen($base));
+                if (empty($ref)) {
+                    $ref = '/';
+                }
                 if ($ref[0] !== '/') {
                     $ref = '/' . $ref;
                 }

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -547,7 +547,7 @@ class Request implements ArrayAccess
         if (!empty($ref) && !empty($base)) {
             if ($local && strpos($ref, $base) === 0) {
                 $ref = substr($ref, strlen($base));
-                if (empty($ref)) {
+                if (!strlen($ref)) {
                     $ref = '/';
                 }
                 if ($ref[0] !== '/') {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -574,6 +574,10 @@ class RequestTest extends TestCase
         $result = $request->referer(true);
         $this->assertSame('/some/path', $result);
 
+        $request->env('HTTP_REFERER', Configure::read('App.fullBaseUrl') . '/0');
+        $result = $request->referer(true);
+        $this->assertSame('/0', $result);
+
         $request->env('HTTP_REFERER', Configure::read('App.fullBaseUrl') . '/');
         $result = $request->referer(true);
         $this->assertSame('/', $result);

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -574,6 +574,10 @@ class RequestTest extends TestCase
         $result = $request->referer(true);
         $this->assertSame('/some/path', $result);
 
+        $request->env('HTTP_REFERER', Configure::read('App.fullBaseUrl') . '/');
+        $result = $request->referer(true);
+        $this->assertSame('/', $result);
+
         $request->env('HTTP_REFERER', Configure::read('App.fullBaseUrl') . '/some/path');
         $result = $request->referer(false);
         $this->assertSame(Configure::read('App.fullBaseUrl') . '/some/path', $result);


### PR DESCRIPTION
Fixes #8794 

As said in the issue, I'm not sure about how I've fixed it. But let me know what could I change to improve it.
