### PR TITLE
Cell::__toString provides incomplete error messages

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -263,7 +263,7 @@ abstract class Cell
         try {
             return $this->render();
         } catch (Exception $e) {
-            trigger_error('Could not render cell - ' . $e->getMessage(), E_USER_WARNING);
+            trigger_error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()), E_USER_WARNING);
             return '';
         }
     }


### PR DESCRIPTION
If you generate an error while rendering a Cell, then it triggers a user warning that reads something like this.

```
Warning (512): Could not render cell - Call to a member function foo() on null [CORE\src\View\Cell.php, line 266]
```

The above error does not point to the source of the problem. It just tells you where the error was caught.

This PR adds the missing details.

```
Warning (512): Could not render cell - Call to a member function foo() on null [\App\src\View\Helper\FooHelper.php, line 138] [CORE\src\View\Cell.php, line 266]
```

All I did was add the location of the original exception.

I didn't run the unit tests. Will have to wait and see if this passes.
