### PR TITLE
Ensure RequestHandler does not override response type set in action.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -310,8 +310,8 @@ class RequestHandlerComponent extends Component
 
         if (!empty($this->ext) && $isRecognized) {
             $this->renderAs($event->subject(), $this->ext);
-        } elseif (empty($this->ext) || in_array($this->ext, ['html', 'htm'])) {
-            $this->respondAs('html', ['charset' => Configure::read('App.encoding')]);
+        } else {
+            $this->response->charset(Configure::read('App.encoding'));
         }
 
         if ($this->_config['checkHttpCache'] &&

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -1189,4 +1189,17 @@ class RequestHandlerComponentTest extends TestCase
         $this->assertArrayHasKey('json', $inputs);
         $this->assertCount(1, $inputs);
     }
+
+    /**
+     * test beforeRender() doesn't override response type set in controller action
+     *
+     * @return void
+     */
+    public function testBeforeRender()
+    {
+        $this->Controller->set_response_type();
+        $event = new Event('Controller.beforeRender', $this->Controller);
+        $this->RequestHandler->beforeRender($event);
+        $this->assertEquals('text/plain', $this->Controller->response->type());
+    }
 }

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -59,4 +59,15 @@ class RequestHandlerTestController extends Controller
         $this->viewBuilder()->layout('ajax2');
         $this->destination();
     }
+
+    /**
+     * test method for testing that response type set in action doesn't get
+     * overridden by RequestHandlerComponent::beforeRender()
+     *
+     * @return void
+     */
+    public function set_response_type()
+    {
+        $this->response->type('txt');
+    }
 }


### PR DESCRIPTION
Currently if you aren't using extension parsing RequestHandler::beforeRender() overrides any response type setting done in controller action.
