### PR TITLE
[RFC] Add assertEventFired and assertEventFiredWith

### DIFF
--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -1,0 +1,50 @@
+<?php
+namespace Cake\TestSuite\Constraint;
+
+use Cake\Event\EventManager;
+use PHPUnit_Framework_Constraint;
+
+/**
+ * EventFired constraint
+ */
+class EventFired extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Array of fired events
+     *
+     * @var EventManager
+     */
+    protected $_eventManager;
+
+    /**
+     * Constructor
+     *
+     * @param EventManager $eventManager Event manager to check
+     */
+    public function __construct($eventManager)
+    {
+        parent::__construct();
+        $this->_eventManager = $eventManager;
+    }
+
+    /**
+     * Checks if event is in fired array
+     *
+     * @param mixed $other Constraint check
+     * @return bool
+     */
+    public function matches($other)
+    {
+        return $this->_eventManager->getEventList()->hasEvent($other);
+    }
+
+    /**
+     * Assertion message string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'was fired';
+    }
+}

--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -2,6 +2,7 @@
 namespace Cake\TestSuite\Constraint;
 
 use Cake\Event\EventManager;
+use PHPUnit_Framework_AssertionFailedError;
 use PHPUnit_Framework_Constraint;
 
 /**
@@ -25,6 +26,10 @@ class EventFired extends PHPUnit_Framework_Constraint
     {
         parent::__construct();
         $this->_eventManager = $eventManager;
+
+        if ($this->_eventManager->getEventList() === null) {
+            throw new PHPUnit_Framework_AssertionFailedError('The event manager you are asserting against is not configured to track events.');
+        }
     }
 
     /**

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -1,0 +1,101 @@
+<?php
+namespace Cake\TestSuite\Constraint;
+
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+use PHPUnit_Framework_AssertionFailedError;
+use PHPUnit_Framework_Constraint;
+
+/**
+ * EventFiredWith constraint
+ *
+ * Another glorified in_array check
+ */
+class EventFiredWith extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Array of fired events
+     *
+     * @var EventManager
+     */
+    protected $_eventManager;
+
+    /**
+     * Event data key
+     *
+     * @var string
+     */
+    protected $_dataKey;
+
+    /**
+     * Event data value
+     *
+     * @var string
+     */
+    protected $_dataValue;
+
+    /**
+     * Constructor
+     *
+     * @param EventManager $eventManager Event manager to check
+     * @param string $dataKey Data key
+     * @param string $dataValue Data value
+     */
+    public function __construct($eventManager, $dataKey, $dataValue)
+    {
+        parent::__construct();
+        $this->_eventManager = $eventManager;
+        $this->_dataKey = $dataKey;
+        $this->_dataValue = $dataValue;
+    }
+
+    /**
+     * Checks if event is in fired array
+     *
+     * @param mixed $other Constraint check
+     * @return bool
+     */
+    public function matches($other)
+    {
+        $firedEvents = [];
+        $list = $this->_eventManager->getEventList();
+        $totalEvents = count($list);
+        for ($e = 0; $e < $totalEvents; $e++) {
+            $firedEvents[] = $list[$e];
+        }
+
+        $eventGroup = collection($firedEvents)
+            ->groupBy(function (Event $event) {
+                return $event->name();
+            })
+            ->toArray();
+
+        if (!array_key_exists($other, $eventGroup)) {
+            return false;
+        }
+
+        $events = $eventGroup[$other];
+
+        if (count($events) > 1) {
+            throw new PHPUnit_Framework_AssertionFailedError(sprintf('Event "%s" was fired %d times, cannot make data assertion', $other, count($events)));
+        }
+
+        $event = $events[0];
+
+        if (array_key_exists($this->_dataKey, $event->data) === false) {
+            return false;
+        }
+
+        return $event->data[$this->_dataKey] === $this->_dataValue;
+    }
+
+    /**
+     * Assertion message string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'was fired with ' . $this->_dataKey . ' matching ' . (string)$this->_dataValue;
+    }
+}

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -47,6 +47,10 @@ class EventFiredWith extends PHPUnit_Framework_Constraint
         $this->_eventManager = $eventManager;
         $this->_dataKey = $dataKey;
         $this->_dataValue = $dataValue;
+
+        if ($this->_eventManager->getEventList() === null) {
+            throw new PHPUnit_Framework_AssertionFailedError('The event manager you are asserting against is not configured to track events.');
+        }
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -141,6 +141,42 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Asserts that a global event was fired. You must track events in your event manager for this assertion to work
+     *
+     * @param string $name Event name
+     * @param EventManager $eventManager Event manager to check, defaults to global event manager
+     * @param string $message Assertion failure message
+     * @return void
+     */
+    public function assertEventFired($name, $eventManager = null, $message = '')
+    {
+        if (!$eventManager) {
+            $eventManager = EventManager::instance();
+        }
+        $this->assertThat($name, new Constraint\EventFired($eventManager), $message);
+    }
+
+    /**
+     * Asserts an event was fired with data
+     *
+     * If a third argument is passed, that value is used to compare with the value in $dataKey
+     *
+     * @param string $name Event name
+     * @param string $dataKey Data key
+     * @param string $dataValue Data value
+     * @param EventManager $eventManager Event manager to check, defaults to global event manager
+     * @param string $message Assertion failure message
+     * @return void
+     */
+    public function assertEventFiredWith($name, $dataKey, $dataValue, $eventManager = null, $message = '')
+    {
+        if (!$eventManager) {
+            $eventManager = EventManager::instance();
+        }
+        $this->assertThat($name, new Constraint\EventFiredWith($eventManager, $dataKey, $dataValue), $message);
+    }
+
+    /**
      * Assert text equality, ignoring differences in newlines.
      * Helpful for doing cross platform tests of blocks of text.
      *

--- a/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Cake\Test\TestCase\TestSuite\Constraint;
+
+use Cake\Event\Event;
+use Cake\Event\EventList;
+use Cake\Event\EventManager;
+use Cake\TestSuite\Constraint\EventFired;
+use Cake\TestSuite\TestCase;
+
+/**
+ * EventFired Test
+ */
+class EventFiredTest extends TestCase
+{
+
+    /**
+     * tests EventFired constraint
+     *
+     * @return void
+     */
+    public function testMatches()
+    {
+        $manager = EventManager::instance();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $myEvent = new Event('my.event', $this, []);
+        $myOtherEvent = new Event('my.other.event', $this, []);
+
+        $manager->getEventList()->add($myEvent);
+        $manager->getEventList()->add($myOtherEvent);
+
+        $constraint = new EventFired($manager);
+
+        $this->assertTrue($constraint->matches('my.event'));
+        $this->assertTrue($constraint->matches('my.other.event'));
+        $this->assertFalse($constraint->matches('event.not.fired'));
+    }
+}

--- a/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Cake\Test\TestCase\TestSuite\Constraint;
+
+use Cake\Event\Event;
+use Cake\Event\EventList;
+use Cake\Event\EventManager;
+use Cake\TestSuite\Constraint\EventFiredWith;
+use Cake\TestSuite\TestCase;
+
+/**
+ * EventFiredWith Test
+ */
+class EventFiredWithTest extends TestCase
+{
+
+    /**
+     * tests EventFiredWith constraint
+     *
+     * @return void
+     */
+    public function testMatches()
+    {
+        $manager = EventManager::instance();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $myEvent = new Event('my.event', $this, [
+            'key' => 'value'
+        ]);
+        $myOtherEvent = new Event('my.other.event', $this, [
+            'key' => null
+        ]);
+
+        $manager->getEventList()->add($myEvent);
+        $manager->getEventList()->add($myOtherEvent);
+
+        $constraint = new EventFiredWith($manager, 'key', 'value');
+
+        $this->assertTrue($constraint->matches('my.event'));
+        $this->assertFalse($constraint->matches('my.other.event'));
+        $this->assertFalse($constraint->matches('event.not.fired'));
+
+        $constraint = new EventFiredWith($manager, 'key', null);
+
+        $this->assertTrue($constraint->matches('my.other.event'));
+        $this->assertFalse($constraint->matches('my.event'));
+    }
+
+    /**
+     * tests trying to assert data key=>value when an event is fired multiple times
+     *
+     * @return void
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     */
+    public function testMatchesInvalid()
+    {
+        $manager = EventManager::instance();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $myEvent = new Event('my.event', $this, [
+            'key' => 'value'
+        ]);
+
+        $manager->getEventList()->add($myEvent);
+        $manager->getEventList()->add($myEvent);
+
+        $constraint = new EventFiredWith($manager, 'key', 'value');
+
+        $constraint->matches('my.event');
+    }
+}

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -17,6 +17,9 @@ namespace Cake\Test\TestCase\TestSuite;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
+use Cake\Event\Event;
+use Cake\Event\EventList;
+use Cake\Event\EventManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -44,6 +47,58 @@ class SecondaryPostsTable extends Table
  */
 class TestCaseTest extends TestCase
 {
+
+    /**
+     * tests assertEventFiredWith
+     *
+     * @return void
+     */
+    public function testEventFiredWith()
+    {
+        $manager = EventManager::instance();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $event = new Event('my.event', $this, [
+            'some' => 'data'
+        ]);
+        $manager->dispatch($event);
+        $this->assertEventFiredWith('my.event', 'some', 'data');
+
+        $manager = new EventManager();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $event = new Event('my.event', $this, [
+            'other' => 'data'
+        ]);
+        $manager->dispatch($event);
+        $this->assertEventFiredWith('my.event', 'other', 'data', $manager);
+    }
+
+    /**
+     * tests assertEventFired
+     *
+     * @return void
+     */
+    public function testEventFired()
+    {
+        $manager = EventManager::instance();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $event = new Event('my.event');
+        $manager->dispatch($event);
+        $this->assertEventFired('my.event');
+
+        $manager = new EventManager();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $event = new Event('my.event');
+        $manager->dispatch($event);
+        $this->assertEventFired('my.event', $manager);
+    }
 
     /**
      * testAssertHtml

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -49,6 +49,28 @@ class TestCaseTest extends TestCase
 {
 
     /**
+     * tests trying to assertEventFired without configuring an event list
+     *
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     */
+    public function testEventFiredMisconfiguredEventList()
+    {
+        $manager = EventManager::instance();
+        $this->assertEventFired('my.event', $manager);
+    }
+
+    /**
+     * tests trying to assertEventFired without configuring an event list
+     *
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     */
+    public function testEventFiredWithMisconfiguredEventList()
+    {
+        $manager = EventManager::instance();
+        $this->assertEventFiredWith('my.event', 'some', 'data', $manager);
+    }
+
+    /**
      * tests assertEventFiredWith
      *
      * @return void


### PR DESCRIPTION
This is an RFC for a compliment to #8853 that allows developers to assert that events were fired, or fired with data. Spawned from a personal project, the addition of event lists makes this more of a candidate for the core than it was before.

As a practical example, I've added it to TableTest::testAfterSave below:

``` php
    /**
     * Asserts that afterSave callback is called on successful save
     *
     * @group save
     * @return void
     */
    public function testAfterSave()
    {
        $table = TableRegistry::get('users');
        $data = new \Cake\ORM\Entity([
            'username' => 'superuser',
            'created' => new Time('2013-10-10 00:00'),
            'updated' => new Time('2013-10-10 00:00')
        ]);

        $table->eventManager()->setEventList(new \Cake\Event\EventList());
        $table->eventManager()->trackEvents(true);

        $called = false;
        $listener = function ($e, $entity, $options) use ($data, &$called) {
            $this->assertSame($data, $entity);
            $this->assertTrue($entity->dirty());
            $called = true;
        };
        $table->eventManager()->on('Model.afterSave', $listener);

        $calledAfterCommit = false;
        $listenerAfterCommit = function ($e, $entity, $options) use ($data, &$calledAfterCommit) {
            $this->assertSame($data, $entity);
            $this->assertFalse($entity->dirty());
            $calledAfterCommit = true;
        };
        $table->eventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);

        $this->assertSame($data, $table->save($data));
        $this->assertEquals($data->id, self::$nextUserId);
        $this->assertTrue($called);
        $this->assertTrue($calledAfterCommit);

        $this->assertEventFired('Model.afterSave', $table->eventManager());
    }
```

By default, it the assertions use the global event manager, so asserting global events were fired would look something like this:

```
$this->assertEventFired('My.Global.Event');
$this->assertEventFiredWith('My.Global.Event', 'data', 'value');
```

The downside is that it's only useable if track events is on, so perhaps it would better be in a trait that the user has to opt-in. I was going to put this into a plugin but it seemed a bit silly so I thought I'd suggest it here first, if it doesn't seem like a feature that would be useful/good for the core I can pull it out into a plugin when event lists are released.
