### PR TITLE
Make constants optional.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -317,17 +317,13 @@ class Debugger
      */
     public static function trimPath($path)
     {
-        if (!defined('CAKE_CORE_INCLUDE_PATH') || !defined('APP')) {
-            return $path;
-        }
-
-        if (strpos($path, APP) === 0) {
+        if (defined('APP') && strpos($path, APP) === 0) {
             return str_replace(APP, 'APP/', $path);
         }
-        if (strpos($path, CAKE_CORE_INCLUDE_PATH) === 0) {
+        if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($path, CAKE_CORE_INCLUDE_PATH) === 0) {
             return str_replace(CAKE_CORE_INCLUDE_PATH, 'CORE', $path);
         }
-        if (strpos($path, ROOT) === 0) {
+        if (defined('ROOT') && strpos($path, ROOT) === 0) {
             return str_replace(ROOT, 'ROOT', $path);
         }
 

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -398,6 +398,7 @@ class Folder
      *
      * @param string $path The path to check.
      * @return bool
+     * @deprecated 3.2.12 This method will be removed in 4.0.0. Use inPath() instead.
      */
     public function inCakePath($path = '')
     {

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -159,7 +159,7 @@ class MessagesFileLoader
         $searchPaths = [];
 
         $localePaths = App::path('Locale');
-        if (empty($localePaths)) {
+        if (empty($localePaths) && defined('APP')) {
             $localePaths[] = APP . 'Locale' . DIRECTORY_SEPARATOR;
         }
         foreach ($localePaths as $path) {

--- a/src/basics.php
+++ b/src/basics.php
@@ -50,7 +50,10 @@ if (!function_exists('debug')) {
         $lineInfo = '';
         if ($showFrom) {
             $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
-            $search = [ROOT];
+            $search = [];
+            if (defined('ROOT')) {
+                $search = [ROOT];
+            }
             if (defined('CAKE_CORE_INCLUDE_PATH')) {
                 array_unshift($search, CAKE_CORE_INCLUDE_PATH);
             }


### PR DESCRIPTION
Don't require constants from the application skeleton in the standalone components. This makes it easier for the components to be used.

I've deprecated Folder::inCakePath() as it is a silly function that can be replaced with usage of inPath()

Refs #9074
