### PR TITLE
Work around Apache handling the Authorization: header differently

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -397,7 +397,7 @@ class CakeRequest implements ArrayAccess {
 
 /**
  * Get the content type used in this request.
- * 
+ *
  * @return string
  */
 	public function contentType() {
@@ -748,7 +748,12 @@ class CakeRequest implements ArrayAccess {
  * @return mixed Either false on no header being set or the value of the header.
  */
 	public static function header($name) {
-		$name = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+		$http_name = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+		if (isset($_SERVER[$http_name])) {
+			return $_SERVER[$http_name];
+		}
+		// Work around Apache issue handling the "Authorization" header
+		// differently than other headers.
 		if (isset($_SERVER[$name])) {
 			return $_SERVER[$name];
 		}

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -148,7 +148,7 @@ class CakeRequestTest extends CakeTestCase {
 
 /**
  * Test the content type method.
- * 
+ *
  * @return void
  */
 	public function testContentType() {
@@ -1147,11 +1147,13 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['HTTP_X_THING'] = '';
 		$_SERVER['HTTP_HOST'] = 'localhost';
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-ca) AppleWebKit/534.8+ (KHTML, like Gecko) Version/5.0 Safari/533.16';
+		$_SERVER['ThatOneHeader'] = 'foobar';
 		$request = new CakeRequest('/', false);
 
 		$this->assertEquals($_SERVER['HTTP_HOST'], $request->header('host'));
 		$this->assertEquals($_SERVER['HTTP_USER_AGENT'], $request->header('User-Agent'));
 		$this->assertSame('', $request->header('X-thing'));
+		$this->assertEquals($_SERVER['ThatOneHeader'], $request->header('ThatOneHeader'));
 	}
 
 /**


### PR DESCRIPTION
As described in #9027, `CakeRequest::header()` can not retrieve the `Authorization` header in some situations, such as passing a JSON Web Token. Using `curl -H "Authorization: Bearer foobar"` will have Apache set an `Authorization` variable in `$_SERVER`, _not_ the `HTTP_AUTHORIZATION` variable `header()` would normally expect. This seems to be specific to `Authorization` though, since `curl -H "Authori2zation: Bearer foobar"` will appropriately set `HTTP_AUTHORI2ZATION` in `$_SERVER`.

It is unknown to me if `Authorization` is the only header treated that way. As a workaround, this PR will have `header()` try to find the header directly in `$_SERVER` if the expected uppercased `HTTP_FOOBAR` header is not found beforehand.

Thanks
I'm using CakePHP 2.8.6 here, this PR is against 2.x

Note that this is **different** from Apache **skipping** the `Authorization` header altogether. For a solution to this specific issue, see [apache2 - Authorization header missing in django rest_framework, is apache to blame? - Stack Overflow](http://stackoverflow.com/questions/13387516/authorization-header-missing-in-django-rest-framework-is-apache-to-blame) or  @ADmad's own recommendation in [ADmad/cakephp-jwt-auth: A CakePHP plugin for authenticating using JSON Web Tokens](https://github.com/ADmad/cakephp-jwt-auth#working). This involves adding the below directives to `webroot/.htaccess`:

```
RewriteEngine On
RewriteCond %{HTTP:Authorization} ^(.*)
RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]
```

Apologies for the hot disaster on #9228. I tried comparing my fork against the 2.8.6 tag in the main fork, but the "Create Pull Request" button didn't show up. I hit back, created the PR, thinking I could change the comparison point after creation. Big fail.
