### PR TITLE
[3.3] Handle errors thrown from a custom stream wrapper

### DIFF
--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -293,26 +293,15 @@ class Stream
      */
     protected function _open($url)
     {
-        set_error_handler([$this, '_connectionErrorHandler']);
+        set_error_handler(function ($code, $message) {
+            $this->_connectionErrors[] = $message;
+        });
         $this->_stream = fopen($url, 'rb', false, $this->_context);
         restore_error_handler();
 
         if (!$this->_stream || !empty($this->_connectionErrors)) {
             throw new Exception(implode("\n", $this->_connectionErrors));
         }
-    }
-
-    /**
-     * Local error handler to capture errors triggered during
-     * stream connection.
-     *
-     * @param int $code Error code.
-     * @param string $message Error message.
-     * @return void
-     */
-    protected function _connectionErrorHandler($code, $message)
-    {
-        $this->_connectionErrors[] = $message;
     }
 
     /**


### PR DESCRIPTION
PHP complains about the error handling method not being accessible when an error gets thrown from a custom stream wrapper.
