### PR TITLE
Don't fail when request contains invalid protocol.

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -77,6 +77,7 @@ class Server
             $request = $request ?: ServerRequestFactory::fromGlobals();
         } catch (UnexpectedValueException $e) {
             $response->getBody()->write('Bad Request');
+
             return $response
                 ->withHeader('Content-Type', 'text/plain')
                 ->withStatus(400);

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -18,6 +18,7 @@ use Cake\Event\EventDispatcherTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
+use UnexpectedValueException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
@@ -71,8 +72,15 @@ class Server
     public function run(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {
         $this->app->bootstrap();
-        $request = $request ?: ServerRequestFactory::fromGlobals();
         $response = $response ?: new Response();
+        try {
+            $request = $request ?: ServerRequestFactory::fromGlobals();
+        } catch (UnexpectedValueException $e) {
+            $response->getBody()->write('Bad Request');
+            return $response
+                ->withHeader('Content-Type', 'text/plain')
+                ->withStatus(400);
+        }
 
         $middleware = $this->app->middleware(new MiddlewareQueue());
         if (!($middleware instanceof MiddlewareQueue)) {

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -116,6 +116,24 @@ class ServerTest extends TestCase
     }
 
     /**
+     * test run where the protocol is invalid
+     *
+     * @return void
+     */
+    public function testRunInvalidProtocol()
+    {
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/onclick 1=1';
+
+        $app = new MiddlewareApplication($this->config);
+        $server = new Server($app);
+
+        $res = $server->run();
+        $this->assertEquals(400, $res->getStatusCode());
+        $this->assertEquals('text/plain', $res->getHeaderLine('content-type'));
+        $this->assertEquals('Bad Request', '' . $res->getBody());
+    }
+
+    /**
      * Test an application failing to build middleware properly
      *
      * @expectedException RuntimeException


### PR DESCRIPTION
When an invalid protocol is received CakePHP should not throw an exception. Instead it should handle that scenario and respond with a 400 series error.

We can't use the error handling middleware as we don't have a request that could be used to render such a page, so simple plain text error will have to suffice.

Refs #9264
