### PR TITLE
3.x/4.x HTTP 306 is deprecated and should not be used

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -56,7 +56,7 @@ class Response
         303 => 'See Other',
         304 => 'Not Modified',
         305 => 'Use Proxy',
-        306 => 'Switch Proxy',
+        306 => '(Unused)',
         307 => 'Temporary Redirect',
         308 => 'Permanent Redirect',
         400 => 'Bad Request',


### PR DESCRIPTION
Ref: https://github.com/cakephp/cakephp/pull/9530#pullrequestreview-1829994
Alternative: Remove the code 306 all-together.
