### PR TITLE
Request: fixed cache for detectors and bug for __call() method

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -577,8 +577,10 @@ class Request implements ArrayAccess
     {
         if (strpos($name, 'is') === 0) {
             $type = strtolower(substr($name, 2));
-
-            return $this->is($type);
+            
+            array_unshift($params, $type);
+            
+            return call_user_func_array([$this, 'is'], $params);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $name));
     }

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -136,13 +136,6 @@ class Request implements ArrayAccess
     ];
 
     /**
-     * Instance cache for results of is(something) calls
-     *
-     * @var array
-     */
-    protected $_detectorCache = [];
-
-    /**
      * Copy of php://input. Since this stream can only be read once in most SAPI's
      * keep a copy of it so users don't need to know about that detail.
      *
@@ -646,21 +639,7 @@ class Request implements ArrayAccess
             return false;
         }
 
-        if (!isset($this->_detectorCache[$type])) {
-            $this->_detectorCache[$type] = $this->_is($type, $args);
-        }
-
-        return $this->_detectorCache[$type];
-    }
-
-    /**
-     * Clears the instance detector cache, used by the is() function
-     *
-     * @return void
-     */
-    public function clearDetectorCache()
-    {
-        $this->_detectorCache = [];
+        return $this->_is($type, $args);
     }
 
     /**
@@ -1291,7 +1270,6 @@ class Request implements ArrayAccess
     {
         if ($value !== null) {
             $this->_environment[$key] = $value;
-            $this->clearDetectorCache();
 
             return $this;
         }

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -134,7 +134,7 @@ class Request implements ArrayAccess
         'json' => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
         'xml' => ['accept' => ['application/xml', 'text/xml'], 'param' => '_ext', 'value' => 'xml'],
     ];
-    
+
     /**
      * Instance cache for results of is(something) calls
      *
@@ -655,10 +655,10 @@ class Request implements ArrayAccess
 
             return $this->_detectorCache[$type];
         }
-        
+		
         return $this->_is($type, $args);
     }
-    
+	
     /**
      * Clears the instance detector cache, used by the is() function
      *

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -655,10 +655,10 @@ class Request implements ArrayAccess
 
             return $this->_detectorCache[$type];
         }
-		
+
         return $this->_is($type, $args);
     }
-	
+
     /**
      * Clears the instance detector cache, used by the is() function
      *

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -650,7 +650,7 @@ class Request implements ArrayAccess
         
         if (empty($args)) {
             if (!isset($this->_detectorCache[$type])) {
-                $this->_detectorCache[$type] = $this->_is($type);
+                $this->_detectorCache[$type] = $this->_is($type, $args);
             }
 
             return $this->_detectorCache[$type];

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -627,14 +627,14 @@ class Request implements ArrayAccess
      */
     public function is($type)
     {
-        $args = func_get_args();
-        array_shift($args);
-
         if (is_array($type)) {
             $result = array_map([$this, 'is'], $type);
 
             return count(array_filter($result)) > 0;
         }
+        
+        $args = func_get_args();
+        array_shift($args);
 
         $type = strtolower($type);
         if (!isset(static::$_detectors[$type])) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -647,16 +647,16 @@ class Request implements ArrayAccess
         if (!isset(static::$_detectors[$type])) {
             return false;
         }
-        
-        if (empty($args)) {
-            if (!isset($this->_detectorCache[$type])) {
-                $this->_detectorCache[$type] = $this->_is($type, $args);
-            }
 
-            return $this->_detectorCache[$type];
+        if ($args) {
+            return $this->_is($type, $args);
+        }
+        
+        if (!isset($this->_detectorCache[$type])) {
+            $this->_detectorCache[$type] = $this->_is($type, $args);
         }
 
-        return $this->_is($type, $args);
+        return $this->_detectorCache[$type];
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -70,7 +70,9 @@ class RequestTest extends TestCase
 
         $request->params = ['controller' => 'cake'];
         $this->assertTrue($request->is('controller', 'cake'));
+        $this->assertFalse($request->is('controller', 'nonExistingController'));
         $this->assertTrue($request->isController('cake'));
+        $this->assertFalse($request->isController('nonExistingController'));
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1012,25 +1012,20 @@ class RequestTest extends TestCase
         Request::addDetector('index', ['param' => 'action', 'value' => 'index']);
 
         $request->params['action'] = 'index';
-        $request->clearDetectorCache();
         $this->assertTrue($request->isIndex());
 
         $request->params['action'] = 'add';
-        $request->clearDetectorCache();
         $this->assertFalse($request->isIndex());
 
         Request::addDetector('callme', [$this, 'detectCallback']);
         $request->return = true;
-        $request->clearDetectorCache();
         $this->assertTrue($request->isCallMe());
 
         Request::addDetector('extension', ['param' => '_ext', 'options' => ['pdf', 'png', 'txt']]);
         $request->params['_ext'] = 'pdf';
-        $request->clearDetectorCache();
         $this->assertTrue($request->is('extension'));
 
         $request->params['_ext'] = 'exe';
-        $request->clearDetectorCache();
         $this->assertFalse($request->isExtension());
     }
 

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1014,20 +1014,25 @@ class RequestTest extends TestCase
         Request::addDetector('index', ['param' => 'action', 'value' => 'index']);
 
         $request->params['action'] = 'index';
+        $request->clearDetectorCache();
         $this->assertTrue($request->isIndex());
 
         $request->params['action'] = 'add';
+        $request->clearDetectorCache();
         $this->assertFalse($request->isIndex());
 
         Request::addDetector('callme', [$this, 'detectCallback']);
         $request->return = true;
+        $request->clearDetectorCache();
         $this->assertTrue($request->isCallMe());
 
         Request::addDetector('extension', ['param' => '_ext', 'options' => ['pdf', 'png', 'txt']]);
         $request->params['_ext'] = 'pdf';
+        $request->clearDetectorCache();
         $this->assertTrue($request->is('extension'));
 
         $request->params['_ext'] = 'exe';
+        $request->clearDetectorCache();
         $this->assertFalse($request->isExtension());
     }
 


### PR DESCRIPTION
This fixes bug issue https://github.com/cakephp/cakephp/issues/9269, removing the cache for request detectors.
