### PR TITLE
Simplify Auth flash to be consistent with default Flash error type.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -473,8 +473,8 @@ class AuthComponent extends Component
         $defaults = [
             'authenticate' => ['Form'],
             'flash' => [
-                'element' => 'default',
-                'key' => 'auth',
+                'element' => 'error',
+                'key' => 'flash',
                 'params' => ['class' => 'error']
             ],
             'loginAction' => [

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -37,11 +37,11 @@ class AuthComponentTest extends TestCase
 {
 
     /**
-     * name property
+     * AuthComponent property
      *
-     * @var string
+     * @var \TestApp\Controller\Component\TestAuthComponent
      */
-    public $name = 'Auth';
+    public $Auth;
 
     /**
      * fixtures property
@@ -223,7 +223,7 @@ class AuthComponentTest extends TestCase
         $result = $this->Controller->Auth->startup($event);
         $this->assertTrue($event->isStopped());
         $this->assertInstanceOf('Cake\Network\Response', $result);
-        $this->assertTrue($this->Auth->session->check('Flash.auth'));
+        $this->assertTrue($this->Auth->session->check('Flash.flash'));
 
         $this->Controller->request->addParams(Router::parse('auth_test/camelCase'));
         $result = $this->Controller->Auth->startup($event);
@@ -1309,7 +1309,7 @@ class AuthComponentTest extends TestCase
                 'Auth failure',
                 [
                     'key' => 'auth-key',
-                    'element' => 'default',
+                    'element' => 'error',
                     'params' => ['class' => 'error']
                 ]
             );


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/9614

Will also need a small note in the migration guide that

```
<?= $this->Flash->render('auth') ?>
<?= $this->Flash->render() ?>
```

can now be simplified back to

```
<?= $this->Flash->render() ?>
```
