### PR TITLE
Reset FormHelper::$_unlockFields

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -420,6 +420,7 @@ class FormHelper extends Helper
         $htmlAttributes += $options;
 
         $this->fields = [];
+        $this->_unlockedFields = [];
         if ($this->requestType !== 'get') {
             $append .= $this->_csrfField();
         }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2287,17 +2287,17 @@ class FormHelperTest extends TestCase
      */
     public function testResetUnlockFields()
     {
-        $this->Form->request['_Token'] = array(
-            'key'            => 'testKey',
-            'unlockedFields' => array()
-        );
+        $this->Form->request['_Token'] = [
+            'key' => 'testKey',
+            'unlockedFields' => []
+        ];
 
         $this->Form->create('Contact');
         $this->Form->unlockField('Contact.id');
         $this->Form->end();
 
         $this->Form->create('Contact');
-        $this->Form->hidden('Contact.id', array('value' => 1));
+        $this->Form->hidden('Contact.id', ['value' => 1]);
         $this->assertEquals(1, $this->Form->fields['Contact.id'], 'Hidden input should be secured.');
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2281,6 +2281,27 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * test reset unlockFields, when create new form.
+     *
+     * @return void
+     */
+    public function testResetUnlockFields()
+    {
+        $this->Form->request['_Token'] = array(
+            'key'            => 'testKey',
+            'unlockedFields' => array()
+        );
+
+        $this->Form->create('Contact');
+        $this->Form->unlockField('Contact.id');
+        $this->Form->end();
+
+        $this->Form->create('Contact');
+        $this->Form->hidden('Contact.id', array('value' => 1));
+        $this->assertEquals(1, $this->Form->fields['Contact.id'], 'Hidden input should be secured.');
+    }
+
+    /**
      * Test that only the path + query elements of a form's URL show up in their hash.
      *
      * @return void


### PR DESCRIPTION
- [x] bug
- [ ] enhancement
- [ ] feature-discussion (RFC)
- CakePHP Version: 2.x, 3.x
### What you did

FormHelper remain $_unlockFields parameter of the previous form, when using multiple times FormHelper on the same page.

```
$this->Form->create(false, ['id' => 'first']);
$this->Form->unlockField('Contact.id');
$this->Form->end();

$this->Form->create(false, ['id' => 'first']);
$this->Form->hidden('Contact.id', ['value' => 1]); // <- UNLOCKED!
$this->Form->end();
```

It will be unexpected unlock field.
### Expected Behavior

FormHelper::$_unlockFields shuould be clear values when each form create.
