### PR TITLE
Don't split strings headers that lack a ':'.

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -577,7 +577,7 @@ class CakeResponse {
 			if (is_numeric($header)) {
 				list($header, $value) = array($value, null);
 			}
-			if ($value === null) {
+			if ($value === null && strpos($header, ':') !== false) {
 				list($header, $value) = explode(':', $header, 2);
 			}
 			$this->_headers[$header] = is_array($value) ? array_map('trim', $value) : trim($value);

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -164,9 +164,13 @@ class CakeResponseTest extends CakeTestCase {
 		$headers += array('Location' => 'http://example.com');
 		$this->assertEquals($headers, $response->header());
 
-		//Headers with the same name are overwritten
+		// Headers with the same name are overwritten
 		$response->header('Location', 'http://example2.com');
 		$headers = array('Location' => 'http://example2.com');
+		$this->assertEquals($headers, $response->header());
+
+		$response->header('Date', null);
+		$headers += array('Date' => null);
 		$this->assertEquals($headers, $response->header());
 
 		$response->header(array('WWW-Authenticate' => 'Negotiate'));


### PR DESCRIPTION
Refs #9106
