### PR TITLE
[3.3] Implement TypeInterface from Type

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -21,7 +21,7 @@ use PDO;
  * Encapsulates all conversion functions for values coming from database into PHP and
  * going from PHP into database.
  */
-class Type
+class Type implements TypeInterface
 {
 
     /**


### PR DESCRIPTION
Existing user land applications and plugins that provide database
types extend the Type class. The changes in #9170 changed the
instanceof check to use TypeInterface causing issues for plugins
trying to support both pre 3.3 and post 3.3 releases.

This change makes sure the Type class implements the TypeInterface
making sure existing type implementations will work with the new
instanceof check.

Moved to master from #9221.
