### PR TITLE
Add config file for stickler-ci.com

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,4 @@
+linters:
+  phpcs:
+    standard: CakePHP
+    extensions: '.php,.ctp'


### PR DESCRIPTION
Hopefully by making PHPCS errors more visible, we can spend less time looking up why travis builds failed.
