### PR TITLE
extend Marshaller and TranslateBehavior to patch translations fields

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -329,19 +329,17 @@ class TranslateBehavior extends Behavior
 
     /**
      * Merges `$data` into `$original` entity recursively using Marshaller merge method, if
-     * original entity is null, new one will be created.
+     * original entity not has language entity, new one will be created.
      * The translated entity may only contain the fields defined in the
      * behavior configuration (`fields`), you can use `fieldList` option as a
      * whitelist of fields to be assigned.
      *
      * The result will be and array [entities, errors]:
-     *  - entities indexed by locale name
-     *  - errors indexed by locale name
+     *  - entities: translated entity indexed by locale name
+     *  - errors: array indexed by locale name
      * or null if there are no fields to merge.
      *
-     * ## Note: Translated entity data not will be validated during merge.
-     *
-     * @param \Cake\Datasource\EntityInterface $original The original entity
+     * @param array $original The original entity data
      * @param array $data key value list of languages with fields to be merged into the translate entity
      * @param \Cake\ORM\Marshaller $marshaller Marshaller
      * @param array $options list of options for Marshaller

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -136,6 +136,8 @@ class Marshaller
             $marshallOptions['forceNew'] = $options['forceNew'];
         }
 
+        $hasTranslations = $this->_hasTranslations($options);
+
         $errors = $this->_validate($data, $options, true);
         $properties = [];
         foreach ($data as $key => $value) {
@@ -155,6 +157,8 @@ class Marshaller
             } elseif ($columnType) {
                 $converter = Type::build($columnType);
                 $value = $converter->marshal($value);
+            } elseif ($key === '_translations' && $hasTranslations) {
+                $value = $this->_mergeTranslations(null, $value, $errors, $options);
             }
             $properties[$key] = $value;
         }
@@ -215,7 +219,7 @@ class Marshaller
      */
     protected function _prepareDataAndOptions($data, $options)
     {
-        $options += ['validate' => true];
+        $options += ['validate' => true, 'translations' => true];
 
         $tableName = $this->_table->alias();
         if (isset($data[$tableName])) {
@@ -439,6 +443,51 @@ class Marshaller
     }
 
     /**
+     * Call translation merge. Validations errors during merge will be added to `$errors` param
+     *
+     * @param \Cake\Datasource\EntityInterface $original The original entity
+     * @param array $data key value list of languages with fields to be merged into the translate entity
+     * @param array $errors array with entity errors
+     * @param array $options list of options
+     * @return array|null
+     */
+    protected function _mergeTranslations($original, array $data, array &$errors, array $options = [])
+    {
+        $result = $this->_table->mergeTranslations($original, $data, $this, $options);
+
+        if (is_array($result)) {
+            if ((bool)$result[1]) {
+                $errors['_translations'] = $result[1];
+            }
+            $result = $result[0];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return if table contains translate behavior or we specificate to use via `translations` options.
+     *
+     * In case that $options has `fieldList` option and `_translations` field is not present inside it, it will include
+     *
+     * ### Options:
+     *
+     * - translations: Set to false to disable translations
+     *
+     * @param array $options List of options
+     * @return bool
+     */
+    protected function _hasTranslations(array &$options = [])
+    {
+        $hasTranslations = ($this->_table->behaviors()->hasMethod('mergeTranslations') && (bool)$options['translations']);
+        if ($hasTranslations && !empty($options['fieldList']) && !in_array('_translations', $options['fieldList'])) {
+            array_push($options['fieldList'], '_translations');
+        }
+
+        return $hasTranslations;
+    }
+
+    /**
      * Merges `$data` into `$entity` and recursively does the same for each one of
      * the association names passed in `$options`. When merging associations, if an
      * entity is not present in the parent entity for a given association, a new one
@@ -492,6 +541,8 @@ class Marshaller
             }
         }
 
+        $hasTranslations = $this->_hasTranslations($options);
+
         $errors = $this->_validate($data + $keys, $options, $isNew);
         $schema = $this->_table->schema();
         $properties = $marshalledAssocs = [];
@@ -519,6 +570,8 @@ class Marshaller
                 ) {
                     continue;
                 }
+            } elseif ($key === '_translations' && $hasTranslations) {
+                $value = $this->_mergeTranslations($original, $value, $errors, $options);
             }
 
             $properties[$key] = $value;

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -2979,4 +2979,388 @@ class MarshallerTest extends TestCase
         ];
         $this->assertEquals($expected, $result->toArray());
     }
+
+    /**
+     * Test all scenarios
+     *
+     * @return void
+     */
+    public function testHasTranslations()
+    {
+        // Mocks
+        $mockBehavior = $this->_getMockBehaviors();
+        $mockBehavior->expects($this->at(1))
+            ->method('hasMethod')
+            ->with('mergeTranslations')
+            ->will($this->returnValue(true));
+        $mockBehavior->expects($this->at(2))
+            ->method('hasMethod')
+            ->with('mergeTranslations')
+            ->will($this->returnValue(true));
+        $mockBehavior->expects($this->at(3))
+            ->method('hasMethod')
+            ->with('mergeTranslations')
+            ->will($this->returnValue(true));
+        $mockBehavior->expects($this->at(4))
+            ->method('hasMethod')
+            ->with('mergeTranslations')
+            ->will($this->returnValue(true));
+        $mockBehavior->expects($this->at(5))
+            ->method('hasMethod')
+            ->with('mergeTranslations')
+            ->will($this->returnValue(false));
+
+        $mockTable = $this->_getMockTable(['mergeTranslations'], ['behaviors' => $mockBehavior]);
+
+        $marshall = new Marshaller($mockTable);
+        $method = $this->_getProtectedMethod($marshall, '_hasTranslations');
+
+        $options = ['translations' => true];
+        $args = [&$options];
+
+        // Must return true
+        $this->assertTrue($method->invokeArgs($marshall, $args));
+
+        // Add _translations to fieldList
+        $options['translations'] = true;
+        $options['fieldList'] = ['title'];
+        $this->assertTrue($method->invokeArgs($marshall, $args));
+        $this->assertContains('_translations', $options['fieldList']);
+
+        // Call again, now _translations is already inside fieldList
+        $this->assertTrue($method->invokeArgs($marshall, $args));
+        $this->assertEquals(['title', '_translations'], $options['fieldList']);
+
+        // Return false
+        $options['translations'] = false;
+        $this->assertFalse($method->invokeArgs($marshall, $args));
+
+        // Table not has behavior
+        $options['translations'] = true;
+        $this->assertFalse($method->invokeArgs($marshall, $args));
+    }
+
+    /**
+     * Test Merge translation without errors
+     *
+     * @return void
+     */
+    public function testMergeTranslations()
+    {
+        // Mocks
+        $mockBehavior = $this->_getMockBehaviors();
+        $mockTable = $this->_getMockTable(['mergeTranslations'], ['behaviors' => $mockBehavior]);
+
+        $marshall = new Marshaller($mockTable);
+        $method = $this->_getProtectedMethod($marshall, '_mergeTranslations');
+
+        $errors = [];
+        $data = ['en' => ['title' => 'Hi'], 'es' => ['title' => 'hola']];
+        $args = [
+            null,
+            $data,
+            &$errors
+        ];
+
+        $returnValue = [
+            [
+                'en' => null,
+                'es' => null
+            ],
+            []
+        ];
+        $mockTable->expects($this->once())
+            ->method('mergeTranslations')
+            ->with(
+                $this->isNull(),
+                $this->equalTo($data),
+                $this->isInstanceOf('Cake\ORM\Marshaller'),
+                $this->equalTo([])
+            )
+            ->will($this->returnValue($returnValue));
+
+        $result = $method->invokeArgs($marshall, $args);
+
+        $this->assertEquals($returnValue[0], $result);
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * Test Merge translation with errors, add to `$errors` parameter
+     *
+     * @return void
+     */
+    public function testMergeTranslationsWithErrors()
+    {
+        // Mocks
+        $mockBehavior = $this->_getMockBehaviors();
+        $mockTable = $this->_getMockTable(['mergeTranslations'], ['behaviors' => $mockBehavior]);
+
+        $marshall = new Marshaller($mockTable);
+        $method = $this->_getProtectedMethod($marshall, '_mergeTranslations');
+
+        $errors = [];
+        $data = ['en' => ['title' => 'Hi'], 'es' => ['title' => 'hola']];
+        $args = [
+            null,
+            $data,
+            &$errors
+        ];
+
+        $returnValue = [
+            [
+                'en' => null,
+                'es' => null
+            ],
+            [
+                'en' => []
+            ]
+        ];
+        $mockTable->expects($this->once())
+            ->method('mergeTranslations')
+            ->with(
+                $this->isNull(),
+                $this->equalTo($data),
+                $this->isInstanceOf('Cake\ORM\Marshaller'),
+                $this->equalTo([])
+            )
+            ->will($this->returnValue($returnValue));
+
+        $result = $method->invokeArgs($marshall, $args);
+
+        $this->assertEquals($returnValue[0], $result);
+        $this->assertArrayHasKey('_translations', $errors);
+    }
+
+    /**
+     * Test Merge translation when return null value
+     *
+     * @return void
+     */
+    public function testMergeTranslationsReturnNull()
+    {
+        // Mocks
+        $mockBehavior = $this->_getMockBehaviors();
+        $mockTable = $this->_getMockTable(['mergeTranslations'], ['behaviors' => $mockBehavior]);
+
+        $marshall = new Marshaller($mockTable);
+        $method = $this->_getProtectedMethod($marshall, '_mergeTranslations');
+
+        $errors = [];
+        $data = ['en' => ['title' => 'Hi'], 'es' => ['title' => 'hola']];
+        $args = [
+            null,
+            $data,
+            &$errors
+        ];
+
+        $mockTable->expects($this->once())
+            ->method('mergeTranslations')
+            ->with(
+                $this->isNull(),
+                $this->equalTo($data),
+                $this->isInstanceOf('Cake\ORM\Marshaller'),
+                $this->equalTo([])
+            )
+            ->will($this->returnValue(null));
+
+        $this->assertNull($method->invokeArgs($marshall, $args));
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * Test calling One method from Marshaller
+     *
+     * @return void
+     */
+    public function testMergeTranslationsViaOneMethod()
+    {
+        $data = [
+           'author_id' => 1,
+           '_translations' => [
+               'en' => [
+                   'title' => 'Title EN'
+               ],
+               'es' => [
+                   'title' => 'Title ES'
+               ]
+           ]
+        ];
+
+        $expectedMarshallerOptions = [
+           'validate' => true,
+           'translations' => true
+        ];
+
+        // Mocks
+        $mockBehavior = $this->_getMockBehaviors();
+        $mockBehavior->expects($this->any())
+           ->method('hasMethod')
+           ->with('mergeTranslations')
+           ->will($this->returnValue(true));
+
+        $mockTable = $this->_getMockTable(['mergeTranslations'], ['behaviors' => $mockBehavior]);
+        $mockTable->expects($this->at(0))
+           ->method('mergeTranslations')
+           ->with(
+               $this->isNull(),
+               $this->equalTo($data['_translations']),
+               $this->isInstanceOf('Cake\ORM\Marshaller'),
+               $this->equalTo($expectedMarshallerOptions)
+           )
+           ->will($this->returnValue(true));
+
+        // Second Call
+        $returnValue = [
+           [
+               'en' => null,
+               'es' => null
+           ],
+           [
+               'en' => []
+           ]
+        ];
+        $mockTable->expects($this->at(1))
+           ->method('mergeTranslations')
+           ->with(
+               $this->isNull(),
+               $this->equalTo($data['_translations']),
+               $this->isInstanceOf('Cake\ORM\Marshaller'),
+               $this->equalTo($expectedMarshallerOptions)
+           )
+           ->will($this->returnValue($returnValue));
+
+        $marshall = new Marshaller($mockTable);
+        $result = $marshall->one($data);
+
+        $this->assertTrue($result->get('_translations'));
+        $this->assertEmpty($result->errors());
+
+        // With errors
+        $result = $marshall->one($data);
+        $this->assertEquals($returnValue[0], $result->get('_translations'));
+        $this->assertNotEmpty($result->errors());
+        $this->assertArrayHasKey('_translations', $result->errors());
+    }
+
+    /**
+     * Test calling merge method from Marshaller
+     *
+     * @return void
+     */
+    public function testMergeTranslationsViaMergeMethod()
+    {
+        $data = [
+          'author_id' => 1,
+          '_translations' => [
+              'en' => [
+                  'title' => 'Title EN'
+              ],
+              'es' => [
+                  'title' => 'Title ES'
+              ]
+          ]
+        ];
+
+        $expectedMarshallerOptions = [
+          'validate' => true,
+          'translations' => true
+        ];
+
+        // Mocks
+        $mockBehavior = $this->_getMockBehaviors();
+        $mockBehavior->expects($this->any())
+          ->method('hasMethod')
+          ->with('mergeTranslations')
+          ->will($this->returnValue(true));
+
+        $mockTable = $this->_getMockTable(['mergeTranslations'], ['behaviors' => $mockBehavior]);
+        $mockTable->expects($this->at(0))
+          ->method('mergeTranslations')
+          ->with(
+              $this->isNull(),
+              $this->equalTo($data['_translations']),
+              $this->isInstanceOf('Cake\ORM\Marshaller'),
+              $this->equalTo($expectedMarshallerOptions)
+          )
+          ->will($this->returnValue(true));
+
+        // Second Call
+        $returnValue = [
+          [
+              'en' => null,
+              'es' => null
+          ],
+          [
+              'en' => []
+          ]
+        ];
+        $mockTable->expects($this->at(1))
+          ->method('mergeTranslations')
+          ->with(
+              $this->isTrue(), // _translation value inside entity is true (see last expect call)
+              $this->equalTo($data['_translations']),
+              $this->isInstanceOf('Cake\ORM\Marshaller'),
+              $this->equalTo($expectedMarshallerOptions)
+          )
+          ->will($this->returnValue($returnValue));
+
+        $entity = $this->articles->newEntity();
+
+        $marshall = new Marshaller($mockTable);
+        $marshall->merge($entity, $data);
+
+        $this->assertTrue($entity->get('_translations'));
+        $this->assertEmpty($entity->errors());
+
+        // Now with errors
+        $marshall->merge($entity, $data);
+        $this->assertEquals($returnValue[0], $entity->get('_translations'));
+        $this->assertNotEmpty($entity->errors());
+        $this->assertArrayHasKey('_translations', $entity->errors());
+    }
+
+    /**
+     * Helper method for making mocks.
+     *
+     * @param array $methods
+     * @return \Cake\ORM\Table (Mock)
+     */
+    protected function _getMockTable(array $methods = [], array $config = [])
+    {
+        $config += [
+            'alias' => 'Articles',
+            'schema' => [
+                'id' => ['type' => 'integer']
+            ]
+        ];
+
+        return $this->getMockBuilder('Cake\ORM\Table')
+            ->setMethods($methods)
+            ->setConstructorArgs([$config])
+            ->getMock();
+    }
+
+    /**
+     * Helper method for making mocks.
+     *
+     * @param array $methods
+     * @return Cake\ORM\BehaviorRegistry (Mock)
+     */
+    protected function _getMockBehaviors(array $methods = [])
+    {
+        return $this->getMockBuilder('Cake\ORM\BehaviorRegistry')
+            ->disableOriginalConstructor()
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    protected function _getProtectedMethod($obj, $name)
+    {
+        $class = new \ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
 }


### PR DESCRIPTION
This PR implements **my** proposed solution for these issues (#7909, #7532, #4902) and it's based on PR #6663
#### How does it work

Marshaller will patch all translates fields into entities like another field:

``` php
<?php
    // $this->request->data
    [
        [...]
        '_translations' => [
            'en' => [
                'name' => 'English name',
                'description' => 'bla bla bla bla'
            ],
            'es' => [
                'name' => 'Spanish name',
                'description' => 'bla bla bla bla but in spanish'
            ]
        ]
    ]

    // On Controller
    $this->Table->patchEntity($Entity, $this->request->data);
    $this->Table->newEntity($this->request->data);

    // Debug Entity
    object(App\Model\Entity\Product) {
        [...]
        '_translations' => [
            'en' => object(App\Model\Entity\Product) {
                'name' => 'English name',
                'description' => 'bla bla bla bla'.
                [...]

            },
            'es' => object(App\Model\Entity\Product) {
                'name' => 'Spanish name',
                'description' => 'bla bla bla bla but in spanish',
                [...]
            }
        ],
    }

```

You could validate translated fields using a new configuration option of TranslateBehavior:

``` php
<?php

public function initialize(array $config) {
    [...]
    $this->addBehavior('Translate', [
        'validator' => 'translate' // or Validator object, etc
    ]);
}
```

If there is an error during validation, error will be added automatically to "parent Entity":

``` php
<?php

object(App\Model\Entity\Product) {
    [...]
    '_translations' => [
        'en' => object(App\Model\Entity\Product) {
            [...]
            '[errors]' => [
                'name' => [...]
            ],

        }
    ],
    [...]
    '[errors]' => [
        '_translations' => [
            'en' => [...] // Same content as _translations.en.errors
        ]
    ],
}
```

If you have translated fields but you don't want to patch automatically (maybe you want to do it manually) you can disable it via configuration option `translations`

``` php
<?php

public function initialize(array $config) {
    $this->addBehavior('Translate', [
        'translations' => false
    ]);
}
```
#### Note

90% of work is inside `TranslationBehavior`, `Marshaller` call a method called `mergeTranslations` and attach result to current `$entity`.
This solution allow to use a custom Translation Behavior and makes process transparent to `Marshaller`.
#### Future Work

Use an array to define which validator will be used depending the language

``` php
// MyTable.php
<?php

public function initialize(array $config) {
    [...]
    $this->addBehavior('Translate', [
        'validator' => [
            'en' => 'english',
            '_default' => 'translations'
        ]
    ]);
}

[...]

public function validationEnglish(Validator $validator) {} // Use when language is English
public function validationTranslations(Validator $validator) {} // Use for other languages
```
#### Important points
- Not need to use nested validators
- Attach errors to forms fields as other field
- Allow to use custom validator
- Don't need to add extra code to save translations

Thanks :)
