### PR TITLE
Table::findOrCreate more unit tests, callable search argument and optional transactions

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1214,9 +1214,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * called allowing you to define additional default values. The new
      * entity will be saved and returned.
      *
-     * If the $search properties do not match the properties of the entity, then you
-     * should disable defaults and define all default values using the callback.
-     *
      * If your find conditions require custom order, associations or conditions, then the $search
      * parameter can be a callable that takes the Query as the argument. Allowing you to
      * customize the find results.
@@ -1229,6 +1226,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   transaction (default: true)
      * - defaults: Whether to use the search criteria as default values for the new entity (default: true)
      *
+     * @param array|\Cake\ORM\Query $search The criteria to find existing
+     *   records by. Note that when you pass a query object you'll have to use
+     *   the 2nd arg of the method to modify the entity data before saving.     
      * @param array|callable $search The criteria to find an existing record by, or a callable that will
      *   customize the find query.
      * @param callable|null $callback A callback that will be invoked for newly
@@ -1286,6 +1286,20 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         unset($options['defaults']);
         return $this->save($entity, $options) ?: $entity;
+    }
+
+    /**
+     * Gets the query object for findOrCreate().
+     *
+     * @param array|\Cake\ORM\Query|string $search The criteria to find existing records by.
+     * @return \Cake\ORM\Query
+     */
+    protected function _getFindOrCreateQuery($search)
+    {
+        if ($search instanceof Query) {
+            return $search;
+        }
+        return $this->find()->where($search);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1217,7 +1217,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * If the $search properties do not match the properties of the entity, then you
      * should disable defaults and define all default values using the callback.
      *
-     * If your find conditions require custom order, associations or conditions. The $search
+     * If your find conditions require custom order, associations or conditions, then the $search
      * parameter can be a callable that takes the Query as the argument. Allowing you to
      * customize the find results.
      *
@@ -1229,7 +1229,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   transaction (default: true)
      * - defaults: Whether to use the search criteria as default values for the new entity (default: true)
      *
-     * @param array|callable $search The criteria to find an existing record by, or a callable tha will
+     * @param array|callable $search The criteria to find an existing record by, or a callable that will
      *   customize the find query.
      * @param callable|null $callback A callback that will be invoked for newly
      *   created entities. This callback will be called *before* the entity
@@ -1240,9 +1240,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function findOrCreate($search, callable $callback = null, $options = [])
     {
         $options = array_merge([
-                'atomic' => true,
-                'defaults' => true
-            ], $options);
+            'atomic' => true,
+            'defaults' => true
+        ], $options);
 
         if ($options['atomic']) {
             return $this->connection()->transactional(function () use ($search, $callback, $options) {
@@ -1264,12 +1264,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array $options The options to use when saving.
      * @return EntityInterface An entity.
      */
-    protected function _processFindOrCreate($search, callable $callback = null, $options)
+    protected function _processFindOrCreate($search, callable $callback = null, $options = [])
     {
         $query = $this->find();
-        if(is_callable($search)) {
+        if (is_callable($search)) {
             call_user_func($search, $query);
-        } else if(is_array($search)) {
+        } elseif (is_array($search)) {
             $query->where($search);
         } else {
             throw new InvalidArgumentException('Search criteria must be an array or callable');
@@ -1279,7 +1279,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $row;
         }
         $entity = $this->newEntity();
-        if($options['defaults'] && is_array($search)) {
+        if ($options['defaults'] && is_array($search)) {
             $entity->set($search, ['guard' => false]);
         }
         if ($callback) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1236,7 +1236,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function findOrCreate($search, callable $callback = null, $options = [])
     {
-        $options = $options + [
+        $options += [
             'atomic' => true,
             'defaults' => true
         ];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1249,7 +1249,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 return $this->_processFindOrCreate($search, $callback, $options);
             });
         }
-        $redundant = 0;
         return $this->_processFindOrCreate($search, $callback, $options);
     }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1248,9 +1248,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $this->connection()->transactional(function () use ($search, $callback, $options) {
                 return $this->_processFindOrCreate($search, $callback, $options);
             });
-        } else {
-            return $this->_processFindOrCreate($search, $callback, $options);
         }
+        $redundant = 0;
+        return $this->_processFindOrCreate($search, $callback, $options);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1215,8 +1215,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * entity will be saved and returned.
      *
      * If your find conditions require custom order, associations or conditions, then the $search
-     * parameter can be a callable that takes the Query as the argument. Allowing you to
-     * customize the find results.
+     * parameter can be a callable that takes the Query as the argument, or a \Cake\ORM\Query object passed
+     * as the $search parameter. Allowing you to customize the find results.
      *
      * ### Options
      *
@@ -1226,11 +1226,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   transaction (default: true)
      * - defaults: Whether to use the search criteria as default values for the new entity (default: true)
      *
-     * @param array|\Cake\ORM\Query $search The criteria to find existing
-     *   records by. Note that when you pass a query object you'll have to use
-     *   the 2nd arg of the method to modify the entity data before saving.     
-     * @param array|callable $search The criteria to find an existing record by, or a callable that will
-     *   customize the find query.
+     * @param array|callable|\Cake\ORM\Query $search The criteria to find an existing record by, or a
+     *   callable that will customize the find query.
      * @param callable|null $callback A callback that will be invoked for newly
      *   created entities. This callback will be called *before* the entity
      *   is persisted.
@@ -1265,7 +1262,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _processFindOrCreate($search, callable $callback = null, $options = [])
     {
-        $query = $this->find();
+        $query = ($search instanceof Query) ? $search : $this->find();
         if (is_callable($search)) {
             $search($query);
         } elseif (is_array($search)) {
@@ -1286,20 +1283,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         unset($options['defaults']);
         return $this->save($entity, $options) ?: $entity;
-    }
-
-    /**
-     * Gets the query object for findOrCreate().
-     *
-     * @param array|\Cake\ORM\Query|string $search The criteria to find existing records by.
-     * @return \Cake\ORM\Query
-     */
-    protected function _getFindOrCreateQuery($search)
-    {
-        if ($search instanceof Query) {
-            return $search;
-        }
-        return $this->find()->where($search);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1268,22 +1268,22 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $query = $this->find();
         if (is_callable($search)) {
-            call_user_func($search, $query);
+            $search($query);
         } elseif (is_array($search)) {
             $query->where($search);
         } else {
             throw new InvalidArgumentException('Search criteria must be an array or callable');
         }
         $row = $query->first();
-        if ($row) {
+        if ($row !== null) {
             return $row;
         }
         $entity = $this->newEntity();
         if ($options['defaults'] && is_array($search)) {
             $entity->set($search, ['guard' => false]);
         }
-        if ($callback) {
-            $callback($entity);
+        if ($callback !== null) {
+            $entity = $callback($entity) ?: $entity;
         }
         unset($options['defaults']);
         return $this->save($entity, $options) ?: $entity;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1262,13 +1262,15 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _processFindOrCreate($search, callable $callback = null, $options = [])
     {
-        $query = ($search instanceof Query) ? $search : $this->find();
         if (is_callable($search)) {
+            $query = $this->find();
             $search($query);
         } elseif (is_array($search)) {
-            $query->where($search);
+            $query = $this->find()->where($search);
+        } elseif ($search instanceof Query) {
+            $query = $search;
         } else {
-            throw new InvalidArgumentException('Search criteria must be an array or callable');
+            throw new InvalidArgumentException('Search criteria must be an array, callable or Query');
         }
         $row = $query->first();
         if ($row !== null) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1236,10 +1236,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function findOrCreate($search, callable $callback = null, $options = [])
     {
-        $options = array_merge([
+        $options = $options + [
             'atomic' => true,
             'defaults' => true
-        ], $options);
+        ];
 
         if ($options['atomic']) {
             return $this->connection()->transactional(function () use ($search, $callback, $options) {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5427,6 +5427,12 @@ class TableTest extends TestCase
         $this->assertEquals('New body', $article->body);
         $this->assertEquals('N', $article->published);
         $this->assertEquals(2, $article->author_id);
+
+        $query = $articles->find()->where(['author_id' => 2, 'title' => 'First Article']);
+        $article = $articles->findOrCreate($query);
+        $this->assertEquals('First Article', $article->title);
+        $this->assertEquals(2, $article->author_id);
+        $this->assertFalse($article->isNew());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5364,25 +5364,25 @@ class TableTest extends TestCase
     {
         $articles = TableRegistry::get('Articles');
 
-        $callback_executed = false;
-        $first_article = $articles->findOrCreate(['title' => 'Not there'], function ($article) use (&$callback_executed) {
+        $callbackExecuted = false;
+        $firstArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) use (&$callbackExecuted) {
             $this->assertTrue($article instanceof EntityInterface);
             $article->body = 'New body';
-            $callback_executed = true;
+            $callbackExecuted = true;
         });
-        $this->assertTrue($callback_executed);
-        $this->assertFalse($first_article->isNew());
-        $this->assertNotNull($first_article->id);
-        $this->assertEquals('Not there', $first_article->title);
-        $this->assertEquals('New body', $first_article->body);
+        $this->assertTrue($callbackExecuted);
+        $this->assertFalse($firstArticle->isNew());
+        $this->assertNotNull($firstArticle->id);
+        $this->assertEquals('Not there', $firstArticle->title);
+        $this->assertEquals('New body', $firstArticle->body);
 
-        $second_article = $articles->findOrCreate(['title' => 'Not there'], function ($article) {
+        $secondArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) {
             $this->fail('Should not be called for existing entities.');
         });
-        $this->assertFalse($second_article->isNew());
-        $this->assertNotNull($second_article->id);
-        $this->assertEquals('Not there', $second_article->title);
-        $this->assertEquals($first_article->id, $second_article->id);
+        $this->assertFalse($secondArticle->isNew());
+        $this->assertNotNull($secondArticle->id);
+        $this->assertEquals('Not there', $secondArticle->title);
+        $this->assertEquals($firstArticle->id, $secondArticle->id);
     }
 
     /**
@@ -5411,16 +5411,16 @@ class TableTest extends TestCase
     {
         $articles = TableRegistry::get('Articles');
 
-        $callback_executed = false;
+        $callbackExecuted = false;
         $article = $articles->findOrCreate(
             ['author_id' => 2, 'title' => 'First Article'],
-            function ($article) use (&$callback_executed) {
+            function ($article) use (&$callbackExecuted) {
                 $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
                 $article->set(['published' => 'N', 'body' => 'New body']);
-                $callback_executed = true;
+                $callbackExecuted = true;
             }
         );
-        $this->assertTrue($callback_executed);
+        $this->assertTrue($callbackExecuted);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
         $this->assertEquals('First Article', $article->title);
@@ -5438,7 +5438,7 @@ class TableTest extends TestCase
     {
         $articles = TableRegistry::get('Articles');
 
-        $article = $articles->findOrCreate(['title'=>'Just Something New']);
+        $article = $articles->findOrCreate(['title' => 'Just Something New']);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
         $this->assertEquals('Just Something New', $article->title);
@@ -5453,19 +5453,19 @@ class TableTest extends TestCase
     {
         $articles = TableRegistry::get('Articles');
 
-        $called_1 = false;
-        $called_2 = false;
-        $article = $articles->findOrCreate(function ($query) use (&$called_1) {
+        $calledOne = false;
+        $calledTwo = false;
+        $article = $articles->findOrCreate(function ($query) use (&$calledOne) {
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $query->where(['title' => 'Something Else']);
-            $called_1 = true;
-        }, function ($article) use (&$called_2) {
+            $calledOne = true;
+        }, function ($article) use (&$calledTwo) {
             $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
             $article->title = 'Set Defaults Here';
-            $called_2 = true;
+            $calledTwo = true;
         });
-        $this->assertTrue($called_1);
-        $this->assertTrue($called_2);
+        $this->assertTrue($calledOne);
+        $this->assertTrue($calledTwo);
         $this->assertFalse($article->isNew());
         $this->assertNotNull($article->id);
         $this->assertEquals('Set Defaults Here', $article->title);


### PR DESCRIPTION
Improves upon #9007 

Contains the following
- adds unit testing for findOrCreate that target specific features of the function
- $search can now be a callable that gets $query as an argument
- $options is now forwarded to `save()`
- $options['defaults']:bool can now disable $search as default entity values for new entities.
- $options['atomic']:bool can now disable the use of transactions.
