### PR TITLE
Remove space before object operator

### DIFF
--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -878,7 +878,7 @@ class TreeBehavior extends Behavior
             $exp = $query->newExpr();
 
             $movement = clone $exp;
-            $movement ->add($field)->add("$shift")->tieWith($dir);
+            $movement->add($field)->add("$shift")->tieWith($dir);
 
             $inverse = clone $exp;
             $movement = $mark ?


### PR DESCRIPTION
http://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/index.html#spacing-before-object-operator

> 1  |  0.01%
