### PR TITLE
Adding a _matchedRoute request param for debugging purposes

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -325,6 +325,8 @@ class Route
                 }
             }
         }
+
+        $route['_matchedRoute'] = $this->template;
         return $route;
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -701,7 +701,8 @@ class Router
             $params['bare'],
             $params['requested'],
             $params['return'],
-            $params['_Token']
+            $params['_Token'],
+            $params['_matchedRoute']
         );
         $params = array_merge($params, $pass);
         if (!empty($url)) {

--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -60,6 +60,9 @@ class RoutesShell extends Shell
                     break;
                 }
             }
+
+            unset($route['_matchedRoute']);
+
             $output = [
                 ['Route name', 'URI template', 'Defaults'],
                 [$name, $url, json_encode($route)]

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -242,13 +242,14 @@ class RouteTest extends TestCase
         $this->assertRegExp($result, '/posts/08/01/2007/title-of-post');
         $result = $route->parse('/posts/08/01/2007/title-of-post');
 
-        $this->assertEquals(count($result), 6);
+        $this->assertEquals(count($result), 7);
         $this->assertEquals($result['controller'], 'posts');
         $this->assertEquals($result['action'], 'view');
         $this->assertEquals($result['year'], '2007');
         $this->assertEquals($result['month'], '08');
         $this->assertEquals($result['day'], '01');
         $this->assertEquals($result['pass'][0], 'title-of-post');
+        $this->assertEquals($result['_matchedRoute'], '/posts/:month/:day/:year/*');
 
         $route = new Route(
             "/:extra/page/:slug/*",
@@ -780,6 +781,7 @@ class RouteTest extends TestCase
             'controller' => 'posts',
             'action' => 'display',
             'pass' => ['home'],
+            '_matchedRoute' => '/:controller'
         ];
         $this->assertEquals($expected, $result);
     }
@@ -801,6 +803,7 @@ class RouteTest extends TestCase
             'action' => 'index',
             'pass' => [],
             '_method' => 'POST',
+            '_matchedRoute' => '/sample'
         ];
         $this->assertEquals($expected, $route->parse('/sample'));
     }
@@ -826,6 +829,7 @@ class RouteTest extends TestCase
             'action' => 'index',
             'pass' => [],
             '_method' => ['PUT', 'POST'],
+            '_matchedRoute' => '/sample'
         ];
         $this->assertEquals($expected, $route->parse('/sample'));
     }
@@ -917,7 +921,12 @@ class RouteTest extends TestCase
         $this->assertNotEmpty($result);
 
         $result = $route->parse('/blog/other');
-        $expected = ['controller' => 'blog_posts', 'action' => 'other', 'pass' => []];
+        $expected = [
+            'controller' => 'blog_posts',
+            'action' => 'other',
+            'pass' => [],
+            '_matchedRoute' => '/blog/:action/*'
+        ];
         $this->assertEquals($expected, $result);
 
         $result = $route->parse('/blog/foobar');
@@ -937,6 +946,7 @@ class RouteTest extends TestCase
             'controller' => 'posts',
             'action' => 'edit',
             'pass' => ['1', '2', '0'],
+            '_matchedRoute' => '/:controller/:action/*'
         ];
         $this->assertEquals($expected, $result);
     }
@@ -994,6 +1004,7 @@ class RouteTest extends TestCase
             'action' => 'view',
             'slug' => 'my-title',
             'pass' => ['my-title'],
+            '_matchedRoute' => '/:controller/:action/:slug'
         ];
         $this->assertEquals($expected, $result, 'Slug should have moved');
     }
@@ -1011,6 +1022,7 @@ class RouteTest extends TestCase
             'controller' => 'posts',
             'action' => 'index',
             'pass' => ['1/2/3/foo:bar'],
+            '_matchedRoute' => '/:controller/:action/**',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1019,6 +1031,7 @@ class RouteTest extends TestCase
             'controller' => 'posts',
             'action' => 'index',
             'pass' => ['http://example.com'],
+            '_matchedRoute' => '/:controller/:action/**',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1036,6 +1049,7 @@ class RouteTest extends TestCase
             'controller' => 'categories',
             'action' => 'index',
             'pass' => ['موبایل'],
+            '_matchedRoute' => '/category/**',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1138,11 +1152,25 @@ class RouteTest extends TestCase
         );
 
         $result = $route->parse('/%D8%A2%D9%85%D9%88%D8%B2%D8%B4');
-        $expected = ['section' => 'آموزش', 'plugin' => 'blogs', 'controller' => 'posts', 'action' => 'index', 'pass' => []];
+        $expected = [
+            'section' => 'آموزش',
+            'plugin' => 'blogs',
+            'controller' => 'posts',
+            'action' => 'index',
+            'pass' => [],
+            '_matchedRoute' => '/:section',
+        ];
         $this->assertEquals($expected, $result);
 
         $result = $route->parse('/weblog');
-        $expected = ['section' => 'weblog', 'plugin' => 'blogs', 'controller' => 'posts', 'action' => 'index', 'pass' => []];
+        $expected = [
+            'section' => 'weblog',
+            'plugin' => 'blogs',
+            'controller' => 'posts',
+            'action' => 'index',
+            'pass' => [],
+            '_matchedRoute' => '/:section',
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -1191,7 +1219,12 @@ class RouteTest extends TestCase
         $this->assertInstanceOf('Cake\Routing\Route\Route', $route);
         $this->assertSame('/', $route->match(['controller' => 'pages', 'action' => 'display', 'home']));
         $this->assertFalse($route->match(['controller' => 'pages', 'action' => 'display', 'about']));
-        $expected = ['controller' => 'pages', 'action' => 'display', 'pass' => ['home']];
+        $expected = [
+            'controller' => 'pages',
+            'action' => 'display',
+            'pass' => ['home'],
+            '_matchedRoute' => '/',
+        ];
         $this->assertEquals($expected, $route->parse('/'));
     }
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -158,7 +158,13 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/articles', ['controller' => 'Articles']);
         $routes->connect('/', ['action' => 'index']);
 
-        $expected = ['plugin' => null, 'controller' => 'Articles', 'action' => 'index', 'pass' => []];
+        $expected = [
+            'plugin' => null,
+            'controller' => 'Articles',
+            'action' => 'index',
+            'pass' => [],
+            '_matchedRoute' => '/articles',
+        ];
         $this->assertEquals($expected, $this->collection->parse('/articles'));
         $this->assertEquals($expected, $this->collection->parse('/articles/'));
     }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -68,6 +68,7 @@ class RouteCollectionTest extends TestCase
             'pass' => [],
             'plugin' => null,
             'key' => 'value',
+            '_matchedRoute' => '/b',
         ];
         $this->assertEquals($expected, $result);
 
@@ -80,6 +81,7 @@ class RouteCollectionTest extends TestCase
             'plugin' => null,
             'key' => 'value',
             '?' => ['one' => 'two'],
+            '_matchedRoute' => '/b/:id',
         ];
         $this->assertEquals($expected, $result);
 
@@ -89,7 +91,8 @@ class RouteCollectionTest extends TestCase
             'pass' => [],
             'plugin' => null,
             'controller' => 'Media',
-            'action' => 'search'
+            'action' => 'search',
+            '_matchedRoute' => '/b/media/search/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -99,7 +102,8 @@ class RouteCollectionTest extends TestCase
             'pass' => ['thing'],
             'plugin' => null,
             'controller' => 'Media',
-            'action' => 'search'
+            'action' => 'search',
+            '_matchedRoute' => '/b/media/search/*',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -121,9 +125,10 @@ class RouteCollectionTest extends TestCase
             'plugin' => null,
             'controller' => 'Events',
             'action' => 'index',
-            'day' => 15,
+            'day' => '15',
             'month' => 'октомври',
             '?' => ['test' => 'foo'],
+            '_matchedRoute' => '/ден/:day-:month',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -146,7 +151,9 @@ class RouteCollectionTest extends TestCase
             'controller' => 'Articles',
             'action' => 'add',
             'plugin' => null,
-            'pass' => []
+            'pass' => [],
+            '_matchedRoute' => '/:controller/:action',
+
         ];
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -143,6 +143,7 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             '_method' => 'GET',
+            '_matchedRoute' => '/posts',
         ];
         $result = Router::parse('/posts');
         $this->assertEquals($expected, $result);
@@ -155,6 +156,7 @@ class RouterTest extends TestCase
             'action' => 'view',
             'id' => '13',
             '_method' => 'GET',
+            '_matchedRoute' => '/posts/:id',
         ];
         $result = Router::parse('/posts/13');
         $this->assertEquals($expected, $result);
@@ -166,6 +168,7 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'add',
             '_method' => 'POST',
+            '_matchedRoute' => '/posts',
         ];
         $result = Router::parse('/posts');
         $this->assertEquals($expected, $result);
@@ -178,6 +181,7 @@ class RouterTest extends TestCase
             'action' => 'edit',
             'id' => '13',
             '_method' => ['PUT', 'PATCH'],
+            '_matchedRoute' => '/posts/:id',
         ];
         $result = Router::parse('/posts/13');
         $this->assertEquals($expected, $result);
@@ -189,6 +193,7 @@ class RouterTest extends TestCase
             'action' => 'edit',
             'id' => '475acc39-a328-44d3-95fb-015000000000',
             '_method' => ['PUT', 'PATCH'],
+            '_matchedRoute' => '/posts/:id',
         ];
         $result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
         $this->assertEquals($expected, $result);
@@ -201,6 +206,7 @@ class RouterTest extends TestCase
             'action' => 'delete',
             'id' => '13',
             '_method' => 'DELETE',
+            '_matchedRoute' => '/posts/:id',
         ];
         $result = Router::parse('/posts/13');
         $this->assertEquals($expected, $result);
@@ -216,6 +222,7 @@ class RouterTest extends TestCase
             'action' => 'view',
             'id' => 'add',
             '_method' => 'GET',
+            '_matchedRoute' => '/posts/:id',
         ];
         $result = Router::parse('/posts/add');
         $this->assertEquals($expected, $result);
@@ -228,6 +235,7 @@ class RouterTest extends TestCase
             'action' => 'edit',
             'id' => 'name',
             '_method' => ['PUT', 'PATCH'],
+            '_matchedRoute' => '/posts/:id',
         ];
         $result = Router::parse('/posts/name');
         $this->assertEquals($expected, $result);
@@ -250,6 +258,7 @@ class RouterTest extends TestCase
             'controller' => 'TestPlugin',
             'action' => 'index',
             '_method' => 'GET',
+            '_matchedRoute' => '/test_plugin/test_plugin',
         ];
         $this->assertEquals($expected, $result);
 
@@ -262,6 +271,7 @@ class RouterTest extends TestCase
             'action' => 'view',
             'id' => '13',
             '_method' => 'GET',
+            '_matchedRoute' => '/test_plugin/test_plugin/:id',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -285,6 +295,7 @@ class RouterTest extends TestCase
             'pass' => [],
             'prefix' => 'api',
             '_method' => 'GET',
+            '_matchedRoute' => '/api/posts',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -307,6 +318,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             'pass' => [],
             '_method' => 'GET',
+            '_matchedRoute' => '/posts',
         ];
 
         $result = Router::parse('/posts');
@@ -356,6 +368,7 @@ class RouterTest extends TestCase
             'prefix' => 'api',
             'action' => 'index',
             '_method' => 'GET',
+            '_matchedRoute' => '/api/test_plugin/test_plugin',
         ];
         $this->assertEquals($expected, $result);
 
@@ -370,6 +383,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             '_method' => 'GET',
             'prefix' => 'api',
+            '_matchedRoute' => '/api/posts',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -390,7 +404,8 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'posts',
             'action' => 'index',
-            '_method' => ['GET', 'POST']
+            '_method' => ['GET', 'POST'],
+            '_matchedRoute' => '/:controller',
         ];
         $this->assertEquals($expected, $result);
 
@@ -401,7 +416,8 @@ class RouterTest extends TestCase
             'plugin' => null,
             'controller' => 'posts',
             'action' => 'index',
-            '_method' => ['GET', 'POST']
+            '_method' => ['GET', 'POST'],
+            '_matchedRoute' => '/:controller',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -574,6 +590,7 @@ class RouterTest extends TestCase
             'controller' => 'categories',
             'action' => 'index',
             'pass' => ['0'],
+            '_matchedRoute' => '/*',
         ];
         $result = Router::parse('/0');
         $this->assertEquals($expected, $result);
@@ -1318,7 +1335,8 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'view',
             'plugin' => null,
-            'pass' => ['0' => 'title-of-post-here']
+            'pass' => ['0' => 'title-of-post-here'],
+            '_matchedRoute' => '/posts/:value/:somevalue/:othervalue/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1336,7 +1354,8 @@ class RouterTest extends TestCase
             'controller' => 'posts',
             'action' => 'view',
             'plugin' => null,
-            'pass' => ['0' => 'title-of-post-here']
+            'pass' => ['0' => 'title-of-post-here'],
+            '_matchedRoute' => '/posts/:year/:month/:day/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1354,7 +1373,8 @@ class RouterTest extends TestCase
             'controller' => 'posts',
             'action' => 'view',
             'plugin' => null,
-            'pass' => ['0' => 'title-of-post-here']
+            'pass' => ['0' => 'title-of-post-here'],
+            '_matchedRoute' => '/posts/:day/:year/:month/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1372,7 +1392,8 @@ class RouterTest extends TestCase
             'controller' => 'posts',
             'action' => 'view',
             'plugin' => null,
-            'pass' => ['0' => 'title-of-post-here']
+            'pass' => ['0' => 'title-of-post-here'],
+            '_matchedRoute' => '/posts/:month/:day/:year/*'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1389,7 +1410,8 @@ class RouterTest extends TestCase
             'controller' => 'posts',
             'action' => 'view',
             'plugin' => null,
-            'pass' => ['0' => 'title-of-post-here']
+            'pass' => ['0' => 'title-of-post-here'],
+            '_matchedRoute' => '/posts/:year/:month/:day/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1400,7 +1422,8 @@ class RouterTest extends TestCase
             'plugin' => null,
             'pass' => ['home'],
             'controller' => 'Pages',
-            'action' => 'display'
+            'action' => 'display',
+            '_matchedRoute' => '/:controller/:action/*',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1413,7 +1436,13 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/page/*', ['controller' => 'test']);
         $result = Router::parse('/page/my-page');
-        $expected = ['pass' => ['my-page'], 'plugin' => null, 'controller' => 'test', 'action' => 'index'];
+        $expected = [
+            'pass' => ['my-page'],
+            'plugin' => null,
+            'controller' => 'test',
+            'action' => 'index',
+            '_matchedRoute' => '/page/*',
+        ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
@@ -1428,7 +1457,8 @@ class RouterTest extends TestCase
             'language' => 'eng',
             'plugin' => 'contact',
             'controller' => 'contact',
-            'action' => 'index'
+            'action' => 'index',
+            '_matchedRoute' => '/:language/contact',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1446,7 +1476,8 @@ class RouterTest extends TestCase
             'controller' => 'shows',
             'action' => 'calendar',
             'year' => 2007,
-            'month' => 10
+            'month' => 10,
+            '_matchedRoute' => '/forestillinger/:month/:year/*'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1454,11 +1485,23 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
         Router::connect('/', ['plugin' => 'pages', 'controller' => 'pages', 'action' => 'display']);
         $result = Router::parse('/');
-        $expected = ['pass' => [], 'controller' => 'pages', 'action' => 'display', 'plugin' => 'pages'];
+        $expected = [
+            'pass' => [],
+            'controller' => 'pages',
+            'action' => 'display',
+            'plugin' => 'pages',
+            '_matchedRoute' => '/',
+        ];
         $this->assertEquals($expected, $result);
 
         $result = Router::parse('/posts/edit/0');
-        $expected = ['pass' => [0], 'controller' => 'posts', 'action' => 'edit', 'plugin' => null];
+        $expected = [
+            'pass' => [0],
+            'controller' => 'posts',
+            'action' => 'edit',
+            'plugin' => null,
+            '_matchedRoute' => '/:controller/:action/*',
+        ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
@@ -1474,7 +1517,8 @@ class RouterTest extends TestCase
             'url_title' => 'sample-post-title',
             'plugin' => null,
             'controller' => 'posts',
-            'action' => 'view'
+            'action' => 'view',
+            '_matchedRoute' => '/posts/:id::url_title',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1491,14 +1535,22 @@ class RouterTest extends TestCase
             'url_title' => 'sample-post-title',
             'plugin' => null,
             'controller' => 'posts',
-            'action' => 'view'
+            'action' => 'view',
+            '_matchedRoute' => '/posts/:id::url_title/*',
         ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect('/posts/view/*', ['controller' => 'posts', 'action' => 'view']);
         $result = Router::parse('/posts/view/10?id=123&tab=abc');
-        $expected = ['pass' => [10], 'plugin' => null, 'controller' => 'posts', 'action' => 'view', '?' => ['id' => '123', 'tab' => 'abc']];
+        $expected = [
+            'pass' => [10],
+            'plugin' => null,
+            'controller' => 'posts',
+            'action' => 'view',
+            '?' => ['id' => '123', 'tab' => 'abc'],
+            '_matchedRoute' => '/posts/view/*',
+        ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
@@ -1514,7 +1566,8 @@ class RouterTest extends TestCase
             'url_title' => 'sample-post-title',
             'plugin' => null,
             'controller' => 'posts',
-            'action' => 'view'
+            'action' => 'view',
+            '_matchedRoute' => '/posts/:url_title-(uuid::id)',
         ];
         $this->assertEquals($expected, $result);
 
@@ -1525,7 +1578,8 @@ class RouterTest extends TestCase
             'pass' => ['foo:bar', 'routing:fun'],
             'plugin' => null,
             'controller' => 'posts',
-            'action' => 'view'
+            'action' => 'view',
+            '_matchedRoute' => '/posts/view/*',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1548,7 +1602,8 @@ class RouterTest extends TestCase
             'category_id' => '4795d601-19c8-49a6-930e-06a8b01d17b7',
             'plugin' => null,
             'controller' => 'subjects',
-            'action' => 'add'
+            'action' => 'add',
+            '_matchedRoute' => '/subjects/add/:category_id'
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1573,7 +1628,8 @@ class RouterTest extends TestCase
             'controller' => 'pages',
             'action' => 'view',
             'slug' => 'this_is_the_slug',
-            'extra' => 'some_extra'
+            'extra' => 'some_extra',
+            '_matchedRoute' => '/:extra/page/:slug/*'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1584,7 +1640,8 @@ class RouterTest extends TestCase
             'controller' => 'pages',
             'action' => 'view',
             'slug' => 'this_is_the_slug',
-            'extra' => null
+            'extra' => null,
+            '_matchedRoute' => '/:extra/page/:slug/*'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1746,7 +1803,8 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             '_ext' => 'rss',
-            'pass' => []
+            'pass' => [],
+            '_matchedRoute' => '/:controller'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1756,7 +1814,8 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'view',
             'pass' => ['1'],
-            '_ext' => 'rss'
+            '_ext' => 'rss',
+            '_matchedRoute' => '/:controller/:action/*'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1774,7 +1833,8 @@ class RouterTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             '_ext' => 'xml',
-            'pass' => []
+            'pass' => [],
+            '_matchedRoute' => '/:controller'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1784,14 +1844,9 @@ class RouterTest extends TestCase
             'controller' => 'Posts.atom',
             'action' => 'index',
             'pass' => [],
-            '?' => ['hello' => 'goodbye']
+            '?' => ['hello' => 'goodbye'],
+            '_matchedRoute' => '/:controller'
         ];
-        $this->assertEquals($expected, $result);
-
-        Router::reload();
-        Router::connect('/controller/action', ['controller' => 'controller', 'action' => 'action', '_ext' => 'rss']);
-        $result = Router::parse('/controller/action');
-        $expected = ['controller' => 'controller', 'action' => 'action', 'plugin' => null, '_ext' => 'rss', 'pass' => []];
         $this->assertEquals($expected, $result);
 
         Router::reload();
@@ -1802,7 +1857,21 @@ class RouterTest extends TestCase
             'action' => 'action',
             'plugin' => null,
             '_ext' => 'rss',
-            'pass' => []
+            'pass' => [],
+            '_matchedRoute' => '/controller/action'
+        ];
+        $this->assertEquals($expected, $result);
+
+        Router::reload();
+        Router::connect('/controller/action', ['controller' => 'controller', 'action' => 'action', '_ext' => 'rss']);
+        $result = Router::parse('/controller/action');
+        $expected = [
+            'controller' => 'controller',
+            'action' => 'action',
+            'plugin' => null,
+            '_ext' => 'rss',
+            'pass' => [],
+            '_matchedRoute' => '/controller/action'
         ];
         $this->assertEquals($expected, $result);
 
@@ -1815,7 +1884,8 @@ class RouterTest extends TestCase
             'action' => 'action',
             'plugin' => null,
             '_ext' => 'rss',
-            'pass' => []
+            'pass' => [],
+            '_matchedRoute' => '/controller/action'
         ];
         $this->assertEquals($expected, $result);
     }
@@ -2098,18 +2168,36 @@ class RouterTest extends TestCase
         Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
 
         $result = Router::parse('/');
-        $expected = ['pass' => ['home'], 'plugin' => null, 'controller' => 'pages', 'action' => 'display'];
+        $expected = [
+            'pass' => ['home'],
+            'plugin' => null,
+            'controller' => 'pages',
+            'action' => 'display',
+            '_matchedRoute' => '/'
+        ];
         $this->assertEquals($expected, $result);
 
         $result = Router::parse('/pages/home/');
-        $expected = ['pass' => ['home'], 'plugin' => null, 'controller' => 'pages', 'action' => 'display'];
+        $expected = [
+            'pass' => ['home'],
+            'plugin' => null,
+            'controller' => 'pages',
+            'action' => 'display',
+            '_matchedRoute' => '/pages/*'
+        ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
 
         $result = Router::parse('/');
-        $expected = ['pass' => ['home'], 'plugin' => null, 'controller' => 'pages', 'action' => 'display'];
+        $expected = [
+            'pass' => ['home'],
+            'plugin' => null,
+            'controller' => 'pages',
+            'action' => 'display',
+            '_matchedRoute' => '/'
+        ];
         $this->assertEquals($expected, $result);
 
         Router::reload();
@@ -2117,7 +2205,13 @@ class RouterTest extends TestCase
         Router::connect('/pages/*', ['controller' => 'pages', 'action' => 'display']);
         $result = Router::parse('/pages/contact/');
 
-        $expected = ['pass' => ['contact'], 'plugin' => null, 'controller' => 'pages', 'action' => 'display'];
+        $expected = [
+            'pass' => ['contact'],
+            'plugin' => null,
+            'controller' => 'pages',
+            'action' => 'display',
+            '_matchedRoute' => '/pages/*'
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -2175,6 +2269,7 @@ class RouterTest extends TestCase
             'controller' => 'blog_posts',
             'action' => 'other',
             'pass' => [],
+            '_matchedRoute' => '/blog/:action/*'
         ];
         $this->assertEquals($expected, $result);
 
@@ -2226,7 +2321,14 @@ class RouterTest extends TestCase
         );
 
         $result = Router::parse('/admin/posts/');
-        $expected = ['pass' => [], 'prefix' => 'admin', 'plugin' => null, 'controller' => 'posts', 'action' => 'index'];
+        $expected = [
+            'pass' => [],
+            'prefix' => 'admin',
+            'plugin' => null,
+            'controller' => 'posts',
+            'action' => 'index',
+            '_matchedRoute' => '/admin/:controller'
+        ];
         $this->assertEquals($expected, $result);
 
         $result = Router::parse('/admin/posts');
@@ -2255,7 +2357,14 @@ class RouterTest extends TestCase
         );
 
         $result = Router::parse('/members/posts/index');
-        $expected = ['pass' => [], 'prefix' => 'members', 'plugin' => null, 'controller' => 'posts', 'action' => 'index'];
+        $expected = [
+            'pass' => [],
+            'prefix' => 'members',
+            'plugin' => null,
+            'controller' => 'posts',
+            'action' => 'index',
+            '_matchedRoute' => '/members/:controller/:action'
+        ];
         $this->assertEquals($expected, $result);
 
         $result = Router::url(['prefix' => 'members', 'controller' => 'users', 'action' => 'add']);
@@ -2359,7 +2468,14 @@ class RouterTest extends TestCase
         Router::connect('/:locale/:controller/:action/*', [], ['locale' => 'dan|eng']);
 
         $result = Router::parse('/eng/test/test_action');
-        $expected = ['pass' => [], 'locale' => 'eng', 'controller' => 'test', 'action' => 'test_action', 'plugin' => null];
+        $expected = [
+            'pass' => [],
+            'locale' => 'eng',
+            'controller' => 'test',
+            'action' => 'test_action',
+            'plugin' => null,
+            '_matchedRoute' => '/:locale/:controller/:action/*'
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -2428,6 +2544,7 @@ class RouterTest extends TestCase
             'action' => 'index',
             'slug' => 'the-best',
             'pass' => [],
+            '_matchedRoute' => '/:slug',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -2728,7 +2845,12 @@ class RouterTest extends TestCase
         $this->assertEquals('/blog/actions/', $result);
 
         $result = $route->parse('/blog/other');
-        $expected = ['controller' => 'blog_posts', 'action' => 'other', 'pass' => []];
+        $expected = [
+            'controller' => 'blog_posts',
+            'action' => 'other',
+            'pass' => [],
+            '_matchedRoute' => '/blog/:action/*',
+        ];
         $this->assertEquals($expected, $result);
 
         $result = $route->parse('/blog/foobar');


### PR DESCRIPTION
This will be used in debug kit to show the route that was matched for the request
