### PR TITLE
Revert "Force ExistsIn rule in new Entity even with a not dirty field"

### DIFF
--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -94,7 +94,7 @@ class ExistsIn
             return true;
         }
 
-        if (!$entity->extract($this->_fields, true) && !$entity->isNew()) {
+        if (!$entity->extract($this->_fields, true)) {
             return true;
         }
 

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -29,7 +29,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.articles', 'core.articles_tags', 'core.authors', 'core.tags', 'core.categories'];
+    public $fixtures = ['core.articles', 'core.articles_tags', 'core.authors', 'core.tags'];
 
     /**
      * Tear down
@@ -442,7 +442,7 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * ExistsIn uses the schema to verify that nullable fields are ok.
      *
-     * @return void
+     * @return
      */
     public function testExistsInNullValue()
     {
@@ -461,32 +461,9 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
-     * Test ExistsIn on not dirty field in new Entity
-     *
-     * @return void
-     */
-    public function testExistsInNotNullValue()
-    {
-        $entity = new Entity([
-            'name' => 'A Category',
-        ]);
-
-        $table = TableRegistry::get('Categories');
-        $table->belongsTo('Categories', [
-            'foreignKey' => 'parent_id',
-            'bindingKey' => 'id',
-        ]);
-        $rules = $table->rulesChecker();
-        $rules->add($rules->existsIn('parent_id', 'Categories'));
-
-        $this->assertFalse($table->save($entity));
-        $this->assertEquals(['_existsIn' => 'This value does not exist'], $entity->errors('parent_id'));
-    }
-
-    /**
      * Tests exists in uses the bindingKey of the association
      *
-     * @return void
+     * @return
      */
     public function testExistsInWithBindingKey()
     {


### PR DESCRIPTION
Reverts cakephp/cakephp#8788.

This change has caused a number of people trouble as code that used to work no longer works. The specific problematic scenario is:
- Have an ExistsIn rule on a foreign key field.
- Create a new entity with the foreign key field set to null.
- Save that entity.
- In a beforeSave callback populate the foreign key field so the insertion does not fail. Alternatively the ORM will populate the foreign key when saving the related belongsTo association.

Refs #8841
