### PR TITLE
Fixing problem with escaping when ['error' => ['escape' => false]]

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1021,7 +1021,11 @@ class FormHelper extends Helper
         $error = null;
         $errorSuffix = '';
         if ($options['type'] !== 'hidden' && $options['error'] !== false) {
-            $error = $this->error($fieldName, $options['error']);
+            if (is_array($options['error'])) {
+                $error = $this->error($fieldName, null, $options['error']);
+            } else {
+                $error = $this->error($fieldName, $options['error']);
+            }
             $errorSuffix = empty($error) ? '' : 'Error';
             unset($options['error']);
         }


### PR DESCRIPTION
Encountered this issue trying to:

``` php
$this->Form->input('password', ['label' => 'Password (if updating)', 'value' => '', 'error' => ['escape' => false]])
```

My error message has HTML within it.

I also think another option could be added to input for errors

``` php
 [
    'error' => [
        'escape' => false,
        'text' => 'Some Text'
    ]
]
```

Then the code could be:

``` php
if ($options['type'] !== 'hidden' && $options['error'] !== false) {
    if (is_array($options['error'])) {
        $errorText = null;
        if (isset($options['error']['text'])) {
            $errorText = $options['error']['text'];
            unset($options['error']['text']);
        }
        $error = $this->error($fieldName, $errorText, $options['error']);
    } else {
        $error = $this->error($fieldName, $options['error']);
    }
    $errorSuffix = empty($error) ? '' : 'Error';
    unset($options['error']);
}
```

That would allow text to be passed along with the error option not to escape.

But the PR as is does fix the escaping issue.
