### PR TITLE
Fix err() to highlight error as red similar to warn() which is yellow.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -640,11 +640,11 @@ class Shell
      *
      * @param string|array|null $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
-     * @return void
+     * @return int|bool Returns the number of bytes returned from writing to stderr.
      */
     public function err($message = null, $newlines = 1)
     {
-        $this->_io->err($message, $newlines);
+        return $this->_io->err('<error>' . $message . '</error>', $newlines);
     }
 
     /**

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -671,7 +671,7 @@ class Shell
      */
     public function warn($message = null, $newlines = 1)
     {
-        return $this->err('<warning>' . $message . '</warning>', $newlines);
+        return $this->_io->err('<warning>' . $message . '</warning>', $newlines);
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -307,7 +307,7 @@ class ShellTest extends TestCase
     {
         $this->io->expects($this->once())
             ->method('err')
-            ->with('Just a test', 1);
+            ->with('<error>Just a test</error>', 1);
 
         $this->Shell->err('Just a test');
     }
@@ -334,7 +334,7 @@ class ShellTest extends TestCase
     public function testWarn()
     {
         $this->io->expects($this->once())
-            ->method('err')
+            ->method('warn')
             ->with('<warning>Just a test</warning>', 1);
 
         $this->Shell->warn('Just a test');

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -334,7 +334,7 @@ class ShellTest extends TestCase
     public function testWarn()
     {
         $this->io->expects($this->once())
-            ->method('warn')
+            ->method('err')
             ->with('<warning>Just a test</warning>', 1);
 
         $this->Shell->warn('Just a test');


### PR DESCRIPTION
Consistency to
- warn(): yellow
- success(): green

Now:
- err(): red (instead of looking like out())

Also returning the byte count as the others do.
