### PR TITLE
Consistency improvement: Type declaration of CakeEmail parameter.

### DIFF
--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -229,7 +229,7 @@ class SmtpTransport extends AbstractTransport {
  * @param CakeEmail $email CakeEmail
  * @return array
  */
-	protected function _prepareFromAddress($email) {
+	protected function _prepareFromAddress(CakeEmail $email) {
 		$from = $email->returnPath();
 		if (empty($from)) {
 			$from = $email->from();


### PR DESCRIPTION
This is something I missed in my previous commits (#9199) which are already merged.

I'm sorry if this is kind of useless, but I think consistency is important and it might help to differentiate between an `$email object` and  an `$email string`.
