### PR TITLE
Fix dirty tracking for array associations

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -545,10 +545,12 @@ class Marshaller
             if (isset($propertyMap[$key])) {
                 $value = $propertyMap[$key]($value, $entity);
 
-                // Don't dirty complex objects that were objects before.
-                $isObject = is_object($value);
-                if ((!$isObject && $original === $value) ||
-                    ($isObject && $original == $value)
+                // Arrays will be marked as dirty always because
+                // the original/updated could contain references to the
+                // same objects, even those those objects may have changed.
+                if (
+                    (is_scalar($value) && $original === $value) ||
+                    (is_object($value) && $original == $value)
                 ) {
                     continue;
                 }
@@ -556,9 +558,9 @@ class Marshaller
             $properties[$key] = $value;
         }
 
+        $entity->errors($errors);
         if (!isset($options['fieldList'])) {
             $entity->set($properties);
-            $entity->errors($errors);
 
             foreach ($properties as $field => $value) {
                 if ($value instanceof EntityInterface) {
@@ -577,8 +579,6 @@ class Marshaller
                 }
             }
         }
-
-        $entity->errors($errors);
 
         return $entity;
     }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -548,8 +548,7 @@ class Marshaller
                 // Arrays will be marked as dirty always because
                 // the original/updated could contain references to the
                 // same objects, even those those objects may have changed.
-                if (
-                    (is_scalar($value) && $original === $value) ||
+                if ((is_scalar($value) && $original === $value) ||
                     (is_object($value) && $original == $value)
                 ) {
                     continue;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3600,6 +3600,34 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests overwriting hasMany associations in an integration scenario.
+     *
+     * @return void
+     */
+    public function testSaveHasManyOverwrite()
+    {
+        $table = TableRegistry::get('authors');
+        $table->hasMany('articles');
+
+        $entity = $table->get(3, ['contain' => ['articles']]);
+        $data = [
+            'name' => 'big jose',
+            'articles' => [
+                [
+                    'id' => 2,
+                    'title' => 'New title'
+                ]
+            ]
+        ];
+        $entity = $table->patchEntity($entity, $data, ['associated' => 'articles']);
+        $this->assertSame($entity, $table->save($entity));
+
+        $entity = $table->get(3, ['contain' => ['articles']]);
+        $this->assertEquals('big jose', $entity->name, 'Author did not persist');
+        $this->assertEquals('New title', $entity->articles[0]->title, 'Article did not persist');
+    }
+
+    /**
      * Tests saving belongsToMany records
      *
      * @group save


### PR DESCRIPTION
1:N association properties should be marked as dirty when they are marshalled, and the resulting list has the same number of elements that it did before. Because we can't easily look inside lists, we'll always treat them as dirty. This is the same behavior that existed prior to #9215 for associations.

Improve test coverage around dirty tracking and associations to help catch future regressions around this behavior.

Refs #9267
