### PR TITLE
Fix requestAction() not working with middleware.

### DIFF
--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -25,7 +25,6 @@ use Cake\Utility\Security;
  */
 class RequestActionTraitTest extends TestCase
 {
-
     /**
      * fixtures
      *
@@ -420,5 +419,20 @@ class RequestActionTraitTest extends TestCase
             ['session' => $session]
         );
         $this->assertEquals('bar', $result);
+    }
+
+    /**
+     * requestAction relies on both the RoutingFilter and ControllerFactory
+     * filters being connected. Ensure it can correct the missing state.
+     *
+     * @return void
+     */
+    public function testRequestActionAddsRequiredFilters()
+    {
+        DispatcherFactory::clear();
+
+        $result = $this->object->requestAction('/request_action/test_request_action');
+        $expected = 'This is a test';
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
The unit tests for requestAction all setup the necessary global state. Which is why they were passing while in reality the code failed. While this feature is deprecated and unloved, it should continue doing the thing it has always done.

Refs #9505
