### PR TITLE
Add result type casting for simple column aliases.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1020,6 +1020,9 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
                 $types[$alias] = $typeMap[$alias];
                 continue;
             }
+            if (is_string($value) && isset($typeMap[$value])) {
+                $types[$alias] = $typeMap[$value];
+            }
             if ($value instanceof TypedResultInterface) {
                 $types[$alias] = $value->returnType();
             }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2948,6 +2948,22 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test that simple aliased field have results typecast.
+     *
+     * @return void
+     */
+    public function testSelectTypeInferSimpleAliases()
+    {
+        $table = TableRegistry::get('comments');
+        $result = $table
+            ->find()
+            ->select(['created', 'updated_time' => 'updated'])
+            ->first();
+        $this->assertInstanceOf(Time::class, $result->created);
+        $this->assertInstanceOf(Time::class, $result->updated_time);
+    }
+
+    /**
      * Tests that isEmpty() can be called on a query
      *
      * @return void


### PR DESCRIPTION
When columns in the schema are aliased to other fields we can easily and correctly infer the result set types. Doing this makes the result sets consistent when columns are aliased and when they are not.

Refs #9402
