### PR TITLE
Add support for dynamic validation rule providers.

### DIFF
--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -121,7 +121,11 @@ class ValidationRule
             $callable = $this->_rule;
             $isCallable = true;
         } else {
-            $provider = $providers[$this->_provider];
+            if (isset($providers[$this->_provider])) {
+                $provider = $providers[$this->_provider];
+            } else {
+                $provider = $this->_provider;
+            }
             $callable = [$provider, $this->_rule];
             $isCallable = is_callable($callable);
         }

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -79,6 +79,21 @@ class ValidationRuleTest extends TestCase
     }
 
     /**
+     * Test using a custom provider without specifying it in providers list
+     *
+     * @return void
+     */
+    public function testCustomProviderNotInProvidersList()
+    {
+        $data = '42';
+        $providers = ['default' => $this];
+
+        $context = ['newRecord' => true];
+        $Rule = new ValidationRule(['rule' => 'is42', 'provider' => 'TestApp\Validation\CustomProvider']);
+        $this->assertTrue($Rule->process($data, $providers, $context));
+    }
+
+    /**
      * Test using a custom validation method with no provider declared.
      *
      * @return void

--- a/tests/test_app/TestApp/Validation/CustomProvider.php
+++ b/tests/test_app/TestApp/Validation/CustomProvider.php
@@ -1,0 +1,10 @@
+<?php
+namespace TestApp\Validation;
+
+class CustomProvider {
+
+	public static function is42($check) {
+		return $check == 42;
+	}
+
+}


### PR DESCRIPTION
Adding a validation provider is too verbose when using one-off providers:

``` php
$validator->provider('AbnValidator', 'AbnValidator')->add('abn', '_validFormat', [
    'rule' => 'isValidAbn',
    'message' => 'Please enter a valid ABN or ACN',
    'provider' => 'AbnValidator'
]);
```

This PR allows late resolving of providers:

``` php
$validator->add('abn', '_validFormat', [
    'rule' => 'isValidAbn',
    'message' => 'Please enter a valid ABN or ACN',
    'provider' => 'AbnValidator'
]);
```
