### PR TITLE
Fixed session regeration issue with the database adapter

### DIFF
--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -144,10 +144,12 @@ class DatabaseSession implements SessionHandlerInterface
      */
     public function destroy($id)
     {
-        return (bool)$this->_table->delete(new Entity(
+        $this->_table->delete(new Entity(
             [$this->_table->primaryKey() => $id],
             ['markNew' => false]
         ));
+
+        return true;
     }
 
     /**

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -142,6 +142,7 @@ class DatabaseSessionTest extends TestCase
 
         $this->assertTrue($this->storage->destroy('foo'), 'Destroy failed');
         $this->assertSame('', $this->storage->read('foo'), 'Value still present.');
+        $this->assertTrue($this->storage->destroy('foo'), 'Destroy should always return true');
     }
 
     /**


### PR DESCRIPTION
When a session is already missing in teh database, the delete operation
should be returning true, as it gets the same result as deleting an
existing session.

Closes #9227
