### PR TITLE
Add missing type cast

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -108,7 +108,7 @@ class FlashComponent extends Component
 
         $messages = [];
         if ($options['clear'] === false) {
-            $messages = $this->_session->read('Flash.' . $options['key']);
+            $messages = (array)$this->_session->read('Flash.' . $options['key']);
         }
 
         $messages[] = [


### PR DESCRIPTION
It is cleaner to cast to an array when the stack is empty and null is returned.
