### PR TITLE
Allow datasource access in constructors of mocked models.

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -40,6 +40,22 @@ class SecondaryPost extends Model {
 }
 
 /**
+ * ConstructorPost test stub.
+ */
+class ConstructorPost extends Model {
+
+/**
+ * @var string
+ */
+	public $useTable = 'posts';
+
+	public function __construct($id = false, $table = null, $ds = null) {
+		parent::__construct($id, $table, $ds);
+		$this->getDataSource()->cacheMethods = false;
+	}
+}
+
+/**
  * CakeTestCaseTest
  *
  * @package       Cake.Test.Case.TestSuite
@@ -433,6 +449,16 @@ class CakeTestCaseTest extends CakeTestCase {
 		$post = $this->getMockForModel('SecondaryPost', array('save'));
 		$this->assertEquals('test_secondary', $post->useDbConfig);
 		ConnectionManager::drop('test_secondary');
+	}
+
+/**
+ * Test getMockForModel when the model accesses the datasource in the constructor.
+ *
+ * @return void
+ */
+	public function testGetMockForModelConstructorDatasource() {
+		$post = $this->getMockForModel('ConstructorPost', array('save'), array('ds' => 'test'));
+		$this->assertEquals('test', $post->useDbConfig);
 	}
 
 /**

--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -53,6 +53,7 @@ class ConstructorPost extends Model {
 		parent::__construct($id, $table, $ds);
 		$this->getDataSource()->cacheMethods = false;
 	}
+
 }
 
 /**

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -718,13 +718,13 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @return Model
  */
 	public function getMockForModel($model, $methods = array(), $config = array()) {
-		$config += ClassRegistry::config('Model');
+		$defaults = ClassRegistry::config('Model');
+		unset($defaults['ds']);
 
 		list($plugin, $name) = pluginSplit($model, true);
 		App::uses($name, $plugin . 'Model');
 
-		$config = array_merge((array)$config, array('name' => $name));
-		unset($config['ds']);
+		$config = array_merge($defaults, (array)$config, array('name' => $name));
 
 		if (!class_exists($name)) {
 			throw new MissingModelException(array($model));


### PR DESCRIPTION
When mock objects are created from models that access their datasource in the constructor, an exception would be raised for the missing default datasource. By changing how configuration data is handled in the mock creation we can avoid this issue and not reopen #4867

Refs #8225
