### PR TITLE
Make stickler ignore 2.x and 2.next branches.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,2 @@
+branches:
+  ignore: ['2.x', '2.next']


### PR DESCRIPTION
The ignore added to .stickler.yml on master branch doesn't seem to have intended effect, hopefully adding it to 2.x branch itself will.
