### PR TITLE
Body should default to null for GET requests with Http Client

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -200,7 +200,7 @@ class Client
     public function get($url, $data = [], array $options = [])
     {
         $options = $this->_mergeOptions($options);
-        $body = [];
+        $body = null;
         if (isset($data['_content'])) {
             $body = $data['_content'];
             unset($data['_content']);


### PR DESCRIPTION
When using Http Client to make a GET request the `Content-Type` header is always set to `application/x-www-form-urlencoded` even if the header is explicitly set. According to `Cake\Http\Client\Request::body` we should leave `$body` set to null for GET requests.

There's a poorly written API I have to deal with that will not accept GET requests unless Content-Type is not set or is set appropriately.
