### PR TITLE
Raise an exception in insertBefore()

### DIFF
--- a/src/Http/MiddlewareStack.php
+++ b/src/Http/MiddlewareStack.php
@@ -15,6 +15,7 @@
 namespace Cake\Http;
 
 use Countable;
+use LogicException;
 
 /**
  * Provides methods for creating and manipulating a 'stack' of
@@ -108,7 +109,7 @@ class MiddlewareStack implements Countable
         if ($found) {
             return $this->insertAt($i, $callable);
         }
-        return $this->push($callable);
+        throw new LogicException(sprintf("No middleware matching '%s' could be found.", $class));
     }
 
     /**

--- a/tests/TestCase/Http/MiddlewareStackTest.php
+++ b/tests/TestCase/Http/MiddlewareStackTest.php
@@ -206,6 +206,8 @@ class MiddlewareStackTest extends TestCase
     /**
      * Test insertBefore an invalid classname
      *
+     * @expectedException LogicException
+     * @expectedExceptionMessage No middleware matching 'InvalidClassName' could be found.
      * @return void
      */
     public function testInsertBeforeInvalid()
@@ -217,11 +219,6 @@ class MiddlewareStackTest extends TestCase
         };
         $stack = new MiddlewareStack();
         $stack->push($one)->push($two)->insertBefore('InvalidClassName', $three);
-
-        $this->assertCount(3, $stack);
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($two, $stack->get(1));
-        $this->assertSame($three, $stack->get(2));
     }
 
     /**


### PR DESCRIPTION
Raise an exception When attempting to insertBefore an unknown middleware. Based on feedback in cakephp/docs#4023 this is what the reviewers felt was a more correct behavior.

Refs #6960 
