### PR TITLE
Make missing associations fail more loudly.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -58,6 +58,7 @@ class Marshaller
      * Build the map of property => association names.
      *
      * @param array $options List of options containing the 'associated' key.
+     * @throws \RuntimeException When associations do not exist.
      * @return array
      */
     protected function _buildPropertyMap($options)
@@ -74,10 +75,18 @@ class Marshaller
                 $key = $nested;
                 $nested = [];
             }
-            $assoc = $this->_table->association($key);
-            if ($assoc) {
-                $map[$assoc->property()] = ['association' => $assoc] + $nested + ['associated' => []];
+            if ($key === '_joinData') {
+                continue;
             }
+            $assoc = $this->_table->association($key);
+            if (!$assoc) {
+                throw new RuntimeException(sprintf(
+                    'Cannot marshal data for "%s" association. It is not associated with "%s".',
+                    $key,
+                    $this->_table->alias()
+                ));
+            }
+            $map[$assoc->property()] = ['association' => $assoc] + $nested + ['associated' => []];
         }
 
         return $map;

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -323,6 +323,29 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test one() with an invalid association
+     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Cannot marshal data for "Derp" association. It is not associated with "Articles".
+     * @return void
+     */
+    public function testOneInvalidAssociation()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'derp' => [
+                'id' => 1,
+                'username' => 'mark',
+            ]
+        ];
+        $marshall = new Marshaller($this->articles);
+        $marshall->one($data, [
+            'associated' => ['Derp']
+        ]);
+    }
+
+    /**
      * Test one() supports accessibleFields option for associations
      *
      * @return void
@@ -1302,6 +1325,33 @@ class MarshallerTest extends TestCase
             'author_id' => 1
         ];
         $this->assertEquals($expected, $result->toArray());
+    }
+
+    /**
+     * Test merge() with an invalid association
+     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Cannot marshal data for "Derp" association. It is not associated with "Articles".
+     * @return void
+     */
+    public function testMergeInvalidAssociation()
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'derp' => [
+                'id' => 1,
+                'username' => 'mark',
+            ]
+        ];
+        $article = new Entity([
+           'title' => 'title for post',
+           'body' => 'body',
+        ]);
+        $marshall = new Marshaller($this->articles);
+        $marshall->merge($article, $data, [
+            'associated' => ['Derp']
+        ]);
     }
 
     /**


### PR DESCRIPTION
When a developer asks for an association that doesn't exist, we should let them know. Silent errors make the ORM harder to debug and understand.

Refs #9166
