### PR TITLE
_lastAction() should also work with named parameters in the url

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -10648,4 +10648,42 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Tests `_lastAction`.
+ *
+ *  With named, numeric value
+ *
+ * @return void
+ */
+	public function testLastActionWithNamedNumeric() {
+		$here = '/users/index/page:1';
+
+		$this->Form->request->here = $here;
+		$this->Form->create('User');
+
+		$expected = $here;
+		$actual = $this->Form->_lastAction;
+
+		$this->assertEquals($expected, $actual);
+	}
+
+/**
+ * Tests `_lastAction`.
+ *
+ *  With named, string value
+ *
+ * @return void
+ */
+	public function testLastActionWithNamedString() {
+		$here = '/users/index/foo:bar';
+
+		$this->Form->request->here = $here;
+		$this->Form->create('User');
+
+		$expected = $here;
+		$actual = $this->Form->_lastAction;
+
+		$this->assertEquals($expected, $actual);
+	}
+
 }

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -10661,10 +10661,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->request->here = $here;
 		$this->Form->create('User');
 
-		$expected = $here;
-		$actual = $this->Form->_lastAction;
-
-		$this->assertEquals($expected, $actual);
+		$this->assertAttributeEquals($here, '_lastAction', $this->Form, "_lastAction shouldn't be empty.");
 	}
 
 /**
@@ -10680,10 +10677,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->request->here = $here;
 		$this->Form->create('User');
 
-		$expected = $here;
-		$actual = $this->Form->_lastAction;
-
-		$this->assertEquals($expected, $actual);
+		$this->assertAttributeEquals($here, '_lastAction', $this->Form, "_lastAction shouldn't be empty.");
 	}
 
 }

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -3107,7 +3107,7 @@ class FormHelper extends AppHelper {
  * @return void
  */
 	protected function _lastAction($url) {
-		$action = html_entity_decode($this->url($url), ENT_QUOTES);
+		$action = html_entity_decode($this->url($url, true), ENT_QUOTES);
 		$query = parse_url($action, PHP_URL_QUERY);
 		$query = $query ? '?' . $query : '';
 		$this->_lastAction = parse_url($action, PHP_URL_PATH) . $query;


### PR DESCRIPTION
Since version [2.8.8](https://github.com/cakephp/cakephp/compare/2.8.7...2.8.8#diff-c02fdc21fc32c45375d9c450dc6bf062L3107) `$this->Form->_lastAction()` does not set the `_lastAction` to a correct value, when the url contains named parameters:
- Output of [/users/index/page:1](https://3v4l.org/6ifYr) url
- Output of [/users/index/foo:bar](https://3v4l.org/goqaN) url

The pull request the caused the behavior to change is #9458.

I've added 2 tests that should succeed as far as I'm concerned.
