### PR TITLE
Optimize Hash::extract() for simple cases.

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -139,6 +139,9 @@ class Hash
         }
 
         if (strpos($path, '[') === false) {
+            if (is_array($data) && preg_match('|^\{n\}\.(\w+)$|', $path, $matches)) {
+                return array_column($data, $matches[1]);
+            }
             $tokens = explode('.', $path);
         } else {
             $tokens = Text::tokenize($path, '.', '[', ']');


### PR DESCRIPTION
When extracting simple dot paths from arrays use a more efficient approach.

ping @ADmad @jrbasso 

Refs #7541
