### PR TITLE
Allow Request::query() to return all query strings.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -584,9 +584,9 @@ class Request implements ArrayAccess
     {
         if (strpos($name, 'is') === 0) {
             $type = strtolower(substr($name, 2));
-            
+
             array_unshift($params, $type);
-            
+
             return call_user_func_array([$this, 'is'], $params);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $name));
@@ -639,7 +639,7 @@ class Request implements ArrayAccess
 
             return count(array_filter($result)) > 0;
         }
-        
+
         $args = func_get_args();
         array_shift($args);
 
@@ -651,7 +651,7 @@ class Request implements ArrayAccess
         if ($args) {
             return $this->_is($type, $args);
         }
-        
+
         if (!isset($this->_detectorCache[$type])) {
             $this->_detectorCache[$type] = $this->_is($type, $args);
         }
@@ -1161,11 +1161,15 @@ class Request implements ArrayAccess
      * Provides a read accessor for `$this->query`. Allows you
      * to use a syntax similar to `CakeSession` for reading URL query data.
      *
-     * @param string $name Query string variable name
+     * @param string|null $name Query string variable name or null to read all.
      * @return mixed The value being read
      */
-    public function query($name)
+    public function query($name = null)
     {
+        if ($name === null) {
+            return $this->query;
+        }
+
         return Hash::get($this->query, $name);
     }
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1162,7 +1162,7 @@ class Request implements ArrayAccess
      * to use a syntax similar to `CakeSession` for reading URL query data.
      *
      * @param string|null $name Query string variable name or null to read all.
-     * @return mixed The value being read
+     * @return string|array|null The value being read
      */
     public function query($name = null)
     {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2000,9 +2000,10 @@ class RequestTest extends TestCase
      */
     public function testQuery()
     {
-        $request = new Request([
+        $array = [
             'query' => ['foo' => 'bar', 'zero' => '0']
-        ]);
+        ];
+        $request = new Request($array);
 
         $result = $request->query('foo');
         $this->assertSame('bar', $result);
@@ -2012,6 +2013,9 @@ class RequestTest extends TestCase
 
         $result = $request->query('imaginary');
         $this->assertNull($result);
+
+        $result = $request->query();
+        $this->assertSame($array, $result);
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2015,7 +2015,7 @@ class RequestTest extends TestCase
         $this->assertNull($result);
 
         $result = $request->query();
-        $this->assertSame($array, $result);
+        $this->assertSame($array['query'], $result);
     }
 
     /**


### PR DESCRIPTION
This comes from the IRC support channel as a request.

In light of https://github.com/cakephp/cakephp/issues/9325 it becomes necessary to not further rely on the soon deprecated `$this->request->query` to read all query strings at once, but instead use `$this->request->query()` method without any argument.
This makes it also consistent to ->request->data() and alike.

PS: why is the whitespace noise not checked by the sniffer/stickler etc?
Should not happen.
