### PR TITLE
problem. In the session of Database use , it expires is long .

### DIFF
--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -158,7 +158,7 @@ class DatabaseSession implements SessionHandlerInterface
      */
     public function gc($maxlifetime)
     {
-        $this->_table->deleteAll(['expires <' => time() - $maxlifetime]);
+        $this->_table->deleteAll(['expires <' => time()]);
         return true;
     }
 }


### PR DESCRIPTION
Session using the database, will expire period is doubled in the gc.

Rather than the update time when you want to save the session , as specified by the expiration time .
Nevertheless , 'gc' at the time of , are we calculate the expire time .
A result , not expire at the correct time .
Indeed , the life of the fold session data time assumes are treated longer.

PHP default session management , use the date and time of the recording as it is .
However, in the moment of CakePHP adds the date and time of the expiration date to use as 'expire'.
Here 's a different point , but seems to change in the processing of as expire in the method of 'gc' is insufficient .
