### PR TITLE
Issue #9040 - Auth saving json in Auth.redirect

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -359,7 +359,7 @@ class AuthComponent extends Component {
 			return true;
 		}
 
-		if (!$controller->request->is('ajax')) {
+		if (!$controller->request->is('ajax') && !$controller->request->is('json')) {
 			$this->flash($this->authError);
 			$this->Session->write('Auth.redirect', $controller->request->here(false));
 			$controller->redirect($this->loginAction);


### PR DESCRIPTION
AuthComponent is storing JSON or any other AJAX request URL into the session variable Auth.redirect used for login redirect if the AJAX request does not send the X-Requested-With:XMLHttpRequest header.

If you send an AJAX request without that header and your request is not a (.json) it will store the URL anyway.
