### PR TITLE
Include the remaining methods in TypeInterface.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -174,9 +174,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Returns type identifier name for this object
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getName()
     {
@@ -184,12 +182,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Returns the base type name that this class is inheriting.
-     * This is useful when extending base type for adding extra functionality
-     * but still want the rest of the framework to use the same assumptions it would
-     * do about the base type it inherits from.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getBaseType()
     {
@@ -197,11 +190,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Casts given value from a PHP type to one acceptable by database
-     *
-     * @param mixed $value value to be converted to database equivalent
-     * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
-     * @return mixed
+     * {@inheritDoc}
      */
     public function toDatabase($value, Driver $driver)
     {
@@ -244,11 +233,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Casts give value to Statement equivalent
-     *
-     * @param mixed $value value to be converted to PHP equivalent
-     * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
-     * @return mixed
+     * {@inheritDoc}
      */
     public function toStatement($value, Driver $driver)
     {
@@ -296,13 +281,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Generate a new primary key value for a given type.
-     *
-     * This method can be used by types to create new primary key values
-     * when entities are inserted.
-     *
-     * @return mixed A new primary key value.
-     * @see \Cake\Database\Type\UuidType
+     * {@inheritDoc}
      */
     public function newId()
     {
@@ -310,13 +289,7 @@ class Type implements TypeInterface
     }
 
     /**
-     * Marshalls flat data into PHP objects.
-     *
-     * Most useful for converting request data into PHP objects
-     * that make sense for the rest of the ORM/Database layers.
-     *
-     * @param mixed $value The value to convert.
-     * @return mixed Converted value.
+     * {@inheritDoc}
      */
     public function marshal($value)
     {

--- a/src/Database/TypeInterface.php
+++ b/src/Database/TypeInterface.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.2.13
+ * @since         3.2.14
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Database;
@@ -68,4 +68,22 @@ interface TypeInterface
      * @return string
      */
     public function getBaseType();
+
+    /**
+     * Returns type identifier name for this object
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Generate a new primary key value for a given type.
+     *
+     * This method can be used by types to create new primary key values
+     * when entities are inserted.
+     *
+     * @return mixed A new primary key value.
+     * @see \Cake\Database\Type\UuidType
+     */
+    public function newId();
 }


### PR DESCRIPTION
A few methods were missed originally, and now that Type implements the interface we can streamline the API docs as well.
