### PR TITLE
Change to allow the class name in the setting of the fixture

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -174,32 +174,38 @@ class FixtureManager
                 continue;
             }
 
-            list($type, $pathName) = explode('.', $fixture, 2);
-            $path = explode('/', $pathName);
-            $name = array_pop($path);
-            $additionalPath = implode('\\', $path);
+            if (strpos($fixture, '.')) {
+                list($type, $pathName) = explode('.', $fixture, 2);
+                $path = explode('/', $pathName);
+                $name = array_pop($path);
+                $additionalPath = implode('\\', $path);
 
-            if ($type === 'core') {
-                $baseNamespace = 'Cake';
-            } elseif ($type === 'app') {
-                $baseNamespace = Configure::read('App.namespace');
-            } elseif ($type === 'plugin') {
-                list($plugin, $name) = explode('.', $pathName);
-                $path = implode('\\', explode('/', $plugin));
-                $baseNamespace = Inflector::camelize(str_replace('\\', '\ ', $path));
-                $additionalPath = null;
+                if ($type === 'core') {
+                    $baseNamespace = 'Cake';
+                } elseif ($type === 'app') {
+                    $baseNamespace = Configure::read('App.namespace');
+                } elseif ($type === 'plugin') {
+                    list($plugin, $name) = explode('.', $pathName);
+                    $path = implode('\\', explode('/', $plugin));
+                    $baseNamespace = Inflector::camelize(str_replace('\\', '\ ', $path));
+                    $additionalPath = null;
+                } else {
+                    $baseNamespace = '';
+                    $name = $fixture;
+                }
+
+                $name = Inflector::camelize($name);
+                $nameSegments = [
+                    $baseNamespace,
+                    'Test\Fixture',
+                    $additionalPath,
+                    $name . 'Fixture'
+                ];
+                $className = implode('\\', array_filter($nameSegments));
             } else {
-                $baseNamespace = '';
-                $name = $fixture;
+                $className = $fixture;
+                $name = preg_replace('/Fixture\z/', '', substr(strrchr($fixture, '\\'), 1));
             }
-            $name = Inflector::camelize($name);
-            $nameSegments = [
-                $baseNamespace,
-                'Test\Fixture',
-                $additionalPath,
-                $name . 'Fixture'
-            ];
-            $className = implode('\\', array_filter($nameSegments));
 
             if (class_exists($className)) {
                 $this->_loaded[$fixture] = new $className();

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -223,6 +223,25 @@ class FixtureManagerTest extends TestCase
     }
 
     /**
+     * Test loading app fixtures.
+     *
+     * @return void
+     */
+    public function testFixturizeClassName()
+    {
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
+        $test->fixtures = ['Company\TestPluginThree\Test\Fixture\ArticlesFixture'];
+        $this->manager->fixturize($test);
+        $fixtures = $this->manager->loaded();
+        $this->assertCount(1, $fixtures);
+        $this->assertArrayHasKey('Company\TestPluginThree\Test\Fixture\ArticlesFixture', $fixtures);
+        $this->assertInstanceOf(
+            'Company\TestPluginThree\Test\Fixture\ArticlesFixture',
+            $fixtures['Company\TestPluginThree\Test\Fixture\ArticlesFixture']
+        );
+    }
+
+    /**
      * Test that unknown types are handled gracefully.
      *
      * @expectedException \UnexpectedValueException


### PR DESCRIPTION
Now, the setting of the class but possible with the class name that contains the name space, the setting of the test case of the fixture is this is not possible.

For setting of the class name that contains the name space is friendly to the IDE, I want to come to adopt.
