### PR TITLE
Fix issue with integration tests and Content-Type headers

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -448,7 +448,11 @@ abstract class IntegrationTestCase extends TestCase
         $env = [];
         if (isset($this->_request['headers'])) {
             foreach ($this->_request['headers'] as $k => $v) {
-                $env['HTTP_' . str_replace('-', '_', strtoupper($k))] = $v;
+                $name = strtoupper(str_replace('-', '_', $k));
+                if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+                    $name = 'HTTP_' . $name;
+                }
+                $env[$name] = $v;
             }
             unset($this->_request['headers']);
         }

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -53,7 +53,11 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     public function testRequestBuilding()
     {
         $this->configRequest([
-            'headers' => ['X-CSRF-Token' => 'abc123'],
+            'headers' => [
+                'X-CSRF-Token' => 'abc123',
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json'
+            ],
             'base' => '',
             'webroot' => '/',
             'environment' => [
@@ -66,6 +70,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
 
         $this->assertEquals('abc123', $request->header('X-CSRF-Token'));
+        $this->assertEquals('application/json', $request->header('Content-Type'));
         $this->assertEquals('tasks/add', $request->url);
         $this->assertArrayHasKey('split_token', $request->cookies);
         $this->assertEquals('def345', $request->cookies['split_token']);


### PR DESCRIPTION
https://github.com/cakephp/cakephp/commit/67ad9beec3757f225f224fd6c295f5cf00b637c0 (and subsequent iterations) broke the ability to set the `Content-Type` header for integration tests.

This fixes that again.
