### PR TITLE
Don't use unset $translator, use given $formatter instead

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -402,7 +402,7 @@ trait DateFormatTrait
             }
             return static::$diffFormatter;
         }
-        return static::$diffFormatter = $translator;
+        return static::$diffFormatter = $formatter;
     }
 
     /**


### PR DESCRIPTION
I think the $translator variable was a left-over or copy & paste error.
