### PR TITLE
(2.next) Adding Base64 support to the HtmlHelper::image() function

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -554,6 +554,40 @@ class HtmlHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testBase64ImageTag method
+ *
+ * @return void
+ */
+	public function testBase64ImageTag() {
+		$this->Html->request->webroot = '';
+
+		$result = $this->Html->image('cake.icon.png', array('base64' => true));
+		$this->assertTags($result, array(
+			'img' => array(
+				'src' => 'preg:/data:image\/png;base64,(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})/',
+				'alt' => ''
+			)));
+
+		$result = $this->Html->image('/img/cake.icon.png', array('base64' => true));
+		$this->assertTags($result, array(
+			'img' => array(
+				'src' => 'preg:/data:image\/png;base64,(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})/',
+				'alt' => ''
+			)));
+	}
+
+/**
+ * testLoadConfigWrongFile method
+ *
+ * @return void
+ * @expectedException InvalidArgumentException
+ */
+	public function testBase64InvalidArgumentException() {
+		$this->Html->request->webroot = '';
+		$this->Html->image('non-existent-image.png', array('base64' => true));
+	}
+
+/**
  * test theme assets in main webroot path
  *
  * @return void


### PR DESCRIPTION
This allows you to do something like:

```
<?= $this->Html->image('cake.icon.png', ['base64' => true]); ?>
```

and get the following (long) output:

```
<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA1FJREFUeNqsVF1IU2EYfraF5U951P0wnTidP/kzm5GZuygNDSWhQRnECMohhgnRnRcpKgQSqGhCEIhLJhkUGhGu0JwiXqSYQyddhG6EG7bQ/E1ccfq+D3fYULvyufgO53vf85zn/RXxPI+jxDF6iEQi4aK0tNRAHtdUKpUuOjpaJ5fLoVAomG1hYQFbW1twuVy2tbW1GXL1YnBwcMb/LRUnYgchpESxsbFtZWVl6vz8fIHkMFDyoaEhjIyMUPKHlJhFSw9C1mCxWPiDMDExwbe0tLDn5ubmPju9a2pq4glHgaCwtraWb25uPlRNTU0NUbwEj+cvpNIMpKVpQaNISkpidpoGk8k009fXl8NySPP0P1RVVaGr6xGKr4SSt0UsLzvR2/sBP5bFkCs0jDwiIoITikJzUVxcDK1WeyAhvc/IuEoUfoRSKYFKFYbUFBnCwmQQIRLfvtnhdrtZccR739jM5ka0traSvy8fSGo0GjE1KcGobQcu5x9IJCGQiEOoMkhjmDi7oJDg1+3b8SQXIeju7sTurgSJiUmIi1NBrVaD4yKxsrKKrKw8zM+P4uvX3xgetiM9XYnTaYlYX/dRjplAQrvF4jFUVuaguroQoaEq5rS46ITD4YDX62VOHMeRFhPDYEiAWMQR+y7mHN9JyG4mKpDQubq6i8eP36O8nEdJSRxIUyMmRhoU9tjYGN6988Fm8yL33Cmcz03FpYtSPO3sR3vHc1sQoUYTgdzcbFitn/HmzSdSOT30ej1rjfDwcObk8/mQnHwSUVFhGHg7T1IzhzPZqVhye51Bo0fjHx//SRxXUF9/DxsbxzE15cDAwAArEp0KP/R6OfLy4lFYcBY7OycwPe0iud8RCIXRM5mu8/HxMYzMaLwFnS6P5SsQVqsVHR0dNq1Woc6/kKnOyswgefSirf1VIxm9BsrlV0j6aNtcUXH5zvZ2JNrbn5F26EVRURE0Gg0CFwTB6JMn5kI6+0ql/YFcFlXgr3CQQuLAJSTIFuvq7nMyWQomJ+dZlWdnZwWFZG5p+HeJGnPAdlKTd6d/2yBwHxKj7ubNG196erp4j8e9bxH09/ezJXDYiAaFTLG323I2NrYML1++Fnai337YFAVCdNQbW4wjxj8BBgDSNqdSpFi+eQAAAABJRU5ErkJggg==" alt=""/>
```

I've included a test for this, and it passes the rest of the tests.

Considerations:

1) No base64'ing a remote image. Can we rely on [allow-url-fopen](http://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen) being enabled? Should I check for the flag and allow you to do it?

2) There's no mime checking, but then again you can currently use image on anything you feel like, so should this code follow convention?

3) How best to handle the case of being unable to file_get_contents? Ideally I'd like to throw, but this would introduce a thrown exception into something that doesn't already throw. 

If this looks all ok, I'll forward-port this to 3.x (I did it into 2.x first as that's what I know better)

Requested by cakephp/cakephp#9560
