### PR TITLE
Fixing 'default current_timestamp' in Sqlite

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -185,6 +185,9 @@ class Sqlite extends DboSource {
 				'default' => $default,
 				'length' => $this->length($column['type'])
 			);
+			if (in_array($fields[$column['name']]['type'], array('timestamp', 'datetime')) && strtoupper($fields[$column['name']]['default']) === 'CURRENT_TIMESTAMP') {
+				$fields[$column['name']]['default'] = null;
+			}
 			if ($column['pk'] == 1) {
 				$fields[$column['name']]['key'] = $this->index['PRI'];
 				$fields[$column['name']]['null'] = false;

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -423,6 +423,40 @@ class SqliteTest extends CakeTestCase {
 	}
 
 /**
+ * Test that describe ignores `default current_timestamp` in timestamp columns.
+ *
+ * @return void
+ */
+	public function testDescribeHandleCurrentTimestamp() {
+		$name = $this->Dbo->fullTableName('timestamp_default_values');
+		$sql = <<<SQL
+CREATE TABLE $name (
+	id INT NOT NULL,
+	phone VARCHAR(10),
+	limit_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (id)
+);
+SQL;
+		$this->Dbo->execute($sql);
+		$model = new Model(array(
+			'table' => 'timestamp_default_values',
+			'ds' => 'test',
+			'alias' => 'TimestampDefaultValue'
+		));
+		$result = $this->Dbo->describe($model);
+		$this->Dbo->execute('DROP TABLE ' . $name);
+
+		$this->assertNull($result['limit_date']['default']);
+
+		$schema = new CakeSchema(array(
+			'connection' => 'test',
+			'testdescribes' => $result
+		));
+		$result = $this->Dbo->createSchema($schema);
+		$this->assertContains('"limit_date" timestamp NOT NULL', $result);
+	}
+
+/**
  * Test virtualFields with functions.
  *
  * @return void


### PR DESCRIPTION
Some of my Sqlite tables have `datetime` or `timestamp` columns with `DEFAULT CURRENT_TIMESTAMP` set - if there values are omitted, the current timestamp is filled in by the database. 
But due to a bug in Sqlite, `CURRENT_TIMESTAMP` is detected as default value, and interpreted as a string. When creating a new record, CakePHP writes this string to the database, and not the current time. 

This problem has also been present in Mysql, and has been fixed there in #4184. I ported the fix (and the corresponding testcase) from 7936b5e7642935983833e3ea28ddafe4f3d84e08 to Sqlite. 
