### PR TITLE
Fix missing base directories in redirect routes.

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -36,6 +36,7 @@ class RoutingMiddleware
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
         try {
+            Router::setRequestContext($request);
             $params = (array)$request->getAttribute('params', []);
             if (empty($params['controller'])) {
                 $path = $request->getUri()->getPath();

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -17,6 +17,8 @@ namespace Cake\Routing;
 use Cake\Core\Configure;
 use Cake\Network\Request;
 use Cake\Utility\Inflector;
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Parses the request URL into controller, action, and parameters. Uses the connected routes
@@ -391,24 +393,40 @@ class Router
     public static function pushRequest(Request $request)
     {
         static::$_requests[] = $request;
-        static::_setContext($request);
+        static::setRequestContext($request);
     }
 
     /**
      * Store the request context for a given request.
      *
-     * @param \Cake\Network\Request $request The request instance.
+     * @param \Cake\Network\Request|\Psr\Http\Message\ServerRequestInterface $request The request instance.
      * @return void
+     * @throws InvalidArgumentException When parameter is an incorrect type.
      */
-    protected static function _setContext($request)
+    public static function setRequestContext($request)
     {
-        static::$_requestContext = [
-            '_base' => $request->base,
-            '_port' => $request->port(),
-            '_scheme' => $request->scheme(),
-            '_host' => $request->host()
-        ];
+        if ($request instanceof Request) {
+            static::$_requestContext = [
+                '_base' => $request->base,
+                '_port' => $request->port(),
+                '_scheme' => $request->scheme(),
+                '_host' => $request->host()
+            ];
+            return;
+        }
+        if ($request instanceof ServerRequestInterface) {
+            $uri = $request->getUri();
+            static::$_requestContext = [
+                '_base' => $request->getAttribute('base'),
+                '_port' => $uri->getPort(),
+                '_scheme' => $uri->getScheme(),
+                '_host' => $uri->getHost(),
+            ];
+            return;
+        }
+        throw new InvalidArgumentException('Unknown request type received.');
     }
+
 
     /**
      * Pops a request off of the request stack.  Used when doing requestAction
@@ -422,7 +440,7 @@ class Router
         $removed = array_pop(static::$_requests);
         $last = end(static::$_requests);
         if ($last) {
-            static::_setContext($last);
+            static::setRequestContext($last);
             reset(static::$_requests);
         }
 
@@ -570,14 +588,17 @@ class Router
         ];
         $here = $base = $output = $frag = null;
 
+        // In 4.x this should be replaced with state injected via setRequestContext
         $request = static::getRequest(true);
         if ($request) {
             $params = $request->params;
             $here = $request->here;
             $base = $request->base;
-        }
-        if (!isset($base)) {
+        } else {
             $base = Configure::read('App.base');
+            if (isset(static::$_requestContext['_base'])) {
+                $base = static::$_requestContext['_base'];
+            }
         }
 
         if (empty($url)) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -412,6 +412,7 @@ class Router
                 '_scheme' => $request->scheme(),
                 '_host' => $request->host()
             ];
+
             return;
         }
         if ($request instanceof ServerRequestInterface) {
@@ -422,6 +423,7 @@ class Router
                 '_scheme' => $uri->getScheme(),
                 '_host' => $uri->getHost(),
             ];
+
             return;
         }
         throw new InvalidArgumentException('Unknown request type received.');

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -47,6 +47,8 @@ class RoutingMiddlewareTest extends TestCase
     {
         Router::redirect('/testpath', '/pages');
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
+        $request = $request->withAttribute('base', '/subdir');
+
         $response = new Response();
         $next = function ($req, $res) {
         };
@@ -54,7 +56,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = $middleware($request, $response, $next);
 
         $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('http://localhost/pages', $response->getHeaderLine('Location'));
+        $this->assertEquals('http://localhost/subdir/pages', $response->getHeaderLine('Location'));
     }
 
     /**


### PR DESCRIPTION
Under the new PSR7 HTTP stack, redirect routes would be missing their base directory as Router did not have the correct context set. Instead of making the Router request stack PSR7 aware, I've made the request context data PSR7 aware by introducing a new public method. Longer term I'd like to remove the request stack entirely, as its requestAction() will also be leaving.

Refs #9470
