### PR TITLE
Fix `notMatching()` without query builder callback triggers an error.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -387,7 +387,9 @@ class BelongsToMany extends Association
             ->where($options['conditions'])
             ->andWhere($this->junctionConditions());
 
-        $subquery = $options['queryBuilder']($subquery);
+        if (!empty($options['queryBuilder'])) {
+            $subquery = $options['queryBuilder']($subquery);
+        }
 
         $assoc = $junction->association($this->target()->alias());
         $conditions = $assoc->_joinCondition([

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1394,4 +1394,25 @@ class QueryRegressionTest extends TestCase
         $result = $query->where(['updated >' => $query->func()->now('datetime')])->first();
         $this->assertSame(6, $result->id);
     }
+
+    /**
+     * Tests that `notMatching()` can be used on `belongsToMany`
+     * associations without passing a query builder callback.
+     *
+     * @return void
+     */
+    public function testNotMatchingForBelongsToManyWithoutQueryBuilder()
+    {
+        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
+
+        $Articles = TableRegistry::get('Articles');
+        $Articles->belongsToMany('Tags');
+
+        $result = $Articles->find('list')->notMatching('Tags')->toArray();
+        $expected = [
+            3 => 'Third Article'
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
For `belongsToMany` associations, calling `notMatching()` without passing a query builder callback caused a fatal error, as the code unconditionally invoked the passed value as a function.

refs #9036
