### PR TITLE
Remove double table registry set

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -670,7 +670,6 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         }
 
         TableRegistry::set($baseClass, $mock);
-        TableRegistry::set($alias, $mock);
 
         return $mock;
     }

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -484,7 +484,6 @@ class TestCaseTest extends TestCase
 
         $result = TableRegistry::get('TestPlugin.TestPluginComments');
         $this->assertInstanceOf('TestPlugin\Model\Table\TestPluginCommentsTable', $result);
-        $this->assertSame($TestPluginComment, $result);
 
         $TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments', ['save']);
 


### PR DESCRIPTION
Remove the double `TableRegistry::set()` in the `getMockForModel` method. Hopefully solves the segfault on travis.
