### PR TITLE
Implement GROUP_CONCAT() function

### DIFF
--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -114,6 +114,7 @@ trait PostgresDialectTrait
                         if ($key === 0) {
                             return new FunctionExpression('array_agg', [$p => 'literal'], [], 'string');
                         }
+
                         return $p;
                     })
                     ->tieWith(',');

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -113,9 +113,8 @@ trait PostgresDialectTrait
                     ->iterateParts(function ($p, $key) use ($expression) {
                         if ($key === 0) {
                             return new FunctionExpression('array_agg', [$p => 'literal'], [], 'string');
-                        } else {
-                            return $p;
                         }
+                        return $p;
                     })
                     ->tieWith(',');
                 break;

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -107,6 +107,18 @@ trait PostgresDialectTrait
                 // CONCAT function is expressed as exp1 || exp2
                 $expression->name('')->tieWith(' ||');
                 break;
+            case 'GROUP_CONCAT':
+                $expression
+                    ->name('array_to_string')
+                    ->iterateParts(function ($p, $key) use ($expression) {
+                        if ($key === 0) {
+                            return new FunctionExpression('array_agg', [$p => 'literal'], [], 'string');
+                        } else {
+                            return $p;
+                        }
+                    })
+                    ->tieWith(',');
+                break;
             case 'DATEDIFF':
                 $expression
                     ->name('')

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -97,6 +97,9 @@ trait SqliteDialectTrait
                 // CONCAT function is expressed as exp1 || exp2
                 $expression->name('')->tieWith(' ||');
                 break;
+            case 'GROUP_CONCAT':
+                $expression->tieWith(',');
+                break;
             case 'DATEDIFF':
                 $expression
                     ->name('ROUND')

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -218,6 +218,9 @@ trait SqlserverDialectTrait
                 // CONCAT function is expressed as exp1 + exp2
                 $expression->name('')->tieWith(' +');
                 break;
+            case 'GROUP_CONCAT':
+                throw new \LogicException('GROUP_CONCAT() is not supported for SQLServer');
+                break;
             case 'DATEDIFF':
                 $hasDay = false;
                 $visitor = function ($value) use (&$hasDay) {

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -220,7 +220,6 @@ trait SqlserverDialectTrait
                 break;
             case 'GROUP_CONCAT':
                 throw new \LogicException('GROUP_CONCAT() is not supported for SQLServer');
-                break;
             case 'DATEDIFF':
                 $hasDay = false;
                 $visitor = function ($value) use (&$hasDay) {

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -211,7 +211,7 @@ trait SqlserverDialectTrait
      * @param \Cake\Database\Expression\FunctionExpression $expression The function expression to convert to TSQL.
      * @return void
      */
-    protected function _transformFunctionExpression(FunctionExpression $expression)
+    protected function _transformFunctionExpression(FunctionExpression $expression, Query $query)
     {
         switch ($expression->name()) {
             case 'CONCAT':
@@ -219,7 +219,24 @@ trait SqlserverDialectTrait
                 $expression->name('')->tieWith(' +');
                 break;
             case 'GROUP_CONCAT':
-                throw new \LogicException('GROUP_CONCAT() is not supported for SQLServer');
+                $expression
+                    ->name('')
+                    ->iterateParts(function ($p, $key) {
+                        return $key === 0 ? $p : null;
+                    });
+                $query->modifier(['_cake_groupconcat_query']);
+                $groupBy = $query->clause('group');
+                if (count($groupBy) === 0) {
+                    $groupBy = [$query->newExpr('(SELECT NULL)')];
+                }
+                $selectRank = $query->newExpr('DENSE_RANK() OVER')
+                    ->add('(ORDER BY')
+                    ->add($groupBy)
+                    ->add(')')
+                    ->tieWith('');
+                $query->select($selectRank)
+                    ->group([], true);
+                break;
             case 'DATEDIFF':
                 $hasDay = false;
                 $visitor = function ($value) use (&$hasDay) {

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\FunctionExpression;
 
 /**
@@ -135,6 +137,22 @@ class FunctionsBuilder
     public function concat($args, $types = [])
     {
         return $this->_build('CONCAT', $args, $types, 'string');
+    }
+    
+    /**
+     * Returns a FunctionExpression representing a group concatenation.
+     *
+     * @param mixed $expression the function argument
+     * @param string|null $separator Separator to use
+     * @param array $types list of types to bind to the arguments
+     * @return \Cake\Database\Expression\FunctionExpression
+     */
+    public function groupConcat($expression, $separator = ',', $types = [])
+    {
+        $expression = $this->_literalArgumentFunction('GROUP_CONCAT', $expression, $types, 'string');
+        $expression->tieWith(' SEPARATOR')->add(["'$separator'" => 'literal'], []);
+        
+        return $expression;
     }
 
     /**

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -138,7 +138,7 @@ class FunctionsBuilder
     {
         return $this->_build('CONCAT', $args, $types, 'string');
     }
-    
+
     /**
      * Returns a FunctionExpression representing a group concatenation.
      *
@@ -151,7 +151,7 @@ class FunctionsBuilder
     {
         $expression = $this->_literalArgumentFunction('GROUP_CONCAT', $expression, $types, 'string');
         $expression->tieWith(' SEPARATOR')->add(["'$separator'" => 'literal'], []);
-        
+
         return $expression;
     }
 

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -142,8 +142,8 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a group concatenation.
      *
-     * @param string $expression the function argument
-     * @param string|null $separator Separator to use
+     * @param mixed $expression the function argument
+     * @param string $separator Separator to use
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -15,8 +15,8 @@
 namespace Cake\Database;
 
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\IdentifierExpression;
 
 /**
  * Contains methods related to generating FunctionExpression objects

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -142,7 +142,7 @@ class FunctionsBuilder
     /**
      * Returns a FunctionExpression representing a group concatenation.
      *
-     * @param mixed $expression the function argument
+     * @param string $expression the function argument
      * @param string|null $separator Separator to use
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -69,12 +69,13 @@ from cte [outer] group by rank";
         if ($isGroupConcatQuery) {
             $sql = sprintf($this->_groupConcatTemplate, $sql);
         }
+        
         return $sql;
     }
     
     /**
      * Check if the given modifier is present in the given query and removes it.
-     * 
+     *
      * @param \Cake\Database\Query $query The query to check
      * @param string $modifierName The modifier to check for
      * @return bool True if the modifier is present, false otherwise
@@ -85,8 +86,10 @@ from cte [outer] group by rank";
             $modifier = $query->clause('modifier');
             unset($modifier[array_search($modifierName, $modifier)]);
             $query->modifier($modifier, true);
+            
             return true;
         }
+        
         return false;
     }
 

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
-use Cake\Datasource\ConnectionManager;
 use Cake\Database\ValueBinder;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use \PDO;
 

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
+use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -181,7 +182,7 @@ class MysqlTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title')])
             ->from('articles')
             ->group('id');
@@ -189,7 +190,7 @@ class MysqlTest extends TestCase
         $query = $translator($query);
         $this->assertEquals('GROUP_CONCAT(title SEPARATOR \',\')', $query->clause('select')[0]->sql(new ValueBinder));
         
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title', '!')])
             ->from('articles')
             ->group('id');

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -165,7 +165,7 @@ class MysqlTest extends TestCase
         $this->assertFalse($driver->commitTransaction());
         $this->assertTrue($driver->isConnected());
     }
-    
+
     /**
      * Tests that GROUP_CONCAT is transformed correctly
      *
@@ -189,7 +189,7 @@ class MysqlTest extends TestCase
         $translator = $driver->queryTranslator('select');
         $query = $translator($query);
         $this->assertEquals('GROUP_CONCAT(title SEPARATOR \',\')', $query->clause('select')[0]->sql(new ValueBinder));
-        
+
         $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title', '!')])
             ->from('articles')

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -173,7 +173,7 @@ class PostgresTest extends TestCase
         $query = $translator($query);
         $this->assertEquals('FOO', $query->clause('epilog'));
     }
-    
+
     /**
      * Tests that GROUP_CONCAT is transformed correctly
      *
@@ -197,7 +197,7 @@ class PostgresTest extends TestCase
         $translator = $driver->queryTranslator('select');
         $query = $translator($query);
         $this->assertEquals('array_to_string((array_agg(title)), \',\')', $query->clause('select')[0]->sql(new ValueBinder));
-        
+
         $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title', '!')])
             ->from('articles')

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
+use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 use \PDO;
@@ -189,7 +190,7 @@ class PostgresTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title')])
             ->from('articles')
             ->group('id');
@@ -197,7 +198,7 @@ class PostgresTest extends TestCase
         $query = $translator($query);
         $this->assertEquals('array_to_string((array_agg(title)), \',\')', $query->clause('select')[0]->sql(new ValueBinder));
         
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title', '!')])
             ->from('articles')
             ->group('id');

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -145,7 +145,7 @@ class SqliteTest extends TestCase
         $driver->connection($mock);
         $this->assertEquals($expected, $driver->schemaValue($input));
     }
-    
+
     /**
      * Tests that GROUP_CONCAT is transformed correctly
      *
@@ -169,7 +169,7 @@ class SqliteTest extends TestCase
         $translator = $driver->queryTranslator('select');
         $query = $translator($query);
         $this->assertEquals('GROUP_CONCAT(title, \',\')', $query->clause('select')[0]->sql(new ValueBinder));
-        
+
         $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title', '!')])
             ->from('articles')

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Driver\Sqlite;
+use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -161,7 +162,7 @@ class SqliteTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title')])
             ->from('articles')
             ->group('id');
@@ -169,7 +170,7 @@ class SqliteTest extends TestCase
         $query = $translator($query);
         $this->assertEquals('GROUP_CONCAT(title, \',\')', $query->clause('select')[0]->sql(new ValueBinder));
         
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title', '!')])
             ->from('articles')
             ->group('id');

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Core\Configure;
+use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 use \PDO;
@@ -247,6 +248,7 @@ class SqlserverTest extends TestCase
      */
     public function testGroupConcatTransform()
     {
+        $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->setMethods(['_connect'])
             ->getMock();
@@ -256,7 +258,7 @@ class SqlserverTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $query = new \Cake\Database\Query($connection);
+        $query = new Query($connection);
         $query->select([$query->func()->groupConcat('title')])
             ->from('articles')
             ->group('id');

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -243,6 +243,7 @@ class SqlserverTest extends TestCase
      * Tests that GROUP_CONCAT is transformed correctly
      *
      * @return void
+     * @expectedException LogicException
      */
     public function testGroupConcatTransform()
     {
@@ -260,7 +261,6 @@ class SqlserverTest extends TestCase
             ->from('articles')
             ->group('id');
         $translator = $driver->queryTranslator('select');
-        $this->expectException(\LogicException::class);
         $query = $translator($query);
     }
 }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -239,7 +239,7 @@ class SqlserverTest extends TestCase
         $expected = 'INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)';
         $this->assertEquals($expected, $query->sql());
     }
-    
+
     /**
      * Tests that GROUP_CONCAT is transformed correctly
      *
@@ -250,7 +250,7 @@ class SqlserverTest extends TestCase
     {
         $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->setMethods(['_connect'])
+            ->setMethods(['_connect', '_version'])
             ->getMock();
         $connection = $this
             ->getMockBuilder('\Cake\Database\Connection')

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Core\Configure;
+use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 use \PDO;
 
@@ -236,5 +237,30 @@ class SqlserverTest extends TestCase
             ->values(['title' => 'A new article']);
         $expected = 'INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)';
         $this->assertEquals($expected, $query->sql());
+    }
+    
+    /**
+     * Tests that GROUP_CONCAT is transformed correctly
+     *
+     * @return void
+     */
+    public function testGroupConcatTransform()
+    {
+        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
+            ->setMethods(['_connect'])
+            ->getMock();
+        $connection = $this
+            ->getMockBuilder('\Cake\Database\Connection')
+            ->setMethods(['connect'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $query = new \Cake\Database\Query($connection);
+        $query->select([$query->func()->groupConcat('title')])
+            ->from('articles')
+            ->group('id');
+        $translator = $driver->queryTranslator('select');
+        $this->expectException(\LogicException::class);
+        $query = $translator($query);
     }
 }

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -132,7 +132,7 @@ class FunctionsBuilderTest extends TestCase
         $this->assertEquals("CONCAT(title, :c0)", $function->sql(new ValueBinder));
         $this->assertEquals('string', $function->returnType());
     }
-    
+
     /**
      * Tests generating a GROUP_CONCAT() function
      *

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -132,6 +132,19 @@ class FunctionsBuilderTest extends TestCase
         $this->assertEquals("CONCAT(title, :c0)", $function->sql(new ValueBinder));
         $this->assertEquals('string', $function->returnType());
     }
+    
+    /**
+     * Tests generating a GROUP_CONCAT() function
+     *
+     * @return void
+     */
+    public function testGroupConcat()
+    {
+        $function = $this->functions->groupConcat('title', ';');
+        $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
+        $this->assertEquals("GROUP_CONCAT(title SEPARATOR ';')", $function->sql(new ValueBinder));
+        $this->assertEquals('string', $function->returnType());
+    }
 
     /**
      * Tests generating a COALESCE() function


### PR DESCRIPTION
As per cakephp/cakephp#9529.

On SQLServer this seems to be impossible to implement, as [a subquery is neccessary](https://social.msdn.microsoft.com/Forums/sqlserver/en-US/f09d4166-2030-41fe-b86e-392fbc94db53/tsql-equivalent-for-groupconcat-function?forum=transactsql).

It's currently not possible to pass in a `ExpressionInterface`, to achive something like `GROUP_CONCAT(id+1), but it looks like that's not supported for the other functions either. (And I have no idea how to implement it).

_I don't have tested the generated queries against a real DB server_ I can test against MySQL later, but I don't have access to the other types of servers.

I'm still slightly confused by the Database system, so please tell me if there is a better way to achive this ;)
