### PR TITLE
Let Stickler CI ignore the 2.x related branches

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,3 +2,5 @@ linters:
   phpcs:
     standard: CakePHP
     extensions: '.php,.ctp'
+branches:
+    ignore: ['2.x', '2.next']


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/8982/files/449e5fc9cf9020b62d8ed4da074e10cadfe9d95e#r67124406
