### PR TITLE
Docblock fix: Controller::referer should support array-based URL structure too

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -642,7 +642,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Returns the referring URL for this request.
      *
-     * @param string|null $default Default URL to use if HTTP_REFERER cannot be read from headers
+     * @param string|array|null $default Default URL to use if HTTP_REFERER cannot be read from headers
      * @param bool $local If true, restrict referring URLs to local server
      * @return string Referring URL
      */


### PR DESCRIPTION
This PR adds `array` to the list of accepted types for the method parameter `$default` of `Controller::referer()`.  This is because `Router::url()`, which is called in the method, accepts array values in order to build URL's.
