### PR TITLE
Start Request deprecations

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1369,6 +1369,7 @@ class Request implements ArrayAccess
      *
      * @param string $name Name of the key being accessed.
      * @return mixed
+     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use param(), data() and query() instead.
      */
     public function offsetGet($name)
     {
@@ -1391,6 +1392,7 @@ class Request implements ArrayAccess
      * @param string $name Name of the key being written
      * @param mixed $value The value being written.
      * @return void
+     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use param(), data() and query() instead.
      */
     public function offsetSet($name, $value)
     {
@@ -1402,6 +1404,7 @@ class Request implements ArrayAccess
      *
      * @param string $name thing to check.
      * @return bool
+     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use param(), data() and query() instead.
      */
     public function offsetExists($name)
     {
@@ -1417,6 +1420,7 @@ class Request implements ArrayAccess
      *
      * @param string $name Name to unset.
      * @return void
+     * @deprecated 3.4.0 The ArrayAccess methods will be removed in 4.0.0. Use param(), data() and query() instead.
      */
     public function offsetUnset($name)
     {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -23,10 +23,6 @@ use Cake\Utility\Hash;
 /**
  * A class that helps wrap Request information and particulars about a single request.
  * Provides methods commonly used to introspect on the request headers and request body.
- *
- * Has both an Array and Object interface. You can access framework parameters using indexes:
- *
- * `$request['controller']` or `$request->controller`.
  */
 class Request implements ArrayAccess
 {
@@ -35,6 +31,7 @@ class Request implements ArrayAccess
      * Array of parameters parsed from the URL.
      *
      * @var array
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use param() instead.
      */
     public $params = [
         'plugin' => null,
@@ -50,6 +47,7 @@ class Request implements ArrayAccess
      * data.
      *
      * @var array
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use data() instead.
      */
     public $data = [];
 
@@ -57,6 +55,7 @@ class Request implements ArrayAccess
      * Array of querystring arguments
      *
      * @var array
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use query() instead.
      */
     public $query = [];
 
@@ -64,6 +63,7 @@ class Request implements ArrayAccess
      * Array of cookie data.
      *
      * @var array
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use cookie() instead.
      */
     public $cookies = [];
 
@@ -597,6 +597,8 @@ class Request implements ArrayAccess
      *
      * @param string $name The property being accessed.
      * @return mixed Either the value of the parameter or null.
+     * @deprecated 3.4.0 Accessing routing parameters through __get will removed in 4.0.0.
+     *   Use param() instead.
      */
     public function __get($name)
     {
@@ -613,6 +615,8 @@ class Request implements ArrayAccess
      *
      * @param string $name The property being accessed.
      * @return bool Existence
+     * @deprecated 3.4.0 Accessing routing parameters through __isset will removed in 4.0.0.
+     *   Use param() instead.
      */
     public function __isset($name)
     {


### PR DESCRIPTION
These methods were compatibility shims from the 1.x days. Deprecating these methods now will make implementing PSR7 simpler as these methods cannot work on immutable objects.

This is only the beginning of the public property deprecations. More properties will be deprecated as new accessor methods are introduced. Next I'll add in some of the new setters so the combined get/set methods can be deprecated.

Refs #9325 
