### PR TITLE
Fix incorrect handling of url in path

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -336,11 +336,10 @@ class Request implements ArrayAccess
         if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '://') === false) {
             $uri = $_SERVER['REQUEST_URI'];
         } elseif (isset($_SERVER['REQUEST_URI'])) {
-            $qPosition = strpos($_SERVER['REQUEST_URI'], '?');
-            if ($qPosition !== false && strpos($_SERVER['REQUEST_URI'], '://') > $qPosition) {
-                $uri = $_SERVER['REQUEST_URI'];
-            } else {
-                $uri = substr($_SERVER['REQUEST_URI'], strlen(Configure::read('App.fullBaseUrl')));
+            $uri = $_SERVER['REQUEST_URI'];
+            $fullBaseUrl = Configure::read('App.fullBaseUrl');
+            if (strpos($uri, $fullBaseUrl) === 0) {
+                $uri = substr($_SERVER['REQUEST_URI'], strlen($fullBaseUrl));
             }
         } elseif (isset($_SERVER['PHP_SELF'], $_SERVER['SCRIPT_NAME'])) {
             $uri = str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['PHP_SELF']);

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -178,6 +178,20 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test that URL in path is handled correctly.
+     */
+    public function testUrlInPath()
+    {
+        $_SERVER['REQUEST_URI'] = '/jump/http://cakephp.org';
+        $request = Request::createFromGlobals();
+        $this->assertEquals('jump/http://cakephp.org', $request->url);
+
+        $_SERVER['REQUEST_URI'] = Configure::read('App.fullBaseUrl') . '/jump/http://cakephp.org';
+        $request = Request::createFromGlobals();
+        $this->assertEquals('jump/http://cakephp.org', $request->url);
+    }
+
+    /**
      * Test addParams() method
      *
      * @return void


### PR DESCRIPTION
`Request::createFromGlobals()` mishandles `REQUEST_URI` if it contains URL in the path such as `/jump/http://cakephp.org`.

``` diff
1) Cake\Test\TestCase\Network\RequestTest::testUrlInPath
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'jump/http://cakephp.org'
+'ephp.org'
```

If there is no problem, I would like to backport this changes into 2.x branch.
