### PR TITLE
Checking for presence of _method and using over getMethod() in RoutingMiddleware

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -40,7 +40,9 @@ class RoutingMiddleware
             $params = (array)$request->getAttribute('params', []);
             if (empty($params['controller'])) {
                 $path = $request->getUri()->getPath();
-                $request = $request->withAttribute('params', Router::parse($path, $request->getMethod()));
+                $parsedBody = $request->getParsedBody();
+                $method = is_array($parsedBody) && isset($parsedBody['_method']) ? $parsedBody['_method'] : $request->getMethod();
+                $request = $request->withAttribute('params', Router::parse($path, $method));
             }
         } catch (RedirectException $e) {
             return new RedirectResponse(

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -39,10 +39,17 @@ class RoutingMiddleware
             Router::setRequestContext($request);
             $params = (array)$request->getAttribute('params', []);
             if (empty($params['controller'])) {
-                $path = $request->getUri()->getPath();
                 $parsedBody = $request->getParsedBody();
-                $method = is_array($parsedBody) && isset($parsedBody['_method']) ? $parsedBody['_method'] : $request->getMethod();
-                $request = $request->withAttribute('params', Router::parse($path, $method));
+                if (is_array($parsedBody) && isset($parsedBody['_method'])) {
+                    $request = $request->withMethod($parsedBody['_method']);
+                }
+                $request = $request->withAttribute(
+                    'params',
+                    Router::parse(
+                        $request->getUri()->getPath(),
+                        $request->getMethod()
+                    )
+                );
             }
         } catch (RedirectException $e) {
             return new RedirectResponse(

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -133,4 +133,33 @@ class RoutingMiddlewareTest extends TestCase
         $middleware = new RoutingMiddleware();
         $middleware($request, $response, $next);
     }
+
+    /**
+     * Test route with _method being parsed correctly.
+     *
+     * @return void
+     */
+    public function testFakedRequestMethodParsed()
+    {
+        Router::connect('/articles-patch', [
+            'controller' => 'Articles',
+            'action' => 'index',
+            '_method' => 'PATCH'
+        ]);
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles-patch'], null, ['_method' => 'PATCH']);
+        $response = new Response();
+        $next = function ($req, $res) {
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'index',
+                '_method' => 'PATCH',
+                'plugin' => null,
+                'pass' => [],
+                '_matchedRoute' => '/articles-patch'
+            ];
+            $this->assertEquals($expected, $req->getAttribute('params'));
+        };
+        $middleware = new RoutingMiddleware();
+        $middleware($request, $response, $next);
+    }
 }

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -146,7 +146,14 @@ class RoutingMiddlewareTest extends TestCase
             'action' => 'index',
             '_method' => 'PATCH'
         ]);
-        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles-patch'], null, ['_method' => 'PATCH']);
+        $request = ServerRequestFactory::fromGlobals(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/articles-patch'
+            ],
+            null,
+            ['_method' => 'PATCH']
+        );
         $response = new Response();
         $next = function ($req, $res) {
             $expected = [

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -165,6 +165,7 @@ class RoutingMiddlewareTest extends TestCase
                 '_matchedRoute' => '/articles-patch'
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
+            $this->assertEquals('PATCH', $req->getMethod());
         };
         $middleware = new RoutingMiddleware();
         $middleware($request, $response, $next);


### PR DESCRIPTION
This is a:
- [x] bug
- [ ] enhancement
- [ ] feature-discussion (RFC)
- CakePHP Version: b03309f
### What you did

Used `_method` in the body of the request to fake a `PATCH` request.
### Expected Behavior

Route is correctly matched.
### Actual Behavior

`Cake\Core\Exception\Exception\MissingRouteException` is thrown.
