### PR TITLE
Change authorization chaining to return false

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -498,14 +498,14 @@ class AuthComponent extends Component
             $this->constructAuthorize();
         }
         foreach ($this->_authorizeObjects as $authorizer) {
-            if ($authorizer->authorize($user, $request) === true) {
+            if ($authorizer->authorize($user, $request) === false) {
                 $this->_authorizationProvider = $authorizer;
 
-                return true;
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
My understanding of the flow of authorization with more than one adaptor configured in the AuthComponent 'authorize'-Array is as follows:

When an adaptor returns "false" then there is no need to proceed to the next adaptor in the array.
But if we return 'true' this specific adaptor allows access but one does not know, if the next one will also. 

So proceed o to the next adaptor and allow the next one to check authorization.

Finally if all adaptors return true then we can allow access.

Currently it is vice versa. The first adaptor returning 'true' stops propagation and chaning and access is granted. But this will stop other adaptors from checking access too.
