### PR TITLE
Fix scoped query parameters not being merged into pagination URLs

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -505,9 +505,16 @@ class PaginatorHelper extends Helper
             $url['sort'] = $url['direction'] = null;
         }
         if (!empty($paging['scope'])) {
-            $url = [$paging['scope'] => $url] + $this->_config['options']['url'];
-            if (empty($url[$paging['scope']]['page'])) {
-                unset($url[$paging['scope']]['page']);
+            $scope = $paging['scope'];
+            $currentParams = $this->_config['options']['url'];
+            // Merge existing query parameters in the scope.
+            if (isset($currentParams['?'][$scope]) && is_array($currentParams['?'][$scope])) {
+                $url += $currentParams['?'][$scope];
+                unset($currentParams['?'][$scope]);
+            }
+            $url = [$scope => $url] + $currentParams;
+            if (empty($url[$scope]['page'])) {
+                unset($url[$scope]['page']);
             }
         }
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -827,6 +827,38 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * test generateUrl with multiple pagination and query string values
+     *
+     * @return void
+     */
+    public function testGenerateUrlMultiplePaginationQueryStringData()
+    {
+        Router::setRequestInfo([
+            ['controller' => 'posts', 'action' => 'index', 'plugin' => null],
+            ['base' => '', 'here' => 'posts/index', 'webroot' => '/']
+        ]);
+        $this->View->request->params['paging']['Article']['scope'] = 'article';
+        $this->View->request->params['paging']['Article']['page'] = 3;
+        $this->View->request->params['paging']['Article']['prevPage'] = true;
+        $this->View->request->query = [
+            'article' => [
+                'puppy' => 'no'
+            ]
+        ];
+        // Need to run __construct to update _config['url']
+        $paginator = new PaginatorHelper($this->View);
+        $paginator->options(['model' => 'Article']);
+
+        $result = $paginator->generateUrl(['sort' => 'name']);
+        $expected = '/posts/index?article%5Bpage%5D=3&amp;article%5Bsort%5D=name&amp;article%5Bpuppy%5D=no';
+        $this->assertEquals($expected, $result);
+
+        $result = $paginator->generateUrl([]);
+        $expected = '/posts/index?article%5Bpage%5D=3&amp;article%5Bpuppy%5D=no';
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * testOptions method
      *
      * @return void


### PR DESCRIPTION
Existing query parameters in the active scope should be present in generated pagination URLs. This fixes pagination URLs 'dropping' scoped parameters.

Refs #9210
