### PR TITLE
Update AssetFilter to use response methods.

### DIFF
--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -87,9 +87,7 @@ class AssetFilter extends DispatcherFilter
 
         $pathSegments = explode('.', $url);
         $ext = array_pop($pathSegments);
-        $this->_deliverAsset($request, $response, $assetFile, $ext);
-
-        return $response;
+        return $this->_deliverAsset($request, $response, $assetFile, $ext);
     }
 
     /**
@@ -142,10 +140,7 @@ class AssetFilter extends DispatcherFilter
             $response->header('Content-Length', filesize($assetFile));
         }
         $response->cache(filemtime($assetFile), $this->_cacheTime);
-        $response->sendHeaders();
-        readfile($assetFile);
-        if ($compressionEnabled) {
-            ob_end_flush();
-        }
+        $response->file($assetFile);
+        return $response;
     }
 }

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -87,6 +87,7 @@ class AssetFilter extends DispatcherFilter
 
         $pathSegments = explode('.', $url);
         $ext = array_pop($pathSegments);
+
         return $this->_deliverAsset($request, $response, $assetFile, $ext);
     }
 
@@ -141,6 +142,7 @@ class AssetFilter extends DispatcherFilter
         }
         $response->cache(filemtime($assetFile), $this->_cacheTime);
         $response->file($assetFile);
+
         return $response;
     }
 }

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -60,8 +60,8 @@ class AssetFilter extends DispatcherFilter
     /**
      * Checks if a requested asset exists and sends it to the browser
      *
-     * @param \Cake\Event\Event $event containing the request and response object
-     * @return \Cake\Network\Response if the client is requesting a recognized asset, null otherwise
+     * @param \Cake\Event\Event $event Event containing the request and response object
+     * @return \Cake\Network\Response|null If the client is requesting a recognized asset, null otherwise
      * @throws \Cake\Network\Exception\NotFoundException When asset not found
      */
     public function beforeDispatch(Event $event)
@@ -124,7 +124,7 @@ class AssetFilter extends DispatcherFilter
      * @param \Cake\Network\Response $response The response object to use.
      * @param string $assetFile Path to the asset file in the file system
      * @param string $ext The extension of the file to determine its mime type
-     * @return void
+     * @return \Caken\Network\Response The updated response.
      */
     protected function _deliverAsset(Request $request, Response $response, $assetFile, $ext)
     {

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -124,7 +124,7 @@ class AssetFilter extends DispatcherFilter
      * @param \Cake\Network\Response $response The response object to use.
      * @param string $assetFile Path to the asset file in the file system
      * @param string $ext The extension of the file to determine its mime type
-     * @return \Caken\Network\Response The updated response.
+     * @return \Cake\Network\Response The updated response.
      */
     protected function _deliverAsset(Request $request, Response $response, $assetFile, $ext)
     {

--- a/tests/TestCase/Routing/Filter/AssetFilterTest.php
+++ b/tests/TestCase/Routing/Filter/AssetFilterTest.php
@@ -245,14 +245,12 @@ class AssetFilterTest extends TestCase
         $request = new Request($url);
         $event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
 
-        ob_start();
-        $filter->beforeDispatch($event);
-        $result = ob_get_contents();
-        ob_end_clean();
+        $response = $filter->beforeDispatch($event);
+        $result = $response->getFile();
 
         $path = TEST_APP . str_replace('/', DS, $file);
         $file = file_get_contents($path);
-        $this->assertEquals($file, $result);
+        $this->assertEquals($file, $result->read());
 
         $expected = filesize($path);
         $headers = $response->header();


### PR DESCRIPTION
Instead of directly outputting to the server, using the response object will make AssetFilter more compatible with applications that straddling PSR7 and dispatcher stacks.

Refs #9260
