### PR TITLE
Always load RequestHandler for ErrorController.

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -34,9 +34,7 @@ class ErrorController extends Controller
     public function __construct($request = null, $response = null)
     {
         parent::__construct($request, $response);
-        if (count(Router::extensions()) &&
-            !isset($this->RequestHandler)
-        ) {
+        if (!isset($this->RequestHandler)) {
             $this->loadComponent('RequestHandler');
         }
         $eventManager = $this->eventManager();


### PR DESCRIPTION
Loading it only when extension routing is used causes problem in cases
one is not using extensions and instead relying on "Accept" header for
response type switching by RequestHandler.
