### PR TITLE
Default output timezone v3

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -17,6 +17,7 @@ namespace Cake\I18n;
 use Cake\Chronos\Date as ChronosDate;
 use Cake\Chronos\MutableDate;
 use IntlDateFormatter;
+use \NotImplementedException;
 
 /**
  * Trait for date formatting methods shared by both Time & Date.
@@ -35,7 +36,7 @@ trait DateFormatTrait
     public static $defaultLocale;
 
     /**
-     * The \DateTimeZone default output timezone.
+     * The \DateTimeZone default output timezone used by Time and FrozenTime.
      * See http://php.net/manual/en/timezones.php.
      *
      * @var \DateTimeZone|null
@@ -72,17 +73,20 @@ trait DateFormatTrait
      */
     protected static $_isDateInstance;
 
-    /** Gets the default output timezone.
+    /** Gets the default output timezone used by Time and FrozenTime.
      *
      * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null.
      */
     public static function getDefaultOutputTimezone()
     {
+        if (static::$_isDateInstance === true) {
+            throw new NotImplementedException('Timezone conversion is not supported by Date/FrozenDate.');
+        }
         return static::$_defaultOutputTimezone;
     }
 
     /**
-     * Sets the default output timezone.
+     * Sets the default output timezone used by Time and FrozenTime.
      *
      * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
      * in which the date will be displayed.
@@ -90,6 +94,9 @@ trait DateFormatTrait
      */
     public static function setDefaultOutputTimezone($timezone)
     {
+        if (static::$_isDateInstance === true) {
+            throw new NotImplementedException('Timezone conversion is not supported by Date/FrozenDate.');
+        }
         if (is_string($timezone)) {
             static::$_defaultOutputTimezone = new \DateTimeZone($timezone);
         } elseif ($timezone instanceof \DateTimeZone) {
@@ -192,10 +199,9 @@ trait DateFormatTrait
     {
         $time = $this;
 
-        // This is required for testI18nFormatWithOffsetTimezone to pass
-        // if ($time->getTimezone()->getName() === date_default_timezone_get()) {
+        if (static::$_isDateInstance === false) {
             $timezone = $timezone ?: static::getDefaultOutputTimezone();
-        // }
+        }
 
         if ($timezone) {
             // Handle the immutable and mutable object cases.

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -75,9 +75,11 @@ trait DateFormatTrait
      */
     protected static $_isDateInstance;
 
-    /** Gets the default output timezone used by Time and FrozenTime.
+    /**
+     * Gets the default output timezone used by Time and FrozenTime.
      *
      * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null.
+     * @throws \RuntimeException When being executed on Date/FrozenDate.
      */
     public static function getDefaultOutputTimezone()
     {
@@ -93,6 +95,8 @@ trait DateFormatTrait
      * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
      * in which the date will be displayed.
      * @return void
+     * @throws \RuntimeException When being executed on Date/FrozenDate.
+     * @throws \InvalidArgumentException When $timezone is neither a valid DateTimeZone string nor a \DateTimeZone object.
      */
     public static function setDefaultOutputTimezone($timezone)
     {

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -39,9 +39,9 @@ trait DateFormatTrait
 
     /**
      * The \DateTimeZone default output timezone used by Time and FrozenTime.
-     * See http://php.net/manual/en/timezones.php.
      *
      * @var \DateTimeZone|null
+     * @see http://php.net/manual/en/timezones.php
      */
     protected static $_defaultOutputTimezone;
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -206,16 +206,16 @@ trait DateFormatTrait
         $time = $this;
 
         if ($time instanceof Time || $time instanceof FrozenTime) {
-            // Remove before merge:
-            // if ((is_string($time->timezone) && $time->timezone === 'UTC')
-            //     || ($time->timezone instanceof \DateTimeZone && $time->timezone->getName() === '+0:00')
-            // ) {
-            // }
-            // if ($time->getOffset() !== 0) {
-            //     $time = clone $time;
-            //     $time->add(new \DateInterval('PT' . $time->getOffset() / 60 . 'M'));
-            // }
             $timezone = $timezone ?: static::getDefaultOutputTimezone();
+        }
+        // Detect and prevent null timezone transitions, as datefmt_create will
+        // doubly apply the TZ offset.
+        $currentTimezone = $time->getTimezone();
+        if ($timezone && (
+            (is_string($timezone) && $currentTimezone->getName() === $timezone) ||
+            ($timezone instanceof DateTimeZone && $currentTimezone->getName() === $timezone->getName())
+        )) {
+            $timezone = null;
         }
 
         if ($timezone) {

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -17,7 +17,9 @@ namespace Cake\I18n;
 use Cake\Chronos\Date as ChronosDate;
 use Cake\Chronos\MutableDate;
 use IntlDateFormatter;
-use \NotImplementedException;
+use \DateTimeZone;
+use \InvalidArgumentException;
+use \RuntimeException;
 
 /**
  * Trait for date formatting methods shared by both Time & Date.
@@ -79,8 +81,8 @@ trait DateFormatTrait
      */
     public static function getDefaultOutputTimezone()
     {
-        if (static::$_isDateInstance === true) {
-            throw new NotImplementedException('Timezone conversion is not supported by Date/FrozenDate.');
+        if (is_subclass_of(static::class, ChronosDate::class) || is_subclass_of(static::class, MutableDate::class)) {
+            throw new \RuntimeException('Timezone conversion is not supported by Date/FrozenDate.');
         }
         return static::$_defaultOutputTimezone;
     }
@@ -94,8 +96,8 @@ trait DateFormatTrait
      */
     public static function setDefaultOutputTimezone($timezone)
     {
-        if (static::$_isDateInstance === true) {
-            throw new NotImplementedException('Timezone conversion is not supported by Date/FrozenDate.');
+        if (is_subclass_of(static::class, ChronosDate::class) || is_subclass_of(static::class, MutableDate::class)) {
+            throw new \RuntimeException('Timezone conversion is not supported by Date/FrozenDate.');
         }
         if (is_string($timezone)) {
             static::$_defaultOutputTimezone = new \DateTimeZone($timezone);
@@ -199,13 +201,22 @@ trait DateFormatTrait
     {
         $time = $this;
 
-        if (static::$_isDateInstance === false) {
+        if ($time instanceof Time || $time instanceof FrozenTime) {
+            // Remove before merge:
+            // if ((is_string($time->timezone) && $time->timezone === 'UTC')
+            //     || ($time->timezone instanceof \DateTimeZone && $time->timezone->getName() === '+0:00')
+            // ) {
+            // }
+            // if ($time->getOffset() !== 0) {
+            //     $time = clone $time;
+            //     $time->add(new \DateInterval('PT' . $time->getOffset() / 60 . 'M'));
+            // }
             $timezone = $timezone ?: static::getDefaultOutputTimezone();
         }
 
         if ($timezone) {
             // Handle the immutable and mutable object cases.
-            $time = clone $this;
+            $time = clone $time;
             $time = $time->timezone($timezone);
         }
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -193,9 +193,9 @@ trait DateFormatTrait
         $time = $this;
 
         // This is required for testI18nFormatWithOffsetTimezone to pass
-        if ($time->getTimezone()->getName() === date_default_timezone_get()) {
+        // if ($time->getTimezone()->getName() === date_default_timezone_get()) {
             $timezone = $timezone ?: static::getDefaultOutputTimezone();
-        }
+        // }
 
         if ($timezone) {
             // Handle the immutable and mutable object cases.

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -35,6 +35,14 @@ trait DateFormatTrait
     public static $defaultLocale;
 
     /**
+     * The \DateTimeZone default output timezone.
+     * See http://php.net/manual/en/timezones.php.
+     *
+     * @var \DateTimeZone|null
+     */
+    protected static $_defaultOutputTimezone;
+
+    /**
      * In-memory cache of date formatters
      *
      * @var array
@@ -63,6 +71,33 @@ trait DateFormatTrait
      * @var boolean
      */
     protected static $_isDateInstance;
+
+    /** Gets the default output timezone.
+     *
+     * @return \DateTimeZone|null DateTimeZone object in which the date will be displayed or null.
+     */
+    public static function getDefaultOutputTimezone()
+    {
+        return static::$_defaultOutputTimezone;
+    }
+
+    /**
+     * Sets the default output timezone.
+     *
+     * @param string|\DateTimeZone $timezone Timezone string or DateTimeZone object
+     * in which the date will be displayed.
+     * @return void
+     */
+    public static function setDefaultOutputTimezone($timezone)
+    {
+        if (is_string($timezone)) {
+            static::$_defaultOutputTimezone = new \DateTimeZone($timezone);
+        } elseif ($timezone instanceof \DateTimeZone) {
+            static::$_defaultOutputTimezone = $timezone;
+        } else {
+            throw new \InvalidArgumentException('Expected valid DateTimeZone string or \DateTimeZone object.');
+        }
+    }
 
     /**
      * Gets the default locale.
@@ -156,6 +191,11 @@ trait DateFormatTrait
     public function i18nFormat($format = null, $timezone = null, $locale = null)
     {
         $time = $this;
+
+        // This is required for testI18nFormatWithOffsetTimezone to pass
+        if ($time->getTimezone()->getName() === date_default_timezone_get()) {
+            $timezone = $timezone ?: static::getDefaultOutputTimezone();
+        }
 
         if ($timezone) {
             // Handle the immutable and mutable object cases.

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -16,10 +16,10 @@ namespace Cake\I18n;
 
 use Cake\Chronos\Date as ChronosDate;
 use Cake\Chronos\MutableDate;
+use DateTimeZone;
 use IntlDateFormatter;
-use \DateTimeZone;
-use \InvalidArgumentException;
-use \RuntimeException;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Trait for date formatting methods shared by both Time & Date.
@@ -71,7 +71,7 @@ trait DateFormatTrait
     /**
      * Caches whether or not this class is a subclass of a Date or MutableDate
      *
-     * @var boolean
+     * @var bool
      */
     protected static $_isDateInstance;
 
@@ -84,7 +84,7 @@ trait DateFormatTrait
     public static function getDefaultOutputTimezone()
     {
         if (is_subclass_of(static::class, ChronosDate::class) || is_subclass_of(static::class, MutableDate::class)) {
-            throw new \RuntimeException('Timezone conversion is not supported by Date/FrozenDate.');
+            throw new RuntimeException('Timezone conversion is not supported by Date/FrozenDate.');
         }
         return static::$_defaultOutputTimezone;
     }
@@ -101,14 +101,14 @@ trait DateFormatTrait
     public static function setDefaultOutputTimezone($timezone)
     {
         if (is_subclass_of(static::class, ChronosDate::class) || is_subclass_of(static::class, MutableDate::class)) {
-            throw new \RuntimeException('Timezone conversion is not supported by Date/FrozenDate.');
+            throw new RuntimeException('Timezone conversion is not supported by Date/FrozenDate.');
         }
         if (is_string($timezone)) {
-            static::$_defaultOutputTimezone = new \DateTimeZone($timezone);
-        } elseif ($timezone instanceof \DateTimeZone) {
+            static::$_defaultOutputTimezone = new DateTimeZone($timezone);
+        } elseif ($timezone instanceof DateTimeZone) {
             static::$_defaultOutputTimezone = $timezone;
         } else {
-            throw new \InvalidArgumentException('Expected valid DateTimeZone string or \DateTimeZone object.');
+            throw new InvalidArgumentException('Expected valid DateTimeZone string or \DateTimeZone object.');
         }
     }
 

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -93,8 +93,12 @@ class RelativeTimeFormatter
     public function timeAgoInWords(DatetimeInterface $time, array $options = [])
     {
         $options = $this->_options($options, FrozenTime::class);
+
+        $timezone = null;
         if ($options['timezone']) {
-            $time = $time->timezone($options['timezone']);
+            $timezone = $options['timezone'];
+        } elseif ($time instanceof Time || $time instanceof FrozenTime) {
+            $timezone = $time->getDefaultOutputTimezone();
         }
 
         $now = $options['from']->format('U');
@@ -114,7 +118,7 @@ class RelativeTimeFormatter
         }
 
         if ($diff > abs($now - (new FrozenTime($options['end']))->format('U'))) {
-            return sprintf($options['absoluteString'], $time->i18nFormat($options['format']));
+            return sprintf($options['absoluteString'], $time->i18nFormat($options['format'], $timezone));
         }
 
         $diffData = $this->_diffData($futureTime, $pastTime, $backwards, $options);

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -208,7 +208,7 @@ class TimeTest extends TestCase
      */
     public function testTimeAgoInWordsTimezone($class)
     {
-        $time = new FrozenTime('1990-07-31 20:33:00 UTC');
+        $time = new $class('1990-07-31 20:33:00 UTC');
         $result = $time->timeAgoInWords(
             [
                 'timezone' => 'America/Vancouver',

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -586,16 +586,19 @@ class TimeTest extends TestCase
      */
     public function testI18nFormatWithOffsetTimezone($class)
     {
+        // Default output format is in UTC
         $time = new $class('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
 
+        $class::setDefaultOutputTimezone('GMT+09:00');
         $time = new $class('2014-01-01T00:00:00+09');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
         $this->assertTimeFormat($expected, $result);
 
+        $class::setDefaultOutputTimezone('GMT-01:30');
         $time = new $class('2014-01-01T00:00:00-01:30');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
@@ -611,22 +614,23 @@ class TimeTest extends TestCase
      */
     public function testI18nFormatWithOffsetTimezoneWithDefaultOutputTimezone($class)
     {
+        // America/Vancouver is GMT-8 in the winter
         $class::setDefaultOutputTimezone('America/Vancouver');
 
         $time = new $class('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
-        $this->assertTimeFormat($expected, $result);
+        $expected = 'Tuesday December 31 2013 4:00:00 PM Pacific Standard Time';
+        $this->assertTimeFormat($expected, $result, 'GMT to GMT-8 should be 8 hours');
 
-        $time = new $class('2014-01-01T00:00:00+09');
+        $time = new $class('2014-01-01T00:00:00+09:00');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
-        $this->assertTimeFormat($expected, $result);
+        $expected = 'Tuesday December 31 2013 7:00:00 AM Pacific Standard Time';
+        $this->assertTimeFormat($expected, $result, 'GMT+9 to GMT-8 should be 17hrs');
 
         $time = new $class('2014-01-01T00:00:00-01:30');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
-        $this->assertTimeFormat($expected, $result);
+        $expected = 'Tuesday December 31 2013 5:30:00 PM Pacific Standard Time';
+        $this->assertTimeFormat($expected, $result, 'GMT-1:30 to GMT-8 is 6.5hrs');
     }
 
     /**
@@ -682,13 +686,13 @@ class TimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testToStringWithdefaultOutputTimezone($class)
+    public function testToStringWithDefaultOutputTimezone($class)
     {
         $class::setDefaultOutputTimezone('America/Vancouver');
-        $time = new $class('2014-04-20 22:10');
+        $time = new $class('2014-04-20 22:10 UTC');
         $class::setDefaultLocale('fr-FR');
         $class::setToStringFormat(\IntlDateFormatter::FULL);
-        $this->assertTimeFormat('dimanche 20 avril 2014 15:10:00 UTC', (string)$time);
+        $this->assertTimeFormat('dimanche 20 avril 2014 15:10:00 heure d’été du Pacifique', (string)$time);
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -1025,10 +1025,12 @@ class TimeTest extends TestCase
     {
         $expected = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA', 'à '], '', $expected);
         $expected = str_replace(['  '], ' ', $expected);
+        $expected = str_replace("d’été", 'avancée', $expected);
 
         $result = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA', 'à '], '', $result);
         $result = str_replace(['گرینویچ'], 'GMT', $result);
         $result = str_replace(['  '], ' ', $result);
+        $expected = str_replace("d’été", 'avancée', $result);
 
         return $this->assertSame($expected, $result, $message);
     }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -553,7 +553,7 @@ class TimeTest extends TestCase
     {
         $time = new $class('Thu Jan 14 13:59:28 2010');
 
-        $class::$defaultLocale = 'en-CA';
+        $class::setDefaultLocale('en-US');
         $class::setDefaultOutputTimezone('America/Vancouver');
 
         $result = $time->i18nFormat();
@@ -565,7 +565,7 @@ class TimeTest extends TestCase
         $this->assertTimeFormat($expected, $result);
 
 
-        $class::$defaultLocale = 'de-DE';
+        $class::setDefaultLocale('de-DE');
         $class::setDefaultOutputTimezone('Europe/Berlin');
 
         $result = $time->i18nFormat();

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -38,6 +38,10 @@ class TimeTest extends TestCase
         $this->locale = Time::getDefaultLocale();
         Time::setDefaultLocale('en_US');
         FrozenTime::setDefaultLocale('en_US');
+
+        date_default_timezone_set('UTC');
+        Time::setDefaultOutputTimezone('UTC');
+        FrozenTime::setDefaultOutputTimezone('UTC');
     }
 
     /**
@@ -55,8 +59,12 @@ class TimeTest extends TestCase
         FrozenTime::setTestNow($this->frozenNow);
         FrozenTime::setDefaultLocale($this->locale);
         FrozenTime::resetToStringFormat();
-        date_default_timezone_set('UTC');
+
         I18n::locale(I18n::DEFAULT_LOCALE);
+
+        date_default_timezone_set('UTC');
+        Time::setDefaultOutputTimezone('UTC');
+        FrozenTime::setDefaultOutputTimezone('UTC');
     }
 
     /**
@@ -478,6 +486,40 @@ class TimeTest extends TestCase
 
         $result = $time->i18nFormat(\IntlDateFormatter::FULL, 'Asia/Tokyo', 'ja-JP@calendar=japanese');
         $expected = '平成22年1月14日木曜日 22時59分28秒 日本標準時';
+        $this->assertTimeFormat($expected, $result);
+    }
+
+    /**
+     * test formatting dates taking in account default output timezones.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testI18nFormatWithDefaultOutputTimezone($class)
+    {
+        $time = new $class('Thu Jan 14 13:59:28 2010');
+
+        $class::$defaultLocale = 'en-CA';
+        $class::setDefaultOutputTimezone('America/Vancouver');
+
+        $result = $time->i18nFormat();
+        $expected = '1/14/10 5:59 AM';
+        $this->assertTimeFormat($expected, $result);
+
+        $result = $time->i18nFormat(null, 'America/Toronto');
+        $expected = '1/14/10 8:59 AM';
+        $this->assertTimeFormat($expected, $result);
+
+
+        $class::$defaultLocale = 'de-DE';
+        $class::setDefaultOutputTimezone('Europe/Berlin');
+
+        $result = $time->i18nFormat();
+        $expected = '14.01.10 14:59';
+        $this->assertTimeFormat($expected, $result);
+
+        $result = $time->i18nFormat(null, 'Europe/London');
+        $expected = '14.01.10 13:59';
         $this->assertTimeFormat($expected, $result);
     }
 

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -581,8 +581,8 @@ class TimeTest extends TestCase
      * test formatting dates with offset style timezone
      *
      * @dataProvider classNameProvider
-     * @see https://github.com/facebook/hhvm/issues/3637
      * @return void
+     * @see https://github.com/facebook/hhvm/issues/3637
      */
     public function testI18nFormatWithOffsetTimezone($class)
     {
@@ -609,8 +609,8 @@ class TimeTest extends TestCase
      * test formatting dates with offset style timezone and defaultOutputTimezone
      *
      * @dataProvider classNameProvider
-     * @see https://github.com/facebook/hhvm/issues/3637
      * @return void
+     * @see https://github.com/facebook/hhvm/issues/3637
      */
     public function testI18nFormatWithOffsetTimezoneWithDefaultOutputTimezone($class)
     {


### PR DESCRIPTION
This pull request continues the work @ionas started in #8753. By having a default output timezone on the Time/Date classes we make it easier to localize all the datetime output an application generates by allowing datetime preferences to be centralized.
