### PR TITLE
Alter `set()` and `write()` docblocks to indicate `mixed` as accepted datatype

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -422,7 +422,7 @@ class Session
      * Writes value to given session variable name.
      *
      * @param string|array $name Name of variable
-     * @param string|null $value Value to write
+     * @param mixed $value Value to write
      * @return void
      */
     public function write($name, $value = null)

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -123,7 +123,7 @@ trait ViewVarsTrait
      * Saves a variable or an associative array of variables for use inside a template.
      *
      * @param string|array $name A string or an array of data.
-     * @param string|array|null|bool $value Value in case $name is a string (which then works as the key).
+     * @param mixed $value Value in case $name is a string (which then works as the key).
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
      */


### PR DESCRIPTION
`ViewVarsTrait::set()` and `Session::write()` can actually accept _any_ value for their second arguments (`$value`).  However their respective `@param` entries in each method's docblock indicates certain restrictions, which, in my opinion are incorrect, and also cause problems with certain CI tools (e.g. if you provide an object such as en Entity or a `\Cake\ORM\Query` as the second parameter).  This PR changes the docblocks to indicate `mixed` as the accepted type for the `$value` arguments, which seems more accurate in covering all use cases of these methods.
