### PR TITLE
Fix marshalling associations with translated records.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -122,7 +122,7 @@ class Marshaller
         foreach ($behaviors->loaded() as $name) {
             $behavior = $behaviors->get($name);
             if ($behavior instanceof PropertyMarshalInterface) {
-                $map = $behavior->buildMarhshalMap($this, $map, $options);
+                $map += $behavior->buildMarhshalMap($this, $map, $options);
             }
         }
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -2435,12 +2435,19 @@ class MarshallerTest extends TestCase
                     'title' => 'Titulo Español',
                     'body' => 'Contenido Español'
                 ]
+            ],
+            'user' => [
+                'id' => 1,
+                'username' => 'mark'
             ]
         ];
 
         $marshall = new Marshaller($this->articles);
-        $result = $marshall->one($data, []);
+        $result = $marshall->one($data, ['associated' => ['Users']]);
         $this->assertEmpty($result->errors());
+        $this->assertEquals(1, $result->author_id);
+        $this->assertInstanceOf(__NAMESPACE__ . '\OpenEntity', $result->user);
+        $this->assertEquals('mark', $result->user->username);
 
         $translations = $result->get('_translations');
         $this->assertCount(2, $translations);


### PR DESCRIPTION
When marshalling a record, with translations and associated records, the associated records would not be marshalled correctly as the $map was overwritten and not updated.

Refs #9289
