### PR TITLE
Validate table name when generating schema file

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -405,8 +405,14 @@ class CakeSchema extends CakeObject {
  * @param string $table Table name you want returned.
  * @param array $fields Array of field information to generate the table with.
  * @return string Variable declaration for a schema class.
+ * @throws Exception
  */
 	public function generateTable($table, $fields) {
+		// Valid var name regex (http://www.php.net/manual/en/language.variables.basics.php)
+		if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $table)) {
+			throw new Exception("Invalid table name '{$table}'");
+		}
+
 		$out = "\tpublic \${$table} = array(\n";
 		if (is_array($fields)) {
 			$cols = array();

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -687,6 +687,22 @@ class CakeSchemaTest extends CakeTestCase {
 	}
 
 /**
+ * test that tables with unsupported name are not getting through
+ *
+ * @return void
+ */
+	public function testGenerateInvalidTable() {
+		$invalidTableName = 'invalid name !@#$%^&*()';
+		$expectedException = "Invalid table name '{$invalidTableName}'";
+		try{
+			$this->Schema->generateTable($invalidTableName, array());
+			$this->fail("Expected exception \"{$expectedException}\" not thrown");
+		} catch (Exception $e) {
+			$this->assertEquals($expectedException, $e->getMessage());
+		}
+	}
+
+/**
  * testSchemaWrite method
  *
  * @return void


### PR DESCRIPTION
When generating schema, if table contains spaces (for example) an invalid schema file is generated without notice.

Refs https://github.com/CakeDC/migrations/issues/262
