### PR TITLE
Fix up forgotten class aliasing issues and typehinting.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -50,7 +50,7 @@ use Cake\Utility\Hash;
  *
  * You can use the 'cookieJar' constructor option to provide a custom
  * cookie jar instance you've restored from cache/disk. By default
- * an empty instance of Cake\Network\Http\CookieCollection will be created.
+ * an empty instance of Cake\Http\Client\CookieCollection will be created.
  *
  * ### Sending request bodies
  *
@@ -124,7 +124,7 @@ class Client
 
     /**
      * Adapter for sending requests. Defaults to
-     * Cake\Network\Http\Adapter\Stream
+     * Cake\Http\Adapter\Stream
      *
      * @var \Cake\Http\Client\Adapter\Stream
      */

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -18,7 +18,7 @@ use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 
 /**
- * Implements sending Cake\Network\Http\Request
+ * Implements sending Cake\Http\Client\Request
  * via php's stream API.
  *
  * This approach and implementation is partly inspired by Aura.Http
@@ -64,7 +64,7 @@ class Stream
     /**
      * Send a request and get a response back.
      *
-     * @param \Cake\Network\Http\Request $request The request object to send.
+     * @param \Cake\Http\Client\Request $request The request object to send.
      * @param array $options Array of options for the stream.
      * @return array Array of populated Response objects
      */
@@ -113,7 +113,7 @@ class Stream
     /**
      * Build the stream context out of the request object.
      *
-     * @param \Cake\Network\Http\Request $request The request to build context from.
+     * @param \Cake\Http\Client\Request $request The request to build context from.
      * @param array $options Additional request options.
      * @return void
      */
@@ -139,7 +139,7 @@ class Stream
      *
      * Creates cookies & headers.
      *
-     * @param \Cake\Network\Http\Request $request The request being sent.
+     * @param \Cake\Http\Client\Request $request The request being sent.
      * @param array $options Array of options to use.
      * @return void
      */
@@ -164,9 +164,9 @@ class Stream
      * Builds the request content based on the request object.
      *
      * If the $request->body() is a string, it will be used as is.
-     * Array data will be processed with Cake\Network\Http\FormData
+     * Array data will be processed with Cake\Http\Client\FormData
      *
-     * @param \Cake\Network\Http\Request $request The request being sent.
+     * @param \Cake\Http\Client\Request $request The request being sent.
      * @param array $options Array of options to use.
      * @return void
      */
@@ -185,7 +185,7 @@ class Stream
     /**
      * Build miscellaneous options for the request.
      *
-     * @param \Cake\Network\Http\Request $request The request being sent.
+     * @param \Cake\Http\Client\Request $request The request being sent.
      * @param array $options Array of options to use.
      * @return void
      */
@@ -209,7 +209,7 @@ class Stream
     /**
      * Build SSL options for the request.
      *
-     * @param \Cake\Network\Http\Request $request The request being sent.
+     * @param \Cake\Http\Client\Request $request The request being sent.
      * @param array $options Array of options to use.
      * @return void
      */
@@ -243,7 +243,7 @@ class Stream
     /**
      * Open the stream and send the request.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @return array Array of populated Response objects
      * @throws \Cake\Core\Exception\Exception
      */

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -16,9 +16,9 @@ namespace Cake\Http\Client\Auth;
 use Cake\Http\Client\Request;
 
 /**
- * Basic authentication adapter for Cake\Network\Http\Client
+ * Basic authentication adapter for Cake\Http\Client
  *
- * Generally not directly constructed, but instead used by Cake\Network\Http\Client
+ * Generally not directly constructed, but instead used by Cake\Http\Client
  * when $options['auth']['type'] is 'basic'
  */
 class Basic
@@ -27,9 +27,9 @@ class Basic
     /**
      * Add Authorization header to the request.
      *
-     * @param \Cake\Network\Http\Request $request Request instance.
+     * @param \Cake\Http\Client\Request $request Request instance.
      * @param array $credentials Credentials.
-     * @return \Cake\Network\Http\Request The updated request.
+     * @return \Cake\Http\Client\Request The updated request.
      * @see http://www.ietf.org/rfc/rfc2617.txt
      */
     public function authentication(Request $request, array $credentials)
@@ -45,9 +45,9 @@ class Basic
     /**
      * Proxy Authentication
      *
-     * @param \Cake\Network\Http\Request $request Request instance.
+     * @param \Cake\Http\Client\Request $request Request instance.
      * @param array $credentials Credentials.
-     * @return \Cake\Network\Http\Request The updated request.
+     * @return \Cake\Http\Client\Request The updated request.
      * @see http://www.ietf.org/rfc/rfc2617.txt
      */
     public function proxyAuthentication(Request $request, array $credentials)

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -17,25 +17,25 @@ use Cake\Http\Client;
 use Cake\Http\Client\Request;
 
 /**
- * Digest authentication adapter for Cake\Network\Http\Client
+ * Digest authentication adapter for Cake\Http\Client
  *
- * Generally not directly constructed, but instead used by Cake\Network\Http\Client
+ * Generally not directly constructed, but instead used by Cake\Http\Client
  * when $options['auth']['type'] is 'digest'
  */
 class Digest
 {
 
     /**
-     * Instance of Cake\Network\Http\Client
+     * Instance of Cake\Http\Client
      *
-     * @var \Cake\Network\Http\Client
+     * @var \Cake\Http\Client
      */
     protected $_client;
 
     /**
      * Constructor
      *
-     * @param \Cake\Network\Http\Client $client Http client object.
+     * @param \Cake\Http\Client $client Http client object.
      * @param array|null $options Options list.
      */
     public function __construct(Client $client, $options = null)
@@ -46,9 +46,9 @@ class Digest
     /**
      * Add Authorization header to the request.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
-     * @return \Cake\Network\Http\Request The updated request.
+     * @return \Cake\Http\Client\Request The updated request.
      * @see http://www.ietf.org/rfc/rfc2617.txt
      */
     public function authentication(Request $request, array $credentials)
@@ -74,7 +74,7 @@ class Digest
      * another request without authentication to get authentication
      * challenge.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return array modified credentials.
      */
@@ -108,7 +108,7 @@ class Digest
     /**
      * Generate the header Authorization
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return string
      */

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -19,13 +19,13 @@ use Cake\Utility\Security;
 use RuntimeException;
 
 /**
- * Oauth 1 authentication strategy for Cake\Network\Http\Client
+ * Oauth 1 authentication strategy for Cake\Http\Client
  *
  * This object does not handle getting Oauth access tokens from the service
  * provider. It only handles make client requests *after* you have obtained the Oauth
  * tokens.
  *
- * Generally not directly constructed, but instead used by Cake\Network\Http\Client
+ * Generally not directly constructed, but instead used by Cake\Http\Client
  * when $options['auth']['type'] is 'oauth'
  */
 class Oauth
@@ -34,9 +34,9 @@ class Oauth
     /**
      * Add headers for Oauth authorization.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
-     * @return \Cake\Network\Http\Request The updated request.
+     * @return \Cake\Http\Client\Request The updated request.
      * @throws \Cake\Core\Exception\Exception On invalid signature types.
      */
     public function authentication(Request $request, array $credentials)
@@ -94,7 +94,7 @@ class Oauth
      * You should only ever use PLAINTEXT when dealing with SSL
      * services.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return string Authorization header.
      */
@@ -123,7 +123,7 @@ class Oauth
      *
      * This method is suitable for plain HTTP or HTTPS.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return string
      */
@@ -160,7 +160,7 @@ class Oauth
      *
      * This method is suitable for plain HTTP or HTTPS.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return string
      *
@@ -231,7 +231,7 @@ class Oauth
      * - The request URL (without querystring) is normalized.
      * - The HTTP method, URL and request parameters are concatenated and returned.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $oauthValues Oauth values.
      * @return string
      */
@@ -281,7 +281,7 @@ class Oauth
      * - URL encode keys + values.
      * - Sort keys & values by byte value.
      *
-     * @param \Cake\Network\Http\Request $request The request object.
+     * @param \Cake\Http\Client\Request $request The request object.
      * @param array $oauthValues Oauth values.
      * @return string sorted and normalized values
      */

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -35,7 +35,7 @@ class CookieCollection
      * Store the cookies that haven't expired. If a cookie has been expired
      * and is currently stored, it will be removed.
      *
-     * @param \Cake\Network\Http\Response $response The response to read cookies from
+     * @param \Cake\Http\Client\Response $response The response to read cookies from
      * @param string $url The request URL used for default host/path values.
      * @return void
      */

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -74,7 +74,7 @@ class FormData implements Countable
      *
      * @param string $name The name of the part.
      * @param string $value The value to add.
-     * @return \Cake\Network\Http\FormDataPart
+     * @return \Cake\Http\Client\FormDataPart
      */
     public function newPart($name, $value)
     {
@@ -90,7 +90,7 @@ class FormData implements Countable
      * If the $value is an array, multiple parts will be added.
      * Files will be read from their current position and saved in memory.
      *
-     * @param string|\Cake\Network\Http\FormData $name The name of the part to add,
+     * @param string|\Cake\Http\Client\FormData $name The name of the part to add,
      *   or the part data object.
      * @param mixed $value The value for the part.
      * @return $this
@@ -141,7 +141,7 @@ class FormData implements Countable
      *
      * @param string $name The name to use.
      * @param mixed $value Either a string filename, or a filehandle.
-     * @return \Cake\Network\Http\FormDataPart
+     * @return \Cake\Http\Client\FormDataPart
      */
     public function addFile($name, $value)
     {

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -17,7 +17,7 @@ namespace Cake\Http\Client;
  * Contains the data and behavior for a single
  * part in a Multipart FormData request body.
  *
- * Added to Cake\Network\Http\FormData when sending
+ * Added to Cake\Http\Client\FormData when sending
  * data to a remote server.
  *
  * @internal

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -22,7 +22,7 @@ use Zend\Diactoros\Stream;
 /**
  * Implements methods for HTTP requests.
  *
- * Used by Cake\Network\Http\Client to contain request information
+ * Used by Cake\Http\Client to contain request information
  * for making requests.
  */
 class Request extends Message implements RequestInterface

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -37,7 +37,7 @@ trait DateFormatTrait
     /**
      * In-memory cache of date formatters
      *
-     * @var array
+     * @var IntlDateFormatter[]
      */
     protected static $_formatters = [];
 

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -20,7 +20,6 @@ use Cake\Core\Configure;
 use Cake\Core\StaticConfigTrait;
 use Cake\Filesystem\File;
 use Cake\Log\Log;
-use Cake\Network\Http\FormData\Part;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
 use Cake\Utility\Text;

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -19,6 +19,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\StaticConfigTrait;
 use Cake\Filesystem\File;
+use Cake\Http\Client\FormDataPart;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -1705,7 +1706,7 @@ class Email implements JsonSerializable, Serializable
                 !isset($fileInfo['contentDisposition']) ||
                 $fileInfo['contentDisposition']
             );
-            $part = new Part(false, $data, false);
+            $part = new FormDataPart(false, $data, false);
 
             if ($hasDisposition) {
                 $part->disposition('attachment');
@@ -1755,7 +1756,7 @@ class Email implements JsonSerializable, Serializable
             $data = isset($fileInfo['data']) ? $fileInfo['data'] : $this->_readFile($fileInfo['file']);
 
             $msg[] = '--' . $boundary;
-            $part = new Part(false, $data, 'inline');
+            $part = new FormDataPart(false, $data, 'inline');
             $part->type($fileInfo['mimetype']);
             $part->transferEncoding('base64');
             $part->contentId($fileInfo['contentId']);

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -55,7 +55,7 @@ class Xml
      * Building XML from a remote URL:
      *
      * ```
-     * use Cake\Network\Http\Client;
+     * use Cake\Http\Client;
      *
      * $http = new Client();
      * $response = $http->get('http://example.com/example.xml');

--- a/tests/TestCase/Network/Http/Adapter/StreamTest.php
+++ b/tests/TestCase/Network/Http/Adapter/StreamTest.php
@@ -13,8 +13,8 @@
  */
 namespace Cake\Test\TestCase\Network\Http\Adapter;
 
-use Cake\Network\Http\Adapter\Stream;
-use Cake\Network\Http\Request;
+use Cake\Http\Client\Adapter\Stream;
+use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -132,7 +132,7 @@ class StreamTest extends TestCase
         } catch (\Cake\Core\Exception\Exception $e) {
             $this->markTestSkipped('Could not connect to localhost, skipping');
         }
-        $this->assertInstanceOf('Cake\Network\Http\Response', $responses[0]);
+        $this->assertInstanceOf('Cake\Http\Client\Response', $responses[0]);
     }
 
     /**
@@ -147,7 +147,7 @@ class StreamTest extends TestCase
         $request->url('http://dummy/');
 
         $responses = $stream->send($request, []);
-        $this->assertInstanceOf('Cake\Network\Http\Response', $responses[0]);
+        $this->assertInstanceOf('Cake\Http\Client\Response', $responses[0]);
 
         $this->assertEquals(20000, strlen($responses[0]->body()));
     }

--- a/tests/TestCase/Network/Http/Auth/DigestTest.php
+++ b/tests/TestCase/Network/Http/Auth/DigestTest.php
@@ -28,12 +28,12 @@ class DigestTest extends TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Cake\Http\Client
      */
-    protected  $client;
+    public $client;
 
     /**
      * @var \Cake\Http\Client\Auth\Digest
      */
-    protected $auth;
+    public $auth;
 
     /**
      * Setup

--- a/tests/TestCase/Network/Http/Auth/DigestTest.php
+++ b/tests/TestCase/Network/Http/Auth/DigestTest.php
@@ -13,9 +13,10 @@
  */
 namespace Cake\Test\TestCase\Network\Http\Auth;
 
-use Cake\Network\Http\Auth\Digest;
-use Cake\Network\Http\Request;
-use Cake\Network\Http\Response;
+use Cake\Http\Client;
+use Cake\Http\Client\Auth\Digest;
+use Cake\Http\Client\Request;
+use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -23,6 +24,16 @@ use Cake\TestSuite\TestCase;
  */
 class DigestTest extends TestCase
 {
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Cake\Http\Client
+     */
+    protected  $client;
+
+    /**
+     * @var \Cake\Http\Client\Auth\Digest
+     */
+    protected $auth;
 
     /**
      * Setup
@@ -33,10 +44,18 @@ class DigestTest extends TestCase
     {
         parent::setUp();
 
-        $this->client = $this->getMockBuilder('Cake\Network\Http\Client')
+        $this->client = $this->getClientMock();
+        $this->auth = new Digest($this->client);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Cake\Http\Client
+     */
+    protected function getClientMock()
+    {
+        return $this->getMockBuilder(Client::class)
             ->setMethods(['send'])
             ->getMock();
-        $this->auth = new Digest($this->client);
     }
 
     /**

--- a/tests/TestCase/Network/Http/Auth/OauthTest.php
+++ b/tests/TestCase/Network/Http/Auth/OauthTest.php
@@ -13,8 +13,8 @@
  */
 namespace Cake\Test\TestCase\Network\Http\Auth;
 
-use Cake\Network\Http\Auth\Oauth;
-use Cake\Network\Http\Request;
+use Cake\Http\Client\Auth\Oauth;
+use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -14,11 +14,10 @@
 namespace Cake\Test\TestCase\Network\Http;
 
 use Cake\Core\Configure;
-use Cake\Network\Http\Client;
-use Cake\Network\Http\Request;
-use Cake\Network\Http\Response;
+use Cake\Http\Client;
+use Cake\Http\Client\Request;
+use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
-use Zend\Diactoros\Uri;
 
 /**
  * HTTP client test.
@@ -169,13 +168,13 @@ class ClientTest extends TestCase
             'split' => 'value'
         ];
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) use ($cookies, $headers) {
-                $this->assertInstanceOf('Cake\Network\Http\Request', $request);
+                $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
                 $this->assertEquals('http://cakephp.org/test.html', $request->getUri() . '');
                 $this->assertEquals($cookies, $request->cookies());
@@ -203,7 +202,7 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
@@ -239,7 +238,7 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
@@ -276,7 +275,7 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
@@ -308,7 +307,7 @@ class ClientTest extends TestCase
      */
     public function testInvalidAuthenticationType()
     {
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->never())
@@ -332,7 +331,7 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $headers = [
@@ -371,7 +370,7 @@ class ClientTest extends TestCase
     {
         Configure::write('App.namespace', 'TestApp');
         $response = new Response();
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $headers = [
@@ -428,13 +427,13 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) use ($method) {
-                $this->assertInstanceOf('Cake\Network\Http\Request', $request);
+                $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals($method, $request->getMethod());
                 $this->assertEquals('http://cakephp.org/projects/add', '' . $request->getUri());
 
@@ -480,7 +479,7 @@ class ClientTest extends TestCase
             'Accept' => $mime,
         ];
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
@@ -511,7 +510,7 @@ class ClientTest extends TestCase
         $response = new Response();
         $data = 'some=value&more=data';
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->any())
@@ -541,7 +540,7 @@ class ClientTest extends TestCase
      */
     public function testExceptionOnUnknownType()
     {
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->never())
@@ -561,10 +560,10 @@ class ClientTest extends TestCase
      */
     public function testCookieStorage()
     {
-        $adapter = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $adapter = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
-        $cookieJar = $this->getMockBuilder('Cake\Network\Http\CookieCollection')->getMock();
+        $cookieJar = $this->getMockBuilder('Cake\Http\Client\CookieCollection')->getMock();
 
         $headers = [
             'HTTP/1.0 200 Ok',
@@ -604,13 +603,13 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder('Cake\Network\Http\Adapter\Stream')
+        $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
         $mock->expects($this->once())
             ->method('send')
             ->with($this->callback(function ($request) {
-                $this->assertInstanceOf('Cake\Network\Http\Request', $request);
+                $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals(Request::METHOD_HEAD, $request->getMethod());
                 $this->assertEquals('http://cakephp.org/search?q=hi+there', '' . $request->getUri());
 

--- a/tests/TestCase/Network/Http/CookieCollectionTest.php
+++ b/tests/TestCase/Network/Http/CookieCollectionTest.php
@@ -13,8 +13,8 @@
  */
 namespace Cake\Test\TestCase\Network\Http;
 
-use Cake\Network\Http\CookieCollection;
-use Cake\Network\Http\Response;
+use Cake\Http\Client\CookieCollection;
+use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Network/Http/FormDataTest.php
+++ b/tests/TestCase/Network/Http/FormDataTest.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Test\TestCase\Network\Http;
 
-use Cake\Network\Http\FormData;
+use Cake\Http\Client\FormData;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Test\TestCase\Network\Http;
 
-use Cake\Network\Http\Request;
+use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;
 use Zend\Diactoros\Uri;
 

--- a/tests/TestCase/Network/Http/ResponseTest.php
+++ b/tests/TestCase/Network/Http/ResponseTest.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\Test\TestCase\Network\Http;
 
-use Cake\Network\Http\Response;
+use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/test_app/TestApp/Http/CompatAuth.php
+++ b/tests/test_app/TestApp/Http/CompatAuth.php
@@ -13,7 +13,7 @@
  */
 namespace TestApp\Http;
 
-use Cake\Network\Http\Request;
+use Cake\Http\Client\Request;
 
 /**
  * Testing stub to ensure that auth providers
@@ -27,9 +27,9 @@ class CompatAuth
     /**
      * Add Authorization header to the request via in-place mutation methods.
      *
-     * @param \Cake\Network\Http\Request $request Request instance.
+     * @param \Cake\Http\Client\Request $request Request instance.
      * @param array $credentials Credentials.
-     * @return \Cake\Network\Http\Request The updated request.
+     * @return \Cake\Http\Client\Request The updated request.
      */
     public function authentication(Request $request, array $credentials)
     {
@@ -39,9 +39,9 @@ class CompatAuth
     /**
      * Proxy Authentication added via in-place mutation methods.
      *
-     * @param \Cake\Network\Http\Request $request Request instance.
+     * @param \Cake\Http\Client\Request $request Request instance.
      * @param array $credentials Credentials.
-     * @return \Cake\Network\Http\Request The updated request.
+     * @return \Cake\Http\Client\Request The updated request.
      */
     public function proxyAuthentication(Request $request, array $credentials)
     {


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/9423

There was a lot of red code and yellow underlining displayed in the IDE.
