### PR TITLE
Don't throw an exception on '' message strings.

### DIFF
--- a/src/I18n/Formatter/IcuFormatter.php
+++ b/src/I18n/Formatter/IcuFormatter.php
@@ -86,6 +86,9 @@ class IcuFormatter implements FormatterInterface
      */
     protected function _formatMessage($locale, $message, $vars)
     {
+        if ($message === '') {
+            return $message;
+        }
         // Using procedural style as it showed twice as fast as
         // its counterpart in PHP 5.5
         $result = MessageFormatter::formatMessage($locale, $message, $vars);

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -22,6 +22,16 @@ use Cake\TestSuite\TestCase;
  */
 class IcuFormatterTest extends TestCase
 {
+    /**
+     * Tests that empty values can be used as formatting strings
+     *
+     * @return void
+     */
+    public function testFormatEmptyValues()
+    {
+        $formatter = new IcuFormatter();
+        $this->assertEquals('', $formatter->format('en_US', '', []));
+    }
 
     /**
      * Tests that variables are interpolated correctly

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -346,6 +346,29 @@ class I18nTest extends TestCase
     }
 
     /**
+     * Tests the __x() function with no msgstr
+     *
+     * @return void
+     */
+    public function testBasicContextFunctionNoString()
+    {
+        I18n::translator('default', 'en_US', function () {
+            $package = new Package('default');
+            $package->setMessages([
+                'letter' => [
+                    '_context' => [
+                        'character' => '',
+                    ]
+                ]
+            ]);
+
+            return $package;
+        });
+
+        $this->assertEquals('', __x('character', 'letter'));
+    }
+
+    /**
      * Tests the __xn() function
      *
      * @return void


### PR DESCRIPTION
Instead return '' instead of an exception when the message string is ''.

Refs #8932
