### PR TITLE
Fix __xn, __dx and __dxn doesn't work with variable arguments

### DIFF
--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -162,7 +162,7 @@ if (!function_exists('__xn')) {
             return null;
         }
 
-        $arguments = func_num_args() === 5 ? (array)$args : array_slice(func_get_args(), 2);
+        $arguments = func_num_args() === 5 ? (array)$args : array_slice(func_get_args(), 4);
 
         return I18n::translator()->translate(
             $plural,
@@ -191,7 +191,7 @@ if (!function_exists('__dx')) {
             return null;
         }
 
-        $arguments = func_num_args() === 4 ? (array)$args : array_slice(func_get_args(), 2);
+        $arguments = func_num_args() === 4 ? (array)$args : array_slice(func_get_args(), 3);
 
         return I18n::translator($domain)->translate(
             $msg,
@@ -223,7 +223,7 @@ if (!function_exists('__dxn')) {
             return null;
         }
 
-        $arguments = func_num_args() === 6 ? (array)$args : array_slice(func_get_args(), 2);
+        $arguments = func_num_args() === 6 ? (array)$args : array_slice(func_get_args(), 5);
 
         return I18n::translator($domain)->translate(
             $plural,

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -305,16 +305,43 @@ class I18nTest extends TestCase
                         'character' => 'The letter {0}',
                         'communication' => 'She wrote a letter to {0}'
                     ]
+                ],
+                'letters' => [
+                    '_context' => [
+                        'character' => [
+                            'The letter {0}',
+                            'The letters {0} and {1}'
+                        ],
+                        'communication' => [
+                            'She wrote a letter to {0}',
+                            'She wrote a letter to {0} and {1}'
+                        ]
+                    ]
                 ]
             ]);
 
             return $package;
         });
 
+        $this->assertEquals('The letters A and B', __x('character', 'letters', ['A', 'B']));
         $this->assertEquals('The letter A', __x('character', 'letter', ['A']));
+
+        $this->assertEquals(
+            'She wrote a letter to Thomas and Sara',
+            __x('communication', 'letters', ['Thomas', 'Sara'])
+        );
         $this->assertEquals(
             'She wrote a letter to Thomas',
             __x('communication', 'letter', ['Thomas'])
+        );
+
+        $this->assertEquals(
+            'She wrote a letter to Thomas and Sara',
+            __x('communication', 'letters', 'Thomas', 'Sara')
+        );
+        $this->assertEquals(
+            'She wrote a letter to Thomas',
+            __x('communication', 'letter', 'Thomas')
         );
     }
 
@@ -361,6 +388,15 @@ class I18nTest extends TestCase
             'She wrote a letter to Thomas',
             __xn('communication', 'letter', 'letters', 1, ['Thomas'])
         );
+
+        $this->assertEquals(
+            'She wrote a letter to Thomas and Sara',
+            __xn('communication', 'letter', 'letters', 2, 'Thomas', 'Sara')
+        );
+        $this->assertEquals(
+            'She wrote a letter to Thomas',
+            __xn('communication', 'letter', 'letters', 1, 'Thomas')
+        );
     }
 
     /**
@@ -378,16 +414,43 @@ class I18nTest extends TestCase
                         'character' => 'The letter {0}',
                         'communication' => 'She wrote a letter to {0}'
                     ]
+                ],
+                'letters' => [
+                    '_context' => [
+                        'character' => [
+                            'The letter {0}',
+                            'The letters {0} and {1}'
+                        ],
+                        'communication' => [
+                            'She wrote a letter to {0}',
+                            'She wrote a letter to {0} and {1}'
+                        ]
+                    ]
                 ]
             ]);
 
             return $package;
         });
 
+        $this->assertEquals('The letters A and B', __dx('custom', 'character', 'letters', ['A', 'B']));
         $this->assertEquals('The letter A', __dx('custom', 'character', 'letter', ['A']));
+
+        $this->assertEquals(
+            'She wrote a letter to Thomas and Sara',
+            __dx('custom', 'communication', 'letters', ['Thomas', 'Sara'])
+        );
         $this->assertEquals(
             'She wrote a letter to Thomas',
             __dx('custom', 'communication', 'letter', ['Thomas'])
+        );
+
+        $this->assertEquals(
+            'She wrote a letter to Thomas and Sara',
+            __dx('custom', 'communication', 'letters', 'Thomas', 'Sara')
+        );
+        $this->assertEquals(
+            'She wrote a letter to Thomas',
+            __dx('custom', 'communication', 'letter', 'Thomas')
         );
     }
 
@@ -439,6 +502,15 @@ class I18nTest extends TestCase
         $this->assertEquals(
             'She wrote a letter to Thomas',
             __dxn('custom', 'communication', 'letter', 'letters', 1, ['Thomas'])
+        );
+
+        $this->assertEquals(
+            'She wrote a letter to Thomas and Sara',
+            __dxn('custom', 'communication', 'letter', 'letters', 2, 'Thomas', 'Sara')
+        );
+        $this->assertEquals(
+            'She wrote a letter to Thomas',
+            __dxn('custom', 'communication', 'letter', 'letters', 1, 'Thomas')
         );
     }
 


### PR DESCRIPTION
### Test

``` php
debug( __dx('domain', 'character', 'The letters {0} and {1}', ['A', 'B']) );
debug( __dx('domain', 'character', 'The letters {0} and {1}', 'A', 'B') );

```
### Expected Behavior

```
The letters A and B
The letters A and B
```
### Actual Behavior

```
The letters A and B
The letters The letters {0} and {1} and A
```

---
### 2.x Behavior

``` php
debug( __dx('domain', 'character', 'The letters %1$s and %2$s', ['A', 'B']) );
debug( __dx('domain', 'character', 'The letters %1$s and %2$s', 'A', 'B') );
```

```
The letters A and B
The letters A and B
```
