### PR TITLE
Allow Route to parse URL with encoded slash character. Fix #9119

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -273,7 +273,8 @@ class Route
         }
         list($url, $ext) = $this->_parseExtension($url);
 
-        if (!preg_match($this->_compiledRoute, urldecode($url), $route)) {
+        $decodedUrl = implode('/', array_map([$this, '_urlDecodeWithoutSlash'], explode('/', $url)));
+        if (!preg_match($this->_compiledRoute, $decodedUrl, $route)) {
             return false;
         }
 
@@ -290,6 +291,7 @@ class Route
         for ($i = 0; $i <= $count; $i++) {
             unset($route[$i]);
         }
+        $route = array_map('urldecode', $route);
         $route['pass'] = [];
 
         // Assign defaults, set passed args to pass
@@ -332,6 +334,19 @@ class Route
         $route['_matchedRoute'] = $this->template;
 
         return $route;
+    }
+
+    /**
+     * Keep the encoding of slash character
+     *
+     * @param string $str The string to decode
+     * @return string
+     */
+    protected function _urlDecodeWithoutSlash($str)
+    {
+        $decodedStr = urldecode($str);
+
+        return str_replace("/", "%2F", $decodedStr);
     }
 
     /**

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -291,7 +291,6 @@ class Route
         for ($i = 0; $i <= $count; $i++) {
             unset($route[$i]);
         }
-        $route = array_map('urldecode', $route);
         $route['pass'] = [];
 
         // Assign defaults, set passed args to pass

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -770,7 +770,7 @@ class RouteTest extends TestCase
         $result = $route->parse('/posts/ABC%2FD');
         $this->assertEquals('posts', $result['controller']);
         $this->assertEquals('view', $result['action']);
-        $this->assertEquals('ABC/D', $result['slug']);
+        $this->assertEquals('ABC%2FD', $result['slug']);
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -766,6 +766,11 @@ class RouteTest extends TestCase
         $this->assertEquals('posts', $result['controller']);
         $this->assertEquals('view', $result['action']);
         $this->assertEquals('∂∂', $result['slug']);
+
+        $result = $route->parse('/posts/ABC%2FD');
+        $this->assertEquals('posts', $result['controller']);
+        $this->assertEquals('view', $result['action']);
+        $this->assertEquals('ABC/D', $result['slug']);
     }
 
     /**


### PR DESCRIPTION
Before this PR, Cakephp::Route couldn't parse URL with encoded slash like: /posts/ABC%2FD
for any route like:
`$route = new Route(
            '/:controller/:slug',
            ['action' => 'view']
        );`

This PR will fix that issue ( #9119 )

Edit: The Travis builds failed for unrelated source code
