### PR TITLE
Generate warning that rule is being replaced.

### DIFF
--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -125,6 +125,9 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
         if (!($rule instanceof ValidationRule)) {
             $rule = new ValidationRule($rule);
         }
+        if (isset($this->_rules[$name])) {
+            trigger_error("Remove rule $name before adding", E_USER_WARNING);
+        }
         $this->_rules[$name] = $rule;
 
         return $this;


### PR DESCRIPTION
Adds a warning when a Validation rule of the same name has already been applied to the field.

I ran into a case where I had two custom rules with the same name on a field, but Cake silently replaced the rule with the new one.

There is a method to remove rules. So add should not be used to overwrite a field rule.

I think a low impact warning is okay in such a case.
