### PR TITLE
Fix btm hydration

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1272,7 +1272,8 @@ class BelongsToMany extends Association
         $query
             ->where($this->junctionConditions())
             ->select($joinFields)
-            ->defaultTypes($types);
+            ->defaultTypes($types)
+            ->addDefaultTypes($this->target());
 
         $query
             ->eagerLoader()

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -32,6 +32,7 @@ class TagsFixture extends TestFixture
         'id' => ['type' => 'integer', 'null' => false],
         'name' => ['type' => 'string', 'null' => false],
         'description' => ['type' => 'text', 'length' => Table::LENGTH_MEDIUM],
+        'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];
 
@@ -41,8 +42,8 @@ class TagsFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['name' => 'tag1', 'description' => 'A big description'],
-        ['name' => 'tag2', 'description' => 'Another big description'],
-        ['name' => 'tag3', 'description' => 'Yet another one']
+        ['name' => 'tag1', 'description' => 'A big description', 'created' => '2016-01-01 00:00'],
+        ['name' => 'tag2', 'description' => 'Another big description', 'created' => '2016-01-01 00:00'],
+        ['name' => 'tag3', 'description' => 'Yet another one', 'created' => '2016-01-01 00:00']
     ];
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3136,12 +3136,14 @@ class MarshallerTest extends TestCase
                 [
                     'id' => 1,
                     'name' => 'tag1',
-                    'description' => 'A big description'
+                    'description' => 'A big description',
+                    'created' => new Time('2016-01-01 00:00'),
                 ],
                 [
                     'id' => 2,
                     'name' => 'tag2',
-                    'description' => 'Another big description'
+                    'description' => 'Another big description',
+                    'created' => new Time('2016-01-01 00:00'),
                 ]
             ]
         ];

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1269,16 +1269,20 @@ class QueryTest extends TestCase
             'name' => 'tag1',
             '_joinData' => ['article_id' => 1, 'tag_id' => 1],
             'description' => 'A big description',
+            'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
+        $this->assertInstanceOf(Time::class, $first->tags[0]->created);
 
         $expected = [
             'id' => 2,
             'name' => 'tag2',
             '_joinData' => ['article_id' => 1, 'tag_id' => 2],
-            'description' => 'Another big description'
+            'description' => 'Another big description',
+            'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
+        $this->assertInstanceOf(Time::class, $first->tags[1]->created);
     }
 
     /**
@@ -1303,7 +1307,6 @@ class QueryTest extends TestCase
                 });
             }, 'Model.beforeFind');
 
-
         $query = new Query($this->connection, $table);
 
         $results = $query
@@ -1322,18 +1325,20 @@ class QueryTest extends TestCase
             'name' => 'tag1',
             '_joinData' => ['article_id' => 1, 'tag_id' => 1],
             'description' => 'A big description',
+            'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
-        $this->assertSame(1, $first->tags[0]->id);
+        $this->assertInstanceOf(Time::class, $first->tags[0]->created);
 
         $expected = [
             'id' => 2,
             'name' => 'tag2',
             '_joinData' => ['article_id' => 1, 'tag_id' => 2],
-            'description' => 'Another big description'
+            'description' => 'Another big description',
+            'created' => new Time('2016-01-01 00:00'),
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
-        $this->assertSame(2, $first->tags[1]->id);
+        $this->assertInstanceOf(Time::class, $first->tags[0]->created);
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -570,13 +570,15 @@ class QueryTest extends TestCase
                         'id' => 1,
                         'name' => 'tag1',
                         '_joinData' => ['article_id' => 1, 'tag_id' => 1],
-                        'description' => 'A big description'
+                        'description' => 'A big description',
+                        'created' => new Time('2016-01-01 00:00'),
                     ],
                     [
                         'id' => 2,
                         'name' => 'tag2',
                         '_joinData' => ['article_id' => 1, 'tag_id' => 2],
-                        'description' => 'Another big description'
+                        'description' => 'Another big description',
+                        'created' => new Time('2016-01-01 00:00'),
                     ]
                 ]
             ],
@@ -591,13 +593,15 @@ class QueryTest extends TestCase
                         'id' => 1,
                         'name' => 'tag1',
                         '_joinData' => ['article_id' => 2, 'tag_id' => 1],
-                        'description' => 'A big description'
+                        'description' => 'A big description',
+                        'created' => new Time('2016-01-01 00:00'),
                     ],
                     [
                         'id' => 3,
                         'name' => 'tag3',
                         '_joinData' => ['article_id' => 2, 'tag_id' => 3],
-                        'description' => 'Yet another one'
+                        'description' => 'Yet another one',
+                        'created' => new Time('2016-01-01 00:00'),
                     ]
                 ]
             ],
@@ -636,7 +640,8 @@ class QueryTest extends TestCase
                         'id' => 3,
                         'name' => 'tag3',
                         '_joinData' => ['article_id' => 2, 'tag_id' => 3],
-                        'description' => 'Yet another one'
+                        'description' => 'Yet another one',
+                        'created' => new Time('2016-01-01 00:00'),
                     ]
                 ]
             ],
@@ -751,6 +756,7 @@ class QueryTest extends TestCase
                         'id' => 3,
                         'name' => 'tag3',
                         'description' => 'Yet another one',
+                        'created' => new Time('2016-01-01 00:00'),
                     ],
                     'ArticlesTags' => ['article_id' => 2, 'tag_id' => 3]
                 ]
@@ -777,6 +783,7 @@ class QueryTest extends TestCase
                         'id' => 2,
                         'name' => 'tag2',
                         'description' => 'Another big description',
+                        'created' => new Time('2016-01-01 00:00'),
                     ],
                     'ArticlesTags' => ['article_id' => 1, 'tag_id' => 2]
                 ]
@@ -814,6 +821,7 @@ class QueryTest extends TestCase
                         'id' => 2,
                         'name' => 'tag2',
                         'description' => 'Another big description',
+                        'created' => new Time('2016-01-01 00:00'),
                     ],
                     'articles' => [
                         'id' => 1,

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1324,6 +1324,7 @@ class QueryTest extends TestCase
             'description' => 'A big description',
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
+        $this->assertSame(1, $first->tags[0]->id);
 
         $expected = [
             'id' => 2,
@@ -1332,6 +1333,7 @@ class QueryTest extends TestCase
             'description' => 'Another big description'
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
+        $this->assertSame(2, $first->tags[1]->id);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3966,7 +3966,8 @@ class TableTest extends TestCase
 
         $newTag = new \TestApp\Model\Entity\Tag([
             'name' => 'Foo',
-            'description' => 'Foo desc'
+            'description' => 'Foo desc',
+            'created' => null,
         ], $source);
         $tags[] = new \TestApp\Model\Entity\Tag([
             'id' => 3


### PR DESCRIPTION
https://github.com/cakephp/cakephp/commit/6b984fb987210a225e6e2d76f6e5f6834164b668 broken hydration of BelongsToMany entities. It caused the entity to use the incorrect column types as the target table default type mapping was lost.
