### PR TITLE
Remove use of TestCase::getMock() from "Database" namepace tests.

### DIFF
--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -112,7 +112,10 @@ class ConnectionTest extends TestCase
      */
     public function testDisabledDriver()
     {
-        $mock = $this->getMock('\Cake\Database\Connection\Driver', ['enabled'], [], 'DriverMock');
+        $mock = $this->getMockBuilder('\Cake\Database\Connection\Driver')
+            ->setMethods(['enabled'])
+            ->setMockClassName('DriverMock')
+            ->getMock();
         $connection = new Connection(['driver' => $mock]);
     }
 
@@ -686,7 +689,9 @@ class ConnectionTest extends TestCase
      */
     public function testQuoteIdentifier()
     {
-        $driver = $this->getMock('Cake\Database\Driver\Sqlite', ['enabled']);
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')
+            ->setMethods(['enabled'])
+            ->getMock();
         $driver->expects($this->once())
             ->method('enabled')
             ->will($this->returnValue(true));
@@ -869,11 +874,10 @@ class ConnectionTest extends TestCase
     public function testLogCommitTransaction()
     {
         $driver = $this->getMockFormDriver();
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect'],
-            [['driver' => $driver]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
 
         $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
         $connection->logger($logger);
@@ -897,11 +901,10 @@ class ConnectionTest extends TestCase
     public function testTransactionalSuccess()
     {
         $driver = $this->getMockFormDriver();
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect', 'commit', 'begin'],
-            [['driver' => $driver]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'commit', 'begin'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
         $connection->expects($this->at(0))->method('begin');
         $connection->expects($this->at(1))->method('commit');
         $result = $connection->transactional(function ($conn) use ($connection) {
@@ -920,11 +923,10 @@ class ConnectionTest extends TestCase
     public function testTransactionalFail()
     {
         $driver = $this->getMockFormDriver();
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect', 'commit', 'begin', 'rollback'],
-            [['driver' => $driver]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'commit', 'begin', 'rollback'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
         $connection->expects($this->at(0))->method('begin');
         $connection->expects($this->at(1))->method('rollback');
         $connection->expects($this->never())->method('commit');
@@ -946,11 +948,10 @@ class ConnectionTest extends TestCase
     public function testTransactionalWithException()
     {
         $driver = $this->getMockFormDriver();
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect', 'commit', 'begin', 'rollback'],
-            [['driver' => $driver]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'commit', 'begin', 'rollback'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
         $connection->expects($this->at(0))->method('begin');
         $connection->expects($this->at(1))->method('rollback');
         $connection->expects($this->never())->method('commit');
@@ -968,16 +969,17 @@ class ConnectionTest extends TestCase
     public function testSchemaCollection()
     {
         $driver = $this->getMockFormDriver();
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect'],
-            [['driver' => $driver]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
 
         $schema = $connection->schemaCollection();
         $this->assertInstanceOf('Cake\Database\Schema\Collection', $schema);
 
-        $schema = $this->getMock('Cake\Database\Schema\Collection', [], [$connection]);
+        $schema = $this->getMockBuilder('Cake\Database\Schema\Collection')
+            ->setConstructorArgs([$connection])
+            ->getMock();
         $connection->schemaCollection($schema);
         $this->assertSame($schema, $connection->schemaCollection());
     }

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
-use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use \PDO;
@@ -45,7 +44,9 @@ class MysqlTest extends TestCase
      */
     public function testConnectionConfigDefault()
     {
-        $driver = $this->getMock('Cake\Database\Driver\Mysql', ['_connect', 'connection']);
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')
+            ->setMethods(['_connect', 'connection'])
+            ->getMock();
         $dsn = 'mysql:host=localhost;port=3306;dbname=cake;charset=utf8';
         $expected = [
             'persistent' => true,
@@ -65,7 +66,9 @@ class MysqlTest extends TestCase
             PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
-        $connection = $this->getMock('StdClass', ['exec']);
+        $connection = $this->getMockBuilder('StdClass')
+            ->setMethods(['exec'])
+            ->getMock();
 
         $driver->expects($this->once())->method('_connect')
             ->with($dsn, $expected);
@@ -98,11 +101,10 @@ class MysqlTest extends TestCase
                 'this too',
             ]
         ];
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Mysql',
-            ['_connect', 'connection'],
-            [$config]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')
+            ->setMethods(['_connect', 'connection'])
+            ->setConstructorArgs([$config])
+            ->getMock();
         $dsn = 'mysql:host=foo;port=3440;dbname=bar;charset=a-language';
         $expected = $config;
         $expected['init'][] = "SET time_zone = 'Antartica'";
@@ -113,7 +115,9 @@ class MysqlTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
 
-        $connection = $this->getMock('StdClass', ['exec']);
+        $connection = $this->getMockBuilder('StdClass')
+            ->setMethods(['exec'])
+            ->getMock();
         $connection->expects($this->at(0))->method('exec')->with('Execute this');
         $connection->expects($this->at(1))->method('exec')->with('this too');
         $connection->expects($this->at(2))->method('exec')->with("SET time_zone = 'Antartica'");

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use \PDO;
 
@@ -31,7 +30,9 @@ class PostgresTest extends TestCase
      */
     public function testConnectionConfigDefault()
     {
-        $driver = $this->getMock('Cake\Database\Driver\Postgres', ['_connect', 'connection']);
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
+            ->setMethods(['_connect', 'connection'])
+            ->getMock();
         $dsn = 'pgsql:host=localhost;port=5432;dbname=cake';
         $expected = [
             'persistent' => true,
@@ -53,7 +54,9 @@ class PostgresTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 
-        $connection = $this->getMock('stdClass', ['exec', 'quote']);
+        $connection = $this->getMockBuilder('stdClass')
+            ->setMethods(['exec', 'quote'])
+            ->getMock();
         $connection->expects($this->any())
             ->method('quote')
             ->will($this->onConsecutiveCalls(
@@ -94,11 +97,10 @@ class PostgresTest extends TestCase
             'schema' => 'fooblic',
             'init' => ['Execute this', 'this too']
         ];
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Postgres',
-            ['_connect', 'connection'],
-            [$config]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
+            ->setMethods(['_connect', 'connection'])
+            ->setConstructorArgs([$config])
+            ->getMock();
         $dsn = 'pgsql:host=foo;port=3440;dbname=bar';
 
         $expected = $config;
@@ -108,7 +110,9 @@ class PostgresTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 
-        $connection = $this->getMock('stdClass', ['exec', 'quote']);
+        $connection = $this->getMockBuilder('stdClass')
+            ->setMethods(['exec', 'quote'])
+            ->getMock();
         $connection->expects($this->any())
             ->method('quote')
             ->will($this->onConsecutiveCalls(
@@ -141,11 +145,10 @@ class PostgresTest extends TestCase
      */
     public function testInsertReturning()
     {
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Postgres',
-            ['_connect', 'connection'],
-            [[]]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
+            ->setMethods(['_connect', 'connection'])
+            ->setConstructorArgs([[]])
+            ->getMock();
         $connection = $this
             ->getMockBuilder('\Cake\Database\Connection')
             ->setMethods(['connect'])

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -14,9 +14,8 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
-use Cake\Core\Configure;
 use Cake\Database\Driver\Sqlite;
-use Cake\Testsuite\TestCase;
+use Cake\TestSuite\TestCase;
 use \PDO;
 
 /**
@@ -32,7 +31,9 @@ class SqliteTest extends TestCase
      */
     public function testConnectionConfigDefault()
     {
-        $driver = $this->getMock('Cake\Database\Driver\Sqlite', ['_connect']);
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')
+            ->setMethods(['_connect'])
+            ->getMock();
         $dsn = 'sqlite::memory:';
         $expected = [
             'persistent' => false,
@@ -69,11 +70,10 @@ class SqliteTest extends TestCase
             'encoding' => 'a-language',
             'init' => ['Execute this', 'this too']
         ];
-        $driver = $this->getMock(
-            'Cake\Database\driver\Sqlite',
-            ['_connect', 'connection'],
-            [$config]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\driver\Sqlite')
+            ->setMethods(['_connect', 'connection'])
+            ->setConstructorArgs([$config])
+            ->getMock();
         $dsn = 'sqlite:bar.db';
 
         $expected = $config;
@@ -84,7 +84,9 @@ class SqliteTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 
-        $connection = $this->getMock('StdClass', ['exec']);
+        $connection = $this->getMockBuilder('StdClass')
+            ->setMethods(['exec'])
+            ->getMock();
         $connection->expects($this->at(0))->method('exec')->with('Execute this');
         $connection->expects($this->at(1))->method('exec')->with('this too');
         $connection->expects($this->exactly(2))->method('exec');
@@ -125,7 +127,9 @@ class SqliteTest extends TestCase
     public function testSchemaValue($input, $expected)
     {
         $driver = new Sqlite();
-        $mock = $this->getMock('FakePdo', ['quote', 'quoteIdentifier']);
+        $mock = $this->getMockBuilder('FakePdo')
+            ->setMethods(['quote', 'quoteIdentifier'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('quote')
             ->will($this->returnCallback(function ($value) {

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -54,11 +54,10 @@ class SqlserverTest extends TestCase
             'init' => ['Execute this', 'this too'],
             'settings' => ['config1' => 'value1', 'config2' => 'value2'],
         ];
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Sqlserver',
-            ['_connect', 'connection'],
-            [$config]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
+            ->setMethods(['_connect', 'connection'])
+            ->setConstructorArgs([$config])
+            ->getMock();
         $dsn = 'sqlsrv:Server=foo;Database=bar;MultipleActiveResultSets=false';
 
         $expected = $config;
@@ -69,7 +68,9 @@ class SqlserverTest extends TestCase
             PDO::SQLSRV_ATTR_ENCODING => 'a-language'
         ];
 
-        $connection = $this->getMock('stdClass', ['exec', 'quote']);
+        $connection = $this->getMockBuilder('stdClass')
+            ->setMethods(['exec', 'quote'])
+            ->getMock();
         $connection->expects($this->any())
             ->method('quote')
             ->will($this->onConsecutiveCalls(
@@ -100,21 +101,19 @@ class SqlserverTest extends TestCase
      */
     public function testSelectLimitVersion12()
     {
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Sqlserver',
-            ['_connect', 'connection', '_version'],
-            [[]]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
+            ->setMethods(['_connect', 'connection', '_version'])
+            ->setConstructorArgs([[]])
+            ->getMock();
         $driver
             ->expects($this->any())
             ->method('_version')
             ->will($this->returnValue(12));
 
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect', 'driver'],
-            [['log' => false]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'driver'])
+            ->setConstructorArgs([['log' => false]])
+            ->getMock();
         $connection
             ->expects($this->any())
             ->method('driver')
@@ -155,21 +154,19 @@ class SqlserverTest extends TestCase
      */
     public function testSelectLimitOldServer()
     {
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Sqlserver',
-            ['_connect', 'connection', '_version'],
-            [[]]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
+            ->setMethods(['_connect', 'connection', '_version'])
+            ->setConstructorArgs([[]])
+            ->getMock();
         $driver
             ->expects($this->any())
             ->method('_version')
             ->will($this->returnValue(8));
 
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect', 'driver'],
-            [['log' => false]]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'driver'])
+            ->setConstructorArgs([['log' => false]])
+            ->getMock();
         $connection
             ->expects($this->any())
             ->method('driver')
@@ -221,16 +218,14 @@ class SqlserverTest extends TestCase
      */
     public function testInsertUsesOutput()
     {
-        $driver = $this->getMock(
-            'Cake\Database\Driver\Sqlserver',
-            ['_connect', 'connection'],
-            [[]]
-        );
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['connect', 'driver'],
-            [['log' => false]]
-        );
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
+            ->setMethods(['_connect', 'connection'])
+            ->setConstructorArgs([[]])
+            ->getMock();
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'driver'])
+            ->setConstructorArgs([['log' => false]])
+            ->getMock();
         $connection
             ->expects($this->any())
             ->method('driver')

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -55,7 +55,9 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolation()
     {
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
         $query = new LoggedQuery;
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4 AND e = :p5 AND f = :p6';
         $query->params = ['p1' => 'string', 'p3' => null, 'p2' => 3, 'p4' => true, 'p5' => false, 'p6' => 0];
@@ -73,7 +75,9 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolation2()
     {
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
         $query = new LoggedQuery;
         $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ? AND d = ? AND e = ? AND f = ?';
         $query->params = ['string', '3', null, true, false, 0];
@@ -91,7 +95,9 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolation3()
     {
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
         $query = new LoggedQuery;
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p1 AND c = :p2 AND d = :p2';
         $query->params = ['p1' => 'string', 'p2' => 3];
@@ -109,7 +115,9 @@ class QueryLoggerTest extends TestCase
      */
     public function testStringInterpolationNamed()
     {
-        $logger = $this->getMock('\Cake\Database\Log\QueryLogger', ['_log']);
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
         $query = new LoggedQuery;
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p11 AND c = :p20 AND d = :p2';
         $query->params = ['p11' => 'test', 'p1' => 'string', 'p2' => 3, 'p20' => 5];
@@ -133,10 +141,16 @@ class QueryLoggerTest extends TestCase
         $query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
         $query->params = ['string', '3', null];
 
-        $engine = $this->getMock('\Cake\Log\Engine\BaseLog', ['log'], ['scopes' => ['queriesLog']]);
+        $engine = $this->getMockBuilder('\Cake\Log\Engine\BaseLog')
+            ->setMethods(['log'])
+            ->setConstructorArgs(['scopes' => ['queriesLog']])
+            ->getMock();
         Log::engine('queryLoggerTest');
 
-        $engine2 = $this->getMock('\Cake\Log\Engine\BaseLog', ['log'], ['scopes' => ['foo']]);
+        $engine2 = $this->getMockBuilder('\Cake\Log\Engine\BaseLog')
+            ->setMethods(['log'])
+            ->setConstructorArgs(['scopes' => ['foo']])
+            ->getMock();
         Log::engine('queryLoggerTest2');
 
         $engine2->expects($this->never())->method('log');

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
-use Cake\Core\Configure;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\MysqlSchema;
 use Cake\Database\Schema\Table;
@@ -195,7 +194,9 @@ class MysqlSchemaTest extends TestCase
         $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')->getMock();
         $dialect = new MysqlSchema($driver);
 
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['table'])
+            ->getMock();
         $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
         $dialect->convertColumnDescription($table, $field);
@@ -776,7 +777,9 @@ SQL;
     public function testAddConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -825,7 +828,9 @@ SQL;
     public function testDropConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -909,7 +914,9 @@ SQL;
     public function testCreateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -959,7 +966,9 @@ SQL;
     public function testCreateTemporary()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
         $table = (new Table('schema_articles'))->addColumn('id', [
@@ -979,7 +988,9 @@ SQL;
     public function testCreateSqlCompositeIntegerKey()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1043,7 +1054,9 @@ SQL;
     public function testDropSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1061,7 +1074,9 @@ SQL;
     public function testTruncateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1092,7 +1107,9 @@ SQL;
     protected function _getMockedDriver()
     {
         $driver = new \Cake\Database\Driver\Mysql();
-        $mock = $this->getMock('FakePdo', ['quote']);
+        $mock = $this->getMockBuilder('FakePdo')
+            ->setMethods(['quote'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('quote')
             ->will($this->returnCallback(function ($value) {

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -14,9 +14,7 @@
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
-use Cake\Core\Configure;
 use Cake\Database\Schema\Collection as SchemaCollection;
-use Cake\Database\Schema\MysqlSchema;
 use Cake\Database\Schema\PostgresSchema;
 use Cake\Database\Schema\Table;
 use Cake\Datasource\ConnectionManager;
@@ -229,7 +227,9 @@ SQL;
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')->getMock();
         $dialect = new PostgresSchema($driver);
 
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['table'])
+            ->getMock();
         $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
         $dialect->convertColumnDescription($table, $field);
@@ -863,7 +863,9 @@ SQL;
     public function testAddConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -912,7 +914,9 @@ SQL;
     public function testDropConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -961,7 +965,9 @@ SQL;
     public function testCreateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1016,7 +1022,9 @@ SQL;
     public function testCreateTemporary()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
         $table = (new Table('schema_articles'))->addColumn('id', [
@@ -1036,7 +1044,9 @@ SQL;
     public function testCreateSqlCompositeIntegerKey()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1100,7 +1110,9 @@ SQL;
     public function testDropSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1118,7 +1130,9 @@ SQL;
     public function testTruncateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -1136,12 +1150,14 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      *
-     * @return Driver
+     * @return \Cake\Database\Driver
      */
     protected function _getMockedDriver()
     {
         $driver = new \Cake\Database\Driver\Postgres();
-        $mock = $this->getMock('FakePdo', ['quote']);
+        $mock = $this->getMockBuilder('FakePdo')
+            ->setMethods(['quote'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('quote')
             ->will($this->returnCallback(function ($value) {

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
-use Cake\Core\Configure;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqliteSchema;
 use Cake\Database\Schema\Table;
@@ -152,7 +151,9 @@ class SqliteSchemaTest extends TestCase
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')->getMock();
         $dialect = new SqliteSchema($driver);
 
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['table'])
+            ->getMock();
         $table->expects($this->at(1))->method('addColumn')->with('field', $expected);
 
         $dialect->convertColumnDescription($table, $field);
@@ -193,7 +194,7 @@ class SqliteSchemaTest extends TestCase
     /**
      * Creates tables for testing listTables/describe()
      *
-     * @param Connection $connection
+     * @param \Cake\Database\Connection $connection
      * @return void
      */
     protected function _createTables($connection)
@@ -587,7 +588,9 @@ SQL;
     public function testAddConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -605,7 +608,9 @@ SQL;
     public function testDropConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -798,7 +803,9 @@ SQL;
     public function testCreateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -846,7 +853,9 @@ SQL;
     public function testCreateTemporary()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
         $table = (new Table('schema_articles'))->addColumn('id', [
@@ -866,7 +875,9 @@ SQL;
     public function testCreateSqlCompositeIntegerKey()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -932,7 +943,9 @@ SQL;
     public function testDropSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -950,14 +963,15 @@ SQL;
     public function testTruncateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $statement = $this->getMock(
-            '\PDOStatement',
-            ['execute', 'rowCount', 'closeCursor', 'fetch']
-        );
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
+            ->getMock();
         $driver->connection()->expects($this->once())->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
             ->will($this->returnValue($statement));
@@ -981,14 +995,15 @@ SQL;
     public function testTruncateSqlNoSequences()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $statement = $this->getMock(
-            '\PDOStatement',
-            ['execute', 'rowCount', 'closeCursor', 'fetch']
-        );
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
+            ->getMock();
         $driver->connection()->expects($this->once())->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
             ->will($this->returnValue($statement));
@@ -1004,12 +1019,14 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      *
-     * @return Driver
+     * @return \Cake\Database\Driver
      */
     protected function _getMockedDriver()
     {
         $driver = new \Cake\Database\Driver\Sqlite();
-        $mock = $this->getMock('FakePdo', ['quote', 'prepare']);
+        $mock = $this->getMockBuilder('FakePdo')
+            ->setMethods(['quote', 'prepare'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('quote')
             ->will($this->returnCallback(function ($value) {

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
-use Cake\Core\Configure;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqlserverSchema;
 use Cake\Database\Schema\Table;
@@ -248,7 +247,9 @@ SQL;
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')->getMock();
         $dialect = new SqlserverSchema($driver);
 
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['table'])
+            ->getMock();
         $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
 
         $dialect->convertColumnDescription($table, $field);
@@ -722,7 +723,9 @@ SQL;
     public function testAddConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -771,7 +774,9 @@ SQL;
     public function testDropConstraintSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -820,7 +825,9 @@ SQL;
     public function testCreateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -870,7 +877,9 @@ SQL;
     public function testDropSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -888,7 +897,9 @@ SQL;
     public function testTruncateSql()
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
@@ -907,12 +918,14 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      *
-     * @return Driver
+     * @return \Cake\Database\Driver
      */
     protected function _getMockedDriver()
     {
         $driver = new \Cake\Database\Driver\Sqlserver();
-        $mock = $this->getMock('FakePdo', ['quote']);
+        $mock = $this->getMockBuilder('FakePdo')
+            ->setMethods(['quote'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('quote')
             ->will($this->returnCallback(function ($value) {

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -62,7 +62,9 @@ class BinaryTypeTest extends TestCase
      */
     public function testToPHPSqlserver()
     {
-        $driver = $this->getMock('Cake\Database\Driver\Sqlserver', [], [], '', false);
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
+            ->disableOriginalConstructor()
+            ->getMock();
         $result = $this->type->toPHP('536F6D652076616C7565', $driver);
         $this->assertInternalType('resource', $result);
         $this->assertSame('Some value', stream_get_contents($result));

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -55,7 +55,9 @@ class StringTypeTest extends TestCase
      */
     public function testToDatabase()
     {
-        $obj = $this->getMock('StdClass', ['__toString']);
+        $obj = $this->getMockBuilder('StdClass')
+            ->setMethods(['__toString'])
+            ->getMock();
         $obj->method('__toString')->will($this->returnValue('toString called'));
 
         $this->assertNull($this->type->toDatabase(null, $this->driver));

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -387,7 +387,9 @@ TEXT;
      */
     public function testLog()
     {
-        $mock = $this->getMock('Cake\Log\Engine\BaseLog', ['log']);
+        $mock = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
+            ->setMethods(['log'])
+            ->getMock();
         Log::config('test', ['engine' => $mock]);
 
         $mock->expects($this->at(0))
@@ -419,7 +421,9 @@ TEXT;
      */
     public function testLogDepth()
     {
-        $mock = $this->getMock('Cake\Log\Engine\BaseLog', ['log']);
+        $mock = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
+            ->setMethods(['log'])
+            ->getMock();
         Log::config('test', ['engine' => $mock]);
 
         $mock->expects($this->at(0))

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -195,7 +195,9 @@ class ExceptionRendererTest extends TestCase
      */
     protected function _mockResponse($error)
     {
-        $error->controller->response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $error->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         return $error;
     }
 
@@ -316,7 +318,9 @@ class ExceptionRendererTest extends TestCase
     {
         $exception = new MissingWidgetThingException('coding fail.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(404);
 
         $result = $ExceptionRenderer->render();
@@ -334,7 +338,9 @@ class ExceptionRendererTest extends TestCase
     {
         $exception = new \OutOfBoundsException('foul ball.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())
             ->method('statusCode')
             ->with(500);
@@ -355,7 +361,9 @@ class ExceptionRendererTest extends TestCase
 
         $exception = new \OutOfBoundsException('foul ball.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())
             ->method('statusCode')
             ->with(500);
@@ -375,7 +383,9 @@ class ExceptionRendererTest extends TestCase
     {
         $exception = new \OutOfBoundsException('foul ball.', 501);
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(501);
 
         $result = $ExceptionRenderer->render();
@@ -397,7 +407,9 @@ class ExceptionRendererTest extends TestCase
 
         $exception = new NotFoundException('Custom message');
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(404);
 
         $result = $ExceptionRenderer->render()->body();
@@ -458,7 +470,9 @@ class ExceptionRendererTest extends TestCase
     {
         $exception = new InternalErrorException('An Internal Error Has Occurred.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(500);
 
         $result = $ExceptionRenderer->render();
@@ -628,7 +642,9 @@ class ExceptionRendererTest extends TestCase
     public function testCakeExceptionHandling($exception, $patterns, $code)
     {
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())
             ->method('statusCode')
             ->with($code);
@@ -663,7 +679,9 @@ class ExceptionRendererTest extends TestCase
         $exception = new MissingHelperException(['class' => 'Fail']);
         $ExceptionRenderer = new ExceptionRenderer($exception);
 
-        $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
+        $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['render'])
+            ->getMock();
         $ExceptionRenderer->controller->helpers = ['Fail', 'Boom'];
         $ExceptionRenderer->controller->request = new Request;
         $ExceptionRenderer->controller->expects($this->at(0))
@@ -692,7 +710,9 @@ class ExceptionRendererTest extends TestCase
         $exception = new NotFoundException('Not there, sorry');
         $ExceptionRenderer = new ExceptionRenderer($exception);
 
-        $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['beforeRender']);
+        $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['beforeRender'])
+            ->getMock();
         $ExceptionRenderer->controller->request = new Request;
         $ExceptionRenderer->controller->expects($this->any())
             ->method('beforeRender')
@@ -717,7 +737,9 @@ class ExceptionRendererTest extends TestCase
         $exception = new NotFoundException();
         $ExceptionRenderer = new ExceptionRenderer($exception);
 
-        $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
+        $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['render'])
+            ->getMock();
         $ExceptionRenderer->controller->helpers = ['Fail', 'Boom'];
         $ExceptionRenderer->controller->eventManager()->on('Controller.beforeRender', function (Event $event) {
             $event->subject()->viewBuilder()->layoutPath('boom');
@@ -754,7 +776,9 @@ class ExceptionRendererTest extends TestCase
         $exception = new NotFoundException();
         $ExceptionRenderer = new ExceptionRenderer($exception);
 
-        $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
+        $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['render'])
+            ->getMock();
         $ExceptionRenderer->controller->plugin = 'TestPlugin';
         $ExceptionRenderer->controller->request = $this->getMockBuilder('Cake\Network\Request')->getMock();
 
@@ -787,7 +811,9 @@ class ExceptionRendererTest extends TestCase
         $exception = new NotFoundException();
         $ExceptionRenderer = new ExceptionRenderer($exception);
 
-        $ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', ['render']);
+        $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['render'])
+            ->getMock();
         $ExceptionRenderer->controller->plugin = 'TestPlugin';
         $ExceptionRenderer->controller->request = $this->getMockBuilder('Cake\Network\Request')->getMock();
 
@@ -886,7 +912,9 @@ class ExceptionRendererTest extends TestCase
         $exception->queryString = 'SELECT * from poo_query < 5 and :seven';
         $exception->params = ['seven' => 7];
         $ExceptionRenderer = new ExceptionRenderer($exception);
-        $ExceptionRenderer->controller->response = $this->getMock('Cake\Network\Response', ['statusCode', '_sendHeader']);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
         $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(500);
 
         $result = $ExceptionRenderer->render()->body();

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -368,8 +368,10 @@ class EventManagerTest extends TestCase
     public function testDispatch()
     {
         $manager = new EventManager();
-        $listener = $this->getMock(__NAMESPACE__ . '\EventTestListener');
-        $anotherListener = $this->getMock(__NAMESPACE__ . '\EventTestListener');
+        $listener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+            ->getMock();
+        $anotherListener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+            ->getMock();
         $manager->attach([$listener, 'listenerFunction'], 'fake.event');
         $manager->attach([$anotherListener, 'listenerFunction'], 'fake.event');
         $event = new Event('fake.event');
@@ -409,8 +411,10 @@ class EventManagerTest extends TestCase
             'These tests fail in PHPUnit 3.6'
         );
         $manager = new EventManager;
-        $listener = $this->getMock(__NAMESPACE__ . '\EventTestListener');
-        $anotherListener = $this->getMock(__NAMESPACE__ . '\EventTestListener');
+        $listener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+            ->getMock();
+        $anotherListener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+            ->getMock();
         $manager->attach([$listener, 'listenerFunction'], 'fake.event');
         $manager->attach([$anotherListener, 'listenerFunction'], 'fake.event');
         $event = new Event('fake.event');
@@ -439,8 +443,10 @@ class EventManagerTest extends TestCase
         );
 
         $manager = new EventManager();
-        $listener = $this->getMock(__NAMESPACE__ . '\EventTestListener');
-        $anotherListener = $this->getMock(__NAMESPACE__ . '\EventTestListener');
+        $listener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+            ->getMock();
+        $anotherListener = $this->getMockBuilder(__NAMESPACE__ . '\EventTestListener')
+            ->getMock();
         $manager->attach([$listener, 'listenerFunction'], 'fake.event');
         $manager->attach([$anotherListener, 'listenerFunction'], 'fake.event');
         $event = new Event('fake.event');
@@ -483,7 +489,9 @@ class EventManagerTest extends TestCase
     public function testAttachSubscriber()
     {
         $manager = new EventManager();
-        $listener = $this->getMock(__NAMESPACE__ . '\CustomTestEventListenerInterface', ['secondListenerFunction']);
+        $listener = $this->getMockBuilder(__NAMESPACE__ . '\CustomTestEventListenerInterface')
+            ->setMethods(['secondListenerFunction'])
+            ->getMock();
         $manager->attach($listener);
 
         $event = new Event('fake.event');
@@ -508,7 +516,9 @@ class EventManagerTest extends TestCase
     public function testAttachSubscriberMultiple()
     {
         $manager = new EventManager();
-        $listener = $this->getMock(__NAMESPACE__ . '\CustomTestEventListenerInterface', ['listenerFunction', 'thirdListenerFunction']);
+        $listener = $this->getMockBuilder(__NAMESPACE__ . '\CustomTestEventListenerInterface')
+            ->setMethods(['listenerFunction', 'thirdListenerFunction'])
+            ->getMock();
         $manager->attach($listener);
         $event = new Event('multiple.handlers');
         $listener->expects($this->once())
@@ -528,7 +538,9 @@ class EventManagerTest extends TestCase
     public function testDetachSubscriber()
     {
         $manager = new EventManager();
-        $listener = $this->getMock(__NAMESPACE__ . '\CustomTestEventListenerInterface', ['secondListenerFunction']);
+        $listener = $this->getMockBuilder(__NAMESPACE__ . '\CustomTestEventListenerInterface')
+            ->setMethods(['secondListenerFunction'])
+            ->getMock();
         $manager->attach($listener);
         $expected = [
             ['callable' => [$listener, 'secondListenerFunction']]
@@ -565,7 +577,9 @@ class EventManagerTest extends TestCase
      */
     public function testDispatchWithGlobal()
     {
-        $generalManager = $this->getMock('Cake\Event\EventManager', ['prioritisedListeners']);
+        $generalManager = $this->getMockBuilder('Cake\Event\EventManager')
+            ->setMethods(['prioritisedListeners'])
+            ->getMock();
         $manager = new EventManager();
         $event = new Event('fake.event');
         EventManager::instance($generalManager);

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -122,7 +122,9 @@ class FormTest extends TestCase
      */
     public function testExecuteInvalid()
     {
-        $form = $this->getMock('Cake\Form\Form', ['_execute']);
+        $form = $this->getMockBuilder('Cake\Form\Form')
+            ->setMethods(['_execute'])
+            ->getMock();
         $form->validator()
             ->add('email', 'format', ['rule' => 'email']);
         $data = [
@@ -141,7 +143,9 @@ class FormTest extends TestCase
      */
     public function testExecuteValid()
     {
-        $form = $this->getMock('Cake\Form\Form', ['_execute']);
+        $form = $this->getMockBuilder('Cake\Form\Form')
+            ->setMethods(['_execute'])
+            ->getMock();
         $form->validator()
             ->add('email', 'format', ['rule' => 'email']);
         $data = [

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -29,11 +29,15 @@ class SyslogLogTest extends TestCase
      */
     public function testOpenLog()
     {
-        $log = $this->getMock('Cake\Log\Engine\SyslogLog', ['_open', '_write']);
+        $log = $this->getMockBuilder('Cake\Log\Engine\SyslogLog')
+            ->setMethods(['_open', '_write'])
+            ->getMock();
         $log->expects($this->once())->method('_open')->with('', LOG_ODELAY, LOG_USER);
         $log->log('debug', 'message');
 
-        $log = $this->getMock('Cake\Log\Engine\SyslogLog', ['_open', '_write']);
+        $log = $this->getMockBuilder('Cake\Log\Engine\SyslogLog')
+            ->setMethods(['_open', '_write'])
+            ->getMock();
         $log->config([
             'prefix' => 'thing',
             'flag' => LOG_NDELAY,
@@ -53,7 +57,9 @@ class SyslogLogTest extends TestCase
      */
     public function testWriteOneLine($type, $expected)
     {
-        $log = $this->getMock('Cake\Log\Engine\SyslogLog', ['_open', '_write']);
+        $log = $this->getMockBuilder('Cake\Log\Engine\SyslogLog')
+            ->setMethods(['_open', '_write'])
+            ->getMock();
         $log->expects($this->once())->method('_write')->with($expected, $type . ': Foo');
         $log->log($type, 'Foo');
     }
@@ -65,7 +71,9 @@ class SyslogLogTest extends TestCase
      */
     public function testWriteMultiLine()
     {
-        $log = $this->getMock('Cake\Log\Engine\SyslogLog', ['_open', '_write']);
+        $log = $this->getMockBuilder('Cake\Log\Engine\SyslogLog')
+            ->setMethods(['_open', '_write'])
+            ->getMock();
         $log->expects($this->at(1))->method('_write')->with(LOG_DEBUG, 'debug: Foo');
         $log->expects($this->at(2))->method('_write')->with(LOG_DEBUG, 'debug: Bar');
         $log->expects($this->exactly(2))->method('_write');

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1432,7 +1432,10 @@ class EmailTest extends TestCase
      */
     public function testSendWithLog()
     {
-        $log = $this->getMock('Cake\Log\Engine\BaseLog', ['log'], [['scopes' => 'email']]);
+        $log = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
+            ->setMethods(['log'])
+            ->setConstructorArgs([['scopes' => 'email']])
+            ->getMock();
 
         $message = 'Logging This';
 
@@ -1466,7 +1469,10 @@ class EmailTest extends TestCase
     {
         $message = 'Logging This';
 
-        $log = $this->getMock('Cake\Log\Engine\BaseLog', ['log'], ['scopes' => ['email']]);
+        $log = $this->getMockBuilder('Cake\Log\Engine\BaseLog')
+            ->setMethods(['log'])
+            ->setConstructorArgs(['scopes' => ['email']])
+            ->getMock();
         $log->expects($this->once())
             ->method('log')
             ->with(
@@ -2454,7 +2460,7 @@ class EmailTest extends TestCase
     /**
      * @param mixed $charset
      * @param mixed $headerCharset
-     * @return CakeEmail
+     * @return \Cake\Mailer\Email
      */
     protected function _getEmailByOldStyleCharset($charset, $headerCharset)
     {
@@ -2479,7 +2485,7 @@ class EmailTest extends TestCase
     /**
      * @param mixed $charset
      * @param mixed $headerCharset
-     * @return CakeEmail
+     * @return \Cake\Mailer\Email
      */
     protected function _getEmailByNewStyleCharset($charset, $headerCharset)
     {

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -19,7 +19,10 @@ class MailerTest extends TestCase
 {
     public function getMockForEmail($methods = [], $args = [])
     {
-        return $this->getMock('Cake\Mailer\Email', (array)$methods, (array)$args);
+        return $this->getMockBuilder('Cake\Mailer\Email')
+            ->setMethods((array)$methods)
+            ->setConstructorArgs((array)$args)
+            ->getMock();
     }
 
     public function testConstructor()
@@ -103,7 +106,10 @@ class MailerTest extends TestCase
             ->method('send')
             ->will($this->returnValue([]));
 
-        $mailer = $this->getMock('TestApp\Mailer\TestMailer', ['test'], [$email]);
+        $mailer = $this->getMockBuilder('TestApp\Mailer\TestMailer')
+            ->setMethods(['test'])
+            ->setConstructorArgs([$email])
+            ->getMock();
         $mailer->expects($this->once())
             ->method('test')
             ->with('foo', 'bar');
@@ -120,7 +126,10 @@ class MailerTest extends TestCase
             ->method('send')
             ->will($this->returnValue([]));
 
-        $mailer = $this->getMock('TestApp\Mailer\TestMailer', ['test'], [$email]);
+        $mailer = $this->getMockBuilder('TestApp\Mailer\TestMailer')
+            ->setMethods(['test'])
+            ->setConstructorArgs([$email])
+            ->getMock();
         $mailer->expects($this->once())
             ->method('test')
             ->with('foo', 'bar');
@@ -141,7 +150,10 @@ class MailerTest extends TestCase
             ->method('send')
             ->will($this->returnValue([]));
 
-        $mailer = $this->getMock('TestApp\Mailer\TestMailer', ['test'], [$email]);
+        $mailer = $this->getMockBuilder('TestApp\Mailer\TestMailer')
+            ->setMethods(['test'])
+            ->setConstructorArgs([$email])
+            ->getMock();
         $mailer->expects($this->once())
             ->method('test')
             ->with('foo', 'bar');

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -44,7 +44,9 @@ class DebugTransportTest extends TestCase
      */
     public function testSend()
     {
-        $email = $this->getMock('Cake\Mailer\Email', ['message']);
+        $email = $this->getMockBuilder('Cake\Mailer\Email')
+            ->setMethods(['message'])
+            ->getMock();
         $email->from('noreply@cakephp.org', 'CakePHP Test');
         $email->to('cake@cakephp.org', 'CakePHP');
         $email->cc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -33,7 +33,9 @@ class MailTransportTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->MailTransport = $this->getMock('Cake\Mailer\Transport\MailTransport', ['_mail']);
+        $this->MailTransport = $this->getMockBuilder('Cake\Mailer\Transport\MailTransport')
+            ->setMethods(['_mail'])
+            ->getMock();
         $this->MailTransport->config(['additionalParameters' => '-f']);
     }
 
@@ -44,7 +46,9 @@ class MailTransportTest extends TestCase
      */
     public function testSendData()
     {
-        $email = $this->getMock('Cake\Mailer\Email', ['message'], []);
+        $email = $this->getMockBuilder('Cake\Mailer\Email')
+            ->setMethods(['message'])
+            ->getMock();
         $email->from('noreply@cakephp.org', 'CakePHP Test');
         $email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $email->to('cake@cakephp.org', 'CakePHP');

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -75,10 +75,9 @@ class SmtpTransportTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->socket = $this->getMock(
-            'Cake\Network\Socket',
-            ['read', 'write', 'connect', 'disconnect', 'enableCrypto']
-        );
+        $this->socket = $this->getMockBuilder('Cake\Network\Socket')
+            ->setMethods(['read', 'write', 'connect', 'disconnect', 'enableCrypto'])
+            ->getMock();
 
         $this->SmtpTransport = new SmtpTestTransport();
         $this->SmtpTransport->setSocket($this->socket);
@@ -379,7 +378,9 @@ class SmtpTransportTest extends TestCase
      */
     public function testSendData()
     {
-        $email = $this->getMock('Cake\Mailer\Email', ['message']);
+        $email = $this->getMockBuilder('Cake\Mailer\Email')
+            ->setMethods(['message'])
+            ->getMock();
         $email->from('noreply@cakephp.org', 'CakePHP Test');
         $email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
         $email->to('cake@cakephp.org', 'CakePHP');
@@ -618,7 +619,9 @@ class SmtpTransportTest extends TestCase
     {
         $this->SmtpTransport->config(['keepAlive' => true]);
 
-        $email = $this->getMock('Cake\Mailer\Email', ['message']);
+        $email = $this->getMockBuilder('Cake\Mailer\Email')
+            ->setMethods(['message'])
+            ->getMock();
         $email->from('noreply@cakephp.org', 'CakePHP Test');
         $email->to('cake@cakephp.org', 'CakePHP');
         $email->expects($this->exactly(2))->method('message')->will($this->returnValue(['First Line']));
@@ -680,7 +683,9 @@ class SmtpTransportTest extends TestCase
      */
     public function testSendDefaults()
     {
-        $email = $this->getMock('Cake\Mailer\Email', ['message']);
+        $email = $this->getMockBuilder('Cake\Mailer\Email')
+            ->setMethods(['message'])
+            ->getMock();
         $email->from('noreply@cakephp.org', 'CakePHP Test');
         $email->to('cake@cakephp.org', 'CakePHP');
         $email->expects($this->once())->method('message')->will($this->returnValue(['First Line']));

--- a/tests/TestCase/Network/Http/Adapter/StreamTest.php
+++ b/tests/TestCase/Network/Http/Adapter/StreamTest.php
@@ -100,10 +100,9 @@ class StreamTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->stream = $this->getMock(
-            'Cake\Network\Http\Adapter\Stream',
-            ['_send']
-        );
+        $this->stream = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['_send'])
+            ->getMock();
         stream_wrapper_register('cakephp', __NAMESPACE__ . '\CakeStreamWrapper');
     }
 

--- a/tests/TestCase/Network/Http/Auth/DigestTest.php
+++ b/tests/TestCase/Network/Http/Auth/DigestTest.php
@@ -33,10 +33,9 @@ class DigestTest extends TestCase
     {
         parent::setUp();
 
-        $this->client = $this->getMock(
-            'Cake\Network\Http\Client',
-            ['send']
-        );
+        $this->client = $this->getMockBuilder('Cake\Network\Http\Client')
+            ->setMethods(['send'])
+            ->getMock();
         $this->auth = new Digest($this->client);
     }
 

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -167,7 +167,9 @@ class ClientTest extends TestCase
             'split' => 'value'
         ];
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
@@ -196,7 +198,9 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
@@ -226,7 +230,9 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
@@ -257,7 +263,9 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
@@ -286,7 +294,9 @@ class ClientTest extends TestCase
      */
     public function testInvalidAuthenticationType()
     {
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->never())
             ->method('send');
 
@@ -308,7 +318,9 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $headers = [
             'Connection' => 'close',
             'User-Agent' => 'CakePHP',
@@ -363,7 +375,9 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
@@ -413,7 +427,9 @@ class ClientTest extends TestCase
             'Accept' => $mime,
         ];
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(
@@ -445,7 +461,9 @@ class ClientTest extends TestCase
             'Content-Type' => 'application/x-www-form-urlencoded',
         ];
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('send')
             ->with($this->logicalAnd(
@@ -471,7 +489,9 @@ class ClientTest extends TestCase
      */
     public function testExceptionOnUnknownType()
     {
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->never())
             ->method('send');
 
@@ -489,10 +509,9 @@ class ClientTest extends TestCase
      */
     public function testCookieStorage()
     {
-        $adapter = $this->getMock(
-            'Cake\Network\Http\Adapter\Stream',
-            ['send']
-        );
+        $adapter = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $cookieJar = $this->getMockBuilder('Cake\Network\Http\CookieCollection')->getMock();
 
         $headers = [
@@ -533,7 +552,9 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMock('Cake\Network\Http\Adapter\Stream', ['send']);
+        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+            ->setMethods(['send'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->logicalAnd(

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2314,7 +2314,9 @@ class RequestTest extends TestCase
      */
     public function testInput()
     {
-        $request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $request->expects($this->once())->method('_readInput')
             ->will($this->returnValue('I came from stdin'));
 
@@ -2329,7 +2331,9 @@ class RequestTest extends TestCase
      */
     public function testInputDecode()
     {
-        $request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $request->expects($this->once())->method('_readInput')
             ->will($this->returnValue('{"name":"value"}'));
 
@@ -2351,7 +2355,9 @@ class RequestTest extends TestCase
 </post>
 XML;
 
-        $request = $this->getMock('Cake\Network\Request', ['_readInput']);
+        $request = $this->getMockBuilder('Cake\Network\Request')
+            ->setMethods(['_readInput'])
+            ->getMock();
         $request->expects($this->once())->method('_readInput')
             ->will($this->returnValue($xml));
 

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -214,7 +214,9 @@ class ResponseTest extends TestCase
      */
     public function testSend()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent', '_setCookies']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent', '_setCookies'])
+            ->getMock();
         $response->header([
             'Content-Language' => 'es',
             'WWW-Authenticate' => 'Negotiate',
@@ -262,7 +264,9 @@ class ResponseTest extends TestCase
      */
     public function testSendChangingContentType($original, $expected)
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent', '_setCookies']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent', '_setCookies'])
+            ->getMock();
         $response->type($original);
         $response->body('the response body');
         $response->expects($this->once())->method('_sendContent')->with('the response body');
@@ -281,7 +285,9 @@ class ResponseTest extends TestCase
      */
     public function testSendChangingContentTypeWithoutCharset()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent', '_setCookies']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent', '_setCookies'])
+            ->getMock();
         $response->type('js');
         $response->charset('');
 
@@ -302,7 +308,9 @@ class ResponseTest extends TestCase
      */
     public function testSendWithLocation()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent', '_setCookies']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent', '_setCookies'])
+            ->getMock();
         $response->header('Location', 'http://www.example.com');
         $response->expects($this->at(0))->method('_setCookies');
         $response->expects($this->at(1))
@@ -321,7 +329,9 @@ class ResponseTest extends TestCase
      */
     public function testSendWithCallableBody()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $response->body(function () {
             echo 'the response body';
         });
@@ -339,7 +349,9 @@ class ResponseTest extends TestCase
      */
     public function testSendWithCallableBodyWithReturn()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $response->body(function () {
             return 'the response body';
         });
@@ -563,7 +575,9 @@ class ResponseTest extends TestCase
      */
     public function testProtocol()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->protocol('HTTP/1.0');
         $this->assertEquals('HTTP/1.0', $response->protocol());
         $response->expects($this->at(0))
@@ -578,7 +592,9 @@ class ResponseTest extends TestCase
      */
     public function testLength()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->length(100);
         $this->assertEquals(100, $response->length());
         $response->expects($this->at(1))
@@ -593,7 +609,9 @@ class ResponseTest extends TestCase
      */
     public function testUnmodifiedContent()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->body('This is a body');
         $response->statusCode(204);
         $response->expects($this->once())
@@ -601,14 +619,18 @@ class ResponseTest extends TestCase
         $response->send();
         $this->assertFalse(array_key_exists('Content-Type', $response->header()));
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->body('This is a body');
         $response->statusCode(304);
         $response->expects($this->once())
             ->method('_sendContent')->with('');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->body('This is a body');
         $response->statusCode(200);
         $response->expects($this->once())
@@ -623,7 +645,9 @@ class ResponseTest extends TestCase
      */
     public function testExpires()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
         $response->expires($now);
         $now->setTimeZone(new \DateTimeZone('UTC'));
@@ -632,7 +656,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Expires', $now->format('D, j M Y H:i:s') . ' GMT');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $now = time();
         $response->expires($now);
         $this->assertEquals(gmdate('D, j M Y H:i:s', $now) . ' GMT', $response->expires());
@@ -640,7 +666,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Expires', gmdate('D, j M Y H:i:s', $now) . ' GMT');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $response->expires('+1 day');
         $this->assertEquals($time->format('D, j M Y H:i:s') . ' GMT', $response->expires());
@@ -656,7 +684,9 @@ class ResponseTest extends TestCase
      */
     public function testModified()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
         $response->modified($now);
         $now->setTimeZone(new \DateTimeZone('UTC'));
@@ -665,7 +695,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Last-Modified', $now->format('D, j M Y H:i:s') . ' GMT');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $now = time();
         $response->modified($now);
         $this->assertEquals(gmdate('D, j M Y H:i:s', $now) . ' GMT', $response->modified());
@@ -673,7 +705,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Last-Modified', gmdate('D, j M Y H:i:s', $now) . ' GMT');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $response->modified('+1 day');
         $this->assertEquals($time->format('D, j M Y H:i:s') . ' GMT', $response->modified());
@@ -689,7 +723,9 @@ class ResponseTest extends TestCase
      */
     public function testSharable()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $this->assertNull($response->sharable());
         $response->sharable(true);
         $headers = $response->header();
@@ -698,7 +734,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Cache-Control', 'public');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->sharable(false);
         $headers = $response->header();
         $this->assertEquals('private', $headers['Cache-Control']);
@@ -706,7 +744,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Cache-Control', 'private');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->sharable(true);
         $headers = $response->header();
         $this->assertEquals('public', $headers['Cache-Control']);
@@ -720,12 +760,16 @@ class ResponseTest extends TestCase
         $response->sharable(true);
         $this->assertTrue($response->sharable());
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $response->sharable(true, 3600);
         $headers = $response->header();
         $this->assertEquals('public, max-age=3600', $headers['Cache-Control']);
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $response->sharable(false, 3600);
         $headers = $response->header();
         $this->assertEquals('private, max-age=3600', $headers['Cache-Control']);
@@ -739,7 +783,9 @@ class ResponseTest extends TestCase
      */
     public function testMaxAge()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $this->assertNull($response->maxAge());
         $response->maxAge(3600);
         $this->assertEquals(3600, $response->maxAge());
@@ -749,7 +795,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Cache-Control', 'max-age=3600');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->maxAge(3600);
         $response->sharable(false);
         $headers = $response->header();
@@ -766,7 +814,9 @@ class ResponseTest extends TestCase
      */
     public function testSharedMaxAge()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $this->assertNull($response->maxAge());
         $response->sharedMaxAge(3600);
         $this->assertEquals(3600, $response->sharedMaxAge());
@@ -776,7 +826,9 @@ class ResponseTest extends TestCase
             ->method('_sendHeader')->with('Cache-Control', 's-maxage=3600');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->sharedMaxAge(3600);
         $response->sharable(true);
         $headers = $response->header();
@@ -793,7 +845,9 @@ class ResponseTest extends TestCase
      */
     public function testMustRevalidate()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $this->assertFalse($response->mustRevalidate());
         $response->mustRevalidate(true);
         $this->assertTrue($response->mustRevalidate());
@@ -805,7 +859,9 @@ class ResponseTest extends TestCase
         $response->mustRevalidate(false);
         $this->assertFalse($response->mustRevalidate());
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->sharedMaxAge(3600);
         $response->mustRevalidate(true);
         $headers = $response->header();
@@ -822,14 +878,18 @@ class ResponseTest extends TestCase
      */
     public function testVary()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->vary('Accept-encoding');
         $this->assertEquals(['Accept-encoding'], $response->vary());
         $response->expects($this->at(1))
             ->method('_sendHeader')->with('Vary', 'Accept-encoding');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->vary(['Accept-language', 'Accept-encoding']);
         $response->expects($this->at(1))
             ->method('_sendHeader')->with('Vary', 'Accept-language, Accept-encoding');
@@ -844,14 +904,18 @@ class ResponseTest extends TestCase
      */
     public function testEtag()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->etag('something');
         $this->assertEquals('"something"', $response->etag());
         $response->expects($this->at(1))
             ->method('_sendHeader')->with('Etag', '"something"');
         $response->send();
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->etag('something', true);
         $this->assertEquals('W/"something"', $response->etag());
         $response->expects($this->at(1))
@@ -866,7 +930,9 @@ class ResponseTest extends TestCase
      */
     public function testNotModified()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', '_sendContent']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', '_sendContent'])
+            ->getMock();
         $response->body('something');
         $response->statusCode(200);
         $response->length(100);
@@ -886,7 +952,9 @@ class ResponseTest extends TestCase
     public function testCheckNotModifiedByEtagStar()
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = '*';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->etag('something');
         $response->expects($this->once())->method('notModified');
         $response->checkNotModified(new Request);
@@ -900,7 +968,9 @@ class ResponseTest extends TestCase
     public function testCheckNotModifiedByEtagExact()
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->etag('something', true);
         $response->expects($this->once())->method('notModified');
         $this->assertTrue($response->checkNotModified(new Request));
@@ -915,7 +985,9 @@ class ResponseTest extends TestCase
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->etag('something', true);
         $response->modified('2012-01-01 00:00:00');
         $response->expects($this->once())->method('notModified');
@@ -931,7 +1003,9 @@ class ResponseTest extends TestCase
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->etag('something', true);
         $response->modified('2012-01-01 00:00:01');
         $response->expects($this->never())->method('notModified');
@@ -947,7 +1021,9 @@ class ResponseTest extends TestCase
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something-else", "other"';
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->etag('something', true);
         $response->modified('2012-01-01 00:00:00');
         $response->expects($this->never())->method('notModified');
@@ -962,7 +1038,9 @@ class ResponseTest extends TestCase
     public function testCheckNotModifiedByTime()
     {
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->modified('2012-01-01 00:00:00');
         $response->expects($this->once())->method('notModified');
         $this->assertTrue($response->checkNotModified(new Request));
@@ -977,7 +1055,9 @@ class ResponseTest extends TestCase
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-        $response = $this->getMock('Cake\Network\Response', ['notModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['notModified'])
+            ->getMock();
         $response->expects($this->never())->method('notModified');
         $this->assertFalse($response->checkNotModified(new Request));
     }
@@ -1113,7 +1193,9 @@ class ResponseTest extends TestCase
         $fooRequest = new Request();
 
         $secureRequest = function () {
-            $secureRequest = $this->getMock('Cake\Network\Request', ['is']);
+            $secureRequest = $this->getMockBuilder('Cake\Network\Request')
+                ->setMethods(['is'])
+                ->getMock();
             $secureRequest->expects($this->any())
                 ->method('is')
                 ->with('ssl')
@@ -1222,13 +1304,15 @@ class ResponseTest extends TestCase
      */
     public function testFile()
     {
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->exactly(1))
             ->method('type')
@@ -1259,14 +1343,16 @@ class ResponseTest extends TestCase
      */
     public function testFileWithDownloadAndName()
     {
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->exactly(1))
             ->method('type')
@@ -1314,14 +1400,16 @@ class ResponseTest extends TestCase
         $currentUserAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : null;
         $_SERVER['HTTP_USER_AGENT'] = 'Some generic browser';
 
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->exactly(1))
             ->method('type')
@@ -1366,14 +1454,16 @@ class ResponseTest extends TestCase
         $currentUserAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : null;
         $_SERVER['HTTP_USER_AGENT'] = 'Opera/9.80 (Windows NT 6.0; U; en) Presto/2.8.99 Version/11.10';
 
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->at(0))
             ->method('type')
@@ -1423,14 +1513,16 @@ class ResponseTest extends TestCase
         $currentUserAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : null;
         $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; Media Center PC 4.0; SLCC1; .NET CLR 3.0.04320)';
 
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->at(0))
             ->method('type')
@@ -1481,14 +1573,16 @@ class ResponseTest extends TestCase
         $currentUserAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : null;
         $_SERVER['HTTP_USER_AGENT'] = 'Some generic browser';
 
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->exactly(1))
             ->method('type')
@@ -1534,14 +1628,16 @@ class ResponseTest extends TestCase
      */
     public function testConnectionAbortedOnBuffering()
     {
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->any())
             ->method('type')
@@ -1565,14 +1661,16 @@ class ResponseTest extends TestCase
      */
     public function testFileUpperExtension()
     {
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->any())
             ->method('type')
@@ -1593,14 +1691,16 @@ class ResponseTest extends TestCase
      */
     public function testFileExtensionNotSet()
     {
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            'download',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                'download',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->any())
             ->method('type')
@@ -1655,12 +1755,15 @@ class ResponseTest extends TestCase
     public function testFileRangeOffsets($range, $length, $offsetResponse)
     {
         $_SERVER['HTTP_RANGE'] = $range;
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->at(1))
             ->method('header')
@@ -1703,13 +1806,15 @@ class ResponseTest extends TestCase
     public function testFileRange()
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=8-25';
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->exactly(1))
             ->method('type')
@@ -1781,10 +1886,12 @@ class ResponseTest extends TestCase
     public function testFileRangeInvalid($range)
     {
         $_SERVER['HTTP_RANGE'] = $range;
-        $response = $this->getMock('Cake\Network\Response', [
-            '_sendHeader',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                '_sendHeader',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->file(
             TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css',
@@ -1809,13 +1916,15 @@ class ResponseTest extends TestCase
     public function testFileRangeReversed()
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=30-2';
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->at(1))
             ->method('header')
@@ -1853,12 +1962,14 @@ class ResponseTest extends TestCase
     public function testFileRangeOffsetsNoDownload($range, $length, $offsetResponse)
     {
         $_SERVER['HTTP_RANGE'] = $range;
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->at(1))
             ->method('header')
@@ -1893,13 +2004,15 @@ class ResponseTest extends TestCase
     public function testFileRangeNoDownload()
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=8-25';
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->exactly(1))
             ->method('type')
@@ -1942,13 +2055,15 @@ class ResponseTest extends TestCase
     public function testFileRangeInvalidNoDownload()
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=30-2';
-        $response = $this->getMock('Cake\Network\Response', [
-            'header',
-            'type',
-            '_sendHeader',
-            '_setContentType',
-            '_isActive',
-        ]);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods([
+                'header',
+                'type',
+                '_sendHeader',
+                '_setContentType',
+                '_isActive',
+            ])
+            ->getMock();
 
         $response->expects($this->at(1))
             ->method('header')

--- a/tests/TestCase/Routing/DispatcherFactoryTest.php
+++ b/tests/TestCase/Routing/DispatcherFactoryTest.php
@@ -41,7 +41,9 @@ class DispatcherFactoryTest extends TestCase
      */
     public function testAddFilter()
     {
-        $mw = $this->getMock('Cake\Routing\DispatcherFilter', ['beforeDispatch']);
+        $mw = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch'])
+            ->getMock();
         $result = DispatcherFactory::add($mw);
         $this->assertSame($mw, $result);
     }
@@ -89,7 +91,9 @@ class DispatcherFactoryTest extends TestCase
      */
     public function testCreate()
     {
-        $mw = $this->getMock('Cake\Routing\DispatcherFilter', ['beforeDispatch']);
+        $mw = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch'])
+            ->getMock();
         DispatcherFactory::add($mw);
         $result = DispatcherFactory::create();
         $this->assertInstanceOf('Cake\Routing\Dispatcher', $result);

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -179,7 +179,9 @@ class DispatcherFilterTest extends TestCase
         $beforeEvent = new Event('Dispatcher.beforeDispatch', $this, compact('response', 'request'));
         $afterEvent = new Event('Dispatcher.afterDispatch', $this, compact('response', 'request'));
 
-        $filter = $this->getMock('Cake\Routing\DispatcherFilter', ['beforeDispatch', 'afterDispatch']);
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch', 'afterDispatch'])
+            ->getMock();
         $filter->expects($this->at(0))
             ->method('beforeDispatch')
             ->with($beforeEvent);
@@ -204,11 +206,10 @@ class DispatcherFilterTest extends TestCase
 
         $event = new Event('Dispatcher.beforeDispatch', $this, compact('response', 'request'));
 
-        $filter = $this->getMock(
-            'Cake\Routing\DispatcherFilter',
-            ['beforeDispatch'],
-            [['for' => '/admin']]
-        );
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch'])
+            ->setConstructorArgs([['for' => '/admin']])
+            ->getMock();
         $filter->expects($this->never())
             ->method('beforeDispatch');
 
@@ -231,11 +232,10 @@ class DispatcherFilterTest extends TestCase
             return false;
         };
 
-        $filter = $this->getMock(
-            'Cake\Routing\DispatcherFilter',
-            ['beforeDispatch'],
-            [['when' => $matcher]]
-        );
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch'])
+            ->setConstructorArgs([['when' => $matcher]])
+            ->getMock();
         $filter->expects($this->never())
             ->method('beforeDispatch');
 

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -361,7 +361,9 @@ class DispatcherTest extends TestCase
                 'pass' => []
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
 
         ob_start();
         $this->dispatcher->dispatch($request, $response);
@@ -484,10 +486,9 @@ class DispatcherTest extends TestCase
      */
     public function testDispatcherFilter()
     {
-        $filter = $this->getMock(
-            'Cake\Routing\DispatcherFilter',
-            ['beforeDispatch', 'afterDispatch']
-        );
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch', 'afterDispatch'])
+            ->getMock();
 
         $filter->expects($this->at(0))
             ->method('beforeDispatch');
@@ -504,7 +505,9 @@ class DispatcherTest extends TestCase
                 'pass' => []
             ]
         ]);
-        $response = $this->getMock('Cake\Network\Response', ['send']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['send'])
+            ->getMock();
         $this->dispatcher->dispatch($request, $response);
     }
 
@@ -515,14 +518,15 @@ class DispatcherTest extends TestCase
      */
     public function testBeforeDispatchAbortDispatch()
     {
-        $response = $this->getMock('Cake\Network\Response', ['send']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['send'])
+            ->getMock();
         $response->expects($this->once())
             ->method('send');
 
-        $filter = $this->getMock(
-            'Cake\Routing\DispatcherFilter',
-            ['beforeDispatch', 'afterDispatch']
-        );
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch', 'afterDispatch'])
+            ->getMock();
         $filter->expects($this->once())
             ->method('beforeDispatch')
             ->will($this->returnValue($response));
@@ -543,14 +547,15 @@ class DispatcherTest extends TestCase
      */
     public function testAfterDispatchReplaceResponse()
     {
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'send']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'send'])
+            ->getMock();
         $response->expects($this->once())
             ->method('send');
 
-        $filter = $this->getMock(
-            'Cake\Routing\DispatcherFilter',
-            ['beforeDispatch', 'afterDispatch']
-        );
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch', 'afterDispatch'])
+            ->getMock();
 
         $filter->expects($this->once())
             ->method('afterDispatch')

--- a/tests/TestCase/Routing/Filter/AssetFilterTest.php
+++ b/tests/TestCase/Routing/Filter/AssetFilterTest.php
@@ -13,7 +13,6 @@
  */
 namespace Cake\Test\TestCase\Routing\Filter;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Event\Event;
 use Cake\Network\Request;
@@ -62,7 +61,9 @@ class AssetFilterTest extends TestCase
         $time = filemtime(Plugin::path('TestTheme') . 'webroot/img/cake.power.gif');
         $time = new \DateTime('@' . $time);
 
-        $response = $this->getMock('Cake\Network\Response', ['send', 'checkNotModified']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['send', 'checkNotModified'])
+            ->getMock();
         $request = new Request('test_theme/img/cake.power.gif');
 
         $response->expects($this->once())->method('checkNotModified')
@@ -76,7 +77,9 @@ class AssetFilterTest extends TestCase
         $this->assertEquals(200, $response->statusCode());
         $this->assertEquals($time->format('D, j M Y H:i:s') . ' GMT', $response->modified());
 
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader', 'checkNotModified', 'send']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader', 'checkNotModified', 'send'])
+            ->getMock();
         $request = new Request('test_theme/img/cake.power.gif');
 
         $response->expects($this->once())->method('checkNotModified')
@@ -99,7 +102,9 @@ class AssetFilterTest extends TestCase
     {
         $filter = new AssetFilter();
 
-        $response = $this->getMock('Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $request = new Request('//index.php');
         $event = new Event('Dispatcher.beforeRequest', $this, compact('request', 'response'));
 
@@ -110,7 +115,7 @@ class AssetFilterTest extends TestCase
     /**
      * Test that 404's are returned when .. is in the URL
      *
-     * @return voi
+     * @return void
      * @triggers Dispatcher.beforeRequest $this, compact('request', 'response')
      * @triggers Dispatcher.beforeRequest $this, compact('request', 'response')
      */
@@ -118,7 +123,9 @@ class AssetFilterTest extends TestCase
     {
         $filter = new AssetFilter();
 
-        $response = $this->getMock('Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $request = new Request('test_theme/../webroot/css/test_asset.css');
         $event = new Event('Dispatcher.beforeRequest', $this, compact('request', 'response'));
 
@@ -232,7 +239,9 @@ class AssetFilterTest extends TestCase
         Plugin::load(['Company/TestPluginThree', 'TestPlugin', 'PluginJs']);
 
         $filter = new AssetFilter();
-        $response = $this->getMock('Cake\Network\Response', ['_sendHeader']);
+        $response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['_sendHeader'])
+            ->getMock();
         $request = new Request($url);
         $event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2770,11 +2770,10 @@ class RouterTest extends TestCase
     {
         $url = 'http://example.com/posts/view/1';
 
-        $route = $this->getMock(
-            'Cake\Routing\Route\Route',
-            ['match'],
-            ['/:controller/:action/*']
-        );
+        $route = $this->getMockBuilder('Cake\Routing\Route\Route')
+            ->setMethods(['match'])
+            ->setConstructorArgs(['/:controller/:action/*'])
+            ->getMock();
         $route->expects($this->any())
             ->method('match')
             ->will($this->returnValue($url));

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -40,17 +40,15 @@ class CommandListShellTest extends TestCase
         $this->out = new ConsoleOutput();
         $io = new ConsoleIo($this->out);
 
-        $this->Shell = $this->getMock(
-            'Cake\Shell\CommandListShell',
-            ['in', 'err', '_stop', 'clear'],
-            [$io]
-        );
+        $this->Shell = $this->getMockBuilder('Cake\Shell\CommandListShell')
+            ->setMethods(['in', 'err', '_stop', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
-        $this->Shell->Command = $this->getMock(
-            'Cake\Shell\Task\CommandTask',
-            ['in', '_stop', 'err', 'clear'],
-            [$io]
-        );
+        $this->Shell->Command = $this->getMockBuilder('Cake\Shell\Task\CommandTask')
+            ->setMethods(['in', '_stop', 'err', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
     }
 
     /**

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -55,17 +55,15 @@ class CompletionShellTest extends TestCase
         $this->out = new TestCompletionStringOutput();
         $io = new ConsoleIo($this->out);
 
-        $this->Shell = $this->getMock(
-            'Cake\Shell\CompletionShell',
-            ['in', '_stop', 'clear'],
-            [$io]
-        );
+        $this->Shell = $this->getMockBuilder('Cake\Shell\CompletionShell')
+            ->setMethods(['in', '_stop', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
 
-        $this->Shell->Command = $this->getMock(
-            'Cake\Shell\Task\CommandTask',
-            ['in', '_stop', 'clear'],
-            [$io]
-        );
+        $this->Shell->Command = $this->getMockBuilder('Cake\Shell\Task\CommandTask')
+            ->setMethods(['in', '_stop', 'clear'])
+            ->setConstructorArgs([$io])
+            ->getMock();
     }
 
     /**

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -33,8 +33,12 @@ class RoutesShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', ['helper', 'out', 'err']);
-        $this->table = $this->getMock('Cake\Shell\Helper\TableHelper', [], [$this->io]);
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->setMethods(['helper', 'out', 'err'])
+            ->getMock();
+        $this->table = $this->getMockBuilder('Cake\Shell\Helper\TableHelper')
+            ->setConstructorArgs([$this->io])
+            ->getMock();
         $this->io->expects($this->any())
             ->method('helper')
             ->with('table')

--- a/tests/TestCase/Shell/Task/AssetsTaskTest.php
+++ b/tests/TestCase/Shell/Task/AssetsTaskTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Shell\Task;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Folder;
 use Cake\TestSuite\TestCase;
@@ -40,13 +39,14 @@ class AssetsTaskTest extends TestCase
             'Skip AssetsTask tests on windows to prevent side effects for UrlHelper tests on AppVeyor.'
         );
 
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->Task = $this->getMock(
-            'Cake\Shell\Task\AssetsTask',
-            ['in', 'out', 'err', '_stop'],
-            [$this->io]
-        );
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\AssetsTask')
+            ->setMethods(['in', 'out', 'err', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
     }
 
     /**
@@ -129,11 +129,10 @@ class AssetsTaskTest extends TestCase
     {
         Plugin::load('TestTheme');
 
-        $shell = $this->getMock(
-            'Cake\Shell\Task\AssetsTask',
-            ['in', 'out', 'err', '_stop', '_createSymlink', '_copyDirectory'],
-            [$this->io]
-        );
+        $shell = $this->getMockBuilder('Cake\Shell\Task\AssetsTask')
+            ->setMethods(['in', 'out', 'err', '_stop', '_createSymlink', '_copyDirectory'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
 
         $this->assertTrue(is_dir(WWW_ROOT . 'test_theme'));
 

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -34,16 +34,19 @@ class ExtractTaskTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
-        $progress = $this->getMock('Cake\Shell\Helper\ProgressHelper', [], [$this->io]);
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $progress = $this->getMockBuilder('Cake\Shell\Helper\ProgressHelper')
+            ->setConstructorArgs([$this->io])
+            ->getMock();
         $this->io->method('helper')
             ->will($this->returnValue($progress));
 
-        $this->Task = $this->getMock(
-            'Cake\Shell\Task\ExtractTask',
-            ['in', 'out', 'err', '_stop'],
-            [$this->io]
-        );
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
+            ->setMethods(['in', 'out', 'err', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
         $this->path = TMP . 'tests/extract_task_test';
         new Folder($this->path . DS . 'locale', true);
     }
@@ -242,11 +245,10 @@ class ExtractTaskTest extends TestCase
     public function testExtractExcludePlugins()
     {
         Configure::write('App.namespace', 'TestApp');
-        $this->Task = $this->getMock(
-            'Cake\Shell\Task\ExtractTask',
-            ['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'],
-            [$this->io]
-        );
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
+            ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
         $this->Task->expects($this->exactly(1))
             ->method('_isExtractingApp')
             ->will($this->returnValue(true));
@@ -269,11 +271,10 @@ class ExtractTaskTest extends TestCase
     {
         Configure::write('App.namespace', 'TestApp');
 
-        $this->Task = $this->getMock(
-            'Cake\Shell\Task\ExtractTask',
-            ['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'],
-            [$this->io]
-        );
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
+            ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
 
         $this->Task->params['output'] = $this->path . DS;
         $this->Task->params['plugin'] = 'TestPlugin';
@@ -294,11 +295,10 @@ class ExtractTaskTest extends TestCase
     {
         Configure::write('App.namespace', 'TestApp');
 
-        $this->Task = $this->getMock(
-            'Cake\Shell\Task\ExtractTask',
-            ['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'],
-            [$this->io]
-        );
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
+            ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
 
         $this->Task->params['output'] = $this->path . DS;
         $this->Task->params['plugin'] = 'Company/TestPluginThree';

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -33,9 +33,14 @@ class LoadTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->Task = $this->getMock('Cake\Shell\Task\LoadTask', ['in', 'out', 'err', '_stop'], [$this->io]);
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\LoadTask')
+            ->setMethods(['in', 'out', 'err', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
 
         $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
 

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -33,9 +33,14 @@ class UnloadTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->Task = $this->getMock('Cake\Shell\Task\UnloadTask', ['in', 'out', 'err', '_stop'], [$this->io]);
+        $this->Task = $this->getMockBuilder('Cake\Shell\Task\UnloadTask')
+            ->setMethods(['in', 'out', 'err', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
 
         $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
 

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -46,7 +46,9 @@ class RulesProviderTest extends TestCase
      */
     public function testCustomObject()
     {
-        $mock = $this->getMock('\Cake\Validation\Validator', ['field']);
+        $mock = $this->getMockBuilder('\Cake\Validation\Validator')
+            ->setMethods(['field'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('field')
             ->with('first', null)

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -758,7 +758,9 @@ class ValidatorTest extends TestCase
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
             ->add('title', 'cool', ['rule' => 'isCool', 'provider' => 'thing']);
 
-        $thing = $this->getMock('\stdClass', ['isCool']);
+        $thing = $this->getMockBuilder('\stdClass')
+            ->setMethods(['isCool'])
+            ->getMock();
         $thing->expects($this->once())->method('isCool')
             ->will($this->returnCallback(function ($data, $context) use ($thing) {
                 $this->assertEquals('bar', $data);
@@ -801,7 +803,9 @@ class ValidatorTest extends TestCase
             'rule' => ['isCool', 'and', 'awesome'],
             'provider' => 'thing'
         ]);
-        $thing = $this->getMock('\stdClass', ['isCool']);
+        $thing = $this->getMockBuilder('\stdClass')
+            ->setMethods(['isCool'])
+            ->getMock();
         $thing->expects($this->once())->method('isCool')
             ->will($this->returnCallback(function ($data, $a, $b, $context) use ($thing) {
                 $this->assertEquals('bar', $data);

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -199,7 +199,9 @@ class FormContextTest extends TestCase
         $this->assertEquals([], $context->error('Alias.name'));
         $this->assertEquals([], $context->error('nope.nope'));
 
-        $mock = $this->getMock('Cake\Validation\Validator', ['errors']);
+        $mock = $this->getMockBuilder('Cake\Validation\Validator')
+            ->setMethods(['errors'])
+            ->getMock();
         $mock->expects($this->once())
             ->method('errors')
             ->willReturn(['key' => 'should be an array, not a string']);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -399,7 +399,10 @@ class FormHelperTest extends TestCase
     public function contextSelectionProvider()
     {
         $entity = new Article();
-        $collection = $this->getMock('Cake\Collection\Collection', ['extract'], [[$entity]]);
+        $collection = $this->getMockBuilder('Cake\Collection\Collection')
+            ->setMethods(['extract'])
+            ->setConstructorArgs([[$entity]])
+            ->getMock();
         $emptyCollection = new Collection([]);
         $emptyArray = [];
         $arrayObject = new \ArrayObject([]);
@@ -3190,11 +3193,10 @@ class FormHelperTest extends TestCase
      */
     public function testInputDatetime()
     {
-        $this->Form = $this->getMock(
-            'Cake\View\Helper\FormHelper',
-            ['datetime'],
-            [new View()]
-        );
+        $this->Form = $this->getMockBuilder('Cake\View\Helper\FormHelper')
+            ->setMethods(['datetime'])
+            ->setConstructorArgs([new View()])
+            ->getMock();
         $this->Form->expects($this->once())->method('datetime')
             ->with('prueba', [
                 'type' => 'datetime',
@@ -3231,11 +3233,10 @@ class FormHelperTest extends TestCase
      */
     public function testInputDatetimeIdPrefix()
     {
-        $this->Form = $this->getMock(
-            'Cake\View\Helper\FormHelper',
-            ['datetime'],
-            [new View()]
-        );
+        $this->Form = $this->getMockBuilder('Cake\View\Helper\FormHelper')
+            ->setMethods(['datetime'])
+            ->setConstructorArgs([new View()])
+            ->getMock();
 
         $this->Form->create(false, ['idPrefix' => 'prefix']);
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -58,7 +58,9 @@ class HtmlHelperTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->View = $this->getMock('Cake\View\View', ['append']);
+        $this->View = $this->getMockBuilder('Cake\View\View')
+            ->setMethods(['append'])
+            ->getMock();
         $this->Html = new HtmlHelper($this->View);
         $this->Html->request = new Request();
         $this->Html->request->webroot = '';

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -107,7 +107,9 @@ class NumberHelperTest extends TestCase
      */
     public function testNumberHelperProxyMethodCalls($method)
     {
-        $number = $this->getMock(__NAMESPACE__ . '\NumberMock', [$method]);
+        $number = $this->getMockBuilder(__NAMESPACE__ . '\NumberMock')
+            ->setMethods([$method])
+            ->getMock();
         $helper = new NumberHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\NumberMock']);
         $helper->attach($number);
         $number->expects($this->at(0))

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -40,7 +40,9 @@ class PaginatorHelperTest extends TestCase
         Configure::write('Config.language', 'eng');
         $this->View = new View();
         $this->Paginator = new PaginatorHelper($this->View);
-        $this->Paginator->Js = $this->getMock('Cake\View\Helper\PaginatorHelper', [], [$this->View]);
+        $this->Paginator->Js = $this->getMockBuilder('Cake\View\Helper\PaginatorHelper')
+            ->setConstructorArgs([$this->View])
+            ->getMock();
         $this->Paginator->request = new Request();
         $this->Paginator->request->addParams([
             'paging' => [

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -90,7 +90,9 @@ class TextHelperTest extends TestCase
         $methods = [
             'stripLinks', 'excerpt', 'toList'
         ];
-        $String = $this->getMock(__NAMESPACE__ . '\StringMock', $methods);
+        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+            ->setMethods($methods)
+            ->getMock();
         $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
         $Text->attach($String);
         foreach ($methods as $method) {
@@ -101,7 +103,9 @@ class TextHelperTest extends TestCase
         $methods = [
             'highlight', 'truncate'
         ];
-        $String = $this->getMock(__NAMESPACE__ . '\StringMock', $methods);
+        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+            ->setMethods($methods)
+            ->getMock();
         $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
         $Text->attach($String);
         foreach ($methods as $method) {
@@ -112,7 +116,9 @@ class TextHelperTest extends TestCase
         $methods = [
             'tail'
         ];
-        $String = $this->getMock(__NAMESPACE__ . '\StringMock', $methods);
+        $String = $this->getMockBuilder(__NAMESPACE__ . '\StringMock')
+            ->setMethods($methods)
+            ->getMock();
         $Text = new TextHelperTestObject($this->View, ['engine' => __NAMESPACE__ . '\StringMock']);
         $Text->attach($String);
         foreach ($methods as $method) {


### PR DESCRIPTION
Refs #8938
