### PR TITLE
Revert changes made in #8807

### DIFF
--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -69,6 +69,9 @@ class IsUnique
     /**
      * Add a model alias to all the keys in a set of conditions.
      *
+     * Null values will be omitted from the generated conditions,
+     * as SQL UNIQUE indexes treat `NULL != NULL`
+     *
      * @param string $alias The alias to add.
      * @param array $conditions The conditions to alias.
      * @return array
@@ -77,7 +80,7 @@ class IsUnique
     {
         $aliased = [];
         foreach ($conditions as $key => $value) {
-            $aliased["$alias.$key IS"] = $value;
+            $aliased["$alias.$key"] = $value;
         }
         return $aliased;
     }

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -371,7 +371,7 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
-     * Tests isUnique with multiple fields and a nulled field.
+     * Tests isUnique with multiple fields emulates SQL UNIQUE keys
      *
      * @group save
      * @return void
@@ -388,13 +388,12 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $this->assertSame($entity, $table->save($entity));
 
-        // Make a duplicate
+        // Make a matching record
         $entity = new Entity([
             'author_id' => null,
-            'title' => 'First Article'
+            'title' => 'New Article'
         ]);
-        $this->assertFalse($table->save($entity));
-        $this->assertEquals(['title' => ['_isUnique' => 'Nope']], $entity->errors());
+        $this->assertSame($entity, $table->save($entity));
     }
 
     /**


### PR DESCRIPTION
While the generated SQL looks incorrect, it is actually what we want. Because SQL always treats NULL != NULL, the generated `field = NULL` conditions emulate how a SQL index would actually work.

We'll need a separate rule to handle more strict unique checks, or better infer behavior based on whether or not columns can be nulled.

Refs #8873
