### PR TITLE
Clean primary entity after "Model.afterSaveCommit" is triggered.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1502,6 +1502,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
             }
             if ($options['atomic'] || $options['_primary']) {
+                $entity->clean();
                 $entity->isNew(false);
                 $entity->source($this->registryAlias());
             }
@@ -1606,8 +1607,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new RolledbackTransactionException(['table' => get_class($this)]);
         }
 
-        $entity->clean();
         if (!$options['atomic'] && !$options['_primary']) {
+            $entity->clean();
             $entity->isNew(false);
             $entity->source($this->registryAlias());
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2209,11 +2209,9 @@ class TableTest extends TestCase
     public function testAfterSave()
     {
         $table = TableRegistry::get('users');
-        $data = new \Cake\ORM\Entity([
-            'username' => 'superuser',
-            'created' => new Time('2013-10-10 00:00'),
-            'updated' => new Time('2013-10-10 00:00')
-        ]);
+        $data = $table->get(1);
+
+        $data->username = 'newusername';
 
         $called = false;
         $listener = function ($e, $entity, $options) use ($data, &$called) {
@@ -2226,13 +2224,13 @@ class TableTest extends TestCase
         $calledAfterCommit = false;
         $listenerAfterCommit = function ($e, $entity, $options) use ($data, &$calledAfterCommit) {
             $this->assertSame($data, $entity);
-            $this->assertFalse($entity->dirty());
+            $this->assertTrue($entity->dirty());
+            $this->assertNotSame($data->get('username'), $data->getOriginal('username'));
             $calledAfterCommit = true;
         };
         $table->eventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
 
         $this->assertSame($data, $table->save($data));
-        $this->assertEquals($data->id, self::$nextUserId);
         $this->assertTrue($called);
         $this->assertTrue($calledAfterCommit);
     }


### PR DESCRIPTION
Previously primary entity was being cleaned too early and callbacks for
Model.afterSaveCommit become useless if one wanted to access original state.
