### PR TITLE
Fix issue with cache groups when creating a cache engine

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -153,6 +153,10 @@ class Cache
         $config = static::$_config[$name];
         $registry->load($name, $config);
 
+        if ($config['className'] instanceof CacheEngine) {
+            $config = $config['className']->config();
+        }
+
         if (!empty($config['groups'])) {
             foreach ($config['groups'] as $group) {
                 static::$_groups[$group][] = $name;

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -354,6 +354,24 @@ class CacheTest extends TestCase
     }
 
     /**
+     * testGroupConfigsWithCacheInstance method
+     */
+    public function testGroupConfigsWithCacheInstance()
+    {
+        Cache::drop('test');
+        $cache = new FileEngine();
+        $cache->init([
+            'duration' => 300,
+            'engine' => 'File',
+            'groups' => ['users', 'comments'],
+        ]);
+        Cache::config('cached', $cache);
+
+        $result = Cache::groupConfigs('users');
+        $this->assertEquals(['users' => ['cached']], $result);
+    }
+
+    /**
      * testGroupConfigsThrowsException method
      * @expectedException \InvalidArgumentException
      */

--- a/tests/TestCase/Shell/OrmCacheShellTest.php
+++ b/tests/TestCase/Shell/OrmCacheShellTest.php
@@ -104,7 +104,7 @@ class OrmCacheShellTest extends TestCase
      */
     public function testBuildNoArgs()
     {
-        $this->cache->expects($this->at(2))
+        $this->cache->expects($this->at(3))
             ->method('write')
             ->with('test_articles');
 
@@ -179,7 +179,7 @@ class OrmCacheShellTest extends TestCase
      */
     public function testClearNoArgs()
     {
-        $this->cache->expects($this->at(2))
+        $this->cache->expects($this->at(3))
             ->method('delete')
             ->with('test_articles');
 


### PR DESCRIPTION
If a cache engine is configured by passing in a already constructed instance, any potential groups used by that engine are lost. This can have dire consequences when trying to call (for example), `Cache::groupConfigs()`. I noticed this problem with DebugKit's cache spies.
