### PR TITLE
[Bugfix] use Model::$cacheQueries as default for ->query(...) (#9575)

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3453,12 +3453,18 @@ class Model extends CakeObject implements CakeEventListener {
  * - 3rd param: If 2nd argument is provided, a boolean flag for enabling/disabled
  *   query caching.
  *
+ * If the query cache param as 2nd or 3rd argument is not given then the model's default $cacheQueries value is used.
+ *
  * @param string $sql SQL statement
  * @return mixed Resultset array or boolean indicating success / failure depending on the query executed
  * @link http://book.cakephp.org/2.0/en/models/retrieving-your-data.html#model-query
  */
 	public function query($sql) {
 		$params = func_get_args();
+		// use $this->cacheQueries as default when argument not explicitly given already
+		if (count($params) === 1 || count($params) === 2 && !is_bool($params[1])) {
+			$params[] = $this->cacheQueries;
+		}
 		$db = $this->getDataSource();
 		return call_user_func_array(array(&$db, 'query'), $params);
 	}

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -403,7 +403,7 @@ class ModelReadTest extends BaseModelTest {
 		$query .= '.id = ? AND ' . $this->db->fullTableName('articles') . '.published = ?';
 
 		$params = array(1, 'Y');
-		$result = $Article->query($query, $params);
+		$result = $Article->query($query, $params, true);
 		$expected = array(
 			'0' => array(
 				$this->db->fullTableName('articles', false, false) => array(
@@ -438,7 +438,7 @@ class ModelReadTest extends BaseModelTest {
 		$query .= ' WHERE ' . $this->db->fullTableName('articles') . '.title LIKE ?';
 
 		$params = array('%First%');
-		$result = $Article->query($query, $params);
+		$result = $Article->query($query, $params, true);
 		$this->assertTrue(is_array($result));
 		$this->assertTrue(
 			isset($result[0][$this->db->fullTableName('articles', false, false)]['title']) ||
@@ -449,7 +449,7 @@ class ModelReadTest extends BaseModelTest {
 		$query = 'SELECT title FROM ';
 		$query .= $this->db->fullTableName('articles') . ' WHERE title = ? AND published = ?';
 		$params = array('First? Article', 'Y');
-		$Article->query($query, $params);
+		$Article->query($query, $params, true);
 
 		$result = $this->db->getQueryCache($query, $params);
 		$this->assertFalse($result === false);
@@ -8530,5 +8530,89 @@ class ModelReadTest extends BaseModelTest {
 			)
 		);
 		$this->assertEquals($expected, $results, 'Model related with belongsTo afterFind callback fails');
+	}
+
+	public static function extractUserNameFromQueryResult(array $result) {
+		return isset($result[0][0]) ? $result[0][0]['user'] : $result[0]['u']['user'];
+	}
+
+	public function testQueryRespectsCacheQueriesAsSecondArgument() {
+		$model = new User();
+		$model->save(array('user' => 'Chuck'));
+		$userTableName = $this->db->fullTableName('users');
+
+		$getUserNameFromDb = function ($cacheArgument) use ($model, $userTableName) {
+			$query = sprintf('SELECT u.user FROM %s u WHERE id=%d', $userTableName, $model->id);
+			$users = $model->query($query, $cacheArgument);
+			return ModelReadTest::extractUserNameFromQueryResult($users);
+		};
+
+		$model->cacheQueries = true;
+		$this->assertSame('Chuck', $getUserNameFromDb(true));
+		$this->assertSame('Chuck', $getUserNameFromDb(false));
+
+		$model->updateAll(array('User.user' => "'Sylvester'"), array('User.id' => $model->id));
+
+		$model->cacheQueries = false;
+		$this->assertSame('Chuck', $getUserNameFromDb(true));
+		$this->assertSame('Sylvester', $getUserNameFromDb(false));
+	}
+
+	public function testQueryRespectsCacheQueriesAsThirdArgument() {
+		$model = new User();
+		$model->save(array('user' => 'Chuck'));
+		$userTableName = $this->db->fullTableName('users');
+
+		$getUserNameFromDb = function ($cacheArgument) use ($model, $userTableName) {
+			$query = sprintf('SELECT u.user FROM %s u WHERE id=?', $userTableName);
+			$users = $model->query($query, array($model->id), $cacheArgument);
+			return ModelReadTest::extractUserNameFromQueryResult($users);
+		};
+
+		$model->cacheQueries = true;
+		$this->assertSame('Chuck', $getUserNameFromDb(true));
+		$this->assertSame('Chuck', $getUserNameFromDb(false));
+		$model->updateAll(array('User.user' => "'Sylvester'"), array('User.id' => $model->id));
+		$model->cacheQueries = false;
+		$this->assertSame('Chuck', $getUserNameFromDb(true));
+		$this->assertSame('Sylvester', $getUserNameFromDb(false));
+	}
+
+	public function testQueryTakesModelCacheQueriesValueAsDefaultForOneArgument() {
+		$model = new User();
+		$model->save(array('user' => 'Chuck'));
+		$userTableName = $this->db->fullTableName('users');
+
+		$getUserNameFromDb = function () use ($model, $userTableName) {
+			$query = sprintf('SELECT u.user FROM %s u WHERE id=%d', $userTableName, $model->id);
+			$users = $model->query($query);
+			return ModelReadTest::extractUserNameFromQueryResult($users);
+		};
+
+		$model->cacheQueries = true;
+		$this->assertSame('Chuck', $getUserNameFromDb());
+		$model->updateAll(array('User.user' => "'Sylvester'"), array('User.id' => $model->id));
+		$this->assertSame('Chuck', $getUserNameFromDb());
+		$model->cacheQueries = false;
+		$this->assertSame('Sylvester', $getUserNameFromDb());
+	}
+
+	public function testQueryTakesModelCacheQueriesValueAsDefaultForTwoArguments() {
+		$model = new User();
+		$model->save(array('user' => 'Chuck'));
+		$userTableName = $this->db->fullTableName('users');
+
+		$getUserNameFromDb = function () use ($model, $userTableName) {
+			$query = sprintf('SELECT u.user FROM %s u WHERE id=?', $userTableName);
+			$users = $model->query($query, array($model->id));
+			return ModelReadTest::extractUserNameFromQueryResult($users);
+		};
+
+		$model->cacheQueries = true;
+		$this->assertSame('Chuck', $getUserNameFromDb());
+		$model->updateAll(array('User.user' => "'Sylvester'"), array('User.id' => $model->id));
+		$this->assertSame('Chuck', $getUserNameFromDb());
+		$model->cacheQueries = false;
+		$this->assertSame('Sylvester', $getUserNameFromDb());
 	}
 }


### PR DESCRIPTION
This is my attempt of fixing https://github.com/cakephp/cakephp/issues/9575.

Note: I never worked with cakephp before :see_no_evil: 
