### PR TITLE
Make Query::insert() behave when called multiple times.

### DIFF
--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -151,7 +151,13 @@ class ValuesExpression implements ExpressionInterface
         }
 
         $i = 0;
-        $defaults = array_fill_keys($this->_columns, null);
+        $columns = [];
+
+        // Remove identifier quoting so column names match keys.
+        foreach ($this->_columns as $col) {
+            $columns[] = trim($col, '`[]"');
+        }
+        $defaults = array_fill_keys($columns, null);
         $placeholders = [];
 
         foreach ($this->_values as $row) {
@@ -173,7 +179,6 @@ class ValuesExpression implements ExpressionInterface
         if ($this->query()) {
             return ' ' . $this->query()->sql($generator);
         }
-
         return sprintf(' VALUES (%s)', implode('), (', $placeholders));
     }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1320,10 +1320,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         $this->_dirty();
         $this->_type = 'insert';
         $this->_parts['insert'][1] = $columns;
-
-        if (!$this->_parts['values']) {
-            $this->_parts['values'] = new ValuesExpression($columns, $this->typeMap()->types($types));
-        }
+        $this->_parts['values'] = new ValuesExpression($columns, $this->typeMap()->types($types));
 
         return $this;
     }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1320,8 +1320,11 @@ class Query implements ExpressionInterface, IteratorAggregate
         $this->_dirty();
         $this->_type = 'insert';
         $this->_parts['insert'][1] = $columns;
-        $this->_parts['values'] = new ValuesExpression($columns, $this->typeMap()->types($types));
-
+        if (!$this->_parts['values']) {
+            $this->_parts['values'] = new ValuesExpression($columns, $this->typeMap()->types($types));
+        } else {
+            $this->_parts['values']->columns($columns);
+        }
         return $this;
     }
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2720,6 +2720,31 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test insert overwrites values
+     *
+     * @return void
+     */
+    public function testInsertOverwritesValues()
+    {
+        $this->loadFixtures('Articles');
+        $query = new Query($this->connection);
+        $query->insert(['title', 'body'])
+            ->insert(['title'])
+            ->into('articles')
+            ->values([
+                'title' => 'mark',
+            ]);
+
+        $result = $query->sql();
+        $this->assertQuotedQuery(
+            'INSERT INTO <articles> \(<title>\) (OUTPUT INSERTED\.\* )?' .
+            'VALUES \(:c0\)',
+            $result,
+            !$this->autoQuote
+        );
+    }
+
+    /**
      * Test inserting a single row.
      *
      * @return void


### PR DESCRIPTION
When `insert()` is invoked multiple times, it should reset the `ValueExpression`. Not doing so causes an incorrect query to be generated.

Refs #8815
