### PR TITLE
Add maxPage config key to limit pagination results as a whole.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -416,7 +416,7 @@ class PaginatorComponent extends Component
     public function checkLimit(array $options)
     {
         $options['limit'] = (int)$options['limit'];
-        if (empty($options['limit']) || $options['limit'] < 1) {
+        if ($options['limit'] < 1) {
             $options['limit'] = 1;
         }
         $options['limit'] = max(min($options['limit'], $options['maxLimit']), 1);
@@ -433,7 +433,7 @@ class PaginatorComponent extends Component
     public function checkPage(array $options)
     {
         $options['page'] = (int)$options['page'];
-        if (empty($options['page']) || $options['page'] < 1) {
+        if ($options['page'] < 1) {
             $options['page'] = 1;
         }
         if ($options['maxPage']) {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -190,8 +190,8 @@ class PaginatorComponent extends Component
         $results = $query->all();
         $numResults = count($results);
         $count = $numResults ? $query->count() : 0;
-        if ($options['maxPage'] && $count > $options['maxPage'] * $options['limit']) {
-            $count = $options['maxPage'] * $options['limit'];
+        if ($options['maxPage'] && $count > $options['maxPage'] * $options['maxLimit']) {
+            $count = $options['maxPage'] * $options['maxLimit'];
         }
 
         $defaults = $this->getDefaults($alias, $settings);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -42,6 +42,11 @@ class PaginatorComponentTest extends TestCase
 {
 
     /**
+     * @var \Cake\Controller\Component\PaginatorComponent
+     */
+    public $Paginator;
+
+    /**
      * fixtures property
      *
      * @var array
@@ -144,6 +149,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null,
             ]);
         $this->Paginator->paginate($table, $settings);
     }
@@ -228,6 +234,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null,
             ]);
 
         $this->Paginator->paginate($table, $settings);
@@ -260,6 +267,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'DESC'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null,
             ]);
 
         $this->Paginator->paginate($table, $settings);
@@ -284,12 +292,19 @@ class PaginatorComponentTest extends TestCase
                 'maxLimit' => 50,
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
         ];
         $result = $this->Paginator->mergeOptions('Silly', $settings);
         $this->assertEquals($settings, $result);
 
         $result = $this->Paginator->mergeOptions('Posts', $settings);
-        $expected = ['page' => 1, 'limit' => 10, 'maxLimit' => 50, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 1,
+            'limit' => 10,
+            'maxLimit' => 50,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -322,6 +337,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -340,6 +356,7 @@ class PaginatorComponentTest extends TestCase
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'non-existent',
+            'maxPage' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -359,6 +376,7 @@ class PaginatorComponentTest extends TestCase
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'scope',
+            'maxPage' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -387,6 +405,7 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -408,7 +427,13 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
         ];
         $result = $this->Paginator->mergeOptions('Post', $settings);
-        $expected = ['page' => 99, 'limit' => 75, 'maxLimit' => 100, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 99,
+            'limit' => 75,
+            'maxLimit' => 100,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -433,7 +458,13 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
         ];
         $result = $this->Paginator->mergeOptions('Post', $settings);
-        $expected = ['page' => 10, 'limit' => 10, 'maxLimit' => 100, 'whitelist' => ['limit', 'sort', 'page', 'direction']];
+        $expected = [
+            'page' => 10,
+            'limit' => 10,
+            'maxLimit' => 100,
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -460,7 +491,12 @@ class PaginatorComponentTest extends TestCase
         $this->Paginator->config('whitelist', ['fields']);
         $result = $this->Paginator->mergeOptions('Post', $settings);
         $expected = [
-            'page' => 10, 'limit' => 10, 'maxLimit' => 100, 'fields' => ['bad.stuff'], 'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields']
+            'page' => 10,
+            'limit' => 10,
+            'maxLimit' => 100,
+            'fields' => ['bad.stuff'],
+            'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
+            'maxPage' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -482,7 +518,8 @@ class PaginatorComponentTest extends TestCase
             'limit' => 200,
             'maxLimit' => 200,
             'paramType' => 'named',
-            'whitelist' => ['limit', 'sort', 'page', 'direction']
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -496,7 +533,32 @@ class PaginatorComponentTest extends TestCase
             'limit' => 20,
             'maxLimit' => 10,
             'paramType' => 'named',
-            'whitelist' => ['limit', 'sort', 'page', 'direction']
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => null,
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * test mergeOptions with page > maxPage in code.
+     *
+     * @return void
+     */
+    public function testMergeOptionsMaxPage()
+    {
+        $settings = [
+            'limit' => 10,
+            'maxPage' => 2,
+            'paramType' => 'named',
+        ];
+        $result = $this->Paginator->mergeOptions('Post', $settings);
+        $expected = [
+            'page' => 1,
+            'limit' => 10,
+            'maxLimit' => 10,
+            'paramType' => 'named',
+            'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'maxPage' => 2,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -522,6 +584,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'asc'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null
             ]);
 
         $this->request->query = [
@@ -909,6 +972,55 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
+     * Integration test for checkPage() being applied inside paginate()
+     *
+     * It will only show limit * maxPage records in "count".
+     *
+     * @return void
+     */
+    public function testPaginateMaxPage()
+    {
+        $this->loadFixtures('Posts');
+        $table = TableRegistry::get('PaginatorPosts');
+
+        $settings = [
+            'limit' => 1,
+            'maxPage' => 2,
+        ];
+        $this->request->query = [
+            'page' => '2',
+        ];
+        $this->Paginator->paginate($table, $settings);
+        $this->assertEquals(2, $this->request->params['paging']['PaginatorPosts']['count']);
+        $this->assertEquals(2, $this->request->params['paging']['PaginatorPosts']['pageCount']);
+        $this->assertEquals(1, $this->request->params['paging']['PaginatorPosts']['perPage']);
+    }
+
+    /**
+     * Tests that pages out of bound by using maxPage will throw an exception.
+     *
+     * @expectedException \Cake\Network\Exception\NotFoundException
+     * @return void
+     */
+    public function testPaginateMaxPageOutOfBounds()
+    {
+        $this->loadFixtures('Posts');
+        $table = TableRegistry::get('PaginatorPosts');
+
+        $settings = [
+            'limit' => 1,
+            'maxPage' => 2,
+        ];
+        $this->request->query = [
+            'page' => '3',
+        ];
+        $this->Paginator->paginate($table, $settings);
+        $this->assertEquals(2, $this->request->params['paging']['PaginatorPosts']['count']);
+        $this->assertEquals(2, $this->request->params['paging']['PaginatorPosts']['pageCount']);
+        $this->assertEquals(1, $this->request->params['paging']['PaginatorPosts']['perPage']);
+    }
+
+    /**
      * test paginate() and custom find, to make sure the correct count is returned.
      *
      * @return void
@@ -1032,6 +1144,7 @@ class PaginatorComponentTest extends TestCase
                 'order' => [],
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null,
             ]);
         $this->Paginator->paginate($table, $settings);
     }
@@ -1066,6 +1179,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null,
             ]);
         $this->Paginator->paginate($query, $settings);
     }
@@ -1126,6 +1240,7 @@ class PaginatorComponentTest extends TestCase
                 'page' => 1,
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
+                'maxPage' => null,
             ]);
         $this->Paginator->paginate($query, $settings);
     }


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/9446

It happened quite a few times now that people were looking for a way to limit results of pagination similar as results would be limited non-paginated.
The limit option for paginations, though, is used per page. There is nothing right now to limit the results in general here.

In order to allow only x records total to be fetched via pagination, one would need to configure `maxLimit` and `maxPage` accordingly as outlined below.

The helper will also only display those pages as it gets its data from the component, which in case of such a maxPage overflow will adjust the count and page number.

@aavrug Can you confirm that this solves your issue?
