### PR TITLE
Add HTTP patch Content-Type check

### DIFF
--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -505,7 +505,12 @@ class RequestHandlerComponent extends Component {
  *   in the request content type will be returned.
  */
 	public function requestedWith($type = null) {
-		if (!$this->request->is('post') && !$this->request->is('put') && !$this->request->is('delete')) {
+		if (
+			!$this->request->is('patch') &&
+			!$this->request->is('post') &&
+			!$this->request->is('put') &&
+			!$this->request->is('delete')
+		) {
 			return null;
 		}
 		if (is_array($type)) {

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -97,6 +97,7 @@ class CakeRequest implements ArrayAccess {
  */
 	protected $_detectors = array(
 		'get' => array('env' => 'REQUEST_METHOD', 'value' => 'GET'),
+		'patch' => array('env' => 'REQUEST_METHOD', 'value' => 'PATCH'),
 		'post' => array('env' => 'REQUEST_METHOD', 'value' => 'POST'),
 		'put' => array('env' => 'REQUEST_METHOD', 'value' => 'PUT'),
 		'delete' => array('env' => 'REQUEST_METHOD', 'value' => 'DELETE'),

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -618,6 +618,9 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$_SERVER['REQUEST_METHOD'] = 'DELETE';
 		$this->assertEquals('json', $this->RequestHandler->requestedWith());
 
+		$_SERVER['REQUEST_METHOD'] = 'PATCH';
+		$this->assertEquals('json', $this->RequestHandler->requestedWith());
+
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		unset($_SERVER['CONTENT_TYPE']);
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';


### PR DESCRIPTION
This an updated version of the pull request created by techbrunch in #8836, and the same issue as reported by me #8843. 

However, the pull requests in #8836 is not sufficient, as it will still return `false` for `patch`. It still needed the change in the $_detectors in file lib/Cake/Network/CakeRequest.php. Although the workaround would be to add it by calling the CakeRequest::addDetector() the HTTP `patch` is too common to be added dynamically.
