### PR TITLE
(2.x) AssetDispatcher should accept trailing slash

### DIFF
--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -116,7 +116,7 @@ class AssetDispatcher extends DispatcherFilter {
 		if ($parts[0] === 'theme') {
 			$themeName = $parts[1];
 			unset($parts[0], $parts[1]);
-			$fileFragment = implode(DS, $parts);
+			$fileFragment = rtrim(implode(DS, $parts), '/');
 			$path = App::themePath($themeName) . 'webroot' . DS;
 			return $path . $fileFragment;
 		}
@@ -124,7 +124,7 @@ class AssetDispatcher extends DispatcherFilter {
 		$plugin = Inflector::camelize($parts[0]);
 		if ($plugin && CakePlugin::loaded($plugin)) {
 			unset($parts[0]);
-			$fileFragment = implode(DS, $parts);
+			$fileFragment = rtrim(implode(DS, $parts), '/');
 			$pluginWebroot = CakePlugin::path($plugin) . 'webroot' . DS;
 			return $pluginWebroot . $fileFragment;
 		}

--- a/lib/Cake/Test/Case/Routing/Filter/AssetDispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/Filter/AssetDispatcherTest.php
@@ -57,6 +57,7 @@ class AssetDispatcherTest extends CakeTestCase {
 			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS),
 			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
 		), App::RESET);
+		CakePlugin::load('TestPlugin');
 
 		$request = new CakeRequest('theme/test_theme/ccss/cake.generic.css');
 		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
@@ -64,6 +65,16 @@ class AssetDispatcherTest extends CakeTestCase {
 		$this->assertTrue($event->isStopped());
 
 		$request = new CakeRequest('theme/test_theme/cjs/debug_kit.js');
+		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
+		$this->assertSame($response, $filter->beforeDispatch($event));
+		$this->assertTrue($event->isStopped());
+
+		$request = new CakeRequest('theme/test_theme/js/theme.js');
+		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
+		$this->assertSame($response, $filter->beforeDispatch($event));
+		$this->assertTrue($event->isStopped());
+
+		$request = new CakeRequest('theme/test_theme/js/theme.js/');
 		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
 		$this->assertSame($response, $filter->beforeDispatch($event));
 		$this->assertTrue($event->isStopped());
@@ -77,6 +88,17 @@ class AssetDispatcherTest extends CakeTestCase {
 		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
 		$this->assertSame($response, $filter->beforeDispatch($event));
 		$this->assertTrue($event->isStopped());
+
+		$request = new CakeRequest('test_plugin/js/test_plugin/test.js');
+		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
+		$this->assertSame($response, $filter->beforeDispatch($event));
+		$this->assertTrue($event->isStopped());
+
+		$request = new CakeRequest('test_plugin/js/test_plugin/test.js/');
+		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
+		$this->assertSame($response, $filter->beforeDispatch($event));
+		$this->assertTrue($event->isStopped());
+
 
 		$request = new CakeRequest('css/ccss/debug_kit.css');
 		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));


### PR DESCRIPTION
If .htaccess rewrites static asset path with trailing slash, AssetDispatcher does not work and returns 404.
(e.g. If `/debug_kit/js/js_debug_toolbar.js` is rewritten to `/debug_kit/js/js_debug_toolbar.js/`, AssetDispatcher cannot handle plugin assets. )
This change addresses such situations.
