### PR TITLE
Add --version to the bin/cake console

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -373,7 +373,7 @@ class ShellDispatcher
     }
 
     /**
-     * Prints the current version of CakePHP. Performs an internal dispatch to the CommandList Shell
+     * Prints the currently installed version of CakePHP. Performs an internal dispatch to the CommandList Shell
      *
      * @return void
      */

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -210,6 +210,10 @@ class ShellDispatcher
             $this->help();
             return true;
         }
+        if (in_array($shell, ['version', '--version'])) {
+            $this->version();
+            return true;
+        }
 
         $Shell = $this->findShell($shell);
 
@@ -365,6 +369,17 @@ class ShellDispatcher
     public function help()
     {
         $this->args = array_merge(['command_list'], $this->args);
+        $this->dispatch();
+    }
+
+    /**
+     * Prints the current version of CakePHP. Performs an internal dispatch to the CommandList Shell
+     *
+     * @return void
+     */
+    public function version()
+    {
+        $this->args = array_merge(['command_list', '--version'], $this->args);
         $this->dispatch();
     }
 }

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -16,6 +16,7 @@ namespace Cake\Shell;
 
 use Cake\Console\ConsoleOutput;
 use Cake\Console\Shell;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use SimpleXmlElement;
@@ -41,7 +42,7 @@ class CommandListShell extends Shell
      */
     public function startup()
     {
-        if (empty($this->params['xml'])) {
+        if (empty($this->params['xml']) && empty($this->params['version'])) {
             parent::startup();
         }
     }
@@ -53,7 +54,7 @@ class CommandListShell extends Shell
      */
     public function main()
     {
-        if (empty($this->params['xml'])) {
+        if (empty($this->params['xml']) && empty($this->params['version'])) {
             $this->out("<info>Current Paths:</info>", 2);
             $this->out("* app:  " . APP_DIR);
             $this->out("* root: " . rtrim(ROOT, DIRECTORY_SEPARATOR));
@@ -65,6 +66,11 @@ class CommandListShell extends Shell
 
         $shellList = $this->Command->getShellList();
         if (empty($shellList)) {
+            return;
+        }
+
+        if (!empty($this->params['version'])) {
+            $this->out(Configure::version());
             return;
         }
 
@@ -135,6 +141,9 @@ class CommandListShell extends Shell
             'Get the list of available shells for this CakePHP application.'
         )->addOption('xml', [
             'help' => 'Get the listing as XML.',
+            'boolean' => true
+        ])->addOption('version', [
+            'help' => 'Prints the current version of CakePHP.',
             'boolean' => true
         ]);
 

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -64,13 +64,13 @@ class CommandListShell extends Shell
             $this->out("<info>Available Shells:</info>", 2);
         }
 
-        $shellList = $this->Command->getShellList();
-        if (empty($shellList)) {
+        if (!empty($this->params['version'])) {
+            $this->out(Configure::version());
             return;
         }
 
-        if (!empty($this->params['version'])) {
-            $this->out(Configure::version());
+        $shellList = $this->Command->getShellList();
+        if (empty($shellList)) {
             return;
         }
 

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -42,7 +42,7 @@ class CommandListShell extends Shell
      */
     public function startup()
     {
-        if (empty($this->params['xml']) && empty($this->params['version'])) {
+        if (!$this->param('xml') && !$this->param('version')) {
             parent::startup();
         }
     }
@@ -54,7 +54,7 @@ class CommandListShell extends Shell
      */
     public function main()
     {
-        if (empty($this->params['xml']) && empty($this->params['version'])) {
+        if (!$this->param('xml') && !$this->param('version')) {
             $this->out("<info>Current Paths:</info>", 2);
             $this->out("* app:  " . APP_DIR);
             $this->out("* root: " . rtrim(ROOT, DIRECTORY_SEPARATOR));
@@ -64,17 +64,17 @@ class CommandListShell extends Shell
             $this->out("<info>Available Shells:</info>", 2);
         }
 
-        if (!empty($this->params['version'])) {
+        if ($this->param('version')) {
             $this->out(Configure::version());
             return;
         }
 
         $shellList = $this->Command->getShellList();
-        if (empty($shellList)) {
+        if (!$shellList) {
             return;
         }
 
-        if (empty($this->params['xml'])) {
+        if (!$this->param('xml')) {
             $this->_asText($shellList);
         } else {
             $this->_asXml($shellList);

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -143,7 +143,7 @@ class CommandListShell extends Shell
             'help' => 'Get the listing as XML.',
             'boolean' => true
         ])->addOption('version', [
-            'help' => 'Prints the current version of CakePHP.',
+            'help' => 'Prints the currently installed version of CakePHP.',
             'boolean' => true
         ]);
 

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Shell;
 
 use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
@@ -130,5 +131,21 @@ class CommandListShellTest extends TestCase
 
         $find = '<shell name="welcome" call_as="TestPluginTwo.welcome" provider="TestPluginTwo" help="TestPluginTwo.welcome -h"';
         $this->assertContains($find, $output);
+    }
+
+    /**
+     * test that main prints the cakephp's version.
+     *
+     * @return void
+     */
+    public function testMainVersion()
+    {
+        $this->Shell->params['version'] = true;
+        $this->Shell->main();
+        $output = $this->out->messages();
+        $output = implode("\n", $output);
+
+        $expected = Configure::version();
+        $this->assertEquals($expected, $output);
     }
 }


### PR DESCRIPTION
Add `--version` parameter CommandList shell.
It prints the current version of CakePHP.

Add `--version` and `version` parameter to ShellDispatcher.
It performs an internal dispatch to CommandList shell.

See #8891.
