### PR TITLE
Fix Validator::equals() never passing.

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -729,7 +729,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equals', $extra + [
-            'rule' => ['comparison', '=', $value]
+            'rule' => ['comparison', '==', $value]
         ]);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1190,7 +1190,8 @@ class ValidatorTest extends TestCase
     public function testEquals()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'equals', 5, ['=', 5], 'comparison');
+        $this->assertProxyMethod($validator, 'equals', 5, ['==', 5], 'comparison');
+        $this->assertEmpty($validator->errors(['username' => 5]));
         $this->assertNotEmpty($validator->errors(['username' => 6]));
     }
 


### PR DESCRIPTION
This method would always trigger validation errors as the conditions were incorrectly defined.

Refs #9238
