### PR TITLE
Adding `$nestingKey` to Collection nest method, with tests.

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -620,9 +620,10 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * whether an element is parent of another
      * @param callable|string $parentPath the column name path to use for determining
      * whether an element is child of another
+     * @param string $nestingKey The key name under which children are nested
      * @return \Cake\Collection\CollectionInterface
      */
-    public function nest($idPath, $parentPath);
+    public function nest($idPath, $parentPath, $nestingKey = 'children');
 
     /**
      * Returns a new collection containing each of the elements found in `$values` as

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -448,6 +448,7 @@ trait CollectionTrait
                     $parents[$id] = $isObject ? $parents[$id] : new ArrayIterator($parents[$id], 1);
                     $mapReduce->emit($parents[$id]);
                 }
+
                 return null;
             }
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -56,8 +56,8 @@ use Traversable;
  * @method \Cake\Collection\CollectionInterface append(array|Traversable $items) Appends more rows to the result of the query.
  * @method \Cake\Collection\CollectionInterface combine($k, $v, $g = null) Returns the values of the column $v index by column $k,
  *   and grouped by $g.
- * @method \Cake\Collection\CollectionInterface nest($k, $p) Creates a tree structure by nesting the values of column $p into that
- *   with the same value for $k.
+ * @method \Cake\Collection\CollectionInterface nest($k, $p, $n = 'children') Creates a tree structure by nesting the values of column $p into that
+ *   with the same value for $k using $n as the nesting key.
  * @method array toArray() Returns a key-value array with the results of this query.
  * @method array toList() Returns a numerically indexed array with the results of this query.
  * @method \Cake\Collection\CollectionInterface stopWhen(callable $c) Returns each row until the callable returns true.

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1085,14 +1085,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * You can customize what fields are used for nesting results, by default the
      * primary key and the `parent_id` fields are used. If you wish to change
-     * these defaults you need to provide the keys `keyField`, `parentField` or `childrenKey` in
+     * these defaults you need to provide the keys `keyField`, `parentField` or `nestingKey` in
      * `$options`:
      *
      * ```
      * $table->find('threaded', [
      *  'keyField' => 'id',
      *  'parentField' => 'ancestor_id'
-     *  'childrenKey' => 'children'
+     *  'nestingKey' => 'children'
      * ]);
      * ```
      *

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1085,13 +1085,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * You can customize what fields are used for nesting results, by default the
      * primary key and the `parent_id` fields are used. If you wish to change
-     * these defaults you need to provide the keys `keyField` or `parentField` in
+     * these defaults you need to provide the keys `keyField`, `parentField` or `childrenKey` in
      * `$options`:
      *
      * ```
      * $table->find('threaded', [
      *  'keyField' => 'id',
      *  'parentField' => 'ancestor_id'
+     *  'childrenKey' => 'children'
      * ]);
      * ```
      *
@@ -1104,6 +1105,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += [
             'keyField' => $this->primaryKey(),
             'parentField' => 'parent_id',
+            'nestingKey' => 'children'
         ];
 
         if (isset($options['idField'])) {
@@ -1115,7 +1117,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options = $this->_setFieldMatchers($options, ['keyField', 'parentField']);
 
         return $query->formatResults(function ($results) use ($options) {
-            return $results->nest($options['keyField'], $options['parentField']);
+            return $results->nest($options['keyField'], $options['parentField'], $options['nestingKey']);
         });
     }
 

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -914,11 +914,116 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Tests the nest method with alternate nesting key
+     *
+     * @return void
+     */
+    public function testNestAlternateNestingKey()
+    {
+        $items = [
+            ['id' => 1, 'parent_id' => null],
+            ['id' => 2, 'parent_id' => 1],
+            ['id' => 3, 'parent_id' => 1],
+            ['id' => 4, 'parent_id' => 1],
+            ['id' => 5, 'parent_id' => 6],
+            ['id' => 6, 'parent_id' => null],
+            ['id' => 7, 'parent_id' => 1],
+            ['id' => 8, 'parent_id' => 6],
+            ['id' => 9, 'parent_id' => 6],
+            ['id' => 10, 'parent_id' => 6]
+        ];
+        $collection = (new Collection($items))->nest('id', 'parent_id', 'nodes');
+        $expected = [
+            [
+                'id' => 1,
+                'parent_id' => null,
+                'nodes' => [
+                    ['id' => 2, 'parent_id' => 1, 'nodes' => []],
+                    ['id' => 3, 'parent_id' => 1, 'nodes' => []],
+                    ['id' => 4, 'parent_id' => 1, 'nodes' => []],
+                    ['id' => 7, 'parent_id' => 1, 'nodes' => []]
+                ]
+            ],
+            [
+                'id' => 6,
+                'parent_id' => null,
+                'nodes' => [
+                    ['id' => 5, 'parent_id' => 6, 'nodes' => []],
+                    ['id' => 8, 'parent_id' => 6, 'nodes' => []],
+                    ['id' => 9, 'parent_id' => 6, 'nodes' => []],
+                    ['id' => 10, 'parent_id' => 6, 'nodes' => []]
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $collection->toArray());
+    }
+
+    /**
      * Tests the nest method with more than one level
      *
      * @return void
      */
     public function testNestMultiLevel()
+    {
+        $items = [
+            ['id' => 1, 'parent_id' => null],
+            ['id' => 2, 'parent_id' => 1],
+            ['id' => 3, 'parent_id' => 2],
+            ['id' => 4, 'parent_id' => 2],
+            ['id' => 5, 'parent_id' => 3],
+            ['id' => 6, 'parent_id' => null],
+            ['id' => 7, 'parent_id' => 3],
+            ['id' => 8, 'parent_id' => 4],
+            ['id' => 9, 'parent_id' => 6],
+            ['id' => 10, 'parent_id' => 6]
+        ];
+        $collection = (new Collection($items))->nest('id', 'parent_id', 'nodes');
+        $expected = [
+            [
+                'id' => 1,
+                'parent_id' => null,
+                'nodes' => [
+                    [
+                        'id' => 2,
+                        'parent_id' => 1,
+                        'nodes' => [
+                            [
+                                'id' => 3,
+                                'parent_id' => 2,
+                                'nodes' => [
+                                    ['id' => 5, 'parent_id' => 3, 'nodes' => []],
+                                    ['id' => 7, 'parent_id' => 3, 'nodes' => []]
+                                ]
+                            ],
+                            [
+                                'id' => 4,
+                                'parent_id' => 2,
+                                'nodes' => [
+                                    ['id' => 8, 'parent_id' => 4, 'nodes' => []]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'id' => 6,
+                'parent_id' => null,
+                'nodes' => [
+                    ['id' => 9, 'parent_id' => 6, 'nodes' => []],
+                    ['id' => 10, 'parent_id' => 6, 'nodes' => []]
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $collection->toArray());
+    }
+
+    /**
+     * Tests the nest method with more than one level
+     *
+     * @return void
+     */
+    public function testNestMultiLevelAlternateNestingKey()
     {
         $items = [
             ['id' => 1, 'parent_id' => null],
@@ -1027,6 +1132,66 @@ class CollectionTest extends TestCase
                 'children' => [
                     new ArrayObject(['id' => 9, 'parent_id' => 6, 'children' => []]),
                     new ArrayObject(['id' => 10, 'parent_id' => 6, 'children' => []])
+                ]
+            ])
+        ];
+        $this->assertEquals($expected, $collection->toArray());
+    }
+
+    /**
+     * Tests the nest method with more than one level
+     *
+     * @return void
+     */
+    public function testNestObjectsAlternateNestingKey()
+    {
+        $items = [
+            new ArrayObject(['id' => 1, 'parent_id' => null]),
+            new ArrayObject(['id' => 2, 'parent_id' => 1]),
+            new ArrayObject(['id' => 3, 'parent_id' => 2]),
+            new ArrayObject(['id' => 4, 'parent_id' => 2]),
+            new ArrayObject(['id' => 5, 'parent_id' => 3]),
+            new ArrayObject(['id' => 6, 'parent_id' => null]),
+            new ArrayObject(['id' => 7, 'parent_id' => 3]),
+            new ArrayObject(['id' => 8, 'parent_id' => 4]),
+            new ArrayObject(['id' => 9, 'parent_id' => 6]),
+            new ArrayObject(['id' => 10, 'parent_id' => 6])
+        ];
+        $collection = (new Collection($items))->nest('id', 'parent_id', 'nodes');
+        $expected = [
+            new ArrayObject([
+                'id' => 1,
+                'parent_id' => null,
+                'nodes' => [
+                    new ArrayObject([
+                        'id' => 2,
+                        'parent_id' => 1,
+                        'nodes' => [
+                            new ArrayObject([
+                                'id' => 3,
+                                'parent_id' => 2,
+                                'nodes' => [
+                                    new ArrayObject(['id' => 5, 'parent_id' => 3, 'nodes' => []]),
+                                    new ArrayObject(['id' => 7, 'parent_id' => 3, 'nodes' => []])
+                                ]
+                            ]),
+                            new ArrayObject([
+                                'id' => 4,
+                                'parent_id' => 2,
+                                'nodes' => [
+                                    new ArrayObject(['id' => 8, 'parent_id' => 4, 'nodes' => []])
+                                ]
+                            ])
+                        ]
+                    ])
+                ]
+            ]),
+            new ArrayObject([
+                'id' => 6,
+                'parent_id' => null,
+                'nodes' => [
+                    new ArrayObject(['id' => 9, 'parent_id' => 6, 'nodes' => []]),
+                    new ArrayObject(['id' => 10, 'parent_id' => 6, 'nodes' => []])
                 ]
             ])
         ];


### PR DESCRIPTION
This enhancements allows for an override of the key used for nesting. Still defaults to `children`.

All of the classes using CollectionInterface were checked to make sure the method signature was update for anything using the CollectionInterface or CollectionTrait.
