### PR TITLE
Secure form url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 #################################
 /nbproject
 .idea
+/.project
+/.buildpath
+/.settings/
 
 # OS generated files #
 ######################

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1888,7 +1888,7 @@ class FormHelper extends AppHelper {
 		}
 
 		$previousLastAction = $this->_lastAction;
-		$this->_lastAction($url);
+		$this->_lastAction($formUrl);
 
 		$out = $this->Html->useTag('form', $formUrl, $formOptions);
 		$out .= $this->Html->useTag('hidden', '_method', array(


### PR DESCRIPTION
See https://github.com/cakephp/cakephp/issues/9392. The problem with blackholed request is caused by wrong URL used to set `_lastAction`. I have `AppHelper::url()` that adds localization parameters to the URL. `$this->_lastAction($url);` used incomplete URL to set `_lastAction`.
