### PR TITLE
Use more concrete array typehinting to fix IDEs not finding the metho…

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -168,14 +168,14 @@ class AuthComponent extends Component
     /**
      * Objects that will be used for authentication checks.
      *
-     * @var array
+     * @var \Cake\Auth\BaseAuthenticate[]
      */
     protected $_authenticateObjects = [];
 
     /**
      * Objects that will be used for authorization checks.
      *
-     * @var array
+     * @var \Cake\Auth\BaseAuthorize[]
      */
     protected $_authorizeObjects = [];
 


### PR DESCRIPTION
…ds used on the stack of objects

Yellow underlining, no click-through.
This is fixed.

We should do this a bit more across the framework.
