### PR TITLE
Fixed phishing vulnerability in HtmlHelper.php

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -344,12 +344,14 @@ class HtmlHelper extends Helper
             $title = h(urldecode($title));
             $escapeTitle = false;
         }
+        
         /* A "simple phishing" vulnerability
          * Consider adding a configuration option to disable?
          */ https://dev.to/ben/the-targetblank-vulnerability-by-example
         if (isset($options['target'])){
             $options['rel'] = 'noopener noreferrer';
         }
+        
         if (isset($options['escapeTitle'])) {
             $escapeTitle = $options['escapeTitle'];
             unset($options['escapeTitle']);

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -344,7 +344,12 @@ class HtmlHelper extends Helper
             $title = h(urldecode($title));
             $escapeTitle = false;
         }
-
+        /* A "simple phishing" vulnerability
+         * Consider adding a configuration option to disable?
+         */ https://dev.to/ben/the-targetblank-vulnerability-by-example
+        if (isset($options['target'])){
+            $options['rel'] = 'noopener noreferrer';
+        }
         if (isset($options['escapeTitle'])) {
             $escapeTitle = $options['escapeTitle'];
             unset($options['escapeTitle']);

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -345,10 +345,7 @@ class HtmlHelper extends Helper
             $escapeTitle = false;
         }
         
-        /* A "simple phishing" vulnerability
-         * Consider adding a configuration option to disable?
-         */ https://dev.to/ben/the-targetblank-vulnerability-by-example
-        if (isset($options['target'])) {
+        if (isset($options['target']) && !isset($options['rel'])) {
             $options['rel'] = 'noopener noreferrer';
         }
         

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -348,7 +348,7 @@ class HtmlHelper extends Helper
         /* A "simple phishing" vulnerability
          * Consider adding a configuration option to disable?
          */ https://dev.to/ben/the-targetblank-vulnerability-by-example
-        if (isset($options['target'])){
+        if (isset($options['target'])) {
             $options['rel'] = 'noopener noreferrer';
         }
         


### PR DESCRIPTION
I recently came across an article that describes a phishing vulnerability. Instagram has already fixed the vulnerability on their site and I feel Cake users should do the same on their projects. Consider adding a configuration option to disable this feature due to using it to find the parent window.

Most users won't need this feature to be disabled, and only should be disabled if the user directly knows the reasoning for doing so.

[Article here](https://dev.to/ben/the-targetblank-vulnerability-by-example)
