### PR TITLE
Fix cookie decryption when using psr7

### DIFF
--- a/src/Http/ResponseTransformer.php
+++ b/src/Http/ResponseTransformer.php
@@ -101,7 +101,7 @@ class ResponseTransformer
             }
 
             list($name, $value) = explode('=', array_shift($parts), 2);
-            $parsed = compact('name', 'value');
+            $parsed = compact('name') + ['value' => urldecode($value)];
 
             foreach ($parts as $part) {
                 if (strpos($part, '=') !== false) {

--- a/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
+++ b/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
@@ -44,6 +44,17 @@ class CookieEncryptedUsingControllerTest extends IntegrationTestCase
     }
 
     /**
+     * tear down.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->_useHttpServer = false;
+    }
+
+    /**
      * Can encrypt/decrypt the cookie value.
      */
     public function testCanEncryptAndDecryptWithAes()
@@ -139,5 +150,15 @@ class CookieEncryptedUsingControllerTest extends IntegrationTestCase
         Security::salt($key);
         $this->get('/cookie_component_test/set_cookie');
         $this->assertCookieEncrypted('abc', 'NameOfCookie', 'aes', $key);
+    }
+
+    /**
+     * Can AssertCookie even if encrypted with the aes when using PSR7 server.
+     */
+    public function testCanAssertCookieEncryptedWithAesWhenUsingPsr7()
+    {
+        $this->_useHttpServer = true;
+        $this->get('/cookie_component_test/set_cookie');
+        $this->assertCookieEncrypted('abc', 'NameOfCookie', 'aes');
     }
 }

--- a/tests/test_app/TestApp/Controller/CookieComponentTestController.php
+++ b/tests/test_app/TestApp/Controller/CookieComponentTestController.php
@@ -27,6 +27,8 @@ class CookieComponentTestController extends Controller
         'Cookie',
     ];
 
+    public $autoRender = false;
+
     /**
      * view
      *


### PR DESCRIPTION
When upgrading an application that uses encrypted cookies, tests failed. After looking for quite some time, I was able to spot cookies being transformed from the PSR7 response to Cake's own but with the `==` encoded; which was unsurprisingly breaking decryption.

I should also add that I am not sure this is the best way to resolve this as I haven't played much with the new PSR7 support yet. Maybe the fix should go elsewhere. 

**Update** Without this change, it also fails when using unencrypted cookies with serialized array values.
