### PR TITLE
Throw a RuntimeException if the validation method does not return a validator

### DIFF
--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -111,7 +111,7 @@ trait ValidatorAwareTrait
             }
 
             if (!$validator instanceof Validator) {
-                throw new RuntimeException(sprintf('The %s::%s() validation method must return an instance of %s.', self::class, 'validation' . ucfirst($name), Validator::class));
+                throw new RuntimeException(sprintf('The %s::%s() validation method must return an instance of %s.', __CLASS__, 'validation' . ucfirst($name), Validator::class));
             }
         }
 

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -92,6 +92,7 @@ trait ValidatorAwareTrait
      * @param \Cake\Validation\Validator|null $validator The validator instance to store,
      *   use null to get a validator.
      * @return \Cake\Validation\Validator
+     * @throws \RuntimeException
      */
     public function validator($name = null, Validator $validator = null)
     {

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Validation;
 
+use \RuntimeException;
 use Cake\Event\EventDispatcherInterface;
 
 /**
@@ -106,6 +107,10 @@ trait ValidatorAwareTrait
             $validator = $this->{'validation' . ucfirst($name)}($validator);
             if ($this instanceof EventDispatcherInterface) {
                 $this->dispatchEvent('Model.buildValidator', compact('validator', 'name'));
+            }
+
+            if (!$validator instanceof Validator) {
+                throw new RuntimeException(sprintf('The %s::%s validation method must return an instance of %s.', self::class, 'validation' . ucfirst($name), Validator::class));
             }
         }
 

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -111,7 +111,7 @@ trait ValidatorAwareTrait
             }
 
             if (!$validator instanceof Validator) {
-                throw new RuntimeException(sprintf('The %s::%s validation method must return an instance of %s.', self::class, 'validation' . ucfirst($name), Validator::class));
+                throw new RuntimeException(sprintf('The %s::%s() validation method must return an instance of %s.', self::class, 'validation' . ucfirst($name), Validator::class));
             }
         }
 

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Validation;
 
-use \RuntimeException;
 use Cake\Event\EventDispatcherInterface;
+use RuntimeException;
 
 /**
  * A trait that provides methods for building and

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3224,7 +3224,7 @@ class TableTest extends TestCase
      *
      * @return void
      */
-    public function functionTestValidationWithDefiner()
+    public function testValidationWithDefiner()
     {
         $table = $this->getMockBuilder('\Cake\ORM\Table')
             ->setMethods(['validationForOtherStuff'])
@@ -3235,6 +3235,23 @@ class TableTest extends TestCase
         $this->assertInstanceOf('Cake\Validation\Validator', $other);
         $this->assertNotSame($other, $table->validator());
         $this->assertSame($table, $other->provider('table'));
+    }
+
+    /**
+     * Tests that a RuntimeException is thrown if the custom validator does not return an Validator instance
+     *
+     * @return void
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The Cake\ORM\Table::validationBad validation method must return an instance of Cake\Validation\Validator.
+     */
+    public function testValidationWithBadDefiner()
+    {
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['validationBad'])
+            ->getMock();
+        $table->expects($this->once())
+            ->method('validationBad');
+        $table->validator('bad');
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3242,7 +3242,7 @@ class TableTest extends TestCase
      *
      * @return void
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage The Cake\ORM\Table::validationBad validation method must return an instance of Cake\Validation\Validator.
+     * @expectedExceptionMessage The Cake\ORM\Table::validationBad() validation method must return an instance of Cake\Validation\Validator.
      */
     public function testValidationWithBadDefiner()
     {


### PR DESCRIPTION
Currently if you forget to return the validator instance in your custom validation method you get a random and very unhelpful `Call to member function provider() on null` error.  This throws a more useful runtime exception explaining what the problem is.
