### PR TITLE
getMockForModel should use the correct alias for plugin models

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -670,6 +670,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         }
 
         TableRegistry::set($baseClass, $mock);
+        TableRegistry::set($alias, $mock);
 
         return $mock;
     }

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -490,6 +490,7 @@ class TestCaseTest extends TestCase
 
         $result = TableRegistry::get('TestPlugin.TestPluginComments');
         $this->assertInstanceOf('TestPlugin\Model\Table\TestPluginCommentsTable', $result);
+        $this->assertSame($TestPluginComment, $result);
 
         $TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments', ['save']);
 


### PR DESCRIPTION
When using `getMockForModel` with a plugin model, the mock is not injected into the table registry with the full plugin alias, but just the base table/model name.
