### PR TITLE
Bugfix/cached viewcells return the same results with different templates when rendering

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -172,7 +172,7 @@ abstract class Cell
     {
         $cache = [];
         if ($this->_cache) {
-            $cache = $this->_cacheConfig($this->action);
+            $cache = $this->_cacheConfig($this->action, $template);
         }
 
         $render = function () use ($template) {
@@ -232,12 +232,13 @@ abstract class Cell
      * @param string $action The action invoked.
      * @return array The cache configuration.
      */
-    protected function _cacheConfig($action)
+    protected function _cacheConfig($action, $template = null)
     {
         if (empty($this->_cache)) {
             return [];
         }
-        $key = 'cell_' . Inflector::underscore(get_class($this)) . '_' . $action;
+        $template = $template ?: "default";
+        $key = 'cell_' . Inflector::underscore(get_class($this)) . '_' . $action . '_' . $template;
         $key = str_replace('\\', '_', $key);
         $default = [
             'config' => 'default',

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -230,6 +230,7 @@ abstract class Cell
      * If the key is undefined, the cell class and action name will be used.
      *
      * @param string $action The action invoked.
+     * @param string|null $template The name of the template to be rendered.
      * @return array The cache configuration.
      */
     protected function _cacheConfig($action, $template = null)

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -479,7 +479,7 @@ class CellTest extends TestCase
             'className' => 'File',
             'path' => CACHE,
         ]);
-        $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => ['key' => 'celltest']]);
+        $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => true]);
         $result = $cell->render("alternate_teaser_list");
         $result2 = $cell->render("not_the_alternate_teaser_list");
         $this->assertContains('This is the alternate template', $result);

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -365,7 +365,7 @@ class CellTest extends TestCase
             ->will($this->returnValue(false));
         $mock->expects($this->once())
             ->method('write')
-            ->with('cell_test_app_view_cell_articles_cell_display', "dummy\n");
+            ->with('cell_test_app_view_cell_articles_cell_display_default', "dummy\n");
         Cache::config('default', $mock);
 
         $cell = $this->View->cell('Articles', [], ['cache' => true]);
@@ -435,7 +435,7 @@ class CellTest extends TestCase
             ->will($this->returnValue(false));
         $mock->expects($this->once())
             ->method('write')
-            ->with('cell_test_app_view_cell_articles_cell_customTemplate', "<h1>This is the alternate template</h1>\n");
+            ->with('cell_test_app_view_cell_articles_cell_customTemplate_default', "<h1>This is the alternate template</h1>\n");
         Cache::config('default', $mock);
 
         $cell = $this->View->cell('Articles::customTemplate', [], ['cache' => true]);

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -466,4 +466,25 @@ class CellTest extends TestCase
         Cache::delete('celltest');
         Cache::drop('default');
     }
+
+    /**
+     * Test that when the cell cache is enabled, the cell action is only invoke the first
+     * time the cell is rendered
+     *
+     * @return void
+     */
+    public function testACachedViewCellReRendersWhenGivenADifferentTemplate()
+    {
+        Cache::config('default', [
+            'className' => 'File',
+            'path' => CACHE,
+        ]);
+        $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => ['key' => 'celltest']]);
+        $result = $cell->render("alternate_teaser_list");
+        $result2 = $cell->render("not_the_alternate_teaser_list");
+        $this->assertContains('This is the alternate template', $result);
+        $this->assertContains('This is NOT the alternate template', $result2);
+        Cache::delete('celltest');
+        Cache::drop('default');
+    }
 }

--- a/tests/test_app/TestApp/Template/Cell/Articles/not_the_alternate_teaser_list.ctp
+++ b/tests/test_app/TestApp/Template/Cell/Articles/not_the_alternate_teaser_list.ctp
@@ -1,0 +1,1 @@
+<h1>This is NOT the alternate template</h1>


### PR DESCRIPTION
See #9531 

The fix was to add the template name to the cache key. However, there is one use-case where the defect is not fixed. If the caller explicitly sets a cache key, then they would always get the same results from `Cell::render()` regardless of the template.
