### PR TITLE
Fix Security::randomBytes() fallback

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -121,13 +121,29 @@ class Security
             'Falling back to an insecure random source.',
             E_USER_WARNING
         );
+        return static::insecureRandomBytes($length);
+    }
+
+    /**
+     * Like randomBytes() above, but not cryptographically secure.
+     *
+     * @param int $length The number of bytes you want.
+     * @return string Random bytes in binary.
+     * @see \Cake\Utility\Security::randomBytes()
+     */
+    public static function insecureRandomBytes($length)
+    {
+        $length *= 2;
+
         $bytes = '';
         $byteLength = 0;
         while ($byteLength < $length) {
             $bytes .= static::hash(Text::uuid() . uniqid(mt_rand(), true), 'sha512', true);
             $byteLength = strlen($bytes);
         }
-        return substr($bytes, 0, $length);
+        $bytes = substr($bytes, 0, $length);
+
+        return pack('H*', $bytes);
     }
 
     /**

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -294,7 +294,7 @@ class SecurityTest extends TestCase
     }
 
     /**
-     * Test the random method.
+     * Test the randomBytes method.
      *
      * @return void
      */
@@ -305,5 +305,23 @@ class SecurityTest extends TestCase
 
         $value = Security::randomBytes(64);
         $this->assertSame(64, strlen($value));
+
+        $this->assertRegExp('/[^0-9a-f]/', $value, 'should return a binary string');
+    }
+
+    /**
+     * Test the insecureRandomBytes method
+     *
+     * @return void
+     */
+    public function testInsecureRandomBytes()
+    {
+        $value = Security::insecureRandomBytes(16);
+        $this->assertSame(16, strlen($value));
+
+        $value = Security::insecureRandomBytes(64);
+        $this->assertSame(64, strlen($value));
+
+        $this->assertRegExp('/[^0-9a-f]/', $value, 'should return a binary string');
     }
 }


### PR DESCRIPTION
`randomBytes()` should return a binary string always. Currently, it fallbacks to a hexadecimal string.

``` php
// Normal
Security::randomBytes(16);
// k#oｴ悄x，nU碾zG8

// Fallback
Security::randomBytes(16);
// c7924462760aa286
```

Add `insecureRandomBytes()` for fallback test.
