### PR TITLE
3.x Allow to specify 'method' and 'enctype' for FormHelper::create()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -415,6 +415,13 @@ class FormHelper extends Helper
             default:
                 $htmlAttributes['method'] = 'post';
         }
+        if (isset($options['method'])) {
+            $htmlAttributes['method'] = strtolower($options['method']);
+        }
+        if (isset($options['enctype'])) {
+            $htmlAttributes['enctype'] = strtolower($options['enctype']);
+        }
+
         $this->requestType = strtolower($options['type']);
 
         if (!empty($options['encoding'])) {


### PR DESCRIPTION
Ref: https://github.com/cakephp/cakephp/issues/7977
@ADmad is this what you had in mind / considered sane?
