### PR TITLE
Improve out of the box composer experience for 2.x

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -1,0 +1,35 @@
+{
+	"name": "cakephp/app",
+	"description": "CakePHP Application skeleton",
+	"type": "library",
+	"keywords": ["application", "cakephp"],
+	"homepage": "http://cakephp.org",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "CakePHP Community",
+			"homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/cakephp/cakephp/issues",
+		"forum": "http://stackoverflow.com/tags/cakephp",
+		"irc": "irc://irc.freenode.org/cakephp",
+		"source": "https://github.com/cakephp/cakephp"
+	},
+	"require": {
+		"php": ">=5.3.0",
+		"ext-mcrypt": "*"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "3.7.*",
+		"cakephp/cakephp": "~2.8",
+		"cakephp/cakephp-codesniffer": "^1.0.0"
+	},
+	"bin": [
+		"lib/Cake/Console/cake"
+	],
+	"config": {
+		"vendor-dir": "Vendor/"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,10 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*",
-		"cakephp/debug_kit" : "^2.2.0",
 		"cakephp/cakephp-codesniffer": "^1.0.0"
+	},
+	"config": {
+		"vendor-dir": "vendors/"
 	},
 	"bin": [
 		"lib/Cake/Console/cake"


### PR DESCRIPTION
- Fix the root `composer.json` file - This config change helps people get started with less friction. I've removed debugkit as a dependency, as it isn't _really_ a dependency for CakePHP itself, and has been included in `app/composer.json`.
- Add composer.json for the app/  - This will act as a stub for developers to extend and improve upon when they build their apps. Hopefully people don't find the two composer.json files overly confusing.

Refs #8765
