### PR TITLE
Fix file responses in IntegrationTestCase

### DIFF
--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -349,12 +349,6 @@ class SocketTest extends TestCase
     public function testEnableCrypto()
     {
         $this->skipIf(!function_exists('stream_socket_enable_crypto'), 'Broken on HHVM');
-        // testing on ssl server
-        $this->_connectSocketToSslTls();
-        $this->assertTrue($this->Socket->enableCrypto('sslv3', 'client'));
-        $this->Socket->disconnect();
-
-        // testing on tls server
         $this->_connectSocketToSslTls();
         $this->assertTrue($this->Socket->enableCrypto('tls', 'client'));
         $this->Socket->disconnect();

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -746,6 +746,20 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test sending file with psr7 stack
+     *
+     * @return void
+     */
+    public function testSendFileHttpServer()
+    {
+        DispatcherFactory::clear();
+        $this->useHttpServer(true);
+
+        $this->get('/posts/file');
+        $this->assertFileResponse(TEST_APP . 'TestApp' . DS . 'Controller' . DS . 'PostsController.php');
+    }
+
+    /**
      * Test that assertFile requires a response
      *
      * @expectedException PHPUnit_Framework_AssertionFailedError

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -470,6 +470,20 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test that exceptions being thrown are handled correctly by the psr7 stack.
+     *
+     * @return void
+     */
+    public function testWithExpectedExceptionHttpServer()
+    {
+        DispatcherFactory::clear();
+        $this->useHttpServer(true);
+
+        $this->get('/tests_apps/throw_exception');
+        $this->assertResponseCode(500);
+    }
+
+    /**
      * Test that exceptions being thrown are handled correctly.
      *
      * @expectedException PHPUnit_Framework_AssertionFailedError
@@ -491,6 +505,21 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->post('/tests_apps/redirect_to');
         $this->assertResponseSuccess();
         $this->assertResponseCode(302);
+    }
+
+    /**
+     * Test redirecting and psr7 stack
+     *
+     * @return void
+     */
+    public function testRedirectHttpServer()
+    {
+        DispatcherFactory::clear();
+        $this->useHttpServer(true);
+
+        $this->post('/tests_apps/redirect_to');
+        $this->assertResponseCode(302);
+        $this->assertHeader('X-Middleware', 'true');
     }
 
     /**


### PR DESCRIPTION
File responses weren't being correctly converted from PSR7 to Cake responses. This made it so you couldn't easily write integration tests for files.

Refs #6960 
