### PR TITLE
Fix MiddlewareQueue::insertAt

### DIFF
--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -145,7 +145,7 @@ class MiddlewareQueue implements Countable
      */
     public function insertAt($index, $middleware)
     {
-        array_splice($this->queue, $index, 0, $middleware);
+        array_splice($this->queue, $index, 0, [$middleware]);
 
         return $this;
     }
@@ -159,7 +159,7 @@ class MiddlewareQueue implements Countable
      * @param string $class The classname to insert the middleware before.
      * @param callable|string $middleware The middleware to insert.
      * @return $this
-     * @throws \LogicException If middlware to insert before is not found.
+     * @throws \LogicException If middleware to insert before is not found.
      */
     public function insertBefore($class, $middleware)
     {

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -240,8 +240,8 @@ class MiddlewareQueueTest extends TestCase
         $queue->add($one)->insertAt(-1, $two)->insertAt(-1, $three);
 
         $this->assertCount(3, $queue);
-        $this->assertSame($three, $queue->get(0));
-        $this->assertSame($two, $queue->get(1));
+        $this->assertSame($two, $queue->get(0));
+        $this->assertSame($three, $queue->get(1));
         $this->assertSame($one, $queue->get(2));
     }
 
@@ -311,13 +311,19 @@ class MiddlewareQueueTest extends TestCase
         };
         $three = function () {
         };
+        $four = new DumbMiddleware();
         $queue = new MiddlewareQueue();
-        $queue->add($one)->add($two)->insertAfter(SampleMiddleware::class, $three);
+        $queue
+            ->add($one)
+            ->add($two)
+            ->insertAfter(SampleMiddleware::class, $three)
+            ->insertAfter(SampleMiddleware::class, $four);
 
-        $this->assertCount(3, $queue);
+        $this->assertCount(4, $queue);
         $this->assertSame($one, $queue->get(0));
-        $this->assertSame($three, $queue->get(1));
-        $this->assertSame($two, $queue->get(2));
+        $this->assertSame($four, $queue->get(1));
+        $this->assertSame($three, $queue->get(2));
+        $this->assertSame($two, $queue->get(3));
 
         $one = 'Sample';
         $queue = new MiddlewareQueue();

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Http;
 use Cake\Core\Configure;
 use Cake\Http\MiddlewareQueue;
 use Cake\TestSuite\TestCase;
+use TestApp\Middleware\DumbMiddleware;
 use TestApp\Middleware\SampleMiddleware;
 
 /**
@@ -186,12 +187,14 @@ class MiddlewareQueueTest extends TestCase
         };
         $three = function () {
         };
+        $four = new SampleMiddleware();
 
         $queue = new MiddlewareQueue();
-        $queue->add($one)->add($two)->insertAt(0, $three);
+        $queue->add($one)->add($two)->insertAt(0, $three)->insertAt(2, $four);
         $this->assertSame($three, $queue->get(0));
         $this->assertSame($one, $queue->get(1));
-        $this->assertSame($two, $queue->get(2));
+        $this->assertSame($four, $queue->get(2));
+        $this->assertSame($two, $queue->get(3));
 
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertAt(1, $three);
@@ -231,13 +234,15 @@ class MiddlewareQueueTest extends TestCase
         };
         $two = function () {
         };
+        $three = new SampleMiddleWare();
 
         $queue = new MiddlewareQueue();
-        $queue->add($one)->insertAt(-1, $two);
+        $queue->add($one)->insertAt(-1, $two)->insertAt(-1, $three);
 
-        $this->assertCount(2, $queue);
-        $this->assertSame($two, $queue->get(0));
-        $this->assertSame($one, $queue->get(1));
+        $this->assertCount(3, $queue);
+        $this->assertSame($three, $queue->get(0));
+        $this->assertSame($two, $queue->get(1));
+        $this->assertSame($one, $queue->get(2));
     }
 
     /**
@@ -252,13 +257,16 @@ class MiddlewareQueueTest extends TestCase
         $two = new SampleMiddleware();
         $three = function () {
         };
+        $four = new DumbMiddleware();
+        
         $queue = new MiddlewareQueue();
-        $queue->add($one)->add($two)->insertBefore(SampleMiddleware::class, $three);
+        $queue->add($one)->add($two)->insertBefore(SampleMiddleware::class, $three)->insertBefore(SampleMiddleware::class, $four);
 
-        $this->assertCount(3, $queue);
+        $this->assertCount(4, $queue);
         $this->assertSame($one, $queue->get(0));
         $this->assertSame($three, $queue->get(1));
-        $this->assertSame($two, $queue->get(2));
+        $this->assertSame($four, $queue->get(2));
+        $this->assertSame($two, $queue->get(3));
 
         $two = SampleMiddleware::class;
         $queue = new MiddlewareQueue();

--- a/tests/test_app/TestApp/Middleware/DumbMiddleware.php
+++ b/tests/test_app/TestApp/Middleware/DumbMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Middleware;
+
+/**
+ * Testing stub for middleware tests.
+ */
+class DumbMiddleWare {
+    function __invoke($request, $response, $next)
+    {
+        return $next($request, $response);
+    }
+}

--- a/tests/test_app/TestApp/Middleware/DumbMiddleware.php
+++ b/tests/test_app/TestApp/Middleware/DumbMiddleware.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.3.0
+ * @since         3.3.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Middleware;
@@ -17,8 +17,9 @@ namespace TestApp\Middleware;
 /**
  * Testing stub for middleware tests.
  */
-class DumbMiddleWare {
-    function __invoke($request, $response, $next)
+class DumbMiddleWare
+{
+    public function __invoke($request, $response, $next)
     {
         return $next($request, $response);
     }


### PR DESCRIPTION
Currently, `MiddlewareQueue::insertAt()` would work just fine with closures but can't work correctly when an instance of a Middleware is given as shown in the [book](http://book.cakephp.org/3.0/en/controllers/middleware.html#using-middleware)
It impacts also all methods that relies on it like `MiddlewareQueue::insertBefore()` 
