### PR TITLE
Revert "Allow Request::query() to return all query strings."

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -584,9 +584,9 @@ class Request implements ArrayAccess
     {
         if (strpos($name, 'is') === 0) {
             $type = strtolower(substr($name, 2));
-
+            
             array_unshift($params, $type);
-
+            
             return call_user_func_array([$this, 'is'], $params);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $name));
@@ -639,7 +639,7 @@ class Request implements ArrayAccess
 
             return count(array_filter($result)) > 0;
         }
-
+        
         $args = func_get_args();
         array_shift($args);
 
@@ -651,7 +651,7 @@ class Request implements ArrayAccess
         if ($args) {
             return $this->_is($type, $args);
         }
-
+        
         if (!isset($this->_detectorCache[$type])) {
             $this->_detectorCache[$type] = $this->_is($type, $args);
         }
@@ -1161,15 +1161,11 @@ class Request implements ArrayAccess
      * Provides a read accessor for `$this->query`. Allows you
      * to use a syntax similar to `CakeSession` for reading URL query data.
      *
-     * @param string|null $name Query string variable name or null to read all.
-     * @return string|array|null The value being read
+     * @param string $name Query string variable name
+     * @return mixed The value being read
      */
-    public function query($name = null)
+    public function query($name)
     {
-        if ($name === null) {
-            return $this->query;
-        }
-
         return Hash::get($this->query, $name);
     }
 

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2000,10 +2000,9 @@ class RequestTest extends TestCase
      */
     public function testQuery()
     {
-        $array = [
+        $request = new Request([
             'query' => ['foo' => 'bar', 'zero' => '0']
-        ];
-        $request = new Request($array);
+        ]);
 
         $result = $request->query('foo');
         $this->assertSame('bar', $result);
@@ -2013,9 +2012,6 @@ class RequestTest extends TestCase
 
         $result = $request->query('imaginary');
         $this->assertNull($result);
-
-        $result = $request->query();
-        $this->assertSame($array['query'], $result);
     }
 
     /**


### PR DESCRIPTION
Reverts cakephp/cakephp#9353

@ADmad pointed out that this will cause strict errors in userland subclasses. To avoid that I'm proposing we revert this and re-add these changes into 3.4.0
