### PR TITLE
Fix insecure login redirection

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -766,7 +766,7 @@ class AuthComponent extends Component
     public function redirectUrl($url = null)
     {
         $redirectUrl = $this->request->query(static::QUERY_STRING_REDIRECT);
-        if ($redirectUrl && (substr($redirectUrl, 0, 1) !== '/')) {
+        if ($redirectUrl && (substr($redirectUrl, 0, 1) !== '/' || substr($redirectUrl, 0, 2) === '//')) {
             $redirectUrl = null;
         }
 

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1408,6 +1408,11 @@ class AuthComponentTest extends TestCase
 
         $result = $this->Auth->redirectUrl();
         $this->assertEquals('/users/home', $result);
+
+        $this->Auth->request->query = ['redirect' => '//some.domain.example/users/login'];
+
+        $result = $this->Auth->redirectUrl();
+        $this->assertEquals('/users/home', $result);
     }
 
     /**


### PR DESCRIPTION
Checking a leading '/' doesn't protect users from phishing because protocol-relative URIs start with '//'.

Refs: #9410
