### PR TITLE
Adding an option to allow the children key to be changed.

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -620,9 +620,10 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * whether an element is parent of another
      * @param callable|string $parentPath the column name path to use for determining
      * whether an element is child of another
+     * @param string $childrenKey The key name to use for the children
      * @return \Cake\Collection\CollectionInterface
      */
-    public function nest($idPath, $parentPath);
+    public function nest($idPath, $parentPath, $childrenKey = null);
 
     /**
      * Returns a new collection containing each of the elements found in `$values` as

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1085,13 +1085,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * You can customize what fields are used for nesting results, by default the
      * primary key and the `parent_id` fields are used. If you wish to change
-     * these defaults you need to provide the keys `keyField` or `parentField` in
+     * these defaults you need to provide the keys `keyField`, `parentField` or `childrenKey` in
      * `$options`:
      *
      * ```
      * $table->find('threaded', [
      *  'keyField' => 'id',
      *  'parentField' => 'ancestor_id'
+     *  'childrenKey' => 'children'
      * ]);
      * ```
      *
@@ -1104,6 +1105,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += [
             'keyField' => $this->primaryKey(),
             'parentField' => 'parent_id',
+            'childrenKey' => 'children'
         ];
 
         if (isset($options['idField'])) {
@@ -1115,7 +1117,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options = $this->_setFieldMatchers($options, ['keyField', 'parentField']);
 
         return $query->formatResults(function ($results) use ($options) {
-            return $results->nest($options['keyField'], $options['parentField']);
+            return $results->nest($options['keyField'], $options['parentField'], $options['childrenKey']);
         });
     }
 


### PR DESCRIPTION
It was hard coded as `children` and several times I have written custom finders to address this so I can change it to `nodes` or `whatever`. Well taking a second look I see no reason for the custom finders if the children key can be pass through as an option.
