### PR TITLE
Add test showing that niceShort translates month names.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
   - sh -c "composer global require 'phpunit/phpunit=3.7.33'"
   - sh -c "ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit ./vendors/PHPUnit"
   - sudo locale-gen de_DE
+  - sudo locale-gen es_ES
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test3;'; fi"

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -460,9 +460,11 @@ class CakeTimeTest extends CakeTestCase {
  * @return void
  */
 	public function testNiceShortI18n() {
+		$restore = setlocale(LC_ALL, 0);
 		setlocale(LC_ALL, 'es_ES');
 		$time = strtotime('2015-01-07 03:05:00');
 		$this->assertEquals('ene 7th 2015, 03:05', $this->Time->niceShort($time));
+		setlocale(LC_ALL, $restore);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -455,6 +455,17 @@ class CakeTimeTest extends CakeTestCase {
 	}
 
 /**
+ * testNiceShort translations
+ *
+ * @return void
+ */
+	public function testNiceShortI18n() {
+		setlocale(LC_ALL, 'es_ES');
+		$time = strtotime('2015-01-07 03:05:00');
+		$this->assertEquals('ene 7th 2015, 03:05', $this->Time->niceShort($time));
+	}
+
+/**
  * testDaysAsSql method
  *
  * @return void


### PR DESCRIPTION
This test passed locally, I am hoping it does the same on travisci.

Refs #8968
