### PR TITLE
Fix missing logging in ErrorHandling Middleware

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -139,12 +139,12 @@ class ErrorHandlerMiddleware
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
      * @param \Exception $exception The exception to log a message for.
-     * @return void
+     * @return void|null
      */
     protected function logException($request, $exception)
     {
         if (!$this->config('log')) {
-            return false;
+            return;
         }
 
         $skipLog = $this->config('skipLog');

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -139,7 +139,7 @@ class ErrorHandlerMiddleware
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
      * @param \Exception $exception The exception to log a message for.
-     * @return void|null
+     * @return void
      */
     protected function logException($request, $exception)
     {

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -21,6 +21,7 @@ use Cake\Log\Log;
 use Cake\Network\Response as CakeResponse;
 use Cake\TestSuite\TestCase;
 use LogicException;
+use Psr\Log\LoggerInterface;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Response;
 
@@ -41,7 +42,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         parent::setUp();
 
         Configure::write('App.namespace', 'TestApp');
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
         Log::reset();
         Log::config('error_test', [


### PR DESCRIPTION
While I remembered to include the error handling for errors raised during rendering, I forgot to include error logging in general. I've replicated the logic present in the ErrorHandler logging code except for the clientIP. This was omitted because it is non-trivial to extract the client IP from a PSR7 request.

Refs #9469
