### PR TITLE
PSR7 Http\Client response

### DIFF
--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -128,32 +128,11 @@ class Message
     const METHOD_HEAD = 'HEAD';
 
     /**
-     * The array of headers in the response.
-     *
-     * @var array
-     */
-    protected $_headers = [];
-
-    /**
      * The array of cookies in the response.
      *
      * @var array
      */
     protected $_cookies = [];
-
-    /**
-     * Normalize header names to Camel-Case form.
-     *
-     * @param string $name The header name to normalize.
-     * @return string Normalized header name.
-     */
-    protected function _normalizeHeader($name)
-    {
-        $parts = explode('-', trim($name));
-        $parts = array_map('strtolower', $parts);
-        $parts = array_map('ucfirst', $parts);
-        return implode('-', $parts);
-    }
 
     /**
      * Get all headers
@@ -163,7 +142,7 @@ class Message
      */
     public function headers()
     {
-        return $this->_headers;
+        return $this->headers;
     }
 
     /**
@@ -174,17 +153,6 @@ class Message
     public function cookies()
     {
         return $this->_cookies;
-    }
-
-    /**
-     * Get the HTTP version used.
-     *
-     * @return string
-     * @deprecated 3.3.0 Use getProtocolVersion()
-     */
-    public function version()
-    {
-        return $this->protocol;
     }
 
     /**

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -383,11 +383,16 @@ class Response extends Message implements ResponseInterface
     /**
      * Read single/multiple cookie values out.
      *
+     * *Note* This method will only provide access to cookies that
+     * were added as part of the constructor. If cookies are added post
+     * construction they will not be accessible via this method.
+     *
      * @param string|null $name The name of the cookie you want. Leave
      *   null to get all cookies.
      * @param bool $all Get all parts of the cookie. When false only
      *   the value will be returned.
      * @return mixed
+     * @deprecated 3.3.0 Use getCookie(), getCookieData() or getCookies() instead.
      */
     public function cookie($name = null, $all = false)
     {
@@ -401,6 +406,44 @@ class Response extends Message implements ResponseInterface
             return $this->_cookies[$name];
         }
         return $this->_cookies[$name]['value'];
+    }
+
+    /**
+     * Get the all cookie data.
+     *
+     * @return array The cookie data
+     */
+    public function getCookies()
+    {
+        return $this->_cookies;
+    }
+
+    /**
+     * Get the value of a single cookie.
+     *
+     * @param string $name The name of the cookie value.
+     * @return string|null Either the cookie's value or null when the cookie is undefined.
+     */
+    public function getCookie($name)
+    {
+        if (!isset($this->_cookies[$name])) {
+            return null;
+        }
+        return $this->_cookies[$name]['value'];
+    }
+
+    /**
+     * Get the full data for a single cookie.
+     *
+     * @param string $name The name of the cookie value.
+     * @return array|null Either the cookie's data or null when the cookie is undefined.
+     */
+    public function getCookieData($name)
+    {
+        if (!isset($this->_cookies[$name])) {
+            return null;
+        }
+        return $this->_cookies[$name];
     }
 
     /**

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -304,6 +304,8 @@ class Response extends Message implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int The status code.
      */
     public function getStatusCode()
     {
@@ -312,6 +314,10 @@ class Response extends Message implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param int $code The status code to set.
+     * @param string $reasonPhrase The status reason phrase.
+     * @return self A copy of the current object with an updated status code.
      */
     public function withStatus($code, $reasonPhrase = '')
     {
@@ -323,6 +329,8 @@ class Response extends Message implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string The current reason phrase.
      */
     public function getReasonPhrase()
     {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -332,8 +332,19 @@ class Response extends Message implements ResponseInterface
      * Get the encoding if it was set.
      *
      * @return string|null
+     * @deprecated 3.3.0 Use getEncoding() instead.
      */
     public function encoding()
+    {
+        return $this->getEncoding();
+    }
+
+    /**
+     * Get the encoding if it was set.
+     *
+     * @return string|null
+     */
+    public function getEncoding()
     {
         $content = $this->getHeaderLine('content-type');
         if (!$content) {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -397,15 +397,12 @@ class Response extends Message implements ResponseInterface
     public function cookie($name = null, $all = false)
     {
         if ($name === null) {
-            return $this->_cookies;
-        }
-        if (!isset($this->_cookies[$name])) {
-            return null;
+            return $this->getCookies();
         }
         if ($all) {
-            return $this->_cookies[$name];
+            return $this->getCookieData($name);
         }
-        return $this->_cookies[$name]['value'];
+        return $this->getCookie($name);
     }
 
     /**

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -30,14 +30,14 @@ use Zend\Diactoros\Stream;
  * when the response is parsed.
  *
  * ```
- * $val = $response->header('content-type');
+ * $val = $response->getHeaderLine('content-type');
  * ```
  *
  * Will read the Content-Type header. You can get all set
  * headers using:
  *
  * ```
- * $response->header();
+ * $response->getHeaders();
  * ```
  *
  * You can also get at the headers using object access. When getting
@@ -50,13 +50,14 @@ use Zend\Diactoros\Stream;
  *
  * ### Get the response body
  *
- * You can access the response body using:
+ * You can access the response body stream using:
  *
  * ```
- * $content = $response->body();
+ * $content = $response->getBody();
  * ```
  *
- * You can also use object access:
+ * You can also use object access to get the string version
+ * of the response body:
  *
  * ```
  * $content = $response->body;
@@ -81,7 +82,7 @@ use Zend\Diactoros\Stream;
  * You can access the response status code using:
  *
  * ```
- * $content = $response->statusCode();
+ * $content = $response->getStatusCode();
  * ```
  *
  * You can also use object access:

--- a/tests/TestCase/Network/Http/ResponseTest.php
+++ b/tests/TestCase/Network/Http/ResponseTest.php
@@ -147,6 +147,16 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Test accessor for json
+     *
+     * @return void
+     */
+    public function testBodyJsonPsr7()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * Test accessor for xml
      *
      * @return void
@@ -279,6 +289,16 @@ XML;
     }
 
     /**
+     * Test accessing cookies set through the PSR7 interface.
+     *
+     * @return void
+     */
+    public function testCookiesPsr7()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * Test statusCode()
      *
      * @return void
@@ -291,6 +311,7 @@ XML;
         ];
         $response = new Response($headers, '');
         $this->assertEquals(404, $response->statusCode());
+        $this->assertEquals(404, $response->getStatusCode());
 
         $this->assertEquals(404, $response->code);
         $this->assertTrue(isset($response->code));
@@ -314,6 +335,7 @@ XML;
             'Content-Type: text/html'
         ];
         $response = new Response($headers, '');
+        $this->assertNull($response->getEncoding());
         $this->assertNull($response->encoding());
 
         $headers = [
@@ -321,6 +343,7 @@ XML;
             'Content-Type: text/html; charset="UTF-8"'
         ];
         $response = new Response($headers, '');
+        $this->assertEquals('UTF-8', $response->getEncoding());
         $this->assertEquals('UTF-8', $response->encoding());
 
         $headers = [
@@ -328,6 +351,7 @@ XML;
             "Content-Type: text/html; charset='ISO-8859-1'"
         ];
         $response = new Response($headers, '');
+        $this->assertEquals('ISO-8859-1', $response->getEncoding());
         $this->assertEquals('ISO-8859-1', $response->encoding());
     }
 

--- a/tests/TestCase/Network/Http/ResponseTest.php
+++ b/tests/TestCase/Network/Http/ResponseTest.php
@@ -21,6 +21,33 @@ use Cake\TestSuite\TestCase;
  */
 class ResponseTest extends TestCase
 {
+    /**
+     * Test parsing headers and reading with PSR7 methods.
+     *
+     * @return void
+     */
+    public function testHeaderParsingPsr7()
+    {
+        $headers = [
+            'HTTP/1.0 200 OK',
+            'Content-Type : text/html;charset="UTF-8"',
+            'date: Tue, 25 Dec 2012 04:43:47 GMT',
+        ];
+        $response = new Response($headers, 'winner!');
+
+        $this->assertEquals('1.0', $response->getProtocolVersion());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('OK', $response->getReasonPhrase());
+        $this->assertEquals(
+            'text/html;charset="UTF-8"',
+            $response->getHeaderLine('content-type')
+        );
+        $this->assertEquals(
+            'Tue, 25 Dec 2012 04:43:47 GMT',
+            $response->getHeaderLine('Date')
+        );
+        $this->assertEquals('winner!', '' . $response->getBody());
+    }
 
     /**
      * Test parsing headers and capturing content
@@ -36,8 +63,8 @@ class ResponseTest extends TestCase
         ];
         $response = new Response($headers, 'ok');
 
-        $this->assertEquals('1.0', $response->version());
         $this->assertEquals(200, $response->statusCode());
+        $this->assertEquals('1.0', $response->version());
         $this->assertEquals(
             'text/html;charset="UTF-8"',
             $response->header('content-type')

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -129,11 +129,10 @@ class QueryRegressionTest extends TestCase
             ->order(['Articles.id' => 'ASC'])
             ->toArray();
 
-        $this->assertCount(3, $results);
+        $this->assertCount(5, $results);
         $this->assertEquals(1, $results[0]->articles_tag->foo->id);
         $this->assertEquals(1, $results[0]->author->favorite_tag->id);
         $this->assertEquals(2, $results[1]->articles_tag->foo->id);
-        $this->assertEquals(1, $results[0]->author->favorite_tag->id);
         $this->assertEquals(1, $results[2]->articles_tag->foo->id);
         $this->assertEquals(3, $results[2]->author->favorite_tag->id);
         $this->assertEquals(3, $results[3]->articles_tag->foo->id);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -129,6 +129,7 @@ class QueryRegressionTest extends TestCase
             ->order(['Articles.id' => 'ASC'])
             ->toArray();
 
+        $this->assertCount(3, $results);
         $this->assertEquals(1, $results[0]->articles_tag->foo->id);
         $this->assertEquals(1, $results[0]->author->favorite_tag->id);
         $this->assertEquals(2, $results[1]->articles_tag->foo->id);


### PR DESCRIPTION
Make the `Http\Client\Response` PSR7 compatible. This adds several new methods to complete the interface implementation, and add new accessor methods that share naming conventions with the PSR7 interface.

I'll be updating all the client internals to only use the PSR7 methods in a future pull request.

Refs #6960 
