### PR TITLE
Remove use of TestCase::getMock() from tests.

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -608,7 +608,10 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         $options += ['alias' => $baseClass, 'connection' => $connection];
         $options += TableRegistry::config($alias);
 
-        $mock = $this->getMock($options['className'], $methods, [$options]);
+        $mock = $this->getMockBuilder($options['className'])
+            ->setMethods($methods)
+            ->setConstructorArgs([$options])
+            ->getMock();
 
         if (empty($options['entityClass']) && $mock->entityClass() === '\Cake\ORM\Entity') {
             $parts = explode('\\', $options['className']);

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -15,9 +15,11 @@
 namespace Cake\Test\TestCase\Auth;
 
 use Cake\Auth\BasicAuthenticate;
+use Cake\Controller\ComponentRegistry;
 use Cake\I18n\Time;
 use Cake\Network\Exception\UnauthorizedException;
 use Cake\Network\Request;
+use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -44,7 +46,7 @@ class BasicAuthenticateTest extends TestCase
     {
         parent::setUp();
 
-        $this->Collection = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->Collection = $this->getMockBuilder(ComponentRegistry::class)->getMock();
         $this->auth = new BasicAuthenticate($this->Collection, [
             'userModel' => 'Users',
             'realm' => 'localhost'
@@ -53,7 +55,7 @@ class BasicAuthenticateTest extends TestCase
         $password = password_hash('password', PASSWORD_BCRYPT);
         $User = TableRegistry::get('Users');
         $User->updateAll(['password' => $password], []);
-        $this->response = $this->getMock('Cake\Network\Response');
+        $this->response = $this->getMockBuilder(Response::class)->getMock();
     }
 
     /**

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -17,6 +17,7 @@
 namespace Cake\Test\TestCase\Auth;
 
 use Cake\Auth\ControllerAuthorize;
+use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
@@ -36,8 +37,11 @@ class ControllerAuthorizeTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->controller = $this->getMock('Cake\Controller\Controller', ['isAuthorized'], [], '', false);
-        $this->components = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->controller = $this->getMockBuilder(Controller::class)
+            ->setMethods(['isAuthorized'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->components = $this->getMockBuilder(ComponentRegistry::class)->getMock();
         $this->components->expects($this->any())
             ->method('getController')
             ->will($this->returnValue($this->controller));

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -17,9 +17,11 @@
 namespace Cake\Test\TestCase\Auth;
 
 use Cake\Auth\DigestAuthenticate;
+use Cake\Controller\ComponentRegistry;
 use Cake\I18n\Time;
 use Cake\Network\Exception\UnauthorizedException;
 use Cake\Network\Request;
+use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -46,7 +48,7 @@ class DigestAuthenticateTest extends TestCase
     {
         parent::setUp();
 
-        $this->Collection = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->Collection = $this->getMockBuilder(ComponentRegistry::class)->getMock();
         $this->auth = new DigestAuthenticate($this->Collection, [
             'realm' => 'localhost',
             'nonce' => 123,
@@ -57,7 +59,7 @@ class DigestAuthenticateTest extends TestCase
         $User = TableRegistry::get('Users');
         $User->updateAll(['password' => $password], []);
 
-        $this->response = $this->getMock('Cake\Network\Response');
+        $this->response = $this->getMockBuilder(Response::class)->getMock();
     }
 
     /**

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -15,10 +15,11 @@
 namespace Cake\Test\TestCase\Auth;
 
 use Cake\Auth\FormAuthenticate;
-use Cake\Core\Configure;
+use Cake\Controller\ComponentRegistry;
 use Cake\Core\Plugin;
 use Cake\I18n\Time;
 use Cake\Network\Request;
+use Cake\Network\Response;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -46,7 +47,7 @@ class FormAuthenticateTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Collection = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->Collection = $this->getMockBuilder(ComponentRegistry::class)->getMock();
         $this->auth = new FormAuthenticate($this->Collection, [
             'userModel' => 'Users'
         ]);
@@ -61,7 +62,7 @@ class FormAuthenticateTest extends TestCase
         ]);
         $AuthUsers->updateAll(['password' => $password], []);
 
-        $this->response = $this->getMock('Cake\Network\Response');
+        $this->response = $this->getMockBuilder(Response::class)->getMock();
     }
 
     /**
@@ -144,16 +145,13 @@ class FormAuthenticateTest extends TestCase
             'password' => ''
         ];
 
-        $this->auth = $this->getMock(
-            'Cake\Auth\FormAuthenticate',
-            ['_checkFields'],
-            [
+        $this->auth = $this->getMockBuilder(FormAuthenticate::class)
+            ->setMethods(['_checkFields'])
+            ->setConstructorArgs([
                 $this->Collection,
-                [
-                    'userModel' => 'Users'
-                ]
-            ]
-        );
+                ['userModel' => 'Users']
+            ])
+            ->getMock();
 
         // Simulate that check for ensuring password is not empty is missing.
         $this->auth->expects($this->once())

--- a/tests/TestCase/Auth/Storage/SessionStorageTest.php
+++ b/tests/TestCase/Auth/Storage/SessionStorageTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Auth;
 use Cake\Auth\Storage\SessionStorage;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -35,7 +36,7 @@ class SessionStorageTest extends TestCase
     {
         parent::setUp();
 
-        $this->session = $this->getMock('Cake\Network\Session');
+        $this->session = $this->getMockBuilder(Session::class)->getMock();
         $this->request = new Request(['session' => $this->session]);
         $this->response = new Response();
         $this->storage = new SessionStorage($this->request, $this->response, ['key' => 'Auth.AuthUser']);

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -244,7 +244,9 @@ class CacheTest extends TestCase
      */
     public function testConfigInvalidObject()
     {
-        $this->getMock('\StdClass', [], [], 'RubbishEngine');
+        $this->getMockBuilder(\StdClass::class)
+            ->setMockClassName('RubbishEngine')
+            ->getMock();
         Cache::config('test', [
             'engine' => '\RubbishEngine'
         ]);

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -82,7 +82,9 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 'a');
@@ -118,7 +120,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->once())
             ->method('__invoke')
             ->with(3, 'c');
@@ -156,7 +161,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 'a')
@@ -181,7 +189,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 'a')
@@ -195,7 +206,10 @@ class CollectionTest extends TestCase
 
         $items = [];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->never())
             ->method('__invoke');
         $this->assertFalse($collection->every($callable));
@@ -210,7 +224,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 'a')
@@ -232,7 +249,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 'a')
@@ -289,7 +309,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(10, 1, 'a')
@@ -314,7 +337,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 2, 'b')
@@ -759,7 +785,10 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+    ->setMethods(['__invoke'])
+    ->getMock();
+
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 'a')

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -121,8 +121,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->once())
             ->method('__invoke')
@@ -162,8 +162,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')
@@ -190,8 +190,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')
@@ -207,8 +207,8 @@ class CollectionTest extends TestCase
         $items = [];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->never())
             ->method('__invoke');
@@ -225,8 +225,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')
@@ -250,8 +250,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')
@@ -310,8 +310,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')
@@ -338,8 +338,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')
@@ -786,8 +786,8 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
         $callable = $this->getMockBuilder(\StdClass::class)
-    ->setMethods(['__invoke'])
-    ->getMock();
+            ->setMethods(['__invoke'])
+            ->getMock();
 
         $callable->expects($this->at(0))
             ->method('__invoke')

--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -32,7 +32,9 @@ class FilterIteratorTest extends TestCase
     public function testFilter()
     {
         $items = new \ArrayIterator([1, 2, 3]);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 0, $items)

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -32,7 +32,9 @@ class ReplaceIteratorTest extends TestCase
     public function testReplace()
     {
         $items = new \ArrayIterator([1, 2, 3]);
-        $callable = $this->getMock('stdClass', ['__invoke']);
+        $callable = $this->getMockBuilder(\StdClass::class)
+            ->setMethods(['__invoke'])
+            ->getMock();
         $callable->expects($this->at(0))
             ->method('__invoke')
             ->with(1, 0, $items)

--- a/tests/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -30,13 +30,18 @@ class ConsoleErrorHandlerTest extends TestCase
     /**
      * setup, create mocks
      *
-     * @return Mock object
+     * @return void
      */
     public function setUp()
     {
         parent::setUp();
-        $this->stderr = $this->getMock('Cake\Console\ConsoleOutput', [], [], '', false);
-        $this->Error = $this->getMock('Cake\Console\ConsoleErrorHandler', ['_stop'], [['stderr' => $this->stderr]]);
+        $this->stderr = $this->getMockBuilder('Cake\Console\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->Error = $this->getMockBuilder('Cake\Console\ConsoleErrorHandler')
+            ->setMethods(['_stop'])
+            ->setConstructorArgs([['stderr' => $this->stderr]])
+            ->getMock();
         Log::drop('stderr');
     }
 

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -35,9 +35,15 @@ class ConsoleIoTest extends TestCase
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
 
-        $this->out = $this->getMock('Cake\Console\ConsoleOutput', [], [], '', false);
-        $this->err = $this->getMock('Cake\Console\ConsoleOutput', [], [], '', false);
-        $this->in = $this->getMock('Cake\Console\ConsoleInput', [], [], '', false);
+        $this->out = $this->getMockBuilder('Cake\Console\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->err = $this->getMockBuilder('Cake\Console\ConsoleOutput')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->in = $this->getMockBuilder('Cake\Console\ConsoleInput')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->io = new ConsoleIo($this->out, $this->err, $this->in);
     }
 

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -34,7 +34,9 @@ class ConsoleOutputTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->output = $this->getMock('Cake\Console\ConsoleOutput', ['_write']);
+        $this->output = $this->getMockBuilder('Cake\Console\ConsoleOutput')
+            ->setMethods(['_write'])
+            ->getMock();
         $this->output->outputAs(ConsoleOutput::COLOR);
     }
 

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -34,7 +34,9 @@ class HelperRegistryTest extends TestCase
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
-        $io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->helpers = new HelperRegistry();
         $this->helpers->setIo($io);
     }

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -154,7 +154,7 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShellWithAbort()
     {
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['main'], [$io]);
         $shell->expects($this->once())
             ->method('main')
@@ -181,7 +181,7 @@ class ShellDispatcherTest extends TestCase
     public function testDispatchShellWithMain()
     {
         $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell']);
-        $Shell = $this->getMock('Cake\Console\Shell');
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $Shell->expects($this->exactly(2))->method('initialize');
         $Shell->expects($this->at(0))->method('runCommand')
@@ -213,7 +213,7 @@ class ShellDispatcherTest extends TestCase
     public function testDispatchShellWithoutMain()
     {
         $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell']);
-        $Shell = $this->getMock('Cake\Console\Shell');
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $Shell->expects($this->once())->method('initialize');
         $Shell->expects($this->once())->method('runCommand')
@@ -241,7 +241,7 @@ class ShellDispatcherTest extends TestCase
             'Cake\Console\ShellDispatcher',
             ['_shellExists', '_createShell']
         );
-        $Shell = $this->getMock('Cake\Console\Shell');
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $dispatcher->expects($this->at(1))
             ->method('_shellExists')
@@ -269,7 +269,7 @@ class ShellDispatcherTest extends TestCase
             'Cake\Console\ShellDispatcher',
             ['_shellExists', '_createShell']
         );
-        $Shell = $this->getMock('Cake\Console\Shell');
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $dispatcher->expects($this->at(1))
             ->method('_shellExists')
@@ -297,7 +297,7 @@ class ShellDispatcherTest extends TestCase
             'Cake\Console\ShellDispatcher',
             ['_shellExists', '_createShell']
         );
-        $Shell = $this->getMock('Cake\Console\Shell');
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $dispatcher->expects($this->at(1))
             ->method('_shellExists')

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -36,7 +36,9 @@ class ShellDispatcherTest extends TestCase
         parent::setUp();
         Plugin::load('TestPlugin');
         Configure::write('App.namespace', 'TestApp');
-        $this->dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['_stop']);
+        $this->dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['_stop'])
+            ->getMock();
     }
 
     /**
@@ -155,14 +157,19 @@ class ShellDispatcherTest extends TestCase
     public function testDispatchShellWithAbort()
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['main'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['main'])
+            ->setConstructorArgs([$io])
+            ->getMock();
         $shell->expects($this->once())
             ->method('main')
             ->will($this->returnCallback(function () use ($shell) {
                 $shell->abort('Bad things', 99);
             }));
 
-        $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell']);
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell'])
+            ->getMock();
         $dispatcher->expects($this->any())
             ->method('findShell')
             ->with('aborter')
@@ -180,7 +187,9 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShellWithMain()
     {
-        $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell']);
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell'])
+            ->getMock();
         $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $Shell->expects($this->exactly(2))->method('initialize');
@@ -212,7 +221,9 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShellWithoutMain()
     {
-        $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell']);
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell'])
+            ->getMock();
         $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $Shell->expects($this->once())->method('initialize');
@@ -237,10 +248,9 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShortPluginAlias()
     {
-        $dispatcher = $this->getMock(
-            'Cake\Console\ShellDispatcher',
-            ['_shellExists', '_createShell']
-        );
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['_shellExists', '_createShell'])
+            ->getMock();
         $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $dispatcher->expects($this->at(1))
@@ -265,10 +275,9 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShortPluginAliasCamelized()
     {
-        $dispatcher = $this->getMock(
-            'Cake\Console\ShellDispatcher',
-            ['_shellExists', '_createShell']
-        );
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['_shellExists', '_createShell'])
+            ->getMock();
         $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $dispatcher->expects($this->at(1))
@@ -293,10 +302,9 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShortPluginAliasConflict()
     {
-        $dispatcher = $this->getMock(
-            'Cake\Console\ShellDispatcher',
-            ['_shellExists', '_createShell']
-        );
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['_shellExists', '_createShell'])
+            ->getMock();
         $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
 
         $dispatcher->expects($this->at(1))
@@ -349,11 +357,15 @@ class ShellDispatcherTest extends TestCase
      */
     public function testHelpOption()
     {
-        $mockShell = $this->getMock('Cake\Shell\CommandListShell', ['main', 'initialize', 'startup']);
+        $mockShell = $this->getMockBuilder('Cake\Shell\CommandListShell')
+            ->setMethods(['main', 'initialize', 'startup'])
+            ->getMock();
         $mockShell->expects($this->once())
             ->method('main');
 
-        $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell', '_stop']);
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell', '_stop'])
+            ->getMock();
         $dispatcher->expects($this->once())
             ->method('findShell')
             ->with('command_list')
@@ -369,11 +381,15 @@ class ShellDispatcherTest extends TestCase
      */
     public function testVersionOption()
     {
-        $mockShell = $this->getMock('Cake\Shell\CommandListShell', ['main', 'initialize', 'startup']);
+        $mockShell = $this->getMockBuilder('Cake\Shell\CommandListShell')
+            ->setMethods(['main', 'initialize', 'startup'])
+            ->getMock();
         $mockShell->expects($this->once())
             ->method('main');
 
-        $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', ['findShell', '_stop']);
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell', '_stop'])
+            ->getMock();
         $dispatcher->expects($this->once())
             ->method('findShell')
             ->with('command_list')

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -682,7 +682,7 @@ class ShellTest extends TestCase
      */
     public function testRunCommandMain()
     {
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['main', 'startup'], [$io]);
 
         $shell->expects($this->once())->method('startup');
@@ -701,7 +701,7 @@ class ShellTest extends TestCase
      */
     public function testRunCommandWithMethod()
     {
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['hitMe', 'startup'], [$io]);
 
         $shell->expects($this->once())->method('startup');
@@ -724,7 +724,7 @@ class ShellTest extends TestCase
     public function testRunCommandWithExtra()
     {
         $Parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $Shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'slice', '_welcome', 'param'], [$io]);
         $Parser->addSubCommand('slice');
         $Shell->expects($this->once())
@@ -865,7 +865,7 @@ TEXT;
      */
     public function testRunCommandAutoMethodOff()
     {
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['hit_me', 'startup'], [$io]);
 
         $shell->expects($this->never())->method('startup');
@@ -886,7 +886,7 @@ TEXT;
     public function testRunCommandWithMethodNotInSubcommands()
     {
         $parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'roll', 'startup'], [$io]);
 
         $parser->addSubCommand('slice');
@@ -913,7 +913,7 @@ TEXT;
     public function testRunCommandWithMethodInSubcommands()
     {
         $parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'slice', 'startup'], [$io]);
 
         $parser->addSubCommand('slice');
@@ -940,7 +940,7 @@ TEXT;
         $parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
         $parser->addSubCommand('slice');
 
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'startup'], [$io]);
         $shell->expects($this->any())
             ->method('getOptionParser')
@@ -1058,7 +1058,7 @@ TEXT;
     {
         $parser = new ConsoleOptionParser('knife');
         $parser->addSubcommand('slice');
-        $io = $this->getMock('Cake\Console\ConsoleIo');
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
 
         $shell = $this->getMock('Cake\Console\Shell', ['hasTask', 'startup', 'getOptionParser'], [], '', false);
         $shell->io($io);

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -44,7 +44,7 @@ class ShellTestShell extends Shell
     /**
      * name property
      *
-     * @var name
+     * @var string
      */
     public $name = 'ShellTestShell';
 
@@ -143,7 +143,9 @@ class ShellTest extends TestCase
     {
         parent::setUp();
 
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->Shell = new ShellTestShell($this->io);
 
         if (is_dir(TMP . 'shell_test')) {
@@ -683,7 +685,10 @@ class ShellTest extends TestCase
     public function testRunCommandMain()
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['main', 'startup'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['main', 'startup'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
         $shell->expects($this->once())->method('startup');
         $shell->expects($this->once())->method('main')
@@ -702,7 +707,10 @@ class ShellTest extends TestCase
     public function testRunCommandWithMethod()
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['hitMe', 'startup'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['hitMe', 'startup'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
         $shell->expects($this->once())->method('startup');
         $shell->expects($this->once())->method('hitMe')
@@ -723,9 +731,15 @@ class ShellTest extends TestCase
      */
     public function testRunCommandWithExtra()
     {
-        $Parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
+        $Parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->setMethods(['help'])
+            ->setConstructorArgs(['knife'])
+            ->getMock();
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $Shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'slice', '_welcome', 'param'], [$io]);
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['getOptionParser', 'slice', '_welcome', 'param'])
+            ->setConstructorArgs([$io])
+            ->getMock();
         $Parser->addSubCommand('slice');
         $Shell->expects($this->once())
             ->method('getOptionParser')
@@ -866,7 +880,10 @@ TEXT;
     public function testRunCommandAutoMethodOff()
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['hit_me', 'startup'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['hit_me', 'startup'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
         $shell->expects($this->never())->method('startup');
         $shell->expects($this->never())->method('hit_me');
@@ -885,9 +902,15 @@ TEXT;
      */
     public function testRunCommandWithMethodNotInSubcommands()
     {
-        $parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
+        $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->setMethods(['help'])
+            ->setConstructorArgs(['knife'])
+            ->getMock();
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'roll', 'startup'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['getOptionParser', 'roll', 'startup'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
         $parser->addSubCommand('slice');
 
@@ -912,9 +935,15 @@ TEXT;
      */
     public function testRunCommandWithMethodInSubcommands()
     {
-        $parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
+        $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->setMethods(['help'])
+            ->setConstructorArgs(['knife'])
+            ->getMock();
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'slice', 'startup'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['getOptionParser', 'slice', 'startup'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
         $parser->addSubCommand('slice');
 
@@ -937,11 +966,17 @@ TEXT;
      */
     public function testRunCommandWithMissingMethodInSubcommands()
     {
-        $parser = $this->getMock('Cake\Console\ConsoleOptionParser', ['help'], ['knife']);
+        $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->setMethods(['help'])
+            ->setConstructorArgs(['knife'])
+            ->getMock();
         $parser->addSubCommand('slice');
 
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
-        $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'startup'], [$io]);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['getOptionParser', 'startup'])
+            ->setConstructorArgs([$io])
+            ->getMock();
         $shell->expects($this->any())
             ->method('getOptionParser')
             ->will($this->returnValue($parser));
@@ -967,8 +1002,10 @@ TEXT;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $shell->io($this->getMock('Cake\Console\ConsoleIo'));
-        $parser = $this->getMock('Cake\Console\ConsoleOptionParser', [], [], '', false);
+        $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
+        $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $parser->expects($this->once())->method('help');
         $shell->expects($this->once())->method('getOptionParser')
@@ -990,8 +1027,10 @@ TEXT;
             ->setMethods(['startup', 'getOptionParser', 'out', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
-        $shell->io($this->getMock('Cake\Console\ConsoleIo'));
-        $parser = $this->getMock('Cake\Console\ConsoleOptionParser', [], [], '', false);
+        $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
+        $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $parser->expects($this->once())->method('help');
         $shell->expects($this->once())->method('getOptionParser')
@@ -1009,14 +1048,19 @@ TEXT;
      */
     public function testRunCommandTriggeringHelp()
     {
-        $parser = $this->getMock('Cake\Console\ConsoleOptionParser', [], [], '', false);
+        $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
+            ->disableOriginalConstructor()
+            ->getMock();
         $parser->expects($this->once())->method('parse')
             ->with(['--help'])
             ->will($this->returnValue([['help' => true], []]));
         $parser->expects($this->once())->method('help');
 
-        $shell = $this->getMock('Cake\Console\Shell', ['getOptionParser', 'out', 'startup', '_welcome'], [], '', false);
-        $shell->io($this->getMock('Cake\Console\ConsoleIo'));
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['getOptionParser', 'out', 'startup', '_welcome'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->once())->method('out');
@@ -1031,9 +1075,15 @@ TEXT;
      */
     public function testRunCommandNotCallUnexposedTask()
     {
-        $shell = $this->getMock('Cake\Console\Shell', ['startup', 'hasTask', 'out'], [], '', false);
-        $shell->io($this->getMock('Cake\Console\ConsoleIo'));
-        $task = $this->getMock('Cake\Console\Shell', ['runCommand'], [], '', false);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['startup', 'hasTask', 'out'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
+        $task = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['runCommand'])
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $task->expects($this->never())
             ->method('runCommand');
@@ -1060,9 +1110,15 @@ TEXT;
         $parser->addSubcommand('slice');
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
 
-        $shell = $this->getMock('Cake\Console\Shell', ['hasTask', 'startup', 'getOptionParser'], [], '', false);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['hasTask', 'startup', 'getOptionParser'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $shell->io($io);
-        $task = $this->getMock('Cake\Console\Shell', ['main', 'runCommand'], [], '', false);
+        $task = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['main', 'runCommand'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $task->io($io);
         $task->expects($this->once())
             ->method('runCommand')
@@ -1186,7 +1242,9 @@ TEXT;
      */
     public function testQuietLog()
     {
-        $io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
         $io->expects($this->once())
             ->method('level')
             ->with(Shell::QUIET);
@@ -1197,7 +1255,10 @@ TEXT;
             ->method('setLoggers')
             ->with(ConsoleIo::QUIET);
 
-        $this->Shell = $this->getMock(__NAMESPACE__ . '\ShellTestShell', ['welcome'], [$io]);
+        $this->Shell = $this->getMockBuilder(__NAMESPACE__ . '\ShellTestShell')
+            ->setMethods(['welcome'])
+            ->setConstructorArgs([$io])
+            ->getMock();
         $this->Shell->runCommand(['foo', '--quiet']);
     }
 

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -33,7 +33,9 @@ class TaskRegistryTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $shell = $this->getMock('Cake\Console\Shell', [], [], '', false);
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->Tasks = new TaskRegistry($shell);
     }
 
@@ -81,8 +83,12 @@ class TaskRegistryTest extends TestCase
      */
     public function testLoadPluginTask()
     {
-        $dispatcher = $this->getMock('Cake\Console\ShellDispatcher', [], [], '', false);
-        $shell = $this->getMock('Cake\Console\Shell', [], [], '', false);
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->disableOriginalConstructor()
+            ->getMock();
         Plugin::load('TestPlugin');
         $this->Tasks = new TaskRegistry($shell, $dispatcher);
 

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -20,7 +20,6 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
-use Cake\Network\Session;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -66,7 +65,9 @@ class AuthComponentTest extends TestCase
         });
 
         $request = new Request();
-        $response = $this->getMock('Cake\Network\Response', ['stop']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['stop'])
+            ->getMock();
 
         $this->Controller = new AuthTestController($request, $response);
         $this->Auth = new TestAuthComponent($this->Controller->components());
@@ -123,13 +124,10 @@ class AuthComponentTest extends TestCase
      */
     public function testIdentify()
     {
-        $AuthLoginFormAuthenticate = $this->getMock(
-            'Cake\Controller\Component\Auth\FormAuthenticate',
-            ['authenticate'],
-            [],
-            '',
-            false
-        );
+        $AuthLoginFormAuthenticate = $this->getMockBuilder('Cake\Controller\Component\Auth\FormAuthenticate')
+            ->setMethods(['authenticate'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->Auth->authenticate = [
             'AuthLoginForm' => [
                 'userModel' => 'AuthUsers'
@@ -231,27 +229,18 @@ class AuthComponentTest extends TestCase
      */
     public function testIsAuthorizedDelegation()
     {
-        $AuthMockOneAuthorize = $this->getMock(
-            'Cake\Controller\Component\BaseAuthorize',
-            ['authorize'],
-            [],
-            '',
-            false
-        );
-        $AuthMockTwoAuthorize = $this->getMock(
-            'Cake\Controller\Component\Auth\BaseAuthorize',
-            ['authorize'],
-            [],
-            '',
-            false
-        );
-        $AuthMockThreeAuthorize = $this->getMock(
-            'Cake\Controller\Component\Auth\BaseAuthorize',
-            ['authorize'],
-            [],
-            '',
-            false
-        );
+        $AuthMockOneAuthorize = $this->getMockBuilder('Cake\Controller\Component\BaseAuthorize')
+            ->setMethods(['authorize'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $AuthMockTwoAuthorize = $this->getMockBuilder('Cake\Controller\Component\BaseAuthorize')
+            ->setMethods(['authorize'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $AuthMockThreeAuthorize = $this->getMockBuilder('Cake\Controller\Component\BaseAuthorize')
+            ->setMethods(['authorize'])
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->Auth->setAuthorizeObject(0, $AuthMockOneAuthorize);
         $this->Auth->setAuthorizeObject(1, $AuthMockTwoAuthorize);
@@ -282,13 +271,10 @@ class AuthComponentTest extends TestCase
      */
     public function testIsAuthorizedUsingUserInSession()
     {
-        $AuthMockFourAuthorize = $this->getMock(
-            'Cake\Controller\Component\Auth\BaseAuthorize',
-            ['authorize'],
-            [],
-            '',
-            false
-        );
+        $AuthMockFourAuthorize = $this->getMockBuilder('Cake\Controller\Component\BaseAuthorize')
+            ->setMethods(['authorize'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->Auth->config('authorize', ['AuthMockFour']);
         $this->Auth->setAuthorizeObject(0, $AuthMockFourAuthorize);
 
@@ -676,13 +662,11 @@ class AuthComponentTest extends TestCase
 
         $this->Auth->session->write('Auth.User.id', '1');
         $this->Auth->config('authenticate', ['Form']);
-        $this->getMock(
-            'Cake\Controller\Component\Auth\BaseAuthorize',
-            ['authorize'],
-            [],
-            'NoLoginRedirectMockAuthorize',
-            false
-        );
+        $this->getMockBuilder('Cake\Controller\Component\BaseAuthorize')
+            ->setMethods(['authorize'])
+            ->disableOriginalConstructor()
+            ->setMockClassName('NoLoginRedirectMockAuthorize')
+            ->getMock();
         $this->Auth->config('authorize', ['NoLoginRedirectMockAuthorize']);
         $this->Auth->config('loginAction', ['controller' => 'auth_test', 'action' => 'login']);
 
@@ -718,11 +702,10 @@ class AuthComponentTest extends TestCase
         ]);
 
         $response = new Response();
-        $Controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['on', 'redirect'],
-            [$request, $response]
-        );
+        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['on', 'redirect'])
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
         $event = new Event('Controller.startup', $Controller);
 
         // Should not contain basedir when redirect is called.
@@ -742,11 +725,10 @@ class AuthComponentTest extends TestCase
     public function testRedirectToUnauthorizedRedirect()
     {
         $url = '/party/on';
-        $this->Auth->Flash = $this->getMock(
-            'Cake\Controller\Component\FlashComponent',
-            ['set'],
-            [$this->Controller->components()]
-        );
+        $this->Auth->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+            ->setMethods(['set'])
+            ->setConstructorArgs([$this->Controller->components()])
+            ->getMock();
         $this->Auth->request = $request = new Request([
             'url' => $url,
             'session' => $this->Auth->session
@@ -759,11 +741,10 @@ class AuthComponentTest extends TestCase
         $this->Auth->config('unauthorizedRedirect', $expected);
 
         $response = new Response();
-        $Controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['on', 'redirect'],
-            [$request, $response]
-        );
+        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['on', 'redirect'])
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
 
         $Controller->expects($this->once())
             ->method('redirect')
@@ -785,11 +766,10 @@ class AuthComponentTest extends TestCase
     public function testRedirectToUnauthorizedRedirectLoginAction()
     {
         $url = '/party/on';
-        $this->Auth->Flash = $this->getMock(
-            'Cake\Controller\Component\FlashComponent',
-            ['set'],
-            [$this->Controller->components()]
-        );
+        $this->Auth->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+            ->setMethods(['set'])
+            ->setConstructorArgs([$this->Controller->components()])
+            ->getMock();
         $this->Auth->request = $request = new Request([
             'url' => $url,
             'session' => $this->Auth->session
@@ -802,11 +782,10 @@ class AuthComponentTest extends TestCase
         $this->Auth->config('loginAction', '/users/login');
 
         $response = new Response();
-        $Controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['on', 'redirect'],
-            [$request, $response]
-        );
+        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['on', 'redirect'])
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
 
         // Uses referrer instead of loginAction.
         $Controller->expects($this->once())
@@ -826,10 +805,9 @@ class AuthComponentTest extends TestCase
     public function testRedirectToUnauthorizedRedirectSuppressedAuthError()
     {
         $url = '/party/on';
-        $this->Auth->session = $this->getMock(
-            'Cake\Network\Session',
-            ['flash']
-        );
+        $this->Auth->session = $this->getMockBuilder('Cake\Network\Session')
+            ->setMethods(['flash'])
+            ->getMock();
         $this->Auth->request = $Request = new Request($url);
         $this->Auth->request->addParams(Router::parse($url));
         $this->Auth->config('authorize', ['Controller']);
@@ -839,11 +817,10 @@ class AuthComponentTest extends TestCase
         $this->Auth->config('authError', false);
 
         $Response = new Response();
-        $Controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['on', 'redirect'],
-            [$Request, $Response]
-        );
+        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['on', 'redirect'])
+            ->setConstructorArgs([$Request, $Response])
+            ->getMock();
 
         $Controller->expects($this->once())
             ->method('redirect')
@@ -875,11 +852,10 @@ class AuthComponentTest extends TestCase
         $this->Auth->setUser(['username' => 'baker', 'password' => 'cake']);
 
         $response = new Response();
-        $Controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['on', 'redirect'],
-            [$request, $response]
-        );
+        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['on', 'redirect'])
+            ->setConstructorArgs([$request, $response])
+            ->getMock();
 
         $event = new Event('Controller.startup', $Controller);
         $this->Auth->startup($event);
@@ -894,7 +870,9 @@ class AuthComponentTest extends TestCase
     public function testNoRedirectOnLoginAction()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->methods = ['login'];
 
         $url = '/AuthTest/login';
@@ -1199,11 +1177,10 @@ class AuthComponentTest extends TestCase
      */
     public function testSetUser()
     {
-        $storage = $this->getMock(
-            'Cake\Auth\Storage\SessionStorage',
-            ['write'],
-            [$this->Auth->request, $this->Auth->response]
-        );
+        $storage = $this->getMockBuilder('Cake\Auth\Storage\SessionStorage')
+            ->setMethods(['write'])
+            ->setConstructorArgs([$this->Auth->request, $this->Auth->response])
+            ->getMock();
         $this->Auth->storage($storage);
 
         $user = ['username' => 'mark', 'role' => 'admin'];
@@ -1243,11 +1220,9 @@ class AuthComponentTest extends TestCase
      */
     public function testFlashSettings()
     {
-        $this->Auth->Flash = $this->getMock(
-            'Cake\Controller\Component\FlashComponent',
-            [],
-            [$this->Controller->components()]
-        );
+        $this->Auth->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+            ->setConstructorArgs([$this->Controller->components()])
+            ->getMock();
         $this->Controller->request->params['action'] = 'add';
         $this->Auth->startup(new Event('Controller.startup', $this->Controller));
 
@@ -1450,7 +1425,9 @@ class AuthComponentTest extends TestCase
      */
     public function testStatelessFollowedByStatefulAuth()
     {
-        $this->Auth->response = $this->getMock('Cake\Network\Response', ['stop', 'statusCode', 'send']);
+        $this->Auth->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['stop', 'statusCode', 'send'])
+            ->getMock();
         $event = new Event('Controller.startup', $this->Controller);
         $this->Auth->authenticate = ['Basic', 'Form'];
         $this->Controller->request['action'] = 'add';

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -36,11 +36,10 @@ class CookieComponentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $controller = $this->getMock(
-            'Cake\Controller\Controller',
-            ['redirect'],
-            [new Request(), new Response()]
-        );
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->setConstructorArgs([new Request(), new Response()])
+            ->getMock();
         $controller->loadComponent('Cookie');
         $this->Controller = $controller;
         $this->Cookie = $controller->Cookie;

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -37,7 +37,9 @@ class CsrfComponentTest extends TestCase
     {
         parent::setUp();
 
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $this->registry = new ComponentRegistry($controller);
         $this->component = new CsrfComponent($this->registry);
     }
@@ -61,7 +63,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testSettingCookie()
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => ['REQUEST_METHOD' => 'GET'],
             'webroot' => '/dir/',
@@ -102,7 +106,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testSafeMethodNoCsrfRequired($method)
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => $method,
@@ -138,7 +144,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testValidTokenInHeader($method)
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => $method,
@@ -164,7 +172,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenInHeader($method)
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => $method,
@@ -188,7 +198,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testValidTokenRequestData($method)
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => $method,
@@ -213,7 +225,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenRequestData($method)
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => $method,
@@ -235,7 +249,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenRequestDataMissing()
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => 'POST',
@@ -258,7 +274,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testInvalidTokenMissingCookie($method)
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => [
                 'REQUEST_METHOD' => $method
@@ -280,7 +298,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testCsrfValidationSkipsRequestAction()
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => ['REQUEST_METHOD' => 'POST'],
             'params' => ['requested' => 1],
@@ -303,7 +323,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testConfigurationCookieCreate()
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => ['REQUEST_METHOD' => 'GET'],
             'webroot' => '/dir/'
@@ -338,7 +360,9 @@ class CsrfComponentTest extends TestCase
      */
     public function testConfigurationValidate()
     {
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $controller->request = new Request([
             'environment' => ['REQUEST_METHOD' => 'POST'],
             'cookies' => ['csrfToken' => 'nope', 'token' => 'yes'],

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -466,7 +466,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortInvalidDirection()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -527,7 +527,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortWhitelistFailure()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -550,7 +550,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortWhitelistTrusted()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -580,7 +580,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortWhitelistEmpty()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -608,7 +608,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortWhitelistNotInSchema()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -637,7 +637,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortWhitelistMultiple()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -668,7 +668,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortMultiple()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -696,7 +696,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortWithString()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -718,7 +718,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortNoSort()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));
@@ -740,7 +740,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortInvalidAlias()
     {
-        $model = $this->getMock('Cake\ORM\Table');
+        $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
             ->method('alias')
             ->will($this->returnValue('model'));

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -73,7 +73,9 @@ class PaginatorComponentTest extends TestCase
         $registry = new ComponentRegistry($controller);
         $this->Paginator = new PaginatorComponent($registry, []);
 
-        $this->Post = $this->getMock('Cake\ORM\Table', [], [], '', false);
+        $this->Post = $this->getMockBuilder('Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**
@@ -1019,14 +1021,13 @@ class PaginatorComponentTest extends TestCase
      * Helper method for making mocks.
      *
      * @param array $methods
-     * @return Table
+     * @return \Cake\ORM\Table
      */
     protected function _getMockPosts($methods = [])
     {
-        return $this->getMock(
-            'TestApp\Model\Table\PaginatorPostsTable',
-            $methods,
-            [[
+        return $this->getMockBuilder('TestApp\Model\Table\PaginatorPostsTable')
+            ->setMethods($methods)
+            ->setConstructorArgs([[
                 'connection' => ConnectionManager::get('test'),
                 'alias' => 'PaginatorPosts',
                 'schema' => [
@@ -1037,14 +1038,14 @@ class PaginatorComponentTest extends TestCase
                     'published' => ['type' => 'string', 'length' => 1, 'default' => 'N'],
                     '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
                 ]
-            ]]
-        );
+            ]])
+            ->getMock();
     }
 
     /**
      * Helper method for mocking queries.
      *
-     * @return Query
+     * @return \Cake\ORM\Query
      */
     protected function _getMockFindQuery($table = null)
     {
@@ -1053,7 +1054,9 @@ class PaginatorComponentTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $results = $this->getMock('Cake\ORM\ResultSet', [], [], '', false);
+        $results = $this->getMockBuilder('Cake\ORM\ResultSet')
+            ->disableOriginalConstructor()
+            ->getMock();
         $query->expects($this->any())
             ->method('count')
             ->will($this->returnValue(2));

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -66,7 +66,9 @@ class RequestHandlerComponentTest extends TestCase
     protected function _init()
     {
         $request = new Request('controller_posts/index');
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'stop'])
+            ->getMock();
         $this->Controller = new RequestHandlerTestController($request, $response);
         $this->RequestHandler = $this->Controller->components()->load('RequestHandler');
         $this->request = $request;
@@ -101,7 +103,9 @@ class RequestHandlerComponentTest extends TestCase
         $config = [
             'viewClassMap' => ['json' => 'MyPlugin.MyJson']
         ];
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $collection = new ComponentRegistry($controller);
         $requestHandler = new RequestHandlerComponent($collection, $config);
         $this->assertEquals(['json' => 'MyPlugin.MyJson'], $requestHandler->config('viewClassMap'));
@@ -293,7 +297,9 @@ class RequestHandlerComponentTest extends TestCase
         $extensions = Router::extensions();
         Router::extensions('xml', false);
 
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['accepts']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['accepts'])
+            ->getMock();
         $this->Controller->request->expects($this->any())
             ->method('accepts')
             ->will($this->returnValue(['application/json']));
@@ -472,7 +478,9 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRender', $this->Controller);
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         $_SERVER['CONTENT_TYPE'] = 'application/xml';
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $this->RequestHandler->beforeRender($event);
         $this->assertTrue(is_array($this->Controller->request->data));
         $this->assertFalse(is_object($this->Controller->request->data));
@@ -489,7 +497,9 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         $_SERVER['CONTENT_TYPE'] = 'application/xml; charset=UTF-8';
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $this->RequestHandler->startup($event);
         $this->assertTrue(is_array($this->Controller->request->data));
         $this->assertFalse(is_object($this->Controller->request->data));
@@ -503,7 +513,9 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testStartupProcessData()
     {
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $this->Controller->request->expects($this->at(0))
             ->method('_readInput')
             ->will($this->returnValue(''));
@@ -536,7 +548,9 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testStartupIgnoreFileAsXml()
     {
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $this->Controller->request->expects($this->any())
             ->method('_readInput')
             ->will($this->returnValue('/dev/random'));
@@ -558,7 +572,9 @@ class RequestHandlerComponentTest extends TestCase
     public function testStartupCustomTypeProcess()
     {
         $restore = error_reporting(E_ALL & ~E_USER_DEPRECATED);
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $this->Controller->request->expects($this->once())
             ->method('_readInput')
             ->will($this->returnValue('"A","csv","string"'));
@@ -631,12 +647,16 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testRenderAsWithAttachment()
     {
-        $this->RequestHandler->request = $this->getMock('Cake\Network\Request', ['parseAccept']);
+        $this->RequestHandler->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['parseAccept'])
+            ->getMock();
         $this->RequestHandler->request->expects($this->any())
             ->method('parseAccept')
             ->will($this->returnValue(['1.0' => ['application/xml']]));
 
-        $this->RequestHandler->response = $this->getMock('Cake\Network\Response', ['type', 'download', 'charset']);
+        $this->RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['type', 'download', 'charset'])
+            ->getMock();
         $this->RequestHandler->response->expects($this->at(0))
             ->method('type')
             ->with('application/xml');
@@ -659,7 +679,9 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testRespondAs()
     {
-        $this->RequestHandler->response = $this->getMock('Cake\Network\Response', ['type']);
+        $this->RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['type'])
+            ->getMock();
         $this->RequestHandler->response->expects($this->at(0))->method('type')
             ->with('application/json');
         $this->RequestHandler->response->expects($this->at(1))->method('type')
@@ -678,13 +700,16 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testRespondAsWithAttachment()
     {
-        $this->RequestHandler = $this->getMock(
-            'Cake\Controller\Component\RequestHandlerComponent',
-            ['_header'],
-            [$this->Controller->components()]
-        );
-        $this->RequestHandler->response = $this->getMock('Cake\Network\Response', ['type', 'download']);
-        $this->RequestHandler->request = $this->getMock('Cake\Network\Request', ['parseAccept']);
+        $this->RequestHandler = $this->getMockBuilder('Cake\Controller\Component\RequestHandlerComponent')
+            ->setMethods(['_header'])
+            ->setConstructorArgs([$this->Controller->components()])
+            ->getMock();
+        $this->RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['type', 'download'])
+            ->getMock();
+        $this->RequestHandler->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['parseAccept'])
+            ->getMock();
 
         $this->RequestHandler->request->expects($this->once())
             ->method('parseAccept')
@@ -794,7 +819,9 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testMobileDeviceDetection()
     {
-        $request = $this->getMock('Cake\Network\Request', ['is']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['is'])
+            ->getMock();
         $request->expects($this->once())->method('is')
             ->with('mobile')
             ->will($this->returnValue(true));
@@ -885,8 +912,12 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
         $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
-        $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['is'])
+            ->getMock();
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'stop'])
+            ->getMock();
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
@@ -912,8 +943,12 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
         $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
-        $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['is'])
+            ->getMock();
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'stop'])
+            ->getMock();
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())
@@ -951,8 +986,12 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
         $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
-        $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['is'])
+            ->getMock();
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'stop'])
+            ->getMock();
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
@@ -984,8 +1023,12 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
         $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
-        $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['is'])
+            ->getMock();
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'stop'])
+            ->getMock();
         $this->Controller->response->statusCode(302);
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
@@ -1014,8 +1057,12 @@ class RequestHandlerComponentTest extends TestCase
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
         $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
-        $this->Controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'stop']);
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['is'])
+            ->getMock();
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'stop'])
+            ->getMock();
         $this->Controller->RequestHandler->request = $this->Controller->request;
         $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
@@ -1087,7 +1134,9 @@ class RequestHandlerComponentTest extends TestCase
         $_SERVER['HTTP_IF_NONE_MATCH'] = '*';
         $event = new Event('Controller.beforeRender', $this->Controller);
         $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMock('Cake\Network\Response', ['notModified', 'stop']);
+        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified', 'stop'])
+            ->getMock();
         $RequestHandler->response->etag('something');
         $RequestHandler->response->expects($this->once())->method('notModified');
         $this->assertFalse($RequestHandler->beforeRender($event));
@@ -1104,7 +1153,9 @@ class RequestHandlerComponentTest extends TestCase
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
         $event = new Event('Controller.beforeRender');
         $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMock('Cake\Network\Response', ['notModified', 'stop']);
+        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified', 'stop'])
+            ->getMock();
         $RequestHandler->response->etag('something', true);
         $RequestHandler->response->expects($this->once())->method('notModified');
         $this->assertFalse($RequestHandler->beforeRender($event));
@@ -1122,7 +1173,9 @@ class RequestHandlerComponentTest extends TestCase
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
         $event = new Event('Controller.beforeRender', $this->Controller);
         $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMock('Cake\Network\Response', ['notModified', 'stop']);
+        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified', 'stop'])
+            ->getMock();
         $RequestHandler->response->etag('something', true);
         $RequestHandler->response->modified('2012-01-01 00:00:00');
         $RequestHandler->response->expects($this->once())->method('notModified');
@@ -1139,7 +1192,9 @@ class RequestHandlerComponentTest extends TestCase
     {
         $event = new Event('Controller.beforeRender', $this->Controller);
         $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMock('Cake\Network\Response', ['notModified', 'stop']);
+        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified', 'stop'])
+            ->getMock();
         $RequestHandler->response->expects($this->never())->method('notModified');
         $this->assertNull($RequestHandler->beforeRender($event));
     }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -598,7 +598,7 @@ class RequestHandlerComponentTest extends TestCase
     {
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->response = $this->getMock('Cake\Network\Response');
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $this->Controller->response->expects($this->never())
             ->method('body');

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -19,7 +19,6 @@ use Cake\Controller\Controller;
 use Cake\Controller\Exception\SecurityException;
 use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
@@ -153,7 +152,10 @@ class SecurityComponentTest extends TestCase
         parent::setUp();
 
         $session = new Session();
-        $request = $this->getMock('Cake\Network\Request', ['here'], ['posts/index']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['here'])
+            ->setConstructorArgs(['posts/index'])
+            ->getMock();
         $request->addParams(['controller' => 'posts', 'action' => 'index']);
         $request->session($session);
         $request->expects($this->any())
@@ -1303,7 +1305,9 @@ class SecurityComponentTest extends TestCase
         ];
         $this->assertTrue($this->validatePost());
 
-        $request = $this->getMock('Cake\Network\Request', ['here']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['here'])
+            ->getMock();
         $request->expects($this->at(0))
             ->method('here')
             ->will($this->returnValue('/posts/index?page=1'));

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -108,7 +108,7 @@ class ComponentRegistryTest extends TestCase
      */
     public function testLoadWithEnableFalse()
     {
-        $mock = $this->getMock('Cake\Event\EventManager');
+        $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->never())
             ->method('attach');
 

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -78,7 +78,7 @@ class ComponentTest extends TestCase
      */
     public function testInnerComponentsAreNotEnabled()
     {
-        $mock = $this->getMock('Cake\Event\EventManager');
+        $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $controller = new Controller();
         $controller->eventManager($mock);
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -272,7 +272,7 @@ class ControllerTest extends TestCase
     public function testTableAutoload()
     {
         $request = new Request('controller_posts/index');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $Controller = new Controller($request, $response);
         $Controller->modelClass = 'SiteArticles';
 
@@ -300,7 +300,7 @@ class ControllerTest extends TestCase
     public function testLoadModel()
     {
         $request = new Request('controller_posts/index');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $Controller = new Controller($request, $response);
 
         $this->assertFalse(isset($Controller->Articles));
@@ -652,7 +652,7 @@ class ControllerTest extends TestCase
      */
     public function testStartupProcess()
     {
-        $eventManager = $this->getMock('Cake\Event\EventManager');
+        $eventManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $controller = new Controller(null, null, null, $eventManager);
 
         $eventManager->expects($this->at(0))->method('dispatch')
@@ -685,7 +685,7 @@ class ControllerTest extends TestCase
      */
     public function testShutdownProcess()
     {
-        $eventManager = $this->getMock('Cake\Event\EventManager');
+        $eventManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $controller = new Controller(null, null, null, $eventManager);
 
         $eventManager->expects($this->once())->method('dispatch')
@@ -761,7 +761,7 @@ class ControllerTest extends TestCase
     {
         $url = new Request('test/missing');
         $url->addParams(['controller' => 'Test', 'action' => 'missing']);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $Controller = new TestController($url, $response);
         $Controller->invokeAction();
@@ -778,7 +778,7 @@ class ControllerTest extends TestCase
     {
         $url = new Request('test/private_m/');
         $url->addParams(['controller' => 'Test', 'action' => 'private_m']);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $Controller = new TestController($url, $response);
         $Controller->invokeAction();
@@ -795,7 +795,7 @@ class ControllerTest extends TestCase
     {
         $url = new Request('test/protected_m/');
         $url->addParams(['controller' => 'Test', 'action' => 'protected_m']);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $Controller = new TestController($url, $response);
         $Controller->invokeAction();
@@ -812,7 +812,7 @@ class ControllerTest extends TestCase
     {
         $url = new Request('test/redirect/');
         $url->addParams(['controller' => 'Test', 'action' => 'redirect']);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $Controller = new TestController($url, $response);
         $Controller->invokeAction();
@@ -831,7 +831,7 @@ class ControllerTest extends TestCase
             'action' => 'returner',
             'pass' => []
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $Controller = new TestController($url, $response);
         $result = $Controller->invokeAction();
@@ -849,7 +849,7 @@ class ControllerTest extends TestCase
         $request->addParams([
             'prefix' => 'admin'
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
         $Controller->eventManager()->on('Controller.beforeRender', function (Event $e) {
             return $e->subject()->response;
@@ -860,7 +860,7 @@ class ControllerTest extends TestCase
         $request->addParams([
             'prefix' => 'admin/super'
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
         $Controller->eventManager()->on('Controller.beforeRender', function (Event $e) {
             return $e->subject()->response;
@@ -888,7 +888,7 @@ class ControllerTest extends TestCase
     public function testComponents()
     {
         $request = new Request('/');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $controller = new TestController($request, $response);
         $this->assertInstanceOf('Cake\Controller\ComponentRegistry', $controller->components());
@@ -905,7 +905,7 @@ class ControllerTest extends TestCase
     public function testComponentsWithCustomRegistry()
     {
         $request = new Request('/');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $componentRegistry = $this->getMock('Cake\Controller\ComponentRegistry', ['offsetGet']);
 
         $controller = new TestController($request, $response, null, null, $componentRegistry);
@@ -923,7 +923,7 @@ class ControllerTest extends TestCase
     public function testLoadComponent()
     {
         $request = new Request('/');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $controller = new TestController($request, $response);
         $result = $controller->loadComponent('Paginator');
@@ -942,7 +942,7 @@ class ControllerTest extends TestCase
     public function testLoadComponentDuplicate()
     {
         $request = new Request('/');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $controller = new TestController($request, $response);
         $this->assertNotEmpty($controller->loadComponent('Paginator'));
@@ -963,7 +963,7 @@ class ControllerTest extends TestCase
     public function testIsAction()
     {
         $request = new Request('/');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $controller = new TestController($request, $response);
 
         $this->assertFalse($controller->isAction('redirect'));

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -23,7 +23,6 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
-use Cake\TestSuite\Fixture\TestModel;
 use Cake\TestSuite\TestCase;
 use TestApp\Controller\Admin\PostsController;
 use TestPlugin\Controller\TestPluginController;
@@ -509,7 +508,9 @@ class ControllerTest extends TestCase
      */
     public function testRedirectBeforeRedirectModifyingStatusCode()
     {
-        $Response = $this->getMock('Cake\Network\Response', ['stop']);
+        $Response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['stop'])
+            ->getMock();
         $Controller = new Controller(null, $Response);
 
         $Controller->eventManager()->attach(function ($event, $url, $response) {
@@ -524,7 +525,9 @@ class ControllerTest extends TestCase
 
     public function testRedirectBeforeRedirectListenerReturnResponse()
     {
-        $Response = $this->getMock('Cake\Network\Response', ['stop', 'header', 'statusCode']);
+        $Response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['stop', 'header', 'statusCode'])
+            ->getMock();
         $Controller = new Controller(null, $Response);
 
         $newResponse = new Response;
@@ -572,7 +575,9 @@ class ControllerTest extends TestCase
      */
     public function testReferer()
     {
-        $request = $this->getMock('Cake\Network\Request', ['referer']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['referer'])
+            ->getMock();
         $request->expects($this->any())->method('referer')
             ->with(true)
             ->will($this->returnValue('/posts/index'));
@@ -581,7 +586,9 @@ class ControllerTest extends TestCase
         $result = $Controller->referer(null, true);
         $this->assertEquals('/posts/index', $result);
 
-        $request = $this->getMock('Cake\Network\Request', ['referer']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['referer'])
+            ->getMock();
         $request->expects($this->any())->method('referer')
             ->with(true)
             ->will($this->returnValue('/posts/index'));
@@ -589,7 +596,9 @@ class ControllerTest extends TestCase
         $result = $Controller->referer(['controller' => 'posts', 'action' => 'index'], true);
         $this->assertEquals('/posts/index', $result);
 
-        $request = $this->getMock('Cake\Network\Request', ['referer']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['referer'])
+            ->getMock();
 
         $request->expects($this->any())->method('referer')
             ->with(false)
@@ -613,7 +622,9 @@ class ControllerTest extends TestCase
      */
     public function testRefererSlash()
     {
-        $request = $this->getMock('Cake\Network\Request', ['referer']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['referer'])
+            ->getMock();
         $request->base = '/base';
         Router::pushRequest($request);
 
@@ -663,7 +674,7 @@ class ControllerTest extends TestCase
                     $this->attributeEqualTo('_subject', $controller)
                 )
             )
-            ->will($this->returnValue($this->getMock('Cake\Event\Event', null, [], '', false)));
+            ->will($this->returnValue($this->getMockBuilder('Cake\Event\Event')->disableOriginalConstructor()->getMock()));
 
         $eventManager->expects($this->at(1))->method('dispatch')
             ->with(
@@ -673,7 +684,7 @@ class ControllerTest extends TestCase
                     $this->attributeEqualTo('_subject', $controller)
                 )
             )
-            ->will($this->returnValue($this->getMock('Cake\Event\Event', null, [], '', false)));
+            ->will($this->returnValue($this->getMockBuilder('Cake\Event\Event')->disableOriginalConstructor()->getMock()));
 
         $controller->startupProcess();
     }
@@ -696,7 +707,7 @@ class ControllerTest extends TestCase
                     $this->attributeEqualTo('_subject', $controller)
                 )
             )
-            ->will($this->returnValue($this->getMock('Cake\Event\Event', null, [], '', false)));
+            ->will($this->returnValue($this->getMockBuilder('Cake\Event\Event')->disableOriginalConstructor()->getMock()));
 
         $controller->shutdownProcess();
     }
@@ -710,7 +721,9 @@ class ControllerTest extends TestCase
     {
         $request = new Request('controller_posts/index');
         $request->params['pass'] = [];
-        $response = $this->getMock('Cake\Network\Response', ['httpCodes']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['httpCodes'])
+            ->getMock();
 
         $Controller = new Controller($request, $response);
         $Controller->request->query['url'] = [];
@@ -740,7 +753,9 @@ class ControllerTest extends TestCase
     {
         $request = new Request('controller_posts/index');
         $request->params['pass'] = [];
-        $response = $this->getMock('Cake\Network\Response', ['httpCodes']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['httpCodes'])
+            ->getMock();
 
         $Controller = new Controller($request, $response);
         $Controller->request->query['url'] = [];
@@ -906,7 +921,9 @@ class ControllerTest extends TestCase
     {
         $request = new Request('/');
         $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
-        $componentRegistry = $this->getMock('Cake\Controller\ComponentRegistry', ['offsetGet']);
+        $componentRegistry = $this->getMockBuilder('Cake\Controller\ComponentRegistry')
+            ->setMethods(['offsetGet'])
+            ->getMock();
 
         $controller = new TestController($request, $response, null, null, $componentRegistry);
         $this->assertInstanceOf(get_class($componentRegistry), $controller->components());

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -49,7 +49,7 @@ class ConnectionTest extends TestCase
      */
     public function getMockFormDriver()
     {
-        $driver = $this->getMock('Cake\Database\Driver');
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $driver->expects($this->once())
             ->method('enabled')
             ->will($this->returnValue(true));
@@ -816,7 +816,7 @@ class ConnectionTest extends TestCase
      */
     public function testLogFunction()
     {
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $this->connection->logger($logger);
         $logger->expects($this->once())->method('log')
             ->with($this->logicalAnd(
@@ -843,7 +843,7 @@ class ConnectionTest extends TestCase
         $driver = $this->getMockFormDriver();
         $connection->driver($driver);
 
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $connection->logger($logger);
         $logger->expects($this->at(0))->method('log')
             ->with($this->logicalAnd(
@@ -875,7 +875,7 @@ class ConnectionTest extends TestCase
             [['driver' => $driver]]
         );
 
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $connection->logger($logger);
 
         $logger->expects($this->at(1))->method('log')

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -31,9 +31,9 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteNoParams()
     {
-        $inner = $this->getMock('PDOStatement');
+        $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->once())->method('rowCount')->will($this->returnValue(3));
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->once())
             ->method('log')
             ->with($this->logicalAnd(
@@ -56,9 +56,9 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteWithParams()
     {
-        $inner = $this->getMock('PDOStatement');
+        $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->once())->method('rowCount')->will($this->returnValue(4));
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->once())
             ->method('log')
             ->with($this->logicalAnd(
@@ -81,9 +81,9 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteWithBinding()
     {
-        $inner = $this->getMock('PDOStatement');
+        $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->any())->method('rowCount')->will($this->returnValue(4));
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->at(0))
             ->method('log')
             ->with($this->logicalAnd(
@@ -105,7 +105,7 @@ class LoggingStatementTest extends TestCase
         $date = new \DateTime('2013-01-01');
         $inner->expects($this->at(0))->method('bindValue')->with('a', 1);
         $inner->expects($this->at(1))->method('bindValue')->with('b', $date);
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
         $st->logger($logger);
@@ -126,10 +126,10 @@ class LoggingStatementTest extends TestCase
     public function testExecuteWithError()
     {
         $exception = new \LogicException('This is bad');
-        $inner = $this->getMock('PDOStatement');
+        $inner = $this->getMockBuilder('PDOStatement')->getMock();
         $inner->expects($this->once())->method('execute')
             ->will($this->throwException($exception));
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger');
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $logger->expects($this->once())
             ->method('log')
             ->with($this->logicalAnd(

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -192,7 +192,7 @@ class MysqlSchemaTest extends TestCase
             'comment' => 'Comment section',
         ];
 
-        $driver = $this->getMock('Cake\Database\Driver\Mysql');
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')->getMock();
         $dialect = new MysqlSchema($driver);
 
         $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
@@ -1078,7 +1078,7 @@ SQL;
      */
     public function testConstructConnectsDriver()
     {
-        $driver = $this->getMock('Cake\Database\Driver');
+        $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $driver->expects($this->once())
             ->method('connect');
         $schema = new MysqlSchema($driver);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -226,7 +226,7 @@ SQL;
             'comment' => 'Comment section',
         ];
 
-        $driver = $this->getMock('Cake\Database\Driver\Postgres');
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')->getMock();
         $dialect = new PostgresSchema($driver);
 
         $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -149,7 +149,7 @@ class SqliteSchemaTest extends TestCase
             'default' => 'Default value',
         ];
 
-        $driver = $this->getMock('Cake\Database\Driver\Sqlite');
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')->getMock();
         $dialect = new SqliteSchema($driver);
 
         $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
@@ -166,7 +166,7 @@ class SqliteSchemaTest extends TestCase
      */
     public function testConvertCompositePrimaryKey()
     {
-        $driver = $this->getMock('Cake\Database\Driver\Sqlite');
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')->getMock();
         $dialect = new SqliteSchema($driver);
 
         $field1 = [

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -245,7 +245,7 @@ SQL;
             'default' => 'Default value',
         ];
 
-        $driver = $this->getMock('Cake\Database\Driver\Sqlserver');
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')->getMock();
         $dialect = new SqlserverSchema($driver);
 
         $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);

--- a/tests/TestCase/Database/Statement/StatementDecoratorTest.php
+++ b/tests/TestCase/Database/Statement/StatementDecoratorTest.php
@@ -32,8 +32,8 @@ class StatemetDecoratorTest extends TestCase
      */
     public function testLastInsertId()
     {
-        $statement = $this->getMock('\PDOStatement');
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $statement = $this->getMockBuilder('\PDOStatement')->getMock();
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $statement = new StatementDecorator($statement, $driver);
 
         $driver->expects($this->once())->method('lastInsertId')
@@ -50,8 +50,8 @@ class StatemetDecoratorTest extends TestCase
      */
     public function testLastInsertIdWithReturning()
     {
-        $internal = $this->getMock('\PDOStatement');
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $internal = $this->getMockBuilder('\PDOStatement')->getMock();
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $statement = new StatementDecorator($internal, $driver);
 
         $internal->expects($this->once())->method('columnCount')
@@ -71,8 +71,8 @@ class StatemetDecoratorTest extends TestCase
      */
     public function testNoDoubleExecution()
     {
-        $inner = $this->getMock('\PDOStatement');
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $inner = $this->getMockBuilder('\PDOStatement')->getMock();
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $statement = new StatementDecorator($inner, $driver);
 
         $inner->expects($this->once())->method('execute');

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -33,7 +33,7 @@ class BinaryTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = Type::build('binary');
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -33,7 +33,7 @@ class BoolTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = Type::build('boolean');
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -40,7 +40,7 @@ class DateTimeTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DateTimeType();
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -34,7 +34,7 @@ class DateTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DateType();
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -35,7 +35,7 @@ class FloatTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = Type::build('float');
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $this->locale = I18n::locale();
         $this->numberClass = FloatType::$numberClass;
 

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -33,7 +33,7 @@ class IntegerTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = Type::build('integer');
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -33,7 +33,7 @@ class StringTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = Type::build('string');
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -33,7 +33,7 @@ class TimeTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new TimeType();
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -33,7 +33,7 @@ class UuidTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = Type::build('uuid');
-        $this->driver = $this->getMock('Cake\Database\Driver');
+        $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -179,7 +179,7 @@ class TypeTest extends TestCase
         );
         $type = Type::build('biginteger');
         $integer = time() * time();
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $this->assertSame($integer, $type->toPHP($integer, $driver));
         $this->assertSame($integer, $type->toPHP('' . $integer, $driver));
         $this->assertSame(3, $type->toPHP(3.57, $driver));
@@ -194,7 +194,7 @@ class TypeTest extends TestCase
     {
         $type = Type::build('biginteger');
         $integer = time() * time();
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $this->assertEquals(PDO::PARAM_INT, $type->toStatement($integer, $driver));
     }
 
@@ -206,7 +206,7 @@ class TypeTest extends TestCase
     public function testDecimalToPHP()
     {
         $type = Type::build('decimal');
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
 
         $this->assertSame(3.14159, $type->toPHP('3.14159', $driver));
         $this->assertSame(3.14159, $type->toPHP(3.14159, $driver));
@@ -223,7 +223,7 @@ class TypeTest extends TestCase
     {
         $type = Type::build('decimal');
         $string = '12.55';
-        $driver = $this->getMock('\Cake\Database\Driver');
+        $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $this->assertEquals(PDO::PARAM_STR, $type->toStatement($string, $driver));
     }
 
@@ -234,7 +234,7 @@ class TypeTest extends TestCase
      */
     public function testSet()
     {
-        $instance = $this->getMock('Cake\Database\Type');
+        $instance = $this->getMockBuilder('Cake\Database\Type')->getMock();
         Type::set('random', $instance);
         $this->assertSame($instance, Type::build('random'));
     }

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -32,7 +32,7 @@ class QueryCacherTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->engine = $this->getMock('Cake\Cache\CacheEngine');
+        $this->engine = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $this->engine->expects($this->any())
             ->method('init')
             ->will($this->returnValue(true));
@@ -60,7 +60,7 @@ class QueryCacherTest extends TestCase
     public function testFetchFunctionKey()
     {
         $this->_mockRead('my_key', 'A winner');
-        $query = $this->getMock('stdClass');
+        $query = $this->getMockBuilder('stdClass')->getMock();
 
         $cacher = new QueryCacher(function ($q) use ($query) {
             $this->assertSame($query, $q);
@@ -81,7 +81,7 @@ class QueryCacherTest extends TestCase
     public function testFetchFunctionKeyNoString()
     {
         $this->_mockRead('my_key', 'A winner');
-        $query = $this->getMock('stdClass');
+        $query = $this->getMockBuilder('stdClass')->getMock();
 
         $cacher = new QueryCacher(function ($q) {
             return false;
@@ -99,7 +99,7 @@ class QueryCacherTest extends TestCase
     {
         $this->_mockRead('my_key', 'A winner');
         $cacher = new QueryCacher('my_key', 'queryCache');
-        $query = $this->getMock('stdClass');
+        $query = $this->getMockBuilder('stdClass')->getMock();
         $result = $cacher->fetch($query);
         $this->assertEquals('A winner', $result);
     }
@@ -113,7 +113,7 @@ class QueryCacherTest extends TestCase
     {
         $this->_mockRead('my_key', 'A winner');
         $cacher = new QueryCacher('my_key', $this->engine);
-        $query = $this->getMock('stdClass');
+        $query = $this->getMockBuilder('stdClass')->getMock();
         $result = $cacher->fetch($query);
         $this->assertEquals('A winner', $result);
     }
@@ -127,7 +127,7 @@ class QueryCacherTest extends TestCase
     {
         $this->_mockRead('my_key', false);
         $cacher = new QueryCacher('my_key', $this->engine);
-        $query = $this->getMock('stdClass');
+        $query = $this->getMockBuilder('stdClass')->getMock();
         $result = $cacher->fetch($query);
         $this->assertNull($result, 'Cache miss should not have an isset() return.');
     }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -87,7 +87,7 @@ class ErrorHandlerTest extends TestCase
         Router::setRequestInfo($request);
         Configure::write('debug', true);
 
-        $this->_logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->_logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         Log::reset();
         Log::config('error_test', [

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -671,7 +671,7 @@ class ExceptionRendererTest extends TestCase
             ->with('missingHelper')
             ->will($this->throwException($exception));
 
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $response->expects($this->once())
             ->method('body')
             ->with($this->stringContains('Helper class Fail'));
@@ -698,7 +698,7 @@ class ExceptionRendererTest extends TestCase
             ->method('beforeRender')
             ->will($this->throwException($exception));
 
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $response->expects($this->once())
             ->method('body')
             ->with($this->stringContains('Not there, sorry'));
@@ -729,7 +729,7 @@ class ExceptionRendererTest extends TestCase
             ->with('error400')
             ->will($this->throwException($exception));
 
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $response->expects($this->once())
             ->method('body')
             ->with($this->stringContains('Not Found'));
@@ -756,7 +756,7 @@ class ExceptionRendererTest extends TestCase
 
         $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
         $ExceptionRenderer->controller->plugin = 'TestPlugin';
-        $ExceptionRenderer->controller->request = $this->getMock('Cake\Network\Request');
+        $ExceptionRenderer->controller->request = $this->getMockBuilder('Cake\Network\Request')->getMock();
 
         $exception = new MissingPluginException(['plugin' => 'TestPlugin']);
         $ExceptionRenderer->controller->expects($this->once())
@@ -764,7 +764,7 @@ class ExceptionRendererTest extends TestCase
             ->with('error400')
             ->will($this->throwException($exception));
 
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $response->expects($this->once())
             ->method('body')
             ->with($this->logicalAnd(
@@ -789,7 +789,7 @@ class ExceptionRendererTest extends TestCase
 
         $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
         $ExceptionRenderer->controller->plugin = 'TestPlugin';
-        $ExceptionRenderer->controller->request = $this->getMock('Cake\Network\Request');
+        $ExceptionRenderer->controller->request = $this->getMockBuilder('Cake\Network\Request')->getMock();
 
         $exception = new MissingPluginException(['plugin' => 'TestPluginTwo']);
         $ExceptionRenderer->controller->expects($this->once())
@@ -797,7 +797,7 @@ class ExceptionRendererTest extends TestCase
             ->with('error400')
             ->will($this->throwException($exception));
 
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $response->expects($this->once())
             ->method('body')
             ->with($this->logicalAnd(

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -583,7 +583,7 @@ class EventManagerTest extends TestCase
      */
     public function testStopPropagation()
     {
-        $generalManager = $this->getMock('Cake\Event\EventManager');
+        $generalManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $manager = new EventManager();
         $listener = new EventTestListener();
 
@@ -612,7 +612,7 @@ class EventManagerTest extends TestCase
      */
     public function testDispatchPrioritizedWithGlobal()
     {
-        $generalManager = $this->getMock('Cake\Event\EventManager');
+        $generalManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $manager = new EventManager();
         $listener = new CustomTestEventListenerInterface();
         $event = new Event('fake.event');
@@ -645,7 +645,7 @@ class EventManagerTest extends TestCase
      */
     public function testDispatchGlobalBeforeLocal()
     {
-        $generalManager = $this->getMock('Cake\Event\EventManager');
+        $generalManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $manager = new EventManager();
         $listener = new CustomTestEventListenerInterface();
         $event = new Event('fake.event');

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -36,7 +36,7 @@ class FormTest extends TestCase
         $this->assertInstanceOf('Cake\Form\Schema', $schema);
         $this->assertSame($schema, $form->schema(), 'Same instance each time');
 
-        $schema = $this->getMock('Cake\Form\Schema');
+        $schema = $this->getMockBuilder('Cake\Form\Schema')->getMock();
         $this->assertSame($schema, $form->schema($schema));
         $this->assertSame($schema, $form->schema());
     }
@@ -54,7 +54,7 @@ class FormTest extends TestCase
         $this->assertInstanceOf('Cake\Validation\Validator', $validator);
         $this->assertSame($validator, $form->validator(), 'Same instance each time');
 
-        $validator = $this->getMock('Cake\Validation\Validator');
+        $validator = $this->getMockBuilder('Cake\Validation\Validator')->getMock();
         $this->assertSame($validator, $form->validator($validator));
         $this->assertSame($validator, $form->validator());
     }

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -29,7 +29,7 @@ class ConsoleLogTest extends TestCase
      */
     public function testConsoleOutputlogs()
     {
-        $output = $this->getMock('Cake\Console\ConsoleOutput');
+        $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
         $output->expects($this->at(0))
             ->method('outputAs');
@@ -74,7 +74,7 @@ class ConsoleLogTest extends TestCase
         } else {
             $expected = ConsoleOutput::COLOR;
         }
-        $output = $this->getMock('Cake\Console\ConsoleOutput');
+        $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
         $output->expects($this->at(0))
             ->method('outputAs')

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -37,7 +37,7 @@ class LogTraitTest extends TestCase
      */
     public function testLog()
     {
-        $mock = $this->getMock('Psr\Log\LoggerInterface');
+        $mock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $mock->expects($this->at(0))
             ->method('log')
             ->with('error', 'Testing');

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -794,7 +794,7 @@ class EmailTest extends TestCase
         $result = $this->CakeEmail->transport();
         $this->assertInstanceOf('Cake\Mailer\Transport\DebugTransport', $result);
 
-        $instance = $this->getMock('Cake\Mailer\Transport\DebugTransport');
+        $instance = $this->getMockBuilder('Cake\Mailer\Transport\DebugTransport')->getMock();
         $this->CakeEmail->transport($instance);
         $this->assertSame($instance, $this->CakeEmail->transport());
     }
@@ -2630,7 +2630,7 @@ HTML;
      */
     public function testMockTransport()
     {
-        $mock = $this->getMock('\Cake\Mailer\AbstractTransport');
+        $mock = $this->getMockBuilder('\Cake\Mailer\AbstractTransport')->getMock();
         $config = ['from' => 'tester@example.org', 'transport' => 'default'];
 
         Email::config('default', $config);

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -493,7 +493,7 @@ class ClientTest extends TestCase
             'Cake\Network\Http\Adapter\Stream',
             ['send']
         );
-        $cookieJar = $this->getMock('Cake\Network\Http\CookieCollection');
+        $cookieJar = $this->getMockBuilder('Cake\Network\Http\CookieCollection')->getMock();
 
         $headers = [
             'HTTP/1.0 200 Ok',

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -456,7 +456,7 @@ class AssociationTest extends TestCase
      */
     public function testLocatorInConstructor()
     {
-        $locator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
+        $locator = $this->getMockBuilder('Cake\ORM\Locator\LocatorInterface')->getMock();
         $config = [
             'className' => '\Cake\Test\TestCase\ORM\TestTable',
             'tableLocator' => $locator

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -52,7 +52,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testImplementedEventsDefault()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
 
         $expected = [
@@ -70,7 +70,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testImplementedEventsCustom()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $settings = ['events' => ['Something.special' => ['date_specialed' => 'always']]];
         $this->Behavior = new TimestampBehavior($table, $settings);
 
@@ -88,7 +88,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testCreatedAbsent()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -110,7 +110,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testCreatedPresent()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -132,7 +132,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testCreatedNotNew()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -154,7 +154,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testModifiedAbsent()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -177,7 +177,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testModifiedPresent()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -204,7 +204,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testInvalidEventConfig()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $settings = ['events' => ['Model.beforeSave' => ['created' => 'fat fingers']]];
         $this->Behavior = new TimestampBehavior($table, $settings);
 
@@ -220,7 +220,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testGetTimestamp()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
 
         $return = $this->Behavior->timestamp();
@@ -283,7 +283,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testSetTimestampExplicit()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
 
         $ts = new \DateTime();
@@ -304,7 +304,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testTouch()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->Behavior = new TimestampBehavior($table);
         $ts = new \DateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
@@ -327,7 +327,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testTouchNoop()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $config = [
             'events' => [
                 'Model.beforeSave' => [
@@ -354,7 +354,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testTouchCustomEvent()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $settings = ['events' => ['Something.special' => ['date_specialed' => 'always']]];
         $this->Behavior = new TimestampBehavior($table, $settings);
         $ts = new \DateTime('2000-01-01');

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -367,7 +367,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testSetTable()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $table->expects($this->once())->method('eventManager');
 
         $this->Behaviors->setTable($table);

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -190,7 +190,7 @@ class BehaviorTest extends TestCase
      */
     public function testConstructor()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $config = ['key' => 'value'];
         $behavior = new TestBehavior($table, $config);
         $this->assertEquals($config, $behavior->config());
@@ -198,7 +198,7 @@ class BehaviorTest extends TestCase
 
     public function testReflectionCache()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test3Behavior($table);
         $expected = [
             'finders' => [
@@ -219,7 +219,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedEvents()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new TestBehavior($table);
         $expected = [
             'Model.beforeFind' => 'beforeFind',
@@ -239,7 +239,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedEventsWithPriority()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new TestBehavior($table, ['priority' => 10]);
         $expected = [
             'Model.beforeFind' => [
@@ -277,7 +277,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedMethods()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table);
         $expected = [
             'doSomething' => 'doSomething'
@@ -292,7 +292,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedMethodsAliased()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [
                 'aliased' => 'doSomething'
@@ -311,7 +311,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedMethodsDisabled()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => []
         ]);
@@ -326,7 +326,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedFinders()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table);
         $expected = [
             'foo' => 'findFoo',
@@ -341,7 +341,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedFindersAliased()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
                 'aliased' => 'findFoo'
@@ -360,7 +360,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedFindersDisabled()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => []
         ]);
@@ -376,7 +376,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyConfig()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table);
         $behavior->verifyConfig();
         $this->assertTrue(true, 'No exception thrown');
@@ -391,7 +391,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyConfigImplementedFindersOverridden()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
                 'aliased' => 'findFoo'
@@ -411,7 +411,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyImplementedFindersInvalid()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
                 'aliased' => 'findNotDefined'
@@ -429,7 +429,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyConfigImplementedMethodsOverridden()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table);
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [
@@ -450,7 +450,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyImplementedMethodsInvalid()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [
                 'aliased' => 'iDoNotExist'

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -46,7 +46,7 @@ class LocatorAwareTraitTest extends TestCase
         $tableLocator = $this->subject->tableLocator();
         $this->assertSame(TableRegistry::locator(), $tableLocator);
 
-        $newLocator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
+        $newLocator = $this->getMockBuilder('Cake\ORM\Locator\LocatorInterface')->getMock();
         $subjectLocator = $this->subject->tableLocator($newLocator);
         $this->assertSame($newLocator, $subjectLocator);
     }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -477,7 +477,7 @@ class TableLocatorTest extends TestCase
      */
     public function testSet()
     {
-        $mock = $this->getMock('Cake\ORM\Table');
+        $mock = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $this->assertSame($mock, $this->_locator->set('Articles', $mock));
         $this->assertSame($mock, $this->_locator->get('Articles'));
     }
@@ -491,7 +491,7 @@ class TableLocatorTest extends TestCase
     {
         Plugin::load('TestPlugin');
 
-        $mock = $this->getMock('TestPlugin\Model\Table\CommentsTable');
+        $mock = $this->getMockBuilder('TestPlugin\Model\Table\CommentsTable')->getMock();
 
         $this->assertSame($mock, $this->_locator->set('TestPlugin.Comments', $mock));
         $this->assertSame($mock, $this->_locator->get('TestPlugin.Comments'));

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -841,7 +841,7 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection, $this->table);
 
-        $stmt = $this->getMock('Cake\Database\StatementInterface');
+        $stmt = $this->getMockBuilder('Cake\Database\StatementInterface')->getMock();
         $results = new ResultSet($query, $stmt);
         $query->setResult($results);
         $this->assertSame($results, $query->all());
@@ -1845,7 +1845,7 @@ class QueryTest extends TestCase
         $query->expects($this->never())
             ->method('execute');
 
-        $cacher = $this->getMock('Cake\Cache\CacheEngine');
+        $cacher = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $cacher->expects($this->once())
             ->method('read')
             ->with('my_key')
@@ -1870,7 +1870,7 @@ class QueryTest extends TestCase
 
         $query->select(['id', 'title']);
 
-        $cacher = $this->getMock('Cake\Cache\CacheEngine');
+        $cacher = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $cacher->expects($this->once())
             ->method('write')
             ->with(

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -331,7 +331,7 @@ class ResultSetTest extends TestCase
         $query->autoFields(false);
 
         $row = ['Other__field' => 'test'];
-        $statement = $this->getMock('Cake\Database\StatementInterface');
+        $statement = $this->getMockBuilder('Cake\Database\StatementInterface')->getMock();
         $statement->method('fetch')
             ->will($this->onConsecutiveCalls($row, $row));
         $statement->method('rowCount')

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -60,7 +60,7 @@ class TableRegistryTest extends TestCase
      */
     protected function _setMockLocator()
     {
-        $locator = $this->getMock('Cake\ORM\Locator\LocatorInterface');
+        $locator = $this->getMockBuilder('Cake\ORM\Locator\LocatorInterface')->getMock();
         TableRegistry::locator($locator);
 
         return $locator;
@@ -124,7 +124,7 @@ class TableRegistryTest extends TestCase
      */
     public function testSet()
     {
-        $table = $this->getMock('Cake\ORM\Table');
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
 
         $locator = $this->_setMockLocator();
         $locator->expects($this->once())->method('set')->with('Test', $table);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2316,7 +2316,7 @@ class TableTest extends TestCase
             ['execute', 'addDefaultTypes'],
             [null, $table]
         );
-        $statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
+        $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
         $data = new \Cake\ORM\Entity([
             'username' => 'superuser',
             'created' => new Time('2013-10-10 00:00'),
@@ -2513,7 +2513,7 @@ class TableTest extends TestCase
         $table->expects($this->once())->method('query')
             ->will($this->returnValue($query));
 
-        $statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
+        $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
         $statement->expects($this->once())
             ->method('rowCount')
             ->will($this->returnValue(0));
@@ -2697,7 +2697,7 @@ class TableTest extends TestCase
         $table->expects($this->once())->method('query')
             ->will($this->returnValue($query));
 
-        $statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
+        $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
         $statement->expects($this->once())
             ->method('errorCode')
             ->will($this->returnValue('00000'));
@@ -3021,7 +3021,7 @@ class TableTest extends TestCase
         $entity = new \Cake\ORM\Entity(['id' => 1, 'name' => 'mark']);
         $options = new \ArrayObject(['atomic' => true, 'checkRules' => false, '_primary' => true]);
 
-        $mock = $this->getMock('Cake\Event\EventManager');
+        $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
 
         $mock->expects($this->at(0))
             ->method('on');
@@ -3136,7 +3136,7 @@ class TableTest extends TestCase
         $entity = new \Cake\ORM\Entity(['id' => 1, 'name' => 'mark']);
         $options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
 
-        $mock = $this->getMock('Cake\Event\EventManager');
+        $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->at(2))
             ->method('dispatch')
             ->will($this->returnCallback(function ($event) {
@@ -3159,7 +3159,7 @@ class TableTest extends TestCase
         $entity = new \Cake\ORM\Entity(['id' => 1, 'name' => 'mark']);
         $options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
 
-        $mock = $this->getMock('Cake\Event\EventManager');
+        $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->at(2))
             ->method('dispatch')
             ->will($this->returnCallback(function ($event) {

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -254,7 +254,7 @@ class DispatcherTest extends TestCase
                 'action' => 'home',
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->dispatcher->dispatch($request, $response, ['return' => 1]);
     }
 
@@ -275,7 +275,7 @@ class DispatcherTest extends TestCase
             ]
         ]);
         $url = new Request('dispatcher_test_interface/index');
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->dispatcher->dispatch($request, $response, ['return' => 1]);
     }
 
@@ -295,7 +295,7 @@ class DispatcherTest extends TestCase
                 'action' => 'index',
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->dispatcher->dispatch($request, $response, ['return' => 1]);
     }
 
@@ -319,7 +319,7 @@ class DispatcherTest extends TestCase
                 'pass' => ['home'],
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->dispatcher->dispatch($request, $response, ['return' => 1]);
     }
 
@@ -339,7 +339,7 @@ class DispatcherTest extends TestCase
                 'return' => 1
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $this->dispatcher->dispatch($url, $response);
         $expected = 'Pages';
@@ -387,7 +387,7 @@ class DispatcherTest extends TestCase
                 'return' => 1
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $this->dispatcher->dispatch($request, $response);
 
@@ -419,7 +419,7 @@ class DispatcherTest extends TestCase
                 'return' => 1
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $this->dispatcher->dispatch($request, $response);
 
@@ -450,7 +450,7 @@ class DispatcherTest extends TestCase
                 'return' => 1
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->dispatcher->dispatch($request, $response);
     }
 
@@ -473,7 +473,7 @@ class DispatcherTest extends TestCase
                 'return' => 1
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response');
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->dispatcher->dispatch($request, $response);
     }
 

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -403,7 +403,7 @@ class RequestActionTraitTest extends TestCase
         $result = $this->object->requestAction('/request_action/session_test');
         $this->assertNull($result);
 
-        $session = $this->getMock('Cake\Network\Session');
+        $session = $this->getMockBuilder('Cake\Network\Session')->getMock();
         $session->expects($this->once())
             ->method('read')
             ->with('foo')

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -31,7 +31,7 @@ class I18nShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->shell = new I18nShell($this->io);
 
         $this->localeDir = TMP . 'Locale' . DS;

--- a/tests/TestCase/Shell/OrmCacheShellTest.php
+++ b/tests/TestCase/Shell/OrmCacheShellTest.php
@@ -40,10 +40,10 @@ class OrmCacheShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->shell = new OrmCacheShell($this->io);
 
-        $this->cache = $this->getMock('Cake\Cache\CacheEngine');
+        $this->cache = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $this->cache->expects($this->any())
             ->method('init')
             ->will($this->returnValue(true));

--- a/tests/TestCase/Shell/PluginShellTest.php
+++ b/tests/TestCase/Shell/PluginShellTest.php
@@ -32,7 +32,7 @@ class PluginShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->shell = new PluginShell($this->io);
     }
 

--- a/tests/TestCase/Shell/ServerShellTest.php
+++ b/tests/TestCase/Shell/ServerShellTest.php
@@ -31,7 +31,7 @@ class ServerShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->shell = new ServerShell($this->io);
     }
 

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -53,7 +53,7 @@ class FixtureManagerTest extends TestCase
      */
     public function testFixturizeCore()
     {
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['core.articles'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
@@ -80,7 +80,7 @@ class FixtureManagerTest extends TestCase
             'stream' => $buffer
         ]);
 
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['core.articles'];
         $this->manager->fixturize($test);
         // Need to load/shutdown twice to ensure fixture is created.
@@ -122,7 +122,7 @@ class FixtureManagerTest extends TestCase
             $db->execute($stmt);
         }
 
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['core.articles'];
         $this->manager->fixturize($test);
         $this->manager->load($test);
@@ -138,7 +138,7 @@ class FixtureManagerTest extends TestCase
      */
     public function testFixturizeCoreConstraint()
     {
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['core.articles', 'core.articles_tags', 'core.tags'];
         $this->manager->fixturize($test);
         $this->manager->load($test);
@@ -191,7 +191,7 @@ class FixtureManagerTest extends TestCase
     {
         Plugin::load('TestPlugin');
 
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['plugin.test_plugin.articles'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
@@ -210,7 +210,7 @@ class FixtureManagerTest extends TestCase
      */
     public function testFixturizeCustom()
     {
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['plugin.Company/TestPluginThree.articles'];
         $this->manager->fixturize($test);
         $fixtures = $this->manager->loaded();
@@ -230,7 +230,7 @@ class FixtureManagerTest extends TestCase
      */
     public function testFixturizeInvalidType()
     {
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['derp.derp'];
         $this->manager->fixturize($test);
     }
@@ -242,7 +242,7 @@ class FixtureManagerTest extends TestCase
      */
     public function testLoadSingle()
     {
-        $test = $this->getMock('Cake\TestSuite\TestCase');
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->autoFixtures = false;
         $test->fixtures = ['core.articles', 'core.articles_tags', 'core.tags'];
         $this->manager->fixturize($test);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -186,7 +186,7 @@ class TestCaseTest extends TestCase
     {
         $test = new FixturizedTestCase('testFixtureLoadOnDemand');
         $test->autoFixtures = false;
-        $manager = $this->getMock('Cake\TestSuite\Fixture\FixtureManager');
+        $manager = $this->getMockBuilder('Cake\TestSuite\Fixture\FixtureManager')->getMock();
         $manager->fixturize($test);
         $test->fixtureManager = $manager;
         $manager->expects($this->once())->method('loadSingle');

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -38,8 +38,8 @@ class CellTest extends TestCase
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
         Plugin::load(['TestPlugin', 'TestTheme']);
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $this->View = new \Cake\View\View($request, $response);
     }
 
@@ -344,8 +344,8 @@ class CellTest extends TestCase
      */
     public function testCellInheritsCustomViewClass()
     {
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
         $view = new CustomJsonView($request, $response);
         $cell = $view->cell('Articles');
         $this->assertSame('TestApp\View\CustomJsonView', $cell->viewClass);
@@ -358,7 +358,7 @@ class CellTest extends TestCase
      */
     public function testCachedRenderSimple()
     {
-        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $mock->method('init')
             ->will($this->returnValue(true));
         $mock->method('read')
@@ -381,7 +381,7 @@ class CellTest extends TestCase
      */
     public function testReadCachedCell()
     {
-        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $mock->method('init')
             ->will($this->returnValue(true));
         $mock->method('read')
@@ -403,7 +403,7 @@ class CellTest extends TestCase
      */
     public function testCachedRenderArrayConfig()
     {
-        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $mock->method('init')
             ->will($this->returnValue(true));
         $mock->method('read')
@@ -428,7 +428,7 @@ class CellTest extends TestCase
      */
     public function testCachedRenderSimpleCustomTemplate()
     {
-        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $mock->method('init')
             ->will($this->returnValue(true));
         $mock->method('read')

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -249,7 +249,7 @@ class FormHelperTest extends TestCase
         $data = [
             'val' => 1
         ];
-        $mock = $this->getMock('Cake\View\Widget\WidgetInterface');
+        $mock = $this->getMockBuilder('Cake\View\Widget\WidgetInterface')->getMock();
         $this->assertNull($this->Form->addWidget('test', $mock));
         $mock->expects($this->once())
             ->method('render')
@@ -271,7 +271,7 @@ class FormHelperTest extends TestCase
             'val' => 1,
             'name' => 'test'
         ];
-        $mock = $this->getMock('Cake\View\Widget\WidgetInterface');
+        $mock = $this->getMockBuilder('Cake\View\Widget\WidgetInterface')->getMock();
         $this->assertNull($this->Form->addWidget('test', $mock));
 
         $mock->expects($this->at(0))
@@ -328,7 +328,7 @@ class FormHelperTest extends TestCase
     public function testAddContextProvider()
     {
         $context = 'My data';
-        $stub = $this->getMock('Cake\View\Form\ContextInterface');
+        $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->Form->addContextProvider('test', function ($request, $data) use ($context, $stub) {
             $this->assertInstanceOf('Cake\Network\Request', $request);
             $this->assertEquals($context, $data['entity']);
@@ -347,7 +347,7 @@ class FormHelperTest extends TestCase
     public function testAddContextProviderReplace()
     {
         $entity = new Article();
-        $stub = $this->getMock('Cake\View\Form\ContextInterface');
+        $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->Form->addContextProvider('orm', function ($request, $data) use ($stub) {
             return $stub;
         });
@@ -364,7 +364,7 @@ class FormHelperTest extends TestCase
     public function testAddContextProviderAdd()
     {
         $entity = new Article();
-        $stub = $this->getMock('Cake\View\Form\ContextInterface');
+        $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->Form->addContextProvider('newshiny', function ($request, $data) use ($stub) {
             if ($data['entity'] instanceof Entity) {
                 return $stub;
@@ -7967,7 +7967,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->context();
         $this->assertInstanceOf('Cake\View\Form\ContextInterface', $result);
 
-        $mock = $this->getMock('Cake\View\Form\ContextInterface');
+        $mock = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->assertSame($mock, $this->Form->context($mock));
         $this->assertSame($mock, $this->Form->context());
     }

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -137,7 +137,7 @@ class HelperTest extends TestCase
     {
         Plugin::loadAll();
 
-        $events = $this->getMock('\Cake\Event\EventManager');
+        $events = $this->getMockBuilder('\Cake\Event\EventManager')->getMock();
         $this->View->eventManager($events);
 
         $events->expects($this->never())

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -109,9 +109,9 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildComplete()
     {
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
-        $events = $this->getMock('Cake\Event\EventManager');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
+        $events = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
 
         $builder = new ViewBuilder();
         $builder->name('Articles')

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -335,8 +335,8 @@ class ViewTest extends TestCase
      */
     public function testGetTemplate()
     {
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $viewOptions = [
             'plugin' => null,
@@ -411,8 +411,8 @@ class ViewTest extends TestCase
      */
     public function testPluginGetTemplateAbsoluteFail()
     {
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $viewOptions = [
             'plugin' => null,
@@ -591,8 +591,8 @@ class ViewTest extends TestCase
             'name' => 'Pages',
             'viewPath' => 'Pages'
         ];
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $View = new TestView(null, null, null, $viewOptions);
 
@@ -637,8 +637,8 @@ class ViewTest extends TestCase
             'name' => 'Pages',
             'viewPath' => 'Pages',
         ];
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $view = new TestView(null, null, null, $viewOptions);
         $view->ext('.php');
@@ -757,8 +757,8 @@ class ViewTest extends TestCase
             'name' => 'Pages',
             'viewPath' => 'Pages',
         ];
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $view = new TestView(null, null, null, $viewOptions);
         $view->ext('.php');
@@ -777,8 +777,8 @@ class ViewTest extends TestCase
             'name' => 'Pages',
             'viewPath' => 'Pages'
         ];
-        $request = $this->getMock('Cake\Network\Request');
-        $response = $this->getMock('Cake\Network\Response');
+        $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
+        $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
 
         $View = new TestView($request, $response, null, $viewOptions);
         $View->getViewFileName('does_not_exist');
@@ -1144,7 +1144,7 @@ class ViewTest extends TestCase
         $View = $this->PostsController->createView();
         $View->templatePath($this->PostsController->name);
 
-        $manager = $this->getMock('Cake\Event\EventManager');
+        $manager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $View->eventManager($manager);
 
         $manager->expects($this->at(0))->method('dispatch')

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -31,7 +31,7 @@ class BasicWidgetTest extends TestCase
             'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -31,7 +31,7 @@ class ButtonWidgetTest extends TestCase
             'button' => '<button{{attrs}}>{{text}}</button>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -36,7 +36,7 @@ class CheckboxWidgetTest extends TestCase
             'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -40,7 +40,7 @@ class DateTimeWidgetTest extends TestCase
             'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}'
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->selectBox = new SelectBoxWidget($this->templates);
         $this->DateTime = new DateTimeWidget($this->templates, $this->selectBox);
     }

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -36,7 +36,7 @@ class FileWidgetTest extends TestCase
             'file' => '<input type="file" name="{{name}}"{{attrs}}>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -36,7 +36,7 @@ class LabelWidgetTest extends TestCase
             'label' => '<label{{attrs}}>{{text}}</label>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -41,7 +41,7 @@ class MultiCheckboxWidgetTest extends TestCase
             'multicheckboxTitle' => '<legend>{{text}}</legend>',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -40,7 +40,7 @@ class RadioWidgetTest extends TestCase
             'radioWrapper' => '{{label}}',
         ];
         $this->templates = new StringTemplate($templates);
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
     }
 
     /**

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -39,7 +39,7 @@ class SelectBoxWidgetTest extends TestCase
             'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
             'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
         ];
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->templates = new StringTemplate($templates);
     }
 

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -35,7 +35,7 @@ class TextareaWidgetTest extends TestCase
         $templates = [
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
         ];
-        $this->context = $this->getMock('Cake\View\Form\ContextInterface');
+        $this->context = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
         $this->templates = new StringTemplate($templates);
     }
 


### PR DESCRIPTION
Everyone is welcome to contribute to this one namespace at a time :)

Namespaces taken care of:
- [x] Auth
- [x] Cache
- [x] Collection
- [x] Console
- [x] Controller
- [x] Core
- [x] Database
- [x] Datasource
- [x] Error
- [x] Event
- [x] Filesystem
- [x] Form
- [x] I18n
- [x] Log
- [x] Mailer
- [x] Network
- [ ] ORM
- [x] Routing
- [x] Shell
- [ ] TestSuite
- [x] Utility
- [x] Validation
- [x] View 
- [x] All usages with single argument.
