### PR TITLE
Allow '' to be a valid key for Hash, and Session

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -230,8 +230,11 @@ class CakeSession {
  * @return bool True if variable is there
  */
 	public static function check($name) {
-		if (empty($name) || !static::_hasSession() || !static::start()) {
+		if (!static::_hasSession() || !static::start()) {
 			return false;
+		}
+		if (isset($_SESSION[$name])) {
+			return true;
 		}
 
 		return Hash::get($_SESSION, $name) !== null;
@@ -380,9 +383,6 @@ class CakeSession {
  *   session not started, or provided name not found in the session, false on failure.
  */
 	public static function read($name = null) {
-		if (empty($name) && $name !== null) {
-			return null;
-		}
 		if (!static::_hasSession() || !static::start()) {
 			return null;
 		}
@@ -418,7 +418,7 @@ class CakeSession {
  * @return bool True if the write was successful, false if the write failed
  */
 	public static function write($name, $value = null) {
-		if (empty($name) || !static::start()) {
+		if (!static::start()) {
 			return false;
 		}
 

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -307,9 +307,9 @@ class CakeSessionTest extends CakeTestCase {
  * @return void
  */
 	public function testWriteEmptyKey() {
-		$this->assertFalse(TestCakeSession::write('', 'graham'));
-		$this->assertFalse(TestCakeSession::write('', ''));
-		$this->assertFalse(TestCakeSession::write(''));
+		$this->assertTrue(TestCakeSession::write('', 'graham'));
+		$this->assertTrue(TestCakeSession::write('', ''));
+		$this->assertTrue(TestCakeSession::write(''));
 	}
 
 /**
@@ -401,6 +401,17 @@ class CakeSessionTest extends CakeTestCase {
 		$this->assertTrue(TestCakeSession::delete('Clearing'));
 		$this->assertFalse(TestCakeSession::check('Clearing.sale'));
 		$this->assertFalse(TestCakeSession::check('Clearing'));
+	}
+
+/**
+ * test delete
+ *
+ * @return void
+ */
+	public function testDeleteEmptyString() {
+		TestCakeSession::write('', 'empty string');
+		$this->assertTrue(TestCakeSession::delete(''));
+		$this->assertFalse(TestCakeSession::check(''));
 	}
 
 /**
@@ -500,6 +511,10 @@ class CakeSessionTest extends CakeTestCase {
  * @return void
  */
 	public function testReadingSavedEmpty() {
+		TestCakeSession::write('', 'empty string');
+		$this->assertTrue(TestCakeSession::check(''));
+		$this->assertEquals('empty string', TestCakeSession::read(''));
+
 		TestCakeSession::write('SessionTestCase', 0);
 		$this->assertEquals(0, TestCakeSession::read('SessionTestCase'));
 
@@ -511,7 +526,7 @@ class CakeSessionTest extends CakeTestCase {
 		$this->assertFalse(TestCakeSession::read('SessionTestCase'));
 
 		TestCakeSession::write('SessionTestCase', null);
-		$this->assertEquals(null, TestCakeSession::read('SessionTestCase'));
+		$this->assertNull(TestCakeSession::read('SessionTestCase'));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -230,6 +230,20 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Test that get() can extract '' key data.
+ *
+ * @return void
+ */
+	public function testGetEmptyKey()
+	{
+		$data = array(
+			'' => 'some value'
+		);
+		$result = Hash::get($data, '');
+		$this->assertSame($data[''], $result);
+	}
+
+/**
  * Test get() with an invalid path
  *
  * @expectedException InvalidArgumentException

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -234,8 +234,7 @@ class HashTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testGetEmptyKey()
-	{
+	public function testGetEmptyKey() {
 		$data = array(
 			'' => 'some value'
 		);

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -43,7 +43,7 @@ class Hash {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::get
  */
 	public static function get(array $data, $path, $default = null) {
-		if (empty($data) || $path === '' || $path === null) {
+		if (empty($data) || $path === null) {
 			return $default;
 		}
 		if (is_string($path) || is_numeric($path)) {


### PR DESCRIPTION
By removing a bunch of empty() guards we can make '' behave like all the other key names. This does change the existing behavior/tests around '' key, but I think that is ok given the need to manipulate ''.

Refs #9632
