### PR TITLE
Don't mark null values as dirty when they are still null.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -552,6 +552,7 @@ class Marshaller
                 // the original/updated list could contain references to the
                 // same objects, even though those objects may have changed internally.
                 if ((is_scalar($value) && $original === $value) ||
+                    ($value === null && $original === $value) ||
                     (is_object($value) && !($value instanceof EntityInterface) && $original == $value)
                 ) {
                     continue;

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1335,6 +1335,31 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test merge() doesn't dirty values that were null and are null again.
+     *
+     * @return void
+     */
+    public function testMergeUnchangedNullValue()
+    {
+        $data = [
+            'title' => 'My title',
+            'author_id' => 1,
+            'body' => null,
+        ];
+        $marshall = new Marshaller($this->articles);
+        $entity = new Entity([
+            'title' => 'Foo',
+            'body' => null
+        ]);
+        $entity->accessible('*', true);
+        $entity->isNew(false);
+        $entity->clean();
+        $result = $marshall->merge($entity, $data, []);
+
+        $this->assertFalse($entity->dirty('body'), 'unchanged null should not be dirty');
+    }
+
+    /**
      * Tests that merge respects the entity accessible methods
      *
      * @return void


### PR DESCRIPTION
`is_scalar()` does not include `null` so treat is specially.

Refs #9381
