### PR TITLE
Fix misnamed variable in default home.ctp

### DIFF
--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -94,7 +94,7 @@ if (isset($filePresent)):
 		$errorMsg = $connectionError->getMessage();
 		if (method_exists($connectionError, 'getAttributes')):
 			$attributes = $connectionError->getAttributes();
-			if (isset($errorMsg['message'])):
+			if (isset($attributes['message'])):
 				$errorMsg .= '<br />' . $attributes['message'];
 			endif;
 		endif;


### PR DESCRIPTION
PDO error message wouldn't appear when using PHP 5.4 or later.

Thanks to **moubo** on Japanese Slack Channel.
