### PR TITLE
Make stripLinks a bit more thorough

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -506,12 +506,19 @@ class Text
     /**
      * Strips given text of all links (<a href=....).
      *
+     * *Warning* This method is not an robust solution in preventing XSS
+     * or malicious HTML.
+     *
      * @param string $text Text
      * @return string The text without links
+     * @deprecated 3.2.12 This method will be removed in 4.0.0
      */
     public static function stripLinks($text)
     {
-        return preg_replace('|<a\s+[^>]+>|im', '', preg_replace('|<\/a>|im', '', $text));
+        do {
+            $text = preg_replace('#</?a([/\s][^>]*)?(>|$)#i', '', $text, -1, $count);
+        } while ($count);
+        return $text;
     }
 
     /**

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -518,6 +518,7 @@ class Text
         do {
             $text = preg_replace('#</?a([/\s][^>]*)?(>|$)#i', '', $text, -1, $count);
         } while ($count);
+
         return $text;
     }
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -809,6 +809,15 @@ HTML;
         $expected = 'This <strong>is</strong> a test and <abbr>some</abbr> other text';
         $result = $this->Text->stripLinks($text);
         $this->assertEquals($expected, $result);
+
+        $text = '<a<a h> href=\'bla\'>test</a</a>>';
+        $this->assertEquals('test', $this->Text->stripLinks($text));
+
+        $text = '<a/href="#">test</a/>';
+        $this->assertEquals('test', $this->Text->stripLinks($text));
+
+        $text = '<a href="#"';
+        $this->assertEquals('', $this->Text->stripLinks($text));
     }
 
     /**


### PR DESCRIPTION
Recursively strip `a` elements to help ensure the output string is clean.

I'm also proposing that we deprecate this method. Using regular expressions to manipulate HTML is a dangerous game that inevitably fails in horrible ways.

/cc @chinpei215 
