### PR TITLE
added `cssBlock()`, `cssStart()` and `cssEnd()` methods

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -474,6 +474,73 @@ class HtmlHelper extends Helper
         }
         $this->_View->append($options['block'], $out);
     }
+    
+    /**
+     * Wrap $css in a style tag.
+     *
+     * ### Options
+     *
+     * - `block` Set to true to append output to view block "css" or provide
+     *   custom block name.
+     *
+     * @param string $css The css code to wrap
+     * @param array $options The options to use. Options not listed above will be
+     *    treated as HTML attributes.
+     * @return string|null String or null depending on the value of `$options['block']`
+     */
+    public function cssBlock($css, array $options = [])
+    {
+        $options += ['block' => null];
+
+        $out = $this->formatTemplate('style', [
+            'attrs' => $this->templater()->formatAttributes($options, ['block']),
+            'content' => $css,
+        ]);
+
+        if (empty($options['block'])) {
+            return $out;
+        }
+        if ($options['block'] === true) {
+            $options['block'] = 'css';
+        }
+        $this->_View->append($options['block'], $out);
+    }
+
+    /**
+     * Begin a css block that captures output until HtmlHelper::cssEnd()
+     * is called. This capturing block will capture all output between the methods
+     * and create a cssBlock from it.
+     *
+     * ### Options
+     *
+     * - `block` Set to true to append output to view block "css" or provide
+     *   custom block name.
+     *
+     * @param array $options Options for the code block.
+     * @return void
+     */
+    public function cssStart(array $options = [])
+    {
+        $options += ['block' => null];
+        $this->_cssBlockOptions = $options;
+        ob_start();
+    }
+
+    /**
+     * End a Buffered section of css capturing.
+     * Generates a style tag inline or appends to specified view block depending on
+     * the settings used when the cssBlock was started
+     *
+     * @return string|null Depending on the settings of cssStart() either a style tag or null
+     */
+    public function cssEnd()
+    {
+        $buffer = ob_get_clean();
+        $options = $this->_cssBlockOptions;
+        $this->_cssBlockOptions = [];
+
+        return $this->cssBlock($buffer, $options);
+    }
 
     /**
      * Returns one or many `<script>` tags depending on the number of scripts given.


### PR DESCRIPTION
What do you think about these?

If there are methods for JavaScript, I do not see why they should not exist for css.

I still have to add the test, for now I would just like to have your own opinion.
