### PR TITLE
no need to ckeck $options['atomic']

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -621,7 +621,7 @@ class BelongsToMany extends Association
 
         $options['associated'] = $joinAssociations;
         $success = $this->_saveLinks($parentEntity, $persisted, $options);
-        if (!$success && !empty($options['atomic'])) {
+        if (!$success) {
             $parentEntity->set($this->property(), $original);
 
             return false;
@@ -673,7 +673,7 @@ class BelongsToMany extends Association
 
             $saved = $junction->save($joint, $options);
 
-            if (!$saved && !empty($options['atomic'])) {
+            if (!$saved) {
                 return false;
             }
 


### PR DESCRIPTION
fix #9109 
please check
for return false we need set atomic options to true ,but maybe `save()` need to atomic=false some times
if atomic=false that function return true always
