### PR TITLE
Restore header() behavior inadvertantely removed.

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -748,13 +748,12 @@ class CakeRequest implements ArrayAccess {
  * @return mixed Either false on no header being set or the value of the header.
  */
 	public static function header($name) {
-		$name = strtoupper(str_replace('-', '_', $name));
-		$httpName = 'HTTP_' . $name;
+		$httpName = 'HTTP_' . strtoupper(str_replace('-', '_', $name)); ;
 		if (isset($_SERVER[$httpName])) {
 			return $_SERVER[$httpName];
 		}
-		// Work around Apache issues where 'Authorization' is not
-		// passed to PHP.
+		// Use the provided value, in some configurations apache will
+		// pass Authorization with no prefix and in Titlecase.
 		if (isset($_SERVER[$name])) {
 			return $_SERVER[$name];
 		}

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1147,13 +1147,14 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['HTTP_X_THING'] = '';
 		$_SERVER['HTTP_HOST'] = 'localhost';
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-ca) AppleWebKit/534.8+ (KHTML, like Gecko) Version/5.0 Safari/533.16';
-		$_SERVER['AUTHORIZATION'] = 'foobar';
+		$_SERVER['Authorization'] = 'foobar';
 		$request = new CakeRequest('/', false);
 
 		$this->assertEquals($_SERVER['HTTP_HOST'], $request->header('host'));
 		$this->assertEquals($_SERVER['HTTP_USER_AGENT'], $request->header('User-Agent'));
 		$this->assertSame('', $request->header('X-thing'));
-		$this->assertEquals($_SERVER['AUTHORIZATION'], $request->header('Authorization'));
+		$this->assertEquals($_SERVER['Authorization'], $request->header('Authorization'));
+		$this->assertFalse($request->header('authorization'));
 	}
 
 /**


### PR DESCRIPTION
In eaa2bbbcaebaa29dc4fb55817b261ccfa9135335 I changed the behavior to now use the TitleCased name as I didn't understand the intended behavior or how apache was working in the reporter's specific case.

Refs #9229
