### PR TITLE
Add allowPartialNulls-flag to ExistsIn() that matches SQLs behavior of composite foreign keys having some nullable nulls

### DIFF
--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -129,7 +129,7 @@ class ExistsIn
     }
 
     /**
-     * Check whether or not the entity fields are nullable and null.
+     * Checks whether or not the given entity fields are nullable and null.
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity to check.
      * @param \Cake\ORM\Table $source The table to use schema from.
@@ -148,7 +148,8 @@ class ExistsIn
     }
 
     /**
-     * Check whether there are nullable nulls in at least one part of the foreign key.
+     * Checks whether or not the give entity fields are null and map to schema NULL
+     * or are not null and map to schema NOT NULL.
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity to check.
      * @param \Cake\ORM\Table $source The table to use schema from.
@@ -158,10 +159,15 @@ class ExistsIn
     {
         $schema = $source->schema();
         foreach ($this->_fields as $field) {
-            if ($schema->isNullable($field) && $entity->get($field) === null) {
-                return true;
+            $isNullable = $schema->isNullable($field);
+            $value = $entity->get($field);
+            if (!$isNullable && $value === null) {
+                return false;
+            }
+            if ($isNullable && $value !== null) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 }

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -160,7 +160,7 @@ class ExistsIn
     {
         $schema = $source->schema();
         foreach ($this->_fields as $field) {
-            if ($schema->isNullable($field) === true && $entity->get($field) === null) {
+            if ($schema->isNullable($field) && $entity->get($field) === null) {
                 return true;
             }
         }

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -50,7 +50,7 @@ class ExistsIn
      * Constructor.
      *
      * Available option for $options is 'allowPartialNulls' flag.
-     * Set to true to accept composite foreign keys where one or more nullable columns are null.'
+     * Set to true to accept composite foreign keys where one or more nullable columns are null.
      *
      * @param string|array $fields The field or fields to check existence as primary key.
      * @param object|string $repository The repository where the field will be looked for,

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -110,9 +110,7 @@ class ExistsIn
             return true;
         }
 
-        if ($this->_options['allowPartialNulls'] === true
-            && $this->_checkPartialSchemaNulls($entity, $source) === true
-        ) {
+        if ($this->_options['allowPartialNulls'] && $this->_checkPartialSchemaNulls($entity, $source)) {
             return true;
         }
         if ($this->_fieldsAreNull($entity, $source)) {

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -78,18 +78,18 @@ class RulesChecker extends BaseRulesChecker
      * @param string|array $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param object|string $table The table name where the fields existence will be checked.
-     * @param array|string|null $options List of options or error message string to show in case the rule does not pass.
+     * @param @param string|array|null $message The error message to show in case the rule does not pass. Can
+     *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return callable
      */
-    public function existsIn($field, $table, $options = null)
+    public function existsIn($field, $table, $message = null)
     {
-        if (is_string($options)) {
-            $options = ['message' => $options];
+        $options = [];
+        if (is_array($message)) {
+            $options = $message + ['message' => null];
+            $message = $options['message'];
+            unset($options['message']);
         }
-
-        $options = (array)$options + ['message' => null];
-        $message = $options['message'];
-        unset($options['message']);
 
         if (!$message) {
             if ($this->_useI18n) {

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -71,14 +71,26 @@ class RulesChecker extends BaseRulesChecker
      * $rules->add($rules->existsIn('site_id', new SitesTable(), 'Invalid Site'));
      * ```
      *
+     * Available $options are error 'message' and 'allowPartialNulls' flag.
+     * 'message' sets a custom error message.
+     * Set 'allowPartialNulls' to true to accept composite foreign keys where one or more nullable columns are null.'
+     *
      * @param string|array $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param object|string $table The table name where the fields existence will be checked.
-     * @param string|null $message The error message to show in case the rule does not pass.
+     * @param array|string|null $options List of options or error message string to show in case the rule does not pass.
      * @return callable
      */
-    public function existsIn($field, $table, $message = null)
+    public function existsIn($field, $table, $options = null)
     {
+        if (is_string($options)) {
+            $options = ['message' => $options];
+        }
+
+        $options = (array)$options + ['message' => null];
+        $message = $options['message'];
+        unset($options['message']);
+
         if (!$message) {
             if ($this->_useI18n) {
                 $message = __d('cake', 'This value does not exist');
@@ -88,7 +100,7 @@ class RulesChecker extends BaseRulesChecker
         }
 
         $errorField = is_string($field) ? $field : current($field);
-        return $this->_addError(new ExistsIn($field, $table), '_existsIn', compact('errorField', 'message'));
+        return $this->_addError(new ExistsIn($field, $table, $options), '_existsIn', compact('errorField', 'message'));
     }
 
     /**

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -73,12 +73,12 @@ class RulesChecker extends BaseRulesChecker
      *
      * Available $options are error 'message' and 'allowPartialNulls' flag.
      * 'message' sets a custom error message.
-     * Set 'allowPartialNulls' to true to accept composite foreign keys where one or more nullable columns are null.'
+     * Set 'allowPartialNulls' to true to accept composite foreign keys where one or more nullable columns are null.
      *
      * @param string|array $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param object|string $table The table name where the fields existence will be checked.
-     * @param @param string|array|null $message The error message to show in case the rule does not pass. Can
+     * @param string|array|null $message The error message to show in case the rule does not pass. Can
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return callable
      */

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -1025,7 +1025,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
             'allowPartialNulls' => true,
-            'message' => 'will not occur']));
+            'message' => 'will not error']));
         $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
     }
 
@@ -1034,7 +1034,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowPartialNullsWithAuthorId1G()
+    public function testExistsInAllowPartialNullsWithAuthorId1F()
     {
         $entity = new Entity([
             'id' => 10,
@@ -1048,8 +1048,82 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
             'allowPartialNulls' => false,
-            'message' => 'will not occur']));
+            'message' => 'will not error']));
         $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 99999999 (does not exist)
+     *
+     * @return
+     */
+    public function testExistsInAllowPartialNullsWithAuthorId1G()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => true,
+            'message' => 'will error']));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'will error']], $entity->errors());
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 99999999 (does not exist)
+     * and site_id set to 99999999 (does not exist)
+     *
+     * @return
+     */
+    public function testExistsInAllowPartialNullsWithAuthorId1H()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 99999999,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => true,
+            'message' => 'will error']));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'will error']], $entity->errors());
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 1 (does exist)
+     * and site_id set to 99999999 (does not exist)
+     *
+     * @return
+     */
+    public function testExistsInAllowPartialNullsWithAuthorId1I()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 99999999,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => true,
+            'message' => 'will error']));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'will error']], $entity->errors());
     }
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -832,7 +832,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdNullA()
+    public function testExistsInAllowPartialNullsWithAuthorIdNullA()
     {
         $entity = new Entity([
             'id' => 10,
@@ -855,7 +855,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdNullB()
+    public function testExistsInAllowPartialNullsWithAuthorIdNullB()
     {
         $entity = new Entity([
             'id' => 10,
@@ -878,7 +878,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdNullC()
+    public function testExistsInAllowPartialNullsWithAuthorIdNullC()
     {
         $entity = new Entity([
             'id' => 10,
@@ -899,7 +899,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdNullD()
+    public function testExistsInAllowPartialNullsWithAuthorIdNullD()
     {
         $entity = new Entity([
             'id' => 10,
@@ -924,7 +924,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdNullE()
+    public function testExistsInAllowPartialNullsWithAuthorIdNullE()
     {
         $entity = new Entity([
             'id' => 10,
@@ -948,7 +948,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentId1A()
+    public function testExistsInAllowPartialNullsWithAuthorId1A()
     {
         $entity = new Entity([
             'id' => 10,
@@ -969,7 +969,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdB()
+    public function testExistsInAllowPartialNullsWithAuthorIdB()
     {
         $entity = new Entity([
             'id' => 10,
@@ -990,7 +990,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentId1C()
+    public function testExistsInAllowPartialNullsWithAuthorId1C()
     {
         $entity = new Entity([
             'id' => 10,
@@ -1011,7 +1011,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentId1E()
+    public function testExistsInAllowPartialNullsWithAuthorId1E()
     {
         $entity = new Entity([
             'id' => 10,
@@ -1034,7 +1034,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentId1G()
+    public function testExistsInAllowPartialNullsWithAuthorId1G()
     {
         $entity = new Entity([
             'id' => 10,

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -832,7 +832,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentIdNull()
+    public function testExistsInAllowSqlNullsWithParentIdNullA()
     {
         $entity = new Entity([
             'id' => 10,
@@ -844,14 +844,103 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->belongsTo('SiteAuthors');
         $rules = $table->rulesChecker();
 
-        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', ['allowPartialNulls' => true]));
-        $this->assertInstanceOf('Cake\ORM\Entity', $table->save(clone $entity));
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => true
+        ]));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
+    }
 
-        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', ['allowPartialNulls' => false]));
-        $this->assertFalse($table->save(clone $entity));
+    /**
+     * Tests new allowPartialNulls flag with author id set to null
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentIdNullB()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => false
+        ]));
+        $this->assertFalse($table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to null
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentIdNullC()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors'));
-        $this->assertFalse($table->save(clone $entity));
+        $this->assertFalse($table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to null
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentIdNullD()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => false,
+            'message' => 'Niente'
+        ]));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'Niente']], $entity->errors());
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to null
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentIdNullE()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => true,
+            'message' => 'Niente'
+        ]));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
     }
 
     /**
@@ -859,7 +948,7 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * @return
      */
-    public function testExistsInAllowSqlNullsWithParentId1()
+    public function testExistsInAllowSqlNullsWithParentId1A()
     {
         $entity = new Entity([
             'id' => 10,
@@ -872,13 +961,95 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', ['allowPartialNulls' => true]));
-        $this->assertInstanceOf('Cake\ORM\Entity', $table->save(clone $entity));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 1
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentIdB()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', ['allowPartialNulls' => false]));
-        $this->assertInstanceOf('Cake\ORM\Entity', $table->save(clone $entity));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 1
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentId1C()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors'));
-        $this->assertInstanceOf('Cake\ORM\Entity', $table->save(clone $entity));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 1
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentId1E()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => true,
+            'message' => 'will not occur']));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
+    }
+
+    /**
+     * Tests new allowPartialNulls flag with author id set to 1
+     *
+     * @return
+     */
+    public function testExistsInAllowSqlNullsWithParentId1G()
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = TableRegistry::get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowPartialNulls' => false,
+            'message' => 'will not occur']));
+        $this->assertInstanceOf('Cake\ORM\Entity', $table->save($entity));
     }
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -32,7 +32,7 @@ class RulesCheckerIntegrationTest extends TestCase
      */
     public $fixtures = [
         'core.articles', 'core.articles_tags', 'core.authors', 'core.tags',
-        'core.special_tags', 'core.categories', 'core.site_articles', 'core.site_authors'    
+        'core.special_tags', 'core.categories', 'core.site_articles', 'core.site_authors'
     ];
 
     /**


### PR DESCRIPTION
Set `'allowPartialNulls'` to `true` to accept composite foreign keys where one or more nullable columns are null.

This Retargets #8903 / #8897 to `3.next` - in a clean way.
