### PR TITLE
Prevent unnecessary joins / complex conditions in delete

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -438,8 +438,9 @@ class Mysql extends DboSource {
 			$alias = $joins = false;
 		}
 		$complexConditions = false;
+		$fields = array_keys($this->describe($model));
 		foreach ((array)$conditions as $key => $value) {
-			if (strpos($key, '.') !== false && strpos($key, $model->alias) === false) {
+			if (strpos($key, $model->alias) === false && !in_array($key, $fields, true)) {
 				$complexConditions = true;
 				break;
 			}

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -439,7 +439,7 @@ class Mysql extends DboSource {
 		}
 		$complexConditions = false;
 		foreach ((array)$conditions as $key => $value) {
-			if (strpos($key, $model->alias) === false) {
+			if (strpos($key, '.') !== false && strpos($key, $model->alias) === false) {
 				$complexConditions = true;
 				break;
 			}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -4046,6 +4046,27 @@ SQL;
 	}
 
 /**
+ * Test deletes without complex conditions.
+ *
+ * @return void
+ */
+	public function testDeleteNoComplexCondition() {
+		$this->loadFixtures('Article', 'User');
+		$test = ConnectionManager::getDatasource('test');
+		$db = $test->config['database'];
+
+		$this->Dbo = $this->getMock('Mysql', array('execute'), array($test->config));
+
+		$this->Dbo->expects($this->at(0))->method('execute')
+			->with("DELETE `Article` FROM `$db`.`articles` AS `Article`   WHERE `id` = 1");
+
+		$Article = new Article();
+
+		$conditions = array('id' => 1);
+		$this->Dbo->delete($Article, $conditions);
+	}
+
+/**
  * Test truncate with a mock.
  *
  * @return void


### PR DESCRIPTION
Prevent unnecessary joins (complex conditions) in delete when there is no model alias given.
