### PR TITLE
Take into account the content-type for the response

### DIFF
--- a/src/Http/ResponseTransformer.php
+++ b/src/Http/ResponseTransformer.php
@@ -51,7 +51,12 @@ class ResponseTransformer
         foreach ($cookies as $cookie) {
             $cake->cookie($cookie);
         }
-        $cake->header(static::collapseHeaders($response));
+        $headers = static::collapseHeaders($response);
+        $cake->header($headers);
+ 
+        if (!empty($headers['Content-Type'])) {
+            $cake->type($headers['Content-Type']);
+        }
 
         return $cake;
     }


### PR DESCRIPTION
The response transformer forgets to set the content type for the CakePHP response object when converting from PSR-7. This especially causes issues for integration tests.
