### PR TITLE
3.x - Strip aliases from update query conditions where possible.

### DIFF
--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -203,14 +203,15 @@ trait SqlDialectTrait
      *
      * @param \Cake\Database\Query $query The query to process.
      * @return \Cake\Database\Query The modified query.
+     * @throws \RuntimeException In case the processed query contains any joins, as removing
+     *  aliases from the conditions can break references to the joined tables.
      */
     protected function _removeAliasesFromConditions($query)
     {
         if (!empty($query->clause('join'))) {
-            trigger_error(
+            throw new \RuntimeException(
                 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
-                'this can break references to joined tables.',
-                E_USER_NOTICE
+                'this can break references to joined tables.'
             );
         }
 

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -208,7 +208,7 @@ trait SqlDialectTrait
      */
     protected function _removeAliasesFromConditions($query)
     {
-        if (!empty($query->clause('join'))) {
+        if ($query->clause('join')) {
             throw new \RuntimeException(
                 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
                 'this can break references to joined tables.'

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -178,6 +178,34 @@ trait SqlDialectTrait
         if (!$hadAlias) {
             return $query;
         }
+
+        return $this->_removeAliasesFromConditions($query);
+    }
+
+    /**
+     * Apply translation steps to update queries.
+     *
+     * Chops out aliases on update query conditions as not all database dialects do support
+     * aliases in update queries.
+     *
+     * Just like for delete queries, joins are currently not supported for update queries.
+     *
+     * @param \Cake\Database\Query $query The query to translate
+     * @return \Cake\Database\Query The modified query
+     */
+    protected function _updateQueryTranslator($query)
+    {
+        return $this->_removeAliasesFromConditions($query);
+    }
+
+    /**
+     * Removes aliases from the `WHERE` clause of a query.
+     *
+     * @param \Cake\Database\Query $query The query to process.
+     * @return \Cake\Database\Query The modified query.
+     */
+    protected function _removeAliasesFromConditions($query)
+    {
         $conditions = $query->clause('where');
         if ($conditions) {
             $conditions->traverse(function ($condition) {
@@ -197,17 +225,6 @@ trait SqlDialectTrait
             });
         }
 
-        return $query;
-    }
-
-    /**
-     * Apply translation steps to update queries.
-     *
-     * @param \Cake\Database\Query $query The query to translate
-     * @return \Cake\Database\Query The modified query
-     */
-    protected function _updateQueryTranslator($query)
-    {
         return $query;
     }
 

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -206,6 +206,14 @@ trait SqlDialectTrait
      */
     protected function _removeAliasesFromConditions($query)
     {
+        if (!empty($query->clause('join'))) {
+            trigger_error(
+                'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
+                'this can break references to joined tables.',
+                E_USER_NOTICE
+            );
+        }
+
         $conditions = $query->clause('where');
         if ($conditions) {
             $conditions->traverse(function ($condition) {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2655,19 +2655,13 @@ class QueryTest extends TestCase
      * warning about possible incompatibilities with aliases being removed
      * from the conditions.
      *
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.
      * @return void
      */
     public function testDeleteRemovingAliasesCanBreakJoins()
     {
-        $message = null;
-        $oldHandler = set_error_handler(function ($errno, $errstr) use (&$oldHandler, &$message) {
-            if ($errno === E_USER_NOTICE) {
-                $message = $errstr;
-            } else {
-                call_user_func_array($oldHandler, func_get_args());
-            }
-        });
-
         $query = new Query($this->connection);
 
         $query
@@ -2677,12 +2671,6 @@ class QueryTest extends TestCase
             ->where(['a.id' => 1]);
 
         $query->sql();
-
-        restore_error_handler();
-
-        $expected = 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
-            'this can break references to joined tables.';
-        $this->assertEquals($expected, $message);
     }
 
     /**
@@ -2913,19 +2901,12 @@ class QueryTest extends TestCase
      * warning about possible incompatibilities with aliases being removed
      * from the conditions.
      *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.
      * @return void
      */
     public function testUpdateRemovingAliasesCanBreakJoins()
     {
-        $message = null;
-        $oldHandler = set_error_handler(function ($errno, $errstr) use (&$oldHandler, &$message) {
-            if ($errno === E_USER_NOTICE) {
-                $message = $errstr;
-            } else {
-                call_user_func_array($oldHandler, func_get_args());
-            }
-        });
-
         $query = new Query($this->connection);
 
         $query
@@ -2935,12 +2916,6 @@ class QueryTest extends TestCase
             ->where(['a.id' => 1]);
 
         $query->sql();
-
-        restore_error_handler();
-
-        $expected = 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
-            'this can break references to joined tables.';
-        $this->assertEquals($expected, $message);
     }
 
     /**


### PR DESCRIPTION
Unlike for delete queries, possible aliases in the conditions of update queries are not being removed, which will fail for some database dialects. Given that update queries currently do not support joins, just like delete queries, removing the aliases here in the same way should be good enough for now I think.

The fact that expressions are being left untouched is something that maybe should go in the docs somewhere, it's something that affects all dependent, non-cascading associated deletes as well, which developers should generally be aware of.

refs #9404
