### PR TITLE
Attach dispatcher filters before firing events.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -371,6 +371,10 @@ class ExceptionRenderer
     {
         $this->controller->dispatchEvent('Controller.shutdown');
         $dispatcher = DispatcherFactory::create();
+        $eventManager = $dispatcher->eventManager();
+        foreach ($dispatcher->filters() as $filter) {
+            $eventManager->attach($filter);
+        }
         $args = [
             'request' => $this->controller->request,
             'response' => $this->controller->response

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -34,6 +34,7 @@ use Cake\Network\Exception\NotFoundException;
 use Cake\Network\Exception\SocketException;
 use Cake\Network\Request;
 use Cake\ORM\Exception\MissingBehaviorException;
+use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Exception\MissingControllerException;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -872,6 +873,28 @@ class ExceptionRendererTest extends TestCase
 
         $expected = ['Controller.shutdown', 'Dispatcher.afterDispatch'];
         $this->assertEquals($expected, $fired);
+    }
+
+    /**
+     * Test that rendering exceptions triggers events
+     * on filters attached to dispatcherfactory
+     *
+     * @return void
+     */
+    public function testRenderShutdownEventsOnDispatcherFacotry()
+    {
+        $filter = $this->getMockBuilder('Cake\Routing\DispatcherFilter')
+            ->setMethods(['afterDispatch'])
+            ->getMock();
+
+        $filter->expects($this->at(0))
+            ->method('afterDispatch');
+
+        DispatcherFactory::add($filter);
+
+        $exception = new Exception('Terrible');
+        $renderer = new ExceptionRenderer($exception);
+        $renderer->render();
     }
 
     /**


### PR DESCRIPTION
In order to preserve behavior where dispatch filters are signalled when an exception is rendered we need to bind those listeners. This will work for both the new and old dispatch stacks. Even in the middleware scenario we'll need to trigger the connected filters as the listeners attached in the ActionDispatcher are not connected to this event manager instance.

Refs #9496
