### PR TITLE
Avoiding circular object reference in SmptTransport

### DIFF
--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -226,6 +226,7 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Prepares the `from` email address.
  *
+ * @param CakeEmail $email CakeEmail
  * @return array
  */
 	protected function _prepareFromAddress($email) {
@@ -239,9 +240,10 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Prepares the recipient email addresses.
  *
+ * @param CakeEmail $email CakeEmail
  * @return array
  */
-	protected function _prepareRecipientAddresses($email) {
+	protected function _prepareRecipientAddresses(CakeEmail $email) {
 		$to = $email->to();
 		$cc = $email->cc();
 		$bcc = $email->bcc();
@@ -251,18 +253,20 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Prepares the message headers.
  *
+ * @param CakeEmail $email CakeEmail
  * @return array
  */
-	protected function _prepareMessageHeaders($email) {
+	protected function _prepareMessageHeaders(CakeEmail $email) {
 		return $email->getHeaders(array('from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject'));
 	}
 
 /**
  * Prepares the message body.
  *
+ * @param CakeEmail $email CakeEmail
  * @return string
  */
-	protected function _prepareMessage($email) {
+	protected function _prepareMessage(CakeEmail $email) {
 		$lines = $email->message();
 		$messages = array();
 		foreach ($lines as $line) {
@@ -278,10 +282,11 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Send emails
  *
+ * @param CakeEmail $email CakeEmail
  * @return void
  * @throws SocketException
  */
-	protected function _sendRcpt($email) {
+	protected function _sendRcpt(CakeEmail $email) {
 		$from = $this->_prepareFromAddress($email);
 		$this->_smtpSend($this->_prepareFromCmd(key($from)));
 
@@ -294,10 +299,11 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Send Data
  *
+ * @param CakeEmail $email CakeEmail
  * @return void
  * @throws SocketException
  */
-	protected function _sendData($email) {
+	protected function _sendData(CakeEmail $email) {
 		$this->_smtpSend('DATA', '354');
 
 		$headers = $this->_headersToString($this->_prepareMessageHeaders($email));

--- a/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
@@ -36,16 +36,6 @@ class SmtpTestTransport extends SmtpTransport {
 	}
 
 /**
- * Helper to change the CakeEmail
- *
- * @param object $cakeEmail An email object.
- * @return void
- */
-	public function setCakeEmail($cakeEmail) {
-		$this->_cakeEmail = $cakeEmail;
-	}
-
-/**
  * Disabled the socket change
  *
  * @return void
@@ -348,8 +338,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->socket->expects($this->at(13))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(14))->method('read')->will($this->returnValue("250 OK\r\n"));
 
-		$this->SmtpTransport->setCakeEmail($email);
-		$this->SmtpTransport->sendRcpt();
+		$this->SmtpTransport->sendRcpt($email);
 	}
 
 /**
@@ -370,8 +359,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->socket->expects($this->at(4))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(5))->method('read')->will($this->returnValue("250 OK\r\n"));
 
-		$this->SmtpTransport->setCakeEmail($email);
-		$this->SmtpTransport->sendRcpt();
+		$this->SmtpTransport->sendRcpt($email);
 	}
 
 /**
@@ -416,8 +404,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->socket->expects($this->at(4))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(5))->method('read')->will($this->returnValue("250 OK\r\n"));
 
-		$this->SmtpTransport->setCakeEmail($email);
-		$this->SmtpTransport->sendData();
+		$this->SmtpTransport->sendData($email);
 	}
 
 /**
@@ -498,8 +485,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->socket->expects($this->at(4))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(5))->method('read')->will($this->returnValue("250 OK\r\n"));
 
-		$this->SmtpTransport->setCakeEmail($email);
-		$this->SmtpTransport->sendRcpt();
+		$this->SmtpTransport->sendRcpt($email);
 
 		$expected = array(
 			array('code' => '250', 'message' => 'OK'),


### PR DESCRIPTION
This fixes a memory leak while sending multiple emails.

Fixes: #9198
