### PR TITLE
make all router methods use static instead of class name.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -721,7 +721,7 @@ class Router
             $params['?'] = $url;
         }
 
-        return Router::url($params, $full);
+        return static::url($params, $full);
     }
 
     /**
@@ -736,12 +736,12 @@ class Router
     public static function normalize($url = '/')
     {
         if (is_array($url)) {
-            $url = Router::url($url);
+            $url = static::url($url);
         }
         if (preg_match('/^[a-z\-]+:\/\//', $url)) {
             return $url;
         }
-        $request = Router::getRequest();
+        $request = static::getRequest();
 
         if (!empty($request->base) && stristr($url, $request->base)) {
             $url = preg_replace('/^' . preg_quote($request->base, '/') . '/', '', $url, 1);


### PR DESCRIPTION
This PR changes all router methods use static instead of class name that makes class more flexible.
