### PR TITLE
Simplify escape for flash messages.

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -75,6 +75,7 @@ class FlashComponent extends Component
      * - `element` The element used to render the flash message. Default to 'default'.
      * - `params` An array of variables to make available when using an element
      * - `clear` A bool stating if the current stack should be cleared to start a new one
+     * - `escape` Set to false to allow templates to print out HTML content
      *
      * @param string|\Exception $message Message to be flashed. If an instance
      *   of \Exception the exception message will be used and code will be set
@@ -89,6 +90,10 @@ class FlashComponent extends Component
         if ($message instanceof Exception) {
             $options['params'] += ['code' => $message->getCode()];
             $message = $message->getMessage();
+        }
+
+        if (isset($options['escape'])) {
+            $options['params'] += ['escape' => $options['escape']];
         }
 
         list($plugin, $element) = pluginSplit($options['element']);

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -111,6 +111,38 @@ class FlashComponentTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testSetEscape()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->set('This is a test message', ['escape' => false, 'params' => ['foo' => 'bar']]);
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'flash',
+                'element' => 'Flash/default',
+                'params' => ['foo' => 'bar', 'escape' => false]
+            ]
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->set('This is a test message', ['key' => 'escaped', 'escape' => false, 'params' => ['foo' => 'bar', 'escape' => true]]);
+        $expected = [
+            [
+                'message' => 'This is a test message',
+                'key' => 'escaped',
+                'element' => 'Flash/default',
+                'params' => ['foo' => 'bar', 'escape' => true]
+            ]
+        ];
+        $result = $this->Session->read('Flash.escaped');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * test setting messages with using the clear option
      *
      * @return void
@@ -223,7 +255,7 @@ class FlashComponentTest extends TestCase
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result, 'Element is ignored in magic call.');
-        
+
         $this->Flash->success('It worked', ['plugin' => 'MyPlugin']);
 
         $expected[] = [

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -117,10 +117,10 @@ class FlashComponentTest extends TestCase
     {
         $this->assertNull($this->Session->read('Flash.flash'));
 
-        $this->Flash->set('This is a test message', ['escape' => false, 'params' => ['foo' => 'bar']]);
+        $this->Flash->set('This is a <b>test</b> message', ['escape' => false, 'params' => ['foo' => 'bar']]);
         $expected = [
             [
-                'message' => 'This is a test message',
+                'message' => 'This is a <b>test</b> message',
                 'key' => 'flash',
                 'element' => 'Flash/default',
                 'params' => ['foo' => 'bar', 'escape' => false]


### PR DESCRIPTION
The Flash component should allow for easier HTML context

Currently one has to do:

``` php
$this->Flash->info('<b>' . h($highlight) . '</b> ' . h($message), ['params' => ['escape' => false]]);
```

It should probably be a bit easier, like:

``` php
$this->Flash->info('<b>' . h($highlight) . '</b> ' . h($message), ['escape' => false]);
```

The templates can then use the escape param to print out the context as required.

Refs https://github.com/cakephp/app/pull/427
