### PR TITLE
Oauth: Fix bug in default creation of nonce values

### DIFF
--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -127,7 +127,7 @@ class Oauth
      */
     protected function _hmacSha1($request, $credentials)
     {
-        $nonce = isset($credentials['nonce']) ? $credentials['nonce'] : Security::randomBytes(16);
+        $nonce = isset($credentials['nonce']) ? $credentials['nonce'] : bin2hex(Security::randomBytes(16));
         $timestamp = isset($credentials['timestamp']) ? $credentials['timestamp'] : time();
         $values = [
             'oauth_version' => '1.0',
@@ -170,7 +170,7 @@ class Oauth
             throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
         }
 
-        $nonce = isset($credentials['nonce']) ? $credentials['nonce'] : Security::randomBytes(16);
+        $nonce = isset($credentials['nonce']) ? $credentials['nonce'] : bin2hex(Security::randomBytes(16));
         $timestamp = isset($credentials['timestamp']) ? $credentials['timestamp'] : time();
         $values = [
             'oauth_version' => '1.0',


### PR DESCRIPTION
Hey and sorry guys, I found a bug in my own further earlier pull request. The problem is, that `Security::randomBytes()` generates content that can't be really used inside a request. To fix this I convert the bytes into a hex string via `bin2hex`.

Modified files:
- Network/Http/Auth/Oauth.php
