### PR TITLE
[WIP] 3.x - Add a rule that checks link constraints.

### DIFF
--- a/src/ORM/Exception/LinkConstraintViolationException.php
+++ b/src/ORM/Exception/LinkConstraintViolationException.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class LinkConstraintViolationException extends Exception
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_messageTemplate =
+        'Cannot modify row: a constraint for the `%s` repositories `%s` association fails';
+
+    /**
+     * Gets the affected association.
+     *
+     * @return string|null
+     */
+    public function getAssociation()
+    {
+        if (isset($this->_attributes['association'])) {
+            return $this->_attributes['association'];
+        }
+        return null;
+    }
+
+    /**
+     * Gets the affected repository.
+     *
+     * @return string|null
+     */
+    public function getRepository()
+    {
+        if (isset($this->_attributes['repository'])) {
+            return $this->_attributes['repository'];
+        }
+        return null;
+    }
+}

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\Rule;
+
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Association;
+use Cake\ORM\Exception\LinkConstraintViolationException;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+
+class LinkConstraint
+{
+    /**
+     * The error more that throws exceptions on failure.
+     *
+     * @var string
+     */
+    const ERROR_MODE_EXCEPTIONS = 'errorModeExceptions';
+
+    /**
+     * The error more that returns a boolean on failure.
+     *
+     * @var string
+     */
+    const ERROR_MODE_RETURN_VALUE = 'errorModeReturnValue';
+
+    /**
+     * Link status that requires a link to be present.
+     *
+     * @var string
+     */
+    const LINK_STATUS_LINKED = 'linkStatusLinked';
+
+    /**
+     * Link status that requires a link to not be present.
+     *
+     * @var string
+     */
+    const LINK_STATUS_NOT_LINKED = 'linkStatusNotLinked';
+
+    /**
+     * The association that should be checked.
+     *
+     * @var \Cake\ORM\Association|string
+     */
+    protected $_association;
+
+    /**
+     * The error mode to use when the check fails.
+     *
+     * @var string
+     */
+    protected $_errorMode;
+
+    /**
+     * The link status that is required to be present in order for the check to succeed.
+     *
+     * @var string
+     */
+    protected $_requiredLinkState;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\ORM\Association|string $association The alias of the association that should be checked.
+     * @param string $requiredLinkStatus The link status that is required to be present in order for the check to
+     *  succeed.
+     * @param string $errorMode The error mode to use, defaults to `LinkConstraint::ERROR_MODE_EXCEPTIONS`.
+     */
+    public function __construct($association, $requiredLinkStatus, $errorMode = null)
+    {
+        if ((!is_string($association) && !$association instanceof Association) || empty($association)) {
+            throw new \InvalidArgumentException(
+                'Argument 1 is expected to be either an instance of `Cake\ORM\Association`, or a non-empty string.'
+            );
+        }
+
+        if (!is_string($requiredLinkStatus) ||
+            !in_array($requiredLinkStatus, [static::LINK_STATUS_LINKED, static::LINK_STATUS_NOT_LINKED], true)
+        ) {
+            throw new \InvalidArgumentException(
+                'Argument 2 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::LINK_STATUS_*` constants.'
+            );
+        }
+
+        if ($errorMode === null) {
+            $errorMode = static::ERROR_MODE_EXCEPTIONS;
+        }
+        if (!is_string($errorMode) ||
+            !in_array($errorMode, [static::ERROR_MODE_EXCEPTIONS, static::ERROR_MODE_RETURN_VALUE], true)
+        ) {
+            throw new \InvalidArgumentException(
+                'Argument 3 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::ERROR_MODE_*` constants.'
+            );
+        }
+
+        $this->_association = $association;
+        $this->_errorMode = $errorMode;
+        $this->_requiredLinkState = $requiredLinkStatus;
+    }
+
+    /**
+     * Callable handler.
+     *
+     * Performs the actual link check.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity involved in the operation.
+     * @param array $options Options passed from the rules checker.
+     * @return bool Whether the check was successful.
+     */
+    public function __invoke(EntityInterface $entity, array $options)
+    {
+        if (!isset($options['repository']) || !$options['repository'] instanceof Table) {
+            throw new \InvalidArgumentException(
+                'Argument 2 is expected to have a `repository` key set that holds an instance of `\Cake\ORM\Table`.'
+            );
+        }
+
+        /* @var $table \Cake\ORM\Table */
+        $table = $options['repository'];
+
+        $association = $this->_association;
+        if (!$association instanceof Association) {
+            $association = $table->association($association);
+            if (!$association) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'The association `%s` could not be found on the repository `%s`.',
+                        $this->_association,
+                        $table->registryAlias()
+                    )
+                );
+            }
+        }
+
+        $count = $this->_countLinks($association, $entity);
+
+        if (!is_int($count) ||
+            ($this->_requiredLinkState === static::LINK_STATUS_LINKED && $count < 1) ||
+            ($this->_requiredLinkState === static::LINK_STATUS_NOT_LINKED && $count !== 0)
+        ) {
+            if ($this->_errorMode === static::ERROR_MODE_EXCEPTIONS) {
+                throw new LinkConstraintViolationException([
+                    'repository' => $table->registryAlias(),
+                    'association' => $association->registryAlias()
+                ]);
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Alias fields.
+     *
+     * @param array $fields The fields that should be aliased.
+     * @param Table $table The table object to use for aliasing.
+     * @return array The aliased fields
+     */
+    protected function _aliasFields($fields, $table)
+    {
+        foreach ($fields as $key => $value) {
+            $fields[$key] = $table->aliasField($value);
+        }
+        return $fields;
+    }
+
+    /**
+     * Build conditions.
+     *
+     * @param array $fields The condition fields.
+     * @param array $values The condition values.
+     * @return array A conditions array combined from the passed fields and values.
+     */
+    protected function _buildConditions($fields, $values)
+    {
+        if (count($fields) !== count($values)) {
+            throw new \InvalidArgumentException('The number of fields is expected to match the number of values.');
+        }
+        return array_combine($fields, $values);
+    }
+
+    /**
+     * Count links.
+     *
+     * @param \Cake\ORM\Association $association The association for which to count links.
+     * @param \Cake\Datasource\EntityInterface $entity The entity involved in the operation.
+     * @return int|null The number of links, or `null` for unsupported association types.
+     */
+    protected function _countLinks($association, $entity)
+    {
+        $count = null;
+
+        switch ($association->type()) {
+            case Association::ONE_TO_ONE:
+            case Association::ONE_TO_MANY:
+                $conditions = $this->_buildConditions(
+                    $this->_aliasFields((array)$association->foreignKey(), $association->target()),
+                    $entity->extract((array)$association->bindingKey())
+                );
+
+                $count = $association
+                    ->target()
+                    ->find()
+                    ->where($conditions)
+                    ->count();
+                break;
+
+            case Association::MANY_TO_MANY:
+                $primaryKey = $association->source()->primaryKey();
+                $conditions = $this->_buildConditions(
+                    $this->_aliasFields((array)$primaryKey, $association->source()),
+                    $entity->extract((array)$primaryKey)
+                );
+
+                $sourceAlias = $association->source()->registryAlias();
+                $sourceAssociation = $association->target()->association($sourceAlias);
+
+                $count = $association
+                    ->target()
+                    ->find()
+                    ->matching(
+                        $sourceAssociation->registryAlias(),
+                        function (Query $query) use ($conditions) {
+                            return $query->where($conditions);
+                        }
+                    )
+                    ->count();
+                break;
+
+            case Association::MANY_TO_ONE:
+                $conditions = $this->_buildConditions(
+                    $this->_aliasFields((array)$association->bindingKey(), $association->target()),
+                    $entity->extract((array)$association->foreignKey())
+                );
+
+                $count = $association
+                    ->target()
+                    ->find()
+                    ->where($conditions)
+                    ->count();
+                break;
+        }
+
+        return $count;
+    }
+}

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -166,13 +166,13 @@ class LinkConstraint
      * Alias fields.
      *
      * @param array $fields The fields that should be aliased.
-     * @param Table $table The table object to use for aliasing.
+     * @param \Cake\ORM\Association|\Cake\ORM\Table $source The object to use for aliasing.
      * @return array The aliased fields
      */
-    protected function _aliasFields($fields, $table)
+    protected function _aliasFields($fields, $source)
     {
         foreach ($fields as $key => $value) {
-            $fields[$key] = $table->aliasField($value);
+            $fields[$key] = $source->aliasField($value);
         }
         return $fields;
     }
@@ -208,15 +208,15 @@ class LinkConstraint
             throw new \InvalidArgumentException('All primary key values are required.');
         }
 
-        $conditions = $this->_buildConditions(
-            $this->_aliasFields((array)$primaryKey, $source),
-            $entity->extract((array)$primaryKey)
-        );
-
         $sourceAlias = $source->registryAlias();
         $sourceAssociation = $association->target()->association($sourceAlias);
 
         if ($sourceAssociation instanceof Association) {
+            $conditions = $this->_buildConditions(
+                $this->_aliasFields((array)$primaryKey, $sourceAssociation),
+                $entity->extract((array)$primaryKey)
+            );
+
             return $association
                 ->find()
                 ->matching(
@@ -227,6 +227,11 @@ class LinkConstraint
                 )
                 ->count();
         }
+
+        $conditions = $this->_buildConditions(
+            $this->_aliasFields((array)$primaryKey, $source),
+            $entity->extract((array)$primaryKey)
+        );
 
         $entity = $source
             ->find()

--- a/tests/TestCase/ORM/Exception/LinkConstraintViolationExceptionTest.php
+++ b/tests/TestCase/ORM/Exception/LinkConstraintViolationExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM\Exception;
+
+use Cake\ORM\Exception\LinkConstraintViolationException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * LinkConstraintViolationException class test.
+ */
+class LinkConstraintViolationExceptionTest extends TestCase
+{
+    public function testGetDefaults()
+    {
+        $exception = new LinkConstraintViolationException('message');
+        $this->assertNull($exception->getAssociation());
+        $this->assertNull($exception->getAssociation());
+    }
+
+    public function testGetRepository()
+    {
+        $exception = new LinkConstraintViolationException([
+            'repository' => 'Repository',
+            'association' => 'Association'
+        ]);
+        $this->assertEquals('Repository', $exception->getRepository());
+    }
+
+    public function testGetAssociation()
+    {
+        $exception = new LinkConstraintViolationException([
+            'repository' => 'Repository',
+            'association' => 'Association'
+        ]);
+        $this->assertEquals('Association', $exception->getAssociation());
+    }
+}

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -39,10 +39,21 @@ class LinkConstraintTest extends TestCase
         'core.users'
     ];
 
+    public $autoFixtures = false;
+
     public function setUp()
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
+
+        $this->loadFixtures(
+            'Authors',
+            'Users',
+            'Articles',
+            'Comments',
+            'Tags',
+            'ArticlesTags'
+        );
     }
 
     public function tearDown()

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM\Rule;
+
+use Cake\Core\Configure;
+use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Rule\LinkConstraint;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * LinkConstraintTest class test.
+ */
+class LinkConstraintTest extends TestCase
+{
+    public $fixtures = [
+        'core.articles',
+        'core.articles_tags',
+        'core.authors',
+        'core.comments',
+        'core.tags',
+        'core.users'
+    ];
+
+    public function setUp()
+    {
+        parent::setUp();
+        Configure::write('App.namespace', 'TestApp');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        TableRegistry::clear();
+    }
+
+    public function invalidConstructorArgumentDataProvider()
+    {
+        return [[''], [null], [1], [[]]];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Argument 1 is expected to be either an instance of `Cake\ORM\Association`, or a non-empty string.
+     *
+     * @dataProvider invalidConstructorArgumentDataProvider
+     * @param mixed $value
+     */
+    public function testInvalidConstructorArgumentOne($value)
+    {
+        new LinkConstraint($value, LinkConstraint::LINK_STATUS_LINKED);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Argument 2 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::LINK_STATUS_*` constants.
+     *
+     * @dataProvider invalidConstructorArgumentDataProvider
+     * @param mixed $value
+     */
+    public function testInvalidConstructorArgumentTwo($value)
+    {
+        new LinkConstraint('Association', $value);
+    }
+
+    public function invalidConstructorArgumentThreeDataProvider()
+    {
+        return [[''], [1], [[]]];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Argument 3 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::ERROR_MODE_*` constants.
+     *
+     * @dataProvider invalidConstructorArgumentThreeDataProvider
+     * @param mixed $value
+     */
+    public function testInvalidConstructorArgumentThree($value)
+    {
+        new LinkConstraint('Association', LinkConstraint::LINK_STATUS_LINKED, $value);
+    }
+
+    public function validConstructorArgumentOneDataProvider()
+    {
+        return [['Association'], [new BelongsTo('Association')]];
+    }
+
+    /**
+     * @dataProvider validConstructorArgumentOneDataProvider
+     * @param mixed $value
+     */
+    public function testValidConstructorArgumentOne($value)
+    {
+        new LinkConstraint($value, LinkConstraint::LINK_STATUS_LINKED);
+    }
+
+    public function validConstructorArgumentTwoDataProvider()
+    {
+        return [[LinkConstraint::LINK_STATUS_LINKED], [LinkConstraint::LINK_STATUS_NOT_LINKED]];
+    }
+
+    /**
+     * @dataProvider validConstructorArgumentTwoDataProvider
+     * @param mixed $value
+     */
+    public function testValidConstructorArgumentTwo($value)
+    {
+        new LinkConstraint('Association', $value);
+    }
+
+    public function validConstructorArgumentThreeDataProvider()
+    {
+        return [[LinkConstraint::ERROR_MODE_EXCEPTIONS], [LinkConstraint::ERROR_MODE_RETURN_VALUE]];
+    }
+
+    /**
+     * @dataProvider validConstructorArgumentThreeDataProvider
+     * @param mixed $value
+     */
+    public function testValidConstructorArgumentThree($value)
+    {
+        new LinkConstraint('Association', LinkConstraint::LINK_STATUS_LINKED, $value);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The association `NonExistent` could not be found on the repository `Articles`.
+     */
+    public function testNonExistentAssociation()
+    {
+        $Articles = TableRegistry::get('Articles');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('NonExistent', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $article = $Articles->get(1);
+        $Articles->delete($article);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The number of fields is expected to match the number of values.
+     */
+    public function testNonMatchingCompositeKeys()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasMany('Comments')->foreignKey(['id', 'article_id']);
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $article = $Articles->get(1);
+        $Articles->delete($article);
+    }
+
+    public function invalidRepositoryOptionsDataProvider()
+    {
+        return [
+            [['repository' => null]],
+            [['repository' => new \stdClass()]],
+            [[]]
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Argument 2 is expected to have a `repository` key set that holds an instance of `\Cake\ORM\Table`
+     *
+     * @dataProvider invalidRepositoryOptionsDataProvider
+     * @param mixed $options
+     */
+    public function testInvalidRepository($options)
+    {
+        $Articles = $this->getMockForModel('Articles', ['buildRules'], ['table' => 'articles']);
+
+        $rulesChecker = new RulesChecker($options);
+        $Articles->expects($this->atLeastOnce())->method('buildRules')->willReturn($rulesChecker);
+
+        $rulesChecker->addDelete(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+        $Articles->buildRules($rulesChecker);
+
+        $article = $Articles->get(1);
+        $Articles->delete($article);
+    }
+
+    public function testReturnValueErrorModeWithMustNotBeLinkedViaBelongsToIsLinked()
+    {
+        $Comments = TableRegistry::get('Comments');
+        $Comments->belongsTo('Articles');
+
+        $rulesChecker = $Comments->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_NOT_LINKED, LinkConstraint::ERROR_MODE_RETURN_VALUE),
+            '_isNotLinked',
+            [
+                'errorField' => 'articles'
+            ]
+        );
+
+        $comment = $Comments->get(1);
+        $this->assertFalse($Comments->delete($comment));
+
+        $expected = [
+            'articles' => [
+                '_isNotLinked' => 'invalid'
+            ]
+        ];
+        $this->assertEquals($expected, $comment->errors());
+    }
+
+    public function testMustBeLinkedViaBelongsToIsLinked()
+    {
+        $Comments = TableRegistry::get('Comments');
+        $Comments->belongsTo('Articles');
+
+        $rulesChecker = $Comments->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $comment = $Comments->get(1);
+        $comment->dirty('comment', true);
+        $this->assertNotFalse($Comments->save($comment));
+    }
+
+    public function testUsingAssociationInstanceMustBeLinkedViaBelongsToIsLinked()
+    {
+        $Comments = TableRegistry::get('Comments');
+        $Comments->belongsTo('Articles');
+
+        $rulesChecker = $Comments->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint($Comments->association('Articles'), LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $comment = $Comments->get(1);
+        $comment->dirty('comment', true);
+        $this->assertNotFalse($Comments->save($comment));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Comments` repositories `Articles` association fails
+     */
+    public function testMustBeLinkedViaBelongsToIsNotLinked()
+    {
+        $Comments = TableRegistry::get('Comments');
+        $Comments->belongsTo('Articles');
+
+        $Comments->save($Comments->newEntity([
+            'article_id' => 9999,
+            'user_id' => 1,
+            'comment' => 'Orphaned Comment'
+        ]));
+
+        $rulesChecker = $Comments->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $comment = $Comments->get(7);
+        $comment->dirty('comment', true);
+        $Comments->save($comment);
+    }
+
+    public function testMustBeLinkedViaBelongsManyToIsLinked()
+    {
+        $Tags = TableRegistry::get('Tags');
+
+        $rulesChecker = $Tags->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $tag = $Tags->get(1);
+        $tag->dirty('name', true);
+        $this->assertNotFalse($Tags->save($tag));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Tags` repositories `articles` association fails
+     */
+    public function testMustBeLinkedViaBelongsToManyIsNotLinked()
+    {
+        $Tags = TableRegistry::get('Tags');
+
+        $Tags->save($Tags->newEntity([
+            'name' => 'Orphaned Tag'
+        ]));
+
+        $rulesChecker = $Tags->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $tag = $Tags->get(4);
+        $tag->dirty('name', true);
+        $Tags->save($tag);
+    }
+
+    public function testMustBeLinkedViaHasManyIsLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasMany('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $article = $Articles->get(1);
+        $article->dirty('comment', true);
+        $this->assertNotFalse($Articles->save($article));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Articles` repositories `Comments` association fails
+     */
+    public function testMustBeLinkedViaHasManyIsNotLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasMany('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $article = $Articles->get(3);
+        $article->dirty('comment', true);
+        $Articles->save($article);
+    }
+
+    public function testMustBeLinkedViaHasOneIsLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasOne('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $article = $Articles->get(1);
+        $article->dirty('title', true);
+        $this->assertNotFalse($Articles->save($article));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Articles` repositories `Comments` association fails
+     */
+    public function testMustBeLinkedViaHasOneIsNotLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasOne('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addUpdate(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_LINKED)
+        );
+
+        $article = $Articles->get(3);
+        $article->dirty('title', true);
+        $Articles->save($article);
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Comments` repositories `Articles` association fails
+     */
+    public function testMustNotBeLinkedViaBelongsToIsLinked()
+    {
+        $Comments = TableRegistry::get('Comments');
+        $Comments->belongsTo('Articles');
+
+        $rulesChecker = $Comments->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $comment = $Comments->get(1);
+        $Comments->delete($comment);
+    }
+
+    public function testMustNotBeLinkedViaBelongsToIsNotLinked()
+    {
+        $Comments = TableRegistry::get('Comments');
+        $Comments->belongsTo('Articles');
+
+        $Comments->save($Comments->newEntity([
+            'article_id' => 9999,
+            'user_id' => 1,
+            'comment' => 'Orphaned Comment'
+        ]));
+
+        $rulesChecker = $Comments->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $comment = $Comments->get(7);
+        $this->assertTrue($Comments->delete($comment));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Tags` repositories `articles` association fails
+     */
+    public function testMustNotBeLinkedViaBelongsToManyIsLinked()
+    {
+        $Tags = TableRegistry::get('Tags');
+
+        $rulesChecker = $Tags->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $tag = $Tags->get(1);
+        $Tags->delete($tag);
+    }
+
+    public function testMustNotBeLinkedViaBelongsToManyIsNotLinked()
+    {
+        $Tags = TableRegistry::get('Tags');
+
+        $Tags->save($Tags->newEntity([
+            'name' => 'Orphaned Tag'
+        ]));
+
+        $rulesChecker = $Tags->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Articles', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $tag = $Tags->get(4);
+        $this->assertTrue($Tags->delete($tag));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Articles` repositories `Comments` association fails
+     */
+    public function testMustNotBeLinkedViaHasManyIsLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasMany('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $article = $Articles->get(1);
+        $Articles->delete($article);
+    }
+
+    public function testMustNotBeLinkedViaHasManyIsNotLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasMany('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $article = $Articles->get(3);
+        $this->assertTrue($Articles->delete($article));
+    }
+
+    /**
+     * @expectedException \Cake\ORM\Exception\LinkConstraintViolationException
+     * @expectedExceptionMessage Cannot modify row: a constraint for the `Articles` repositories `Comments` association fails
+     */
+    public function testMustNotBeLinkedViaHasOneIsLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasOne('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $article = $Articles->get(1);
+        $Articles->delete($article);
+    }
+
+    public function testMustNotBeLinkedViaHasOneIsNotLinked()
+    {
+        $Articles = TableRegistry::get('Articles');
+        $Articles->hasOne('Comments');
+
+        $rulesChecker = $Articles->rulesChecker();
+        $rulesChecker->addDelete(
+            new LinkConstraint('Comments', LinkConstraint::LINK_STATUS_NOT_LINKED)
+        );
+
+        $article = $Articles->get(3);
+        $this->assertTrue($Articles->delete($article));
+    }
+}

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\ORM\Rule;
 
 use Cake\Core\Configure;
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Event\Event;
 use Cake\ORM\Association\BelongsTo;
@@ -586,7 +587,12 @@ class LinkConstraintTest extends TestCase
                     ->newQuery()
                     ->select(['RecentComments.id'])
                     ->from(['RecentComments' => 'comments'])
-                    ->where(['Articles.id = RecentComments.article_id'])
+                    ->where(function (QueryExpression $exp) {
+                        return $exp->eq(
+                            new IdentifierExpression('Articles.id'),
+                            new IdentifierExpression('RecentComments.article_id')
+                        );
+                    })
                     ->order(['RecentComments.created' => 'DESC'])
                     ->limit(1);
 
@@ -616,7 +622,12 @@ class LinkConstraintTest extends TestCase
                     ->newQuery()
                     ->select(['RecentComments.id'])
                     ->from(['RecentComments' => 'comments'])
-                    ->where(['Articles.id = RecentComments.article_id'])
+                    ->where(function (QueryExpression $exp) {
+                        return $exp->eq(
+                            new IdentifierExpression('Articles.id'),
+                            new IdentifierExpression('RecentComments.article_id')
+                        );
+                    })
                     ->order(['RecentComments.created' => 'DESC'])
                     ->limit(1);
 
@@ -684,9 +695,12 @@ class LinkConstraintTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasOne('Comments', [
-            'conditions' => [
-                'Comments.published = Articles.published'
-            ]
+            'conditions' => function (QueryExpression $exp) {
+                return $exp->eq(
+                    new IdentifierExpression('Comments.published'),
+                    new IdentifierExpression('Articles.published')
+                );
+            }
         ]);
         $Articles->association('Comments')->belongsTo('Articles');
 
@@ -703,9 +717,12 @@ class LinkConstraintTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasOne('Comments', [
-            'conditions' => [
-                'Comments.published != Articles.published'
-            ]
+            'conditions' => function (QueryExpression $exp) {
+                return $exp->notEq(
+                    new IdentifierExpression('Comments.published'),
+                    new IdentifierExpression('Articles.published')
+                );
+            }
         ]);
         $Articles->association('Comments')->belongsTo('Articles');
 

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -1052,7 +1052,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Comments = TableRegistry::get('Comments');
         $Comments->belongsTo('Articles');
+        $Comments->association('Articles')->hasMany('Comments');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
             $rulesChecker->isLinkedTo('Articles', 'articles')
@@ -1067,6 +1069,7 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Comments = TableRegistry::get('Comments');
         $Comments->belongsTo('Articles');
+        $Comments->association('Articles')->hasMany('Comments');
 
         $Comments->save($Comments->newEntity([
             'article_id' => 9999,
@@ -1074,6 +1077,7 @@ class RulesCheckerIntegrationTest extends TestCase
             'comment' => 'Orphaned Comment'
         ]));
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
             $rulesChecker->isLinkedTo('Articles', 'articles')
@@ -1095,7 +1099,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasMany('Comments');
+        $Articles->association('Comments')->belongsTo('Articles');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
             $rulesChecker->isNotLinkedTo('Comments', 'comments')
@@ -1116,7 +1122,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasMany('Comments');
+        $Articles->association('Comments')->belongsTo('Articles');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
             $rulesChecker->isNotLinkedTo('Comments', 'comments')
@@ -1130,7 +1138,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Comments = TableRegistry::get('Comments');
         $Comments->belongsTo('Articles');
+        $Comments->association('Articles')->hasMany('Comments');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
             $rulesChecker->isLinkedTo($Comments->association('Articles'), 'articles')
@@ -1145,7 +1155,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasMany('Comments');
+        $Articles->association('Comments')->belongsTo('Articles');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
             $rulesChecker->isNotLinkedTo($Articles->association('Comments'), 'comments')
@@ -1159,7 +1171,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Comments = TableRegistry::get('Comments');
         $Comments->belongsTo('Articles');
+        $Comments->association('Articles')->hasMany('Comments');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
             $rulesChecker->isLinkedTo($Comments->association('Articles')->target(), 'articles')
@@ -1174,7 +1188,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasMany('Comments');
+        $Articles->association('Comments')->belongsTo('Articles');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
             $rulesChecker->isNotLinkedTo($Articles->association('Comments')->target(), 'comments')
@@ -1188,6 +1204,7 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Comments = TableRegistry::get('Comments');
         $Comments->belongsTo('Articles');
+        $Comments->association('Articles')->hasMany('Comments');
 
         $Comments->save($Comments->newEntity([
             'article_id' => 9999,
@@ -1195,6 +1212,7 @@ class RulesCheckerIntegrationTest extends TestCase
             'comment' => 'Orphaned Comment'
         ]));
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
             $rulesChecker->isLinkedTo('Articles')
@@ -1210,7 +1228,9 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $Articles = TableRegistry::get('Articles');
         $Articles->hasMany('Comments');
+        $Articles->association('Comments')->belongsTo('Articles');
 
+        /* @var $rulesChecker \Cake\ORM\RulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
             $rulesChecker->isNotLinkedTo('Comments')

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -36,7 +36,7 @@ class ArticlesTable extends Table
      */
     public function findPublished($query)
     {
-        return $query->where(['published' => 'Y']);
+        return $query->where([$this->aliasField('published') => 'Y']);
     }
 
     /**


### PR DESCRIPTION
This is a first implementation of #6327, for now I've just ported it from my plugin into the core and added additional support for `belongsToMany` associations and configurable error behavior - that means, the rule still includes the highly debatable exception mechanism.

Before eventually removing exceptions, and adding/shifting (more) tests into the rules checker integration test, I wanted to put this up for further feedback as is.
