### PR TITLE
fix PHP7.1 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ matrix:
 
   allow_failures:
     - php: hhvm
-    - php: 7.1
 
 before_install:
   - if [ $HHVM != 1 && $TRAVIS_PHP_VERSION != 7.* ]; then phpenv config-rm xdebug.ini; fi

--- a/tests/TestCase/Utility/Crypto/McryptTest.php
+++ b/tests/TestCase/Utility/Crypto/McryptTest.php
@@ -31,7 +31,7 @@ class McryptTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->skipIf(!function_exists('mcrypt_encrypt'), 'No mcrypt skipping tests');
+        $this->skipIf(!function_exists('mcrypt_encrypt') || version_compare(PHP_VERSION, '7.1', '>='), 'No mcrypt skipping tests');
         $this->crypt = new Mcrypt();
     }
 

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -76,7 +76,7 @@ class SecurityTest extends TestCase
      */
     public function testRijndael()
     {
-        $this->skipIf(!function_exists('mcrypt_encrypt'));
+        $this->skipIf(!function_exists('mcrypt_encrypt') || version_compare(PHP_VERSION, '7.1', '>='));
         $engine = Security::engine();
 
         Security::engine(new Mcrypt());
@@ -259,8 +259,8 @@ class SecurityTest extends TestCase
      */
     public function testEngineEquivalence()
     {
-        $this->skipIf(!defined('MCRYPT_RIJNDAEL_128'), 'This needs mcrypt extension to be loaded.');
-
+        $this->skipIf(!function_exists('mcrypt_encrypt') || version_compare(PHP_VERSION, '7.1', '>='), 'This needs mcrypt extension to be loaded.');
+        
         $restore = Security::engine();
         $txt = "Obi-wan you're our only hope";
         $key = 'This is my secret key phrase it is quite long.';


### PR DESCRIPTION
The only remaining failing builds are PHP7.1.

I didn't found the way to just disable the `mcrypt` extension for php7.1+, I believe it would be a cleaner solution.
