### PR TITLE
Allow unescaped URLs to be built. Other helpers need this internally.

### DIFF
--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -38,7 +38,7 @@ class UrlHelper extends Helper
      * @param string|array|null $url Either a relative string url like `/products/view/23` or
      *    an array of URL parameters. Using an array for URLs will allow you to leverage
      *    the reverse routing features of CakePHP.
-     * @param bool $options Array options; bool $full for BC reasons.
+     * @param array|bool $options Array of options; bool `full` for BC reasons.
      * @return string Full translated URL with base path.
      */
     public function build($url = null, $options = false)

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -33,7 +33,7 @@ class UrlHelper extends Helper
      *
      * - `escape`: If false, the URL will be returned unescaped, do only use if it is manually
      *    escaped afterwards before being displayed.
-     * - `full`: If true, the full base URL will be prepended to the result
+     * - `fullBase`: If true, the full base URL will be prepended to the result
      *
      * @param string|array|null $url Either a relative string url like `/products/view/23` or
      *    an array of URL parameters. Using an array for URLs will allow you to leverage
@@ -44,15 +44,15 @@ class UrlHelper extends Helper
     public function build($url = null, $options = false)
     {
         $defaults = [
-            'full' => false,
+            'fullBase' => false,
             'escape' => true,
         ];
         if (!is_array($options)) {
-            $options = ['full' => $options];
+            $options = ['fullBase' => $options];
         }
         $options += $defaults;
 
-        $url = Router::url($url, $options['full']);
+        $url = Router::url($url, $options['fullBase']);
         if ($options['escape']) {
             $url = h($url);
         }

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -29,15 +29,35 @@ class UrlHelper extends Helper
     /**
      * Returns a URL based on provided parameters.
      *
+     * ### Options:
+     *
+     * - `escape`: If false, the URL will be returned unescaped, do only use if it is manually
+     *    escaped afterwards before being displayed.
+     * - `full`: If true, the full base URL will be prepended to the result
+     *
      * @param string|array|null $url Either a relative string url like `/products/view/23` or
      *    an array of URL parameters. Using an array for URLs will allow you to leverage
      *    the reverse routing features of CakePHP.
-     * @param bool $full If true, the full base URL will be prepended to the result
+     * @param bool $options Array options; bool $full for BC reasons.
      * @return string Full translated URL with base path.
      */
-    public function build($url = null, $full = false)
+    public function build($url = null, $options = false)
     {
-        return h(Router::url($url, $full));
+        $defaults = [
+            'full' => false,
+            'escape' => true,
+        ];
+        if (!is_array($options)) {
+            $options = ['full' => $options];
+        }
+        $options += $defaults;
+
+        $url = Router::url($url, $options['full']);
+        if ($options['escape']) {
+            $url = h($url);
+        }
+
+        return $url;
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -100,6 +100,26 @@ class UrlHelperTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testUrlConversionUnescaped()
+    {
+        $result = $this->Helper->build('/controller/action/1?one=1&two=2', ['escape' => false]);
+        $this->assertEquals('/controller/action/1?one=1&two=2', $result);
+
+        $result = $this->Helper->build([
+            'controller' => 'posts',
+            'action' => 'view',
+            'param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24',
+            '?' => [
+                'k' => 'v',
+                '1' => '2'
+            ]
+        ], ['escape' => false]);
+        $this->assertEquals("/posts/view?k=v&1=2&param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524", $result);
+    }
+
+    /**
      * test assetTimestamp application
      *
      * @return void


### PR DESCRIPTION
This is the first step towards https://github.com/cakephp/cakephp/issues/9310 and resolving URLs being needed unespaced for further processing.

This PR should start the discussion how to achieve that.
I think this additional param is one option.
It is a rare use case, but easily doable if needed this way.
But I wonder if "full => true" and "escape => false" make any sense.

If this is not BC for extension, we need to target 3.4 instead here, or do in fact need a new method `buildRaw()` or just `raw()` here.
This method could then only have two arguments: $url and $escape.
