### PR TITLE
Improve TestShell

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -152,6 +152,7 @@ class TestShell extends Shell {
 			'default' => false
 		))->addOption('directive', array(
 			'help' => __d('cake_console', 'key[=value] Sets a php.ini value.'),
+			'short' => 'd',
 			'default' => false
 		))->addOption('fixture', array(
 			'help' => __d('cake_console', 'Choose a custom fixture manager.')
@@ -234,7 +235,11 @@ class TestShell extends Shell {
 			if ($value === false) {
 				continue;
 			}
-			$options[] = '--' . $param;
+			if ($param === 'directive') {
+				$options[] = '-d';
+			} else {
+				$options[] = '--' . $param;
+			}
 			if (is_string($value)) {
 				$options[] = $value;
 			}

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -71,6 +71,9 @@ class TestShell extends Shell {
 		))->addOption('coverage-clover', array(
 			'help' => __d('cake_console', '<file> Write code coverage data in Clover XML format.'),
 			'default' => false
+		))->addOption('coverage-text', array(
+			'help' => __d('cake_console', 'Output code coverage report in Text format.'),
+			'boolean' => true
 		))->addOption('testdox-html', array(
 			'help' => __d('cake_console', '<file> Write agile documentation in HTML format to file.'),
 			'default' => false

--- a/lib/Cake/Test/Case/Console/Command/TestShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/TestShellTest.php
@@ -359,4 +359,22 @@ class TestShellTest extends CakeTestCase {
 			);
 		$this->Shell->main();
 	}
+
+/**
+ * Tests that the '--directive' parameter change to '-d' before calling PHPUnit
+ *
+ * @return void
+ */
+	public function testRunnerOptionsDirective() {
+		$this->Shell->startup();
+		$this->Shell->args = array('core', 'Basics');
+		$this->Shell->params = array('directive' => 'memory_limit=128M');
+
+		$this->Shell->expects($this->once())->method('_run')
+			->with(
+				array('app' => false, 'plugin' => null, 'core' => true, 'output' => 'text', 'case' => 'Basics'),
+				array('-d', 'memory_limit=128M', '--colors')
+			);
+		$this->Shell->main();
+	}
 }


### PR DESCRIPTION
- support `--coverage-text` option.
- `--directive` option pass to PHPUnit correctly. (PHPUnit's directive option is `-d`) https://phpunit.de/manual/3.7/en/textui.html
