### PR TITLE
Adding ability to pass templateVars to Form->create()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -435,7 +435,8 @@ class FormHelper extends Helper
         $actionAttr = $templater->formatAttributes(['action' => $action, 'escape' => false]);
 
         return $this->formatTemplate('formStart', [
-            'attrs' => $templater->formatAttributes($htmlAttributes) . $actionAttr
+            'attrs' => $templater->formatAttributes($htmlAttributes) . $actionAttr,
+            'templateVars' => isset($options['templateVars']) ? $options['templateVars'] : []
         ]) . $append;
     }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -655,6 +655,32 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Test using template vars in Create (formStart template)
+     *
+     * @return void
+     */
+    public function testCreateTemplateVars()
+    {
+        $result = $this->Form->create($this->article, [
+            'templates' => [
+                'formStart' => '<h4 class="mb">{{header}}</h4><form{{attrs}}>',
+            ],
+            'templateVars' => ['header' => 'headertext']
+        ]);
+        $expected = [
+            'h4' => ['class'],
+            'headertext',
+            '/h4',
+            'form' => [
+                'method' => 'post',
+                'action' => '/articles/add',
+                'accept-charset' => 'utf-8'
+            ]
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * Test opening a form for an update operation.
      *
      * @return void


### PR DESCRIPTION
This duplicates the functionality already present on inputs of being able to pass in templateVars for use in your form (described here: http://book.cakephp.org/3.0/en/views/helpers/form.html#adding-additional-template-variables-to-templates) to the Form->create() call as well.

This let's you do things like:

``` php
'formStart' => '<div class="form row mt"><div class="col-lg-12"><div class="form-panel"><h4 class="mb">{{header}}</h4><form class="form-horizontal style-form"{{attrs}}>',
```

``` php
<?=$this->Form->create('Device',['templateVars'=>['header'=>'Add Device']]);?>
```
