### PR TITLE
Don't double bind DispatcherFilters in old dispatcher setups

### DIFF
--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -53,8 +53,8 @@ class ActionDispatcher
     /**
      * Constructor
      *
-     * @param \Cake\Http\ControllerFactory $factory A controller factory instance.
-     * @param \Cake\Event\EventManager $eventManager An event manager if you want to inject one.
+     * @param \Cake\Http\ControllerFactory|null $factory A controller factory instance.
+     * @param \Cake\Event\EventManager|null $eventManager An event manager if you want to inject one.
      * @param array $filters The list of filters to include.
      */
     public function __construct($factory = null, $eventManager = null, array $filters = [])

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -55,15 +55,14 @@ class ActionDispatcher
      *
      * @param \Cake\Http\ControllerFactory $factory A controller factory instance.
      * @param \Cake\Event\EventManager $eventManager An event manager if you want to inject one.
+     * @param array $filters The list of filters to include.
      */
-    public function __construct($factory = null, $eventManager = null)
+    public function __construct($factory = null, $eventManager = null, array $filters = [])
     {
         if ($eventManager) {
             $this->eventManager($eventManager);
         }
-
-        // Compatibility with DispatcherFilters.
-        foreach (DispatcherFactory::filters() as $filter) {
+        foreach ($filters as $filter) {
             $this->addFilter($filter);
         }
         $this->factory = $factory ?: new ControllerFactory();

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Http;
 
+use Cake\Routing\DispatcherFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -92,6 +93,6 @@ abstract class BaseApplication
      */
     protected function getDispatcher()
     {
-        return new ActionDispatcher();
+        return new ActionDispatcher(null, null, DispatcherFactory::filters());
     }
 }

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -58,10 +58,7 @@ class Dispatcher
      */
     public function dispatch(Request $request, Response $response)
     {
-        $actionDispatcher = new ActionDispatcher(null, $this->eventManager());
-        foreach ($this->_filters as $filter) {
-            $actionDispatcher->addFilter($filter);
-        }
+        $actionDispatcher = new ActionDispatcher(null, $this->eventManager(), $this->_filters);
         $response = $actionDispatcher->dispatch($request, $response);
         if (isset($request->params['return'])) {
             return $response->body();

--- a/tests/TestCase/Http/ActionDispatcherTest.php
+++ b/tests/TestCase/Http/ActionDispatcherTest.php
@@ -79,7 +79,7 @@ class ActionDispatcherTest extends TestCase
             ->setMethods(['beforeDispatch', 'afterDispatch'])
             ->getMock();
         DispatcherFactory::add($filter);
-        $dispatcher = new ActionDispatcher();
+        $dispatcher = new ActionDispatcher(null, null, DispatcherFactory::filters());
         $this->assertCount(1, $dispatcher->getFilters());
         $this->assertSame($filter, $dispatcher->getFilters()[0]);
     }

--- a/tests/test_app/TestApp/Routing/Filter/AppendFilter.php
+++ b/tests/test_app/TestApp/Routing/Filter/AppendFilter.php
@@ -1,0 +1,15 @@
+<?php
+namespace TestApp\Routing\Filter;
+
+use Cake\Event\Event;
+use Cake\Network\Response;
+use Cake\Routing\DispatcherFilter;
+
+class AppendFilter extends DispatcherFilter
+{
+    public function afterDispatch(Event $event)
+    {
+        $response = $event->data['response'];
+        $response->body($response->body() . ' appended content');
+    }
+}


### PR DESCRIPTION
When an application isn't using the Http\Server stack we shouldn't double bind the Dispatcher filters. Previously they were bound in both DispatcherFactory::create(), and then again in ActionDispatcher::__construct() as the filters would be pulled in from global state. By injecting all the dependencies where needed we can avoid doubly registering a filter.

This shouldn't be a breaking change, but could be if people have overidden the getDispatcher() method in an incompatible way.

Refs #9296
