### PR TITLE
Fix issues loading nested associations on belongsToMany junction tables.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -431,7 +431,14 @@ class BelongsToMany extends Association
                     $property
                 ));
             }
-            $result[$this->_junctionProperty] = $result[$property];
+            $junctionData = $result[$property];
+
+            // Account for incorrectly nested data from hasMany
+            // bindings when junction tables have additional associations loaded
+            if (isset($result[$property][0])) {
+                $junctionData = $result[$property][0];
+            }
+            $result[$this->_junctionProperty] = $junctionData;
             unset($result[$property]);
 
             if ($hydrated) {
@@ -1245,7 +1252,12 @@ class BelongsToMany extends Association
             ->where($this->junctionConditions())
             ->select($query->aliasFields((array)$assoc->foreignKey(), $name));
 
-        $assoc->attachTo($query);
+        // If this hasMany attaches any other containments, then the junction
+        // table is queried twice. Ideally the EagerLoader could resolve the duplication,
+        // and merge the resulting eagerloadable instances.
+        //
+        // We have to define aliasPath, so any nested contains will work.
+        $assoc->attachTo($query, ['aliasPath' => $assoc->alias()]);
 
         return $query;
     }

--- a/tests/Fixture/TranslatesFixture.php
+++ b/tests/Fixture/TranslatesFixture.php
@@ -80,5 +80,6 @@ class TranslatesFixture extends TestFixture
         ['locale' => 'eng', 'model' => 'Authors', 'foreign_key' => 1, 'field' => 'name', 'content' => 'May-rianoh'],
         ['locale' => 'dan', 'model' => 'NumberTrees', 'foreign_key' => 1, 'field' => 'name', 'content' => 'Elektroniker'],
         ['locale' => 'dan', 'model' => 'NumberTrees', 'foreign_key' => 11, 'field' => 'name', 'content' => 'Alien Tingerne'],
+        ['locale' => 'eng', 'model' => 'SpecialTags', 'foreign_key' => 2, 'field' => 'highlighted_time', 'content' => 'Translated Time'],
     ];
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -44,6 +44,8 @@ class TranslateBehaviorTest extends TestCase
     public $fixtures = [
         'core.articles',
         'core.authors',
+        'core.special_tags',
+        'core.tags',
         'core.comments',
         'core.translates'
     ];
@@ -659,6 +661,28 @@ class TranslateBehaviorTest extends TestCase
             return $r->toArray();
         }, $results->toArray());
         $this->assertEquals($expected, $results);
+    }
+
+    /**
+     * Tests that it is possible to translate belongsToMany associations
+     *
+     * @return void
+     */
+    public function testFindSingleLocaleBelongsToMany()
+    {
+        $table = TableRegistry::get('Articles');
+        $specialTags = TableRegistry::get('SpecialTags');
+        $specialTags->addBehavior('Translate', ['fields' => ['highlighted_time']]);
+
+        $table->belongsToMany('Tags', [
+            'through' => $specialTags
+        ]);
+        $specialTags->locale('eng');
+
+        $result = $table->get(2, ['contain' => 'Tags']);
+        $this->assertNotEmpty($result);
+        $this->assertNotEmpty($result->tags);
+        $this->assertEquals('Translated Time', $result->tags[0]->_joinData->highlighted_time);
     }
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1128,6 +1128,37 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Tests that it is possible to contain to fetch
+     * associations off of a junction table.
+     *
+     * @return void
+     */
+    public function testBelongsToManyJoinDataAssociation()
+    {
+        $articles = TableRegistry::get('Articles');
+
+        $tags = TableRegistry::get('Tags');
+        $tags->hasMany('SpecialTags');
+
+        $specialTags = TableRegistry::get('SpecialTags');
+        $specialTags->belongsTo('Authors');
+        $specialTags->belongsTo('Articles');
+        $specialTags->belongsTo('Tags');
+
+        $articles->belongsToMany('Tags', [
+            'through' => $specialTags
+        ]);
+        $query = $articles->find()
+            ->contain(['Tags', 'Tags.SpecialTags.Authors'])
+            ->where(['Articles.id' => 1]);
+        $result = $query->first();
+        $this->assertNotEmpty($result->tags, 'Missing tags');
+        $this->assertNotEmpty($result->tags[0], 'Missing first tag');
+        $this->assertNotEmpty($result->tags[0]->_joinData, 'Missing _joinData');
+        $this->assertNotEmpty($result->tags[0]->_joinData->author, 'Missing author on _joinData');
+    }
+
+    /**
      * Tests that it is possible to use matching with dot notation
      * even when part of the part of the path in the dot notation is
      * shared for two different calls


### PR DESCRIPTION
In #8485 an issue with TranslateBehavior was reported, after doing some poking around, the issue is applies to any nested associations that are loaded from a belongsToMany junction table. I've added tests for both the translate scenario, and the general case.

I don't think I've made an ideal solution by any means, and would appreciate any alternatives.

cc @lorenzo 
