### PR TITLE
Ensure Object is autoloaded.

### DIFF
--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -146,6 +146,7 @@ App::uses('Configure', 'Core');
 App::uses('CakePlugin', 'Core');
 App::uses('Cache', 'Cache');
 App::uses('CakeObject', 'Core');
+App::uses('Object', 'Core');
 App::uses('Multibyte', 'I18n');
 
 App::$bootstrapping = true;


### PR DESCRIPTION
When Object was renamed to CakeObject we broke behavior where plugins and app code were relying on Object being configured in the autoloader automatically.

Refs cakephp/debug_kit#450
