### PR TITLE
Remove unstable branch badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Code Consistency](https://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/grade.svg)](http://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/)
 [![Total Downloads](https://img.shields.io/packagist/dt/cakephp/cakephp.svg?style=flat-square)](https://packagist.org/packages/cakephp/cakephp)
 [![Latest Stable Version](https://img.shields.io/packagist/v/cakephp/cakephp.svg?style=flat-square&label=stable)](https://packagist.org/packages/cakephp/cakephp)
-[![Latest Unstable Version](https://img.shields.io/packagist/vpre/cakephp/cakephp.svg?style=flat-square&label=unstable)](https://packagist.org/packages/cakephp/cakephp)
 
 [CakePHP](http://www.cakephp.org) is a rapid development framework for PHP which
 uses commonly known design patterns like Associative Data


### PR DESCRIPTION
Because shields.io uses dev-master we can't leverage the pre-release badge as it will always point to the latest tag, and shields.io doesn't give us many knobs to tweak.

Refs #8939
