### PR TITLE
PSR7 IntegrationTestCase part 1

### DIFF
--- a/src/Http/RequestTransformer.php
+++ b/src/Http/RequestTransformer.php
@@ -48,6 +48,12 @@ class RequestTransformer
             $post = Hash::merge($post, $files);
         }
 
+        $input = null;
+        $stream = $request->getBody();
+        if ($stream->getSize()) {
+            $input = $stream->getContents();
+        }
+
         return new CakeRequest([
             'query' => $request->getQueryParams(),
             'post' => $post,
@@ -58,6 +64,7 @@ class RequestTransformer
             'base' => $request->getAttribute('base', ''),
             'webroot' => $request->getAttribute('webroot', '/'),
             'session' => $request->getAttribute('session', null),
+            'input' => $input,
         ]);
     }
 

--- a/src/Http/RequestTransformer.php
+++ b/src/Http/RequestTransformer.php
@@ -57,6 +57,7 @@ class RequestTransformer
             'url' => $request->getUri()->getPath(),
             'base' => $request->getAttribute('base', ''),
             'webroot' => $request->getAttribute('webroot', '/'),
+            'session' => $request->getAttribute('session', null),
         ]);
     }
 

--- a/src/Http/RequestTransformer.php
+++ b/src/Http/RequestTransformer.php
@@ -48,11 +48,8 @@ class RequestTransformer
             $post = Hash::merge($post, $files);
         }
 
-        $input = null;
-        $stream = $request->getBody();
-        if ($stream->getSize()) {
-            $input = $stream->getContents();
-        }
+        $input = $request->getBody()->getContents();
+        $input = $input === '' ? null : $input;
 
         return new CakeRequest([
             'query' => $request->getQueryParams(),

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -19,8 +19,8 @@ use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
-use Cake\TestSuite\Stub\Response;
 use Cake\TestSuite\RequestDispatcher;
+use Cake\TestSuite\Stub\Response;
 use Cake\Utility\CookieCryptTrait;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -139,7 +139,7 @@ abstract class IntegrationTestCase extends TestCase
     protected $_cookieEncriptionKey = null;
 
     /**
-     * Auto-detect if the Http middleware stack should be used.
+     * Auto-detect if the HTTP middleware stack should be used.
      *
      * @return void
      */
@@ -175,7 +175,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Toggle whether or not you want to use the HTTP Server stack.
      *
-     * @param bool $enable Enable/disable the usage of the Http Stack.
+     * @param bool $enable Enable/disable the usage of the HTTP Stack.
      * @return void
      */
     public function useHttpServer($enable)
@@ -409,7 +409,7 @@ abstract class IntegrationTestCase extends TestCase
      * Adds additional event spies to the controller/view event manager.
      *
      * @param \Cake\Event\Event $event A dispatcher event.
-     * @param \Cake\Controller\Controller $controller Controller instance.
+     * @param \Cake\Controller\Controller|null $controller Controller instance.
      * @return void
      */
     public function controllerSpy($event, $controller = null)

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -393,7 +393,7 @@ abstract class IntegrationTestCase extends TestCase
         try {
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
-            $this->_requestSession = $request->session();
+            $this->_requestSession = $request['session'];
             $this->_response = $response;
         } catch (PHPUnit_Exception $e) {
             throw $e;
@@ -455,7 +455,7 @@ abstract class IntegrationTestCase extends TestCase
      * @param string|array $url The URL
      * @param string $method The HTTP method
      * @param array|null $data The request data.
-     * @return \Cake\Network\Request The built request.
+     * @return array The request context
      */
     protected function _buildRequest($url, $method, $data)
     {
@@ -486,7 +486,7 @@ abstract class IntegrationTestCase extends TestCase
         $env['REQUEST_METHOD'] = $method;
         $props['environment'] = $env;
         $props = Hash::merge($props, $this->_request);
-        return new Request($props);
+        return $props;
     }
 
     /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -386,9 +386,7 @@ abstract class IntegrationTestCase extends TestCase
     protected function _sendRequest($url, $method, $data = [])
     {
         if ($this->_useHttpServer) {
-            // The PSR7 mode will need to convert back into a cake request.
-            // and figure out how to handle the session data.
-            throw new \LogicException('Not implemented yet.');
+            $dispatcher = new MiddlewareDispatcher($this);
         } else {
             $dispatcher = new RequestDispatcher($this);
         }
@@ -414,8 +412,11 @@ abstract class IntegrationTestCase extends TestCase
      * @param \Cake\Controller\Controller $controller Controller instance.
      * @return void
      */
-    public function controllerSpy($event, $controller)
+    public function controllerSpy($event, $controller = null)
     {
+        if (!$controller) {
+            $controller = $event->subject();
+        }
         $this->_controller = $controller;
         $events = $controller->eventManager();
         $events->on('View.beforeRender', function ($event, $viewFile) {

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -18,7 +18,8 @@ use Cake\Database\Exception as DatabaseException;
 use Cake\Network\Session;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
-use Cake\TestSuite\RequestDispatcher;
+use Cake\TestSuite\LegacyRequestDispatcher;
+use Cake\TestSuite\MiddlewareDispatcher;
 use Cake\TestSuite\Stub\Response;
 use Cake\Utility\CookieCryptTrait;
 use Cake\Utility\Hash;
@@ -384,11 +385,7 @@ abstract class IntegrationTestCase extends TestCase
      */
     protected function _sendRequest($url, $method, $data = [])
     {
-        if ($this->_useHttpServer) {
-            $dispatcher = new MiddlewareDispatcher($this);
-        } else {
-            $dispatcher = new RequestDispatcher($this);
-        }
+        $dispatcher = $this->_makeDispatcher();
         try {
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
@@ -402,6 +399,19 @@ abstract class IntegrationTestCase extends TestCase
             $this->_exception = $e;
             $this->_handleError($e);
         }
+    }
+
+    /**
+     * Get the correct dispatcher instance.
+     *
+     * @return object A dispatcher instance
+     */
+    protected function _makeDispatcher()
+    {
+        if ($this->_useHttpServer) {
+            return new MiddlewareDispatcher($this);
+        }
+        return new LegacyRequestDispatcher($this);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -15,7 +15,6 @@ namespace Cake\TestSuite;
 
 use Cake\Core\Configure;
 use Cake\Database\Exception as DatabaseException;
-use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;

--- a/src/TestSuite/LegacyRequestDispatcher.php
+++ b/src/TestSuite/LegacyRequestDispatcher.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\Stub\Response;
  *
  * @internal
  */
-class RequestDispatcher
+class LegacyRequestDispatcher
 {
     /**
      * Constructor

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Core\Configure;
+use Cake\Event\EventManager;
+use Cake\Http\ResponseTransformer;
+use Cake\Http\Server;
+use Cake\Http\ServerRequestFactory;
+use LogicException;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * Dispatches a request capturing the response for integration
+ * testing purposes into the Cake\Http stack.
+ *
+ * @internal
+ */
+class MiddlewareDispatcher
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\TestSuite\IntegrationTestCase $test The test case to run.
+     */
+    public function __construct($test)
+    {
+        $this->_test = $test;
+    }
+
+    /**
+     * Run a request and get the response.
+     *
+     * @param \Cake\Network\Request $request The request to execute.
+     * @return \Cake\Network\Response The generated response.
+     */
+    public function execute($request)
+    {
+        try {
+            $namespace = Configure::read('App.namespace');
+            $reflect = new ReflectionClass($namespace . '\Application');
+            $app = $reflect->newInstance('./config');
+        } catch (ReflectionException $e) {
+            throw new LogicException(sprintf(
+                'Cannot load "%s" for use in integration testing.',
+                $class
+            ));
+        }
+
+        // Spy on the controller using the initialize hook instead
+        // of the dispatcher hooks as those will be going away one day.
+        EventManager::instance()->on(
+            'Controller.initialize',
+            [$this->_test, 'controllerSpy']
+        );
+
+        $server = new Server($app);
+
+        // TODO How to handle passing all headers.
+        // The Request doesn't expose a way to read all headers values.
+        // TODO How to pass session data? PSR7 requests don't handle sessions..
+        // TODO pass php://input stream, base, webroot
+        $serverData = [
+            'REQUEST_URI' => $request->here,
+            'REQUEST_METHOD' => $request->method(),
+        ];
+        $psrRequest = ServerRequestFactory::fromGlobals(
+            array_merge($_SERVER, $serverData),
+            $request->query,
+            $request->data(),
+            $request->cookies
+        );
+        $response = $server->run($psrRequest);
+        return ResponseTransformer::toCake($response);
+    }
+}

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -68,19 +68,13 @@ class MiddlewareDispatcher
 
         $server = new Server($app);
 
-        // TODO How to handle passing all headers.
-        // The Request doesn't expose a way to read all headers values.
         // TODO How to pass session data? PSR7 requests don't handle sessions..
         // TODO pass php://input stream, base, webroot
-        $serverData = [
-            'REQUEST_URI' => $request->here,
-            'REQUEST_METHOD' => $request->method(),
-        ];
         $psrRequest = ServerRequestFactory::fromGlobals(
-            array_merge($_SERVER, $serverData),
-            $request->query,
-            $request->data(),
-            $request->cookies
+            array_merge($_SERVER, $request['environment'], ['REQUEST_URI' => $request['url']]),
+            $request['query'],
+            $request['post'],
+            $request['cookies']
         );
         $response = $server->run($psrRequest);
         return ResponseTransformer::toCake($response);

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -76,6 +76,7 @@ class MiddlewareDispatcher
             $request['post'],
             $request['cookies']
         );
+        $psrRequest = $psrRequest->withAttribute('session', $request['session']);
         $response = $server->run($psrRequest);
         return ResponseTransformer::toCake($response);
     }

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -67,9 +67,6 @@ class MiddlewareDispatcher
         );
 
         $server = new Server($app);
-
-        // TODO How to pass session data? PSR7 requests don't handle sessions..
-        // TODO pass php://input stream, base, webroot
         $psrRequest = ServerRequestFactory::fromGlobals(
             array_merge($_SERVER, $request['environment'], ['REQUEST_URI' => $request['url']]),
             $request['query'],

--- a/src/TestSuite/RequestDispatcher.php
+++ b/src/TestSuite/RequestDispatcher.php
@@ -40,11 +40,12 @@ class RequestDispatcher
     /**
      * Run a request and get the response.
      *
-     * @param \Cake\Network\Request $request The request to execute.
+     * @param array $request The request context to execute.
      * @return \Cake\Network\Response The generated response.
      */
     public function execute($request)
     {
+        $request = new Request($request);
         $response = new Response();
         $dispatcher = DispatcherFactory::create();
         $dispatcher->eventManager()->on(

--- a/src/TestSuite/RequestDispatcher.php
+++ b/src/TestSuite/RequestDispatcher.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Core\Configure;
+use Cake\Network\Request;
+use Cake\Network\Session;
+use Cake\Routing\DispatcherFactory;
+use Cake\TestSuite\Stub\Response;
+
+/**
+ * Dispatches a request capturing the response for integration testing
+ * purposes into the Routing\Dispatcher stack.
+ *
+ * @internal
+ */
+class RequestDispatcher
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\TestSuite\IntegrationTestCase $test The test case to run.
+     */
+    public function __construct($test)
+    {
+        $this->_test = $test;
+    }
+
+    /**
+     * Run a request and get the response.
+     *
+     * @param \Cake\Network\Request $request The request to execute.
+     * @return \Cake\Network\Response The generated response.
+     */
+    public function execute($request)
+    {
+        $response = new Response();
+        $dispatcher = DispatcherFactory::create();
+        $dispatcher->eventManager()->on(
+            'Dispatcher.invokeController',
+            ['priority' => 999],
+            [$this->_test, 'controllerSpy']
+        );
+        $dispatcher->dispatch($request, $response);
+        return $response;
+    }
+}

--- a/tests/TestCase/Http/RequestTransformerTest.php
+++ b/tests/TestCase/Http/RequestTransformerTest.php
@@ -18,6 +18,7 @@ use Cake\Core\Configure;
 use Cake\Http\RequestTransformer;
 use Cake\Http\ServerRequestFactory;
 use Cake\Network\Request;
+use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -258,5 +259,21 @@ class RequestTransformerTest extends TestCase
         $cake = RequestTransformer::toCake($psr);
 
         $this->assertEquals('/thisapp', ini_get('session.cookie_path'));
+    }
+
+    /**
+     * Test transforming session objects
+     *
+     * @return void
+     */
+    public function testToCakeSession()
+    {
+        $psr = ServerRequestFactory::fromGlobals();
+        $session = new Session(['defaults' => 'php']);
+        $session->write('test', 'value');
+        $psr = $psr->withAttribute('session', $session);
+        $cake = RequestTransformer::toCake($psr);
+
+        $this->assertSame($session, $cake->session());
     }
 }

--- a/tests/TestCase/Http/RequestTransformerTest.php
+++ b/tests/TestCase/Http/RequestTransformerTest.php
@@ -20,6 +20,7 @@ use Cake\Http\ServerRequestFactory;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
+use Zend\Diactoros\Stream;
 
 /**
  * Test for RequestTransformer
@@ -275,5 +276,22 @@ class RequestTransformerTest extends TestCase
         $cake = RequestTransformer::toCake($psr);
 
         $this->assertSame($session, $cake->session());
+    }
+
+    /**
+     * Test transforming request bodies
+     *
+     * @return void
+     */
+    public function testToCakeRequestBody()
+    {
+        $psr = ServerRequestFactory::fromGlobals();
+        $stream = new Stream('php://memory', 'rw');
+        $stream->write('{"hello":"world"}');
+        $stream->rewind();
+        $psr = $psr->withBody($stream);
+
+        $cake = RequestTransformer::toCake($psr);
+        $this->assertSame(['hello' => 'world'], $cake->input('json_decode', true));
     }
 }

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -229,7 +229,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
-     * Test that the PSR7 requests get post data
+     * Test that the PSR7 requests receive post data
      *
      * @return void
      */
@@ -240,6 +240,20 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->post('/request_action/post_pass', ['title' => 'value']);
         $data = json_decode($this->_response->body());
         $this->assertEquals('value', $data->title);
+        $this->assertHeader('X-Middleware', 'true');
+    }
+
+    /**
+     * Test that the PSR7 requests receive encoded data.
+     *
+     * @return void
+     */
+    public function testInputDataHttpServer()
+    {
+        $this->useHttpServer(true);
+
+        $this->post('/request_action/input_test', '{"hello":"world"}');
+        $this->assertSame('world', $this->_response->body());
         $this->assertHeader('X-Middleware', 'true');
     }
 

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -43,6 +43,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         DispatcherFactory::clear();
         DispatcherFactory::add('Routing');
         DispatcherFactory::add('ControllerFactory');
+        $this->useHttpServer(false);
     }
 
     /**
@@ -173,6 +174,23 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test sending get requests with Http\Server
+     *
+     * @return void
+     */
+    public function testGetHttpServer()
+    {
+        DispatcherFactory::clear();
+        $this->useHttpServer(true);
+        $this->assertNull($this->_response);
+
+        $this->get('/request_action/test_request_action');
+        $this->assertNotEmpty($this->_response);
+        $this->assertInstanceOf('Cake\Network\Response', $this->_response);
+        $this->assertEquals('This is a test', $this->_response->body());
+    }
+
+    /**
      * Test sending requests stores references to controller/view/layout.
      *
      * @return void
@@ -189,6 +207,39 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertTemplate('index');
         $this->assertLayout('default');
         $this->assertEquals('value', $this->viewVariable('test'));
+    }
+
+    /**
+     * Test PSR7 requests store references to controller/view/layout
+     *
+     * @return void
+     */
+    public function testRequestSetsPropertiesHttpServer()
+    {
+        $this->markTestIncomplete('not done');
+        DispatcherFactory::clear();
+        $this->useHttpServer(true);
+
+        $this->post('/posts/index');
+        $this->assertInstanceOf('Cake\Controller\Controller', $this->_controller);
+        $this->assertNotEmpty($this->_viewName, 'View name not set');
+        $this->assertContains('Template' . DS . 'Posts' . DS . 'index.ctp', $this->_viewName);
+        $this->assertNotEmpty($this->_layoutName, 'Layout name not set');
+        $this->assertContains('Template' . DS . 'Layout' . DS . 'default.ctp', $this->_layoutName);
+
+        $this->assertTemplate('index');
+        $this->assertLayout('default');
+        $this->assertEquals('value', $this->viewVariable('test'));
+    }
+
+    /**
+     * Test that the PSR7 requests get post, cookies, and other request data passed along.
+     *
+     * @return void
+     */
+    public function testPsrRequestData()
+    {
+        $this->markTestIncomplete('not done');
     }
 
     /**
@@ -241,7 +292,6 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->post('/posts/index');
         $this->assertCookieNotSet('remember_me');
     }
-
 
     /**
      * Tests the failure message for assertCookieNotSet when no

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -243,6 +243,21 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->assertHeader('X-Middleware', 'true');
     }
 
+    /**
+     * Test that the PSR7 requests get cookies
+     *
+     * @return void
+     */
+    public function testSessionHttpServer()
+    {
+        $this->useHttpServer(true);
+
+        $this->session(['foo' => 'session data']);
+        $this->get('/request_action/session_test');
+        $this->assertResponseOk();
+        $this->assertResponseContains('session data');
+        $this->assertHeader('X-Middleware', 'true');
+    }
 
     /**
      * Test sending requests stores references to controller/view/layout.

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp;
+
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+class Application extends BaseApplication
+{
+    /**
+     * Bootstrap hook.
+     *
+     * Nerfed as this is for IntegrationTestCase testing.
+     *
+     * @return void
+     */
+    public function bootstrap()
+    {
+        // Do nothing.
+    }
+
+    public function middleware($middleware)
+    {
+        $middleware->push(new RoutingMiddleware());
+        return $middleware;
+    }
+}

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -34,6 +34,10 @@ class Application extends BaseApplication
     public function middleware($middleware)
     {
         $middleware->push(new RoutingMiddleware());
+        $middleware->push(function ($req, $res, $next) {
+            $res = $next($req, $res);
+            return $res->withHeader('X-Middleware', 'true');
+        });
         return $middleware;
     }
 }

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -134,7 +134,7 @@ class RequestActionController extends AppController
             'params' => $this->request->params,
             'query' => $this->request->query,
             'url' => $this->request->url,
-            'contentType' => $this->request->env('CONTENT_TYPE'),
+            'contentType' => $this->request->contentType(),
         ]));
         return $this->response;
     }

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -167,6 +167,17 @@ class RequestActionController extends AppController
     }
 
     /**
+     * Tests input data transmission
+     *
+     * @return \Cake\Network\Response
+     */
+    public function input_test()
+    {
+        $this->response->body($this->request->input('json_decode')->hello);
+        return $this->response;
+    }
+
+    /**
      * Tests exception handling
      *
      * @throws \Cake\Network\Exception\NotFoundException


### PR DESCRIPTION
This is the start of adding PSR7 compatibility to `IntegrationTestCase`. I feel being able to do full-stack integration testing is pretty important for PSR7 to be a really viable option for developers.
### Breaking Changes

This contains a breaking change for the `_buildRequest` method. I feel this is a reasonable change to make as it is a protected method. What I needed was a way to get the request parameters not in an object form. Trying to extract all the headers and other data out of a `Cake\Network\Request` was not looking feasible because of how headers are implemented.
### Questions
- Is the general approach of using 'strategy' adapters for each HTTP stack a reasonable approach?
- Is the testing approach looking reasonable, or should I create another test case file with all the PSR7 specific tests?
- Does auto-detecting the `Application` class seem like a reasonable way to behave? Or should using PSR7 always require a call to `useHttpServer()`?
- Do the classnames I've chosen make sense? Are there better names that you can suggest?]
- How should sessions be handled? I was considering using a PSR7 attribute.

Refs #6960 
