### PR TITLE
Processes error options in FormHelper input function

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1021,7 +1021,12 @@ class FormHelper extends Helper
         $error = null;
         $errorSuffix = '';
         if ($options['type'] !== 'hidden' && $options['error'] !== false) {
-            $error = $this->error($fieldName, $options['error']);
+            if (is_array($options['error'])) {
+                $error = $this->error($fieldName, $options['error'], $options['error']);
+            }
+            else {
+                $error = $this->error($fieldName, $options['error']);
+            }
             $errorSuffix = empty($error) ? '' : 'Error';
             unset($options['error']);
         }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1023,8 +1023,7 @@ class FormHelper extends Helper
         if ($options['type'] !== 'hidden' && $options['error'] !== false) {
             if (is_array($options['error'])) {
                 $error = $this->error($fieldName, $options['error'], $options['error']);
-            }
-            else {
+            } else {
                 $error = $this->error($fieldName, $options['error']);
             }
             $errorSuffix = empty($error) ? '' : 'Error';

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -718,7 +718,7 @@ class HashTest extends TestCase
     {
         $result = Hash::merge(
             ['hkuc' => ['lion']],
-            ['hkuc' =>'lion']
+            ['hkuc' => 'lion']
         );
         $expected = ['hkuc' => 'lion'];
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2355,7 +2355,10 @@ class FormHelperTest extends TestCase
     public function testErrorMessageDisplay()
     {
         $this->article['errors'] = [
-            'Article' => ['title' => 'error message']
+            'Article' => [
+                'title' => 'error message',
+                'content' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars'
+            ]
         ];
         $this->Form->create($this->article);
 
@@ -2391,6 +2394,58 @@ class FormHelperTest extends TestCase
                 'type' => 'text', 'name' => 'Article[title]',
                 'id' => 'article-title', 'class' => 'form-error'
             ],
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+
+
+        $result = $this->Form->input('Article.content');
+        $expected = [
+            'div' => ['class' => 'input text error'],
+            'label' => ['for' => 'article-content'],
+            'Content',
+            '/label',
+            'input' => [
+                'type' => 'text', 'name' => 'Article[content]',
+                'id' => 'article-content', 'class' => 'form-error'
+            ],
+            ['div' => ['class' => 'error-message']],
+            'some &lt;strong&gt;test&lt;/strong&gt; data with &lt;a href=&quot;#&quot;&gt;HTML&lt;/a&gt; chars',
+            '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->input('Article.content',['error' => ['escape' => true]]);
+        $expected = [
+            'div' => ['class' => 'input text error'],
+            'label' => ['for' => 'article-content'],
+            'Content',
+            '/label',
+            'input' => [
+                'type' => 'text', 'name' => 'Article[content]',
+                'id' => 'article-content', 'class' => 'form-error'
+            ],
+            ['div' => ['class' => 'error-message']],
+            'some &lt;strong&gt;test&lt;/strong&gt; data with &lt;a href=&quot;#&quot;&gt;HTML&lt;/a&gt; chars',
+            '/div',
+            '/div'
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->input('Article.content',['error' => ['escape' => false]]);
+        $expected = [
+            'div' => ['class' => 'input text error'],
+            'label' => ['for' => 'article-content'],
+            'Content',
+            '/label',
+            'input' => [
+                'type' => 'text', 'name' => 'Article[content]',
+                'id' => 'article-content', 'class' => 'form-error'
+            ],
+            ['div' => ['class' => 'error-message']],
+            'some <strong>test</strong> data with <a href="#">HTML</a> chars',
+            '/div',
             '/div'
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2416,7 +2416,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Article.content',['error' => ['escape' => true]]);
+        $result = $this->Form->input('Article.content', ['error' => ['escape' => true]]);
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-content'],
@@ -2433,7 +2433,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Article.content',['error' => ['escape' => false]]);
+        $result = $this->Form->input('Article.content', ['error' => ['escape' => false]]);
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-content'],


### PR DESCRIPTION
When input function is called with error message options, they are passed to the error function in both parameters, text and options.

I think error message in the input function should be passed in a different parameter, like this:

```
'error' => [
     'message' => 'Custom error message or even an array of them',
     'options' => [
          'escape' => false
          'any_other_option' => 'whatever'
     ]
]

```

...but if I make the change that way, it will break backwards compatibility.

fixes #8821, fixes #8809
