### PR TITLE
Make Http\Client use PSR7 internally

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -421,10 +421,7 @@ class Client
      */
     protected function _createRequest($method, $url, $data, $options)
     {
-        $request = new Request();
-        $request = $request->withMethod($method)
-            ->url($url)
-            ->body($data);
+        $request = new Request($url, $method, $data);
 
         if (isset($options['type'])) {
             $request->header($this->_typeHeaders($options['type']));

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -421,17 +421,15 @@ class Client
      */
     protected function _createRequest($method, $url, $data, $options)
     {
-        $request = new Request($url, $method, $data);
-
+        $headers = isset($options['headers']) ? (array)$options['headers'] : [];
         if (isset($options['type'])) {
-            $request->header($this->_typeHeaders($options['type']));
+            $headers = array_merge($headers, $this->_typeHeaders($options['type']));
         }
-        if (isset($options['headers'])) {
-            $request->header($options['headers']);
+        if (is_string($data) && !isset($headers['Content-Type']) && !isset($headers['content-type'])) {
+            $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
-        if (is_string($data) && !$request->header('content-type')) {
-            $request->header('Content-Type', 'application/x-www-form-urlencoded');
-        }
+
+        $request = new Request($url, $method, $headers, $data);
         $request->cookie($this->_cookies->get($url));
         if (isset($options['cookies'])) {
             $request->cookie($options['cookies']);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -435,10 +435,10 @@ class Client
             $request->cookie($options['cookies']);
         }
         if (isset($options['auth'])) {
-            $this->_addAuthentication($request, $options);
+            $request = $this->_addAuthentication($request, $options);
         }
         if (isset($options['proxy'])) {
-            $this->_addProxy($request, $options);
+            $request = $this->_addProxy($request, $options);
         }
         return $request;
     }
@@ -480,13 +480,14 @@ class Client
      *
      * @param \Cake\Http\Client\Request $request The request to modify.
      * @param array $options Array of options containing the 'auth' key.
-     * @return void
+     * @return \Cake\Http\Client\Request The updated request object.
      */
     protected function _addAuthentication(Request $request, $options)
     {
         $auth = $options['auth'];
         $adapter = $this->_createAuth($auth, $options);
-        $adapter->authentication($request, $options['auth']);
+        $result = $adapter->authentication($request, $options['auth']);
+        return $result ?: $request;
     }
 
     /**
@@ -497,13 +498,14 @@ class Client
      *
      * @param \Cake\Http\Client\Request $request The request to modify.
      * @param array $options Array of options containing the 'proxy' key.
-     * @return void
+     * @return \Cake\Http\Client\Request The updated request object.
      */
     protected function _addProxy(Request $request, $options)
     {
         $auth = $options['proxy'];
         $adapter = $this->_createAuth($auth, $options);
-        $adapter->proxyAuthentication($request, $options['proxy']);
+        $result = $adapter->proxyAuthentication($request, $options['proxy']);
+        return $result ?: $request;
     }
 
     /**

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -29,15 +29,16 @@ class Basic
      *
      * @param \Cake\Network\Http\Request $request Request instance.
      * @param array $credentials Credentials.
-     * @return void
+     * @return \Cake\Network\Http\Request The updated request.
      * @see http://www.ietf.org/rfc/rfc2617.txt
      */
     public function authentication(Request $request, array $credentials)
     {
         if (isset($credentials['username'], $credentials['password'])) {
             $value = $this->_generateHeader($credentials['username'], $credentials['password']);
-            $request->header('Authorization', $value);
+            $request = $request->withHeader('Authorization', $value);
         }
+        return $request;
     }
 
     /**
@@ -45,15 +46,16 @@ class Basic
      *
      * @param \Cake\Network\Http\Request $request Request instance.
      * @param array $credentials Credentials.
-     * @return void
+     * @return \Cake\Network\Http\Request The updated request.
      * @see http://www.ietf.org/rfc/rfc2617.txt
      */
     public function proxyAuthentication(Request $request, array $credentials)
     {
         if (isset($credentials['username'], $credentials['password'])) {
             $value = $this->_generateHeader($credentials['username'], $credentials['password']);
-            $request->header('Proxy-Authorization', $value);
+            $request = $request->withHeader('Proxy-Authorization', $value);
         }
+        return $request;
     }
 
     /**

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -48,22 +48,22 @@ class Digest
      *
      * @param \Cake\Network\Http\Request $request The request object.
      * @param array $credentials Authentication credentials.
-     * @return void
+     * @return \Cake\Network\Http\Request The updated request.
      * @see http://www.ietf.org/rfc/rfc2617.txt
      */
     public function authentication(Request $request, array $credentials)
     {
         if (!isset($credentials['username'], $credentials['password'])) {
-            return;
+            return $request;
         }
         if (!isset($credentials['realm'])) {
             $credentials = $this->_getServerInfo($request, $credentials);
         }
         if (!isset($credentials['realm'])) {
-            return;
+            return $request;
         }
         $value = $this->_generateHeader($request, $credentials);
-        $request->header('Authorization', $value);
+        return $request->withHeader('Authorization', $value);
     }
 
     /**

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -85,12 +85,12 @@ class Digest
             ['auth' => []]
         );
 
-        if (!$response->header('WWW-Authenticate')) {
+        if (!$response->getHeader('WWW-Authenticate')) {
             return [];
         }
         preg_match_all(
             '@(\w+)=(?:(?:")([^"]+)"|([^\s,$]+))@',
-            $response->header('WWW-Authenticate'),
+            $response->getHeaderLine('WWW-Authenticate'),
             $matches,
             PREG_SET_ORDER
         );
@@ -112,7 +112,7 @@ class Digest
      */
     protected function _generateHeader(Request $request, $credentials)
     {
-        $path = parse_url($request->url(), PHP_URL_PATH);
+        $path = $request->getUri()->getPath();
         $a1 = md5($credentials['username'] . ':' . $credentials['realm'] . ':' . $credentials['password']);
         $a2 = md5($request->method() . ':' . $path);
 

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -163,7 +163,7 @@ class Oauth
      *
      * Section 9.1.2. of the Oauth spec
      *
-     * @param Psr\Http\Message\UriInterface $url URL
+     * @param Psr\Http\Message\UriInterface $uri Uri object to build a normalized version of.
      * @return string Normalized URL
      */
     protected function _normalizedUrl($uri)

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -150,8 +150,8 @@ class Oauth
     public function baseString($request, $oauthValues)
     {
         $parts = [
-            $request->method(),
-            $this->_normalizedUrl($request->url()),
+            $request->getMethod(),
+            $this->_normalizedUrl($request->getUri()),
             $this->_normalizedParams($request, $oauthValues),
         ];
         $parts = array_map([$this, '_encode'], $parts);
@@ -163,27 +163,23 @@ class Oauth
      *
      * Section 9.1.2. of the Oauth spec
      *
-     * @param string $url URL
+     * @param Psr\Http\Message\UriInterface $url URL
      * @return string Normalized URL
-     * @throws \Cake\Core\Exception\Exception On invalid URLs
      */
-    protected function _normalizedUrl($url)
+    protected function _normalizedUrl($uri)
     {
-        $parts = parse_url($url);
-        if (!$parts) {
-            throw new Exception('Unable to parse URL');
-        }
-        $scheme = strtolower($parts['scheme'] ?: 'http');
+        $scheme = $uri->getScheme();
         $defaultPorts = [
             'http' => 80,
             'https' => 443
         ];
-        if (isset($parts['port']) && $parts['port'] != $defaultPorts[$scheme]) {
-            $parts['host'] .= ':' . $parts['port'];
+        $port = $uri->getPort();
+        if ($port && $port != $defaultPorts[$scheme]) {
+            $parts['host'] .= ':' . $port;
         }
         $out = $scheme . '://';
-        $out .= strtolower($parts['host']);
-        $out .= $parts['path'];
+        $out .= strtolower($uri->getHost());
+        $out .= $uri->getPath();
         return $out;
     }
 

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -34,7 +34,7 @@ class Oauth
      *
      * @param \Cake\Network\Http\Request $request The request object.
      * @param array $credentials Authentication credentials.
-     * @return void
+     * @return \Cake\Network\Http\Request The updated request.
      * @throws \Cake\Core\Exception\Exception On invalid signature types.
      */
     public function authentication(Request $request, array $credentials)
@@ -46,7 +46,7 @@ class Oauth
             $credentials['tokenSecret']
         );
         if (!$hasKeys) {
-            return;
+            return $request;
         }
         if (empty($credentials['method'])) {
             $credentials['method'] = 'hmac-sha1';
@@ -64,7 +64,7 @@ class Oauth
             default:
                 throw new Exception(sprintf('Unknown Oauth signature method %s', $credentials['method']));
         }
-        $request->header('Authorization', $value);
+        return $request->withHeader('Authorization', $value);
     }
 
     /**

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -38,7 +38,7 @@ class Request extends Message implements RequestInterface
      * @param string $url The request URL
      * @param string $method The HTTP method to use.
      * @param array $headers The HTTP headers to set.
-     * @param array|string $body The request body to use.
+     * @param array|string $data The request body to use.
      */
     public function __construct($url = '', $method = self::METHOD_GET, array $headers = [], $data = null)
     {

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -34,11 +34,17 @@ class Request extends Message implements RequestInterface
      * Constructor
      *
      * Provides backwards compatible defaults for some properties.
+     *
+     * @param string $url The request URL
+     * @param string $method The HTTP method to use.
+     * @param array|string $body The request body to use.
      */
-    public function __construct()
+    public function __construct($url = '', $method = self::METHOD_GET, $data = null)
     {
-        $this->method = static::METHOD_GET;
-
+        $this->validateMethod($method);
+        $this->method = $method;
+        $this->uri = $this->createUri($url);
+        $this->body($data);
         $this->header([
             'Connection' => 'close',
             'User-Agent' => 'CakePHP'

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -37,18 +37,20 @@ class Request extends Message implements RequestInterface
      *
      * @param string $url The request URL
      * @param string $method The HTTP method to use.
+     * @param array $headers The HTTP headers to set.
      * @param array|string $body The request body to use.
      */
-    public function __construct($url = '', $method = self::METHOD_GET, $data = null)
+    public function __construct($url = '', $method = self::METHOD_GET, array $headers = [], $data = null)
     {
         $this->validateMethod($method);
         $this->method = $method;
         $this->uri = $this->createUri($url);
         $this->body($data);
-        $this->header([
+        $headers += [
             'Connection' => 'close',
             'User-Agent' => 'CakePHP'
-        ]);
+        ];
+        $this->addHeaders($headers);
     }
 
     /**
@@ -139,12 +141,23 @@ class Request extends Message implements RequestInterface
         if ($value !== null && !is_array($name)) {
             $name = [$name => $value];
         }
-        foreach ($name as $key => $val) {
+        $this->addHeaders($name);
+        return $this;
+    }
+
+    /**
+     * Add an array of headers to the request.
+     *
+     * @param array $headers The headers to add.
+     * @return void
+     */
+    protected function addHeaders($headers)
+    {
+        foreach ($headers as $key => $val) {
             $normalized = strtolower($key);
             $this->headers[$key] = (array)$val;
             $this->headerNames[$normalized] = $key;
         }
-        return $this;
     }
 
     /**

--- a/tests/TestCase/Network/Http/Auth/DigestTest.php
+++ b/tests/TestCase/Network/Http/Auth/DigestTest.php
@@ -57,12 +57,10 @@ class DigestTest extends TestCase
             ->will($this->returnValue($response));
 
         $auth = ['username' => 'admin', 'password' => '1234'];
-        $request = (new Request())->method(Request::METHOD_GET)
-            ->url('http://example.com/some/path');
+        $request = new Request('http://example.com/some/path', Request::METHOD_GET);
+        $request = $this->auth->authentication($request, $auth);
 
-        $this->auth->authentication($request, $auth);
-
-        $result = $request->header('Authorization');
+        $result = $request->getHeaderLine('Authorization');
         $this->assertContains('Digest', $result);
         $this->assertContains('realm="The batcave"', $result);
         $this->assertContains('nonce="4cded326c6c51"', $result);
@@ -89,11 +87,9 @@ class DigestTest extends TestCase
             ->will($this->returnValue($response));
 
         $auth = ['username' => 'admin', 'password' => '1234'];
-        $request = (new Request())->method(Request::METHOD_GET)
-            ->url('http://example.com/some/path');
-
-        $this->auth->authentication($request, $auth);
-        $result = $request->header('Authorization');
+        $request = new Request('http://example.com/some/path', Request::METHOD_GET);
+        $request = $this->auth->authentication($request, $auth);
+        $result = $request->getHeaderLine('Authorization');
 
         $this->assertContains('qop="auth"', $result);
         $this->assertContains('nc=00000001', $result);
@@ -117,11 +113,9 @@ class DigestTest extends TestCase
             ->will($this->returnValue($response));
 
         $auth = ['username' => 'admin', 'password' => '1234'];
-        $request = (new Request())->method(Request::METHOD_GET)
-            ->url('http://example.com/some/path');
-
-        $this->auth->authentication($request, $auth);
-        $result = $request->header('Authorization');
+        $request = new Request('http://example.com/some/path', Request::METHOD_GET);
+        $request = $this->auth->authentication($request, $auth);
+        $result = $request->getHeaderLine('Authorization');
 
         $this->assertContains('opaque="d8ea7aa61a1693024c4cc3a516f49b3c"', $result);
     }

--- a/tests/TestCase/Network/Http/Auth/OauthTest.php
+++ b/tests/TestCase/Network/Http/Auth/OauthTest.php
@@ -56,9 +56,9 @@ class OauthTest extends TestCase
             'method' => 'plaintext',
         ];
         $request = new Request();
-        $auth->authentication($request, $creds);
+        $request = $auth->authentication($request, $creds);
 
-        $result = $request->header('Authorization');
+        $result = $request->getHeaderLine('Authorization');
         $this->assertContains('OAuth', $result);
         $this->assertContains('oauth_version="1.0"', $result);
         $this->assertContains('oauth_token="a%20token%20value"', $result);
@@ -204,9 +204,9 @@ class OauthTest extends TestCase
             'timestamp' => '1191242096'
         ];
         $auth = new Oauth();
-        $auth->authentication($request, $options);
+        $request = $auth->authentication($request, $options);
 
-        $result = $request->header('Authorization');
+        $result = $request->getHeaderLine('Authorization');
         $expected = 'tR3+Ty81lMeYAr/Fid0kMTYa/WM=';
         $this->assertContains(
             'oauth_signature="' . $expected . '"',

--- a/tests/test_app/TestApp/Http/CompatAuth.php
+++ b/tests/test_app/TestApp/Http/CompatAuth.php
@@ -47,5 +47,4 @@ class CompatAuth
     {
         $request->header('Proxy-Authorization', 'Bearer abc123');
     }
-
 }

--- a/tests/test_app/TestApp/Http/CompatAuth.php
+++ b/tests/test_app/TestApp/Http/CompatAuth.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Http;
+
+use Cake\Network\Http\Request;
+
+/**
+ * Testing stub to ensure that auth providers
+ * that mutate requests in place continue to work.
+ *
+ * @deprecated 3.3.0 Remove this compatibility behavior in 4.0.0
+ */
+class CompatAuth
+{
+
+    /**
+     * Add Authorization header to the request via in-place mutation methods.
+     *
+     * @param \Cake\Network\Http\Request $request Request instance.
+     * @param array $credentials Credentials.
+     * @return \Cake\Network\Http\Request The updated request.
+     */
+    public function authentication(Request $request, array $credentials)
+    {
+        $request->header('Authorization', 'Bearer abc123');
+    }
+
+    /**
+     * Proxy Authentication added via in-place mutation methods.
+     *
+     * @param \Cake\Network\Http\Request $request Request instance.
+     * @param array $credentials Credentials.
+     * @return \Cake\Network\Http\Request The updated request.
+     */
+    public function proxyAuthentication(Request $request, array $credentials)
+    {
+        $request->header('Proxy-Authorization', 'Bearer abc123');
+    }
+
+}


### PR DESCRIPTION
This migrates all the internals of `Http\Client` to use the PSR7 interfaces, and also adds a more useful constructor to `Client\Response`.

This prepares Http\Client for when we remove the deprecated methods, which while far away is easy to do now.
### Backwards Compatibility Relevant Changes

Having the authentication providers return a request is one possible place where BC could have broken. I think the new test case and stub proves that backwards compatibility has been preserved, but if people think this is a risky change, I'm happy to revert those bits.

I have intentionally not changed any typehints as that frequently causes problems in userland code.

Refs #6960 
