### PR TITLE
Use ServerRequest factory to create request instances

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -64,7 +64,7 @@ abstract class BaseApplication
     /**
      * Invoke the application.
      *
-     * - Convert the PSR request/response into CakePHP equivalents.
+     * - Convert the PSR response into CakePHP equivalents.
      * - Create the controller that will handle this request.
      * - Invoke the controller.
      *
@@ -75,12 +75,10 @@ abstract class BaseApplication
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
-        // Convert the request/response to CakePHP equivalents.
-        $cakeRequest = RequestTransformer::toCake($request);
         $cakeResponse = ResponseTransformer::toCake($response);
 
         // Dispatch the request/response to CakePHP
-        $cakeResponse = $this->getDispatcher()->dispatch($cakeRequest, $cakeResponse);
+        $cakeResponse = $this->getDispatcher()->dispatch($request, $cakeResponse);
 
         // Convert the response back into a PSR7 object.
         return ResponseTransformer::toPsr($cakeResponse);

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -73,15 +73,7 @@ class Server
     {
         $this->app->bootstrap();
         $response = $response ?: new Response();
-        try {
-            $request = $request ?: ServerRequestFactory::fromGlobals();
-        } catch (UnexpectedValueException $e) {
-            $response->getBody()->write('Bad Request');
-
-            return $response
-                ->withHeader('Content-Type', 'text/plain')
-                ->withStatus(400);
-        }
+        $request = $request ?: ServerRequestFactory::fromGlobals();
 
         $middleware = $this->app->middleware(new MiddlewareQueue());
         if (!($middleware instanceof MiddlewareQueue)) {

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -58,6 +58,7 @@ abstract class ServerRequestFactory extends BaseFactory
             'base' => $uri->base,
             'session' => $session,
         ]);
+
         return $request;
     }
 

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -15,6 +15,7 @@
 namespace Cake\Http;
 
 use Cake\Core\Configure;
+use Cake\Network\Request;
 use Cake\Network\Session;
 use Cake\Utility\Hash;
 use Zend\Diactoros\ServerRequestFactory as BaseFactory;
@@ -38,18 +39,25 @@ abstract class ServerRequestFactory extends BaseFactory
         array $cookies = null,
         array $files = null
     ) {
-        $request = parent::fromGlobals($server, $query, $body, $cookies, $files);
-        $uri = $request->getUri();
-
+        $server = static::normalizeServer($server ?: $_SERVER);
+        $uri = static::createUri($server);
         $sessionConfig = (array)Configure::read('Session') + [
             'defaults' => 'php',
             'cookiePath' => $uri->webroot
         ];
         $session = Session::create($sessionConfig);
-        $request = $request->withAttribute('base', $uri->base)
-            ->withAttribute('webroot', $uri->webroot)
-            ->withAttribute('session', $session);
-
+        $request = new Request([
+            'environment' => $server,
+            'uri' => $uri,
+            'files' => $files,
+            'input' => 'php://input',
+            'cookies' => $cookies ?: $_COOKIE,
+            'query' => $query ?: $_GET,
+            'post' => $body ?: $_POST,
+            'webroot' => $uri->webroot,
+            'base' => $uri->base,
+            'session' => $session,
+        ]);
         return $request;
     }
 

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -217,31 +217,11 @@ class Request implements ArrayAccess, ServerRequestInterface
      * the request.
      *
      * @return \Cake\Network\Request
+     * @deprecated 3.4.0 Use `Cake\Http\ServerRequestFactory` instead.
      */
     public static function createFromGlobals()
     {
-        $uri = ServerRequestFactory::createUri($_SERVER);
-        $base = $uri->base;
-        $webroot = $uri->webroot;
-
-        $sessionConfig = (array)Configure::read('Session') + [
-            'defaults' => 'php',
-            'cookiePath' => $webroot
-        ];
-
-        $config = [
-            'query' => $_GET,
-            'post' => $_POST,
-            'files' => $_FILES,
-            'cookies' => $_COOKIE,
-            'environment' => $_SERVER + $_ENV,
-            'uri' => $uri,
-            'base' => $base,
-            'webroot' => $webroot,
-            'session' => Session::create($sessionConfig)
-        ];
-
-        return new static($config);
+        return ServerRequestFactory::fromGlobals();
     }
 
     /**
@@ -256,15 +236,16 @@ class Request implements ArrayAccess, ServerRequestInterface
      * - `files` Uploaded file data formatted like $_FILES.
      * - `cookies` Cookies for this request.
      * - `environment` $_SERVER and $_ENV data.
-     * - `url` The URL without the base path for the request.
+     * - ~~`url`~~ The URL without the base path for the request. This option is deprecated and will be removed in 4.0.0
      * - `uri` The PSR7 UriInterface object. If null, one will be created.
      * - `base` The base URL for the request.
      * - `webroot` The webroot directory for the request.
      * - `input` The data that would come from php://input this is useful for simulating
-     * - `session` An instance of a Session object
      *   requests with put, patch or delete data.
+     * - `session` An instance of a Session object
      *
      * @param string|array $config An array of request data to create a request with.
+     *   The string version of this argument is *deprecated* and will be removed in 4.0.0
      */
     public function __construct($config = [])
     {

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -117,24 +117,6 @@ class ServerTest extends TestCase
     }
 
     /**
-     * test run where the protocol is invalid
-     *
-     * @return void
-     */
-    public function testRunInvalidProtocol()
-    {
-        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/onclick 1=1';
-
-        $app = new MiddlewareApplication($this->config);
-        $server = new Server($app);
-
-        $res = $server->run();
-        $this->assertEquals(400, $res->getStatusCode());
-        $this->assertEquals('text/plain', $res->getHeaderLine('content-type'));
-        $this->assertEquals('Bad Request', '' . $res->getBody());
-    }
-
-    /**
      * Test an application failing to build middleware properly
      *
      * @expectedException RuntimeException

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Network;
 
 use Cake\Core\Configure;
+use Cake\Http\ServerRequestFactory;
 use Cake\Network\Exception;
 use Cake\Network\Request;
 use Cake\Network\Session;
@@ -2366,7 +2367,7 @@ class RequestTest extends TestCase
         $_GET = [];
         $this->_loadEnvironment($env);
 
-        $request = Request::createFromGlobals();
+        $request = ServerRequestFactory::fromGlobals();
         $uri = $request->getUri();
 
         $this->assertEquals($expected['url'], $request->url, "URL is incorrect");


### PR DESCRIPTION
Now that `Network\Request` implements the PSR7 interface, we can remove the usage of the `RequestTransformer`. I've not removed the transformer in case someone is referencing it in their code.

I've removed the Bad Request error on malformed HTTP versions, instead we ignore the user input and assume they meant `1.1`.

Refs #9325
