### PR TITLE
3.next - Allow image inline in templates and use of mime_content_type in function attachments.

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1931,7 +1931,7 @@ class Email implements JsonSerializable, Serializable
 
         /* Embed images inline in html templates */
         if (!empty($rendered['html'])) {
-            preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', print_r($this->viewVars, true), $userFiles);
+            preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', serialize($this->viewVars), $userFiles);
             $userFiles = array_unique($userFiles[3]);
             preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', $rendered['html'], $embebFiles);
             $embebFiles = array_unique($embebFiles[3]);

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1931,12 +1931,13 @@ class Email implements JsonSerializable, Serializable
 
         /* Embed images inline in html templates */
         if (!empty($rendered['html'])) {
-            $rendered['html'] = str_replace(array('file:', 'file://', 'cid://'), 'cid:', $rendered['html']);
-            if (preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $img)) {
+            $rendered['html'] = str_replace(['file:', 'file://', 'cid://'], 'cid:', $rendered['html']);
+            $embed_images = preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $img);
+            if ($embed_images) {
                 $img = array_unique($img[2]);
                 foreach ($img as $file) if (is_file($file)) {
                     $cid = sha1($file);
-                    $images['cid:' . $cid] = array('file' => $file, 'contentId' => $cid);
+                    $images['cid:' . $cid] = ['file' => $file, 'contentId' => $cid];
                     $files['cid:' . $cid] = $file;
                     $cids['cid:' . $cid] = $cid;
                 }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1935,11 +1935,13 @@ class Email implements JsonSerializable, Serializable
             $hasEmbedImages = preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $embedImages);
             if ($hasEmbedImages > 0) {
                 $embedImages = array_unique($embedImages[2]);
-                foreach ($embedImages as $file) if (is_file($file)) {
-                    $cid = sha1($file);
-                    $images['cid:' . $cid] = ['file' => $file, 'contentId' => $cid];
-                    $files['cid:' . $cid] = $file;
-                    $cids['cid:' . $cid] = $cid;
+                foreach ($embedImages as $file) {
+                    if (is_file($file)) {
+                        $cid = sha1($file);
+                        $images['cid:' . $cid] = ['file' => $file, 'contentId' => $cid];
+                        $files['cid:' . $cid] = $file;
+                        $cids['cid:' . $cid] = $cid;
+                    }
                 }
                 $this->addAttachments($images);
                 $rendered['html'] = str_replace($files, $cids, $rendered['html']);

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1932,10 +1932,10 @@ class Email implements JsonSerializable, Serializable
         /* Embed images inline in html templates */
         if (!empty($rendered['html'])) {
             $rendered['html'] = str_replace(['file:', 'file://', 'cid://'], 'cid:', $rendered['html']);
-            $embed_images = preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $img);
-            if ($embed_images) {
-                $img = array_unique($img[2]);
-                foreach ($img as $file) if (is_file($file)) {
+            $hasEmbedImages = preg_match_all('~(["\'])cid:([^\1]+)\1~iU', $rendered['html'], $embedImages);
+            if ($hasEmbedImages > 0) {
+                $embedImages = array_unique($embedImages[2]);
+                foreach ($embedImages as $file) if (is_file($file)) {
                     $cid = sha1($file);
                     $images['cid:' . $cid] = ['file' => $file, 'contentId' => $cid];
                     $files['cid:' . $cid] = $file;

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1942,6 +1942,7 @@ class Email implements JsonSerializable, Serializable
                 }
             }
             if (!empty($images)) {
+                $this->addAttachments($images);
                 $rendered['html'] = preg_replace($files, $cids, $rendered['html']);
             }
         }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1940,7 +1940,7 @@ class Email implements JsonSerializable, Serializable
                 if (is_file($file)) {
                     $cid = sha1($file);
                     $images['cid:' . $cid] = ['file' => $file, 'contentId' => $cid];
-                    $files['cid:' . $cid] = '~(<img[^>]*src\s*=\s*)(["\'])(cid://|file://|cid:|file:)' . $file . '\2~iU';
+                    $files['cid:' . $cid] = '~(<img[^>]*src\s*=\s*)(["\'])(cid://|file://|cid:|file:)' . preg_quote($file) . '\2~iU';
                     $cids['cid:' . $cid] = '\1\2cid:' . $cid . '\2';
                 }
             }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1931,8 +1931,11 @@ class Email implements JsonSerializable, Serializable
 
         /* Embed images inline in html templates */
         if (!empty($rendered['html'])) {
+            preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', print_r($this->viewVars, true), $userFiles);
+            $userFiles = array_unique($userFiles[3]);
             preg_match_all('~<img[^>]*src\s*=\s*(["\'])(cid://|file://|cid:|file:)([^\1]+)\1~iU', $rendered['html'], $embebFiles);
             $embebFiles = array_unique($embebFiles[3]);
+            $embebFiles = array_diff($embebFiles, $userFiles);
             foreach ($embebFiles as $file) {
                 if (is_file($file)) {
                     $cid = sha1($file);


### PR DESCRIPTION
Use of mime_content_type in function attachments.

Allowing image inline in templates:

``` php
  <img src="cid:/full/path/image">
  <img src="cid:///full/path/image">
  <img src="file:/full/path/image">
  <img src="file:///full/path/image">
  echo $this->Html->image('cid:///full/path/image');
  echo $this->Html->image('file:///full/path/image');
```

This changes are compatible with CakePHP 2.x and 3.x

https://github.com/fawno/FawnoEmail
