### PR TITLE
Fix Documentation on Cake/ORM/Query

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -66,7 +66,7 @@ use Traversable;
  * @method \Cake\Collection\CollectionInterface zipWith(...$collections, callable $c) Returns each of the results out of calling $c
  *   with the first rows of the query and each of the items, then the second rows and so on.
  * @method \Cake\Collection\CollectionInterface chunk($size) Groups the results in arrays of $size rows each.
- * @method bool isEmpty($size) Returns true if this query found no results.
+ * @method bool isEmpty() Returns true if this query found no results.
  */
 class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
 {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -63,7 +63,7 @@ use Traversable;
  * @method \Cake\Collection\CollectionInterface stopWhen(callable $c) Returns each row until the callable returns true.
  * @method \Cake\Collection\CollectionInterface zip(array|\Traversable $c) Returns the first result of both the query and $c in an array,
  *   then the second results and so on.
- * @method \Cake\Collection\CollectionInterface zipWith(...$collections, callable $c) Returns each of the results out of calling $c
+ * @method \Cake\Collection\CollectionInterface zipWith($collections, callable $callable) Returns each of the results out of calling $c
  *   with the first rows of the query and each of the items, then the second rows and so on.
  * @method \Cake\Collection\CollectionInterface chunk($size) Groups the results in arrays of $size rows each.
  * @method bool isEmpty() Returns true if this query found no results.


### PR DESCRIPTION
When developing with IDE's (like PHP Storm) you can face warnings and errors because of wrong method documentation that does not match implementation on traits. This PR solve this issue.

This PR solves issue #9497 reported by me. 
