### PR TITLE
Fix getMock() deprecations in TestSuite.

### DIFF
--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -319,7 +319,9 @@ class TestFixtureTest extends TestCase
     public function testCreate()
     {
         $fixture = new ArticlesFixture();
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $table = $this->getMockBuilder('Cake\Database\Schema\Table')
             ->setConstructorArgs(['articles'])
             ->getMock();
@@ -349,7 +351,9 @@ class TestFixtureTest extends TestCase
     public function testCreateError()
     {
         $fixture = new ArticlesFixture();
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $table = $this->getMockBuilder('Cake\Database\Schema\Table')
             ->setConstructorArgs(['articles'])
             ->getMock();
@@ -371,7 +375,9 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $query = $this->getMockBuilder('Cake\Database\Query')
             ->setConstructorArgs([$db])
             ->getMock();
@@ -427,7 +433,9 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ImportsFixture();
 
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $query = $this->getMockBuilder('Cake\Database\Query')
             ->setConstructorArgs([$db])
             ->getMock();
@@ -473,7 +481,9 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new StringsTestsFixture();
 
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $query = $this->getMockBuilder('Cake\Database\Query')
             ->setConstructorArgs([$db])
             ->getMock();
@@ -529,7 +539,9 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $statement = $this->getMockBuilder('\PDOStatement')
             ->setMethods(['closeCursor'])
             ->getMock();
@@ -559,7 +571,9 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $db = $this->createMock('Cake\Database\Connection');
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $statement = $this->getMockBuilder('\PDOStatement')
             ->setMethods(['closeCursor'])
             ->getMock();

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -299,7 +299,10 @@ class TestFixtureTest extends TestCase
         $fixture->init();
         $this->assertEquals(['id', 'letter'], $fixture->schema()->columns());
 
-        $db = $this->getMock('Cake\Database\Connection', ['prepare', 'execute'], [], '', false);
+        $db = $this->getMockBuilder('Cake\Database\Connection')
+            ->setMethods(['prepare', 'execute'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $db->expects($this->never())
             ->method('prepare');
         $db->expects($this->never())
@@ -316,15 +319,19 @@ class TestFixtureTest extends TestCase
     public function testCreate()
     {
         $fixture = new ArticlesFixture();
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['articles']);
+        $db = $this->createMock('Cake\Database\Connection');
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['articles'])
+            ->getMock();
         $table->expects($this->once())
             ->method('createSql')
             ->with($db)
             ->will($this->returnValue(['sql', 'sql']));
         $fixture->schema($table);
 
-        $statement = $this->getMock('\PDOStatement', ['execute', 'closeCursor']);
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['execute', 'closeCursor'])
+            ->getMock();
         $statement->expects($this->atLeastOnce())->method('closeCursor');
         $statement->expects($this->atLeastOnce())->method('execute');
         $db->expects($this->exactly(2))
@@ -342,8 +349,10 @@ class TestFixtureTest extends TestCase
     public function testCreateError()
     {
         $fixture = new ArticlesFixture();
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['articles']);
+        $db = $this->createMock('Cake\Database\Connection');
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['articles'])
+            ->getMock();
         $table->expects($this->once())
             ->method('createSql')
             ->with($db)
@@ -362,8 +371,10 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $query = $this->getMock('Cake\Database\Query', [], [$db]);
+        $db = $this->createMock('Cake\Database\Connection');
+        $query = $this->getMockBuilder('Cake\Database\Query')
+            ->setConstructorArgs([$db])
+            ->getMock();
         $db->expects($this->once())
             ->method('newQuery')
             ->will($this->returnValue($query));
@@ -396,7 +407,9 @@ class TestFixtureTest extends TestCase
             ->with($expected[2])
             ->will($this->returnSelf());
 
-        $statement = $this->getMock('\PDOStatement', ['closeCursor']);
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['closeCursor'])
+            ->getMock();
         $statement->expects($this->once())->method('closeCursor');
         $query->expects($this->once())
             ->method('execute')
@@ -414,8 +427,10 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ImportsFixture();
 
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $query = $this->getMock('Cake\Database\Query', [], [$db]);
+        $db = $this->createMock('Cake\Database\Connection');
+        $query = $this->getMockBuilder('Cake\Database\Query')
+            ->setConstructorArgs([$db])
+            ->getMock();
         $db->expects($this->once())
             ->method('newQuery')
             ->will($this->returnValue($query));
@@ -438,7 +453,9 @@ class TestFixtureTest extends TestCase
             ->with($expected[0])
             ->will($this->returnSelf());
 
-        $statement = $this->getMock('\PDOStatement', ['closeCursor']);
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['closeCursor'])
+            ->getMock();
         $statement->expects($this->once())->method('closeCursor');
         $query->expects($this->once())
             ->method('execute')
@@ -456,8 +473,10 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new StringsTestsFixture();
 
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $query = $this->getMock('Cake\Database\Query', [], [$db]);
+        $db = $this->createMock('Cake\Database\Connection');
+        $query = $this->getMockBuilder('Cake\Database\Query')
+            ->setConstructorArgs([$db])
+            ->getMock();
         $db->expects($this->once())
             ->method('newQuery')
             ->will($this->returnValue($query));
@@ -490,7 +509,9 @@ class TestFixtureTest extends TestCase
             ->with($expected[2])
             ->will($this->returnSelf());
 
-        $statement = $this->getMock('\PDOStatement', ['closeCursor']);
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['closeCursor'])
+            ->getMock();
         $statement->expects($this->once())->method('closeCursor');
         $query->expects($this->once())
             ->method('execute')
@@ -508,14 +529,18 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $statement = $this->getMock('\PDOStatement', ['closeCursor']);
+        $db = $this->createMock('Cake\Database\Connection');
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['closeCursor'])
+            ->getMock();
         $statement->expects($this->once())->method('closeCursor');
         $db->expects($this->once())->method('execute')
             ->with('sql')
             ->will($this->returnValue($statement));
 
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['articles']);
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['articles'])
+            ->getMock();
         $table->expects($this->once())
             ->method('dropSql')
             ->with($db)
@@ -534,14 +559,18 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $db = $this->getMock('Cake\Database\Connection', [], [], '', false);
-        $statement = $this->getMock('\PDOStatement', ['closeCursor']);
+        $db = $this->createMock('Cake\Database\Connection');
+        $statement = $this->getMockBuilder('\PDOStatement')
+            ->setMethods(['closeCursor'])
+            ->getMock();
         $statement->expects($this->once())->method('closeCursor');
         $db->expects($this->once())->method('execute')
             ->with('sql')
             ->will($this->returnValue($statement));
 
-        $table = $this->getMock('Cake\Database\Schema\Table', [], ['articles']);
+        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+            ->setConstructorArgs(['articles'])
+            ->getMock();
         $table->expects($this->once())
             ->method('truncateSql')
             ->with($db)

--- a/tests/TestCase/TestSuite/TestSuiteTest.php
+++ b/tests/TestCase/TestSuite/TestSuiteTest.php
@@ -34,7 +34,9 @@ class TestSuiteTest extends TestCase
         $testFolder = CORE_TEST_CASES . DS . 'TestSuite';
         $count = count(glob($testFolder . DS . '*Test.php'));
 
-        $suite = $this->getMock('Cake\TestSuite\TestSuite', ['addTestFile']);
+        $suite = $this->getMockBuilder('Cake\TestSuite\TestSuite')
+            ->setMethods(['addTestFile'])
+            ->getMock();
         $suite
             ->expects($this->exactly($count))
             ->method('addTestFile');
@@ -53,7 +55,9 @@ class TestSuiteTest extends TestCase
         $count = count(glob($testFolder . DS . '*Test.php'));
         $count += count(glob($testFolder . DS . 'Engine/*Test.php'));
 
-        $suite = $this->getMock('Cake\TestSuite\TestSuite', ['addTestFile']);
+        $suite = $this->getMockBuilder('Cake\TestSuite\TestSuite')
+            ->setMethods(['addTestFile'])
+            ->getMock();
         $suite
             ->expects($this->exactly($count))
             ->method('addTestFile');
@@ -76,7 +80,9 @@ class TestSuiteTest extends TestCase
         touch($Folder->path . DS . 'NotHiddenTest.php');
         touch($Folder->path . DS . '.HiddenTest.php');
 
-        $suite = $this->getMock('Cake\TestSuite\TestSuite', ['addTestFile']);
+        $suite = $this->getMockBuilder('Cake\TestSuite\TestSuite')
+            ->setMethods(['addTestFile'])
+            ->getMock();
         $suite
             ->expects($this->exactly(1))
             ->method('addTestFile');
@@ -100,7 +106,9 @@ class TestSuiteTest extends TestCase
         touch($Folder->path . DS . 'SomeNotesTest.txt');
         touch($Folder->path . DS . 'NotHiddenTest.php');
 
-        $suite = $this->getMock('Cake\TestSuite\TestSuite', ['addTestFile']);
+        $suite = $this->getMockBuilder('Cake\TestSuite\TestSuite')
+            ->setMethods(['addTestFile'])
+            ->getMock();
         $suite
             ->expects($this->exactly(1))
             ->method('addTestFile');


### PR DESCRIPTION
Only the ORM remains.
