### PR TITLE
Fix viewBuilder() config not taking precedence.

### DIFF
--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -70,8 +70,8 @@ trait ViewVarsTrait
     public function createView($viewClass = null)
     {
         $builder = $this->viewBuilder();
-        if ($viewClass === null) {
-            $viewClass = $this->viewClass;
+        if ($viewClass === null && $builder->className() === null) {
+            $builder->className($this->viewClass);
         }
         if ($viewClass) {
             $builder->className($viewClass);

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -189,6 +189,44 @@ class ViewVarsTraitTest extends TestCase
     }
 
     /**
+     * test that viewClass is used to create the view
+     *
+     * @return void
+     */
+    public function testCreateViewViewClass()
+    {
+        $this->subject->viewClass = 'Json';
+        $view = $this->subject->createView();
+        $this->assertInstanceof('Cake\View\JsonView', $view);
+    }
+
+    /**
+     * test that viewBuilder settings override viewClass
+     *
+     * @return void
+     */
+    public function testCreateViewViewBuilder()
+    {
+        $this->subject->viewBuilder()->className('Xml');
+        $this->subject->viewClass = 'Json';
+        $view = $this->subject->createView();
+        $this->assertInstanceof('Cake\View\XmlView', $view);
+    }
+
+    /**
+     * test that parameters beats viewBuilder() and viewClass
+     *
+     * @return void
+     */
+    public function testCreateViewParameter()
+    {
+        $this->subject->viewBuilder()->className('View');
+        $this->subject->viewClass = 'Json';
+        $view = $this->subject->createView('Xml');
+        $this->assertInstanceof('Cake\View\XmlView', $view);
+    }
+
+    /**
      * test createView() throws exception if view class cannot be found
      *
      * @expectedException \Cake\View\Exception\MissingViewException


### PR DESCRIPTION
The viewBuilder()->className() settings should over-ride `$this->viewClass` property. If it doesn't, then you cannot use `viewBuilder()->viewClass()` when `$this->viewClass` is set. Because the property is deprecated, we should favour the builder method.

Refs #8770
