### PR TITLE
TimeHelper outputTimezone

### DIFF
--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -49,7 +49,7 @@ class TimeHelper extends Helper
      * @param null|string|DateTimeZone $timezone The override timezone if applicable.
      * @return null|string|DateTimeZone The chosen timezone or null.
      */
-    protected function _timezone($timezone)
+    protected function _getTimezone($timezone)
     {
         if ($timezone) {
             return $timezone;
@@ -79,7 +79,7 @@ class TimeHelper extends Helper
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
     {
-        $timezone = $this->_timezone($timezone);
+        $timezone = $this->_getTimezone($timezone);
         return (new Time($dateString))->nice($timezone, $locale);
     }
 
@@ -216,7 +216,7 @@ class TimeHelper extends Helper
      */
     public function toAtom($dateString, $timezone = null)
     {
-        $timezone = $this->_timezone($timezone) ?: date_default_timezone_get();
+        $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
         return (new Time($dateString))->timezone($timezone)->toAtomString();
     }
 
@@ -229,7 +229,7 @@ class TimeHelper extends Helper
      */
     public function toRss($dateString, $timezone = null)
     {
-        $timezone = $this->_timezone($timezone) ?: date_default_timezone_get();
+        $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
         return (new Time($dateString))->timezone($timezone)->toRssString();
     }
 
@@ -256,7 +256,7 @@ class TimeHelper extends Helper
             'element' => null,
             'timezone' => null
         ];
-        $options['timezone'] = $this->_timezone($options['timezone']);
+        $options['timezone'] = $this->_getTimezone($options['timezone']);
         if ($options['timezone']) {
             $dateTime = $dateTime->timezone($options['timezone']);
             unset($options['timezone']);
@@ -367,7 +367,7 @@ class TimeHelper extends Helper
         if (!isset($date)) {
             return $invalid;
         }
-        $timezone = $this->_timezone($timezone);
+        $timezone = $this->_getTimezone($timezone);
 
         try {
             $time = new Time($date);

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -46,8 +46,8 @@ class TimeHelper extends Helper
      *
      * Will use the provided timezone, or default output timezone if defined.
      *
-     * @param null|string|DateTimeZone $timezone The override timezone if applicable.
-     * @return null|string|DateTimeZone The chosen timezone or null.
+     * @param null|string|\DateTimeZone $timezone The override timezone if applicable.
+     * @return null|string|\DateTimeZone The chosen timezone or null.
      */
     protected function _getTimezone($timezone)
     {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -33,6 +33,31 @@ class TimeHelper extends Helper
     use StringTemplateTrait;
 
     /**
+     * Config options
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'outputTimezone' => null
+    ];
+
+    /**
+     * Get a timezone.
+     *
+     * Will use the provided timezone, or default output timezone if defined.
+     *
+     * @param null|string|DateTimeZone $timezone The override timezone if applicable.
+     * @return null|string|DateTimeZone The chosen timezone or null.
+     */
+    protected function _timezone($timezone)
+    {
+        if ($timezone) {
+            return $timezone;
+        }
+        return $this->config('outputTimezone');
+    }
+
+    /**
      * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
      *
      * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
@@ -54,6 +79,7 @@ class TimeHelper extends Helper
      */
     public function nice($dateString = null, $timezone = null, $locale = null)
     {
+        $timezone = $this->_timezone($timezone);
         return (new Time($dateString))->nice($timezone, $locale);
     }
 
@@ -190,7 +216,7 @@ class TimeHelper extends Helper
      */
     public function toAtom($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: date_default_timezone_get();
+        $timezone = $this->_timezone($timezone) ?: date_default_timezone_get();
         return (new Time($dateString))->timezone($timezone)->toAtomString();
     }
 
@@ -203,7 +229,7 @@ class TimeHelper extends Helper
      */
     public function toRss($dateString, $timezone = null)
     {
-        $timezone = $timezone ?: date_default_timezone_get();
+        $timezone = $this->_timezone($timezone) ?: date_default_timezone_get();
         return (new Time($dateString))->timezone($timezone)->toRssString();
     }
 
@@ -226,6 +252,15 @@ class TimeHelper extends Helper
     public function timeAgoInWords($dateTime, array $options = [])
     {
         $element = null;
+        $options += [
+            'element' => null,
+            'timezone' => null
+        ];
+        $options['timezone'] = $this->_timezone($options['timezone']);
+        if ($options['timezone']) {
+            $dateTime = $dateTime->timezone($options['timezone']);
+            unset($options['timezone']);
+        }
 
         if (!empty($options['element'])) {
             $element = [
@@ -332,6 +367,7 @@ class TimeHelper extends Helper
         if (!isset($date)) {
             return $invalid;
         }
+        $timezone = $this->_timezone($timezone);
 
         try {
             $time = new Time($date);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -166,6 +166,18 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test nice with outputTimezone
+     *
+     * @return void
+     */
+    public function testNiceOutputTimezone()
+    {
+        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $time = '2014-04-20 20:00';
+        $this->assertTimeFormat('Apr 20, 2014, 1:00 PM', $this->Time->nice($time));
+    }
+
+    /**
      * testToUnix method
      *
      * @return void
@@ -227,7 +239,12 @@ class TimeHelperTest extends TestCase
      */
     public function testToRssOutputTimezone()
     {
-        $this->markTestIncomplete();
+        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $dateTime = new Time;
+        $vancouver = clone $dateTime;
+        $vancouver->timezone('America/Vancouver');
+
+        $this->assertEquals($vancouver->format('r'), $this->Time->toRss($vancouver));
     }
 
     /**
@@ -249,22 +266,15 @@ class TimeHelperTest extends TestCase
     {
         $result = $this->Time->isToday('+1 day');
         $this->assertFalse($result);
+
         $result = $this->Time->isToday('+1 days');
         $this->assertFalse($result);
+
         $result = $this->Time->isToday('+0 day');
         $this->assertTrue($result);
+
         $result = $this->Time->isToday('-1 day');
         $this->assertFalse($result);
-    }
-
-    /**
-     * test isToday with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsTodayOutputTimezone()
-    {
-        $this->markTestIncomplete();
     }
 
     /**
@@ -286,16 +296,6 @@ class TimeHelperTest extends TestCase
     }
 
     /**
-     * test isFuture with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsFutureOutputTimezone()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
      * testIsPast method
      *
      * @return void
@@ -311,16 +311,6 @@ class TimeHelperTest extends TestCase
         $this->assertTrue($this->Time->isPast('-1 day'));
         $this->assertTrue($this->Time->isPast('-1 week'));
         $this->assertTrue($this->Time->isPast('-1 month'));
-    }
-
-    /**
-     * test isPast with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsPastOutputTimezone()
-    {
-        $this->markTestIncomplete();
     }
 
     /**
@@ -346,16 +336,6 @@ class TimeHelperTest extends TestCase
     }
 
     /**
-     * test isThisWeek with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsThisWeekOutputTimezone()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
      * testIsThisMonth method
      *
      * @return void
@@ -373,16 +353,6 @@ class TimeHelperTest extends TestCase
     }
 
     /**
-     * test isThisMonth with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsThisMonthOutputTimezone()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
      * testIsThisYear method
      *
      * @return void
@@ -393,16 +363,6 @@ class TimeHelperTest extends TestCase
         $this->assertTrue($result);
         $result = $this->Time->isThisYear(mktime(0, 0, 0, mt_rand(1, 12), mt_rand(1, 28), date('Y')));
         $this->assertTrue($result);
-    }
-
-    /**
-     * test isThisYear with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsThisYearOutputTimezone()
-    {
-        $this->markTestIncomplete();
     }
 
     /**
@@ -427,16 +387,6 @@ class TimeHelperTest extends TestCase
     }
 
     /**
-     * test wasYesterday with outputTimezone
-     *
-     * @return void
-     */
-    public function testWasYesterdayOutputTimezone()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
      * testIsTomorrow method
      *
      * @return void
@@ -451,16 +401,6 @@ class TimeHelperTest extends TestCase
         $this->assertFalse($result);
         $result = $this->Time->isTomorrow('-1 day');
         $this->assertFalse($result);
-    }
-
-    /**
-     * test isTomorrow with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsTomorrowOutputTimezone()
-    {
-        $this->markTestIncomplete();
     }
 
     /**
@@ -510,16 +450,6 @@ class TimeHelperTest extends TestCase
     }
 
     /**
-     * test wasWithinLast with outputTimezone
-     *
-     * @return void
-     */
-    public function testWasWithinLastOutputTimezone()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
      * testWasWithinLast method
      *
      * @return void
@@ -566,16 +496,6 @@ class TimeHelperTest extends TestCase
     }
 
     /**
-     * test isWithinNext with outputTimezone
-     *
-     * @return void
-     */
-    public function testIsWithinNextOutputTimezone()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
      * test formatting dates taking in account preferred i18n locale file
      *
      * @return void
@@ -611,7 +531,32 @@ class TimeHelperTest extends TestCase
      */
     public function testFormatOutputTimezone()
     {
-        $this->markTestIncomplete();
+        $this->Time->config('outputTimezone', 'America/Vancouver');
+
+        $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
+        $result = $this->Time->format($time);
+        $expected = '1/14/10, 12:59 AM';
+        $this->assertTimeFormat($expected, $result);
+
+        $time = new Time('Thu Jan 14 8:59:28 2010', 'UTC');
+        $result = $this->Time->format($time);
+        $expected = '1/14/10, 12:59 AM';
+        $this->assertTimeFormat($expected, $result);
+    }
+
+    /**
+     * test i18nFormat with outputTimezone
+     *
+     * @return void
+     */
+    public function testI18nFormatOutputTimezone()
+    {
+        $this->Time->config('outputTimezone', 'America/Vancouver');
+
+        $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
+        $result = $this->Time->i18nFormat($time, \IntlDateFormatter::SHORT);
+        $expected = '1/14/10, 12:59:28 AM';
+        $this->assertStringStartsWith($expected, $result);
     }
 
     /**

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -114,6 +114,33 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * Test output timezone with timeAgoInWords
+     *
+     * @return void
+     */
+    public function testTimeAgoInWordsOutputTimezone()
+    {
+        $Time = new TimeHelper($this->View, ['outputTimezone' => 'America/Vancouver']);
+        $timestamp = new Time('+8 years, +4 months +2 weeks +3 days');
+        $result = $Time->timeAgoInWords($timestamp, [
+            'end' => '1 years',
+            'element' => 'span'
+        ]);
+        $vancouver = clone $timestamp;
+        $vancouver->timezone('America/Vancouver');
+
+        $expected = [
+            'span' => [
+                'title' => $vancouver->__toString(),
+                'class' => 'time-ago-in-words'
+            ],
+            'on ' . $vancouver->format('n/j/y'),
+            '/span'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * testToQuarter method
      *
      * @return void
@@ -160,6 +187,20 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * testToAtom method
+     *
+     * @return void
+     */
+    public function testToAtomOutputTimezone()
+    {
+        $this->Time->config('outputTimezone', 'America/Vancouver');
+        $dateTime = new Time;
+        $vancouver = clone $dateTime;
+        $vancouver->timezone('America/Vancouver');
+        $this->assertEquals($vancouver->format(Time::ATOM), $this->Time->toAtom($vancouver));
+    }
+
+    /**
      * testToRss method
      *
      * @return void
@@ -177,6 +218,16 @@ class TimeHelperTest extends TestCase
             $time = $yourTime->format('U');
             $this->assertEquals($yourTime->format('r'), $this->Time->toRss($time, $timezone), "Failed on $timezone");
         }
+    }
+
+    /**
+     * test toRss with outputTimezone
+     *
+     * @return void
+     */
+    public function testToRssOutputTimezone()
+    {
+        $this->markTestIncomplete();
     }
 
     /**
@@ -205,6 +256,17 @@ class TimeHelperTest extends TestCase
         $result = $this->Time->isToday('-1 day');
         $this->assertFalse($result);
     }
+
+    /**
+     * test isToday with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsTodayOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
     /**
      * testIsFuture method
      *
@@ -224,6 +286,16 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test isFuture with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsFutureOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * testIsPast method
      *
      * @return void
@@ -239,6 +311,16 @@ class TimeHelperTest extends TestCase
         $this->assertTrue($this->Time->isPast('-1 day'));
         $this->assertTrue($this->Time->isPast('-1 week'));
         $this->assertTrue($this->Time->isPast('-1 month'));
+    }
+
+    /**
+     * test isPast with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsPastOutputTimezone()
+    {
+        $this->markTestIncomplete();
     }
 
     /**
@@ -264,6 +346,16 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test isThisWeek with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsThisWeekOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * testIsThisMonth method
      *
      * @return void
@@ -281,6 +373,16 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test isThisMonth with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsThisMonthOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * testIsThisYear method
      *
      * @return void
@@ -291,6 +393,16 @@ class TimeHelperTest extends TestCase
         $this->assertTrue($result);
         $result = $this->Time->isThisYear(mktime(0, 0, 0, mt_rand(1, 12), mt_rand(1, 28), date('Y')));
         $this->assertTrue($result);
+    }
+
+    /**
+     * test isThisYear with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsThisYearOutputTimezone()
+    {
+        $this->markTestIncomplete();
     }
 
     /**
@@ -315,6 +427,16 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test wasYesterday with outputTimezone
+     *
+     * @return void
+     */
+    public function testWasYesterdayOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * testIsTomorrow method
      *
      * @return void
@@ -329,6 +451,16 @@ class TimeHelperTest extends TestCase
         $this->assertFalse($result);
         $result = $this->Time->isTomorrow('-1 day');
         $this->assertFalse($result);
+    }
+
+    /**
+     * test isTomorrow with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsTomorrowOutputTimezone()
+    {
+        $this->markTestIncomplete();
     }
 
     /**
@@ -378,6 +510,16 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test wasWithinLast with outputTimezone
+     *
+     * @return void
+     */
+    public function testWasWithinLastOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * testWasWithinLast method
      *
      * @return void
@@ -424,6 +566,16 @@ class TimeHelperTest extends TestCase
     }
 
     /**
+     * test isWithinNext with outputTimezone
+     *
+     * @return void
+     */
+    public function testIsWithinNextOutputTimezone()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
      * test formatting dates taking in account preferred i18n locale file
      *
      * @return void
@@ -450,6 +602,16 @@ class TimeHelperTest extends TestCase
         $result = $this->Time->format($time, \IntlDateFormatter::FULL);
         $expected = 'jeudi 14 janvier 2010 13:59:28 UTC';
         $this->assertTimeFormat($expected, $result);
+    }
+
+    /**
+     * test format with outputTimezone
+     *
+     * @return void
+     */
+    public function testFormatOutputTimezone()
+    {
+        $this->markTestIncomplete();
     }
 
     /**


### PR DESCRIPTION
This works off the ideas discussed in #8948 and implements the `outputTimezone` as an option to `TimeHelper`. I've not modified the various `isXX` methods as those are generally all proxy methods to Time instance methods. I'm happy to revisit that decision, but I figured this was a minimal amount of code that we could discuss further, while still achieving some of the goals for a default output timezone.
