### PR TITLE
Sqlite testcase enhancements

### DIFF
--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -168,7 +168,13 @@ class SqliteTest extends CakeTestCase {
 		$dbName = 'db' . rand() . '$(*%&).db';
 		$this->assertFalse(file_exists(TMP . $dbName));
 
-		$db = new Sqlite(array_merge($this->Dbo->config, array('database' => TMP . $dbName)));
+		try {
+			$db = new Sqlite(array_merge($this->Dbo->config, array('database' => TMP . $dbName)));
+		} catch (MissingConnectionException $e) {
+			// This might be caused by NTFS file systems, where '*' is a forbidden character. Repeat without this character.
+			$dbName = str_replace('*', '', $dbName);
+			$db = new Sqlite(array_merge($this->Dbo->config, array('database' => TMP . $dbName)));
+		}
 		$this->assertTrue(file_exists(TMP . $dbName));
 
 		$db->execute("CREATE TABLE test_list (id VARCHAR(255));");

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -472,6 +472,7 @@ class SqliteTest extends CakeTestCase {
  * @return void
  */
 	public function testNestedTransaction() {
+		$this->Dbo->useNestedTransactions = true;
 		$this->skipIf($this->Dbo->nestedTransactionSupported() === false, 'The Sqlite version do not support nested transaction');
 
 		$this->loadFixtures('User');


### PR DESCRIPTION
Fixes two little problems with the Sqlite testcases. 

First, it can happen that `testCacheKeyName` fails because Sqlite can't create the database file. This is caused by the `*` in the database filename, which is not valid in filenames on Windows / NTFS platforms. 
My fix detects this case, and falls back to a database name without `*`. 
As an alternative, you could simply remove `*` from the database filename, but this might weaken the testcase on other filesystems (that support `*` in filenames). 

Second, `testNestedTransaction` tries to test a feature that is always disabled (in `DBOSource`), so this testcase is always skipped. My fix enables nested transactions before testing them, if the Sqlite version supports it. 

With these fixes, all Sqlite testcases pass on my Win10 machine. 
