### PR TITLE
Provide access to content-* headers via header()

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -455,10 +455,7 @@ class RequestHandlerComponent extends Component
             return false;
         }
 
-        list($contentType) = explode(';', $request->env('CONTENT_TYPE'));
-        if ($contentType === '') {
-            list($contentType) = explode(';', $request->header('CONTENT_TYPE'));
-        }
+        list($contentType) = explode(';', $request->contentType());
         $response = $this->response;
         if ($type === null) {
             return $response->mapType($contentType);

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -893,7 +893,10 @@ class Request implements ArrayAccess
      */
     public function header($name)
     {
-        $name = 'HTTP_' . str_replace('-', '_', $name);
+        $name = str_replace('-', '_', $name);
+        if (strtoupper(substr($name, 0, 8)) !== 'CONTENT_') {
+            $name = 'HTTP_' . $name;
+        }
         return $this->env($name);
     }
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -894,7 +894,7 @@ class Request implements ArrayAccess
     public function header($name)
     {
         $name = str_replace('-', '_', $name);
-        if (strtoupper(substr($name, 0, 8)) !== 'CONTENT_') {
+        if (!in_array(strtoupper($name), ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
             $name = 'HTTP_' . $name;
         }
         return $this->env($name);

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -773,8 +773,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->assertEquals('json', $this->RequestHandler->requestedWith());
 
         $this->request->env('REQUEST_METHOD', 'POST');
-        $this->request->env('CONTENT_TYPE', '');
-        $this->request->env('HTTP_CONTENT_TYPE', 'application/json');
+        $this->request->env('CONTENT_TYPE', 'application/json');
 
         $result = $this->RequestHandler->requestedWith(['json', 'xml']);
         $this->assertEquals('json', $result);

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1038,11 +1038,15 @@ class RequestTest extends TestCase
     {
         $request = new Request(['environment' => [
             'HTTP_HOST' => 'localhost',
-            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-ca) AppleWebKit/534.8+ (KHTML, like Gecko) Version/5.0 Safari/533.16'
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-ca) AppleWebKit/534.8+ (KHTML, like Gecko) Version/5.0 Safari/533.16',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
         ]]);
 
         $this->assertEquals($request->env('HTTP_HOST'), $request->header('host'));
         $this->assertEquals($request->env('HTTP_USER_AGENT'), $request->header('User-Agent'));
+        $this->assertEquals($request->env('CONTENT_LENGTH'), $request->header('content-length'));
+        $this->assertEquals($request->env('CONTENT_TYPE'), $request->header('content-type'));
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1041,12 +1041,14 @@ class RequestTest extends TestCase
             'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-ca) AppleWebKit/534.8+ (KHTML, like Gecko) Version/5.0 Safari/533.16',
             'CONTENT_TYPE' => 'application/json',
             'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123'
         ]]);
 
         $this->assertEquals($request->env('HTTP_HOST'), $request->header('host'));
         $this->assertEquals($request->env('HTTP_USER_AGENT'), $request->header('User-Agent'));
         $this->assertEquals($request->env('CONTENT_LENGTH'), $request->header('content-length'));
         $this->assertEquals($request->env('CONTENT_TYPE'), $request->header('content-type'));
+        $this->assertEquals($request->env('HTTP_CONTENT_MD5'), $request->header('content-md5'));
     }
 
     /**


### PR DESCRIPTION
The content-\* headers are not prefixed with HTTP_ like most other headers.

Refs #9027
