### PR TITLE
Introduces a BreadcrumbsHelper

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -59,14 +59,32 @@ class BreadcrumbsHelper extends Helper
     /**
      * Add a crumb to the trail.
      *
-     * @param string $title Title of the crumb
+     * @param string|array $title Title of the crumb. If provided as an array, it will add each values of the array
+     * as a single crumb. This allows you to add multiple crumbs in the trail at once. Arrays are expected to be of this
+     * form:
+     * - *title* The title of the crumb
+     * - *link* The link of the crumb. If not provided, no link will be made
+     * - *options* Options of the crumb. See description of params option of this method.
      * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
-     * @param array $options Array of options
+     * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     * the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
     public function add($title, $link = null, array $options = [])
     {
+        if (is_array($title)) {
+            foreach ($title as $crumb) {
+                $crumb = array_merge(['title' => '', 'link' => null, 'options' => []], $crumb);
+                $this->crumbs[] = $crumb;
+            }
+
+            return $this;
+        }
+
         $this->crumbs[] = ['title' => $title, 'link' => $link, 'options' => $options];
 
         return $this;
@@ -78,7 +96,11 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb
      * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
-     * @param array $options Array of options
+     * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     * the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
     public function prepend($title, $link = null, array $options = [])
@@ -98,7 +120,11 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb
      * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
-     * @param array $options Array of options
+     * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     * the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
     public function insertAt($index, $title, $link = null, array $options = [])
@@ -118,7 +144,11 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb
      * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
-     * @param array $options Array of options
+     * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     * the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
     public function insertBefore($matchingTitle, $title, $link = null, array $options = [])
@@ -141,7 +171,11 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb
      * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
-     * @param array $options Array of options
+     * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     * the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
     public function insertAfter($matchingTitle, $title, $link = null, array $options = [])
@@ -167,8 +201,15 @@ class BreadcrumbsHelper extends Helper
     /**
      * Renders the breadcrumbs trail
      *
-     * @param array $attributes Array of attributes applied to the wrapper element
-     * @param array $separator Array of attributes for the `separator` template
+     * @param array $attributes Array of attributes applied to the `wrapper` template. Accepts the `templateVars` key to
+     * allow the insertion of custom template variable in the template.
+     * @param array $separator Array of attributes for the `separator` template.
+     * Possible properties are :
+     * - *separator* The string to be displayed as a separator
+     * - *templateVars* Allows the insertion of custom template variable in the template
+     * - *innerAttrs* To provide attributes in case your separator is divided in two elements
+     * All other properties will be converted as HTML attributes and will replace the *attrs* key in the template
+     * If you use the default for this option (empty), it will not render a separator.
      * @return string The breadcrumbs trail
      */
     public function render(array $attributes = [], array $separator = [])

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -92,7 +92,12 @@ class BreadcrumbsHelper extends Helper
     /**
      * Prepend a crumb to the start of the queue.
      *
-     * @param string $title Title of the crumb.
+     * @param string $title If provided as a string, it represents the title of the crumb.
+     * Alternatively, if you want to add multiple crumbs at once, you can provide an array, with each values being a
+     * single crumb. Arrays are expected to be of this form:
+     * - *title* The title of the crumb
+     * - *link* The link of the crumb. If not provided, no link will be made
+     * - *options* Options of the crumb. See description of params option of this method.
      * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
@@ -104,6 +109,17 @@ class BreadcrumbsHelper extends Helper
      */
     public function prepend($title, $url = null, array $options = [])
     {
+        if (is_array($title)) {
+            $crumbs = [];
+            foreach ($title as $crumb) {
+                $crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
+            }
+
+            array_splice($this->crumbs, 0, 0, $crumbs);
+
+            return $this;
+        }
+
         array_unshift($this->crumbs, compact('title', 'url', 'options'));
 
         return $this;

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.6
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Helper;
+
+use Cake\View\Helper;
+use LogicException;
+
+/**
+ * BreadcrumbsHelper to register and display a breadcrumb trail for your views
+ */
+class BreadcrumbsHelper extends Helper
+{
+    /**
+     * The crumbs list.
+     *
+     * @var array
+     */
+    protected $crumbs = [];
+
+    /**
+     * Add a crumb to the trail.
+     *
+     * @param string $title Title of the crumb
+     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * Url::build() or null / empty if the crumb does not have a link
+     * @param array $options Array of options
+     * @return $this
+     */
+    public function add($title, $link = null, array $options = [])
+    {
+        $this->crumbs[] = ['title' => $title, 'link' => $link, 'options' => $options];
+
+        return $this;
+    }
+
+    /**
+     * Prepend a crumb to the start of the queue.
+     *
+     * @param string $title Title of the crumb
+     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * Url::build() or null / empty if the crumb does not have a link
+     * @param array $options Array of options
+     * @return $this
+     */
+    public function prepend($title, $link = null, array $options = [])
+    {
+        array_unshift($this->crumbs, ['title' => $title, 'link' => $link, 'options' => $options]);
+
+        return $this;
+    }
+
+    /**
+     * Insert a crumb at a specific index.
+     *
+     * If the index already exists, the new crumb will be inserted,
+     * and the existing element will be shifted one index greater.
+     *
+     * @param int $index The index to insert at.
+     * @param string $title Title of the crumb
+     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * Url::build() or null / empty if the crumb does not have a link
+     * @param array $options Array of options
+     * @return $this
+     */
+    public function insertAt($index, $title, $link = null, array $options = [])
+    {
+        array_splice($this->crumbs, $index, 0, [['title' => $title, 'link' => $link, 'options' => $options]]);
+
+        return $this;
+    }
+
+    /**
+     * Insert a crumb before the first matching crumb with the specified title.
+     *
+     * Finds the index of the first middleware that matches the provided class,
+     * and inserts the supplied callable before it.
+     *
+     * @param string $matchingTitle The title of the crumb you want to insert this one before
+     * @param string $title Title of the crumb
+     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * Url::build() or null / empty if the crumb does not have a link
+     * @param array $options Array of options
+     * @return $this
+     */
+    public function insertBefore($matchingTitle, $title, $link = null, array $options = [])
+    {
+        $found = false;
+        foreach ($this->crumbs as $key => $crumb) {
+            if ($crumb['title'] === $matchingTitle) {
+                $found = true;
+                break;
+            }
+        }
+
+        if ($found) {
+            return $this->insertAt($key, $title, $link, $options);
+        }
+        throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
+    }
+
+    /**
+     * Insert a crumb after the first matching crumb with the specified title.
+     *
+     * Finds the index of the first middleware that matches the provided class,
+     * and inserts the supplied callable before it.
+     *
+     * @param string $matchingTitle The title of the crumb you want to insert this one after
+     * @param string $title Title of the crumb
+     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * Url::build() or null / empty if the crumb does not have a link
+     * @param array $options Array of options
+     * @return $this
+     */
+    public function insertAfter($matchingTitle, $title, $link = null, array $options = [])
+    {
+        $found = false;
+        foreach ($this->crumbs as $key => $crumb) {
+            if ($crumb['title'] === $matchingTitle) {
+                $found = true;
+                break;
+            }
+        }
+
+        if ($found) {
+            return $this->insertAt($key + 1, $title, $link, $options);
+        }
+        throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
+    }
+
+    /**
+     * Returns the crumbs list
+     *
+     * @return array
+     */
+    public function getCrumbs()
+    {
+       return $this->crumbs;
+    }
+}

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -218,24 +218,15 @@ class BreadcrumbsHelper extends Helper
         $crumbsCount = count($crumbs);
         $templater = $this->templater();
 
-        $separatorParams = [];
         if ($separator) {
             if (isset($separator['innerAttrs'])) {
-                $separatorParams['innerAttrs'] = $templater->formatAttributes($separator['innerAttrs']);
-                unset($separator['innerAttrs']);
+                $separator['innerAttrs'] = $templater->formatAttributes($separator['innerAttrs']);
             }
 
-            if (isset($separator['separator'])) {
-                $separatorParams['separator'] = $separator['separator'];
-                unset($separator['separator']);
-            }
-
-            if (isset($separator['templateVars'])) {
-                $separatorParams['templateVars'] = $separator['templateVars'];
-                unset($separator['templateVars']);
-            }
-
-            $separatorParams['attrs'] = $templater->formatAttributes($separator);
+            $separator['attrs'] = $templater->formatAttributes(
+                $separator,
+                ['innerAttrs', 'separator']
+            );
         }
 
         $crumbTrail = '';
@@ -264,8 +255,8 @@ class BreadcrumbsHelper extends Helper
                 $template = 'itemWithoutLink';
             }
 
-            if ($separatorParams && $key !== ($crumbsCount - 1)) {
-                $templateParams['separator'] = $this->formatTemplate('separator', $separatorParams);
+            if ($separator && $key !== ($crumbsCount - 1)) {
+                $templateParams['separator'] = $this->formatTemplate('separator', $separator);
             }
 
             $crumbTrail .= $this->formatTemplate($template, $templateParams);

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -194,7 +194,7 @@ class BreadcrumbsHelper extends Helper
             throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
         }
 
-        return $this->insertAt($key, $title, $url, $options);
+        return $this->insertAt($key + 1, $title, $url, $options);
     }
 
     /**

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -50,14 +50,14 @@ class BreadcrumbsHelper extends Helper
     ];
 
     /**
-     * The crumbs list.
+     * The crumb list.
      *
      * @var array
      */
     protected $crumbs = [];
 
     /**
-     * Add a crumb to the trail.
+     * Add a crumb to the end of the trail.
      *
      * @param string|array $title If provided as a string, it represents the title of the crumb.
      * Alternatively, if you want to add multiple crumbs at once, you can provide an array, with each values being a

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -114,7 +114,7 @@ class BreadcrumbsHelper extends Helper
      *
      * If the index already exists, the new crumb will be inserted,
      * and the existing element will be shifted one index greater.
-     * If the index is out of bounds, it will be added to the end.
+     * If the index is out of bounds, it will throw an exception.
      *
      * @param int $index The index to insert at.
      * @param string $title Title of the crumb.
@@ -126,9 +126,14 @@ class BreadcrumbsHelper extends Helper
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
+     * @throws LogicException In case the index is out of bound
      */
     public function insertAt($index, $title, $url = null, array $options = [])
     {
+        if (!isset($this->crumbs[$index])) {
+            throw new LogicException(sprintf("No crumb could be found at index '%s'", $index));
+        }
+
         array_splice($this->crumbs, $index, 0, [compact('title', 'url', 'options')]);
 
         return $this;

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -45,7 +45,7 @@ class BreadcrumbsHelper extends Helper
             'wrapper' => '<ul{{attrs}}>{{content}}</ul>',
             'item' => '<li{{attrs}}><a href="{{url}}"{{innerAttrs}}>{{title}}</a></li>{{separator}}',
             'itemWithoutLink' => '<li{{attrs}}><span{{innerAttrs}}>{{title}}</span></li>{{separator}}',
-            'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{custom}}{{separator}}</span></li>'
+            'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
         ]
     ];
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -104,7 +104,7 @@ class BreadcrumbsHelper extends Helper
      */
     public function prepend($title, $url = null, array $options = [])
     {
-        array_unshift($this->crumbs, ['title' => $title, 'url' => $url, 'options' => $options]);
+        array_unshift($this->crumbs, compact('title', 'url', 'options'));
 
         return $this;
     }
@@ -128,7 +128,7 @@ class BreadcrumbsHelper extends Helper
      */
     public function insertAt($index, $title, $url = null, array $options = [])
     {
-        array_splice($this->crumbs, $index, 0, [['title' => $title, 'url' => $url, 'options' => $options]]);
+        array_splice($this->crumbs, $index, 0, [compact('title', 'url', 'options')]);
 
         return $this;
     }

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -173,7 +173,7 @@ class BreadcrumbsHelper extends Helper
      */
     public function getCrumbs()
     {
-       return $this->crumbs;
+        return $this->crumbs;
     }
 
     /**
@@ -229,7 +229,7 @@ class BreadcrumbsHelper extends Helper
                 $template = 'itemWithoutLink';
             }
 
-            if (isset($separatorParams) && $key !== ($crumbsCount-1)) {
+            if (isset($separatorParams) && $key !== ($crumbsCount - 1)) {
                 $templateParams['separator'] = $this->formatTemplate('separator', $separatorParams);
             }
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -217,6 +217,7 @@ class BreadcrumbsHelper extends Helper
         $crumbs = $this->crumbs;
         $crumbsCount = count($crumbs);
         $templater = $this->templater();
+        $separatorString = '';
 
         if ($separator) {
             if (isset($separator['innerAttrs'])) {
@@ -227,6 +228,8 @@ class BreadcrumbsHelper extends Helper
                 $separator,
                 ['innerAttrs', 'separator']
             );
+
+            $separatorString = $this->formatTemplate('separator', $separator);
         }
 
         $crumbTrail = '';
@@ -255,8 +258,8 @@ class BreadcrumbsHelper extends Helper
                 $template = 'itemWithoutLink';
             }
 
-            if ($separator && $key !== ($crumbsCount - 1)) {
-                $templateParams['separator'] = $this->formatTemplate('separator', $separator);
+            if ($separatorString && $key !== ($crumbsCount - 1)) {
+                $templateParams['separator'] = $separatorString;
             }
 
             $crumbTrail .= $this->formatTemplate($template, $templateParams);

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -29,7 +29,7 @@ class BreadcrumbsHelper extends Helper
     use StringTemplateTrait;
 
     /**
-     * Other helpers used by BreadcrumbsHelper
+     * Other helpers used by BreadcrumbsHelper.
      *
      * @var array
      */
@@ -59,19 +59,19 @@ class BreadcrumbsHelper extends Helper
     /**
      * Add a crumb to the trail.
      *
-     * @param string|array $title Title of the crumb. If provided as an array, it will add each values of the array
-     * as a single crumb. This allows you to add multiple crumbs in the trail at once. Arrays are expected to be of this
-     * form:
+     * @param string|array $title If provided as a string, it represents the title of the crumb.
+     * Alternatively, if you want to add multiple crumbs at once, you can provide an array, with each values being a
+     * single crumb. Arrays are expected to be of this form:
      * - *title* The title of the crumb
      * - *link* The link of the crumb. If not provided, no link will be made
      * - *options* Options of the crumb. See description of params option of this method.
      * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
-     * Url::build() or null / empty if the crumb does not have a link
+     * Url::build() or null / empty if the crumb does not have a link.
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
-     * - *templateVars*: Specific template vars in case you override the templates provided
+     * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
      */
     public function add($title, $url = null, array $options = [])
@@ -92,14 +92,14 @@ class BreadcrumbsHelper extends Helper
     /**
      * Prepend a crumb to the start of the queue.
      *
-     * @param string $title Title of the crumb
+     * @param string $title Title of the crumb.
      * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
-     * Url::build() or null / empty if the crumb does not have a link
+     * Url::build() or null / empty if the crumb does not have a link.
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
-     * - *templateVars*: Specific template vars in case you override the templates provided
+     * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
      */
     public function prepend($title, $url = null, array $options = [])
@@ -114,16 +114,17 @@ class BreadcrumbsHelper extends Helper
      *
      * If the index already exists, the new crumb will be inserted,
      * and the existing element will be shifted one index greater.
+     * If the index is out of bounds, it will be added to the end.
      *
      * @param int $index The index to insert at.
-     * @param string $title Title of the crumb
+     * @param string $title Title of the crumb.
      * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
-     * Url::build() or null / empty if the crumb does not have a link
+     * Url::build() or null / empty if the crumb does not have a link.
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
-     * - *templateVars*: Specific template vars in case you override the templates provided
+     * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
      */
     public function insertAt($index, $title, $url = null, array $options = [])
@@ -136,18 +137,18 @@ class BreadcrumbsHelper extends Helper
     /**
      * Insert a crumb before the first matching crumb with the specified title.
      *
-     * Finds the index of the first middleware that matches the provided class,
+     * Finds the index of the first crumb that matches the provided class,
      * and inserts the supplied callable before it.
      *
-     * @param string $matchingTitle The title of the crumb you want to insert this one before
-     * @param string $title Title of the crumb
+     * @param string $matchingTitle The title of the crumb you want to insert this one before.
+     * @param string $title Title of the crumb.
      * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
-     * Url::build() or null / empty if the crumb does not have a link
+     * Url::build() or null / empty if the crumb does not have a link.
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
-     * - *templateVars*: Specific template vars in case you override the templates provided
+     * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
      * @throws LogicException In case the matching crumb can not be found
      */
@@ -155,42 +156,44 @@ class BreadcrumbsHelper extends Helper
     {
         $key = $this->findCrumb($matchingTitle);
 
-        if ($key !== null) {
-            return $this->insertAt($key, $title, $url, $options);
+        if ($key === null) {
+            throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
         }
-        throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
+
+        return $this->insertAt($key, $title, $url, $options);
     }
 
     /**
      * Insert a crumb after the first matching crumb with the specified title.
      *
-     * Finds the index of the first middleware that matches the provided class,
+     * Finds the index of the first crumb that matches the provided class,
      * and inserts the supplied callable before it.
      *
-     * @param string $matchingTitle The title of the crumb you want to insert this one after
-     * @param string $title Title of the crumb
+     * @param string $matchingTitle The title of the crumb you want to insert this one after.
+     * @param string $title Title of the crumb.
      * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
-     * Url::build() or null / empty if the crumb does not have a link
+     * Url::build() or null / empty if the crumb does not have a link.
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
-     * - *templateVars*: Specific template vars in case you override the templates provided
+     * - *templateVars*: Specific template vars in case you override the templates provided.
      * @return $this
-     * @throws LogicException In case the matching crumb can not be found
+     * @throws LogicException In case the matching crumb can not be found.
      */
     public function insertAfter($matchingTitle, $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
-        if ($key !== null) {
-            return $this->insertAt($key + 1, $title, $url, $options);
+        if ($key === null) {
+            throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
         }
-        throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
+
+        return $this->insertAt($key, $title, $url, $options);
     }
 
     /**
-     * Returns the crumbs list
+     * Returns the crumb list.
      *
      * @return array
      */
@@ -200,7 +203,7 @@ class BreadcrumbsHelper extends Helper
     }
 
     /**
-     * Renders the breadcrumbs trail
+     * Renders the breadcrumbs trail.
      *
      * @param array $attributes Array of attributes applied to the `wrapper` template. Accepts the `templateVars` key to
      * allow the insertion of custom template variable in the template.
@@ -208,8 +211,8 @@ class BreadcrumbsHelper extends Helper
      * Possible properties are :
      * - *separator* The string to be displayed as a separator
      * - *templateVars* Allows the insertion of custom template variable in the template
-     * - *innerAttrs* To provide attributes in case your separator is divided in two elements
-     * All other properties will be converted as HTML attributes and will replace the *attrs* key in the template
+     * - *innerAttrs* To provide attributes in case your separator is divided in two elements.
+     * All other properties will be converted as HTML attributes and will replace the *attrs* key in the template.
      * If you use the default for this option (empty), it will not render a separator.
      * @return string The breadcrumbs trail
      */
@@ -279,8 +282,8 @@ class BreadcrumbsHelper extends Helper
      * Search a crumb in the current stack which title matches the one provided as argument.
      * If found, the index of the matching crumb will be returned.
      *
-     * @param string $title Title to find
-     * @return int|null Index of the crumb found, or null if it can not be found
+     * @param string $title Title to find.
+     * @return int|null Index of the crumb found, or null if it can not be found.
      */
     protected function findCrumb($title)
     {

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -43,7 +43,7 @@ class BreadcrumbsHelper extends Helper
     protected $_defaultConfig = [
         'templates' => [
             'wrapper' => '<ul{{attrs}}>{{content}}</ul>',
-            'item' => '<li{{attrs}}><a href="{{link}}"{{innerAttrs}}>{{title}}</a></li>{{separator}}',
+            'item' => '<li{{attrs}}><a href="{{url}}"{{innerAttrs}}>{{title}}</a></li>{{separator}}',
             'itemWithoutLink' => '<li{{attrs}}><span{{innerAttrs}}>{{title}}</span></li>{{separator}}',
             'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{custom}}{{separator}}</span></li>'
         ]
@@ -65,7 +65,7 @@ class BreadcrumbsHelper extends Helper
      * - *title* The title of the crumb
      * - *link* The link of the crumb. If not provided, no link will be made
      * - *options* Options of the crumb. See description of params option of this method.
-     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
@@ -74,18 +74,17 @@ class BreadcrumbsHelper extends Helper
      * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
-    public function add($title, $link = null, array $options = [])
+    public function add($title, $url = null, array $options = [])
     {
         if (is_array($title)) {
             foreach ($title as $crumb) {
-                $crumb = array_merge(['title' => '', 'link' => null, 'options' => []], $crumb);
-                $this->crumbs[] = $crumb;
+                $this->crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
             }
 
             return $this;
         }
 
-        $this->crumbs[] = ['title' => $title, 'link' => $link, 'options' => $options];
+        $this->crumbs[] = compact('title', 'url', 'options');
 
         return $this;
     }
@@ -94,7 +93,7 @@ class BreadcrumbsHelper extends Helper
      * Prepend a crumb to the start of the queue.
      *
      * @param string $title Title of the crumb
-     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
@@ -103,9 +102,9 @@ class BreadcrumbsHelper extends Helper
      * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
-    public function prepend($title, $link = null, array $options = [])
+    public function prepend($title, $url = null, array $options = [])
     {
-        array_unshift($this->crumbs, ['title' => $title, 'link' => $link, 'options' => $options]);
+        array_unshift($this->crumbs, ['title' => $title, 'url' => $url, 'options' => $options]);
 
         return $this;
     }
@@ -118,7 +117,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @param int $index The index to insert at.
      * @param string $title Title of the crumb
-     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
@@ -127,9 +126,9 @@ class BreadcrumbsHelper extends Helper
      * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
      */
-    public function insertAt($index, $title, $link = null, array $options = [])
+    public function insertAt($index, $title, $url = null, array $options = [])
     {
-        array_splice($this->crumbs, $index, 0, [['title' => $title, 'link' => $link, 'options' => $options]]);
+        array_splice($this->crumbs, $index, 0, [['title' => $title, 'url' => $url, 'options' => $options]]);
 
         return $this;
     }
@@ -142,7 +141,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @param string $matchingTitle The title of the crumb you want to insert this one before
      * @param string $title Title of the crumb
-     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
@@ -150,13 +149,14 @@ class BreadcrumbsHelper extends Helper
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
+     * @throws LogicException In case the matching crumb can not be found
      */
-    public function insertBefore($matchingTitle, $title, $link = null, array $options = [])
+    public function insertBefore($matchingTitle, $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
         if ($key !== null) {
-            return $this->insertAt($key, $title, $link, $options);
+            return $this->insertAt($key, $title, $url, $options);
         }
         throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
     }
@@ -169,7 +169,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @param string $matchingTitle The title of the crumb you want to insert this one after
      * @param string $title Title of the crumb
-     * @param string|array|null $link Link of the crumb. Either a string, an array of route params to pass to
+     * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link
      * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
@@ -177,13 +177,14 @@ class BreadcrumbsHelper extends Helper
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided
      * @return $this
+     * @throws LogicException In case the matching crumb can not be found
      */
-    public function insertAfter($matchingTitle, $title, $link = null, array $options = [])
+    public function insertAfter($matchingTitle, $title, $url = null, array $options = [])
     {
         $key = $this->findCrumb($matchingTitle);
 
         if ($key !== null) {
-            return $this->insertAt($key + 1, $title, $link, $options);
+            return $this->insertAt($key + 1, $title, $url, $options);
         }
         throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
     }
@@ -234,7 +235,7 @@ class BreadcrumbsHelper extends Helper
 
         $crumbTrail = '';
         foreach ($crumbs as $key => $crumb) {
-            $link = $this->prepareLink($crumb['link']);
+            $url = $crumb['url'] ? $this->Url->build($crumb['url']) : null;
             $title = $crumb['title'];
             $options = $crumb['options'];
 
@@ -249,12 +250,12 @@ class BreadcrumbsHelper extends Helper
                 'attrs' => $templater->formatAttributes($options, ['templateVars']),
                 'innerAttrs' => $templater->formatAttributes($optionsLink),
                 'title' => $title,
-                'link' => $link,
+                'url' => $url,
                 'separator' => '',
                 'templateVars' => isset($options['templateVars']) ? $options['templateVars'] : []
             ];
 
-            if (!($link)) {
+            if (!$url) {
                 $template = 'itemWithoutLink';
             }
 
@@ -290,23 +291,5 @@ class BreadcrumbsHelper extends Helper
         }
 
         return null;
-    }
-
-    /**
-     * Prepare the URL for a specific `link` param of a crumb
-     *
-     * @param array|string|null $link If array, an array of Router url params
-     * If string, will be used as is
-     * If empty, will consider that there is no link
-     *
-     * @return null|string The URL of a crumb
-     */
-    protected function prepareLink($link = null)
-    {
-        if (!$link) {
-            return null;
-        }
-
-        return $this->Url->build($link);
     }
 }

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -178,7 +178,7 @@ class BreadcrumbsHelper extends Helper
         $templater = $this->templater();
 
         $separatorParams = [];
-        if (!empty($separator)) {
+        if ($separator) {
             if (isset($separator['innerAttrs'])) {
                 $separatorParams['innerAttrs'] = $templater->formatAttributes($separator['innerAttrs']);
                 unset($separator['innerAttrs']);
@@ -219,7 +219,7 @@ class BreadcrumbsHelper extends Helper
                 'templateVars' => isset($options['templateVars']) ? $options['templateVars'] : []
             ];
 
-            if (empty($link)) {
+            if (!($link)) {
                 $template = 'itemWithoutLink';
             }
 
@@ -268,10 +268,10 @@ class BreadcrumbsHelper extends Helper
      */
     protected function prepareLink($link = null)
     {
-        if (!empty($link)) {
-            return $this->Url->build($link);
+        if (!$link) {
+            return null;
         }
 
-        return null;
+        return $this->Url->build($link);
     }
 }

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -43,8 +43,8 @@ class BreadcrumbsHelper extends Helper
     protected $_defaultConfig = [
         'templates' => [
             'wrapper' => '<ul{{attrs}}>{{content}}</ul>',
-            'item' => '<li{{attrs}}><a href="{{link}}"{{innerAttrs}}>{{title}}</a></li>',
-            'itemWithoutLink' => '<li{{attrs}}><span{{innerAttrs}}>{{title}}</span></li>',
+            'item' => '<li{{attrs}}><a href="{{link}}"{{innerAttrs}}>{{title}}</a></li>{{separator}}',
+            'itemWithoutLink' => '<li{{attrs}}><span{{innerAttrs}}>{{title}}</span></li>{{separator}}',
             'separator' => '<li{{attrs}}><span{{innerAttrs}}>{{separator}}</span></li>'
         ]
     ];
@@ -222,17 +222,18 @@ class BreadcrumbsHelper extends Helper
                 'innerAttrs' => $templater->formatAttributes($optionsLink),
                 'title' => $title,
                 'link' => $link,
+                'separator' => '',
             ];
 
             if (empty($link)) {
                 $template = 'itemWithoutLink';
             }
 
-            $crumbTrail .= $this->formatTemplate($template, $templateParams);
-
             if (isset($separatorParams) && $key !== ($crumbsCount-1)) {
-                $crumbTrail .= $this->formatTemplate('separator', $separatorParams);
+                $templateParams['separator'] = $this->formatTemplate('separator', $separatorParams);
             }
+
+            $crumbTrail .= $this->formatTemplate($template, $templateParams);
         }
 
         $crumbTrail = $this->formatTemplate('wrapper', [

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -89,6 +89,7 @@ class HtmlHelper extends Helper
      * Breadcrumbs.
      *
      * @var array
+     * @deprecated 3.3.6 Use the BreadcrumbsHelper instead
      */
     protected $_crumbs = [];
 
@@ -153,6 +154,7 @@ class HtmlHelper extends Helper
      * @return $this
      * @see \Cake\View\Helper\HtmlHelper::link() for details on $options that can be used.
      * @link http://book.cakephp.org/3.0/en/views/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
+     * @deprecated 3.3.6 Use the BreadcrumbsHelper instead
      */
     public function addCrumb($name, $link = null, array $options = [])
     {
@@ -677,6 +679,7 @@ class HtmlHelper extends Helper
      *   also be an array, see above for details.
      * @return string|null Composed bread crumbs
      * @link http://book.cakephp.org/3.0/en/views/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
+     * @deprecated 3.3.6 Use the BreadcrumbsHelper instead
      */
     public function getCrumbs($separator = '&raquo;', $startText = false)
     {
@@ -715,6 +718,7 @@ class HtmlHelper extends Helper
      *   also be an array, see `HtmlHelper::getCrumbs` for details.
      * @return string|null Breadcrumbs HTML list.
      * @link http://book.cakephp.org/3.0/en/views/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
+     * @deprecated 3.3.6 Use the BreadcrumbsHelper instead
      */
     public function getCrumbList(array $options = [], $startText = false)
     {
@@ -767,6 +771,7 @@ class HtmlHelper extends Helper
      * @param string|array|bool $startText Text to prepend
      * @param bool $escape If the output should be escaped or not
      * @return array Crumb list including startText (if provided)
+     * @deprecated 3.3.6 Use the BreadcrumbsHelper instead
      */
     protected function _prepareCrumbs($startText, $escape = true)
     {

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -54,14 +54,14 @@ class BreadcrumbsHelperTest extends TestCase
         $expected = [
             [
                 'title' => 'Home',
-                'link' => '/',
+                'url' => '/',
                 'options' => [
                     'class' => 'first'
                 ]
             ],
             [
                 'title' => 'Some text',
-                'link' => [
+                'url' => [
                     'controller' => 'Some',
                     'action' => 'text'
                 ],
@@ -82,12 +82,12 @@ class BreadcrumbsHelperTest extends TestCase
             ->add([
                 [
                     'title' => 'Home',
-                    'link' => '/',
+                    'url' => '/',
                     'options' => ['class' => 'first']
                 ],
                 [
                     'title' => 'Some text',
-                    'link' => ['controller' => 'Some', 'action' => 'text']
+                    'url' => ['controller' => 'Some', 'action' => 'text']
                 ],
                 [
                     'title' => 'Final',
@@ -98,14 +98,14 @@ class BreadcrumbsHelperTest extends TestCase
         $expected = [
             [
                 'title' => 'Home',
-                'link' => '/',
+                'url' => '/',
                 'options' => [
                     'class' => 'first'
                 ]
             ],
             [
                 'title' => 'Some text',
-                'link' => [
+                'url' => [
                     'controller' => 'Some',
                     'action' => 'text'
                 ],
@@ -113,7 +113,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Final',
-                'link' => null,
+                'url' => null,
                 'options' => []
             ]
         ];
@@ -135,12 +135,12 @@ class BreadcrumbsHelperTest extends TestCase
         $expected = [
             [
                 'title' => 'The root',
-                'link' => '/root',
+                'url' => '/root',
                 'options' => ['data-name' => 'some-name']
             ],
             [
                 'title' => 'Some text',
-                'link' => [
+                'url' => [
                     'controller' => 'Some',
                     'action' => 'text'
                 ],
@@ -148,7 +148,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Home',
-                'link' => '/',
+                'url' => '/',
                 'options' => [
                     'class' => 'first'
                 ]
@@ -173,7 +173,7 @@ class BreadcrumbsHelperTest extends TestCase
         $expected = [
             [
                 'title' => 'Some text',
-                'link' => [
+                'url' => [
                     'controller' => 'Some',
                     'action' => 'text'
                 ],
@@ -181,7 +181,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Insert At Again',
-                'link' => [
+                'url' => [
                     'controller' => 'Insert',
                     'action' => 'at_again'
                 ],
@@ -189,7 +189,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Insert At',
-                'link' => [
+                'url' => [
                     'controller' => 'Insert',
                     'action' => 'at'
                 ],
@@ -197,7 +197,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Home',
-                'link' => '/',
+                'url' => '/',
                 'options' => [
                     'class' => 'first'
                 ]
@@ -222,17 +222,17 @@ class BreadcrumbsHelperTest extends TestCase
         $expected = [
             [
                 'title' => 'The super root',
-                'link' => null,
+                'url' => null,
                 'options' => []
             ],
             [
                 'title' => 'The root',
-                'link' => '/root',
+                'url' => '/root',
                 'options' => ['data-name' => 'some-name']
             ],
             [
                 'title' => 'Some text',
-                'link' => [
+                'url' => [
                     'controller' => 'Some',
                     'action' => 'text'
                 ],
@@ -240,7 +240,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Home',
-                'link' => '/',
+                'url' => '/',
                 'options' => [
                     'class' => 'first'
                 ]
@@ -265,17 +265,17 @@ class BreadcrumbsHelperTest extends TestCase
         $expected = [
             [
                 'title' => 'The root',
-                'link' => '/root',
+                'url' => '/root',
                 'options' => ['data-name' => 'some-name']
             ],
             [
                 'title' => 'The less super root',
-                'link' => null,
+                'url' => null,
                 'options' => []
             ],
             [
                 'title' => 'Some text',
-                'link' => [
+                'url' => [
                     'controller' => 'Some',
                     'action' => 'text'
                 ],
@@ -283,7 +283,7 @@ class BreadcrumbsHelperTest extends TestCase
             ],
             [
                 'title' => 'Home',
-                'link' => '/',
+                'url' => '/',
                 'options' => [
                     'class' => 'first'
                 ]
@@ -348,7 +348,7 @@ class BreadcrumbsHelperTest extends TestCase
         $this->breadcrumbs = new BreadcrumbsHelper(new View(), [
             'templates' => [
                 'wrapper' => '<ol itemtype="http://schema.org/BreadcrumbList"{{attrs}}>{{content}}</ol>',
-                'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{link}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a></li>',
+                'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{url}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a></li>',
                 'itemWithoutLink' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><span itemprop="name"{{innerAttrs}}>{{title}}</span></li>',
             ]
         ]);
@@ -388,7 +388,7 @@ class BreadcrumbsHelperTest extends TestCase
         $this->breadcrumbs = new BreadcrumbsHelper(new View(), [
             'templates' => [
                 'wrapper' => '{{thing}}<ol itemtype="http://schema.org/BreadcrumbList"{{attrs}}>{{content}}</ol>',
-                'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{link}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a>{{foo}}</li>',
+                'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{url}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a>{{foo}}</li>',
                 'itemWithoutLink' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><span itemprop="name"{{innerAttrs}}>{{title}}</span>{{barbaz}}</li>',
             ]
         ]);

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -161,6 +161,46 @@ class BreadcrumbsHelperTest extends TestCase
     }
 
     /**
+     * Test adding crumbs to the trail using prepend()
+     *
+     * @return void
+     */
+    public function testPrependMultiple()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend([
+                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text']],
+                ['title' => 'The root', 'url' => '/root', 'options' => ['data-name' => 'some-name']]
+            ]);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'The root',
+                'url' => '/root',
+                'options' => ['data-name' => 'some-name']
+            ],
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test adding crumbs to a specific index
      *
      * @return void

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.6
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Helper;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Helper\BreadcrumbsHelper;
+use Cake\View\View;
+
+class BreadcrumbsHelperTest extends TestCase
+{
+
+    /**
+     * Instance of the BreadcrumbsHelper
+     *
+     * @var BreadcrumbsHelper
+     */
+    public $breadcrumbs;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $view = new View();
+        $this->breadcrumbs = new BreadcrumbsHelper($view);
+    }
+
+    /**
+     * Test adding crumbs to the trail using add()
+     * @return void
+     */
+    public function testAdd()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->add('Some text', ['controller' => 'Some', 'action' => 'text']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'link' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ],
+            [
+                'title' => 'Some text',
+                'link' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding crumbs to the trail using prepend()
+     * @return void
+     */
+    public function testPrepend()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend('Some text', ['controller' => 'Some', 'action' => 'text'])
+            ->prepend('The root', '/root', ['data-name' => 'some-name']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'The root',
+                'link' => '/root',
+                'options' => ['data-name' => 'some-name']
+            ],
+            [
+                'title' => 'Some text',
+                'link' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Home',
+                'link' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding crumbs to a specific index
+     * @return void
+     */
+    public function testInsertAt()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend('Some text', ['controller' => 'Some', 'action' => 'text'])
+            ->insertAt(1, 'Insert At', ['controller' => 'Insert', 'action' => 'at'])
+            ->insertAt(1, 'Insert At Again', ['controller' => 'Insert', 'action' => 'at_again']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'link' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Insert At Again',
+                'link' => [
+                    'controller' => 'Insert',
+                    'action' => 'at_again'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Insert At',
+                'link' => [
+                    'controller' => 'Insert',
+                    'action' => 'at'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Home',
+                'link' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding crumbs before a specific one
+     * @return void
+     */
+    public function testInsertBefore()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend('Some text', ['controller' => 'Some', 'action' => 'text'])
+            ->prepend('The root', '/root', ['data-name' => 'some-name'])
+            ->insertBefore('The root', 'The super root');
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'The super root',
+                'link' => null,
+                'options' => []
+            ],
+            [
+                'title' => 'The root',
+                'link' => '/root',
+                'options' => ['data-name' => 'some-name']
+            ],
+            [
+                'title' => 'Some text',
+                'link' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Home',
+                'link' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding crumbs after a specific one
+     * @return void
+     */
+    public function testInsertAfter()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend('Some text', ['controller' => 'Some', 'action' => 'text'])
+            ->prepend('The root', '/root', ['data-name' => 'some-name'])
+            ->insertAfter('The root', 'The less super root');
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'The root',
+                'link' => '/root',
+                'options' => ['data-name' => 'some-name']
+            ],
+            [
+                'title' => 'The less super root',
+                'link' => null,
+                'options' => []
+            ],
+            [
+                'title' => 'Some text',
+                'link' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Home',
+                'link' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -42,6 +42,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to the trail using add()
+     *
      * @return void
      */
     public function testAdd()
@@ -74,6 +75,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding multiple crumbs at once to the trail using add()
+     *
      * @return void
      */
     public function testAddMultiple()
@@ -122,6 +124,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to the trail using prepend()
+     *
      * @return void
      */
     public function testPrepend()
@@ -159,6 +162,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to a specific index
+     *
      * @return void
      */
     public function testInsertAt()
@@ -207,7 +211,20 @@ class BreadcrumbsHelperTest extends TestCase
     }
 
     /**
+     * Test adding crumbs to a specific index
+     *
+     * @expectedException \LogicException
+     */
+    public function testInsertAtIndexOutOfBounds()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->insertAt(2, 'Insert At Again', ['controller' => 'Insert', 'action' => 'at_again']);
+    }
+
+    /**
      * Test adding crumbs before a specific one
+     *
      * @return void
      */
     public function testInsertBefore()
@@ -251,6 +268,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs after a specific one
+     *
      * @return void
      */
     public function testInsertAfter()
@@ -294,6 +312,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Tests the render method
+     *
      * @return void
      */
     public function testRender()
@@ -343,6 +362,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Tests the render method with custom templates
+     *
      * @return void
      */
     public function testRenderCustomTemplate()
@@ -383,6 +403,7 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Tests the render method with template vars
+     *
      * @return void
      */
     public function testRenderCustomTemplateTemplateVars()

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -242,4 +242,92 @@ class BreadcrumbsHelperTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Tests the render method
+     * @return void
+     */
+    public function testRender()
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first', 'innerAttrs' => ['data-foo' => 'bar']])
+            ->add('Some text', ['controller' => 'tests_apps', 'action' => 'some_method'])
+            ->add('Final crumb', null, ['class' => 'final', 'innerAttrs' => ['class' => 'final-link']]);
+
+        $result = $this->breadcrumbs->render(
+            ['data-stuff' => 'foo and bar'],
+            ['separator' => ' > ', 'class' => 'separator']
+        );
+        $expected = [
+            ['ul' => ['data-stuff' => 'foo and bar']],
+            ['li' => ['class' => 'first']],
+            ['a' => ['href' => '/', 'data-foo' => 'bar']],
+            'Home',
+            '/a',
+            '/li',
+            ['li' => ['class' => 'separator']],
+            ['span' => []],
+            ' > ',
+            '/span',
+            '/li',
+            ['li' => []],
+            ['a' => ['href' => '/some_alias']],
+            'Some text',
+            '/a',
+            '/li',
+            ['li' => ['class' => 'separator']],
+            ['span' => []],
+            ' > ',
+            '/span',
+            '/li',
+            ['li' => ['class' => 'final']],
+            ['span' => ['class' => 'final-link']],
+            'Final crumb',
+            '/span',
+            '/li',
+            '/ul'
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Tests the render method with custom templates
+     * @return void
+     */
+    public function testRenderCustomTemplate()
+    {
+        $this->breadcrumbs = new BreadcrumbsHelper(new View(), [
+            'templates' => [
+                'wrapper' => '<ol itemtype="http://schema.org/BreadcrumbList"{{attrs}}>{{content}}</ol>',
+                'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{link}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a></li>',
+                'itemWithoutLink' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><span itemprop="name"{{innerAttrs}}>{{title}}</span></li>',
+                'separator' => ''
+            ]
+        ]);
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first', 'innerAttrs' => ['data-foo' => 'bar']])
+            ->add('Final crumb', null, ['class' => 'final', 'innerAttrs' => ['class' => 'final-link']]);
+
+        $result = $this->breadcrumbs->render(
+            ['data-stuff' => 'foo and bar'],
+            ['separator' => ' > ', 'class' => 'separator']
+        );
+        $expected = [
+            ['ol' => ['itemtype' => 'http://schema.org/BreadcrumbList', 'data-stuff' => 'foo and bar']],
+            ['li' => ['itemprop' => 'itemListElement', 'itemtype' => 'http://schema.org/ListItem', 'class' => 'first']],
+            ['a' => ['itemtype' => 'http://schema.org/Thing', 'itemprop' => 'item', 'href' => '/', 'data-foo' => 'bar']],
+            ['span' => ['itemprop' => 'name']],
+            'Home',
+            '/span',
+            '/a',
+            '/li',
+            ['li' => ['itemprop' => 'itemListElement', 'itemtype' => 'http://schema.org/ListItem', 'class' => 'final']],
+            ['span' => ['itemprop' => 'name', 'class' => 'final-link']],
+            'Final crumb',
+            '/span',
+            '/li',
+            '/ol'
+        ];
+        $this->assertHtml($expected, $result, true);
+    }
 }

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -256,7 +256,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->breadcrumbs->render(
             ['data-stuff' => 'foo and bar'],
-            ['separator' => ' > ', 'class' => 'separator']
+            ['separator' => ' > ', 'class' => 'separator', 'templateVars' => ['custom' => 'custom']]
         );
         $expected = [
             ['ul' => ['data-stuff' => 'foo and bar']],
@@ -267,7 +267,7 @@ class BreadcrumbsHelperTest extends TestCase
             '/li',
             ['li' => ['class' => 'separator']],
             ['span' => []],
-            ' > ',
+            'custom > ',
             '/span',
             '/li',
             ['li' => []],
@@ -277,7 +277,7 @@ class BreadcrumbsHelperTest extends TestCase
             '/li',
             ['li' => ['class' => 'separator']],
             ['span' => []],
-            ' > ',
+            'custom > ',
             '/span',
             '/li',
             ['li' => ['class' => 'final']],
@@ -324,6 +324,49 @@ class BreadcrumbsHelperTest extends TestCase
             ['span' => ['itemprop' => 'name', 'class' => 'final-link']],
             'Final crumb',
             '/span',
+            '/li',
+            '/ol'
+        ];
+        $this->assertHtml($expected, $result, true);
+    }
+
+    /**
+     * Tests the render method with template vars
+     * @return void
+     */
+    public function testRenderCustomTemplateTemplateVars()
+    {
+        $this->breadcrumbs = new BreadcrumbsHelper(new View(), [
+            'templates' => [
+                'wrapper' => '{{thing}}<ol itemtype="http://schema.org/BreadcrumbList"{{attrs}}>{{content}}</ol>',
+                'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{link}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a>{{foo}}</li>',
+                'itemWithoutLink' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><span itemprop="name"{{innerAttrs}}>{{title}}</span>{{barbaz}}</li>',
+            ]
+        ]);
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first', 'innerAttrs' => ['data-foo' => 'bar'], 'templateVars' => ['foo' => 'barbaz']])
+            ->add('Final crumb', null, ['class' => 'final', 'innerAttrs' => ['class' => 'final-link'], 'templateVars' => ['barbaz' => 'foo']]);
+
+        $result = $this->breadcrumbs->render(
+            ['data-stuff' => 'foo and bar', 'templateVars' => ['thing' => 'somestuff']],
+            ['separator' => ' > ', 'class' => 'separator']
+        );
+        $expected = [
+            'somestuff',
+            ['ol' => ['itemtype' => 'http://schema.org/BreadcrumbList', 'data-stuff' => 'foo and bar']],
+            ['li' => ['itemprop' => 'itemListElement', 'itemtype' => 'http://schema.org/ListItem', 'class' => 'first']],
+            ['a' => ['itemtype' => 'http://schema.org/Thing', 'itemprop' => 'item', 'href' => '/', 'data-foo' => 'bar']],
+            ['span' => ['itemprop' => 'name']],
+            'Home',
+            '/span',
+            '/a',
+            'barbaz',
+            '/li',
+            ['li' => ['itemprop' => 'itemListElement', 'itemtype' => 'http://schema.org/ListItem', 'class' => 'final']],
+            ['span' => ['itemprop' => 'name', 'class' => 'final-link']],
+            'Final crumb',
+            '/span',
+            'foo',
             '/li',
             '/ol'
         ];

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -301,7 +301,6 @@ class BreadcrumbsHelperTest extends TestCase
                 'wrapper' => '<ol itemtype="http://schema.org/BreadcrumbList"{{attrs}}>{{content}}</ol>',
                 'item' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><a itemtype="http://schema.org/Thing" itemprop="item" href="{{link}}"{{innerAttrs}}><span itemprop="name">{{title}}</span></a></li>',
                 'itemWithoutLink' => '<li itemprop="itemListElement" itemtype="http://schema.org/ListItem"{{attrs}}><span itemprop="name"{{innerAttrs}}>{{title}}</span></li>',
-                'separator' => ''
             ]
         ]);
         $this->breadcrumbs

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -71,6 +71,55 @@ class BreadcrumbsHelperTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+
+    /**
+     * Test adding multiple crumbs at once to the trail using add()
+     * @return void
+     */
+    public function testAddMultiple()
+    {
+        $this->breadcrumbs
+            ->add([
+                [
+                    'title' => 'Home',
+                    'link' => '/',
+                    'options' => ['class' => 'first']
+                ],
+                [
+                    'title' => 'Some text',
+                    'link' => ['controller' => 'Some', 'action' => 'text']
+                ],
+                [
+                    'title' => 'Final',
+                ],
+            ]);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'link' => '/',
+                'options' => [
+                    'class' => 'first'
+                ]
+            ],
+            [
+                'title' => 'Some text',
+                'link' => [
+                    'controller' => 'Some',
+                    'action' => 'text'
+                ],
+                'options' => []
+            ],
+            [
+                'title' => 'Final',
+                'link' => null,
+                'options' => []
+            ]
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
     /**
      * Test adding crumbs to the trail using prepend()
      * @return void
@@ -256,7 +305,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->breadcrumbs->render(
             ['data-stuff' => 'foo and bar'],
-            ['separator' => ' > ', 'class' => 'separator', 'templateVars' => ['custom' => 'custom']]
+            ['separator' => '<i class="fa fa-angle-right"></i>', 'class' => 'separator', 'templateVars' => ['custom' => 'custom']]
         );
         $expected = [
             ['ul' => ['data-stuff' => 'foo and bar']],
@@ -267,7 +316,7 @@ class BreadcrumbsHelperTest extends TestCase
             '/li',
             ['li' => ['class' => 'separator']],
             ['span' => []],
-            'custom > ',
+            'custom<i class="fa fa-angle-right"></i>',
             '/span',
             '/li',
             ['li' => []],
@@ -277,7 +326,7 @@ class BreadcrumbsHelperTest extends TestCase
             '/li',
             ['li' => ['class' => 'separator']],
             ['span' => []],
-            'custom > ',
+            'custom<i class="fa fa-angle-right"></i>',
             '/span',
             '/li',
             ['li' => ['class' => 'final']],

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -305,7 +305,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->breadcrumbs->render(
             ['data-stuff' => 'foo and bar'],
-            ['separator' => '<i class="fa fa-angle-right"></i>', 'class' => 'separator', 'templateVars' => ['custom' => 'custom']]
+            ['separator' => '<i class="fa fa-angle-right"></i>', 'class' => 'separator']
         );
         $expected = [
             ['ul' => ['data-stuff' => 'foo and bar']],
@@ -316,7 +316,8 @@ class BreadcrumbsHelperTest extends TestCase
             '/li',
             ['li' => ['class' => 'separator']],
             ['span' => []],
-            'custom<i class="fa fa-angle-right"></i>',
+            ['i' => ['class' => 'fa fa-angle-right']],
+            '/i',
             '/span',
             '/li',
             ['li' => []],
@@ -326,7 +327,8 @@ class BreadcrumbsHelperTest extends TestCase
             '/li',
             ['li' => ['class' => 'separator']],
             ['span' => []],
-            'custom<i class="fa fa-angle-right"></i>',
+            ['i' => ['class' => 'fa fa-angle-right']],
+            '/i',
             '/span',
             '/li',
             ['li' => ['class' => 'final']],


### PR DESCRIPTION
This PR aims to introduce a `BreadcrumbsHelper` as discussed in #9542.
It exposes an API that allow precise insertions of crumbs (much like the way you'd manage your middlewares) to get around common issues related to the way Cake renders the views.

It also gives an easier way to customize the way the trail is rendered by using the `StringTemplateTrait`, the same way the `FormHelper` does.

The `render()` methods accepts two arguments : 
- the first argument will be used to customize the wrapper of the crumbs trail
- the second argument to customize the separator between crumbs. By default, no separator will be added between each crumbs.

For the templates, I went with what I think are sane default. Feel free to comment on this.

Once this is approved, I'll document the docblocks a bit more (to give more details about the arguments of the `render()` methods for instance and how to customize the "innerAttrs") and write something for the book.

Refs #9542 
