### PR TITLE
Allow adding class name string to middware queue.

### DIFF
--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -78,7 +78,7 @@ class MiddlewareQueue implements Countable
                 ));
             }
 
-            $callable = new $class;
+            $callable = new $className;
         } else {
             $callable = $this->queue[$index];
         }

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -168,7 +168,9 @@ class MiddlewareQueue implements Countable
     {
         $found = false;
         foreach ($this->queue as $i => $object) {
-            if (is_a($object, $class)) {
+            if ((is_string($object) && $object === $class)
+                || is_a($object, $class)
+            ) {
                 $found = true;
                 break;
             }
@@ -194,7 +196,9 @@ class MiddlewareQueue implements Countable
     {
         $found = false;
         foreach ($this->queue as $i => $object) {
-            if (is_a($object, $class)) {
+            if ((is_string($object) && $object === $class)
+                || is_a($object, $class)
+            ) {
                 $found = true;
                 break;
             }

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -157,12 +157,12 @@ class MiddlewareQueue implements Countable
      * Insert a middleware object before the first matching class.
      *
      * Finds the index of the first middleware that matches the provided class,
-     * and inserts the supplied callable before it. If the class is not found,
-     * this method will behave like add().
+     * and inserts the supplied callable before it.
      *
      * @param string $class The classname to insert the middleware before.
      * @param callable|string $middleware The middleware to insert.
      * @return $this
+     * @throws \LogicException If middlware to insert before is not found.
      */
     public function insertBefore($class, $middleware)
     {

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -143,12 +143,12 @@ class MiddlewareQueue implements Countable
      * and the existing element will be shifted one index greater.
      *
      * @param int $index The index to insert at.
-     * @param callable $callable The callable to insert.
+     * @param callable|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertAt($index, callable $callable)
+    public function insertAt($index, $middleware)
     {
-        array_splice($this->queue, $index, 0, $callable);
+        array_splice($this->queue, $index, 0, $middleware);
 
         return $this;
     }
@@ -161,10 +161,10 @@ class MiddlewareQueue implements Countable
      * this method will behave like add().
      *
      * @param string $class The classname to insert the middleware before.
-     * @param callable $callable The middleware to insert
+     * @param callable|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertBefore($class, callable $callable)
+    public function insertBefore($class, $middleware)
     {
         $found = false;
         foreach ($this->queue as $i => $object) {
@@ -174,7 +174,7 @@ class MiddlewareQueue implements Countable
             }
         }
         if ($found) {
-            return $this->insertAt($i, $callable);
+            return $this->insertAt($i, $middleware);
         }
         throw new LogicException(sprintf("No middleware matching '%s' could be found.", $class));
     }
@@ -187,10 +187,10 @@ class MiddlewareQueue implements Countable
      * this method will behave like add().
      *
      * @param string $class The classname to insert the middleware before.
-     * @param callable $callable The middleware to insert
+     * @param callable|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertAfter($class, callable $callable)
+    public function insertAfter($class, $middleware)
     {
         $found = false;
         foreach ($this->queue as $i => $object) {
@@ -200,10 +200,10 @@ class MiddlewareQueue implements Countable
             }
         }
         if ($found) {
-            return $this->insertAt($i + 1, $callable);
+            return $this->insertAt($i + 1, $middleware);
         }
 
-        return $this->add($callable);
+        return $this->add($middleware);
     }
 
     /**

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -95,7 +95,9 @@ class MiddlewareQueue implements Countable
     public function add($middleware)
     {
         if (is_array($middleware)) {
-            return $this->queue = array_merge($this->queue, $middleware);
+            $this->queue = array_merge($this->queue, $middleware);
+
+            return $this;
         }
 
         $this->queue[] = $middleware;
@@ -124,7 +126,9 @@ class MiddlewareQueue implements Countable
     public function prepend($middleware)
     {
         if (is_array($middleware)) {
-            return $this->queue = array_merge($middleware, $this->queue);
+            $this->queue = array_merge($middleware, $this->queue);
+
+            return $this;
         }
 
         array_unshift($this->queue, $middleware);

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -44,6 +44,8 @@ class MiddlewareQueueTest extends TestCase
      */
     public function tearDown()
     {
+        parent::tearDown();
+
         Configure::write('App.namespace', $this->appNamespace);
     }
 

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -30,12 +30,12 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testGet()
     {
-        $stack = new MiddlewareQueue();
+        $queue = new MiddlewareQueue();
         $cb = function () {
         };
-        $stack->add($cb);
-        $this->assertSame($cb, $stack->get(0));
-        $this->assertNull($stack->get(1));
+        $queue->add($cb);
+        $this->assertSame($cb, $queue->get(0));
+        $this->assertNull($queue->get(1));
     }
 
 
@@ -46,10 +46,10 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testAddReturn()
     {
-        $stack = new MiddlewareQueue();
+        $queue = new MiddlewareQueue();
         $cb = function () {
         };
-        $this->assertSame($stack, $stack->add($cb));
+        $this->assertSame($queue, $queue->add($cb));
     }
 
     /**
@@ -64,17 +64,17 @@ class MiddlewareQueueTest extends TestCase
         $two = function () {
         };
 
-        $stack = new MiddlewareQueue();
-        $this->assertCount(0, $stack);
+        $queue = new MiddlewareQueue();
+        $this->assertCount(0, $queue);
 
-        $stack->add($one);
-        $this->assertCount(1, $stack);
+        $queue->add($one);
+        $this->assertCount(1, $queue);
 
-        $stack->add($two);
-        $this->assertCount(2, $stack);
+        $queue->add($two);
+        $this->assertCount(2, $queue);
 
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($two, $stack->get(1));
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($two, $queue->get(1));
     }
 
     /**
@@ -86,8 +86,8 @@ class MiddlewareQueueTest extends TestCase
     {
         $cb = function () {
         };
-        $stack = new MiddlewareQueue();
-        $this->assertSame($stack, $stack->prepend($cb));
+        $queue = new MiddlewareQueue();
+        $this->assertSame($queue, $queue->prepend($cb));
     }
 
     /**
@@ -102,17 +102,17 @@ class MiddlewareQueueTest extends TestCase
         $two = function () {
         };
 
-        $stack = new MiddlewareQueue();
-        $this->assertCount(0, $stack);
+        $queue = new MiddlewareQueue();
+        $this->assertCount(0, $queue);
 
-        $stack->add($one);
-        $this->assertCount(1, $stack);
+        $queue->add($one);
+        $this->assertCount(1, $queue);
 
-        $stack->prepend($two);
-        $this->assertCount(2, $stack);
+        $queue->prepend($two);
+        $this->assertCount(2, $queue);
 
-        $this->assertSame($two, $stack->get(0));
-        $this->assertSame($one, $stack->get(1));
+        $this->assertSame($two, $queue->get(0));
+        $this->assertSame($one, $queue->get(1));
     }
 
     /**
@@ -129,17 +129,17 @@ class MiddlewareQueueTest extends TestCase
         $three = function () {
         };
 
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->add($two)->insertAt(0, $three);
-        $this->assertSame($three, $stack->get(0));
-        $this->assertSame($one, $stack->get(1));
-        $this->assertSame($two, $stack->get(2));
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->add($two)->insertAt(0, $three);
+        $this->assertSame($three, $queue->get(0));
+        $this->assertSame($one, $queue->get(1));
+        $this->assertSame($two, $queue->get(2));
 
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->add($two)->insertAt(1, $three);
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($three, $stack->get(1));
-        $this->assertSame($two, $stack->get(2));
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->add($two)->insertAt(1, $three);
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($three, $queue->get(1));
+        $this->assertSame($two, $queue->get(2));
     }
 
     /**
@@ -154,12 +154,12 @@ class MiddlewareQueueTest extends TestCase
         $two = function () {
         };
 
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->insertAt(99, $two);
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->insertAt(99, $two);
 
-        $this->assertCount(2, $stack);
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($two, $stack->get(1));
+        $this->assertCount(2, $queue);
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($two, $queue->get(1));
     }
 
     /**
@@ -174,12 +174,12 @@ class MiddlewareQueueTest extends TestCase
         $two = function () {
         };
 
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->insertAt(-1, $two);
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->insertAt(-1, $two);
 
-        $this->assertCount(2, $stack);
-        $this->assertSame($two, $stack->get(0));
-        $this->assertSame($one, $stack->get(1));
+        $this->assertCount(2, $queue);
+        $this->assertSame($two, $queue->get(0));
+        $this->assertSame($one, $queue->get(1));
     }
 
     /**
@@ -194,13 +194,13 @@ class MiddlewareQueueTest extends TestCase
         $two = new SampleMiddleware();
         $three = function () {
         };
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->add($two)->insertBefore(SampleMiddleware::class, $three);
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->add($two)->insertBefore(SampleMiddleware::class, $three);
 
-        $this->assertCount(3, $stack);
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($three, $stack->get(1));
-        $this->assertSame($two, $stack->get(2));
+        $this->assertCount(3, $queue);
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($three, $queue->get(1));
+        $this->assertSame($two, $queue->get(2));
     }
 
     /**
@@ -217,8 +217,8 @@ class MiddlewareQueueTest extends TestCase
         $two = new SampleMiddleware();
         $three = function () {
         };
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->add($two)->insertBefore('InvalidClassName', $three);
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->add($two)->insertBefore('InvalidClassName', $three);
     }
 
     /**
@@ -233,13 +233,13 @@ class MiddlewareQueueTest extends TestCase
         };
         $three = function () {
         };
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->add($two)->insertAfter(SampleMiddleware::class, $three);
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->add($two)->insertAfter(SampleMiddleware::class, $three);
 
-        $this->assertCount(3, $stack);
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($three, $stack->get(1));
-        $this->assertSame($two, $stack->get(2));
+        $this->assertCount(3, $queue);
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($three, $queue->get(1));
+        $this->assertSame($two, $queue->get(2));
     }
 
     /**
@@ -254,12 +254,12 @@ class MiddlewareQueueTest extends TestCase
         };
         $three = function () {
         };
-        $stack = new MiddlewareQueue();
-        $stack->add($one)->add($two)->insertAfter('InvalidClass', $three);
+        $queue = new MiddlewareQueue();
+        $queue->add($one)->add($two)->insertAfter('InvalidClass', $three);
 
-        $this->assertCount(3, $stack);
-        $this->assertSame($one, $stack->get(0));
-        $this->assertSame($two, $stack->get(1));
-        $this->assertSame($three, $stack->get(2));
+        $this->assertCount(3, $queue);
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($two, $queue->get(1));
+        $this->assertSame($three, $queue->get(2));
     }
 }

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Http;
 
+use Cake\Core\Configure;
 use Cake\Http\MiddlewareQueue;
 use Cake\TestSuite\TestCase;
 use TestApp\Middleware\SampleMiddleware;
@@ -37,7 +38,6 @@ class MiddlewareQueueTest extends TestCase
         $this->assertSame($cb, $queue->get(0));
         $this->assertNull($queue->get(1));
     }
-
 
     /**
      * Test the return value of add()
@@ -112,6 +112,44 @@ class MiddlewareQueueTest extends TestCase
         $this->assertCount(2, $queue);
 
         $this->assertSame($two, $queue->get(0));
+        $this->assertSame($one, $queue->get(1));
+    }
+
+    /**
+     * Test updating queue using class name
+     *
+     * @return void
+     */
+    public function testAddingPrependingUsingString()
+    {
+        $appNamespace = Configure::read('App.namespace');
+        Configure::write('App.namespace', 'TestApp');
+
+        $queue = new MiddlewareQueue();
+        $queue->add('Sample');
+        $queue->prepend('TestApp\Middleware\SampleMiddleware');
+
+        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(0));
+        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(1));
+
+        Configure::write('App.namespace', $appNamespace);
+    }
+
+    /**
+     * Test updating queue using array
+     *
+     * @return void
+     */
+    public function testAddingPrependingUsingArray()
+    {
+        $one = function () {
+        };
+
+        $queue = new MiddlewareQueue();
+        $queue->add([$one]);
+        $queue->prepend(['TestApp\Middleware\SampleMiddleware']);
+
+        $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(0));
         $this->assertSame($one, $queue->get(1));
     }
 

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -44,7 +44,7 @@ class MiddlewareQueueTest extends TestCase
      *
      * @return void
      */
-    public function testPushReturn()
+    public function testAddReturn()
     {
         $stack = new MiddlewareQueue();
         $cb = function () {
@@ -57,7 +57,7 @@ class MiddlewareQueueTest extends TestCase
      *
      * @return void
      */
-    public function testPushOrdering()
+    public function testAddOrdering()
     {
         $one = function () {
         };

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -25,6 +25,29 @@ use TestApp\Middleware\SampleMiddleware;
 class MiddlewareQueueTest extends TestCase
 {
     /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->appNamespace = Configure::read('App.namespace');
+        Configure::write('App.namespace', 'TestApp');
+    }
+
+    /**
+     * tearDown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        Configure::write('App.namespace', $this->appNamespace);
+    }
+
+    /**
      * Test get()
      *
      * @return void
@@ -122,17 +145,12 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testAddingPrependingUsingString()
     {
-        $appNamespace = Configure::read('App.namespace');
-        Configure::write('App.namespace', 'TestApp');
-
         $queue = new MiddlewareQueue();
         $queue->add('Sample');
         $queue->prepend('TestApp\Middleware\SampleMiddleware');
 
         $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(0));
         $this->assertInstanceOf('TestApp\Middleware\SampleMiddleware', $queue->get(1));
-
-        Configure::write('App.namespace', $appNamespace);
     }
 
     /**
@@ -239,6 +257,18 @@ class MiddlewareQueueTest extends TestCase
         $this->assertSame($one, $queue->get(0));
         $this->assertSame($three, $queue->get(1));
         $this->assertSame($two, $queue->get(2));
+
+        $two = SampleMiddleware::class;
+        $queue = new MiddlewareQueue();
+        $queue
+            ->add($one)
+            ->add($two)
+            ->insertBefore(SampleMiddleware::class, $three);
+
+        $this->assertCount(3, $queue);
+        $this->assertSame($one, $queue->get(0));
+        $this->assertSame($three, $queue->get(1));
+        $this->assertInstanceOf(SampleMiddleware::class, $queue->get(2));
     }
 
     /**
@@ -276,6 +306,18 @@ class MiddlewareQueueTest extends TestCase
 
         $this->assertCount(3, $queue);
         $this->assertSame($one, $queue->get(0));
+        $this->assertSame($three, $queue->get(1));
+        $this->assertSame($two, $queue->get(2));
+
+        $one = 'Sample';
+        $queue = new MiddlewareQueue();
+        $queue
+            ->add($one)
+            ->add($two)
+            ->insertAfter('Sample', $three);
+
+        $this->assertCount(3, $queue);
+        $this->assertInstanceOf(SampleMiddleware::class, $queue->get(0));
         $this->assertSame($three, $queue->get(1));
         $this->assertSame($two, $queue->get(2));
     }


### PR DESCRIPTION
The strings are resolved to class instance when Middleware::get() is called.

Also for convenience add()/push() and prepend() can now take an array of middlewares.

I will add tests and also update other methods to accept strings if the changes are approved.
