### PR TITLE
add a method to get all subdirectories of a folder

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -487,7 +487,7 @@ class Folder
      * Returns an array of subdirectories for the provided or current path.
      *
      * @param string|null $path The directory path to get subdirectories for.
-     * @param bool $fullPath Wheter to return the full path or only the directory name.
+     * @param bool $fullPath Whether to return the full path or only the directory name.
      * @return array Array of subdirectories for the provided or current path.
      */
     public function subdirectories($path = null, $fullPath = true)

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -484,6 +484,35 @@ class Folder
     }
 
     /**
+     * Returns an array of subdirectories for the provided or current path.
+     *
+     * @param string|null $path The directory path to get subdirectories for.
+     * @param bool $fullPath Wheter to return the full path or only the directory name.
+     * @return array Array of subdirectories for the provided or current path.
+     */
+    public function subdirectories($path = null, $fullPath = true)
+    {
+        if (!$path) {
+            $path = $this->path;
+        }
+        $subdirectories = [];
+
+        try {
+            $iterator = new DirectoryIterator($path);
+        } catch (Exception $e) {
+            return [];
+        }
+
+        foreach ($iterator as $item) {
+            if (!$item->isDir() || $item->isDot()) {
+                continue;
+            }
+            $subdirectories[] = $fullPath ? $item->getRealPath() : $item->getFilename();
+        }
+        return $subdirectories;
+    }
+
+    /**
      * Returns an array of nested directories and files in each directory
      *
      * @param string|null $path the directory path to build the tree from

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -428,6 +428,43 @@ class FolderTest extends TestCase
     }
 
     /**
+     * testFolderSubdirectories method
+     *
+     * @return void
+     */
+    public function testFolderSubdirectories()
+    {
+        $path = CAKE . 'Network';
+        $folder = new Folder($path);
+
+        $expected = [
+            $path . DS . 'Exception',
+            $path . DS . 'Http',
+            $path . DS . 'Session'
+        ];
+        $result = $folder->subdirectories();
+        $this->assertEquals($expected, $result);
+        $result = $folder->subdirectories($path);
+        $this->assertEquals($expected, $result);
+
+        $expected = [
+            'Exception',
+            'Http',
+            'Session'
+        ];
+        $result = $folder->subdirectories(null, false);
+        $this->assertEquals($expected, $result);
+        $result = $folder->subdirectories($path, false);
+        $this->assertEquals($expected, $result);
+
+        $expected = [];
+        $result = $folder->subdirectories('NonExistantPath');
+        $this->assertEquals($expected, $result);
+        $result = $folder->subdirectories($path . DS . 'Exception');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * testFolderTree method
      *
      * @return void
@@ -1235,7 +1272,7 @@ class FolderTest extends TestCase
         $Folder = new Folder($path);
         $Folder->delete();
     }
-    
+
     public function testMoveWithoutRecursive()
     {
         extract($this->_setupFilesystem());

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -443,9 +443,9 @@ class FolderTest extends TestCase
             $path . DS . 'Session'
         ];
         $result = $folder->subdirectories();
-        $this->assertEquals($expected, $result);
+        $this->assertSame([], array_diff($expected, $result));
         $result = $folder->subdirectories($path);
-        $this->assertEquals($expected, $result);
+        $this->assertSame([], array_diff($expected, $result));
 
         $expected = [
             'Exception',
@@ -453,15 +453,15 @@ class FolderTest extends TestCase
             'Session'
         ];
         $result = $folder->subdirectories(null, false);
-        $this->assertEquals($expected, $result);
+        $this->assertSame([], array_diff($expected, $result));
         $result = $folder->subdirectories($path, false);
-        $this->assertEquals($expected, $result);
+        $this->assertSame([], array_diff($expected, $result));
 
         $expected = [];
         $result = $folder->subdirectories('NonExistantPath');
-        $this->assertEquals($expected, $result);
+        $this->assertSame([], array_diff($expected, $result));
         $result = $folder->subdirectories($path . DS . 'Exception');
-        $this->assertEquals($expected, $result);
+        $this->assertSame([], array_diff($expected, $result));
     }
 
     /**


### PR DESCRIPTION
This PR provides easy access to the subdirectories of a folder.

Until now you would use something obscure like

``` php
$folder = new Folder();
$subdirectories = $folder->read(Folder::SORT_NAME, false, true)[0];
```

to get all subdirectories.

With this PR you can use

``` php
$folder = new Folder();
$subdirectories = $folder->subdirectories();
```

which is not obscure and follows the method definition of other Folder methods by providing an optional `$path` and `$fullPath` parameter.
