### PR TITLE
Allow the application class to be configured.

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -208,7 +208,7 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @param string $class The application class name.
      * @param array|null $constructorArgs The constructor arguments for your application class.
-     *   @return void
+     * @return void
      */
     public function configApplication($class, $constructorArgs)
     {

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -32,13 +32,39 @@ use Zend\Diactoros\Stream;
 class MiddlewareDispatcher
 {
     /**
+     * The test case being run.
+     *
+     * @var \Cake\TestSuite\IntegrationTestCase
+     */
+    protected $_test;
+
+    /**
+     * The application class name
+     *
+     * @var string
+     */
+    protected $_class;
+
+    /**
+     * Constructor arguments for your application class.
+     *
+     * @var array
+     */
+    protected $_constructorArgs;
+
+    /**
      * Constructor
      *
      * @param \Cake\TestSuite\IntegrationTestCase $test The test case to run.
+     * @param string $class The application class name. Defaults to App\Application.
+     * @param array|null $constructorArgs The constructor arguments for your application class.
+     *   Defaults to `['./config']`
      */
-    public function __construct($test)
+    public function __construct($test, $class = null, $constructorArgs = null)
     {
         $this->_test = $test;
+        $this->_class = $class ?: Configure::read('App.namespace') . '\Application';
+        $this->_constructorArgs = $constructorArgs ?: ['./config'];
     }
 
     /**
@@ -50,13 +76,12 @@ class MiddlewareDispatcher
     public function execute($request)
     {
         try {
-            $namespace = Configure::read('App.namespace');
-            $reflect = new ReflectionClass($namespace . '\Application');
-            $app = $reflect->newInstance('./config');
+            $reflect = new ReflectionClass($this->_class);
+            $app = $reflect->newInstanceArgs($this->_constructorArgs);
         } catch (ReflectionException $e) {
             throw new LogicException(sprintf(
                 'Cannot load "%s" for use in integration testing.',
-                $class
+                $this->_class
             ));
         }
 

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -178,6 +178,21 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test customizing the app class.
+     *
+     * @expectedException LogicException
+     * @expectedExceptionMessage Cannot load "TestApp\MissingApp" for use in integration
+     * @return void
+     */
+    public function testConfigApplication()
+    {
+        DispatcherFactory::clear();
+        $this->useHttpServer(true);
+        $this->configApplication('TestApp\MissingApp', []);
+        $this->get('/request_action/test_request_action');
+    }
+
+    /**
      * Test sending get requests with Http\Server
      *
      * @return void


### PR DESCRIPTION
In integration tests, we'll need a way for users to set the classname, and constructor arguments for their application. I chose to track more state in IntegrationTestCase as it makes the easiest to use API for people writing tests.

Refs #6960
