### PR TITLE
Formhelper source rename

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -206,11 +206,11 @@ class FormHelper extends Helper
     protected $_lastAction = '';
 
     /**
-     * The values sources to be used to retrieve prefilled input values from.
+     * The sources to be used when retrieving prefilled input values.
      *
      * @var array
      */
-    protected $_valuesSources = ['context'];
+    protected $_valueSources = ['context'];
 
     /**
      * Construct the widgets and binds the default context providers
@@ -338,6 +338,7 @@ class FormHelper extends Helper
      * - `context` Additional options for the context class. For example the EntityContext accepts a 'table'
      *   option that allows you to set the specific Table class the form should be based on.
      * - `idPrefix` Prefix for generated ID attributes.
+     * - `valueSources` The sources that values should be read from. See FormHelper::setValueSources()
      *
      * @param mixed $model The context for which the form is being defined. Can
      *   be an ORM entity, ORM resultset, or an array of meta data. You can use false or null
@@ -366,15 +367,17 @@ class FormHelper extends Helper
             'encoding' => strtolower(Configure::read('App.encoding')),
             'templates' => null,
             'idPrefix' => null,
-            'valuesSources' => $this->getValuesSources(),
+            'valueSources' => null,
         ];
 
         if (isset($options['action'])) {
             trigger_error('Using key `action` is deprecated, use `url` directly instead.', E_USER_DEPRECATED);
         }
 
-        $this->setValuesSources($options['valuesSources']);
-        unset($options['valuesSources']);
+        if (isset($options['valueSources'])) {
+            $this->setValueSources($options['valueSources']);
+            unset($options['valueSources']);
+        }
 
         if ($options['idPrefix'] !== null) {
             $this->_idPrefix = $options['idPrefix'];
@@ -557,7 +560,7 @@ class FormHelper extends Helper
         $this->templater()->pop();
         $this->requestType = null;
         $this->_context = null;
-        $this->_valuesSources = ['context'];
+        $this->_valueSources = ['context'];
         $this->_idPrefix = $this->config('idPrefix');
 
         return $out;
@@ -2701,9 +2704,9 @@ class FormHelper extends Helper
      *
      * @return array List of value sources.
      */
-    public function getValuesSources()
+    public function getValueSources()
     {
-        return $this->_valuesSources;
+        return $this->_valueSources;
     }
 
     /**
@@ -2715,9 +2718,9 @@ class FormHelper extends Helper
      * @param string|array $sources A string or a list of strings identifying a source.
      * @return $this
      */
-    public function setValuesSources($sources)
+    public function setValueSources($sources)
     {
-        $this->_valuesSources = array_values(array_intersect((array)$sources, ['context', 'data', 'query']));
+        $this->_valueSources = array_values(array_intersect((array)$sources, ['context', 'data', 'query']));
 
         return $this;
     }
@@ -2731,7 +2734,7 @@ class FormHelper extends Helper
      */
     public function getSourceValue($fieldname, $options = [])
     {
-        foreach ($this->getValuesSources() as $valuesSource) {
+        foreach ($this->getValueSources() as $valuesSource) {
             if ($valuesSource === 'context') {
                 $val = $this->_getContext()->val($fieldname, $options);
                 if ($val !== null) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8171,10 +8171,10 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesSettersGetters()
+    public function testFormValueSourcesSettersGetters()
     {
         $expected = ['context'];
-        $result = $this->Form->getValuesSources();
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
 
         $expected = null;
@@ -8182,34 +8182,34 @@ class FormHelperTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $expected = ['query', 'data', 'context'];
-        $this->Form->setValuesSources(['query', 'data', 'invalid', 'context', 'foo']);
-        $result = $this->Form->getValuesSources();
+        $this->Form->setValueSources(['query', 'data', 'invalid', 'context', 'foo']);
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
 
 
         $this->Form->request->data['id'] = '1';
         $this->Form->request->query['id'] = '2';
 
-        $this->Form->setValuesSources(['context']);
+        $this->Form->setValueSources(['context']);
         $expected = '1';
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals($expected, $result);
 
-        $this->Form->setValuesSources('query');
+        $this->Form->setValueSources('query');
         $expected = ['query'];
-        $result = $this->Form->getValuesSources();
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
 
         $expected = '2';
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals($expected, $result);
 
-        $this->Form->setValuesSources(['data']);
+        $this->Form->setValueSources(['data']);
         $expected = '1';
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals($expected, $result);
 
-        $this->Form->setValuesSources(['query', 'data']);
+        $this->Form->setValueSources(['query', 'data']);
         $expected = '2';
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals($expected, $result);
@@ -8220,7 +8220,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesSingleSwitchRendering()
+    public function testFormValueSourcesSingleSwitchRendering()
     {
         $this->loadFixtures('Articles');
         $articles = TableRegistry::get('Articles');
@@ -8229,7 +8229,7 @@ class FormHelperTest extends TestCase
 
 
         $this->Form->create($article);
-        $this->Form->setValuesSources(['context']);
+        $this->Form->setValueSources(['context']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
@@ -8238,7 +8238,7 @@ class FormHelperTest extends TestCase
 
 
         $this->Form->request->query['id'] = '5';
-        $this->Form->setValuesSources(['query']);
+        $this->Form->setValueSources(['query']);
         $this->Form->create($article);
         $result = $this->Form->input('id');
         $expected = [
@@ -8247,7 +8247,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->create($article);
-        $this->Form->setValuesSources(['query']);
+        $this->Form->setValueSources(['query']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
@@ -8258,7 +8258,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->query['id'] = '5a';
         $this->Form->request->data['id'] = '5b';
 
-        $this->Form->setValuesSources(['context']);
+        $this->Form->setValueSources(['context']);
         $this->Form->create($article);
         $result = $this->Form->input('id');
         $expected = [
@@ -8266,7 +8266,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources(['data']);
+        $this->Form->setValueSources(['data']);
         $this->Form->create($article);
         $result = $this->Form->input('id');
         $expected = [
@@ -8277,7 +8277,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '6';
         $this->Form->request->query['id'] = '7';
         $this->Form->create($article);
-        $this->Form->setValuesSources(['data']);
+        $this->Form->setValueSources(['data']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '6']],
@@ -8287,7 +8287,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '8';
         $this->Form->request->query['id'] = '9';
         $this->Form->create($article);
-        $this->Form->setValuesSources(['query']);
+        $this->Form->setValueSources(['query']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
@@ -8301,7 +8301,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesListSwitchRendering()
+    public function testFormValueSourcesListSwitchRendering()
     {
         $this->loadFixtures('Articles');
         $articles = TableRegistry::get('Articles');
@@ -8311,35 +8311,35 @@ class FormHelperTest extends TestCase
         $this->Form->request->query['id'] = '9';
 
         $this->Form->create($article);
-        $this->Form->setValuesSources(['context']);
+        $this->Form->setValueSources(['context']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources(['query']);
+        $this->Form->setValueSources(['query']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources(['context', 'query']);
+        $this->Form->setValueSources(['context', 'query']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources(['query', 'context']);
+        $this->Form->setValueSources(['query', 'context']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources(['data', 'query', 'context']);
+        $this->Form->setValueSources(['data', 'query', 'context']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
@@ -8349,7 +8349,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->request->data['id'] = '8';
         $this->Form->request->query['id'] = '9';
-        $this->Form->setValuesSources(['data', 'query', 'context']);
+        $this->Form->setValueSources(['data', 'query', 'context']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '8']],
@@ -8362,7 +8362,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesSwitchViaOptionsRendering()
+    public function testFormValueSourcesSwitchViaOptionsRendering()
     {
         $this->loadFixtures('Articles');
         $articles = TableRegistry::get('Articles');
@@ -8373,7 +8373,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '4';
         $this->Form->request->query['id'] = '5';
 
-        $this->Form->create($article, ['valuesSources' => 'query']);
+        $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
@@ -8386,8 +8386,8 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '6';
         $this->Form->request->query['id'] = '7';
 
-        $this->Form->setValuesSources(['context']);
-        $this->Form->create($article, ['valuesSources' => 'query']);
+        $this->Form->setValueSources(['context']);
+        $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '7']],
@@ -8396,8 +8396,8 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals('7', $result);
 
-        $this->Form->setValuesSources(['query']);
-        $this->Form->create($article, ['valuesSources' => 'data']);
+        $this->Form->setValueSources(['query']);
+        $this->Form->create($article, ['valueSources' => 'data']);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '6']],
@@ -8410,8 +8410,8 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '8';
         $this->Form->request->query['id'] = '9';
 
-        $this->Form->setValuesSources(['query']);
-        $this->Form->create($article, ['valuesSources' => ['context', 'data']]);
+        $this->Form->setValueSources(['query']);
+        $this->Form->create($article, ['valueSources' => ['context', 'data']]);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '8']],
@@ -8426,7 +8426,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesSwitchViaOptionsAndSetterRendering()
+    public function testFormValueSourcesSwitchViaOptionsAndSetterRendering()
     {
         $this->loadFixtures('Articles');
         $articles = TableRegistry::get('Articles');
@@ -8437,7 +8437,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '10';
         $this->Form->request->query['id'] = '11';
 
-        $this->Form->setValuesSources(['context'])->create($article, ['valuesSources' => ['query', 'data']]);
+        $this->Form->setValueSources(['context'])->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '11']],
@@ -8447,7 +8447,7 @@ class FormHelperTest extends TestCase
         $this->assertEquals('11', $result);
 
         unset($this->Form->request->query['id']);
-        $this->Form->setValuesSources(['context'])->create($article, ['valuesSources' => ['query', 'data']]);
+        $this->Form->setValueSources(['context'])->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '10']],
@@ -8462,25 +8462,25 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesResetViaEnd()
+    public function testFormValueSourcesResetViaEnd()
     {
         $expected = ['context'];
-        $result = $this->Form->getValuesSources();
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
         
         $expected = ['query', 'context', 'data'];
-        $this->Form->setValuesSources(['query', 'context', 'data']);
+        $this->Form->setValueSources(['query', 'context', 'data']);
 
-        $result = $this->Form->getValuesSources();
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
         
         $this->Form->create();
-        $result = $this->Form->getValuesSources();
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
 
         $this->Form->end();
         $expected = ['context'];
-        $result = $this->Form->getValuesSources();
+        $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
     }
 
@@ -8489,7 +8489,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesSchemaDefaults()
+    public function testFormValueSourcesSchemaDefaults()
     {
         $Articles = TableRegistry::get('Articles');
         $entity = $Articles->newEntity();
@@ -8518,11 +8518,11 @@ class FormHelperTest extends TestCase
         );
         $entity = $Articles->newEntity();
         $this->Form->create($entity);
-        $this->Form->setValuesSources(['query']);
+        $this->Form->setValueSources(['query']);
         $result = $this->Form->getSourceValue('title');
         $expected = '';
         $this->assertEquals($expected, $result);
-        $this->Form->setValuesSources(['context']);
+        $this->Form->setValueSources(['context']);
         $result = $this->Form->getSourceValue('title');
         $expected = 'default title';
         $this->assertEquals($expected, $result);
@@ -8533,7 +8533,7 @@ class FormHelperTest extends TestCase
      *
      * @return void
      */
-    public function testFormValuesSourcesDefaults()
+    public function testFormValueSourcesDefaults()
     {
         $this->Form->request->query['password'] = 'open Sesame';
         $this->Form->create();
@@ -8546,12 +8546,12 @@ class FormHelperTest extends TestCase
         $expected = ['input' => ['type' => 'password', 'name' => 'password', 'value' => 'helloworld']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources('query');
+        $this->Form->setValueSources('query');
         $result = $this->Form->password('password', ['default' => 'helloworld']);
         $expected = ['input' => ['type' => 'password', 'name' => 'password', 'value' => 'open Sesame']];
         $this->assertHtml($expected, $result);
 
-        $this->Form->setValuesSources('data');
+        $this->Form->setValueSources('data');
         $result = $this->Form->password('password', ['default' => 'helloworld']);
         $expected = ['input' => ['type' => 'password', 'name' => 'password', 'value' => 'helloworld']];
         $this->assertHtml($expected, $result);
@@ -8571,12 +8571,12 @@ class FormHelperTest extends TestCase
         $entity = $Articles->newEntity();
         $this->Form->create($entity);
 
-        $this->Form->setValuesSources(['query', 'context']);
+        $this->Form->setValueSources(['query', 'context']);
         $result = $this->Form->getSourceValue('category');
         $expected = 'sesame-cookies';
         $this->assertEquals($expected, $result);
 
-        $this->Form->setValuesSources(['context', 'query']);
+        $this->Form->setValueSources(['context', 'query']);
         $result = $this->Form->getSourceValue('category');
         $expected = 'sesame-cookies';
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8227,7 +8227,6 @@ class FormHelperTest extends TestCase
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
 
-
         $this->Form->create($article);
         $this->Form->setValueSources(['context']);
         $result = $this->Form->input('id');
@@ -8236,24 +8235,13 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-
         $this->Form->request->query['id'] = '5';
         $this->Form->setValueSources(['query']);
-        $this->Form->create($article);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
         ];
         $this->assertHtml($expected, $result);
-
-        $this->Form->create($article);
-        $this->Form->setValueSources(['query']);
-        $result = $this->Form->input('id');
-        $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
-        ];
-        $this->assertHtml($expected, $result);
-
 
         $this->Form->request->query['id'] = '5a';
         $this->Form->request->data['id'] = '5b';
@@ -8274,23 +8262,10 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->Form->request->data['id'] = '6';
-        $this->Form->request->query['id'] = '7';
-        $this->Form->create($article);
-        $this->Form->setValueSources(['data']);
-        $result = $this->Form->input('id');
-        $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '6']],
-        ];
-        $this->assertHtml($expected, $result);
-
-        $this->Form->request->data['id'] = '8';
-        $this->Form->request->query['id'] = '9';
-        $this->Form->create($article);
         $this->Form->setValueSources(['query']);
         $result = $this->Form->input('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5a']],
         ];
         $this->assertHtml($expected, $result);
     }
@@ -8307,24 +8282,9 @@ class FormHelperTest extends TestCase
         $articles = TableRegistry::get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
-
         $this->Form->request->query['id'] = '9';
 
         $this->Form->create($article);
-        $this->Form->setValueSources(['context']);
-        $result = $this->Form->input('id');
-        $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
-        ];
-        $this->assertHtml($expected, $result);
-
-        $this->Form->setValueSources(['query']);
-        $result = $this->Form->input('id');
-        $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
-        ];
-        $this->assertHtml($expected, $result);
-
         $this->Form->setValueSources(['context', 'query']);
         $result = $this->Form->input('id');
         $expected = [
@@ -8345,7 +8305,6 @@ class FormHelperTest extends TestCase
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
         ];
         $this->assertHtml($expected, $result);
-
 
         $this->Form->request->data['id'] = '8';
         $this->Form->request->query['id'] = '9';
@@ -8368,8 +8327,6 @@ class FormHelperTest extends TestCase
         $articles = TableRegistry::get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
-
-
         $this->Form->request->data['id'] = '4';
         $this->Form->request->query['id'] = '5';
 
@@ -8382,43 +8339,36 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getSourceValue('id');
         $this->assertEquals('5', $result);
 
-
-        $this->Form->request->data['id'] = '6';
-        $this->Form->request->query['id'] = '7';
-
         $this->Form->setValueSources(['context']);
         $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->input('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '7']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('7', $result);
+        $this->assertEquals('5', $result);
 
         $this->Form->setValueSources(['query']);
         $this->Form->create($article, ['valueSources' => 'data']);
         $result = $this->Form->input('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '6']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '4']],
         ];
         $this->assertHtml($expected, $result);
+
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('6', $result);
-
-
-        $this->Form->request->data['id'] = '8';
-        $this->Form->request->query['id'] = '9';
+        $this->assertEquals('4', $result);
 
         $this->Form->setValueSources(['query']);
         $this->Form->create($article, ['valueSources' => ['context', 'data']]);
         $result = $this->Form->input('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '8']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '4']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
-        $this->assertEquals('8', $result);
+        $this->assertEquals('4', $result);
     }
 
     /**
@@ -8433,11 +8383,11 @@ class FormHelperTest extends TestCase
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
 
-
         $this->Form->request->data['id'] = '10';
         $this->Form->request->query['id'] = '11';
 
-        $this->Form->setValueSources(['context'])->create($article, ['valueSources' => ['query', 'data']]);
+        $this->Form->setValueSources(['context'])
+            ->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '11']],
@@ -8447,7 +8397,8 @@ class FormHelperTest extends TestCase
         $this->assertEquals('11', $result);
 
         unset($this->Form->request->query['id']);
-        $this->Form->setValueSources(['context'])->create($article, ['valueSources' => ['query', 'data']]);
+        $this->Form->setValueSources(['context'])
+            ->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->input('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '10']],
@@ -8467,65 +8418,20 @@ class FormHelperTest extends TestCase
         $expected = ['context'];
         $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
-        
+
         $expected = ['query', 'context', 'data'];
         $this->Form->setValueSources(['query', 'context', 'data']);
 
         $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
-        
+
         $this->Form->create();
         $result = $this->Form->getValueSources();
         $this->assertEquals($expected, $result);
 
         $this->Form->end();
-        $expected = ['context'];
         $result = $this->Form->getValueSources();
-        $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * Test sources values schema defaults handling
-     *
-     * @return void
-     */
-    public function testFormValueSourcesSchemaDefaults()
-    {
-        $Articles = TableRegistry::get('Articles');
-        $entity = $Articles->newEntity();
-        $this->Form->create($entity);
-        $result = $this->Form->getSourceValue('title');
-        $expected = '';
-        $this->assertEquals($expected, $result);
-
-        $Articles = TableRegistry::get('Articles');
-        $title = $Articles->schema()->column('title');
-        $Articles->schema()->addColumn(
-            'title',
-            ['default' => 'default title'] + $title
-        );
-        $entity = $Articles->newEntity();
-        $this->Form->create($entity);
-        $result = $this->Form->getSourceValue('title');
-        $expected = 'default title';
-        $this->assertEquals($expected, $result);
-
-        $Articles = TableRegistry::get('Articles');
-        $title = $Articles->schema()->column('title');
-        $Articles->schema()->addColumn(
-            'title',
-            ['default' => 'default title'] + $title
-        );
-        $entity = $Articles->newEntity();
-        $this->Form->create($entity);
-        $this->Form->setValueSources(['query']);
-        $result = $this->Form->getSourceValue('title');
-        $expected = '';
-        $this->assertEquals($expected, $result);
-        $this->Form->setValueSources(['context']);
-        $result = $this->Form->getSourceValue('title');
-        $expected = 'default title';
-        $this->assertEquals($expected, $result);
+        $this->assertEquals(['context'], $result);
     }
 
     /**
@@ -8557,7 +8463,6 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-
     /**
      * Test sources values schema defaults handling
      *
@@ -8567,18 +8472,16 @@ class FormHelperTest extends TestCase
     {
         $this->Form->request->query['category'] = 'sesame-cookies';
 
-        $Articles = TableRegistry::get('Articles');
-        $entity = $Articles->newEntity();
+        $articles = TableRegistry::get('Articles');
+        $entity = $articles->newEntity();
         $this->Form->create($entity);
 
         $this->Form->setValueSources(['query', 'context']);
         $result = $this->Form->getSourceValue('category');
-        $expected = 'sesame-cookies';
-        $this->assertEquals($expected, $result);
+        $this->assertEquals('sesame-cookies', $result);
 
         $this->Form->setValueSources(['context', 'query']);
         $result = $this->Form->getSourceValue('category');
-        $expected = 'sesame-cookies';
-        $this->assertEquals($expected, $result);
+        $this->assertEquals('sesame-cookies', $result);
     }
 }


### PR DESCRIPTION
After reading the method names a bunch of times, I found the double plural awkward to say. I also cleaned up the tests a bit as there were a few duplicate assertions/redundant tests.

Refs #9127
