### PR TITLE
Fix Http client headers when array data is used.

### DIFF
--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -45,12 +45,12 @@ class Request extends Message implements RequestInterface
         $this->validateMethod($method);
         $this->method = $method;
         $this->uri = $this->createUri($url);
-        $this->body($data);
         $headers += [
             'Connection' => 'close',
             'User-Agent' => 'CakePHP'
         ];
         $this->addHeaders($headers);
+        $this->body($data);
     }
 
     /**

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -163,7 +163,7 @@ class ClientTest extends TestCase
         $headers = [
             'User-Agent' => 'Cake',
             'Connection' => 'close',
-            'Content-Type' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded',
         ];
         $cookies = [
             'split' => 'value'

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -22,6 +22,45 @@ use Zend\Diactoros\Uri;
  */
 class RequestTest extends TestCase
 {
+    /**
+     * test string ata, header and constructor
+     *
+     * @return void
+     */
+    public function testConstructorStringData()
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer valid-token',
+        ];
+        $data = ['a' => 'b', 'c' => 'd'];
+        $request = new Request('http://example.com', 'POST', $headers, json_encode($data));
+
+        $this->assertEquals('http://example.com', $request->url());
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('application/json', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals(json_encode($data), $request->body());
+    }
+
+    /**
+     * test array data, header and constructor
+     *
+     * @return void
+     */
+    public function testConstructorArrayData()
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer valid-token',
+        ];
+        $data = ['a' => 'b', 'c' => 'd'];
+        $request = new Request('http://example.com', 'POST', $headers, $data);
+
+        $this->assertEquals('http://example.com', $request->url());
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals('a=b&c=d', $request->body());
+    }
 
     /**
      * test url method


### PR DESCRIPTION
When building a client request with constructor arguments, the headers should be applied before the body is set. This is necessary as setting the body can change the content-type based on the contents. Arrays are converted into urlencoded data, which needs to override the
content-type on the request.

Without this, requests like:

``` php
$data = [ ... ];
$response = $http->post(
    'https://github.com/login/oauth/access_token',
    $data,
    ['type' => 'json']
);
```

will fail as the request data is URL encode, but the content-type will be `application/json`.
