### PR TITLE
Fixed a problem with the find method in BelongsToMany Association

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -894,7 +894,7 @@ class BelongsToMany extends Association
 
         $belongsTo = $this->junction()->association($this->target()->alias());
         $conditions = $belongsTo->_joinCondition([
-            'foreignKey' => $this->foreignKey()
+            'foreignKey' => $this->targetForeignKey()
         ]);
         $conditions += $this->junctionConditions();
         return $this->_appendJunctionJoin($query, $conditions);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1022,6 +1022,7 @@ class BelongsToManyTest extends TestCase
         $query = $table->Tags->find();
         $result = $query->toArray();
         $this->assertCount(1, $result);
+        $this->assertEquals(1, $result[0]->id);
     }
 
     /**
@@ -1045,6 +1046,7 @@ class BelongsToManyTest extends TestCase
         $query = $table->Tags->find();
         $result = $query->toArray();
         $this->assertCount(1, $result);
+        $this->assertEquals(1, $result[0]->id);
     }
 
     /**


### PR DESCRIPTION
I recognized that the wrong foreign key was used for the association table in the `find` method when using conditions.
It has to be the target foreign key and not the foreign key of the source itself.

The tests weren't wrong as it just checks the total count of the result set. I added an additional assert which checks the id of the Tag, which was found.

E.g. the test `testAssociationProxyFindWithConditions` did find exactly 1 result, but it was the Tag with the id `2` and not the correct Tag with id `1`.
