### PR TITLE
remove getMock() deprecations

### DIFF
--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -42,11 +42,10 @@ class BelongsToManyTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->tag = $this->getMock(
-            'Cake\ORM\Table',
-            ['find', 'delete'],
-            [['alias' => 'Tags', 'table' => 'tags']]
-        );
+        $this->tag = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['find', 'delete'])
+            ->setConstructorArgs([['alias' => 'Tags', 'table' => 'tags']])
+            ->getMock();
         $this->tag->schema([
             'id' => ['type' => 'integer'],
             'name' => ['type' => 'string'],
@@ -54,11 +53,10 @@ class BelongsToManyTest extends TestCase
                 'primary' => ['type' => 'primary', 'columns' => ['id']]
             ]
         ]);
-        $this->article = $this->getMock(
-            'Cake\ORM\Table',
-            ['find', 'delete'],
-            [['alias' => 'Articles', 'table' => 'articles']]
-        );
+        $this->article = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['find', 'delete'])
+            ->setConstructorArgs([['alias' => 'Articles', 'table' => 'articles']])
+            ->getMock();
         $this->article->schema([
             'id' => ['type' => 'integer'],
             'name' => ['type' => 'string'],
@@ -258,7 +256,9 @@ class BelongsToManyTest extends TestCase
      */
     public function testCascadeDelete()
     {
-        $articleTag = $this->getMock('Cake\ORM\Table', ['deleteAll'], []);
+        $articleTag = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['deleteAll'])
+            ->getMock();
         $config = [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
@@ -288,7 +288,9 @@ class BelongsToManyTest extends TestCase
      */
     public function testCascadeDeleteDependent()
     {
-        $articleTag = $this->getMock('Cake\ORM\Table', ['delete', 'deleteAll'], []);
+        $articleTag = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['delete', 'deleteAll'])
+            ->getMock();
         $config = [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
@@ -327,7 +329,9 @@ class BelongsToManyTest extends TestCase
         $association->junction($articleTag);
         $this->article->association($articleTag->alias());
 
-        $counter = $this->getMock('StdClass', ['__invoke']);
+        $counter = $this->getMockBuilder('StdClass')
+            ->setMethods(['__invoke'])
+            ->getMock();
         $counter->expects($this->exactly(2))->method('__invoke');
         $articleTag->eventManager()->on('Model.beforeDelete', $counter);
 
@@ -386,11 +390,11 @@ class BelongsToManyTest extends TestCase
     public function testLinkSuccess()
     {
         $connection = ConnectionManager::get('test');
-        $joint = $this->getMock(
-            '\Cake\ORM\Table',
-            ['save'],
-            [['alias' => 'ArticlesTags', 'connection' => $connection]]
-        );
+        $joint = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['save'])
+            ->setConstructorArgs([['alias' => 'ArticlesTags', 'connection' => $connection]])
+            ->getMock();
+
         $config = [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
@@ -696,13 +700,14 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedEmptySetSuccess($value)
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $assoc = $this->getMock(
-            '\Cake\ORM\Association\BelongsToMany',
-            ['_saveTarget', 'replaceLinks'],
-            ['tags', ['sourceTable' => $table]]
-        );
+        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+            ->setMethods(['_saveTarget', 'replaceLinks'])
+            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
+            ->getMock();
         $entity = new Entity([
             'id' => 1,
             'tags' => $value,
@@ -724,13 +729,14 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedEmptySetUpdateSuccess($value)
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $assoc = $this->getMock(
-            '\Cake\ORM\Association\BelongsToMany',
-            ['_saveTarget', 'replaceLinks'],
-            ['tags', ['sourceTable' => $table]]
-        );
+        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+            ->setMethods(['_saveTarget', 'replaceLinks'])
+            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
+            ->getMock();
         $entity = new Entity([
             'id' => 1,
             'tags' => $value,
@@ -755,13 +761,14 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedWithReplace()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $assoc = $this->getMock(
-            '\Cake\ORM\Association\BelongsToMany',
-            ['replaceLinks'],
-            ['tags', ['sourceTable' => $table]]
-        );
+        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+            ->setMethods(['replaceLinks'])
+            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
+            ->getMock();
         $entity = new Entity([
             'id' => 1,
             'tags' => [
@@ -784,13 +791,14 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedWithReplaceReturnFalse()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $assoc = $this->getMock(
-            '\Cake\ORM\Association\BelongsToMany',
-            ['replaceLinks'],
-            ['tags', ['sourceTable' => $table]]
-        );
+        $assoc = $this->getMockBuilder('\Cake\ORM\Association\BelongsToMany')
+            ->setMethods(['replaceLinks'])
+            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
+            ->getMock();
         $entity = new Entity([
             'id' => 1,
             'tags' => [
@@ -814,11 +822,10 @@ class BelongsToManyTest extends TestCase
     public function testSaveAssociatedOnlyEntitiesAppend()
     {
         $connection = ConnectionManager::get('test');
-        $mock = $this->getMock(
-            'Cake\ORM\Table',
-            ['saveAssociated', 'schema'],
-            [['table' => 'tags', 'connection' => $connection]]
-        );
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['saveAssociated', 'schema'])
+            ->setConstructorArgs([['table' => 'tags', 'connection' => $connection]])
+            ->getMock();
         $mock->primaryKey('id');
 
         $config = [
@@ -908,7 +915,9 @@ class BelongsToManyTest extends TestCase
      */
     public function testPropertyNoPlugin()
     {
-        $mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->article,
             'targetTable' => $mock,

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -265,7 +265,9 @@ class BelongsToTest extends TestCase
      */
     public function testCascadeDelete()
     {
-        $mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $mock,
@@ -287,7 +289,10 @@ class BelongsToTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities()
     {
-        $mock = $this->getMock('Cake\ORM\Table', ['saveAssociated'], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['saveAssociated'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $mock,
@@ -326,7 +331,9 @@ class BelongsToTest extends TestCase
      */
     public function testPropertyNoPlugin()
     {
-        $mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $mock,
@@ -348,7 +355,9 @@ class BelongsToTest extends TestCase
             'sourceTable' => $this->client,
             'targetTable' => $this->company
         ];
-        $listener = $this->getMock('stdClass', ['__invoke']);
+        $listener = $this->getMockBuilder('stdClass')
+            ->setMethods(['__invoke'])
+            ->getMock();
         $this->company->eventManager()->attach($listener, 'Model.beforeFind');
         $association = new BelongsTo('Companies', $config);
         $listener->expects($this->once())->method('__invoke')
@@ -374,7 +383,9 @@ class BelongsToTest extends TestCase
             'sourceTable' => $this->client,
             'targetTable' => $this->company
         ];
-        $listener = $this->getMock('stdClass', ['__invoke']);
+        $listener = $this->getMockBuilder('stdClass')
+            ->setMethods(['__invoke'])
+            ->getMock();
         $this->company->eventManager()->attach($listener, 'Model.beforeFind');
         $association = new BelongsTo('Companies', $config);
         $options = new \ArrayObject(['something' => 'more']);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -57,11 +57,10 @@ class HasManyTest extends TestCase
             ]
         ]);
         $connection = ConnectionManager::get('test');
-        $this->article = $this->getMock(
-            'Cake\ORM\Table',
-            ['find', 'deleteAll', 'delete'],
-            [['alias' => 'Articles', 'table' => 'articles', 'connection' => $connection]]
-        );
+        $this->article = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['find', 'deleteAll', 'delete'])
+            ->setConstructorArgs([['alias' => 'Articles', 'table' => 'articles', 'connection' => $connection]])
+            ->getMock();
         $this->article->schema([
             'id' => ['type' => 'integer'],
             'title' => ['type' => 'string'],
@@ -388,7 +387,10 @@ class HasManyTest extends TestCase
         $this->author->primaryKey(['id', 'site_id']);
         $association = new HasMany('Articles', $config);
         $keys = [[1, 10], [2, 20], [3, 30], [4, 40]];
-        $query = $this->getMock('Cake\ORM\Query', ['all', 'andWhere'], [null, null]);
+        $query = $this->getMockBuilder('Cake\ORM\Query')
+            ->setMethods(['all', 'andWhere'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $this->article->method('find')
             ->with('all')
             ->will($this->returnValue($query));
@@ -486,7 +488,10 @@ class HasManyTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities()
     {
-        $mock = $this->getMock('Cake\ORM\Table', ['saveAssociated'], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['saveAssociated'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->author,
             'targetTable' => $mock,
@@ -527,7 +532,9 @@ class HasManyTest extends TestCase
      */
     public function testPropertyNoPlugin()
     {
-        $mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->author,
             'targetTable' => $mock,

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -98,7 +98,10 @@ class HasOneTest extends TestCase
      */
     public function testAttachTo()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join', 'select'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $config = [
             'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
@@ -138,7 +141,10 @@ class HasOneTest extends TestCase
      */
     public function testAttachToNoFields()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join', 'select'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
@@ -168,7 +174,10 @@ class HasOneTest extends TestCase
      */
     public function testAttachToMultiPrimaryKey()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join', 'select'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
@@ -203,7 +212,10 @@ class HasOneTest extends TestCase
      */
     public function testAttachToMultiPrimaryKeyMistmatch()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join', 'select'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
@@ -221,7 +233,10 @@ class HasOneTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities()
     {
-        $mock = $this->getMock('Cake\ORM\Table', ['saveAssociated'], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['saveAssociated'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $mock,
@@ -260,7 +275,9 @@ class HasOneTest extends TestCase
      */
     public function testPropertyNoPlugin()
     {
-        $mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->getMock();
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $mock,
@@ -277,13 +294,18 @@ class HasOneTest extends TestCase
      */
     public function testAttachToBeforeFind()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join', 'select'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $config = [
             'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
         ];
-        $listener = $this->getMock('stdClass', ['__invoke']);
+        $listener = $this->getMockBuilder('stdClass')
+            ->setMethods(['__invoke'])
+            ->getMock();
         $this->profile->eventManager()->attach($listener, 'Model.beforeFind');
         $association = new HasOne('Profiles', $config);
         $listener->expects($this->once())->method('__invoke')
@@ -304,13 +326,18 @@ class HasOneTest extends TestCase
      */
     public function testAttachToBeforeFindExtraOptions()
     {
-        $query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join', 'select'])
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $config = [
             'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
         ];
-        $listener = $this->getMock('stdClass', ['__invoke']);
+        $listener = $this->getMockBuilder('stdClass')
+            ->setMethods(['__invoke'])
+            ->getMock();
         $this->profile->eventManager()->attach($listener, 'Model.beforeFind');
         $association = new HasOne('Profiles', $config);
         $opts = new \ArrayObject(['something' => 'more']);

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -91,7 +91,9 @@ class AssociationCollectionTest extends TestCase
      */
     public function testGetByProperty()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
         $belongsTo = new BelongsTo('Users', [
             'sourceTable' => $table
@@ -164,8 +166,12 @@ class AssociationCollectionTest extends TestCase
      */
     public function testCascadeDelete()
     {
-        $mockOne = $this->getMock('Cake\ORM\Association\BelongsTo', [], ['']);
-        $mockTwo = $this->getMock('Cake\ORM\Association\HasMany', [], ['']);
+        $mockOne = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
+            ->setConstructorArgs([''])
+            ->getMock();
+        $mockTwo = $this->getMockBuilder('Cake\ORM\Association\HasMany')
+            ->setConstructorArgs([''])
+            ->getMock();
 
         $entity = new Entity();
         $options = ['option' => 'value'];
@@ -190,22 +196,22 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveParents()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $mockOne = $this->getMock(
-            'Cake\ORM\Association\BelongsTo',
-            ['saveAssociated'],
-            ['Parent', [
+        $mockOne = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
+            ->setMethods(['saveAssociated'])
+            ->setConstructorArgs(['Parent', [
                 'sourceTable' => $table,
-            ]]
-        );
-        $mockTwo = $this->getMock(
-            'Cake\ORM\Association\HasMany',
-            ['saveAssociated'],
-            ['Child', [
+            ]])
+            ->getMock();
+        $mockTwo = $this->getMockBuilder('Cake\ORM\Association\HasMany')
+            ->setMethods(['saveAssociated'])
+            ->setConstructorArgs(['Child', [
                 'sourceTable' => $table
-            ]]
-        );
+            ]])
+            ->getMock();
 
         $this->associations->add('Parent', $mockOne);
         $this->associations->add('Child', $mockTwo);
@@ -240,22 +246,22 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveParentsFiltered()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $mockOne = $this->getMock(
-            'Cake\ORM\Association\BelongsTo',
-            ['saveAssociated'],
-            ['Parents', [
+        $mockOne = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
+            ->setMethods(['saveAssociated'])
+            ->setConstructorArgs(['Parents', [
                 'sourceTable' => $table,
-            ]]
-        );
-        $mockTwo = $this->getMock(
-            'Cake\ORM\Association\BelongsTo',
-            ['saveAssociated'],
-            ['Categories', [
+            ]])
+            ->getMock();
+        $mockTwo = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
+            ->setMethods(['saveAssociated'])
+            ->setConstructorArgs(['Categories', [
                 'sourceTable' => $table
-            ]]
-        );
+            ]])
+            ->getMock();
 
         $this->associations->add('Parents', $mockOne);
         $this->associations->add('Categories', $mockTwo);
@@ -290,22 +296,22 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveChildrenFiltered()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['table'], [[]]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['table'])
+            ->getMock();
         $table->schema([]);
-        $mockOne = $this->getMock(
-            'Cake\ORM\Association\HasMany',
-            ['saveAssociated'],
-            ['Comments', [
+        $mockOne = $this->getMockBuilder('Cake\ORM\Association\HasMany')
+            ->setMethods(['saveAssociated'])
+            ->setConstructorArgs(['Comments', [
                 'sourceTable' => $table,
-            ]]
-        );
-        $mockTwo = $this->getMock(
-            'Cake\ORM\Association\HasOne',
-            ['saveAssociated'],
-            ['Profiles', [
+            ]])
+            ->getMock();
+        $mockTwo = $this->getMockBuilder('Cake\ORM\Association\HasOne')
+            ->setMethods(['saveAssociated'])
+            ->setConstructorArgs(['Profiles', [
                 'sourceTable' => $table
-            ]]
-        );
+            ]])
+            ->getMock();
 
         $this->associations->add('Comments', $mockOne);
         $this->associations->add('Profiles', $mockTwo);
@@ -341,11 +347,10 @@ class AssociationCollectionTest extends TestCase
      */
     public function testErrorOnUnknownAlias()
     {
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['save'],
-            [['alias' => 'Users']]
-        );
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['save'])
+            ->setConstructorArgs([['alias' => 'Users']])
+            ->getMock();
 
         $entity = new Entity();
         $entity->set('profile', ['key' => 'value']);

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -145,7 +145,9 @@ class AssociationProxyTest extends TestCase
     public function testAssociationMethodProxy()
     {
         $articles = TableRegistry::get('articles');
-        $mock = $this->getMock('Cake\ORM\Table', ['crazy']);
+        $mock = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['crazy'])
+            ->getMock();
         $articles->belongsTo('authors', [
             'targetTable' => $mock
         ]);

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -62,14 +62,13 @@ class AssociationTest extends TestCase
             'sourceTable' => $this->source,
             'joinType' => 'INNER'
         ];
-        $this->association = $this->getMock(
-            '\Cake\ORM\Association',
-            [
+        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+            ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type'
-            ],
-            ['Foo', $config]
-        );
+            ])
+            ->setConstructorArgs(['Foo', $config])
+            ->getMock();
     }
 
     /**
@@ -128,14 +127,13 @@ class AssociationTest extends TestCase
         $config = [
             'className' => 'Test',
         ];
-        $this->association = $this->getMock(
-            '\Cake\ORM\Association',
-            [
+        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+            ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type'
-            ],
-            ['Foo', $config]
-        );
+            ])
+            ->setConstructorArgs(['Foo', $config])
+            ->getMock();
 
         $this->assertEquals('Test', $this->association->className());
     }
@@ -266,11 +264,10 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER'
         ];
 
-        $this->association = $this->getMock(
-            '\Cake\ORM\Association',
-            ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
-            ['ThisAssociationName', $config]
-        );
+        $this->association = $this->getMockBuilder('\Cake\ORM\Association')
+            ->setMethods(['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
+            ->setConstructorArgs(['ThisAssociationName', $config])
+            ->getMock();
 
         $table = $this->association->target();
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $table);
@@ -360,14 +357,13 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
             'propertyName' => 'foo'
         ];
-        $association = $this->getMock(
-            '\Cake\ORM\Association',
-            [
+        $association = $this->getMockBuilder('\Cake\ORM\Association')
+            ->setMethods([
                 '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type'
-            ],
-            ['Foo', $config]
-        );
+            ])
+            ->setConstructorArgs(['Foo', $config])
+            ->getMock();
 
         $this->assertEquals('foo', $association->property());
     }
@@ -426,11 +422,10 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
             'finder' => 'published'
         ];
-        $assoc = $this->getMock(
-            '\Cake\ORM\Association',
-            ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
-            ['Foo', $config]
-        );
+        $assoc = $this->getMockBuilder('\Cake\ORM\Association')
+            ->setMethods(['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
+            ->setConstructorArgs(['Foo', $config])
+            ->getMock();
         $this->assertEquals('published', $assoc->finder());
     }
 
@@ -461,11 +456,10 @@ class AssociationTest extends TestCase
             'className' => '\Cake\Test\TestCase\ORM\TestTable',
             'tableLocator' => $locator
         ];
-        $assoc = $this->getMock(
-            '\Cake\ORM\Association',
-            ['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'],
-            ['Foo', $config]
-        );
+        $assoc = $this->getMockBuilder('\Cake\ORM\Association')
+            ->setMethods(['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
+            ->setConstructorArgs(['Foo', $config])
+            ->getMock();
         $this->assertEquals($locator, $assoc->tableLocator());
     }
 }

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -293,7 +293,9 @@ class BehaviorRegistryTest extends TestCase
             ->getMock();
         $this->Behaviors->set('Sluggable', $mockedBehavior);
 
-        $query = $this->getMock('Cake\ORM\Query', [], [null, null]);
+        $query = $this->getMockBuilder('Cake\ORM\Query')
+            ->setConstructorArgs([null, null])
+            ->getMock();
         $mockedBehavior
             ->expects($this->once())
             ->method('findNoSlug')

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -588,11 +588,10 @@ class CompositeKeyTest extends TestCase
     public function testFindThreadedCompositeKeys()
     {
         $table = TableRegistry::get('SiteAuthors');
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['_addDefaultFields', 'execute'],
-            [null, $table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['_addDefaultFields', 'execute'])
+            ->setConstructorArgs([null, $table])
+            ->getMock();
 
         $items = new \Cake\Datasource\ResultSetDecorator([
             ['id' => 1, 'name' => 'a', 'site_id' => 1, 'parent_id' => null],

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -159,7 +159,10 @@ class EagerLoaderTest extends TestCase
             ]
         ];
 
-        $query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join'])
+            ->setConstructorArgs([$this->connection, $this->table])
+            ->getMock();
 
         $query->typeMap($this->clientsTypeMap);
 
@@ -445,11 +448,10 @@ class EagerLoaderTest extends TestCase
             ]
         ];
 
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['join'],
-            [$this->connection, $this->table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['join'])
+            ->setConstructorArgs([$this->connection, $this->table])
+            ->getMock();
 
         $loader = new EagerLoader;
         $loader->contain($contains);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -162,7 +162,9 @@ class EntityTest extends TestCase
      */
     public function testSetOneParamWithSetter()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setName'])
+            ->getMock();
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
@@ -180,7 +182,9 @@ class EntityTest extends TestCase
      */
     public function testMultipleWithSetter()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName', '_setStuff']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setName', '_setStuff'])
+            ->getMock();
         $entity->accessible('*', true);
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
@@ -206,7 +210,9 @@ class EntityTest extends TestCase
      */
     public function testBypassSetters()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName', '_setStuff']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setName', '_setStuff'])
+            ->getMock();
         $entity->accessible('*', true);
 
         $entity->expects($this->never())->method('_setName');
@@ -282,7 +288,9 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGetters()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->expects($this->any())
             ->method('_getName')
             ->with('Jones')
@@ -301,7 +309,9 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGettersAfterSet()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->expects($this->any())
             ->method('_getName')
             ->will($this->returnCallback(function ($name) {
@@ -323,7 +333,9 @@ class EntityTest extends TestCase
      */
     public function testGetCacheClearedByUnset()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->expects($this->any())->method('_getName')
             ->will($this->returnCallback(function ($name) {
                 return 'Dr. ' . $name;
@@ -342,7 +354,9 @@ class EntityTest extends TestCase
      */
     public function testGetCamelCasedProperties()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getListIdName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getListIdName'])
+            ->getMock();
         $entity->expects($this->any())->method('_getListIdName')
             ->will($this->returnCallback(function ($name) {
                 return 'A name';
@@ -373,7 +387,9 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetter()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setName'])
+            ->getMock();
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
@@ -391,7 +407,9 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetterTitleCase()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setName'])
+            ->getMock();
         $entity->expects($this->once())
             ->method('_setName')
             ->with('Jones')
@@ -411,7 +429,9 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetter()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->expects($this->once())->method('_getName')
             ->with('Jones')
             ->will($this->returnCallback(function ($name) {
@@ -429,7 +449,9 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetterTitleCase()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->expects($this->once())
             ->method('_getName')
             ->with('Jones')
@@ -473,7 +495,9 @@ class EntityTest extends TestCase
         $this->assertFalse($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
 
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getThings']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getThings'])
+            ->getMock();
         $entity->expects($this->once())->method('_getThings')
             ->will($this->returnValue(0));
         $this->assertTrue($entity->has('things'));
@@ -542,7 +566,9 @@ class EntityTest extends TestCase
      */
     public function testMagicUnset()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['unsetProperty']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['unsetProperty'])
+            ->getMock();
         $entity->expects($this->at(0))
             ->method('unsetProperty')
             ->with('foo');
@@ -570,7 +596,9 @@ class EntityTest extends TestCase
      */
     public function testGetArrayAccess()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['get']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['get'])
+            ->getMock();
         $entity->expects($this->at(0))
             ->method('get')
             ->with('foo')
@@ -592,7 +620,9 @@ class EntityTest extends TestCase
      */
     public function testSetArrayAccess()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['set']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['set'])
+            ->getMock();
         $entity->accessible('*', true);
 
         $entity->expects($this->at(0))
@@ -616,7 +646,9 @@ class EntityTest extends TestCase
      */
     public function testUnsetArrayAccess()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['unsetProperty']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['unsetProperty'])
+            ->getMock();
         $entity->expects($this->at(0))
             ->method('unsetProperty')
             ->with('foo');
@@ -632,8 +664,12 @@ class EntityTest extends TestCase
      */
     public function testMethodCache()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_setFoo', '_getBar']);
-        $entity2 = $this->getMock('\Cake\ORM\Entity', ['_setBar']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setFoo', '_getBar'])
+            ->getMock();
+        $entity2 = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_setBar'])
+            ->getMock();
         $entity->expects($this->once())->method('_setFoo');
         $entity->expects($this->once())->method('_getBar');
         $entity2->expects($this->once())->method('_setBar');
@@ -650,7 +686,9 @@ class EntityTest extends TestCase
      */
     public function testSetGetLongProperyNames()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getVeryLongProperty', '_setVeryLongProperty']);
+        $entity = $this->getMockBUilder('\Cake\ORM\Entity')
+            ->setMethods(['_getVeryLongProperty', '_setVeryLongProperty'])
+            ->getMock();
         $entity->expects($this->once())->method('_getVeryLongProperty');
         $entity->expects($this->once())->method('_setVeryLongProperty');
         $entity->get('very_long_property');
@@ -930,7 +968,9 @@ class EntityTest extends TestCase
      */
     public function testToArrayWithAccessor()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->accessible('*', true);
         $entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
         $entity->expects($this->any())
@@ -961,7 +1001,9 @@ class EntityTest extends TestCase
      */
     public function testToArrayVirtualProperties()
     {
-        $entity = $this->getMock('\Cake\ORM\Entity', ['_getName']);
+        $entity = $this->getMockBuilder('\Cake\ORM\Entity')
+            ->setMethods(['_getName'])
+            ->getMock();
         $entity->accessible('*', true);
 
         $entity->expects($this->any())

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1781,13 +1781,14 @@ class QueryTest extends TestCase
      */
     public function testCollectionProxy($method, $arg)
     {
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['all'],
-            [$this->connection, $this->table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['all'])
+            ->setConstructorArgs([$this->connection, $this->table])
+            ->getMock();
         $query->select();
-        $resultSet = $this->getMock('\Cake\ORM\ResultSet', [], [$query, null]);
+        $resultSet = $this->getMockbuilder('\Cake\ORM\ResultSet')
+            ->setConstructorArgs([$query, null])
+            ->getMock();
         $query->expects($this->once())
             ->method('all')
             ->will($this->returnValue($resultSet));
@@ -1835,12 +1836,13 @@ class QueryTest extends TestCase
      */
     public function testCacheReadIntegration()
     {
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['execute'],
-            [$this->connection, $this->table]
-        );
-        $resultSet = $this->getMock('\Cake\ORM\ResultSet', [], [$query, null]);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['execute'])
+            ->setConstructorArgs([$this->connection, $this->table])
+            ->getMock();
+        $resultSet = $this->getMockBuilder('\Cake\ORM\ResultSet')
+            ->setConstructorArgs([$query, null])
+            ->getMock();
 
         $query->expects($this->never())
             ->method('execute');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -335,9 +335,10 @@ class TableTest extends TestCase
     public function testSchemaInitialize()
     {
         $schema = $this->connection->schemaCollection()->describe('users');
-        $table = $this->getMock('Cake\ORM\Table', ['_initializeSchema'], [
-            ['table' => 'users', 'connection' => $this->connection]
-        ]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['_initializeSchema'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
         $table->expects($this->once())
             ->method('_initializeSchema')
             ->with($schema)
@@ -874,12 +875,14 @@ class TableTest extends TestCase
      */
     public function testUpdateAllFailure()
     {
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['query'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
-        $query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection, $table]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
+        $query = $this->getMockBuilder('Cake\ORM\Query')
+            ->setMethods(['execute'])
+            ->setConstructorArgs([$this->connection, $table])
+            ->getMock();
         $table->expects($this->once())
             ->method('query')
             ->will($this->returnValue($query));
@@ -937,12 +940,14 @@ class TableTest extends TestCase
      */
     public function testDeleteAllFailure()
     {
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['query'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
-        $query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection, $table]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
+        $query = $this->getMockBuilder('Cake\ORM\Query')
+            ->setMethods(['execute'])
+            ->setConstructorArgs([$this->connection, $table])
+            ->getMock();
         $table->expects($this->once())
             ->method('query')
             ->will($this->returnValue($query));
@@ -961,12 +966,13 @@ class TableTest extends TestCase
      */
     public function testFindApplyOptions()
     {
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['query', 'findAll'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
-        $query = $this->getMock('Cake\ORM\Query', [], [$this->connection, $table]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['query', 'findAll'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
+        $query = $this->getMockBuilder('Cake\ORM\Query')
+            ->setConstructorArgs([$this->connection, $table])
+            ->getMock();
         $table->expects($this->once())
             ->method('query')
             ->will($this->returnValue($query));
@@ -1118,9 +1124,15 @@ class TableTest extends TestCase
      */
     public function testStackingFinders()
     {
-        $table = $this->getMock('\Cake\ORM\Table', ['find', 'findList'], [], '', false);
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['find', 'findList'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $params = [$this->connection, $table];
-        $query = $this->getMock('\Cake\ORM\Query', ['addDefaultTypes'], $params);
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['addDefaultTypes'])
+            ->setConstructorArgs($params)
+            ->getMock();
 
         $table->expects($this->once())
             ->method('find')
@@ -1522,7 +1534,9 @@ class TableTest extends TestCase
      */
     public function testAddBehavior()
     {
-        $mock = $this->getMock('Cake\ORM\BehaviorRegistry', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\BehaviorRegistry')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mock->expects($this->once())
             ->method('load')
             ->with('Sluggable');
@@ -1559,7 +1573,9 @@ class TableTest extends TestCase
      */
     public function testRemoveBehavior()
     {
-        $mock = $this->getMock('Cake\ORM\BehaviorRegistry', [], [], '', false);
+        $mock = $this->getMockBuilder('Cake\ORM\BehaviorRegistry')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mock->expects($this->once())
             ->method('unload')
             ->with('Sluggable');
@@ -1655,10 +1671,9 @@ class TableTest extends TestCase
      */
     public function testImplementedEvents()
     {
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['beforeFind', 'beforeSave', 'afterSave', 'beforeDelete', 'afterDelete']
-        );
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['beforeFind', 'beforeSave', 'afterSave', 'beforeDelete', 'afterDelete'])
+            ->getMock();
         $result = $table->implementedEvents();
         $expected = [
             'Model.beforeFind' => 'beforeFind',
@@ -1713,15 +1728,14 @@ class TableTest extends TestCase
      */
     public function testSaveNewEntityNoExists()
     {
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['exists'],
-            [[
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['exists'])
+            ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'alias' => 'Users',
                 'table' => 'users',
-            ]]
-        );
+            ]])
+            ->getMock();
         $entity = $table->newEntity(['username' => 'mark']);
         $this->assertTrue($entity->isNew());
 
@@ -1739,17 +1753,14 @@ class TableTest extends TestCase
     public function testSavePrimaryKeyEntityExists()
     {
         $this->skipIfSqlServer();
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['exists'],
-            [
-                [
-                    'connection' => $this->connection,
-                    'alias' => 'Users',
-                    'table' => 'users',
-                ]
-            ]
-        );
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['exists'])
+            ->setConstructorArgs([[
+                'connection' => $this->connection,
+                'alias' => 'Users',
+                'table' => 'users',
+            ]])
+            ->getMock();
         $entity = $table->newEntity(['id' => 20, 'username' => 'mark']);
         $this->assertTrue($entity->isNew());
 
@@ -2052,17 +2063,14 @@ class TableTest extends TestCase
     public function testSavePrimaryKeyEntityNoExists()
     {
         $this->skipIfSqlServer();
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['exists'],
-            [
-                [
-                    'connection' => $this->connection,
-                    'alias' => 'Users',
-                    'table' => 'users',
-                ]
-            ]
-        );
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['exists'])
+            ->setConstructorArgs([[
+                'connection' => $this->connection,
+                'alias' => 'Users',
+                'table' => 'users',
+            ]])
+            ->getMock();
         $entity = $table->newEntity(['id' => 20, 'username' => 'mark']);
         $this->assertTrue($entity->isNew());
 
@@ -2306,16 +2314,14 @@ class TableTest extends TestCase
      */
     public function testAfterSaveNotCalled()
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['query'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['execute', 'addDefaultTypes'],
-            [null, $table]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['execute', 'addDefaultTypes'])
+            ->setConstructorArgs([null, $table])
+            ->getMock();
         $statement = $this->getMockBuilder('\Cake\Database\Statement\StatementDecorator')->getMock();
         $data = new \Cake\ORM\Entity([
             'username' => 'superuser',
@@ -2417,14 +2423,16 @@ class TableTest extends TestCase
     {
         $config = ConnectionManager::config('test');
 
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['begin', 'commit'],
-            [$config]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['begin', 'commit'])
+            ->setConstructorArgs([$config])
+            ->getMock();
         $connection->driver($this->connection->driver());
 
-        $table = $this->getMock('\Cake\ORM\Table', ['connection'], [['table' => 'users']]);
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['connection'])
+            ->setConstructorArgs([['table' => 'users']])
+            ->getMock();
         $table->expects($this->any())->method('connection')
             ->will($this->returnValue($connection));
 
@@ -2447,22 +2455,19 @@ class TableTest extends TestCase
      */
     public function testAtomicSaveRollback()
     {
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['begin', 'rollback'],
-            [ConnectionManager::config('test')]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['begin', 'rollback'])
+            ->setConstructorArgs([ConnectionManager::config('test')])
+            ->getMock();
         $connection->driver(ConnectionManager::get('test')->driver());
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['query', 'connection'],
-            [['table' => 'users']]
-        );
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['execute', 'addDefaultTypes'],
-            [null, $table]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['query', 'connection'])
+            ->setConstructorArgs([['table' => 'users']])
+            ->getMock();
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['execute', 'addDefaultTypes'])
+            ->setConstructorArgs([null, $table])
+            ->getMock();
         $table->expects($this->any())->method('connection')
             ->will($this->returnValue($connection));
 
@@ -2490,22 +2495,19 @@ class TableTest extends TestCase
      */
     public function testAtomicSaveRollbackOnFailure()
     {
-        $connection = $this->getMock(
-            '\Cake\Database\Connection',
-            ['begin', 'rollback'],
-            [ConnectionManager::config('test')]
-        );
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['begin', 'rollback'])
+            ->setConstructorArgs([ConnectionManager::config('test')])
+            ->getMock();
         $connection->driver(ConnectionManager::get('test')->driver());
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['query', 'connection', 'exists'],
-            [['table' => 'users']]
-        );
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['execute', 'addDefaultTypes'],
-            [null, $table]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['query', 'connection', 'exists'])
+            ->setConstructorArgs([['table' => 'users']])
+            ->getMock();
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['execute', 'addDefaultTypes'])
+            ->setConstructorArgs([null, $table])
+            ->getMock();
 
         $table->expects($this->any())->method('connection')
             ->will($this->returnValue($connection));
@@ -2659,11 +2661,10 @@ class TableTest extends TestCase
      */
     public function testSaveUpdateWithHint()
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['exists'],
-            [['table' => 'users', 'connection' => ConnectionManager::get('test')]]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['exists'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => ConnectionManager::get('test')]])
+            ->getMock();
         $entity = new \Cake\ORM\Entity([
             'id' => 2,
             'username' => 'baggins'
@@ -2682,17 +2683,15 @@ class TableTest extends TestCase
      */
     public function testSaveUpdatePrimaryKeyNotModified()
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['query'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
 
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['execute', 'addDefaultTypes', 'set'],
-            [null, $table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['execute', 'addDefaultTypes', 'set'])
+            ->setConstructorArgs([null, $table])
+            ->getMock();
 
         $table->expects($this->once())->method('query')
             ->will($this->returnValue($query));
@@ -2726,11 +2725,10 @@ class TableTest extends TestCase
      */
     public function testUpdateNoChange()
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['query'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
         $table->expects($this->never())->method('query');
         $entity = new \Cake\ORM\Entity([
             'id' => 2,
@@ -2765,11 +2763,10 @@ class TableTest extends TestCase
      */
     public function testUpdateNoPrimaryButOtherKeys()
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['query'],
-            [['table' => 'users', 'connection' => $this->connection]]
-        );
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->getMock();
         $table->expects($this->never())->method('query');
         $entity = new \Cake\ORM\Entity([
             'username' => 'mariano',
@@ -3182,11 +3179,10 @@ class TableTest extends TestCase
     {
         $entity = new \Cake\ORM\Entity(['id' => 1, 'name' => 'mark']);
 
-        $table = $this->getMock(
-            'Cake\ORM\Table',
-            ['query'],
-            [['connection' => $this->connection]]
-        );
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['query'])
+            ->setConstructorArgs([['connection' => $this->connection]])
+            ->getMock();
         $table->expects($this->never())
             ->method('query');
 
@@ -3230,7 +3226,9 @@ class TableTest extends TestCase
      */
     public function functionTestValidationWithDefiner()
     {
-        $table = $this->getMock('\Cake\ORM\Table', ['validationForOtherStuff']);
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['validationForOtherStuff'])
+            ->getMock();
         $table->expects($this->once())->method('validationForOtherStuff')
             ->will($this->returnArgument(0));
         $other = $table->validator('forOtherStuff');
@@ -3803,7 +3801,9 @@ class TableTest extends TestCase
      */
     public function testSaveCleanEntity()
     {
-        $table = $this->getMock('\Cake\ORM\Table', ['_processSave']);
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['_processSave'])
+            ->getMock();
         $entity = new \Cake\ORM\Entity(
             ['id' => 'foo'],
             ['markNew' => false, 'markClean' => true]
@@ -3845,30 +3845,26 @@ class TableTest extends TestCase
      */
     public function testSaveDeepAssociationOptions()
     {
-        $articles = $this->getMock(
-            '\Cake\ORM\Table',
-            ['_insert'],
-            [['table' => 'articles', 'connection' => $this->connection]]
-        );
-        $authors = $this->getMock(
-            '\Cake\ORM\Table',
-            ['_insert'],
-            [['table' => 'authors', 'connection' => $this->connection]]
-        );
-        $supervisors = $this->getMock(
-            '\Cake\ORM\Table',
-            ['_insert', 'validate'],
-            [[
+        $articles = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['_insert'])
+            ->setConstructorArgs([['table' => 'articles', 'connection' => $this->connection]])
+            ->getMock();
+        $authors = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['_insert'])
+            ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
+            ->getMock();
+        $supervisors = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['_insert', 'validate'])
+            ->setConstructorArgs([[
                 'table' => 'authors',
                 'alias' => 'supervisors',
                 'connection' => $this->connection
-            ]]
-        );
-        $tags = $this->getMock(
-            '\Cake\ORM\Table',
-            ['_insert'],
-            [['table' => 'tags', 'connection' => $this->connection]]
-        );
+            ]])
+            ->getMock();
+        $tags = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['_insert'])
+            ->setConstructorArgs([['table' => 'tags', 'connection' => $this->connection]])
+            ->getMock();
 
         $articles->belongsTo('authors', ['targetTable' => $authors]);
         $authors->hasOne('supervisors', ['targetTable' => $supervisors]);
@@ -4226,24 +4222,22 @@ class TableTest extends TestCase
      */
     public function testReplaceHasManyOnErrorDependentCascadeCallbacks()
     {
-        $articles = $this->getMock(
-            'Cake\ORM\Table',
-            ['delete'],
-            [[
+        $articles = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['delete'])
+            ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'alias' => 'Articles',
                 'table' => 'articles',
-            ]]
-        );
+            ]])
+            ->getMock();
 
         $articles->method('delete')->willReturn(false);
 
         $associations = new AssociationCollection();
 
-        $hasManyArticles = $this->getMock(
-            'Cake\ORM\Association\HasMany',
-            ['target'],
-            [
+        $hasManyArticles = $this->getMockBuilder('Cake\ORM\Association\HasMany')
+            ->setMethods(['target'])
+            ->setConstructorArgs([
                 'articles',
                 [
                     'target' => $articles,
@@ -4251,8 +4245,8 @@ class TableTest extends TestCase
                     'dependent' => true,
                     'cascadeCallbacks' => true
                 ]
-            ]
-        );
+            ])
+            ->getMock();
         $hasManyArticles->method('target')->willReturn($articles);
 
         $associations->add('articles', $hasManyArticles);
@@ -5021,14 +5015,13 @@ class TableTest extends TestCase
      */
     public function testSimplifiedFind()
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['callFinder'],
-            [[
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['callFinder'])
+            ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => ['id' => ['type' => 'integer']]
-            ]]
-        );
+            ]])
+            ->getMock();
 
         $query = (new \Cake\ORM\Query($this->connection, $table))->select();
         $table->expects($this->once())->method('callFinder')
@@ -5054,24 +5047,22 @@ class TableTest extends TestCase
      */
     public function testGet($options)
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['callFinder', 'query'],
-            [[
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['callFinder', 'query'])
+            ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => [
                     'id' => ['type' => 'integer'],
                     'bar' => ['type' => 'integer'],
                     '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]]
                 ]
-            ]]
-        );
+            ]])
+            ->getMock();
 
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['addDefaultTypes', 'firstOrFail', 'where', 'cache'],
-            [$this->connection, $table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
+            ->setConstructorArgs([$this->connection, $table])
+            ->getMock();
 
         $entity = new \Cake\ORM\Entity;
         $table->expects($this->once())->method('query')
@@ -5106,24 +5097,22 @@ class TableTest extends TestCase
      */
     public function testGetWithCustomFinder($options)
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['callFinder', 'query'],
-            [[
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['callFinder', 'query'])
+            ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => [
                     'id' => ['type' => 'integer'],
                     'bar' => ['type' => 'integer'],
                     '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]]
                 ]
-            ]]
-        );
+            ]])
+            ->getMock();
 
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['addDefaultTypes', 'firstOrFail', 'where', 'cache'],
-            [$this->connection, $table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
+            ->setConstructorArgs([$this->connection, $table])
+            ->getMock();
 
         $entity = new \Cake\ORM\Entity;
         $table->expects($this->once())->method('query')
@@ -5167,25 +5156,23 @@ class TableTest extends TestCase
      */
     public function testGetWithCache($options, $cacheKey, $cacheConfig)
     {
-        $table = $this->getMock(
-            '\Cake\ORM\Table',
-            ['callFinder', 'query'],
-            [[
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['callFinder', 'query'])
+            ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => [
                     'id' => ['type' => 'integer'],
                     'bar' => ['type' => 'integer'],
                     '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]]
                 ]
-            ]]
-        );
+            ]])
+            ->getMock();
         $table->table('table_name');
 
-        $query = $this->getMock(
-            '\Cake\ORM\Query',
-            ['addDefaultTypes', 'firstOrFail', 'where', 'cache'],
-            [$this->connection, $table]
-        );
+        $query = $this->getMockBuilder('\Cake\ORM\Query')
+            ->setMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
+            ->setConstructorArgs([$this->connection, $table])
+            ->getMock();
 
         $entity = new \Cake\ORM\Entity;
         $table->expects($this->once())->method('query')
@@ -5265,8 +5252,12 @@ class TableTest extends TestCase
      */
     public function testPatchEntity()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['marshaller']);
-        $marshaller = $this->getMock('Cake\ORM\Marshaller', [], [$table]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['marshaller'])
+            ->getMock();
+        $marshaller = $this->getMockBuilder('Cake\ORM\Marshaller')
+            ->setConstructorArgs([$table])
+            ->getMock();
         $table->belongsTo('users');
         $table->hasMany('articles');
         $table->expects($this->once())->method('marshaller')
@@ -5289,8 +5280,12 @@ class TableTest extends TestCase
      */
     public function testPatchEntities()
     {
-        $table = $this->getMock('Cake\ORM\Table', ['marshaller']);
-        $marshaller = $this->getMock('Cake\ORM\Marshaller', [], [$table]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods(['marshaller'])
+            ->getMock();
+        $marshaller = $this->getMockBuilder('Cake\ORM\Marshaller')
+            ->setConstructorArgs([$table])
+            ->getMock();
         $table->belongsTo('users');
         $table->hasMany('articles');
         $table->expects($this->once())->method('marshaller')


### PR DESCRIPTION
remove the latest deprecation warning in the ORM testsuite
