### PR TITLE
Update controllers and components to use PSR7 methods

### DIFF
--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -93,7 +93,7 @@ class CsrfComponent extends Component
         if ($request->is('get') && $cookieData === null) {
             $this->_setCookie($request, $response);
         }
-        if ($request->is(['put', 'post', 'delete', 'patch']) || !empty($request->data())) {
+        if ($request->is(['put', 'post', 'delete', 'patch']) || $request->data()) {
             $this->_validateToken($request);
             unset($request->data[$this->_config['field']]);
         }

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -93,7 +93,7 @@ class CsrfComponent extends Component
         if ($request->is('get') && $cookieData === null) {
             $this->_setCookie($request, $response);
         }
-        if ($request->is(['put', 'post', 'delete', 'patch']) || !empty($request->data)) {
+        if ($request->is(['put', 'post', 'delete', 'patch']) || !empty($request->data())) {
             $this->_validateToken($request);
             unset($request->data[$this->_config['field']]);
         }

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -223,10 +223,10 @@ class PaginatorComponent extends Component
             'scope' => $options['scope'],
         ];
 
-        if (!isset($request['paging'])) {
-            $request['paging'] = [];
+        if (!$request->param('paging')) {
+            $request->params['paging'] = [];
         }
-        $request['paging'] = [$alias => $paging] + (array)$request['paging'];
+        $request->params['paging'] = [$alias => $paging] + (array)$request->param('paging');
 
         if ($requestedPage > $page) {
             throw new NotFoundException();
@@ -276,9 +276,9 @@ class PaginatorComponent extends Component
         $defaults = $this->getDefaults($alias, $settings);
         $request = $this->_registry->getController()->request;
         $scope = Hash::get($settings, 'scope', null);
-        $query = $request->query;
+        $query = $request->getQueryParams();
         if ($scope) {
-            $query = Hash::get($request->query, $scope, []);
+            $query = Hash::get($request->getQueryParams(), $scope, []);
         }
         $request = array_intersect_key($query, array_flip($this->_config['whitelist']));
 

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -196,8 +196,8 @@ class RequestHandlerComponent extends Component
         $controller = $event->subject();
         $request = $controller->request;
 
-        if (isset($request->params['_ext'])) {
-            $this->ext = $request->params['_ext'];
+        if ($request->param('_ext')) {
+            $this->ext = $request->param('_ext');
         }
         if (empty($this->ext) || in_array($this->ext, ['html', 'htm'])) {
             $this->_setExtension($request, $this->response);
@@ -205,7 +205,7 @@ class RequestHandlerComponent extends Component
 
         $request->params['isAjax'] = $request->is('ajax');
 
-        if (empty($this->ext) && $request->params['isAjax']) {
+        if (empty($this->ext) && $request->is('ajax')) {
             $this->ext = 'ajax';
         }
 
@@ -640,7 +640,7 @@ class RequestHandlerComponent extends Component
         if (!$type) {
             return false;
         }
-        if (empty($this->request->params['requested'])) {
+        if (!$this->request->param('requested')) {
             $response->type($cType);
         }
         if (!empty($options['charset'])) {

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -109,7 +109,7 @@ class SecurityComponent extends Component
         $controller = $event->subject();
         $this->session = $this->request->session();
         $this->_action = $this->request->param('action');
-        $hasData = !empty($this->request->data());
+        $hasData = (bool)$this->request->data();
         try {
             $this->_secureRequired($controller);
             $this->_authRequired($controller);
@@ -266,7 +266,7 @@ class SecurityComponent extends Component
     {
         if (is_array($this->_config['requireAuth']) &&
             !empty($this->_config['requireAuth']) &&
-            !empty($this->request->data())
+            $this->request->data()
         ) {
             $requireAuth = $this->_config['requireAuth'];
 
@@ -318,7 +318,7 @@ class SecurityComponent extends Component
      */
     protected function _validatePost(Controller $controller)
     {
-        if (empty($controller->request->data())) {
+        if (!$controller->request->data()) {
             return true;
         }
         $token = $this->_validToken($controller);


### PR DESCRIPTION
Where possible use the the PSR7 & undeprecated methods in controller & components. I didn't change any of the operations that mutated the request to use the immutable interfaces as there is simply too much shared state in components and controllers right now.

In the future Components will need to stop holding on to references of the request, and instead fetch the request from the controller. This will allow PSR7 methods to be used in more places.

Refs #9325
