### PR TITLE
2.x sort locale backport

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -1361,6 +1361,34 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Test sort() with locale option.
+ *
+ * @return void
+ */
+	public function testSortLocale() {
+		// get the current locale
+		$oldLocale = setlocale(LC_COLLATE, '0');
+		// the de_DE.utf8 locale must be installed on the system where the test is performed
+		setlocale(LC_COLLATE, 'de_DE.utf8');
+		$items = array(
+			array('Item' => array('entry' => 'Übergabe')),
+			array('Item' => array('entry' => 'Ostfriesland')),
+			array('Item' => array('entry' => 'Äpfel')),
+			array('Item' => array('entry' => 'Apfel')),
+		);
+		$result = Hash::sort($items, '{n}.Item.entry', 'asc', 'locale');
+		$expected = array(
+			array('Item' => array('entry' => 'Apfel')),
+			array('Item' => array('entry' => 'Äpfel')),
+			array('Item' => array('entry' => 'Ostfriesland')),
+			array('Item' => array('entry' => 'Übergabe')),
+		);
+		$this->assertEquals($expected, $result);
+		// change to the original locale
+		setlocale(LC_COLLATE, $oldLocale);
+	}
+
+/**
  * test sorting with out of order keys.
  *
  * @return void

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -1368,9 +1368,9 @@ class HashTest extends CakeTestCase {
 	public function testSortLocale() {
 		// get the current locale
 		$oldLocale = setlocale(LC_COLLATE, '0');
-
-		// the de_DE.utf8 locale must be installed on the system where the test is performed
-		setlocale(LC_COLLATE, 'de_DE.utf8');
+		
+		$updated = setlocale(LC_COLLATE, 'de_DE.utf8');
+		$this->skipIf($updated === false, 'Could not set locale to de_DE.utf8, skipping test.');
 
 		$items = array(
 			array('Item' => array('entry' => 'Übergabe')),

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -1368,14 +1368,17 @@ class HashTest extends CakeTestCase {
 	public function testSortLocale() {
 		// get the current locale
 		$oldLocale = setlocale(LC_COLLATE, '0');
+
 		// the de_DE.utf8 locale must be installed on the system where the test is performed
 		setlocale(LC_COLLATE, 'de_DE.utf8');
+
 		$items = array(
 			array('Item' => array('entry' => 'Übergabe')),
 			array('Item' => array('entry' => 'Ostfriesland')),
 			array('Item' => array('entry' => 'Äpfel')),
 			array('Item' => array('entry' => 'Apfel')),
 		);
+
 		$result = Hash::sort($items, '{n}.Item.entry', 'asc', 'locale');
 		$expected = array(
 			array('Item' => array('entry' => 'Apfel')),
@@ -1384,6 +1387,7 @@ class HashTest extends CakeTestCase {
 			array('Item' => array('entry' => 'Übergabe')),
 		);
 		$this->assertEquals($expected, $result);
+
 		// change to the original locale
 		setlocale(LC_COLLATE, $oldLocale);
 	}

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -836,6 +836,7 @@ class Hash {
  * - `regular` For regular sorting (don't change types)
  * - `numeric` Compare values numerically
  * - `string` Compare values as strings
+ * - `locale` Compare items as strings, based on the current locale
  * - `natural` Compare items as strings using "natural ordering" in a human friendly way.
  *   Will sort foo10 below foo2 as an example. Requires PHP 5.4 or greater or it will fallback to 'regular'
  *
@@ -904,6 +905,8 @@ class Hash {
 			$type = SORT_STRING;
 		} elseif ($type === 'natural') {
 			$type = SORT_NATURAL;
+		} elseif ($type === 'locale') {
+			$type = SORT_LOCALE_STRING;
 		} else {
 			$type = SORT_REGULAR;
 		}


### PR DESCRIPTION
Backport https://github.com/cakephp/cakephp/pull/9335 from 3.x to 2.x
