### PR TITLE
fix forward slash on nested prefixes

### DIFF
--- a/src/Template/Error/missing_action.ctp
+++ b/src/Template/Error/missing_action.ctp
@@ -23,7 +23,7 @@ if (!empty($plugin)) {
 $prefixNs = '';
 if (!empty($prefix)) {
     $prefix = Inflector::camelize($prefix);
-    $prefixNs = '\\' . $prefix;
+    $prefixNs = '\\' . str_replace('/', '\\', $prefix);
     $prefix .= DIRECTORY_SEPARATOR;
 }
 


### PR DESCRIPTION
When the `missing_action` error is triggered for a controller that uses a nested prefix. The namespace in the code example contains a forward slash instead of a back slash.

Most have at least a prefix depth of 2 or more to reproduce.
