### PR TITLE
[3.3] Implement TypeInterface from Type

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -21,7 +21,7 @@ use PDO;
  * Encapsulates all conversion functions for values coming from database into PHP and
  * going from PHP into database.
  */
-class Type
+class Type implements TypeInterface
 {
 
     /**

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Core\Exception\Exception;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use PDO;
 
@@ -25,7 +26,7 @@ use PDO;
  *
  * Use to convert binary data between PHP and the database types.
  */
-class BinaryType implements TypeInterface
+class BinaryType extends Type implements TypeInterface
 {
 
     /**
@@ -43,19 +44,6 @@ class BinaryType implements TypeInterface
     public function __construct($name = null)
     {
         $this->_name = $name;
-    }
-
-    /**
-     * Returns the base type name that this class is inheriting.
-     * This is useful when extending base type for adding extra functionality
-     * but still want the rest of the framework to use the same assumptions it would
-     * do about the base type it inherits from.
-     *
-     * @return string
-     */
-    public function getBaseType()
-    {
-        return $this->_name;
     }
 
     /**

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
+use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use InvalidArgumentException;
 use PDO;
@@ -24,7 +25,7 @@ use PDO;
  *
  * Use to convert bool data between PHP and the database types.
  */
-class BoolType implements TypeInterface
+class BoolType extends Type implements TypeInterface
 {
 
     /**
@@ -42,19 +43,6 @@ class BoolType implements TypeInterface
     public function __construct($name = null)
     {
         $this->_name = $name;
-    }
-
-    /**
-     * Returns the base type name that this class is inheriting.
-     * This is useful when extending base type for adding extra functionality
-     * but still want the rest of the framework to use the same assumptions it would
-     * do about the base type it inherits from.
-     *
-     * @return string
-     */
-    public function getBaseType()
-    {
-        return $this->_name;
     }
 
     /**

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
+use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use DateTimeInterface;
 use Exception;
@@ -26,7 +27,7 @@ use RuntimeException;
  *
  * Use to convert datetime instances to strings & back.
  */
-class DateTimeType implements TypeInterface
+class DateTimeType extends Type implements TypeInterface
 {
 
     /**

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
+use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use PDO;
 use RuntimeException;
@@ -24,7 +25,7 @@ use RuntimeException;
  *
  * Use to convert float/decimal data between PHP and the database types.
  */
-class FloatType implements TypeInterface
+class FloatType extends Type implements TypeInterface
 {
 
     /**
@@ -42,19 +43,6 @@ class FloatType implements TypeInterface
     public function __construct($name = null)
     {
         $this->_name = $name;
-    }
-
-    /**
-     * Returns the base type name that this class is inheriting.
-     * This is useful when extending base type for adding extra functionality
-     * but still want the rest of the framework to use the same assumptions it would
-     * do about the base type it inherits from.
-     *
-     * @return string
-     */
-    public function getBaseType()
-    {
-        return $this->_name;
     }
 
     /**

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
+use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use InvalidArgumentException;
 use PDO;
@@ -24,52 +25,8 @@ use PDO;
  *
  * Use to convert integer data between PHP and the database types.
  */
-class IntegerType implements TypeInterface
+class IntegerType extends Type implements TypeInterface
 {
-
-    /**
-     * Identifier name for this type
-     *
-     * @var string|null
-     */
-    protected $_name = null;
-
-    /**
-     * Constructor
-     *
-     * @param string|null $name The name identifying this type
-     */
-    public function __construct($name = null)
-    {
-        $this->_name = $name;
-    }
-
-    /**
-     * Returns the base type name that this class is inheriting.
-     * This is useful when extending base type for adding extra functionality
-     * but still want the rest of the framework to use the same assumptions it would
-     * do about the base type it inherits from.
-     *
-     * @return string
-     */
-    public function getBaseType()
-    {
-        return $this->_name;
-    }
-
-    /**
-     * Generate a new primary key value for a given type.
-     *
-     * This method can be used by types to create new primary key values
-     * when entities are inserted.
-     *
-     * @return mixed A new primary key value.
-     * @see \Cake\Database\Type\UuidType
-     */
-    public function newId()
-    {
-        return null;
-    }
 
     /**
      * Convert integer data into the database format.

--- a/src/Database/TypeInterface.php
+++ b/src/Database/TypeInterface.php
@@ -58,4 +58,14 @@ interface TypeInterface
      * @return mixed Converted value.
      */
     public function marshal($value);
+
+    /**
+     * Returns the base type name that this class is inheriting.
+     * This is useful when extending base type for adding extra functionality
+     * but still want the rest of the framework to use the same assumptions it would
+     * do about the base type it inherits from.
+     *
+     * @return string
+     */
+    public function getBaseType();
 }


### PR DESCRIPTION
Existing user land applications and plugins that provide database
types extend the Type class. The changes in #9170 changed the
instanceof check to use TypeInterface causing issues for plugins
trying to support both pre 3.3 and post 3.3 releases.

This change makes sure the Type class implements the TypeInterface
making sure existing type implementations will work with the new
instanceof check.
