### PR TITLE
Add a branch alias for 3.next to make installation easier.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,5 +69,10 @@
         "cakephp/orm": "self.version",
         "cakephp/utility": "self.version",
         "cakephp/validation": "self.version"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-3.next": "dev-3.3.0"
+        }
     }
 }


### PR DESCRIPTION
To make the 3.next branch installable, it needs a branch alias that can be compared with other version numbers.
