### PR TITLE
Move tests for Http\Client.

### DIFF
--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http\Adapter;
+namespace Cake\Test\TestCase\Http\Client\Adapter;
 
 use Cake\Http\Client\Adapter\Stream;
 use Cake\Http\Client\Request;

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http\Auth;
+namespace Cake\Test\TestCase\Http\Client\Auth;
 
 use Cake\Http\Client;
 use Cake\Http\Client\Auth\Digest;

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http\Auth;
+namespace Cake\Test\TestCase\Http\Client\Auth;
 
 use Cake\Http\Client\Auth\Oauth;
 use Cake\Http\Client\Request;

--- a/tests/TestCase/Http/Client/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Client/CookieCollectionTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http;
+namespace Cake\Test\TestCase\Http\Client;
 
 use Cake\Http\Client\CookieCollection;
 use Cake\Http\Client\Response;

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http;
+namespace Cake\Test\TestCase\Http\Client;
 
 use Cake\Http\Client\FormData;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http;
+namespace Cake\Test\TestCase\Http\Client;
 
 use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http;
+namespace Cake\Test\TestCase\Http\Client;
 
 use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -11,7 +11,7 @@
  * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Network\Http;
+namespace Cake\Test\TestCase\Http;
 
 use Cake\Core\Configure;
 use Cake\Http\Client;


### PR DESCRIPTION
The code was moved in 3.3 and the tests were left alone to ensure backwards compat. Now that development on the client has completed, moving the tests makes sense.
