### PR TITLE
Improvements for PaginatorHelper

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1116,7 +1116,7 @@ class PaginatorHelper extends Helper
      */
     public function meta(array $options = [])
     {
-        $options = $options + [
+        $options += [
                 'model' => null,
                 'block' => false,
                 'prev' => true,
@@ -1151,7 +1151,7 @@ class PaginatorHelper extends Helper
             $options['block'] = __FUNCTION__;
         }
 
-        if (!empty($options['block'])) {
+        if ($options['block']) {
             $this->_View->append($options['block'], $out);
 
             return null;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -195,6 +195,23 @@ class PaginatorHelper extends Helper
     }
 
     /**
+     * Gets the total number of pages in the recordset for the given model.
+     *
+     * @param string|null $model Optional model name. Uses the default if none is specified.
+     * @return int The total pages for the recordset.
+     */
+    public function total($model = null)
+    {
+        $params = $this->params($model);
+
+        if (isset($params['pageCount'])) {
+            return $params['pageCount'];
+        }
+
+        return 0;
+    }
+
+    /**
      * Gets the current key by which the recordset is sorted
      *
      * @param string|null $model Optional model name. Uses the default if none is specified.
@@ -482,9 +499,6 @@ class PaginatorHelper extends Helper
      */
     public function generateUrl(array $options = [], $model = null, $urlOptions = false)
     {
-        $paging = $this->params($model);
-        $paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
-
         if (!is_array($urlOptions)) {
             $urlOptions = ['fullBase' => $urlOptions];
         }
@@ -492,6 +506,21 @@ class PaginatorHelper extends Helper
             'escape' => true,
             'fullBase' => false
         ];
+
+        return $this->Url->build($this->generateUrlParams($options, $model), $urlOptions);
+    }
+
+    /**
+     * Merges passed URL options with current pagination state to generate a pagination URL.
+     *
+     * @param array $options Pagination/URL options array
+     * @param string|null $model Which model to paginate on
+     * @return array An array of URL parameters
+     */
+    public function generateUrlParams(array $options = [], $model = null)
+    {
+        $paging = $this->params($model);
+        $paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
 
         $url = [
             'page' => $paging['page'],
@@ -519,6 +548,7 @@ class PaginatorHelper extends Helper
         ) {
             $url['sort'] = $url['direction'] = null;
         }
+
         if (!empty($paging['scope'])) {
             $scope = $paging['scope'];
             $currentParams = $this->_config['options']['url'];
@@ -533,7 +563,7 @@ class PaginatorHelper extends Helper
             }
         }
 
-        return $this->Url->build($url, $urlOptions);
+        return $url;
     }
 
     /**
@@ -1076,40 +1106,58 @@ class PaginatorHelper extends Helper
      *
      * - `model` The model to use defaults to PaginatorHelper::defaultModel()
      * - `block` The block name to append the output to, or false/absenst to return as a string
+     * - `prev` (default True) True to generate meta for previous page
+     * - `next` (default True) True to generate meta for next page
+     * - `first` (default False) True to generate meta for first page
+     * - `last` (default False) True to generate meta for last page
      *
      * @param array $options Array of options
      * @return string|null Meta links
      */
     public function meta(array $options = [])
     {
+        $options = $options + [
+                'model' => null,
+                'block' => false,
+                'prev' => true,
+                'next' => true,
+                'first' => false,
+                'last' => false
+            ];
+
         $model = isset($options['model']) ? $options['model'] : null;
         $params = $this->params($model);
         $links = [];
 
-        if ($this->hasPrev()) {
-            $links[] = $this->Html->templater()->format('css', [
-                'rel' => 'prev',
-                'url' => $this->generateUrl(['page' => $params['page'] - 1], null, true)
-            ]);
+        if ($options['prev'] && $this->hasPrev()) {
+            $links[] = $this->Html->meta('prev', $this->generateUrl(['page' => $params['page'] - 1], null, true));
         }
 
-        if ($this->hasNext()) {
-            $links[] = $this->Html->templater()->format('css', [
-                'rel' => 'next',
-                'url' => $this->generateUrl(['page' => $params['page'] + 1], null, true)
-            ]);
+        if ($options['next'] && $this->hasNext()) {
+            $links[] = $this->Html->meta('next', $this->generateUrl(['page' => $params['page'] + 1], null, true));
+        }
+
+        if ($options['first']) {
+            $links[] = $this->Html->meta('first', $this->generateUrl(['page' => 1], null, true));
+        }
+
+        if ($options['last']) {
+            $links[] = $this->Html->meta('last', $this->generateUrl(['page' => $params['pageCount']], null, true));
         }
 
         $out = implode($links);
 
-        if (empty($options['block'])) {
-            return $out;
-        }
-
         if ($options['block'] === true) {
             $options['block'] = __FUNCTION__;
         }
-        $this->_View->append($options['block'], $out);
+
+        if (!empty($options['block'])) {
+            $this->_View->append($options['block'], $out);
+
+            return null;
+        }
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
Adds the following to the helper
- moved core of generateUrl() to buildUrl() and returns a raw URL array of pagination parameters.
- generateUrl calls buildUrl()
- added total() which returns page count.
- added to meta() support for generating first and last meta links
- The object of the PR is to allow developers to generate pagination URLs in their array format for easier modification outside of the helper.

closes #9503
