### PR TITLE
Change default transport to 'default'

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1386,7 +1386,7 @@ class Email implements JsonSerializable, Serializable
      * @return \Cake\Mailer\Email Instance of Cake\Mailer\Email
      * @throws \InvalidArgumentException
      */
-    public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'fast', $send = true)
+    public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'default', $send = true)
     {
         $class = __CLASS__;
         $instance = new $class($transportConfig);

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1389,6 +1389,10 @@ class Email implements JsonSerializable, Serializable
     public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'default', $send = true)
     {
         $class = __CLASS__;
+
+        if (is_array($transportConfig)) {
+            $transportConfig += ['transport' => 'default'];
+        }
         $instance = new $class($transportConfig);
         if ($to !== null) {
             $instance->to($to);

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -1906,11 +1906,15 @@ class EmailTest extends TestCase
      */
     public function testDeliver()
     {
+        Email::dropTransport('default');
+        Email::configTransport('default', ['className' => 'Debug']);
+
         $instance = Email::deliver('all@cakephp.org', 'About', 'Everything ok', ['from' => 'root@cakephp.org'], false);
         $this->assertInstanceOf('Cake\Mailer\Email', $instance);
         $this->assertSame($instance->to(), ['all@cakephp.org' => 'all@cakephp.org']);
         $this->assertSame($instance->subject(), 'About');
         $this->assertSame($instance->from(), ['root@cakephp.org' => 'root@cakephp.org']);
+        $this->assertInstanceOf('Cake\Mailer\AbstractTransport', $instance->transport());
 
         $config = [
             'from' => 'cake@cakephp.org',
@@ -2668,6 +2672,8 @@ HTML;
      */
     public function testMockTransport()
     {
+        Email::dropTransport('default');
+
         $mock = $this->getMockBuilder('\Cake\Mailer\AbstractTransport')->getMock();
         $config = ['from' => 'tester@example.org', 'transport' => 'default'];
 


### PR DESCRIPTION
We don't include a 'fast' configuration in the application skeleton, and 'fast' is a strange default name for a mailer transport anyways.

Refs #9286
