### PR TITLE
Change error message for fatal errors in Cell::__toString()

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -268,7 +268,7 @@ abstract class Cell
         } catch (Exception $e) {
             trigger_error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()), E_USER_WARNING);
             return '';
-        } catch(Error $e) {
+        } catch (Error $e) {
             throw new Error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()));
         }
     }

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -25,6 +25,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 use Cake\View\Exception\MissingCellViewException;
 use Cake\View\Exception\MissingTemplateException;
+use Error;
 use Exception;
 use ReflectionException;
 use ReflectionMethod;
@@ -257,8 +258,8 @@ abstract class Cell
      *
      * *Note* This method will trigger an error when view rendering has a problem.
      * This is because PHP will not allow a __toString() method to throw an exception.
-     *
      * @return string Rendered cell
+     * @throws Error Include error details for PHP 7 fatal errors.
      */
     public function __toString()
     {
@@ -266,8 +267,9 @@ abstract class Cell
             return $this->render();
         } catch (Exception $e) {
             trigger_error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()), E_USER_WARNING);
-
             return '';
+        } catch(Error $e) {
+            throw new Error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()));
         }
     }
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -258,8 +258,9 @@ abstract class Cell
      *
      * *Note* This method will trigger an error when view rendering has a problem.
      * This is because PHP will not allow a __toString() method to throw an exception.
+     *
      * @return string Rendered cell
-     * @throws Error Include error details for PHP 7 fatal errors.
+     * @throws \Error Include error details for PHP 7 fatal errors.
      */
     public function __toString()
     {


### PR DESCRIPTION
Okay, I'm doing another PR related to fatal errors in PHP 7.

If you get a critical error in PHP 7 from inside a Cell it's not possible to see (from the error message or stack trace) the source of the error. PHP will replace the error message with a complaint that `__toString` can not throw an error. That itself happens to hide the original error. Making it difficult to find (without debugging).

There are some possible changes to this issue.
## Rethrow Error with a better message

Catch and throw new `Error` with a better description.

```
        try {
            return $this->render();
        } catch (Exception $e) {
            trigger_error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()), E_USER_WARNING);
            return '';
        } catch(Error $e) {
            throw new Error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()));
        }
```
## Catching Error

Change the `__toString` in `Cell.php` to catch `Error` which is very nice for me, because it formats the error message as a regular warning.

```
        try {
            return $this->render();
        } catch (Error $e) {
            trigger_error(sprintf('Could not render cell - %s [%s, line %d]', $e->getMessage(), $e->getFile(), $e->getLine()), E_USER_WARNING);
            return '';
        }
```
## Deprecate __toString

Let's be reasonable here. It's one line of code `$this-render()` wrapped in a `try/catch` but it's a finicky issue with PHP. PHP does not like this method to throw errors. So maybe we shouldn't be using since Cells are so critical to the rendering of the views. Had I used `$this->cell()->render()` this wouldn't be an issue, but maybe we should force people to do that.
## Finally

This PR uses the first solution. It appears to work fine on PHP 5/6 
