### PR TITLE
Implement PSR7 header methods

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -944,6 +944,21 @@ class Request implements ArrayAccess
     }
 
     /**
+     * Normalize a header name into the SERVER version.
+     *
+     * @param string $name The header name.
+     * @return string The normalized header name.
+     */
+    protected function normalizeHeaderName($name)
+    {
+        $name = str_replace('-', '_', strtoupper($name));
+        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+            $name = 'HTTP_' . $name;
+        }
+        return $name;
+    }
+
+    /**
      * Read an HTTP header from the Request information.
      *
      * @param string $name Name of the header you want.
@@ -951,11 +966,7 @@ class Request implements ArrayAccess
      */
     public function header($name)
     {
-        $name = str_replace('-', '_', $name);
-        if (!in_array(strtoupper($name), ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
-            $name = 'HTTP_' . $name;
-        }
-
+        $name = $this->normalizeHeaderName($name);
         return $this->env($name);
     }
 
@@ -986,10 +997,7 @@ class Request implements ArrayAccess
      */
     public function getHeader($name)
     {
-        $name = str_replace('-', '_', strtoupper($name));
-        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
-            $name = 'HTTP_' . $name;
-        }
+        $name = $this->normalizeHeaderName($name);
         if (isset($this->_environment[$name])) {
             return (array)$this->_environment[$name];
         }
@@ -1020,10 +1028,7 @@ class Request implements ArrayAccess
     public function withHeader($name, $value)
     {
         $new = clone $this;
-        $name = strtoupper(str_replace('-', '_', $name));
-        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
-            $name = 'HTTP_' . $name;
-        }
+        $name = $this->normalizeHeaderName($name);
         $new->_environment[$name] = $value;
 
         return $new;
@@ -1051,6 +1056,11 @@ class Request implements ArrayAccess
      */
     public function withoutHeader($name)
     {
+        $new = clone $this;
+        $name = $this->normalizeHeaderName($name);
+        $new->_environment[$name] = $value;
+
+        return $new;
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1051,14 +1051,14 @@ class Request implements ArrayAccess
     /**
      * Get a modified request without a provided header.
      *
-     * @param string $name The header name.
+     * @param string $name The header name to remove.
      * @return static
      */
     public function withoutHeader($name)
     {
         $new = clone $this;
         $name = $this->normalizeHeaderName($name);
-        $new->_environment[$name] = $value;
+        unset($new->_environment[$name]);
 
         return $new;
     }

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -961,8 +961,13 @@ class Request implements ArrayAccess
     /**
      * Read an HTTP header from the Request information.
      *
+     * If the header is not defined in the request, this method
+     * will fallback to reading data from $_SERVER and $_ENV.
+     * This fallback behavior is deprecated, and will be removed in 4.0.0
+     *
      * @param string $name Name of the header you want.
      * @return string|null Either null on no header being set or the value of the header.
+     * @deprecated 4.0.0 The automatic fallback to env() will be removed in 4.0.0
      */
     public function header($name)
     {
@@ -1311,7 +1316,7 @@ class Request implements ArrayAccess
      */
     public function parseAccept()
     {
-        return $this->_parseAcceptWithQualifier($this->header('accept'));
+        return $this->_parseAcceptWithQualifier($this->getHeaderLine('Accept'));
     }
 
     /**
@@ -1330,7 +1335,7 @@ class Request implements ArrayAccess
      */
     public function acceptLanguage($language = null)
     {
-        $raw = $this->_parseAcceptWithQualifier($this->header('Accept-Language'));
+        $raw = $this->_parseAcceptWithQualifier($this->getHeaderLine('Accept-Language'));
         $accept = [];
         foreach ($raw as $languages) {
             foreach ($languages as &$lang) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -981,8 +981,8 @@ class Request implements ArrayAccess
      * Returns an associative array where the header names are
      * the keys and the values are a list of header values.
      *
-     * While header names are not case-sensitive, getHeaders() will preserve the
-     * exact case in which headers were originally specified.
+     * While header names are not case-sensitive, getHeaders() will normalize
+     * the headers.
      *
      * @return array An associative array of headers and their values.
      */

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1019,6 +1019,14 @@ class Request implements ArrayAccess
      */
     public function withHeader($name, $value)
     {
+        $new = clone $this;
+        $name = strtoupper(str_replace('-', '_', $name));
+        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+            $name = 'HTTP_' . $name;
+        }
+        $new->_environment[$name] = $value;
+
+        return $new;
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -955,6 +955,7 @@ class Request implements ArrayAccess
         if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
             $name = 'HTTP_' . $name;
         }
+
         return $name;
     }
 
@@ -972,6 +973,7 @@ class Request implements ArrayAccess
     public function header($name)
     {
         $name = $this->normalizeHeaderName($name);
+
         return $this->env($name);
     }
 
@@ -1003,6 +1005,7 @@ class Request implements ArrayAccess
                 $headers[$name] = (array)$value;
             }
         }
+
         return $headers;
     }
 
@@ -1015,6 +1018,7 @@ class Request implements ArrayAccess
     public function hasHeader($name)
     {
         $name = $this->normalizeHeaderName($name);
+
         return array_key_exists($name, $this->_environment);
     }
 
@@ -1034,6 +1038,7 @@ class Request implements ArrayAccess
         if (isset($this->_environment[$name])) {
             return (array)$this->_environment[$name];
         }
+
         return [];
     }
 
@@ -1048,6 +1053,7 @@ class Request implements ArrayAccess
     public function getHeaderLine($name)
     {
         $value = $this->getHeader($name);
+
         return implode(', ', $value);
     }
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -367,8 +367,8 @@ class Request implements ArrayAccess
             $data = $this->input();
             parse_str($data, $data);
         }
-        if ($this->env('HTTP_X_HTTP_METHOD_OVERRIDE')) {
-            $data['_method'] = $this->env('HTTP_X_HTTP_METHOD_OVERRIDE');
+        if ($this->hasHeader('X-Http-Method-Override')) {
+            $data['_method'] = $this->getHeaderLine('X-Http-Method_Override');
             $override = true;
         }
         $this->_environment['ORIGINAL_REQUEST_METHOD'] = $method;
@@ -983,6 +983,34 @@ class Request implements ArrayAccess
      */
     public function getHeaders()
     {
+        $headers = [];
+        foreach ($this->_environment as $key => $value) {
+            $name = null;
+            if (strpos($key, 'HTTP_') === 0) {
+                $name = substr($key, 5);
+            }
+            if (strpos($key, 'CONTENT_') === 0) {
+                $name = $key;
+            }
+            if ($name !== null) {
+                $name = strtr(strtolower($name), '_', ' ');
+                $name = strtr(ucwords($name), ' ', '-');
+                $headers[$name] = (array)$value;
+            }
+        }
+        return $headers;
+    }
+
+    /**
+     * Check if a header exists in the request.
+     *
+     * @param string $name The header you want to get (case-insensitive)
+     * @return bool Whether or not the header is defined.
+     */
+    public function hasHeader($name)
+    {
+        $name = $this->normalizeHeaderName($name);
+        return array_key_exists($name, $this->_environment);
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1046,6 +1046,16 @@ class Request implements ArrayAccess
      */
     public function withAddedHeader($name, $value)
     {
+        $new = clone $this;
+        $name = $this->normalizeHeaderName($name);
+        $existing = [];
+        if (isset($new->_environment[$name])) {
+            $existing = (array)$new->_environment[$name];
+        }
+        $existing = array_merge($existing, (array)$value);
+        $new->_environment[$name] = $existing;
+
+        return $new;
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -368,7 +368,7 @@ class Request implements ArrayAccess
             parse_str($data, $data);
         }
         if ($this->hasHeader('X-Http-Method-Override')) {
-            $data['_method'] = $this->getHeaderLine('X-Http-Method_Override');
+            $data['_method'] = $this->getHeaderLine('X-Http-Method-Override');
             $override = true;
         }
         $this->_environment['ORIGINAL_REQUEST_METHOD'] = $method;
@@ -1010,7 +1010,7 @@ class Request implements ArrayAccess
     }
 
     /**
-     * Check if a header exists in the request.
+     * Check if a header is set in the request.
      *
      * @param string $name The header you want to get (case-insensitive)
      * @return bool Whether or not the header is defined.
@@ -1019,7 +1019,7 @@ class Request implements ArrayAccess
     {
         $name = $this->normalizeHeaderName($name);
 
-        return array_key_exists($name, $this->_environment);
+        return isset($this->_environment[$name]);
     }
 
     /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -960,6 +960,92 @@ class Request implements ArrayAccess
     }
 
     /**
+     * Get all headers in the request.
+     *
+     * Returns an associative array where the header names are
+     * the keys and the values are a list of header values.
+     *
+     * While header names are not case-sensitive, getHeaders() will preserve the
+     * exact case in which headers were originally specified.
+     *
+     * @return array An associative array of headers and their values.
+     */
+    public function getHeaders()
+    {
+    }
+
+    /**
+     * Get a single header from the request.
+     *
+     * Return the header value as an array. If the header
+     * is not present an empty array will be returned.
+     *
+     * @param string $name The header you want to get (case-insensitive)
+     * @return array An associative array of headers and their values.
+     *   If the header doesn't exist, an empty array will be returned.
+     */
+    public function getHeader($name)
+    {
+        $name = str_replace('-', '_', strtoupper($name));
+        if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+            $name = 'HTTP_' . $name;
+        }
+        if (isset($this->_environment[$name])) {
+            return (array)$this->_environment[$name];
+        }
+        return [];
+    }
+
+    /**
+     * Get a single header as a string from the request.
+     *
+     * Return an array of header values
+     *
+     * @param string $name The header you want to get (case-insensitive)
+     * @return string Header values collapsed into a comma separated string.
+     */
+    public function getHeaderLine($name)
+    {
+        $value = $this->getHeader($name);
+        return implode(', ', $value);
+    }
+
+    /**
+     * Get a modified request with the provided header.
+     *
+     * @param string $name The header name.
+     * @param string|array $value The header value
+     * @return static
+     */
+    public function withHeader($name, $value)
+    {
+    }
+
+    /**
+     * Get a modified request with the provided header.
+     *
+     * Existing header values will be retained. The provided value
+     * will be appended into the existing values.
+     *
+     * @param string $name The header name.
+     * @param string|array $value The header value
+     * @return static
+     */
+    public function withAddedHeader($name, $value)
+    {
+    }
+
+    /**
+     * Get a modified request without a provided header.
+     *
+     * @param string $name The header name.
+     * @return static
+     */
+    public function withoutHeader($name)
+    {
+    }
+
+    /**
      * Get the HTTP method used for this request.
      *
      * @return string The name of the HTTP method used.

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1283,6 +1283,52 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test getting headers with psr7 methods
+     *
+     * @return void
+     */
+    public function testGetHeader()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $this->assertEquals([], $request->getHeader('Not-there'));
+
+        $expected = [$request->env('HTTP_HOST')];
+        $this->assertEquals($expected, $request->getHeader('Host'));
+        $this->assertEquals($expected, $request->getHeader('host'));
+        $this->assertEquals($expected, $request->getHeader('HOST'));
+        $this->assertEquals(['a', 'b'], $request->getHeader('Double'));
+    }
+
+    /**
+     * Test getting headers with psr7 methods
+     *
+     * @return void
+     */
+    public function testGetHeaderLine()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $this->assertEquals('', $request->getHeaderLine('Authorization'));
+
+        $expected = $request->env('CONTENT_LENGTH');
+        $this->assertEquals($expected, $request->getHeaderLine('Content-Length'));
+        $this->assertEquals($expected, $request->getHeaderLine('content-Length'));
+        $this->assertEquals($expected, $request->getHeaderLine('ConTent-LenGth'));
+        $this->assertEquals('a, b', $request->getHeaderLine('Double'));
+    }
+
+    /**
      * Test accepts() with and without parameters
      *
      * @return void

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1355,6 +1355,34 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test adding a header.
+     *
+     * @return void
+     */
+    public function testWithAddedHeader()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $new = $request->withAddedHeader('Double', 'c');
+        $this->assertNotSame($new, $request);
+
+        $this->assertEquals('a, b', $request->getHeaderLine('Double'), 'old request is unchanged');
+        $this->assertEquals('a, b, c', $new->getHeaderLine('Double'), 'new request is correct');
+        $this->assertEquals(['a', 'b', 'c'], $new->header('Double'));
+
+        $new = $request->withAddedHeader('Content-Length', 777);
+        $this->assertEquals([1337, 777], $new->getHeader('Content-Length'), 'scalar values are appended');
+
+        $new = $request->withAddedHeader('Content-Length', [123, 456]);
+        $this->assertEquals([1337, 123, 456], $new->getHeader('Content-Length'), 'List values are merged');
+    }
+
+    /**
      * Test removing a header.
      *
      * @return void

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1347,9 +1347,11 @@ class RequestTest extends TestCase
 
         $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
         $this->assertEquals(999, $new->getHeaderLine('Content-length'), 'new request is correct');
+        $this->assertEquals(999, $new->header('Content-Length'));
 
         $new = $request->withHeader('Double', ['a']);
         $this->assertEquals(['a'], $new->getHeader('Double'), 'List values are overwritten');
+        $this->assertEquals(['a'], $new->header('Double'), 'headers written in bc way.');
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1355,6 +1355,28 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test removing a header.
+     *
+     * @return void
+     */
+    public function testWithoutHeader()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $new = $request->withoutHeader('Content-Length', 999);
+        $this->assertNotSame($new, $request);
+
+        $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
+        $this->assertEquals('', $new->getHeaderLine('Content-length'), 'new request is correct');
+        $this->assertNull($new->header('Content-Length'));
+    }
+
+    /**
      * Test accepts() with and without parameters
      *
      * @return void

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1287,6 +1287,52 @@ class RequestTest extends TestCase
      *
      * @return void
      */
+    public function testGetHeaders()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $headers = $request->getHeaders();
+        $expected = [
+            'Host' => ['localhost'],
+            'Content-Type' => ['application/json'],
+            'Content-Length' => [1337],
+            'Content-Md5' => ['abc123'],
+            'Double' => ['a', 'b'],
+        ];
+        $this->assertEquals($expected, $headers);
+    }
+
+    /**
+     * Test hasHeader
+     *
+     * @return void
+     */
+    public function testHasHeader()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $this->assertTrue($request->hasHeader('Host'));
+        $this->assertTrue($request->hasHeader('Content-Type'));
+        $this->assertTrue($request->hasHeader('Content-MD5'));
+        $this->assertTrue($request->hasHeader('Double'));
+        $this->assertFalse($request->hasHeader('Authorization'));
+    }
+
+    /**
+     * Test getting headers with psr7 methods
+     *
+     * @return void
+     */
     public function testGetHeader()
     {
         $request = new Request(['environment' => [
@@ -2440,7 +2486,6 @@ class RequestTest extends TestCase
         $expected = $vars + [
             'CONTENT_TYPE' => null,
             'HTTP_CONTENT_TYPE' => null,
-            'HTTP_X_HTTP_METHOD_OVERRIDE' => null,
             'ORIGINAL_REQUEST_METHOD' => 'PUT',
         ];
         $this->assertSame($expected, $request->getServerParams());

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1329,6 +1329,30 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test setting a header.
+     *
+     * @return void
+     */
+    public function testWithHeader()
+    {
+        $request = new Request(['environment' => [
+            'HTTP_HOST' => 'localhost',
+            'CONTENT_TYPE' => 'application/json',
+            'CONTENT_LENGTH' => 1337,
+            'HTTP_CONTENT_MD5' => 'abc123',
+            'HTTP_DOUBLE' => ['a', 'b']
+        ]]);
+        $new = $request->withHeader('Content-Length', 999);
+        $this->assertNotSame($new, $request);
+
+        $this->assertEquals(1337, $request->getHeaderLine('Content-length'), 'old request is unchanged');
+        $this->assertEquals(999, $new->getHeaderLine('Content-length'), 'new request is correct');
+
+        $new = $request->withHeader('Double', ['a']);
+        $this->assertEquals(['a'], $new->getHeader('Double'), 'List values are overwritten');
+    }
+
+    /**
      * Test accepts() with and without parameters
      *
      * @return void


### PR DESCRIPTION
Implement the header related method required for the PSR7 ServerRequestInterface. 

I've chosen to make the new methods read from the existing data as with the other changes I've done so far. This should hopefully make the new methods non-destructive to the existing ones.

Refs #9325 
