### PR TITLE
Bind DispatchFilter in the new ActionDispatcher.

### DIFF
--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -61,6 +61,11 @@ class ActionDispatcher
         if ($eventManager) {
             $this->eventManager($eventManager);
         }
+
+        // Compatibility with DispatcherFilters.
+        foreach (DispatcherFactory::filters() as $filter) {
+            $this->addFilter($filter);
+        }
         $this->factory = $factory ?: new ControllerFactory();
     }
 

--- a/tests/TestCase/Http/ActionDispatcherTest.php
+++ b/tests/TestCase/Http/ActionDispatcherTest.php
@@ -19,6 +19,7 @@ use Cake\Http\ActionDispatcher;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Network\Session;
+use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Filter\ControllerFactoryFilter;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -43,6 +44,17 @@ class ActionDispatcherTest extends TestCase
     }
 
     /**
+     * Teardown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        DispatcherFactory::clear();
+    }
+
+    /**
      * Ensure the constructor args end up on the right protected properties.
      *
      * @return void
@@ -55,6 +67,21 @@ class ActionDispatcherTest extends TestCase
 
         $this->assertAttributeSame($events, '_eventManager', $dispatcher);
         $this->assertAttributeSame($factory, 'factory', $dispatcher);
+    }
+
+    /**
+     * Ensure that filters connected to the DispatcherFactory are
+     * also applied
+     */
+    public function testDispatcherFactoryCompat()
+    {
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['beforeDispatch', 'afterDispatch'])
+            ->getMock();
+        DispatcherFactory::add($filter);
+        $dispatcher = new ActionDispatcher();
+        $this->assertCount(1, $dispatcher->getFilters());
+        $this->assertSame($filter, $dispatcher->getFilters()[0]);
     }
 
     /**


### PR DESCRIPTION
Previously I removed this code as I thought the global dependencies were a bit icky - they still are. However, without this code someone who updates to the middleware stack cannot use any dispatch filters. This is not desirable, as I'd like people to be able to upgrade their dispatch
filters piece by piece, and avoid a big rewrite.

This reverts commit 366484c270c1cd6a85bd5b8f03629380d192a0c3.
