### PR TITLE
Forward the current connection to the generated table.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -191,7 +191,10 @@ class BelongsToMany extends Association
 
                 $config = [];
                 if (!$tableLocator->exists($tableAlias)) {
-                    $config = ['table' => $tableName];
+                    $config = [
+                        'table' => $tableName,
+                        'connection' => $this->source()->connection()
+                    ];
                 }
                 $table = $tableLocator->get($tableAlias, $config);
             }
@@ -200,8 +203,8 @@ class BelongsToMany extends Association
         if (is_string($table)) {
             $table = $tableLocator->get($table);
         }
-        $target = $this->target();
         $source = $this->source();
+        $target = $this->target();
 
         $this->_generateSourceAssociations($table, $source);
         $this->_generateTargetAssociations($table, $source, $target);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -169,6 +169,29 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests the junction passes the source connection name on.
+     *
+     * @return void
+     */
+    public function testJunctionConnection()
+    {
+        $mock = $this->getMockBuilder('Cake\Database\Connection')
+                ->setMethods(['driver'])
+                ->setConstructorArgs(['name' => 'other_source'])
+                ->getMock();
+        ConnectionManager::config('other_source', $mock);
+        $this->article->connection(ConnectionManager::get('other_source'));
+
+        $assoc = new BelongsToMany('Test', [
+            'sourceTable' => $this->article,
+            'targetTable' => $this->tag
+        ]);
+        $junction = $assoc->junction();
+        $this->assertSame($mock, $junction->connection());
+        ConnectionManager::drop('other_source');
+    }
+
+    /**
      * Tests the junction method custom keys
      *
      * @return void


### PR DESCRIPTION
This helps make belongsToMany associations in plugins easier to work with, as the generated table will inherit the source table's connection, which is _generally_ what people will expect.

Refs #9016
