### PR TITLE
Use more secure boundary

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -22,6 +22,7 @@ use Cake\Filesystem\File;
 use Cake\Log\Log;
 use Cake\Network\Http\FormData\Part;
 use Cake\Utility\Hash;
+use Cake\Utility\Security;
 use Cake\Utility\Text;
 use Cake\View\ViewVarsTrait;
 use Closure;
@@ -1610,7 +1611,7 @@ class Email implements JsonSerializable, Serializable
     protected function _createBoundary()
     {
         if (!empty($this->_attachments) || $this->_emailFormat === 'both') {
-            $this->_boundary = md5(uniqid(time()));
+            $this->_boundary = md5(Security::randomBytes(16));
         }
     }
 

--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -14,6 +14,7 @@
 namespace Cake\Network\Http;
 
 use Cake\Network\Http\FormData\Part;
+use Cake\Utility\Security;
 use Countable;
 use finfo;
 
@@ -66,7 +67,7 @@ class FormData implements Countable
         if ($this->_boundary) {
             return $this->_boundary;
         }
-        $this->_boundary = md5(uniqid(time()));
+        $this->_boundary = md5(Security::randomBytes(16));
         return $this->_boundary;
     }
 

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -2071,7 +2071,7 @@ class EmailTest extends TestCase
         $this->assertNotEmpty($result);
 
         $result = $this->CakeEmail->getBoundary();
-        $this->assertNotEmpty($result);
+        $this->assertRegExp('/^[0-9a-f]{32}$/', $result);
     }
 
     /**


### PR DESCRIPTION
Use `Security::randomBytes()` instead of `uniqid()`.
