### PR TITLE
Revert "CakeFixtureManager: Truncate tables only if not dropped."

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -98,7 +98,7 @@ class CakeFixtureManager {
 /**
  * Parse the fixture path included in test cases, to get the fixture class name, and the
  * real fixture path including sub-directories
- * 
+ *
  * @param string $fixturePath the fixture path to parse
  * @return array containing fixture class name and optional additional path
  */

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -98,7 +98,7 @@ class CakeFixtureManager {
 /**
  * Parse the fixture path included in test cases, to get the fixture class name, and the
  * real fixture path including sub-directories
- *
+ * 
  * @param string $fixturePath the fixture path to parse
  * @return array containing fixture class name and optional additional path
  */
@@ -218,7 +218,7 @@ class CakeFixtureManager {
 		if (empty($test->fixtures)) {
 			return;
 		}
-		$fixtures = array_unique($test->fixtures);
+		$fixtures = $test->fixtures;
 		if (empty($fixtures) || !$test->autoFixtures) {
 			return;
 		}
@@ -229,9 +229,7 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 				$db->begin();
 				$this->_setupTable($fixture, $db, $test->dropTables);
-				if (!$test->dropTables) {
-					$fixture->truncate($db);
-				}
+				$fixture->truncate($db);
 				$fixture->insert($db);
 				$db->commit();
 			}
@@ -276,9 +274,7 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 			}
 			$this->_setupTable($fixture, $db, $dropTables);
-			if (!$dropTables) {
-				$fixture->truncate($db);
-			}
+			$fixture->truncate($db);
 			$fixture->insert($db);
 		} else {
 			throw new UnexpectedValueException(__d('cake_dev', 'Referenced fixture class %s not found', $name));


### PR DESCRIPTION
Reverts cakephp/cakephp#9368. This change caused regressions in applications.

Refs #9452
