### PR TITLE
Can't override CakeEmail class and use deliver

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1203,7 +1203,7 @@ class CakeEmail {
  * @throws SocketException
  */
 	public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'fast', $send = true) {
-		$class = __CLASS__;
+		$class = get_called_class();
 		/** @var CakeEmail $instance */
 		$instance = new $class($transportConfig);
 		if ($to !== null) {


### PR DESCRIPTION
When using TemplateEmail::deliver it always create new instance of CakeEmail, I assume it should create my extended "TemplateEmail" class insted.

PHP >5.3 compatible
[http://php.net/manual/en/function.get-called-class.php](http://php.net/manual/en/function.get-called-class.php)

---

While trying to create a wrapper to override some classes to add custom template functionality I hit a wall because half of my app did use wrong CakeEmail instance skipping my TemplateEmail that extends CakeEmail.

---

Expected result:
$x = TemplateEmail::deliver(...);
$x instanceOf TemplateEmail;

Actual result:
$x = TemplateEmail::deliver(...);
$x instanceOf CakeEmail
