### PR TITLE
Add PSR7 attribute methods to Network\Request

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1444,6 +1444,7 @@ class Request implements ArrayAccess
         } else {
             $new->attributes[$name] = $value;
         }
+
         return $new;
     }
 
@@ -1451,7 +1452,6 @@ class Request implements ArrayAccess
      * Return an instance without the specified request attribute.
      *
      * @param string $name The attribute name.
-     * @param mixed $value The value of the attribute.
      * @return static
      * @throws InvalidArgumentException
      */
@@ -1465,6 +1465,7 @@ class Request implements ArrayAccess
             );
         }
         unset($new->attributes[$name]);
+
         return $new;
     }
 
@@ -1484,6 +1485,7 @@ class Request implements ArrayAccess
         if (array_key_exists($name, $this->attributes)) {
             return $this->attributes[$name];
         }
+
         return $default;
     }
 
@@ -1502,6 +1504,7 @@ class Request implements ArrayAccess
             'webroot' => $this->webroot,
             'base' => $this->base
         ];
+
         return $this->attributes + $emulated;
     }
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -166,6 +166,13 @@ class Request implements ArrayAccess
     protected $attributes = [];
 
     /**
+     * A list of propertes that emulated by the PSR7 attribute methods.
+     *
+     * @var array
+     */
+    protected $emulatedAttributes = ['webroot', 'base', 'params'];
+
+    /**
      * Wrapper method to create a new request from PHP superglobals.
      *
      * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
@@ -1438,8 +1445,7 @@ class Request implements ArrayAccess
     public function withAttribute($name, $value)
     {
         $new = clone $this;
-        $emulated = ['webroot', 'base', 'params'];
-        if (in_array($name, $emulated, true)) {
+        if (in_array($name, $this->emulatedAttributes, true)) {
             $new->{$name} = $value;
         } else {
             $new->attributes[$name] = $value;
@@ -1458,8 +1464,7 @@ class Request implements ArrayAccess
     public function withoutAttribute($name)
     {
         $new = clone $this;
-        $emulated = ['webroot', 'base', 'params'];
-        if (in_array($name, $emulated, true)) {
+        if (in_array($name, $this->emulatedAttributes, true)) {
             throw new InvalidArgumentException(
                 "You cannot unset '$name'. It is a required CakePHP attribute."
             );
@@ -1478,8 +1483,7 @@ class Request implements ArrayAccess
      */
     public function getAttribute($name, $default = null)
     {
-        $emulated = ['webroot', 'base', 'params'];
-        if (in_array($name, $emulated, true)) {
+        if (in_array($name, $this->emulatedAttributes, true)) {
             return $this->{$name};
         }
         if (array_key_exists($name, $this->attributes)) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -158,6 +158,13 @@ class Request implements ArrayAccess
     protected $_session;
 
     /**
+     * Store the additional attributes attached to the request.
+     *
+     * @var array
+     */
+    protected $attributes = [];
+
+    /**
      * Wrapper method to create a new request from PHP superglobals.
      *
      * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
@@ -1418,6 +1425,59 @@ class Request implements ArrayAccess
         $copy->params = Hash::insert($copy->params, $name, $value);
 
         return $copy;
+    }
+
+    /**
+     * Return an instance with the specified request attribute.
+     *
+     * @param string $name The attribute name.
+     * @param mixed $value The value of the attribute.
+     * @return static
+     */
+    public function withAttribute($name, $value)
+    {
+        $new = clone $this;
+        $new->attributes[$name] = $value;
+        return $new;
+    }
+
+    /**
+     * Return an instance without the specified request attribute.
+     *
+     * @param string $name The attribute name.
+     * @param mixed $value The value of the attribute.
+     * @return static
+     */
+    public function withoutAttribute($name)
+    {
+        $new = clone $this;
+        unset($new->attributes[$name]);
+        return $new;
+    }
+
+    /**
+     * Read an attribute from the request, or get the default
+     *
+     * @param string $name The attribute name.
+     * @param mixed $default The default value if the attribute has not been set.
+     * @return static
+     */
+    public function getAttribute($name, $default = null)
+    {
+        if (array_key_exists($name, $this->attributes)) {
+            return $this->attributes[$name];
+        }
+        return $default;
+    }
+
+    /**
+     * Get all the attributes in the request.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -86,6 +86,7 @@ class Request implements ArrayAccess
      * Base URL path.
      *
      * @var string
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getAttribute('base') instead.
      */
     public $base;
 
@@ -93,6 +94,7 @@ class Request implements ArrayAccess
      * webroot path segment for the request.
      *
      * @var string
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use getAttribute('webroot') instead.
      */
     public $webroot = '/';
 
@@ -100,6 +102,7 @@ class Request implements ArrayAccess
      * The full address to the current request
      *
      * @var string
+     * @deprecated 3.4.0 This public property will be removed in 4.0.0. Use here() instead.
      */
     public $here;
 
@@ -1478,7 +1481,7 @@ class Request implements ArrayAccess
      * Read an attribute from the request, or get the default
      *
      * @param string $name The attribute name.
-     * @param mixed $default The default value if the attribute has not been set.
+     * @param mixed|null $default The default value if the attribute has not been set.
      * @return static
      */
     public function getAttribute($name, $default = null)

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2639,6 +2639,64 @@ XML;
     }
 
     /**
+     * Test setting attributes.
+     *
+     * @return void
+     */
+    public function testWithAttribute()
+    {
+        $request = new Request([]);
+        $this->assertNull($request->getAttribute('key'));
+        $this->assertSame('default', $request->getAttribute('key', 'default'));
+
+        $new = $request->withAttribute('key', 'value');
+        $this->assertNotEquals($new, $request, 'Should be different');
+        $this->assertNull($request->getAttribute('key'), 'Old instance not modified');
+        $this->assertSame('value', $new->getAttribute('key'));
+
+        $update = $new->withAttribute('key', ['complex']);
+        $this->assertNotEquals($update, $new, 'Should be different');
+        $this->assertSame(['complex'], $update->getAttribute('key'));
+    }
+
+    /**
+     * Test getting all attributes.
+     *
+     * @return void
+     */
+    public function testGetAttributes()
+    {
+        $request = new Request([]);
+        $new = $request->withAttribute('key', 'value')
+            ->withAttribute('nully', null)
+            ->withAttribute('falsey', false);
+
+        $this->assertFalse($new->getAttribute('falsey'));
+        $this->assertNull($new->getAttribute('nully'));
+        $expected = [
+            'key' => 'value',
+            'nully' => null,
+            'falsey' => false
+        ];
+        $this->assertEquals($expected, $new->getAttributes());
+    }
+
+    /**
+     * Test unsetting attributes.
+     *
+     * @return void
+     */
+    public function testWithoutAttribute()
+    {
+        $request = new Request([]);
+        $new = $request->withAttribute('key', 'value');
+        $update = $request->withoutAttribute('key');
+
+        $this->assertNotEquals($update, $new, 'Should be different');
+        $this->assertNull($update->getAttribute('key'));
+    }
+
+    /**
      * loadEnvironment method
      *
      * @param array $env

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2660,6 +2660,63 @@ XML;
     }
 
     /**
+     * Test that withAttribute() can modify the deprecated public properties.
+     *
+     * @return void
+     */
+    public function testWithAttributesCompatibility()
+    {
+        $request = new Request([
+            'params' => [
+                'controller' => 'Articles',
+                'action' => 'index'
+            ],
+            'base' => '/cakeapp',
+            'webroot' => '/cakeapp/'
+        ]);
+
+        $new = $request->withAttribute('base', '/replace')
+            ->withAttribute('webroot', '/replace/')
+            ->withAttribute('params', ['controller' => 'Tags']);
+
+        // Original request should not change.
+        $this->assertSame('/cakeapp', $request->getAttribute('base'));
+        $this->assertSame('/cakeapp/', $request->getAttribute('webroot'));
+        $this->assertSame(
+            ['controller' => 'Articles', 'action' => 'index'],
+            $request->getAttribute('params')
+        );
+
+        $this->assertSame('/replace', $new->getAttribute('base'));
+        $this->assertSame('/replace', $new->base);
+        $this->assertSame('/replace/', $new->getAttribute('webroot'));
+        $this->assertSame('/replace/', $new->webroot);
+
+        $this->assertSame(['controller' => 'Tags'], $new->getAttribute('params'));
+        $this->assertSame(['controller' => 'Tags'], $new->params);
+    }
+
+    /**
+     * Test that getAttribute() can read deprecated public properties.
+     *
+     * @dataProvider emulatedPropertyProvider
+     * @return void
+     */
+    public function testGetAttributesCompatibility($prop)
+    {
+        $request = new Request([
+            'params' => [
+                'controller' => 'Articles',
+                'action' => 'index'
+            ],
+            'base' => '/cakeapp',
+            'webroot' => '/cakeapp/'
+        ]);
+
+        $this->assertSame($request->{$prop}, $request->getAttribute($prop));
+    }
+
+    /**
      * Test getting all attributes.
      *
      * @return void
@@ -2676,7 +2733,16 @@ XML;
         $expected = [
             'key' => 'value',
             'nully' => null,
-            'falsey' => false
+            'falsey' => false,
+            'params' => [
+                'plugin' => null,
+                'controller' => null,
+                'action' => null,
+                '_ext' => null,
+                'pass' => [],
+            ],
+            'webroot' => '',
+            'base' => ''
         ];
         $this->assertEquals($expected, $new->getAttributes());
     }
@@ -2694,6 +2760,33 @@ XML;
 
         $this->assertNotEquals($update, $new, 'Should be different');
         $this->assertNull($update->getAttribute('key'));
+    }
+
+    /**
+     * Test that withoutAttribute() cannot remove deprecated public properties.
+     *
+     * @dataProvider emulatedPropertyProvider
+     * @expectedException InvalidArgumentException
+     * @return void
+     */
+    public function testWithoutAttributesDenyEmulatedProperties($prop)
+    {
+        $request = new Request([]);
+        $request->withoutAttribute($prop);
+    }
+
+    /**
+     * Data provider for emulated property tests.
+     *
+     * @return array
+     */
+    public function emulatedPropertyProvider()
+    {
+        return [
+            ['params'],
+            ['base'],
+            ['webroot']
+        ];
     }
 
     /**


### PR DESCRIPTION
Add the attribute related methods that are part of `ServerRequestInterface` to `Network\Request`. After a bunch of thinking, I feel that having the PSR7 methods manipulate the existing public properties in an immutable way will be safer than trying to emulate the properties through magic methods.

I've disallowed the required CakePHP 'attributes' to be unset. I didn't want to allow people to blow their applications up by removing attributes like `params` or `webroot`.

Refs #9325 
