### PR TITLE
Docblock says wrong type

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -327,7 +327,7 @@ class Response
      * Content type to send. This can be an 'extension' that will be transformed using the $_mimetypes array
      * or a complete mime-type
      *
-     * @var int
+     * @var string
      */
     protected $_contentType = 'text/html';
 


### PR DESCRIPTION
Docblock says `$_contentType` is an int, when it's in fact a string.
