### PR TITLE
Add space before operators

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -576,7 +576,7 @@ trait CollectionTrait
     public function through(callable $handler)
     {
         $result = $handler($this);
-        return $result instanceof CollectionInterface ? $result: new Collection($result);
+        return $result instanceof CollectionInterface ? $result : new Collection($result);
     }
 
     /**

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -882,7 +882,7 @@ class TreeBehavior extends Behavior
 
             $inverse = clone $exp;
             $movement = $mark ?
-                $inverse->add($movement)->tieWith('*')->add('-1'):
+                $inverse->add($movement)->tieWith('*')->add('-1') :
                 $movement;
 
             $where = clone $exp;


### PR DESCRIPTION
http://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/index.html#space-before-operator

> 0 | 0.05%

Interestingly PhpStorm does not  show this error when checking with the file with the CakePHP standard.

It seems, it's because we don't include the [OperatorSpacingSniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/2.6.1/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php) in our ruleset.

https://github.com/cakephp/cakephp-codesniffer/blob/2.0.7/CakePHP/ruleset.xml#L76-L81

Is there a reason we don't?
