### PR TITLE
refs #8654 FormHelper cleanup unlockFields key

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1598,6 +1598,29 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * test unlockField removing from fields array. multiple field version.
+ *
+ * @return void
+ */
+	public function testUnlockMultipleFieldRemovingFromFields() {
+		$this->Form->request['_Token'] = array(
+			'key' => 'testKey',
+			'unlockedFields' => array()
+		);
+		$this->Form->create('Order');
+		$this->Form->hidden('Order.id', array('value' => 1));
+		$this->Form->checkbox('Ticked.id.');
+		$this->Form->checkbox('Ticked.id.');
+
+		$this->assertEquals(1, $this->Form->fields['Order.id'], 'Hidden input should be secured.');
+		$this->assertTrue(in_array('Ticked.id', $this->Form->fields), 'Field should be secured.');
+
+		$this->Form->unlockField('Order.id');
+		$this->Form->unlockField('Ticked.id');
+		$this->assertEquals(array(), $this->Form->fields);
+	}
+
+/**
  * testTagIsInvalid method
  *
  * @return void

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -664,6 +664,10 @@ class FormHelper extends AppHelper {
 			$field = Hash::filter(explode('.', $field));
 		}
 
+		if (is_array($field)) {
+			$field = array_filter($field, 'strlen');
+		}
+
 		foreach ($this->_unlockedFields as $unlockField) {
 			$unlockParts = explode('.', $unlockField);
 			if (array_values(array_intersect($field, $unlockParts)) === $unlockParts) {


### PR DESCRIPTION
refs #8654 

Cleanup unlockFields key in FormHelper::_secure(), like 3.x.

eg.

```
[
    'Ticket',
    'id',
    ''
]
```

to

```
[
    'Ticket',
    'id',
]
```
