### PR TITLE
2.x - adds a check that dir() has returned an instance of Directory to FileEngine::_clearDirectory()

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -267,6 +267,10 @@ class FileEngine extends CacheEngine {
 		}
 
 		$dir = dir($path);
+		if ($dir === false) {
+			return;
+		}
+
 		while (($entry = $dir->read()) !== false) {
 			if (substr($entry, 0, $prefixLength) !== $this->settings['prefix']) {
 				continue;


### PR DESCRIPTION
I'm seeing some strange behaviour in production where [the call](https://github.com/cakephp/cakephp/blob/2.next/lib/Cake/Cache/Engine/FileEngine.php#L269) to `dir()` in `FileEngine::_clearDirectory()`  is returning `false` rather than an instance of `Directory`. Subsequently, PHP dies with a fatal error in the next section where it tries to call a method on a non-object.

This PR checks the return value of `dir()` before doing anything with it so that PHP doesn't fatal error.

I am not sure how to test this so at present there are no changes to the tests (existing tests pass OK).
