### PR TITLE
The _lastAction property should not double include the base path.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -539,6 +539,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->request['action'] = 'add';
 		$this->Form->request->webroot = '';
 		$this->Form->request->base = '';
+		Router::setRequestInfo($this->Form->request);
 
 		ClassRegistry::addObject('Contact', new Contact());
 		ClassRegistry::addObject('ContactNonStandardPk', new ContactNonStandardPk());
@@ -8191,12 +8192,14 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testPostLinkSecurityHashInline() {
 		$hash = Security::hash(
-			'/posts/delete/1' .
+			'/basedir/posts/delete/1' .
 			serialize(array()) .
 			'' .
 			Configure::read('Security.salt')
 		);
 		$hash .= '%3A';
+		$this->Form->request->base = '/basedir';
+		$this->Form->request->webroot = '/basedir/';
 		$this->Form->request->params['_Token']['key'] = 'test';
 
 		$this->Form->create('Post', array('url' => array('action' => 'add')));
@@ -8206,7 +8209,11 @@ class FormHelperTest extends CakeTestCase {
 
 		$this->assertEquals(array('Post.title'), $this->Form->fields);
 		$this->assertContains($hash, $result, 'Should contain the correct hash.');
-		$this->assertAttributeEquals('/posts/add', '_lastAction', $this->Form, 'lastAction was should be restored.');
+		$this->assertAttributeEquals(
+			'/basedir/posts/add',
+			'_lastAction',
+			$this->Form,
+			'lastAction was should be restored.');
 	}
 
 /**

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1888,7 +1888,7 @@ class FormHelper extends AppHelper {
 		}
 
 		$previousLastAction = $this->_lastAction;
-		$this->_lastAction($formUrl);
+		$this->_lastAction($url);
 
 		$out = $this->Html->useTag('form', $formUrl, $formOptions);
 		$out .= $this->Html->useTag('hidden', '_method', array(
@@ -3105,7 +3105,7 @@ class FormHelper extends AppHelper {
  * @return void
  */
 	protected function _lastAction($url) {
-		$action = Router::url($url, true);
+		$action = html_entity_decode($this->url($url), ENT_QUOTES);
 		$query = parse_url($action, PHP_URL_QUERY);
 		$query = $query ? '?' . $query : '';
 		$this->_lastAction = parse_url($action, PHP_URL_PATH) . $query;


### PR DESCRIPTION
FormHelper should not run URLs through Router twice when determining the the form's lastAction attribute. However, because we're using the helper method (see #9414) we do need to HTML decode the URL before using it in form token generation.

Refs #9455
