### PR TITLE
CLI renderer should use inner exception for PHP7ErrorException instance

### DIFF
--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -16,6 +16,7 @@ namespace Cake\Console;
 
 use Cake\Error\BaseErrorHandler;
 use Cake\Error\FatalErrorException;
+use Cake\Error\PHP7ErrorException;
 use Exception;
 
 /**
@@ -83,6 +84,11 @@ class ConsoleErrorHandler extends BaseErrorHandler
         if ($exception instanceof FatalErrorException) {
             $errorName = 'Fatal Error:';
         }
+
+        if ($exception instanceof PHP7ErrorException) {
+            $exception = $exception->getError();
+        }
+
         $message = sprintf(
             "<error>%s</error> %s in [%s, line %s]",
             $errorName,


### PR DESCRIPTION
This will ensure a proper stacktrace and error message in CLI

**before**

```
Exception: (ParseError) - syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ')' in [/var/www/insights/htdocs/vendor/cakephp/cakephp/src/Error/BaseErrorHandler.php, line 162]
Thu, 04 Aug 2016 10:19:25 +0000 - error     - [ParseError] syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ')'
Stack Trace:
```

**after**

```
-> bin/cake alert server
Exception: syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ')' in [/var/www/insights/htdocs/vendor/bownty/base/src/Shell/Task/RabbitMQWorkerTask.php, line 115]
Thu, 04 Aug 2016 10:19:18 +0000 - error     - [ParseError] syntax error, unexpected '->' (T_OBJECT_OPERATOR), expecting ')'
Stack Trace:
```
