### PR TITLE
Fix issues working with large float values.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -37,7 +37,7 @@ class Type implements TypeInterface
         'boolean' => 'Cake\Database\Type\BoolType',
         'date' => 'Cake\Database\Type\DateType',
         'datetime' => 'Cake\Database\Type\DateTimeType',
-        'decimal' => 'Cake\Database\Type\FloatType',
+        'decimal' => 'Cake\Database\Type\DecimalType',
         'float' => 'Cake\Database\Type\FloatType',
         'integer' => 'Cake\Database\Type\IntegerType',
         'json' => 'Cake\Database\Type\JsonType',

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
+use InvalidArgumentException;
 use PDO;
 use RuntimeException;
 
@@ -66,14 +67,15 @@ class DecimalType extends Type implements TypeInterface
      * @param string|int|float $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
+     * @throws \InvalidArgumentException
      */
     public function toDatabase($value, Driver $driver)
     {
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_array($value)) {
-            return '1';
+        if (!is_scalar($value)) {
+            throw new InvalidArgumentException('Cannot convert value to a decimal.');
         }
         if (is_string($value) && is_numeric($value)) {
             return $value;

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -63,7 +63,7 @@ class DecimalType extends Type implements TypeInterface
     /**
      * Convert integer data into the database format.
      *
-     * @param string|resource $value The value to convert.
+     * @param string|int|float $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
@@ -79,7 +79,7 @@ class DecimalType extends Type implements TypeInterface
             return $value;
         }
 
-        return sprintf('%F', (float)$value);
+        return sprintf('%F', $value);
     }
 
     /**
@@ -94,9 +94,6 @@ class DecimalType extends Type implements TypeInterface
     {
         if ($value === null) {
             return null;
-        }
-        if (is_array($value)) {
-            return 1;
         }
 
         return (float)$value;

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
+ * @since         3.3.4
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Database\Type;

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -21,11 +21,11 @@ use PDO;
 use RuntimeException;
 
 /**
- * Float type converter.
+ * Decimal type converter.
  *
- * Use to convert float/decimal data between PHP and the database types.
+ * Use to convert decimal data between PHP and the database types.
  */
-class FloatType extends Type implements TypeInterface
+class DecimalType extends Type implements TypeInterface
 {
 
     /**
@@ -73,10 +73,13 @@ class FloatType extends Type implements TypeInterface
             return null;
         }
         if (is_array($value)) {
-            return 1;
+            return '1';
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return $value;
         }
 
-        return (float)$value;
+        return sprintf('%F', (float)$value);
     }
 
     /**

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -72,9 +72,6 @@ class FloatType extends Type implements TypeInterface
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_array($value)) {
-            return 1;
-        }
 
         return (float)$value;
     }

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -65,7 +65,7 @@ class FloatType extends Type implements TypeInterface
      *
      * @param string|resource $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
-     * @return string|resource
+     * @return string|null
      */
     public function toDatabase($value, Driver $driver)
     {
@@ -73,10 +73,10 @@ class FloatType extends Type implements TypeInterface
             return null;
         }
         if (is_array($value)) {
-            return 1;
+            return '1';
         }
 
-        return (float)$value;
+        return sprintf('%F', (float)$value);
     }
 
     /**

--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.4
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Fixture for testing decimal, float and bigint types
+ */
+class DatatypesFixture extends TestFixture
+{
+
+    /**
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'biginteger'],
+        'cost' => ['type' => 'decimal', 'length' => 20, 'precision' => 0, 'null' => true],
+        'floaty' => ['type' => 'float', 'null' => true],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * @var array
+     */
+    public $records = [];
+}

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -723,7 +723,7 @@ class QueryTest extends TestCase
                     'id' => '1something-crazy',
                     'created <' => new \DateTime('2013-01-01 12:00')
                 ],
-                ['created' => 'datetime', 'id' => 'float']
+                ['created' => 'datetime', 'id' => 'integer']
             )
             ->execute();
         $this->assertCount(1, $result);

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -100,9 +100,17 @@ class DecimalTypeTest extends TestCase
 
         $result = $this->type->toDatabase('2.51', $this->driver);
         $this->assertSame('2.51', $result);
+    }
 
-        $result = $this->type->toDatabase(['3', '4'], $this->driver);
-        $this->assertSame('1', $result);
+    /**
+     * Arrays are invalid.
+     *
+     * @expectedException InvalidArgumentException
+     * @return void
+     */
+    public function testToDatabaseInvalid()
+    {
+        $this->type->toDatabase(['3', '4'], $this->driver);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -15,15 +15,15 @@
 namespace Cake\Test\TestCase\Database\Type;
 
 use Cake\Database\Type;
-use Cake\Database\Type\FloatType;
+use Cake\Database\Type\DecimalType;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use \PDO;
 
 /**
- * Test for the Float type.
+ * Test for the Decimal type.
  */
-class FloatTypeTest extends TestCase
+class DecimalTypeTest extends TestCase
 {
 
     /**
@@ -34,10 +34,10 @@ class FloatTypeTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->type = Type::build('float');
+        $this->type = Type::build('decimal');
         $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $this->locale = I18n::locale();
-        $this->numberClass = FloatType::$numberClass;
+        $this->numberClass = DecimalType::$numberClass;
 
         I18n::locale($this->locale);
     }
@@ -51,7 +51,7 @@ class FloatTypeTest extends TestCase
     {
         parent::tearDown();
         I18n::locale($this->locale);
-        FloatType::$numberClass = $this->numberClass;
+        DecimalType::$numberClass = $this->numberClass;
     }
 
     /**
@@ -90,16 +90,19 @@ class FloatTypeTest extends TestCase
         $this->assertNull($result);
 
         $result = $this->type->toDatabase('some data', $this->driver);
-        $this->assertSame(0.0, $result);
+        $this->assertSame('0.000000', $result);
 
         $result = $this->type->toDatabase(2, $this->driver);
-        $this->assertSame(2.0, $result);
+        $this->assertSame('2.000000', $result);
+
+        $result = $this->type->toDatabase(2.99, $this->driver);
+        $this->assertSame('2.990000', $result);
 
         $result = $this->type->toDatabase('2.51', $this->driver);
-        $this->assertSame(2.51, $result);
+        $this->assertSame('2.51', $result);
 
         $result = $this->type->toDatabase(['3', '4'], $this->driver);
-        $this->assertSame(1, $result);
+        $this->assertSame('1', $result);
     }
 
     /**
@@ -159,7 +162,7 @@ class FloatTypeTest extends TestCase
      */
     public function testUseLocaleParsingInvalid()
     {
-        FloatType::$numberClass = 'stdClass';
+        DecimalType::$numberClass = 'stdClass';
         $this->type->useLocaleParser();
     }
 

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -73,7 +73,7 @@ class DecimalTypeTest extends TestCase
         $this->assertSame(2.0, $result);
 
         $result = $this->type->toPHP(['3', '4'], $this->driver);
-        $this->assertSame(1, $result);
+        $this->assertSame(1.0, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -90,16 +90,16 @@ class FloatTypeTest extends TestCase
         $this->assertNull($result);
 
         $result = $this->type->toDatabase('some data', $this->driver);
-        $this->assertSame(0.0, $result);
+        $this->assertSame('0.000000', $result);
 
         $result = $this->type->toDatabase(2, $this->driver);
-        $this->assertSame(2.0, $result);
+        $this->assertSame('2.000000', $result);
 
         $result = $this->type->toDatabase('2.51', $this->driver);
-        $this->assertSame(2.51, $result);
+        $this->assertSame('2.510000', $result);
 
         $result = $this->type->toDatabase(['3', '4'], $this->driver);
-        $this->assertSame(1, $result);
+        $this->assertSame('1', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -99,7 +99,7 @@ class FloatTypeTest extends TestCase
         $this->assertSame(2.51, $result);
 
         $result = $this->type->toDatabase(['3', '4'], $this->driver);
-        $this->assertSame(1, $result);
+        $this->assertSame(1.0, $result);
     }
 
     /**

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -210,7 +210,7 @@ class TypeTest extends TestCase
         $this->assertSame(3.14159, $type->toPHP('3.14159', $driver));
         $this->assertSame(3.14159, $type->toPHP(3.14159, $driver));
         $this->assertSame(3.0, $type->toPHP(3, $driver));
-        $this->assertSame(1, $type->toPHP(['3', '4'], $driver));
+        $this->assertSame(1.0, $type->toPHP(['3', '4'], $driver));
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -42,6 +42,7 @@ class QueryTest extends TestCase
         'core.articles_tags',
         'core.authors',
         'core.comments',
+        'core.datatypes',
         'core.posts',
         'core.tags'
     ];
@@ -2911,6 +2912,28 @@ class QueryTest extends TestCase
         $this->assertEquals(1, $result->id);
         $this->assertCount(2, $result->tags);
         $this->assertEquals(2, $result->_matchingData['tags']->id);
+    }
+
+
+    /**
+     * Tests that it is possible to find large numeric values.
+     *
+     * @return void
+     */
+    public function testSelectLargeNumbers()
+    {
+        $this->loadFixtures('Datatypes');
+
+        $big = '1234567890123456789';
+        $table = TableRegistry::get('Datatypes');
+        $entity = $table->newEntity([
+            'cost' => $big,
+        ]);
+        $table->save($entity);
+        $out = $table->find()->where([
+            'cost' => $big
+        ])->first();
+        $this->assertSame(sprintf('%F', $big), sprintf('%F', $out->cost));
     }
 
     /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2924,15 +2924,15 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Datatypes');
 
-        $big = '1234567890123456789';
+        $big = 1234567890123456789.2;
         $table = TableRegistry::get('Datatypes');
-        $entity = $table->newEntity([
-            'cost' => $big,
-        ]);
+        $entity = $table->newEntity([]);
+        $entity->cost = $big;
         $table->save($entity);
         $out = $table->find()->where([
             'cost' => $big
         ])->first();
+        $this->assertNotEmpty($out, 'Should get a record');
         $this->assertSame(sprintf('%F', $big), sprintf('%F', $out->cost));
     }
 


### PR DESCRIPTION
Large float values were being truncated to scientific notation when being passed into PDO. This was caused by PHP's implicit float->string behavior that loses precision. Formatting into %F will retain all the necessary precision.

Refs #9424
