### PR TITLE
$query->selecet() to return fields array if no parameter

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -296,6 +296,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function select($fields = [], $overwrite = false)
     {
+        if (empty($fields)) {
+            return $this->_parts['select'];
+        }
+
         if (!is_string($fields) && is_callable($fields)) {
             $fields = $fields($this);
         }


### PR DESCRIPTION
I want to append the field `app_id` to the select by retrieve the query's fields selected from the Table event, I don't know if there is other way to achieve that

``` php
public function beforeFind(Event $event, Query $query, $options, $primary)
{
    if (sizeof($query->select()) > 0 && !in_array('app_id', $query->select())) {
        $query->select('app_id');
    }
}
```
