### PR TITLE
Ignore final hyphen in column name when requoting

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2884,7 +2884,7 @@ class DboSource extends DataSource {
 		// Remove quotes and requote all the Model.field names.
 		$conditions = str_replace(array($start, $end), '', $conditions);
 		$conditions = preg_replace_callback(
-			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*)/i',
+			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*[a-z0-9_])/i',
 			array(&$this, '_quoteMatchedField'),
 			$conditions
 		);

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -198,6 +198,18 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * test that PostgreSQL json operators can be used.
+ *
+ * @return void
+ */
+	public function testColumnHyphenOperator() {
+		$result = $this->testDb->conditions(array('Foo.bar->>\'fieldName\'' => 42));
+		echo "Result is: ";
+		echo $result;
+		$this->assertEquals(' WHERE `Foo`.`bar`->>\'fieldName\' = 42', $result, 'pgsql json operator failed');
+	}
+
+/**
  * test that order() will accept objects made from DboSource::expression
  *
  * @return void


### PR DESCRIPTION
An expression like `"Foo"."bar"->>'prop'` should not be re-quoted as
`"Foo"."bar-">>'prop'`. Otherwise you cannot do things like create a virtualField for a postgres JSON field.

Fixes issue #8856 
