### PR TITLE
Fix validateUnique emitting errors when non-scalar data is received.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2274,6 +2274,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
         $rule = new IsUnique($fields);
+
         return $rule($entity, ['repository' => $this]);
     }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2267,8 +2267,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             [$context['field']],
             isset($options['scope']) ? (array)$options['scope'] : []
         );
+        $values = $entity->extract($fields);
+        foreach ($values as $field) {
+            if ($field !== null && !is_scalar($field)) {
+                return false;
+            }
+        }
         $rule = new IsUnique($fields);
-
         return $rule($entity, ['repository' => $this]);
     }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5608,6 +5608,10 @@ class TableTest extends TestCase
         $validator = new Validator;
         $validator->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
         $validator->provider('table', $table);
+
+        $data = ['username' => ['larry', 'notthere']];
+        $this->assertNotEmpty($validator->errors($data));
+
         $data = ['username' => 'larry'];
         $this->assertNotEmpty($validator->errors($data));
 


### PR DESCRIPTION
While normally the `IsUnique()` rule can expect sane data as it will have already been validated, that is not true when the rule is used inside a validator function. This prevents non-scalar data from getting to the rule by failing early.

Refs #9088
