### PR TITLE
Reset ValueBinder in SubQuery

### DIFF
--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -16,6 +16,7 @@ namespace Cake\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\ValueBinder;
 use InvalidArgumentException;
 
 /**
@@ -222,7 +223,7 @@ trait SelectableAssociationTrait
         $filterQuery->mapReduce(null, null, true);
         $filterQuery->formatResults(null, true);
         $filterQuery->contain([], true);
-        $filterQuery->valueBinder()->resetCount();
+        $filterQuery->valueBinder(new ValueBinder());
 
         if (!$filterQuery->clause('limit')) {
             $filterQuery->limit(null);

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -222,6 +222,7 @@ trait SelectableAssociationTrait
         $filterQuery->mapReduce(null, null, true);
         $filterQuery->formatResults(null, true);
         $filterQuery->contain([], true);
+        $filterQuery->valueBinder()->resetCount();
 
         if (!$filterQuery->clause('limit')) {
             $filterQuery->limit(null);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -553,8 +553,7 @@ class HasManyTest extends TestCase
             ->select([
                 'id',
                 'slug' => $query->func()->concat([
-                    'id' => 'identifier',
-                    '-',
+                    '---',
                     'name' => 'identifier'
                 ])
             ])


### PR DESCRIPTION
This PR fixes issue #8796.

It reset the ValueBinder in the subquery ($filterQuery) hereby ignoring the possible removed placeholders from the select part of the statement.
