### PR TITLE
Re-add query() getting all parameters.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -584,9 +584,9 @@ class Request implements ArrayAccess
     {
         if (strpos($name, 'is') === 0) {
             $type = strtolower(substr($name, 2));
-            
+
             array_unshift($params, $type);
-            
+
             return call_user_func_array([$this, 'is'], $params);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $name));
@@ -643,7 +643,7 @@ class Request implements ArrayAccess
 
             return count(array_filter($result)) > 0;
         }
-        
+
         $args = func_get_args();
         array_shift($args);
 
@@ -655,7 +655,7 @@ class Request implements ArrayAccess
         if ($args) {
             return $this->_is($type, $args);
         }
-        
+
         if (!isset($this->_detectorCache[$type])) {
             $this->_detectorCache[$type] = $this->_is($type, $args);
         }
@@ -1165,11 +1165,15 @@ class Request implements ArrayAccess
      * Provides a read accessor for `$this->query`. Allows you
      * to use a syntax similar to `CakeSession` for reading URL query data.
      *
-     * @param string $name Query string variable name
-     * @return mixed The value being read
+     * @param string|null $name Query string variable name or null to read all.
+     * @return string|array|null The value being read
      */
-    public function query($name)
+    public function query($name = null)
     {
+        if ($name === null) {
+            return $this->query;
+        }
+
         return Hash::get($this->query, $name);
     }
 

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2000,9 +2000,10 @@ class RequestTest extends TestCase
      */
     public function testQuery()
     {
-        $request = new Request([
+        $array = [
             'query' => ['foo' => 'bar', 'zero' => '0']
-        ]);
+        ];
+        $request = new Request($array);
 
         $result = $request->query('foo');
         $this->assertSame('bar', $result);
@@ -2012,6 +2013,9 @@ class RequestTest extends TestCase
 
         $result = $request->query('imaginary');
         $this->assertNull($result);
+
+        $result = $request->query();
+        $this->assertSame($array['query'], $result);
     }
 
     /**


### PR DESCRIPTION
Revert "Revert "Allow Request::query() to return all query strings.""

This reverts commit 6d9f2fcefa7e4e6b3bec552514aa9bbbfbdec3f4.

Refs #9356
