### PR TITLE
Make named route match failures more obvious.

### DIFF
--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -31,6 +31,9 @@ class MissingRouteException extends Exception
      */
     public function __construct($message, $code = 404)
     {
+        if (is_array($message) && isset($message['message'])) {
+            $this->_messageTemplate = $message['message'];
+        }
         parent::__construct($message, $code);
     }
 }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -237,9 +237,14 @@ class RouteCollection
             if (isset($this->_named[$name])) {
                 $route = $this->_named[$name];
                 $out = $route->match($url + $route->defaults, $context);
-            }
-            if ($out) {
-                return $out;
+                if ($out) {
+                    return $out;
+                }
+                throw new MissingRouteException([
+                    'url' => $name,
+                    'context' => $context,
+                    'message' => 'A named route was found for "%s", but matching failed.',
+                ]);
             }
             throw new MissingRouteException(['url' => $name, 'context' => $context]);
         }

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -30,7 +30,7 @@ $this->start('subheading');
 <?php $this->end() ?>
 
 <?php $this->start('file') ?>
-<p>None of the currently connected routes match the given URL or parameters.
+<p>None of the currently connected routes match the provided parameters.
 Add a matching route to <?= 'config' . DIRECTORY_SEPARATOR . 'routes.php' ?></p>
 
 <?php if (!empty($attributes['context'])): ?>

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -167,8 +167,7 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b');
         $routes->connect('/', ['controller' => 'Articles']);
 
-        $result = $this->collection->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'add'], $context);
-        $this->assertFalse($result, 'No matches');
+        $this->collection->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'add'], $context);
     }
 
     /**
@@ -221,12 +220,31 @@ class RouteCollectionTest extends TestCase
     }
 
     /**
+     * Test match() throws an error on named routes that fail to match
+     *
+     * @expectedException \Cake\Routing\Exception\MissingRouteException
+     * @expectedExceptionMessage A named route was found for "fail", but matching failed
+     */
+    public function testMatchNamedError()
+    {
+        $context = [
+            '_base' => '/',
+            '_scheme' => 'http',
+            '_host' => 'example.org',
+        ];
+        $routes = new RouteBuilder($this->collection, '/b');
+        $routes->connect('/:lang/articles', ['controller' => 'Articles'], ['_name' => 'fail']);
+
+        $this->collection->match(['_name' => 'fail'], $context);
+    }
+
+    /**
      * Test matching routes with names and failing
      *
      * @expectedException \Cake\Routing\Exception\MissingRouteException
      * @return void
      */
-    public function testMatchNamedError()
+    public function testMatchNamedMissingError()
     {
         $context = [
             '_base' => '/',


### PR DESCRIPTION
This adds specific error messages when known named routes fail to match correctly. This should help make diagnosing routing errors easier.

Refs #8798
