### PR TITLE
Fixes using expression in Query::from()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -432,7 +432,7 @@ class Query implements ExpressionInterface, IteratorAggregate
             return $this->_parts['from'];
         }
 
-        if (is_string($tables)) {
+        if (is_string($tables) || $tables instanceof ExpressionInterface) {
             $tables = [$tables];
         }
 


### PR DESCRIPTION
closes #9372 

I just assumed converting the parameter to an array would resolve the issue. Will let the tests bake and see what happens.
