### PR TITLE
3.x - Fix/tighten `Folder::inPath()` checks

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -418,12 +418,17 @@ class Folder
     /**
      * Returns true if the Folder is in the given path.
      *
-     * @param string $path The absolute path to check that the current `pwd()` resides within.
+     * @param string $path The absolute path to check that the current `pwd()` resides within. If omitted
+     *  (or empty), the current top level directory is assumed.
      * @param bool $reverse Reverse the search, check if the given `$path` resides within the current `pwd()`.
      * @return bool
      */
     public function inPath($path = '', $reverse = false)
     {
+        if (empty($path)) {
+            $path = DS;
+        }
+
         $dir = Folder::slashTerm($path);
         $current = Folder::slashTerm($this->pwd());
 

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -401,7 +401,7 @@ class Folder
     }
 
     /**
-     * Returns true if the File is in a given CakePath.
+     * Returns true if the Folder is in the given Cake path.
      *
      * @param string $path The path to check.
      * @return bool
@@ -416,10 +416,10 @@ class Folder
     }
 
     /**
-     * Returns true if the File is in given path.
+     * Returns true if the Folder is in the given path.
      *
-     * @param string $path The path to check that the current pwd() resides with in.
-     * @param bool $reverse Reverse the search, check that pwd() resides within $path.
+     * @param string $path The absolute path to check that the current `pwd()` resides within.
+     * @param bool $reverse Reverse the search, check if the given `$path` resides within the current `pwd()`.
      * @return bool
      */
     public function inPath($path = '', $reverse = false)
@@ -428,9 +428,9 @@ class Folder
         $current = Folder::slashTerm($this->pwd());
 
         if (!$reverse) {
-            $return = preg_match('/^(.*)' . preg_quote($dir, '/') . '(.*)/', $current);
+            $return = preg_match('/^' . preg_quote($dir, '/') . '(.*)/', $current);
         } else {
-            $return = preg_match('/^(.*)' . preg_quote($current, '/') . '(.*)/', $dir);
+            $return = preg_match('/^' . preg_quote($current, '/') . '(.*)/', $dir);
         }
 
         return (bool)$return;

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -16,6 +16,7 @@ namespace Cake\Filesystem;
 
 use DirectoryIterator;
 use Exception;
+use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -418,15 +419,15 @@ class Folder
     /**
      * Returns true if the Folder is in the given path.
      *
-     * @param string $path The absolute path to check that the current `pwd()` resides within. If omitted
-     *  (or empty), the current top level directory is assumed.
+     * @param string $path The absolute path to check that the current `pwd()` resides within.
      * @param bool $reverse Reverse the search, check if the given `$path` resides within the current `pwd()`.
      * @return bool
+     * @throws \InvalidArgumentException When the given `$path` argument is not an absolute path.
      */
-    public function inPath($path = '', $reverse = false)
+    public function inPath($path, $reverse = false)
     {
-        if (empty($path)) {
-            $path = realpath(DS);
+        if (!Folder::isAbsolute($path)) {
+            throw new InvalidArgumentException('The $path argument is expected to be an absolute path.');
         }
 
         $dir = Folder::slashTerm($path);

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -426,7 +426,7 @@ class Folder
     public function inPath($path = '', $reverse = false)
     {
         if (empty($path)) {
-            $path = DS;
+            $path = realpath(DS);
         }
 
         $dir = Folder::slashTerm($path);

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -95,63 +95,62 @@ class FolderTest extends TestCase
      */
     public function testInPath()
     {
-        // "/tests/base/"
-        $basePath = TMP . 'tests' . DS . 'base' . DS;
-        $Base = new Folder($basePath, true);
+        // "/tests/test_app/"
+        $basePath = TEST_APP;
+        $Base = new Folder($basePath);
 
         $result = $Base->pwd();
         $this->assertEquals($basePath, $result);
 
-
-        // is "/" in "/tests/base/"
-        $result = $Base->inPath();
+        // is "/" in "/tests/test_app/"
+        $result = $Base->inPath('', true);
         $this->assertFalse($result, true);
 
-        // is "/tests/base/" in "/tests/base/"
+        // is "/tests/test_app/" in "/tests/test_app/"
         $result = $Base->inPath($basePath, true);
         $this->assertTrue($result);
 
-        // is "/tests/base" in "/tests/base/"
+        // is "/tests/test_app" in "/tests/test_app/"
         $result = $Base->inPath(mb_substr($basePath, 0, -1), true);
         $this->assertTrue($result);
 
-        // is "/tests/base/sub" in "/tests/base/"
+        // is "/tests/test_app/sub" in "/tests/test_app/"
         $result = $Base->inPath($basePath . 'sub', true);
         $this->assertTrue($result);
 
-        // is "/tests" in "/tests/base/"
+        // is "/tests" in "/tests/test_app/"
         $result = $Base->inPath(dirname($basePath), true);
         $this->assertFalse($result);
 
-        // is "/tests/other/(...)tests/base" in "/tests/base/"
+        // is "/tests/other/(...)tests/test_app" in "/tests/test_app/"
         $result = $Base->inPath(TMP . 'tests' . DS . 'other' . DS . $basePath, true);
         $this->assertFalse($result);
 
 
-        // is "/tests/base/" in "/"
+        // is "/tests/test_app/" in "/"
         $result = $Base->inPath();
-        $this->assertFalse($result);
+        $this->assertTrue($result);
 
-        // is "/tests/base/" in "/tests/base/"
+        // is "/tests/test_app/" in "/tests/test_app/"
         $result = $Base->inPath($basePath);
         $this->assertTrue($result);
 
-        // is "/tests/base/" in "/tests/base"
+        // is "/tests/test_app/" in "/tests/test_app"
         $result = $Base->inPath(mb_substr($basePath, 0, -1));
         $this->assertTrue($result);
 
-        // is "/tests/base/" in "/tests"
+        // is "/tests/test_app/" in "/tests"
         $result = $Base->inPath(dirname($basePath));
         $this->assertTrue($result);
 
-        // is "/tests/base/" in "/tests/base/sub"
+        // is "/tests/test_app/" in "/tests/test_app/sub"
         $result = $Base->inPath($basePath . 'sub');
         $this->assertFalse($result);
 
-        // is "/other/tests/base/" in "/tests/base/"
+        // is "/other/tests/test_app/" in "/tests/test_app/"
         $VirtualBase = new Folder();
-        $VirtualBase->path = '/other/tests/base';
-        $result = $VirtualBase->inPath('/tests/base/');
+        $VirtualBase->path = '/other/tests/test_app';
+        $result = $VirtualBase->inPath('/tests/test_app/');
         $this->assertFalse($result);
     }
 

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -95,28 +95,64 @@ class FolderTest extends TestCase
      */
     public function testInPath()
     {
-        $path = dirname(__DIR__);
-        $inside = dirname($path) . DS;
+        // "/tests/base/"
+        $basePath = TMP . 'tests' . DS . 'base' . DS;
+        $Base = new Folder($basePath, true);
 
-        $Folder = new Folder($path);
+        $result = $Base->pwd();
+        $this->assertEquals($basePath, $result);
 
-        $result = $Folder->pwd();
-        $this->assertEquals($path, $result);
 
-        $result = Folder::isSlashTerm($inside);
+        // is "/" in "/tests/base/"
+        $result = $Base->inPath();
+        $this->assertFalse($result, true);
+
+        // is "/tests/base/" in "/tests/base/"
+        $result = $Base->inPath($basePath, true);
         $this->assertTrue($result);
 
-        $result = $Folder->realpath('tests' . DS);
-        $this->assertEquals($path . DS . 'tests' . DS, $result);
-
-        $result = $Folder->inPath('tests' . DS);
+        // is "/tests/base" in "/tests/base/"
+        $result = $Base->inPath(mb_substr($basePath, 0, -1), true);
         $this->assertTrue($result);
 
-        $result = $Folder->inPath(DS . 'non-existing' . $inside);
+        // is "/tests/base/sub" in "/tests/base/"
+        $result = $Base->inPath($basePath . 'sub', true);
+        $this->assertTrue($result);
+
+        // is "/tests" in "/tests/base/"
+        $result = $Base->inPath(dirname($basePath), true);
         $this->assertFalse($result);
 
-        $result = $Folder->inPath($path . DS . 'Model', true);
+        // is "/tests/other/(...)tests/base" in "/tests/base/"
+        $result = $Base->inPath(TMP . 'tests' . DS . 'other' . DS . $basePath, true);
+        $this->assertFalse($result);
+
+
+        // is "/tests/base/" in "/"
+        $result = $Base->inPath();
+        $this->assertFalse($result);
+
+        // is "/tests/base/" in "/tests/base/"
+        $result = $Base->inPath($basePath);
         $this->assertTrue($result);
+
+        // is "/tests/base/" in "/tests/base"
+        $result = $Base->inPath(mb_substr($basePath, 0, -1));
+        $this->assertTrue($result);
+
+        // is "/tests/base/" in "/tests"
+        $result = $Base->inPath(dirname($basePath));
+        $this->assertTrue($result);
+
+        // is "/tests/base/" in "/tests/base/sub"
+        $result = $Base->inPath($basePath . 'sub');
+        $this->assertFalse($result);
+
+        // is "/other/tests/base/" in "/tests/base/"
+        $VirtualBase = new Folder();
+        $VirtualBase->path = '/other/tests/base';
+        $result = $VirtualBase->inPath('/tests/base/');
+        $this->assertFalse($result);
     }
 
     /**

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -102,8 +102,9 @@ class FolderTest extends TestCase
         $result = $Base->pwd();
         $this->assertEquals($basePath, $result);
 
+
         // is "/" in "/tests/test_app/"
-        $result = $Base->inPath('', true);
+        $result = $Base->inPath(realpath(DS), true);
         $this->assertFalse($result, true);
 
         // is "/tests/test_app/" in "/tests/test_app/"
@@ -128,7 +129,7 @@ class FolderTest extends TestCase
 
 
         // is "/tests/test_app/" in "/"
-        $result = $Base->inPath();
+        $result = $Base->inPath(realpath(DS));
         $this->assertTrue($result);
 
         // is "/tests/test_app/" in "/tests/test_app/"
@@ -152,6 +153,32 @@ class FolderTest extends TestCase
         $VirtualBase->path = '/other/tests/test_app';
         $result = $VirtualBase->inPath('/tests/test_app/');
         $this->assertFalse($result);
+    }
+
+    /**
+     * Data provider for the testInPathInvalidPathArgument test
+     *
+     * @return array
+     */
+    public function inPathInvalidPathArgumentDataProvider()
+    {
+        return [
+            [''],
+            ['relative/path/'],
+            ['unknown://stream-wrapper']
+        ];
+    }
+
+    /**
+     * @dataProvider inPathInvalidPathArgumentDataProvider
+     * @param string $path
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The $path argument is expected to be an absolute path.
+     */
+    public function testInPathInvalidPathArgument($path)
+    {
+        $Folder = new Folder();
+        $Folder->inPath($path);
     }
 
     /**


### PR DESCRIPTION
The `Folder::inPath()` code hasn't changed in like forever, and I'm kinda surprised that this hasn't come up before in all these years. Given this is a valid change, it would need to be applied to 2.x too. 

Currently `Folder::inPath()` uses a very relaxed check that can easily fail, or even be tricked and potentially turn into a security related problem, as paths may slip through that are actually _not_ in the tested path. Since exploiting this problem requires a lot of knowledge about what's going on in the application, about what the directory structure looks like, and another path being present that contains the tested one, I thought I'd just push this fix instead of reporting this to security [at] cakephp.org.

Example:

``` php
(new Folder('/var/www'))->inPath('/foo/var/www/bar', true)
```

``` php
(new Folder('/foo/var/www'))->inPath('/var/www', false)
```

Currently both of these checks would come back as `true`, but cleary `/foo/var/www/bar` is outside of `/var/www`, just like `/var/www` is outside of `/foo/var/www`. Currently this is pretty much a substring test, and I think we can all agree that this is problematic and most likely unexpected, so changing this behavior to be more strict should be an OK change I guess, even if it it's a little backwards incompatible.

The current tests however made me a little unsure about how exactly the method is expected to behave, as it explicitly tested a relative path fragment, which passed the test.

https://github.com/cakephp/cakephp/blob/3.3.2/tests/TestCase/Filesystem/FolderTest.php#L112-L113

So I'm wondering whether the method was ever ment to be able to find path fragments? Personally I think that is out of scope, and that the method should stick to comparing absolute paths.

Also I'm not sure about the behavior when no/an empty path is passed. The current behavior would be that things would be tested against `/`, ie the top level directory. So for now I've fixed this up (without changing the signature) so that the correct path is used on Windows too, but I'm not sure whether this behavior is overly useful in the first place?

Personally I'd like to see it removed, as it's a possible pitfall too in case one doesn't properly check the passed path. I'd even go a step further, and make the argument required, and throw an exception in case the passed path is not an absolute path, but that would be pretty backwards incompatible of course!?
