### PR TITLE
2.next - Allow image inline in templates and use of mime_content_type in function attachments.

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1727,11 +1727,13 @@ class CakeEmail {
 			$rendered['html'] = str_replace(array('file:', 'file://', 'cid://'), 'cid:', $rendered['html']);
 			if (preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $img)) {
 				$img = array_unique($img[2]);
-				foreach ($img as $file) if (is_file($file)) {
-					$cid = sha1($file);
-					$images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
-					$files['cid:' . $cid] = $file;
-					$cids['cid:' . $cid] = $cid;
+				foreach ($img as $file) {
+					if (is_file($file)) {
+						$cid = sha1($file);
+						$images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
+						$files['cid:' . $cid] = $file;
+						$cids['cid:' . $cid] = $cid;
+					}
 				}
 				$this->addAttachments($images);
 				$rendered['html'] = str_replace($files, $cids, $rendered['html']);

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1733,7 +1733,7 @@ class CakeEmail {
 				if (is_file($file)) {
 					$cid = sha1($file);
 					$images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
-					$files['cid:' . $cid] = '~(<img[^>]*src\s*=\s*)(["\'])(cid://|file://|cid:|file:)' . str_replace('\\', '\\\\', $file) . '\2~iU';
+					$files['cid:' . $cid] = '~(<img[^>]*src\s*=\s*)(["\'])(cid://|file://|cid:|file:)' . preg_quote($file) . '\2~iU';
 					$cids['cid:' . $cid] = '\1\2cid:' . $cid . '\2';
 				}
 			}

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1724,19 +1724,22 @@ class CakeEmail {
 
 		/* Embed images inline in html templates */
 		if (!empty($rendered['html'])) {
-			$rendered['html'] = str_replace(array('file:', 'file://', 'cid://'), 'cid:', $rendered['html']);
-			if (preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $img)) {
-				$img = array_unique($img[2]);
-				foreach ($img as $file) {
-					if (is_file($file)) {
-						$cid = sha1($file);
-						$images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
-						$files['cid:' . $cid] = $file;
-						$cids['cid:' . $cid] = $cid;
-					}
+			preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', print_r($this->viewVars, true), $userFiles);
+			$userFiles = array_unique($userFiles[3]);
+			preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', $rendered['html'], $embebFiles);
+			$embebFiles = array_unique($embebFiles[3]);
+			$embebFiles = array_diff($embebFiles, $userFiles);
+			foreach ($embebFiles as $file) {
+				if (is_file($file)) {
+					$cid = sha1($file);
+					$images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
+					$files['cid:' . $cid] = '~(<img[^>]*src\s*=\s*)(["\'])(cid://|file://|cid:|file:)' . str_replace('\\', '\\\\', $file) . '\2~iU';
+					$cids['cid:' . $cid] = '\1\2cid:' . $cid . '\2';
 				}
+			}
+			if (!empty($images)) {
 				$this->addAttachments($images);
-				$rendered['html'] = str_replace($files, $cids, $rendered['html']);
+				$rendered['html'] = preg_replace($files, $cids, $rendered['html']);
 			}
 		}
 		return $rendered;

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1724,7 +1724,7 @@ class CakeEmail {
 
 		/* Embed images inline in html templates */
 		if (!empty($rendered['html'])) {
-			preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', print_r($this->viewVars, true), $userFiles);
+			preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', serialize($this->viewVars), $userFiles);
 			$userFiles = array_unique($userFiles[3]);
 			preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', $rendered['html'], $embebFiles);
 			$embebFiles = array_unique($embebFiles[3]);
@@ -1732,7 +1732,7 @@ class CakeEmail {
 			foreach ($embebFiles as $file) {
 				if (is_file($file)) {
 					$cid = sha1($file);
-					$images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
+					$images['cid:' . $cid] = ['file' => $file, 'contentId' => $cid];
 					$files['cid:' . $cid] = '~(<img[^>]*src\s*=\s*)(["\'])(cid://|file://|cid:|file:)' . preg_quote($file) . '\2~iU';
 					$cids['cid:' . $cid] = '\1\2cid:' . $cid . '\2';
 				}


### PR DESCRIPTION
Use of mime_content_type in function attachments.

Allowing image inline in templates:

``` php
  <img src="cid:/full/path/image">
  <img src="cid:///full/path/image">
  <img src="file:/full/path/image">
  <img src="file:///full/path/image">
  echo $this->Html->image('cid:///full/path/image');
  echo $this->Html->image('file:///full/path/image');
```

This changes are compatible with CakePHP 2.x and 3.x

https://github.com/fawno/FawnoEmail
