### PR TITLE
Ensure getMockForModel sets proper table name if it's not predefined

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -664,6 +664,10 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
             }
         }
 
+        if (stripos($mock->table(), 'mock') === 0) {
+            $mock->table(Inflector::tableize($baseClass));
+        }
+
         TableRegistry::set($baseClass, $mock);
 
         return $mock;

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -549,8 +549,8 @@ class TestCaseTest extends TestCase
     {
         Configure::write('App.namespace', 'TestApp');
 
-        $Tags = $this->getMockForModel('I18n', ['doSomething']);
-        $this->assertEquals('custom_i18n_table', $Tags->table());
+        $I18n = $this->getMockForModel('I18n', ['doSomething']);
+        $this->assertEquals('custom_i18n_table', $I18n->table());
 
         $Tags = $this->getMockForModel('Tags', ['doSomething']);
         $this->assertEquals('tags', $Tags->table());

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -539,4 +539,20 @@ class TestCaseTest extends TestCase
         $this->assertTrue($Mock->save($entity));
         $this->assertFalse($Mock->save($entity));
     }
+
+    /**
+     * Test getting a table mock that doesn't have a preset table name sets the proper name
+     *
+     * @return void
+     */
+    public function testGetMockForModelSetTable()
+    {
+        Configure::write('App.namespace', 'TestApp');
+
+        $Tags = $this->getMockForModel('I18n', ['doSomething']);
+        $this->assertEquals('custom_i18n_table', $Tags->table());
+
+        $Tags = $this->getMockForModel('Tags', ['doSomething']);
+        $this->assertEquals('tags', $Tags->table());
+    }
 }


### PR DESCRIPTION
This fixes a bug where table names based off of the mock class name (e.g. `mock__tags_table_b8b`). I'm a tad surprised this hasn't been discovered yet 😄  we've been overwriting it in our test case base for some time, I thought it was just something wonky with our classes. (Maybe no one uses `getMockForModel` anymore?)
