### PR TITLE
Adding an option builder for the save options

### DIFF
--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -48,6 +48,7 @@ class SaveOptionsBuilder extends ArrayObject
      * Constructor.
      *
      * @param \Cake\ORM\Table $table A table instance.
+     * @param array $options Options to parse when instantiating.
      */
     public function __construct(Table $table, array $options = [])
     {

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -92,6 +92,7 @@ class SaveOptionsBuilder extends ArrayObject
      *
      * @param \Cake\ORM\Table $table Table object.
      * @param array $associations An associations array.
+     * @return void
      */
     protected function _associated(Table $table, array $associations)
     {
@@ -114,6 +115,7 @@ class SaveOptionsBuilder extends ArrayObject
      * @throws \RuntimeException If no such association exists for the given table.
      * @param \Cake\ORM\Table $table Table object.
      * @param string $association Association name.
+     * @return void
      */
     protected function _checkAssociation(Table $table, $association)
     {
@@ -194,13 +196,16 @@ class SaveOptionsBuilder extends ArrayObject
     /**
      * Setting custom options.
      *
+     * @param string $option Option key.
+     * @param mixed $value Option value.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function __call($name, $args)
+    public function set($option, $value)
     {
-        if (isset($args[0])) {
-            $this->_options[$name] = $args[0];
-            return $this;
+        if (method_exists($this, $option)) {
+            return $this->{$option}($value);
         }
+        $this->_options[$option] = $value;
+        return $this;
     }
 }

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -14,10 +14,8 @@
  */
 namespace Cake\ORM;
 
-use ArrayAccess;
 use ArrayObject;
 use RuntimeException;
-use Cake\ORM\AssociationsNormalizerTrait;
 
 /**
  * OOP style Save Option Builder.
@@ -27,7 +25,7 @@ use Cake\ORM\AssociationsNormalizerTrait;
  *
  * @see \Cake\Datasource\RulesChecker
  */
-class SaveOptionsBuilder extends ArrayObject implements ArrayAccess
+class SaveOptionsBuilder extends ArrayObject
 {
 
     use AssociationsNormalizerTrait;
@@ -54,21 +52,26 @@ class SaveOptionsBuilder extends ArrayObject implements ArrayAccess
     public function __construct(Table $table, array $options = [])
     {
         $this->_table = $table;
-        $this->parseArray($options);
+        $this->parseArrayOptions($options);
     }
 
     /**
      * Takes an options array and populates the option object with the data.
      *
-     * @param array $array Options array
+     * This can be used to turn an options array into the object.
+     *
+     * @throws \InvalidArgumentException If a given option key does not exist.
+     * @param array $array Options array.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function parseArray($array)
+    public function parseArrayOptions($array)
     {
         foreach ($array as $key => $value) {
             if (method_exists($this, $key)) {
                 $this->{$key}($value);
+                continue;
             }
+            throw new \InvalidArgumentException(sprintf('Key `%s` is not a valid option!', $key));
         }
         return $this;
     }
@@ -88,7 +91,13 @@ class SaveOptionsBuilder extends ArrayObject implements ArrayAccess
         return $this;
     }
 
-    protected function _associated(Table $table, $associations)
+    /**
+     * Checks that the associations exists recursively.
+     *
+     * @param \Cake\ORM\Table $table Table object.
+     * @param array $associations An associations array.
+     */
+    protected function _associated(Table $table, array $associations)
     {
         foreach ($associations as $key => $associated) {
             if (is_int($key)) {
@@ -103,6 +112,13 @@ class SaveOptionsBuilder extends ArrayObject implements ArrayAccess
         }
     }
 
+    /**
+     * Checks if an association exists.
+     *
+     * @throws \RuntimeException If no such association exists for the given table.
+     * @param \Cake\ORM\Table $table Table object.
+     * @param string $association Association name.
+     */
     protected function _checkAssociation(Table $table, $association)
     {
         if (!$table->associations()->has($association)) {
@@ -177,71 +193,5 @@ class SaveOptionsBuilder extends ArrayObject implements ArrayAccess
     public function toArray()
     {
         return $this->_options;
-    }
-
-    /**
-     * Whether a offset exists
-     *
-     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
-     * @param mixed $offset <p>
-     * An offset to check for.
-     * </p>
-     * @return boolean true on success or false on failure.
-     * </p>
-     * <p>
-     * The return value will be casted to boolean if non-boolean was returned.
-     * @since 5.0.0
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->_options[$offset]);
-    }
-
-    /**
-     * Offset to retrieve
-     *
-     * @link http://php.net/manual/en/arrayaccess.offsetget.php
-     * @param mixed $offset <p>
-     * The offset to retrieve.
-     * </p>
-     * @return mixed Can return all value types.
-     * @since 5.0.0
-     */
-    public function offsetGet($offset)
-    {
-        return $this->_options[$offset];
-    }
-
-    /**
-     * Offset to set
-     *
-     * @link http://php.net/manual/en/arrayaccess.offsetset.php
-     * @param mixed $offset <p>
-     * The offset to assign the value to.
-     * </p>
-     * @param mixed $value <p>
-     * The value to set.
-     * </p>
-     * @return void
-     * @since 5.0.0
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->{$offset}($value);
-    }
-
-    /**
-     * Offset to unset
-     *
-     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
-     * @param mixed $offset <p>
-     * The offset to unset.
-     * </p>
-     * @return void
-     * @since 5.0.0
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->_options[$offset]);
     }
 }

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM;
+
+use ArrayAccess;
+use ArrayObject;
+use RuntimeException;
+use Cake\ORM\AssociationsNormalizerTrait;
+
+/**
+ * OOP style Save Option Builder.
+ *
+ * This allows you to build options to save entities in a OOP style and helps
+ * you to avoid mistakes by validating the options as you build them.
+ *
+ * @see \Cake\Datasource\RulesChecker
+ */
+class SaveOptionsBuilder extends ArrayObject implements ArrayAccess
+{
+
+    use AssociationsNormalizerTrait;
+
+    /**
+     * Options
+     *
+     * @var array
+     */
+    protected $_options = [];
+
+    /**
+     * Table object.
+     *
+     * @var \Cake\ORM\Table;
+     */
+    protected $_table;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\ORM\Table $table A table instance.
+     */
+    public function __construct(Table $table, array $options = [])
+    {
+        $this->_table = $table;
+        $this->parseArray($options);
+    }
+
+    /**
+     * Takes an options array and populates the option object with the data.
+     *
+     * @param array $array Options array
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function parseArray($array)
+    {
+        foreach ($array as $key => $value) {
+            if (method_exists($this, $key)) {
+                $this->{$key}($value);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Set associated options.
+     *
+     * @param string|array $associated String or array of associations.
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function associated($associated)
+    {
+        $associated = $this->_normalizeAssociations($associated);
+        $this->_associated($this->_table, $associated);
+        $this->_options['associated'] = $associated;
+
+        return $this;
+    }
+
+    protected function _associated(Table $table, $associations)
+    {
+        foreach ($associations as $key => $associated) {
+            if (is_int($key)) {
+                $this->_checkAssociation($table, $associated);
+                continue;
+            }
+            $this->_checkAssociation($table, $key);
+            if (isset($associated['associated'])) {
+                $this->_associated($table->association($key)->target(), $associated['associated']);
+                continue;
+            }
+        }
+    }
+
+    protected function _checkAssociation(Table $table, $association)
+    {
+        if (!$table->associations()->has($association)) {
+            throw new RuntimeException(sprintf('Table `%s` is not associated with `%s`', get_class($table), $association));
+        }
+    }
+
+    /**
+     * Set the guard option.
+     *
+     * @param bool $guard Guard the properties or not.
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function guard($guard)
+    {
+        $this->_options['guard'] = (bool)$guard;
+        return $this;
+    }
+
+    /**
+     * Set the validation rule set to use.
+     *
+     * @param string $validate Name of the validation rule set to use.
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function validate($validate)
+    {
+        $this->_table->validator($validate);
+        $this->_options['validate'] = $validate;
+        return $this;
+    }
+
+    /**
+     * Set check existing option.
+     *
+     * @param bool $checkExisting Guard the properties or not.
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function checkExisting($checkExisting)
+    {
+        $this->_options['checkExisting'] = (bool)$checkExisting;
+        return $this;
+    }
+
+    /**
+     * Option to check the rules.
+     *
+     * @param bool $checkRules Check the rules or not.
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function checkRules($checkRules)
+    {
+        $this->_options['checkRules'] = (bool)$checkRules;
+        return $this;
+    }
+
+    /**
+     * Sets the atomic option.
+     *
+     * @param bool $atomic Atomic or not.
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function atomic($atomic)
+    {
+        $this->_options['atomic'] = (bool)$atomic;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->_options;
+    }
+
+    /**
+     * Whether a offset exists
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @param mixed $offset <p>
+     * An offset to check for.
+     * </p>
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->_options[$offset]);
+    }
+
+    /**
+     * Offset to retrieve
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @param mixed $offset <p>
+     * The offset to retrieve.
+     * </p>
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return $this->_options[$offset];
+    }
+
+    /**
+     * Offset to set
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @param mixed $offset <p>
+     * The offset to assign the value to.
+     * </p>
+     * @param mixed $value <p>
+     * The value to set.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->{$offset}($value);
+    }
+
+    /**
+     * Offset to unset
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @param mixed $offset <p>
+     * The offset to unset.
+     * </p>
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->_options[$offset]);
+    }
+}

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -67,11 +67,7 @@ class SaveOptionsBuilder extends ArrayObject
     public function parseArrayOptions($array)
     {
         foreach ($array as $key => $value) {
-            if (method_exists($this, $key)) {
-                $this->{$key}($value);
-                continue;
-            }
-            throw new \InvalidArgumentException(sprintf('Key `%s` is not a valid option!', $key));
+            $this->{$key}($value);
         }
         return $this;
     }
@@ -193,5 +189,18 @@ class SaveOptionsBuilder extends ArrayObject
     public function toArray()
     {
         return $this->_options;
+    }
+
+    /**
+     * Setting custom options.
+     *
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function __call($name, $args)
+    {
+        if (isset($args[0])) {
+            $this->_options[$name] = $args[0];
+            return $this;
+        }
     }
 }

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -70,6 +70,7 @@ class SaveOptionsBuilder extends ArrayObject
         foreach ($array as $key => $value) {
             $this->{$key}($value);
         }
+
         return $this;
     }
 
@@ -134,6 +135,7 @@ class SaveOptionsBuilder extends ArrayObject
     public function guard($guard)
     {
         $this->_options['guard'] = (bool)$guard;
+
         return $this;
     }
 
@@ -147,6 +149,7 @@ class SaveOptionsBuilder extends ArrayObject
     {
         $this->_table->validator($validate);
         $this->_options['validate'] = $validate;
+
         return $this;
     }
 
@@ -159,6 +162,7 @@ class SaveOptionsBuilder extends ArrayObject
     public function checkExisting($checkExisting)
     {
         $this->_options['checkExisting'] = (bool)$checkExisting;
+
         return $this;
     }
 
@@ -171,6 +175,7 @@ class SaveOptionsBuilder extends ArrayObject
     public function checkRules($checkRules)
     {
         $this->_options['checkRules'] = (bool)$checkRules;
+
         return $this;
     }
 
@@ -183,6 +188,7 @@ class SaveOptionsBuilder extends ArrayObject
     public function atomic($atomic)
     {
         $this->_options['atomic'] = (bool)$atomic;
+
         return $this;
     }
 
@@ -207,6 +213,7 @@ class SaveOptionsBuilder extends ArrayObject
             return $this->{$option}($value);
         }
         $this->_options[$option] = $value;
+
         return $this;
     }
 }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2371,6 +2371,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Gets a SaveOptionsBuilder instance.
      *
+     * @param array $options Options to load into the builder.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
     public function getSaveOptionsBuilder(array $options = [])

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2373,9 +2373,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\ORM\SaveOptionsBuilder
      */
-    public function getSaveOptionsBuilder()
+    public function getSaveOptionsBuilder(array $options = [])
     {
-        return new SaveOptionsBuilder();
+        return new SaveOptionsBuilder($this, $options);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1442,6 +1442,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function save(EntityInterface $entity, $options = [])
     {
+        if ($options instanceof SaveOptionsBuilder) {
+            $options = $options->toArray();
+        }
+
         $options = new ArrayObject($options + [
             'atomic' => true,
             'associated' => true,
@@ -2113,6 +2117,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function newEntity($data = null, array $options = [])
     {
+        if ($options instanceof SaveOptionsBuilder) {
+            $options = $options->toArray();
+        }
+
         if ($data === null) {
             $class = $this->entityClass();
             $entity = new $class([], ['source' => $this->registryAlias()]);
@@ -2157,6 +2165,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function newEntities(array $data, array $options = [])
     {
+        if ($options instanceof SaveOptionsBuilder) {
+            $options = $options->toArray();
+        }
+
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
         }
@@ -2198,6 +2210,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function patchEntity(EntityInterface $entity, array $data, array $options = [])
     {
+        if ($options instanceof SaveOptionsBuilder) {
+            $options = $options->toArray();
+        }
+
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
         }
@@ -2233,6 +2249,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function patchEntities($entities, array $data, array $options = [])
     {
+        if ($options instanceof SaveOptionsBuilder) {
+            $options = $options->toArray();
+        }
+
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
         }
@@ -2362,6 +2382,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function buildRules(RulesChecker $rules)
     {
         return $rules;
+    }
+
+    /**
+     * Gets a SaveOptionsBuilder instance.
+     *
+     * @return \Cake\ORM\SaveOptionsBuilder
+     */
+    public function getSaveOptionsBuilder()
+    {
+        return new SaveOptionsBuilder();
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2371,7 +2371,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Gets a SaveOptionsBuilder instance.
      *
-     * @param array $options Options to load into the builder.
+     * @param array $options Options to parse by the builder.
      * @return \Cake\ORM\SaveOptionsBuilder
      */
     public function getSaveOptionsBuilder(array $options = [])

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2117,10 +2117,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function newEntity($data = null, array $options = [])
     {
-        if ($options instanceof SaveOptionsBuilder) {
-            $options = $options->toArray();
-        }
-
         if ($data === null) {
             $class = $this->entityClass();
             $entity = new $class([], ['source' => $this->registryAlias()]);
@@ -2165,10 +2161,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function newEntities(array $data, array $options = [])
     {
-        if ($options instanceof SaveOptionsBuilder) {
-            $options = $options->toArray();
-        }
-
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
         }
@@ -2210,10 +2202,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function patchEntity(EntityInterface $entity, array $data, array $options = [])
     {
-        if ($options instanceof SaveOptionsBuilder) {
-            $options = $options->toArray();
-        }
-
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
         }
@@ -2249,10 +2237,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function patchEntities($entities, array $data, array $options = [])
     {
-        if ($options instanceof SaveOptionsBuilder) {
-            $options = $options->toArray();
-        }
-
         if (!isset($options['associated'])) {
             $options['associated'] = $this->_associations->keys();
         }

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -210,17 +210,18 @@ class SaveOptionsBuilderTest extends TestCase
     }
 
     /**
-     * Test setting user defined options using the magic __call()
+     * testSettingCustomOptions
      *
      * @return void
      */
-    public function testMagicCall()
+    public function testSettingCustomOptions()
     {
-        $options = [
+        $expected = [
             'myOption' => true,
         ];
 
-        $builder = new SaveOptionsBuilder($this->table, $options);
-        $this->assertEquals($options, $builder->toArray());
+        $builder = new SaveOptionsBuilder($this->table);
+        $builder->set('myOption', true);
+        $this->assertEquals($expected, $builder->toArray());
     }
 }

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Entity;
+use Cake\ORM\SaveOptionsBuilder;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * SaveOptionsBuilder test case.
+ */
+class SaveOptionsBuilderTest extends TestCase
+{
+
+    public $fixtures = [
+        'core.articles',
+        'core.authors',
+        'core.comments',
+        'core.users',
+    ];
+
+    /**
+     * setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+        $this->table = new Table([
+            'table' => 'articles',
+            'connection' => $this->connection,
+        ]);
+
+        $this->table->belongsTo('Authors');
+        $this->table->hasMany('Comments');
+        $this->table->Comments->belongsTo('Users');
+    }
+
+    /**
+     * testAssociatedChecks
+     *
+     * @return void
+     */
+    public function testAssociatedChecks()
+    {
+        $expected = [
+            'associated' => [
+                'Comments' => []
+            ]
+        ];
+        $builder = new SaveOptionsBuilder($this->table);
+        $builder->associated(
+            'Comments'
+        );
+        $result = $builder->toArray();
+        $this->assertEquals($expected, $result);
+
+        $expected = [
+            'associated' => [
+                'Comments' => [
+                    'associated' => [
+                        'Users' => []
+                    ]
+                ]
+            ]
+        ];
+        $builder = new SaveOptionsBuilder($this->table);
+        $builder->associated(
+            'Comments.Users'
+        );
+        $result = $builder->toArray();
+        $this->assertEquals($expected, $result);
+
+        try {
+            $builder = new SaveOptionsBuilder($this->table);
+            $builder->associated(
+                'Comments.DoesNotExist'
+            );
+            $this->fail('No \RuntimeException throw for invalid association!');
+        } catch (\RuntimeException $e) {
+        }
+
+        $expected = [
+            'associated' => [
+                'Comments' => [
+                    'associated' => [
+                        (int)0 => 'Users'
+                    ]
+                ]
+            ]
+        ];
+        $builder = new SaveOptionsBuilder($this->table);
+        $builder->associated([
+            'Comments' => [
+                'associated' => [
+                    'Users'
+                ]
+            ]
+        ]);
+        $result = $builder->toArray();
+        $this->assertEquals($expected, $result);
+
+        $expected = [
+            'associated' => [
+                'Authors' => [],
+                'Comments' => [
+                    'associated' => [
+                        (int)0 => 'Users'
+                    ]
+                ]
+            ]
+        ];
+        $builder = new SaveOptionsBuilder($this->table);
+        $builder->associated([
+            'Authors',
+            'Comments' => [
+                'associated' => [
+                    'Users'
+                ]
+            ]
+        ]);
+        $result = $builder->toArray();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * testBuilder
+     *
+     * @return void
+     */
+    public function testBuilder()
+    {
+        $expected = [
+            'associated' => [
+                'Authors' => [],
+                'Comments' => [
+                    'associated' => [
+                        (int)0 => 'Users'
+                    ]
+                ]
+            ],
+            'guard' => false,
+            'checkRules' => false,
+            'checkExisting' => true,
+            'atomic' => true,
+            'validate' => 'default'
+        ];
+
+        $builder = new SaveOptionsBuilder($this->table);
+        $builder->associated([
+            'Authors',
+            'Comments' => [
+                'associated' => [
+                    'Users'
+                ]
+            ]
+        ])
+        ->guard(false)
+        ->checkRules(false)
+        ->checkExisting(true)
+        ->atomic(true)
+        ->validate('default');
+
+        $result = $builder->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -210,16 +210,17 @@ class SaveOptionsBuilderTest extends TestCase
     }
 
     /**
-     * testParseOptionsArrayInvalidArgumentException
+     * Test setting user defined options using the magic __call()
      *
-     * @expectedException \InvalidArgumentException
+     * @return void
      */
-    public function testParseOptionsArrayInvalidArgumentException() {
+    public function testMagicCall()
+    {
         $options = [
-            'does-not-exist' => 'no-really',
-            'validate' => 'default'
+            'myOption' => true,
         ];
 
-        new SaveOptionsBuilder($this->table, $options);
+        $builder = new SaveOptionsBuilder($this->table, $options);
+        $this->assertEquals($options, $builder->toArray());
     }
 }

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -181,4 +181,45 @@ class SaveOptionsBuilderTest extends TestCase
         $result = $builder->toArray();
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * testParseOptionsArray
+     *
+     * @return void
+     */
+    public function testParseOptionsArray()
+    {
+        $options = [
+            'associated' => [
+                'Authors' => [],
+                'Comments' => [
+                    'associated' => [
+                        (int)0 => 'Users'
+                    ]
+                ]
+            ],
+            'guard' => false,
+            'checkRules' => false,
+            'checkExisting' => true,
+            'atomic' => true,
+            'validate' => 'default'
+        ];
+
+        $builder = new SaveOptionsBuilder($this->table, $options);
+        $this->assertEquals($options, $builder->toArray());
+    }
+
+    /**
+     * testParseOptionsArrayInvalidArgumentException
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testParseOptionsArrayInvalidArgumentException() {
+        $options = [
+            'does-not-exist' => 'no-really',
+            'validate' => 'default'
+        ];
+
+        new SaveOptionsBuilder($this->table, $options);
+    }
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3823,20 +3823,49 @@ class TableTest extends TestCase
      */
     public function testSaveWithOptionBuilder()
     {
-        $table = $this->getMockBuilder('\Cake\ORM\Table')
-            ->setMethods(['_processSave'])
-            ->getMock();
+        $articles = new Table([
+            'table' => 'articles',
+            'connection' => $this->connection,
+        ]);
+        $articles->belongsTo('Authors');
 
-        $optionBuilder = new SaveOptionsBuilder($table, [
+        $optionBuilder = new SaveOptionsBuilder($articles, [
+            'associated' => [
+                'Authors'
+            ]
+        ]);
+
+        $entity = $articles->newEntity([
+            'title' => 'test save options',
+            'author' => [
+                'name' => 'author name'
+            ]
+        ]);
+
+        $articles->save($entity, $optionBuilder);
+        $this->assertFalse($entity->isNew());
+        $this->assertEquals('test save options', $entity->title);
+        $this->assertNotEmpty($entity->id);
+        $this->assertNotEmpty($entity->author->id);
+        $this->assertEquals('author name', $entity->author->name);
+
+        $entity = $articles->newEntity([
+            'title' => 'test save options 2',
+            'author' => [
+                'name' => 'author name'
+            ]
+        ]);
+
+        $optionBuilder = new SaveOptionsBuilder($articles, [
             'associated' => []
         ]);
 
-        $entity = new \Cake\ORM\Entity(
-            ['id' => 'foo'],
-            ['markNew' => false, 'markClean' => true]
-        );
-
-        $this->assertSame($entity, $table->save($entity, $optionBuilder));
+        $articles->save($entity, $optionBuilder);
+        $this->assertFalse($entity->isNew());
+        $this->assertEquals('test save options 2', $entity->title);
+        $this->assertNotEmpty($entity->id);
+        $this->assertEmpty($entity->author->id);
+        $this->assertTrue($entity->author->isNew());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6012,6 +6012,18 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test getting the save options builder.
+     *
+     * @return void
+     */
+    public function getSaveOptionsBuilder()
+    {
+        $table = TableRegistry::get('Authors');
+        $result = $table->getSaveOptionsBuilder();
+        $this->assertInstanceOf('Cake\ORM\SaveOptionsBuilder', $result);
+    }
+
+    /**
      * Helper method to skip tests when connection is SQLServer.
      *
      * @return void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -32,6 +32,7 @@ use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
+use Cake\ORM\SaveOptionsBuilder;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -3812,6 +3813,30 @@ class TableTest extends TestCase
         ];
         $result = $articles->save($article);
         $this->assertSame($result, $article);
+    }
+
+    /**
+     * Test that a save call takes a SaveOptionBuilder object as well.
+     *
+     * @group save
+     * @return void
+     */
+    public function testSaveWithOptionBuilder()
+    {
+        $table = $this->getMockBuilder('\Cake\ORM\Table')
+            ->setMethods(['_processSave'])
+            ->getMock();
+
+        $optionBuilder = new SaveOptionsBuilder($table, [
+            'associated' => []
+        ]);
+
+        $entity = new \Cake\ORM\Entity(
+            ['id' => 'foo'],
+            ['markNew' => false, 'markClean' => true]
+        );
+
+        $this->assertSame($entity, $table->save($entity, $optionBuilder));
     }
 
     /**


### PR DESCRIPTION
The option builder allows building the options through a chainable interface and does checks on some of the options to prevent mistakes like types in the associations. This helps the developer and ensures everything that is supposed to be saved gets really set up and saved right.
