### PR TITLE
Add a clear of the TableRegistry to tearDown

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -120,6 +120,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
             Configure::clear();
             Configure::write($this->_configure);
         }
+        TableRegistry::clear();
     }
 
     /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -631,6 +631,8 @@ class EntityContextTest extends TestCase
      */
     public function testValAssociatedCustomIds()
     {
+        $this->_setupTables();
+
         $row = new Article([
             'title' => 'First post',
             'user' => new Entity([


### PR DESCRIPTION
Adding a `TableRegistry::clear()` to the tearDown means that any instances of table classes loaded by tests are reset between test cases.

Without this it's possible to persist changes to the table class between test cases. Even if you unset the class instance.

Relates to https://github.com/cakephp/bake/pull/275
