### PR TITLE
Add support for EXPLAIN statement

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -745,9 +745,11 @@ class Connection implements ConnectionInterface
      * Executes an EXPLAIN statement for the specified query.
      *
      * @param string $query The query to be explained
+     * @param array $params list or associative array of params to be interpolated in $query as values
+     * @param array $types list or associative array of types to be used for casting values in query
      * @return \Cake\Database\StatementInterface
      */
-    public function explain($query)
+    public function explain($query, array $params = [], array $types = [])
     {
         $query = (string)$query;
 
@@ -755,7 +757,7 @@ class Connection implements ConnectionInterface
             throw new InvalidArgumentException('Cannot explain query');
         }
 
-        return $this->execute($this->_driver->explainSQL($query));
+        return $this->execute($this->_driver->explainSQL($query), $params, $types);
     }
 
     /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -25,6 +25,7 @@ use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Datasource\ConnectionInterface;
 use Exception;
+use InvalidArgumentException;
 
 /**
  * Represents a connection with a database server.
@@ -724,6 +725,37 @@ class Connection implements ConnectionInterface
         $log->logger($this->logger());
 
         return $log;
+    }
+
+    /**
+     * Checks if the driver supports EXPLAIN statement for the specified query.
+     *
+     * @param string $query The query to be explained
+     * @return bool
+     */
+    public function canExplain($query)
+    {
+        $query = (string)$query;
+
+        return preg_match('/^\s*(SELECT|INSERT|UPDATE|DELETE)\s/i', $query)
+            && $this->_driver->explainSQL($query) !== false;
+    }
+
+    /**
+     * Executes an EXPLAIN statement for the specified query.
+     *
+     * @param string $query The query to be explained
+     * @return \Cake\Database\StatementInterface
+     */
+    public function explain($query)
+    {
+        $query = (string)$query;
+
+        if (!$this->canExplain($query)) {
+            throw new InvalidArgumentException('Cannot explain query');
+        }
+
+        return $this->execute($this->_driver->explainSQL($query));
     }
 
     /**

--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -81,4 +81,12 @@ trait MysqlDialectTrait
     {
         return 'SET foreign_key_checks = 1';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function explainSQL($query)
+    {
+        return "EXPLAIN $query";
+    }
 }

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -186,4 +186,12 @@ trait PostgresDialectTrait
     {
         return 'SET CONSTRAINTS ALL IMMEDIATE';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function explainSQL($query)
+    {
+        return "EXPLAIN $query";
+    }
 }

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -186,6 +186,14 @@ trait SqliteDialectTrait
 
     /**
      * {@inheritDoc}
+     */
+    public function explainSQL($query)
+    {
+        return "EXPLAIN QUERY PLAN $query";
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @return \Cake\Database\SqliteCompiler
      */

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -235,6 +235,17 @@ abstract class Driver
     abstract public function quoteIdentifier($identifier);
 
     /**
+     * Get the SQL for explaining the query.
+     *
+     * @param string $query The query to be explained
+     * @return string|bool
+     */
+    public function explainSQL($query)
+    {
+        return false;
+    }
+
+    /**
      * Escapes values for use in schema definitions.
      *
      * @param mixed $value The value to escape.

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -25,6 +25,15 @@ class LoggedQuery
 
     /**
      * Query string that was executed
+     * This value should not be modified once assigned
+     *
+     * @var string
+     */
+    public $queryString;
+
+    /**
+     * Query string that was executed
+     * This value may be modified by QueryLogger
      *
      * @var string
      */

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -80,7 +80,7 @@ class LoggingStatement extends StatementDecorator
     {
         $query->took = round((microtime(true) - $startTime) * 1000, 0);
         $query->params = $params ?: $this->_compiledParams;
-        $query->query = $this->queryString;
+        $query->query = $query->queryString = $this->queryString;
         $this->logger()->log($query);
     }
 

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -60,6 +60,10 @@ class QueryLogger
      */
     protected function _interpolate($query)
     {
+        if ($query->queryString === null) {
+            $query->queryString = $query->query;
+        }
+
         $params = array_map(function ($p) {
             if ($p === null) {
                 return 'NULL';
@@ -77,6 +81,6 @@ class QueryLogger
             $keys[] = is_string($key) ? "/:$key\b/" : '/[?]/';
         }
 
-        return preg_replace($keys, $params, $query->query, $limit);
+        return preg_replace($keys, $params, $query->queryString, $limit);
     }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -987,4 +987,91 @@ class ConnectionTest extends TestCase
         $connection->schemaCollection($schema);
         $this->assertSame($schema, $connection->schemaCollection());
     }
+
+    /**
+     * Test canExplain
+     *
+     * @return void
+     */
+    public function testCanExplain()
+    {
+        $driver = $this->getMockBuilder('Cake\Database\Driver')
+            ->getMock();
+
+        $driver->expects($this->once())
+            ->method('enabled')
+            ->will($this->returnValue(true));
+
+        $driver->expects($this->any())
+            ->method('explainSQL')
+            ->will($this->returnValue('EXPLAIN something'));
+
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
+
+        $this->assertTrue($connection->canExplain("INSERT INTO things (title, body) VALUES ('foo', 'bar')"));
+        $this->assertTrue($connection->canExplain("UPDATE things SET title = 'bar'"));
+        $this->assertTrue($connection->canExplain("SELECT * FROM things"));
+        $this->assertTrue($connection->canExplain("DELETE FROM things WHERE id = 1"));
+        $this->assertFalse($connection->canExplain("TRUNCATE things"));
+    }
+
+    /**
+     * Test explain
+     *
+     * @return void
+     */
+    public function testExplain()
+    {
+        $driver = $this->getMockBuilder('Cake\Database\Driver')
+            ->getMock();
+
+        $driver->expects($this->once())
+            ->method('enabled')
+            ->will($this->returnValue(true));
+
+        $driver->expects($this->any())
+            ->method('explainSQL')
+            ->will($this->returnValue('EXPLAIN something'));
+
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'execute'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
+
+        $connection->expects($this->once())
+            ->method('execute')
+            ->with('EXPLAIN something');
+
+        $connection->explain('SELECT 1');
+    }
+
+    /**
+     * Test explain throws an exception if not supported.
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Cannot explain query
+     */
+    public function testExplainNotSupported()
+    {
+        $driver = $this->getMockBuilder('Cake\Database\Driver')
+            ->getMock();
+
+        $driver->expects($this->once())
+            ->method('enabled')
+            ->will($this->returnValue(true));
+
+        $driver->expects($this->any())
+            ->method('explainSQL')
+            ->will($this->returnValue(false));
+
+        $connection = $this->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect', 'execute'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
+
+        $connection->explain('SELECT 1');
+    }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1042,10 +1042,10 @@ class ConnectionTest extends TestCase
             ->getMock();
 
         $connection->expects($this->once())
-            ->method('execute')
+            ->method('execute', ['number' => 100], ['number' => 'integer'])
             ->with('EXPLAIN something');
 
-        $connection->explain('SELECT 1');
+        $connection->explain('SELECT :number', ['number' => 100], ['number' => 'integer']);
     }
 
     /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -23,6 +23,7 @@ use PDO;
  */
 class MysqlTest extends TestCase
 {
+
     /**
      * setup
      *
@@ -171,7 +172,7 @@ class MysqlTest extends TestCase
     public function testExplain()
     {
         $connection = ConnectionManager::get('test');
-        $result = $connection->explain('SELECT 1');
+        $result = $connection->explain('SELECT ?', [1]);
 
         $expected = [
             'id',

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -16,14 +16,13 @@ namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use \PDO;
+use PDO;
 
 /**
  * Tests Mysql driver
  */
 class MysqlTest extends TestCase
 {
-
     /**
      * setup
      *
@@ -162,5 +161,31 @@ class MysqlTest extends TestCase
 
         $this->assertFalse($driver->commitTransaction());
         $this->assertTrue($driver->isConnected());
+    }
+
+    /**
+     * Test EXPLAIN
+     *
+     * @return void
+     */
+    public function testExplain()
+    {
+        $connection = ConnectionManager::get('test');
+        $result = $connection->explain('SELECT 1');
+
+        $expected = [
+            'id',
+            'select_type',
+            'table',
+            'type',
+            'possible_keys',
+            'key',
+            'key_len',
+            'ref',
+            'rows',
+            'Extra',
+        ];
+
+        $this->assertEquals($expected, array_keys($result->fetch('assoc')));
     }
 }

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -24,6 +24,10 @@ use \PDO;
 class PostgresTest extends TestCase
 {
 
+    public $fixtures = ['core.things'];
+
+    public $autoFixtures = false;
+
     /**
      * Test connecting to Postgres with default configuration
      *
@@ -183,8 +187,10 @@ class PostgresTest extends TestCase
         $config = ConnectionManager::config('test');
         $this->skipIf(strpos($config['driver'], 'Postgres') === false, 'Not using Postgres for test config');
 
+        $this->loadFixtures('Things');
+
         $connection = ConnectionManager::get('test');
-        $result = $connection->explain('SELECT 1');
+        $result = $connection->explain('SELECT * FROM things WHERE id = ?', [1]);
 
         $expected = [
             'QUERY PLAN',

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use \PDO;
 
@@ -170,5 +171,25 @@ class PostgresTest extends TestCase
             ->epilog('FOO');
         $query = $translator($query);
         $this->assertEquals('FOO', $query->clause('epilog'));
+    }
+
+    /**
+     * Test EXPLAIN
+     *
+     * @return void
+     */
+    public function testExplain()
+    {
+        $config = ConnectionManager::config('test');
+        $this->skipIf(strpos($config['driver'], 'Postgres') === false, 'Not using Postgres for test config');
+
+        $connection = ConnectionManager::get('test');
+        $result = $connection->explain('SELECT 1');
+
+        $expected = [
+            'QUERY PLAN',
+        ];
+
+        $this->assertEquals($expected, array_keys($result->fetch('assoc')));
     }
 }

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
 
@@ -23,6 +24,9 @@ use PDO;
  */
 class SqliteTest extends TestCase
 {
+    public $fixtures = ['core.things'];
+
+    public $autoFixtures = false;
 
     /**
      * Test connecting to Sqlite with default configuration
@@ -142,5 +146,30 @@ class SqliteTest extends TestCase
             }));
         $driver->connection($mock);
         $this->assertEquals($expected, $driver->schemaValue($input));
+    }
+
+    /**
+     * Test EXPLAIN
+     *
+     * @return void
+     */
+    public function testExplain()
+    {
+        $config = ConnectionManager::config('test');
+        $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite for test config');
+
+        $this->loadFixtures('Things');
+
+        $connection = ConnectionManager::get('test');
+        $result = $connection->explain('SELECT * FROM things');
+
+        $expected = [
+            'selectid',
+            'order',
+            'from',
+            'detail',
+        ];
+
+        $this->assertEquals($expected, array_keys($result->fetch('assoc')));
     }
 }

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -24,6 +24,7 @@ use PDO;
  */
 class SqliteTest extends TestCase
 {
+
     public $fixtures = ['core.things'];
 
     public $autoFixtures = false;
@@ -161,7 +162,7 @@ class SqliteTest extends TestCase
         $this->loadFixtures('Things');
 
         $connection = ConnectionManager::get('test');
-        $result = $connection->explain('SELECT * FROM things');
+        $result = $connection->explain('SELECT * FROM things WHERE id = ?', [1]);
 
         $expected = [
             'selectid',

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -15,8 +15,9 @@
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use \PDO;
+use PDO;
 
 /**
  * Tests Sqlserver driver
@@ -236,5 +237,20 @@ class SqlserverTest extends TestCase
             ->values(['title' => 'A new article']);
         $expected = 'INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)';
         $this->assertEquals($expected, $query->sql());
+    }
+
+    /**
+     * Test EXPLAIN
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Cannot explain query
+     */
+    public function testExplain()
+    {
+        $config = ConnectionManager::config('test');
+        $this->skipIf(strpos($config['driver'], 'Sqlserver') === false, 'Not using Sqlserver for test config');
+
+        $connection = ConnectionManager::get('test');
+        $connection->explain('SELECT 1');
     }
 }

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -92,6 +92,17 @@ class DriverTest extends TestCase
     }
 
     /**
+     * Test explainSQL().
+     *
+     * @return void
+     */
+    public function testExplainSQL()
+    {
+        $result = $this->driver->explainSQL('SELECT 1');
+        $this->assertFalse($result);
+    }
+
+    /**
      * Test schemaValue().
      * Uses a provider for all the different values we can pass to the method.
      *

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -155,4 +155,45 @@ class QueryLoggerTest extends TestCase
         $engine2->expects($this->never())->method('log');
         $logger->log($query);
     }
+
+    /**
+     * Tests that calling log method twice works
+     *
+     * @return void
+     */
+    public function testCallingLogMethodTwice()
+    {
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
+        $query = new LoggedQuery;
+        $query->query = 'SELECT :value';
+        $query->params = ['value' => ':value'];
+
+        $logger->log($query);
+        $this->assertEquals("SELECT ':value'", $query->query);
+
+        $logger->log($query);
+        $this->assertEquals("SELECT ':value'", $query->query);
+    }
+
+    /**
+     * Tests that the queryString property and the params property are not modified.
+     *
+     * @return void
+     */
+    public function testKeepingOriginalQueryAndParams()
+    {
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
+        $query = new LoggedQuery;
+        $query->queryString = 'SELECT :value';
+        $query->params = ['value' => 100];
+
+        $logger->log($query);
+        $this->assertEquals("SELECT 100", $query->query);
+        $this->assertEquals("SELECT :value", $query->queryString);
+        $this->assertEquals(['value' => 100], $query->params);
+    }
 }


### PR DESCRIPTION
This pull request is necessary to re-implement Explain button in debug toolbar.
### What is changed
- Added `Connection::canExplain()` method. Returns true If driver is supporting EXPLAIN statement for the specified query. Mysql, Postgres and Sqlite will return true if the specified query starts with SELECT, INSERT, UPDATE or DELETE. Sqlserver or other unknown drivers will always return false.
- Added `Connection::explain()` method. Excecutes EXPLAIN query If driver is supporting EXPLAIN statement. If not supporting, throws an exception.
- Added `LoggedQuery::$queryString` property because `LoggedQuery::$query` may be modified by QueryLogger. If LoggedQuery doesn't keep original query, DebugKit cannot execute correct EXPLAIN query.
### Usage

``` php
$connection = ConnectionManager::get('default');
$query = 'SELECT * FROM users WHERE id = :id';
if ($connection->canExplan($query)) {
    $stmt = $connection->explain($query, ['id' => 1], ['id' => 'integer']);
    $result = $stmt->fetchAll();
}
```

**Edit:** Fixed incorrect explanation 
