### PR TITLE
Adding $params argument to prefix() method of RouteBuilder.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -606,6 +606,9 @@ class RouteBuilder
     public function prefix($name, $params = [], callable $callback = null)
     {
         if ($callback === null) {
+            if (!is_callable($params)) {
+                throw new InvalidArgumentException('A valid callback is expected');
+            }
             $callback = $params;
             $params = [];
         }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -596,17 +596,23 @@ class RouteBuilder
      * to the `Controller\Admin\Api\` namespace.
      *
      * @param string $name The prefix name to use.
-     * @param callable $callback The callback to invoke that builds the prefixed routes.
+     * @param array|callable $params An array of routing defaults to add to each connected route.
+     *   If you have no parameters, this argument can be a callable.
+     * @param callable|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
      */
-    public function prefix($name, callable $callback)
+    public function prefix($name, $params = [], callable $callback = null)
     {
+        if ($callback === null) {
+            $callback = $params;
+            $params = [];
+        }
         $name = Inflector::underscore($name);
         $path = '/' . $name;
         if (isset($this->_params['prefix'])) {
             $name = $this->_params['prefix'] . '/' . $name;
         }
-        $params = ['prefix' => $name];
+        $params = array_merge($params, ['prefix' => $name]);
         $this->scope($path, $params, $callback);
     }
 

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -20,7 +20,6 @@ use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 
-
 /**
  * Provides features for building routes inside scopes.
  *

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -20,6 +20,7 @@ use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 
+
 /**
  * Provides features for building routes inside scopes.
  *
@@ -600,6 +601,7 @@ class RouteBuilder
      *   If you have no parameters, this argument can be a callable.
      * @param callable|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
+     * @throws \InvalidArgumentException If a valid callback is not passed
      */
     public function prefix($name, $params = [], callable $callback = null)
     {

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -306,7 +306,24 @@ class RouteBuilderTest extends TestCase
     public function testPrefix()
     {
         $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
-        $res = $routes->prefix('admin', ['key' => 'value'], function ($r) {
+        $res = $routes->prefix('admin', ['param' => 'value'], function ($r) {
+            $this->assertInstanceOf('Cake\Routing\RouteBuilder', $r);
+            $this->assertCount(0, $this->collection->routes());
+            $this->assertEquals('/path/admin', $r->path());
+            $this->assertEquals(['prefix' => 'admin', 'key' => 'value', 'param' => 'value'], $r->params());
+        });
+        $this->assertNull($res);
+    }
+
+    /**
+     * Test creating sub-scopes with prefix()
+     *
+     * @return void
+     */
+    public function testPrefixWithNoParams()
+    {
+        $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
+        $res = $routes->prefix('admin', function ($r) {
             $this->assertInstanceOf('Cake\Routing\RouteBuilder', $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertEquals('/path/admin', $r->path());

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -306,7 +306,7 @@ class RouteBuilderTest extends TestCase
     public function testPrefix()
     {
         $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
-        $res = $routes->prefix('admin', function ($r) {
+        $res = $routes->prefix('admin', ['key' => 'value'], function ($r) {
             $this->assertInstanceOf('Cake\Routing\RouteBuilder', $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertEquals('/path/admin', $r->path());
@@ -323,9 +323,10 @@ class RouteBuilderTest extends TestCase
     public function testNestedPrefix()
     {
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'admin']);
-        $res = $routes->prefix('api', function ($r) {
+        $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function ($r) {
             $this->assertEquals('/admin/api', $r->path());
             $this->assertEquals(['prefix' => 'admin/api'], $r->params());
+            $this->assertEquals('api:', $r->namePrefix());
         });
         $this->assertNull($res);
     }


### PR DESCRIPTION
Refers to #9631 
