### PR TITLE
Stop the beforeDispatch event on redirect routes.

### DIFF
--- a/src/Routing/Filter/RoutingFilter.php
+++ b/src/Routing/Filter/RoutingFilter.php
@@ -58,6 +58,7 @@ class RoutingFilter extends DispatcherFilter
                 $request->addParams($params);
             }
         } catch (RedirectException $e) {
+            $event->stopPropagation();
             $response = $event->data['response'];
             $response->statusCode($e->getCode());
             $response->header('Location', $e->getMessage());

--- a/tests/TestCase/Routing/Filter/RoutingFilterTest.php
+++ b/tests/TestCase/Routing/Filter/RoutingFilterTest.php
@@ -90,6 +90,7 @@ class RoutingFilterTest extends TestCase
         $this->assertInstanceOf('Cake\Network\Response', $response);
         $this->assertSame('http://localhost/articles', $response->header()['Location']);
         $this->assertSame(301, $response->statusCode());
+        $this->assertTrue($event->isStopped());
     }
 
     /**


### PR DESCRIPTION
By stopping the beforeDispatch event we can ensure that a controller is not built, and that no other dispatch filters are invoked. This lets the redirect happen.

Refs #9336
