### PR TITLE
Make Table::aliasField() idempotent.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -371,11 +371,17 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Alias a field with the table's current alias.
      *
+     * If field is already aliased it will result in no-op.
+     *
      * @param string $field The field to alias.
      * @return string The field prefixed with the table alias.
      */
     public function aliasField($field)
     {
+        if (strpos($field, '.') !== false) {
+            return $field;
+        }
+
         return $this->alias() . '.' . $field;
     }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -192,6 +192,8 @@ class TableTest extends TestCase
     {
         $table = new Table(['alias' => 'Users']);
         $this->assertEquals('Users.id', $table->aliasField('id'));
+
+        $this->assertEquals('Users.id', $table->aliasField('Users.id'));
     }
 
     /**


### PR DESCRIPTION
Closes #9244

We don't support table column names with dot right? :)
