### PR TITLE
Rework cid: images

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -776,6 +776,22 @@ class HtmlHelper extends Helper
     }
 
     /**
+     * Check if a given image path is a CID.
+     *
+     * @param array|string $path The image path to check if it is a CID.
+     * @return bool
+     */
+    protected function _isCid($path)
+    {
+        if (is_array($path)) {
+            return false;
+        }
+
+        $isCid = substr($path, 0, 4);
+        return is_string($isCid) && (strtolower($isCid) === 'cid:');
+    }
+
+    /**
      * Creates a formatted IMG element.
      *
      * This method will set an empty alt attribute if one is not supplied.
@@ -808,7 +824,9 @@ class HtmlHelper extends Helper
      */
     public function image($path, array $options = [])
     {
-        $path = $this->Url->image($path, $options);
+        if (!$this->_isCid($path)) {
+            $path = $this->Url->image($path, $options);
+        }
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
         if (!isset($options['alt'])) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -776,22 +776,6 @@ class HtmlHelper extends Helper
     }
 
     /**
-     * Check if a given image path is a CID.
-     *
-     * @param array|string $path The image path to check if it is a CID.
-     * @return bool
-     */
-    protected function _isCid($path)
-    {
-        if (is_array($path)) {
-            return false;
-        }
-
-        $isCid = substr($path, 0, 4);
-        return is_string($isCid) && (strtolower($isCid) === 'cid:');
-    }
-
-    /**
      * Creates a formatted IMG element.
      *
      * This method will set an empty alt attribute if one is not supplied.
@@ -824,9 +808,7 @@ class HtmlHelper extends Helper
      */
     public function image($path, array $options = [])
     {
-        if (!$this->_isCid($path)) {
-            $path = $this->Url->image($path, $options);
-        }
+        $path = $this->Url->image($path, $options);
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
         if (!isset($options['alt'])) {

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -120,7 +120,7 @@ class UrlHelper extends Helper
         if (is_array($path)) {
             return $this->build($path, !empty($options['fullBase']));
         }
-        if (strpos($path, '://') !== false || preg_match('/^[a-z]+:/', $path)) {
+        if (strpos($path, '://') !== false || preg_match('/^[a-z]+:/i', $path)) {
             return $path;
         }
         if (!array_key_exists('plugin', $options) || $options['plugin'] !== false) {

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -120,7 +120,7 @@ class UrlHelper extends Helper
         if (is_array($path)) {
             return $this->build($path, !empty($options['fullBase']));
         }
-        if (strpos($path, '://') !== false) {
+        if (strpos($path, '://') !== false || preg_match('/^[a-z]+:/', $path)) {
             return $path;
         }
         if (!array_key_exists('plugin', $options) || $options['plugin'] !== false) {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -336,6 +336,10 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->image('/test/view/1.gif');
         $expected = ['img' => ['src' => '/test/view/1.gif', 'alt' => '']];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Html->image('cid:cakephp_logo');
+        $expected = ['img' => ['src' => 'cid:cakephp_logo', 'alt' => '']];
+        $this->assertHtml($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -296,6 +296,9 @@ class UrlHelperTest extends TestCase
 
         $result = $this->Helper->image('cid:foo.jpg');
         $this->assertEquals('cid:foo.jpg', $result);
+
+        $result = $this->Helper->image('CID:foo.jpg');
+        $this->assertEquals('CID:foo.jpg', $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -293,6 +293,9 @@ class UrlHelperTest extends TestCase
 
         $result = $this->Helper->image('dir/big+tall/image.jpg');
         $this->assertEquals('img/dir/big%2Btall/image.jpg', $result);
+
+        $result = $this->Helper->image('cid:foo.jpg');
+        $this->assertEquals('cid:foo.jpg', $result);
     }
 
     /**


### PR DESCRIPTION
Rework the changes started in #8898. This makes cid: and other alpha prefixes available to all asset types as well.

There is some potential for people using assets like `custom:stuff.css` to break. However, I'm assuming that most folks don't put colons in their file names.
