### PR TITLE
Take priorities into account when counting listeners for EventManager::__debugInfo

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -577,8 +577,12 @@ class EventManager
         $properties = get_object_vars($this);
         $properties['_generalManager'] = '(object) EventManager';
         $properties['_listeners'] = [];
-        foreach ($this->_listeners as $key => $listeners) {
-            $properties['_listeners'][$key] = count($listeners) . ' listener(s)';
+        foreach ($this->_listeners as $key => $priorities) {
+            $listenerCount = 0;
+            foreach ($priorities as $listeners) {
+                $listenerCount += count($listeners);
+            }
+            $properties['_listeners'][$key] = $listenerCount . ' listener(s)';
         }
         if ($this->_eventList) {
             foreach ($this->_eventList as $event) {

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -808,4 +808,71 @@ class EventManagerTest extends TestCase
 
         $this->assertFalse($manager->isTrackingEvents());
     }
+
+    public function testDebugInfo()
+    {
+        $eventManager = new EventManager();
+
+        $this->assertSame(
+            [
+                '_listeners' => [],
+                '_isGlobal' => false,
+                '_eventList' => null,
+                '_trackEvents' => false,
+                '_generalManager' => '(object) EventManager',
+            ],
+            $eventManager->__debugInfo()
+        );
+
+        $func = function () {};
+        $eventManager->on('foo', $func);
+
+        $this->assertSame(
+            [
+                '_listeners' => [
+                    'foo' => '1 listener(s)',
+                ],
+                '_isGlobal' => false,
+                '_eventList' => null,
+                '_trackEvents' => false,
+                '_generalManager' => '(object) EventManager',
+            ],
+            $eventManager->__debugInfo()
+        );
+
+        $eventManager->off('foo', $func);
+
+        $this->assertSame(
+            [
+                '_listeners' => [
+                    'foo' => '0 listener(s)',
+                ],
+                '_isGlobal' => false,
+                '_eventList' => null,
+                '_trackEvents' => false,
+                '_generalManager' => '(object) EventManager',
+            ],
+            $eventManager->__debugInfo()
+        );
+
+        $eventManager->on('bar', function () {});
+        $eventManager->on('bar', function () {});
+        $eventManager->on('bar', function () {});
+        $eventManager->on('baz', function () {});
+
+        $this->assertSame(
+            [
+                '_listeners' => [
+                    'foo' => '0 listener(s)',
+                    'bar' => '3 listener(s)',
+                    'baz' => '1 listener(s)',
+                ],
+                '_isGlobal' => false,
+                '_eventList' => null,
+                '_trackEvents' => false,
+                '_generalManager' => '(object) EventManager',
+            ],
+            $eventManager->__debugInfo()
+        );
+    }
 }

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -824,7 +824,8 @@ class EventManagerTest extends TestCase
             $eventManager->__debugInfo()
         );
 
-        $func = function () {};
+        $func = function () {
+        };
         $eventManager->on('foo', $func);
 
         $this->assertSame(
@@ -855,10 +856,14 @@ class EventManagerTest extends TestCase
             $eventManager->__debugInfo()
         );
 
-        $eventManager->on('bar', function () {});
-        $eventManager->on('bar', function () {});
-        $eventManager->on('bar', function () {});
-        $eventManager->on('baz', function () {});
+        $eventManager->on('bar', function () {
+        });
+        $eventManager->on('bar', function () {
+        });
+        $eventManager->on('bar', function () {
+        });
+        $eventManager->on('baz', function () {
+        });
 
         $this->assertSame(
             [


### PR DESCRIPTION
Came across this issue when trying to find an event related bug. When printing the event manager with debug it always showed 1 listener for each event even though I was 100% this shouldn't be the case. For example:

``` php
########## DEBUG ##########
object(Cake\Event\EventManager) {
        '_listeners' => [
                'TwigView.TwigView.construct' => '1 listener(s)',
        ],
        '_isGlobal' => true,
        '_eventList' => null,
        '_trackEvents' => false,
        '_generalManager' => '(object) EventManager'
}
###########################
```

After diving into the event manager I found out the `__debugInfo` doesn't take into account that listeners are ordered for execution by priority. After changing the code to take that into account the output is the expected following:

``` php
########## DEBUG ##########
object(Cake\Event\EventManager) {
        '_listeners' => [
                'TwigView.TwigView.construct' => '3 listener(s)',
        ],
        '_isGlobal' => true,
        '_eventList' => null,
        '_trackEvents' => false,
        '_generalManager' => '(object) EventManager'
}
###########################
```
