### PR TITLE
Log a warning when headers have been sent.

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -16,6 +16,7 @@ namespace Cake\Network;
 
 use Cake\Core\Configure;
 use Cake\Filesystem\File;
+use Cake\Log\Log;
 use Cake\Network\Exception\NotFoundException;
 use DateTime;
 use DateTimeZone;
@@ -446,7 +447,10 @@ class Response
      */
     public function sendHeaders()
     {
-        if (headers_sent()) {
+        $file = $line = null;
+        if (headers_sent($file, $line)) {
+            Log::warning("Headers already sent in {$file}:{$line}");
+
             return;
         }
 


### PR DESCRIPTION
When headers have already been sent, we can be more helpful by logging a warning. I've chosen warning as generally production systems I've worked on have WARN+ enabled as those severity levels indicate issues that need humans to fix them.

Refs #9159
