### PR TITLE
Fixed bug in FormHelper::error()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -712,7 +712,7 @@ class FormHelper extends Helper
             foreach ($error as $k => $e) {
                 if (isset($text[$k])) {
                     $tmp[] = $text[$k];
-                } else if (isset($text[$e])) {
+                } elseif (isset($text[$e])) {
                     $tmp[] = $text[$e];
                 } else {
                     $tmp[] = $e;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -709,7 +709,7 @@ class FormHelper extends Helper
 
         if (is_array($text)) {
             $tmp = [];
-            foreach ($error as $e) {
+            foreach ($error as $e => $m) {
                 if (isset($text[$e])) {
                     $tmp[] = $text[$e];
                 } else {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -709,8 +709,10 @@ class FormHelper extends Helper
 
         if (is_array($text)) {
             $tmp = [];
-            foreach ($error as $e => $m) {
-                if (isset($text[$e])) {
+            foreach ($error as $k => $e) {
+                if (isset($text[$k])) {
+                    $tmp[] = $text[$k];
+                } else if (isset($text[$e])) {
                     $tmp[] = $text[$e];
                 } else {
                     $tmp[] = $e;


### PR DESCRIPTION
In FormHelper::error(), param array $text doesn't work.
Fixed it.
