### PR TITLE
Always load RequestHandler for ErrorController.

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -26,26 +26,13 @@ class ErrorController extends Controller
 {
 
     /**
-     * Constructor
+     * Initialization hook method.
      *
-     * @param \Cake\Network\Request|null $request Request instance.
-     * @param \Cake\Network\Response|null $response Response instance.
+     * @return void
      */
-    public function __construct($request = null, $response = null)
+    public function initialize()
     {
-        parent::__construct($request, $response);
-        if (count(Router::extensions()) &&
-            !isset($this->RequestHandler)
-        ) {
-            $this->loadComponent('RequestHandler');
-        }
-        $eventManager = $this->eventManager();
-        if (isset($this->Auth)) {
-            $eventManager->off($this->Auth);
-        }
-        if (isset($this->Security)) {
-            $eventManager->off($this->Security);
-        }
+        $this->loadComponent('RequestHandler');
     }
 
     /**


### PR DESCRIPTION
Loading it only when extension routing is used causes problem in cases where
one is not using extensions and instead relying on "Accept" header for response
type switching by RequestHandler.

Also removed unneeded check for Auth and Security components. Since
ErrorController extends core Controller no components are going to be preloaded.
