### PR TITLE
Ensure the app is always last in the middleware stack.

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -82,7 +82,7 @@ abstract class BaseApplication
         $cakeResponse = $this->getDispatcher()->dispatch($cakeRequest, $cakeResponse);
 
         // Convert the response back into a PSR7 object.
-        return $next($request, ResponseTransformer::toPsr($cakeResponse));
+        return ResponseTransformer::toPsr($cakeResponse);
     }
 
     /**

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -77,8 +77,8 @@ class Server
         if (!($middleware instanceof MiddlewareStack)) {
             throw new RuntimeException('The application `middleware` method did not return a middleware stack.');
         }
-        $middleware->push($this->app);
         $this->dispatchEvent('Server.buildMiddleware', ['middleware' => $middleware]);
+        $middleware->push($this->app);
         $response = $this->runner->run($middleware, $request, $response);
 
         if (!($response instanceof ResponseInterface)) {

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -191,7 +191,7 @@ class ServerTest extends TestCase
         });
         $server->run();
         $this->assertTrue($this->called, 'Middleware added in the event was not triggered.');
-        $this->assertInstanceOf('Closure', $this->middleware->get(3), '2nd last middleware is a clousure');
+        $this->assertInstanceOf('Closure', $this->middleware->get(3), '2nd last middleware is a closure');
         $this->assertSame($app, $this->middleware->get(4), 'Last middleware is an app instance');
     }
 }

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -179,12 +179,19 @@ class ServerTest extends TestCase
     {
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
-        $called = false;
-        $server->eventManager()->on('Server.buildMiddleware', function ($event, $middleware) use (&$called) {
-            $called = true;
+        $this->called = false;
+
+        $server->eventManager()->on('Server.buildMiddleware', function ($event, $middleware) {
             $this->assertInstanceOf('Cake\Http\MiddlewareStack', $middleware);
+            $middleware->push(function ($req, $res, $next) {
+                $this->called = true;
+                return $next($req, $res);
+            });
+            $this->middleware = $middleware;
         });
         $server->run();
-        $this->assertTrue($called, 'Event not triggered.');
+        $this->assertTrue($this->called, 'Middleware added in the event was not triggered.');
+        $this->assertInstanceOf('Closure', $this->middleware->get(3), '2nd last middleware is a clousure');
+        $this->assertSame($app, $this->middleware->get(4), 'Last middleware is an app instance');
     }
 }


### PR DESCRIPTION
By ensuring the app is always bound after the event, event listeners can be less careful. Without this plugins would always have to use `insertBefore()` which is kind of awkward.
