### PR TITLE
Fix sentence structure for DebugTransport description

### DIFF
--- a/src/Mailer/Transport/DebugTransport.php
+++ b/src/Mailer/Transport/DebugTransport.php
@@ -20,8 +20,8 @@ use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Email;
 
 /**
- * Debug Transport class, useful for emulate the email sending process and inspect the resulted
- * email message before actually send it during development
+ * Debug Transport class, useful for emulating the email sending process and inspecting
+ * the resultant email message before actually sending it during development
  */
 class DebugTransport extends AbstractTransport
 {


### PR DESCRIPTION
Just a minor fix that I caught while working on a new CakePHP plugin.
