### PR TITLE
Use ellipsis character instead of three dots

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -73,7 +73,7 @@ class PaginatorHelper extends Helper
             'last' => '<li class="last"><a href="{{url}}">{{text}}</a></li>',
             'number' => '<li><a href="{{url}}">{{text}}</a></li>',
             'current' => '<li class="active"><a href="">{{text}}</a></li>',
-            'ellipsis' => '<li class="ellipsis">…</li>',
+            'ellipsis' => '<li class="ellipsis">&hellip;</li>',
             'sort' => '<a href="{{url}}">{{text}}</a>',
             'sortAsc' => '<a class="asc" href="{{url}}">{{text}}</a>',
             'sortDesc' => '<a class="desc" href="{{url}}">{{text}}</a>',

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -73,7 +73,7 @@ class PaginatorHelper extends Helper
             'last' => '<li class="last"><a href="{{url}}">{{text}}</a></li>',
             'number' => '<li><a href="{{url}}">{{text}}</a></li>',
             'current' => '<li class="active"><a href="">{{text}}</a></li>',
-            'ellipsis' => '<li class="ellipsis">...</li>',
+            'ellipsis' => '<li class="ellipsis">…</li>',
             'sort' => '<a href="{{url}}">{{text}}</a>',
             'sortAsc' => '<a class="asc" href="{{url}}">{{text}}</a>',
             'sortDesc' => '<a class="desc" href="{{url}}">{{text}}</a>',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1255,7 +1255,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['first' => 'first', 'last' => 'last']);
         $expected = [
             ['li' => ['class' => 'first']], ['a' => ['href' => '/index']], 'first', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
@@ -1265,7 +1265,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=10']], '10', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=11']], '11', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=12']], '12', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => ['class' => 'last']], ['a' => ['href' => '/index?page=15']], 'last', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
@@ -1273,7 +1273,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['first' => '2', 'last' => '8']);
         $expected = [
             ['li' => ['class' => 'first']], ['a' => ['href' => '/index']], '2', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
@@ -1283,7 +1283,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=10']], '10', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=11']], '11', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=12']], '12', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => ['class' => 'last']], ['a' => ['href' => '/index?page=15']], '8', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
@@ -1291,7 +1291,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['first' => '8', 'last' => '8']);
         $expected = [
             ['li' => ['class' => 'first']], ['a' => ['href' => '/index']], '8', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
@@ -1301,7 +1301,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=10']], '10', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=11']], '11', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=12']], '12', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => ['class' => 'last']], ['a' => ['href' => '/index?page=15']], '8', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
@@ -1407,7 +1407,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['first' => 1]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=7']], '7', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=8']], '8', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=9']], '9', '/a', '/li',
@@ -1434,7 +1434,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=7']], '7', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=8']], '8', '/a', '/li',
@@ -1471,7 +1471,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=8']], '8', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=9']], '9', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=10']], '10', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=42']], '42', '/a', '/li',
         ];
         $this->assertHtml($expected, $result);
@@ -1490,7 +1490,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=33']], '33', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=34']], '34', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=35']], '35', '/a', '/li',
@@ -1594,7 +1594,7 @@ class PaginatorHelperTest extends TestCase
         $expected = [
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4894']], '4894', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '4895', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
@@ -1610,7 +1610,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '3', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
         ];
@@ -1622,7 +1622,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '3', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
         ];
@@ -1636,7 +1636,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4893']], '4893', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4894']], '4894', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4895']], '4895', '/a', '/li',
@@ -1653,7 +1653,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=3']], '3', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4891']], '4891', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4892']], '4892', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '4893', '/a', '/li',
@@ -1672,13 +1672,13 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=3']], '3', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=56']], '56', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=57']], '57', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '58', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=59']], '59', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=60']], '60', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4893']], '4893', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4894']], '4894', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4895']], '4895', '/a', '/li',
@@ -1697,7 +1697,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => ['class' => 'active']], '<a href=""', '5', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=7']], '7', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4893']], '4893', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4894']], '4894', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4895']], '4895', '/a', '/li',
@@ -1713,7 +1713,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '3', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
         ];
@@ -1725,7 +1725,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index']], '1', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=2']], '2', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '3', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896']], '4896', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4897']], '4897', '/a', '/li',
         ];
@@ -1813,7 +1813,7 @@ class PaginatorHelperTest extends TestCase
             ['li' => []], ['a' => ['href' => '/index?page=2&amp;foo=bar']], '2', '/a', '/li',
             ['li' => ['class' => 'active']], '<a href=""', '3', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4&amp;foo=bar']], '4', '/a', '/li',
-            ['li' => ['class' => 'ellipsis']], '...', '/li',
+            ['li' => ['class' => 'ellipsis']], '&hellip;', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4896&amp;foo=bar']], '4896', '/a', '/li',
             ['li' => []], ['a' => ['href' => '/index?page=4897&amp;foo=bar']], '4897', '/a', '/li',
         ];


### PR DESCRIPTION
It is not sematically correct to use three dots indicating more content. 
Also as pointed out, three dots can be broken into two lines without additional markup.
#9279
