### PR TITLE
Throw exception when passing input as type option to FormHelper::input

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1025,7 +1025,7 @@ class FormHelper extends Helper
         $options += ['id' => $this->_domId($fieldName)];
 
         if (strtolower($options['type']) === 'input') {
-                throw new Exception(sprintf('Input is an invalid type option for input field %s', $fieldName));
+                throw new RuntimeException(sprintf('Invalid type "input" used for field "%s"', $fieldName));
         }
 
         $templater = $this->templater();

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1024,7 +1024,7 @@ class FormHelper extends Helper
         $options = $this->_parseOptions($fieldName, $options);
         $options += ['id' => $this->_domId($fieldName)];
 
-        if (strtolower($options['type']) == 'input') {
+        if (strtolower($options['type']) === 'input') {
                 throw new Exception(sprintf('Input is an invalid type option for input field %s', $fieldName));
         }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1024,6 +1024,10 @@ class FormHelper extends Helper
         $options = $this->_parseOptions($fieldName, $options);
         $options += ['id' => $this->_domId($fieldName)];
 
+        if (strtolower($options['type']) == 'input') {
+                throw new Exception(sprintf('Input is an invalid type option for input field %s', $fieldName));
+        }
+
         $templater = $this->templater();
         $newTemplates = $options['templates'];
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3680,6 +3680,28 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Test invalid 'input' type option to input() function.
+     *
+     * @expectedException \RuntimeException
+     * @return void
+     */
+    public function testInvalidInputTypeOptionLowercase()
+    {
+        $this->Form->input('text', ['type' => 'input']);
+    }
+
+    /**
+     * Test invalid 'Input' type option to input() function.
+     *
+     * @expectedException \RuntimeException
+     * @return void
+     */
+    public function testInvalidInputTypeOptionUppercase()
+    {
+        $this->Form->input('text', ['type' => 'Input']);
+    }
+
+    /**
      * Test that magic input() selects can easily be converted into radio types without error.
      *
      * @return void


### PR DESCRIPTION
Throw exception when passing input as type option to FormHelper::input.
This is to prevent the infinite loop being created and gives the user better feedback than needing to debug.

As reported in issue #9185 
