### PR TITLE
Remove conditional inline assignment in View class.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -588,7 +588,8 @@ class View implements EventDispatcherInterface
             $this->layout = $layout;
         }
 
-        if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {
+        $viewFileName = $view !== false ? $this->_getViewFileName($view) : null;
+        if ($viewFileName) {
             $this->_currentType = static::TYPE_TEMPLATE;
             $this->dispatchEvent('View.beforeRender', [$viewFileName]);
             $this->Blocks->set('content', $this->_render($viewFileName));


### PR DESCRIPTION
In the future a sniffer could even assert that we do not have conditional inline assignment (accidental or on purpose) in the code.
