### PR TITLE
Fix computed fields in contained associations

### DIFF
--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -134,12 +134,20 @@ trait SelectableAssociationTrait
         if (empty($select)) {
             return;
         }
-        $missingFields = array_diff($key, $select) !== [];
+        $missingKey = function ($fieldList, $key) {
+            foreach ($key as $keyField) {
+                if (!in_array($keyField, $fieldList, true)) {
+                    return true;
+                }
+            }
+            return false;
+        };
 
+        $missingFields = $missingKey($select, $key);
         if ($missingFields) {
             $driver = $fetchQuery->connection()->driver();
             $quoted = array_map([$driver, 'quoteIdentifier'], $key);
-            $missingFields = array_diff($quoted, $select) !== [];
+            $missingFields = $missingKey($select, $quoted);
         }
 
         if ($missingFields) {

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -140,6 +140,7 @@ trait SelectableAssociationTrait
                     return true;
                 }
             }
+
             return false;
         };
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -948,6 +948,32 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Tests that find() and contained associations using computed fields doesn't error out.
+     *
+     * @see https://github.com/cakephp/cakephp/issues/9326
+     * @return void
+     */
+    public function testContainWithComputedField()
+    {
+        $this->loadFixtures('Comments', 'Users');
+        $table = TableRegistry::get('Users');
+        $table->hasMany('Comments');
+
+        $query = $table->find()->contain([
+            'Comments' => function ($q) {
+                return $q->select([
+                    'concat' => $q->func()->concat(['red', 'blue']),
+                    'user_id'
+                ]);
+            }])
+            ->where(['Users.id' => 2]);
+
+        $results = $query->toArray();
+        $this->assertCount(1, $results);
+        $this->assertEquals('redblue', $results[0]->comments[0]->concat);
+    }
+
+    /**
      * Tests that using matching and selecting no fields for that association
      * will no trigger any errors and fetch the right results
      *


### PR DESCRIPTION
When selecting computed fields in contained associations, an object to string error would be emitted. This caused queries to work incorrectly in both PHP5.x and PHP7 but in different ways. By doing a slightly slower check we can avoid string conversion errors.

Refs #9326
