### PR TITLE
Invert the order in which the belongsToMany joins are created

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -575,6 +575,7 @@ abstract class Association
         $dummy = $this
             ->find($finder, $opts)
             ->eagerLoaded(true);
+
         if (!empty($options['queryBuilder'])) {
             $dummy = $options['queryBuilder']($dummy);
             if (!($dummy instanceof Query)) {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -382,7 +382,7 @@ class BelongsToMany extends Association
 
         $subquery = $options['queryBuilder']($subquery);
 
-        $assoc = $this->junction()->association($this->target()->alias());
+        $assoc = $junction->association($this->target()->alias());
         $conditions = $assoc->_joinCondition([
             'foreignKey' => $this->targetForeignKey()
         ]);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -378,7 +378,8 @@ class BelongsToMany extends Association
 
         $subquery = $this->find()
             ->select(array_values($conds))
-            ->where($options['conditions']);
+            ->where($options['conditions'])
+            ->andWhere($this->junctionConditions());
 
         $subquery = $options['queryBuilder']($subquery);
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2995,7 +2995,8 @@ class QueryTest extends TestCase
             ->find()
             ->select([
                 'authors.id',
-                'total_articles' => 'count(tags.id)'])
+                'tagged_articles' => 'count(tags.id)'
+            ])
             ->leftJoinWith('articles.tags', function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })
@@ -3007,7 +3008,7 @@ class QueryTest extends TestCase
             3 => 1,
             4 => 0
         ];
-        $this->assertEquals($expected, $results->combine('id', 'total_articles')->toArray());
+        $this->assertEquals($expected, $results->combine('id', 'tagged_articles')->toArray());
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3029,7 +3029,6 @@ class QueryTest extends TestCase
             })
             ->autoFields(true)
             ->where(['ArticlesTags.tag_id' => 3])
-            ->distinct(['authors.id'])
             ->all();
 
         $expected = ['id' => 2, 'title' => 'Second Article'];
@@ -3165,8 +3164,9 @@ class QueryTest extends TestCase
             ->hydrate(false)
             ->notMatching('tags', function ($q) {
                 return $q->where(['tags.name' => 'tag2']);
-            })
-            ->toArray();
+            });
+
+        $results = $results->toArray();
 
         $expected = [
             [
@@ -3200,6 +3200,7 @@ class QueryTest extends TestCase
 
         $results = $table->find()
             ->hydrate(false)
+            ->select('authors.id')
             ->notMatching('articles.tags', function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2993,22 +2993,21 @@ class QueryTest extends TestCase
 
         $results = $table
             ->find()
-            ->select(['total_articles' => 'count(articles.id)'])
+            ->select([
+                'authors.id',
+                'total_articles' => 'count(tags.id)'])
             ->leftJoinWith('articles.tags', function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })
-            ->autoFields(true)
-            ->group(['authors.id', 'authors.name']);
+            ->group(['authors.id']);
 
         $expected = [
-            1 => 2,
+            1 => 0,
             2 => 0,
             3 => 1,
             4 => 0
         ];
         $this->assertEquals($expected, $results->combine('id', 'total_articles')->toArray());
-        $fields = ['total_articles', 'id', 'name'];
-        $this->assertEquals($fields, array_keys($results->first()->toArray()));
     }
 
     /**


### PR DESCRIPTION
This took me a couple months to get right... but finally here it is.

It has been a frequently reported problem the order in which the belongsToMany `matching` joins where created up until this point. For example:

``` sql
select * from articles inner join tags inner join articles_tags on (...) ...
```

The main problems have been:
1. It was not possible to reference the joint table from the query builder closure:

``` php
$query->matching('tags', function ($q) { $q->where('ArticlesTags.foo is null'); }) // SQL ERROR
```
1. `leftJoinWith` produces surprisingly odd results, although they are semantically correct.

``` sql
-- $query->leftJoinWith('tags');

LEFT JOIN tags on 1 = 1 -- This is surprising to some and don't know how to deal with it
LEFT JOIN articles_tags on (...)
WHERE articles_tags.id is null
```

The changes in this branch solve both problems by inverting the order of the joins:

``` sql
select * from articles inner join articles_tags on (...) inner join tags on (...) ...
```

These changes are potentially problematic: I'm not really sure what all the consequences for people's code might be. One example of the consequences is that I had to re-implement `notMatching`  for belongs to many associations, given that the new joins order made it impossible to keep the current logic.

In the great majority of applications, I would say that the changes are beneficial and would very rarely produce any noticeable change for anyone, but I'm targeting 3.next so that people have the chance to test before we mark it as stable.
