### PR TITLE
mcrypt extension is deprecated in PHP7.1

### DIFF
--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -20,6 +20,7 @@ namespace Cake\Utility\Crypto;
  * This class is not intended to be used directly and should only
  * be used in the context of Cake\Utility\Security.
  *
+ * @deprecated 3.3.0 It is recommended to use {@see Cake\Utility\Crypto\OpenSsl} instead.
  * @internal
  */
 class Mcrypt


### PR DESCRIPTION
ref https://github.com/tpunt/PHP7-Reference/blob/master/php71-reference.md#deprecation-of-extmcrypt

Note that this class is marked `@internal` so it won't be generated in the api deprecation list but IDE should still warn the users.
