### PR TITLE
Implement PSR7 uploaded files

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -460,15 +460,26 @@ class Request implements ArrayAccess
      */
     protected function _processFiles($post, $files)
     {
-        if (is_array($files)) {
+        if (!is_array($files)) {
+            return $post;
+        }
+
+        $fileData = [];
+        foreach ($files as $key => $data) {
             foreach ($files as $key => $data) {
                 if (isset($data['tmp_name']) && is_string($data['tmp_name'])) {
-                    $post[$key] = $data;
+                    $fileData[$key] = $data;
                 } else {
                     $keyData = isset($post[$key]) ? $post[$key] : [];
-                    $post[$key] = $this->_processFileData($keyData, $data);
+                    $fileData[$key] = $this->_processFileData($keyData, $data);
                 }
             }
+        }
+
+        // Make a flat map that can be inserted into $post for BC.
+        $fileMap = Hash::flatten($fileData);
+        foreach ($fileMap as $key => $file) {
+            $post = Hash::insert($post, $key, $file);
         }
 
         return $post;

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1692,6 +1692,22 @@ class Request implements ArrayAccess
     }
 
     /**
+     * Get the uploaded file from a dotted path.
+     *
+     * @param string $path The dot separated path to the file you want.
+     * @return null|Psr\Http\Message\UploadedFileInterface
+     */
+    public function getUploadedFile($path)
+    {
+        $file = Hash::get($this->uploadedFiles, $path);
+        if (!$file instanceof UploadedFile) {
+            return null;
+        }
+
+        return $file;
+    }
+
+    /**
      * Get the array of uploaded files from the request.
      *
      * @return array

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1702,6 +1702,43 @@ class Request implements ArrayAccess
     }
 
     /**
+     * Update the request replacing the files, and creating a new instance.
+     *
+     * @param array $files An array of uploaded file objects.
+     * @return static
+     * @throws InvalidArgumentException when $files contains an invalid object.
+     */
+    public function withUploadedFiles(array $files)
+    {
+        $this->validateUploadedFiles($files, '');
+        $new = clone $this;
+        $new->uploadedFiles = $files;
+
+        return $new;
+    }
+
+    /**
+     * Recursively validate uploaded file data.
+     *
+     * @param array $uploadedFiles
+     * @param string $path The path thus far.
+     * @throws InvalidArgumentException If any leaf elements are not valid files.
+     */
+    private function validateUploadedFiles(array $uploadedFiles, $path)
+    {
+        foreach ($uploadedFiles as $key => $file) {
+            if (is_array($file)) {
+                $this->validateUploadedFiles($file, $key . '.');
+                continue;
+            }
+
+            if (!$file instanceof UploadedFileInterface) {
+                throw new InvalidArgumentException("Invalid file at '{$path}{$key}'");
+            }
+        }
+    }
+
+    /**
      * Array access read implementation
      *
      * @param string $name Name of the key being accessed.

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -19,6 +19,8 @@ use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Network\Exception\MethodNotAllowedException;
 use Cake\Utility\Hash;
+use Psr\Http\Message\UploadedFileInterface;
+use Zend\Diactoros\UploadedFile;
 use InvalidArgumentException;
 
 /**
@@ -463,59 +465,91 @@ class Request implements ArrayAccess
         if (!is_array($files)) {
             return $post;
         }
-
         $fileData = [];
-        foreach ($files as $key => $data) {
-            foreach ($files as $key => $data) {
-                if (isset($data['tmp_name']) && is_string($data['tmp_name'])) {
-                    $fileData[$key] = $data;
-                } else {
-                    $keyData = isset($post[$key]) ? $post[$key] : [];
-                    $fileData[$key] = $this->_processFileData($keyData, $data);
-                }
+        foreach ($files as $key => $value) {
+            if ($value instanceof UploadedFileInterface) {
+                $fileData[$key] = $value;
+                continue;
             }
+
+            if (is_array($value) && isset($value['tmp_name'])) {
+                $fileData[$key] = $this->_createUploadedFile($value);
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf(
+                'Invalid value in FILES "%s"',
+                json_encode($value)
+            ));
         }
 
         // Make a flat map that can be inserted into $post for BC.
         $fileMap = Hash::flatten($fileData);
         foreach ($fileMap as $key => $file) {
-            $post = Hash::insert($post, $key, $file);
+            $error = $file->getError();
+            $tmpName = '';
+            if ($error === UPLOAD_ERR_OK) {
+                $tmpName = $file->getStream()->getMetadata('uri');
+            }
+            $post = Hash::insert($post, $key, [
+                'tmp_name' => $tmpName,
+                'error' => $error,
+                'name' => $file->getClientFilename(),
+                'type' => $file->getClientMediaType(),
+                'size' => $file->getSize(),
+            ]);
         }
 
         return $post;
     }
 
     /**
-     * Recursively walks the FILES array restructuring the data
-     * into something sane and usable.
+     * Create an UploadedFile instance from a $_FILES array.
      *
-     * @param array $data The data being built
-     * @param array $post The post data being traversed
-     * @param string $path The dot separated path to insert $data into.
-     * @param string $field The terminal field in the path. This is one of the
-     *   $_FILES properties e.g. name, tmp_name, size, error
-     * @return array The restructured FILES data
+     * If the value represents an array of values, this method will
+     * recursively process the data.
+     *
+     * @param array $value $_FILES struct
+     * @return array|UploadedFileInterface
      */
-    protected function _processFileData($data, $post, $path = '', $field = '')
+    protected function _createUploadedFile(array $value)
     {
-        foreach ($post as $key => $fields) {
-            $newField = $field;
-            $newPath = $path;
-            if ($path === '' && $newField === '') {
-                $newField = $key;
-            }
-            if ($field === $newField) {
-                $newPath .= '.' . $key;
-            }
-            if (is_array($fields)) {
-                $data = $this->_processFileData($data, $fields, $newPath, $newField);
-            } else {
-                $newPath = trim($newPath . '.' . $field, '.');
-                $data = Hash::insert($data, $newPath, $fields);
-            }
+        if (is_array($value['tmp_name'])) {
+            return $this->_normalizeNestedFiles($value);
         }
 
-        return $data;
+        return new UploadedFile(
+            $value['tmp_name'],
+            $value['size'],
+            $value['error'],
+            $value['name'],
+            $value['type']
+        );
+    }
+
+    /**
+     * Normalize an array of file specifications.
+     *
+     * Loops through all nested files and returns a normalized array of
+     * UploadedFileInterface instances.
+     *
+     * @param array $files The file data to normalize & convert.
+     * @return array An array of UploadedFileInterface objects.
+     */
+    protected function _normalizeNestedFiles(array $files = [])
+    {
+        $normalizedFiles = [];
+        foreach (array_keys($files['tmp_name']) as $key) {
+            $spec = [
+                'tmp_name' => $files['tmp_name'][$key],
+                'size' => $files['size'][$key],
+                'error' => $files['error'][$key],
+                'name' => $files['name'][$key],
+                'type' => $files['type'][$key],
+            ];
+            $normalizedFiles[$key] = $this->_createUploadedFile($spec);
+        }
+        return $normalizedFiles;
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -19,9 +19,9 @@ use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Network\Exception\MethodNotAllowedException;
 use Cake\Utility\Hash;
+use InvalidArgumentException;
 use Psr\Http\Message\UploadedFileInterface;
 use Zend\Diactoros\UploadedFile;
-use InvalidArgumentException;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.
@@ -557,6 +557,7 @@ class Request implements ArrayAccess
             ];
             $normalizedFiles[$key] = $this->_createUploadedFile($spec);
         }
+
         return $normalizedFiles;
     }
 
@@ -1736,11 +1737,12 @@ class Request implements ArrayAccess
     /**
      * Recursively validate uploaded file data.
      *
-     * @param array $uploadedFiles
+     * @param array $uploadedFiles The new files array to validate.
      * @param string $path The path thus far.
+     * @return void
      * @throws InvalidArgumentException If any leaf elements are not valid files.
      */
-    private function validateUploadedFiles(array $uploadedFiles, $path)
+    protected function validateUploadedFiles(array $uploadedFiles, $path)
     {
         foreach ($uploadedFiles as $key => $file) {
             if (is_array($file)) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -178,6 +178,13 @@ class Request implements ArrayAccess
     protected $emulatedAttributes = ['webroot', 'base', 'params'];
 
     /**
+     * Array of Psr\Http\Message\UploadedFileInterface objects.
+     *
+     * @var array
+     */
+    protected $uploadedFiles = [];
+
+    /**
      * Wrapper method to create a new request from PHP superglobals.
      *
      * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
@@ -482,6 +489,7 @@ class Request implements ArrayAccess
                 json_encode($value)
             ));
         }
+        $this->uploadedFiles = $fileData;
 
         // Make a flat map that can be inserted into $post for BC.
         $fileMap = Hash::flatten($fileData);
@@ -1681,6 +1689,16 @@ class Request implements ArrayAccess
         ];
 
         return $this->attributes + $emulated;
+    }
+
+    /**
+     * Get the array of uploaded files from the request.
+     *
+     * @return array
+     */
+    public function getUploadedFiles()
+    {
+        return $this->uploadedFiles;
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -19,6 +19,7 @@ use Cake\Network\Exception;
 use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;
+use Zend\Diactoros\UploadedFile;
 
 /**
  * TestRequest
@@ -467,7 +468,7 @@ class RequestTest extends TestCase
      *
      * @return void
      */
-    public function testProcessFilesFlat()
+    public function testFilesFlat()
     {
         $files = [
             'birth_cert' => [
@@ -525,6 +526,54 @@ class RequestTest extends TestCase
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);
         $this->assertEquals($files[0]['name'], $uploads[0]->getClientFilename());
+    }
+
+    /**
+     * Test replacing files.
+     *
+     * @return void
+     */
+    public function testWithUploadedFiles()
+    {
+        $file = new UploadedFile(
+            __FILE__,
+            123,
+            UPLOAD_ERR_OK,
+            'test.php',
+            'text/plain'
+        );
+        $request = new Request();
+        $new = $request->withUploadedFiles(['picture' => $file]);
+
+        $this->assertSame([], $request->getUploadedFiles());
+        $this->assertNotSame($new, $request);
+        $this->assertSame(['picture' => $file], $new->getUploadedFiles());
+    }
+
+    /**
+     * Test replacing files with an invalid file
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid file at 'avatar'
+     * @return void
+     */
+    public function testWithUploadedFilesInvalidFile()
+    {
+        $request = new Request();
+        $request->withUploadedFiles(['avatar' => 'not a file']);
+    }
+
+    /**
+     * Test replacing files with an invalid file
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid file at 'user.avatar'
+     * @return void
+     */
+    public function testWithUploadedFilesInvalidFileNested()
+    {
+        $request = new Request();
+        $request->withUploadedFiles(['user' => ['avatar' => 'not a file']]);
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -354,7 +354,7 @@ class RequestTest extends TestCase
      *
      * @return void
      */
-    public function testProcessFilesNested()
+    public function testFilesNested()
     {
         $files = [
             'image_main' => [
@@ -448,6 +448,18 @@ class RequestTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $request->data);
+
+        $uploads = $request->getUploadedFiles();
+        $this->assertCount(3, $uploads);
+        $this->assertArrayHasKey(0, $uploads);
+        $this->assertEquals('scratch.text', $uploads[0]['image']->getClientFilename());
+
+        $this->assertArrayHasKey('pictures', $uploads);
+        $this->assertEquals('a-file.png', $uploads['pictures'][0]['file']->getClientFilename());
+        $this->assertEquals('a-moose.png', $uploads['pictures'][1]['file']->getClientFilename());
+
+        $this->assertArrayHasKey('image_main', $uploads);
+        $this->assertEquals('born on.txt', $uploads['image_main']['file']->getClientFilename());
     }
 
     /**
@@ -478,6 +490,14 @@ class RequestTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $request->data);
+
+        $uploads = $request->getUploadedFiles();
+        $this->assertCount(1, $uploads);
+        $this->assertArrayHasKey('birth_cert', $uploads);
+        $this->assertEquals('born on.txt', $uploads['birth_cert']->getClientFilename());
+        $this->assertEquals(0, $uploads['birth_cert']->getError());
+        $this->assertEquals('application/octet-stream', $uploads['birth_cert']->getClientMediaType());
+        $this->assertEquals(123, $uploads['birth_cert']->getSize());
     }
 
     /**
@@ -501,6 +521,10 @@ class RequestTest extends TestCase
             'files' => $files
         ]);
         $this->assertEquals($files, $request->data);
+
+        $uploads = $request->getUploadedFiles();
+        $this->assertCount(1, $uploads);
+        $this->assertEquals($files[0]['name'], $uploads[0]->getClientFilename());
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -360,14 +360,14 @@ class RequestTest extends TestCase
             'image_main' => [
                 'name' => ['file' => 'born on.txt'],
                 'type' => ['file' => 'text/plain'],
-                'tmp_name' => ['file' => '/private/var/tmp/php'],
+                'tmp_name' => ['file' => __FILE__],
                 'error' => ['file' => 0],
                 'size' => ['file' => 17178]
             ],
             0 => [
                 'name' => ['image' => 'scratch.text'],
                 'type' => ['image' => 'text/plain'],
-                'tmp_name' => ['image' => '/private/var/tmp/phpChIZPb'],
+                'tmp_name' => ['image' => __FILE__],
                 'error' => ['image' => 0],
                 'size' => ['image' => 1490]
             ],
@@ -381,12 +381,12 @@ class RequestTest extends TestCase
                     1 => ['file' => 'image/jpg']
                 ],
                 'tmp_name' => [
-                    0 => ['file' => '/tmp/file123'],
-                    1 => ['file' => '/tmp/file234']
+                    0 => ['file' => __FILE__],
+                    1 => ['file' => __FILE__]
                 ],
                 'error' => [
-                    0 => ['file' => '0'],
-                    1 => ['file' => '0']
+                    0 => ['file' => 0],
+                    1 => ['file' => 0]
                 ],
                 'size' => [
                     0 => ['file' => 17188],
@@ -409,7 +409,7 @@ class RequestTest extends TestCase
                 'file' => [
                     'name' => 'born on.txt',
                     'type' => 'text/plain',
-                    'tmp_name' => '/private/var/tmp/php',
+                    'tmp_name' => __FILE__,
                     'error' => 0,
                     'size' => 17178,
                 ]
@@ -420,7 +420,7 @@ class RequestTest extends TestCase
                     'file' => [
                         'name' => 'a-file.png',
                         'type' => 'image/png',
-                        'tmp_name' => '/tmp/file123',
+                        'tmp_name' => __FILE__,
                         'error' => '0',
                         'size' => 17188,
                     ]
@@ -430,7 +430,7 @@ class RequestTest extends TestCase
                     'file' => [
                         'name' => 'a-moose.png',
                         'type' => 'image/jpg',
-                        'tmp_name' => '/tmp/file234',
+                        'tmp_name' => __FILE__,
                         'error' => '0',
                         'size' => 2010,
                     ]
@@ -441,7 +441,7 @@ class RequestTest extends TestCase
                 'image' => [
                     'name' => 'scratch.text',
                     'type' => 'text/plain',
-                    'tmp_name' => '/private/var/tmp/phpChIZPb',
+                    'tmp_name' => __FILE__,
                     'error' => 0,
                     'size' => 1490
                 ]
@@ -461,7 +461,7 @@ class RequestTest extends TestCase
             'birth_cert' => [
                 'name' => 'born on.txt',
                 'type' => 'application/octet-stream',
-                'tmp_name' => '/private/var/tmp/phpbsUWfH',
+                'tmp_name' => __FILE__,
                 'error' => 0,
                 'size' => 123,
             ]
@@ -472,7 +472,7 @@ class RequestTest extends TestCase
             'birth_cert' => [
                 'name' => 'born on.txt',
                 'type' => 'application/octet-stream',
-                'tmp_name' => '/private/var/tmp/phpbsUWfH',
+                'tmp_name' => __FILE__,
                 'error' => 0,
                 'size' => 123
             ]
@@ -491,7 +491,7 @@ class RequestTest extends TestCase
             0 => [
                 'name' => 'cake_sqlserver_patch.patch',
                 'type' => 'text/plain',
-                'tmp_name' => '/private/var/tmp/phpy05Ywj',
+                'tmp_name' => __FILE__,
                 'error' => 0,
                 'size' => 6271,
             ],

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -529,6 +529,25 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test that the constructor uses uploaded file objects
+     * if they are present. This could happen in test scenarios.
+     *
+     * @return void
+     */
+    public function testFilesObject()
+    {
+        $file = new UploadedFile(
+            __FILE__,
+            123,
+            UPLOAD_ERR_OK,
+            'test.php',
+            'text/plain'
+        );
+        $request = new Request(['files' => ['avatar' => $file]]);
+        $this->assertSame(['avatar' => $file], $request->getUploadedFiles());
+    }
+
+    /**
      * Test replacing files.
      *
      * @return void

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -551,6 +551,38 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test getting a single file
+     *
+     * @return void
+     */
+    public function testGetUploadedFile()
+    {
+        $file = new UploadedFile(
+            __FILE__,
+            123,
+            UPLOAD_ERR_OK,
+            'test.php',
+            'text/plain'
+        );
+        $request = new Request();
+        $new = $request->withUploadedFiles(['picture' => $file]);
+        $this->assertNull($new->getUploadedFile(''));
+        $this->assertSame($file, $new->getUploadedFile('picture'));
+
+        $new = $request->withUploadedFiles([
+            'pictures' => [
+                [
+                    'image' => $file
+                ]
+            ]
+        ]);
+        $this->assertNull($new->getUploadedFile('pictures'));
+        $this->assertNull($new->getUploadedFile('pictures.0'));
+        $this->assertNull($new->getUploadedFile('pictures.1'));
+        $this->assertSame($file, $new->getUploadedFile('pictures.0.image'));
+    }
+
+    /**
      * Test replacing files with an invalid file
      *
      * @expectedException InvalidArgumentException


### PR DESCRIPTION
Implement PSR7 uploaded file support in the request object. I've re-factored and replaced uploaded file handling in the request object so that it first creates the new style `UploadedFile` objects and then uses those to down-sample for backwards compatibility.

I've also implemented `getUploadedFile()` which is not part of the interface, but is a nice to have method in my opinion.

Refs #9325 
