### PR TITLE
replaces fieldList with fields

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -138,7 +138,7 @@ class Marshaller
      * - validate: Set to false to disable validation. Can also be a string of the validator ruleset to be applied.
      *   Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well. Defaults to null.
-     * - fieldList: (deprecated) use fields instead.
+     * - fieldList: (deprecated) Since 3.4.0. Use fields instead.
      * - fields: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used. Defaults to null.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields. Defaults to null
@@ -160,6 +160,7 @@ class Marshaller
      * @param array $options List of options
      * @return \Cake\ORM\Entity
      * @see \Cake\ORM\Table::newEntity()
+     * @see \Cake\ORM\Entity::$_accessible
      */
     public function one(array $data, array $options = [])
     {
@@ -197,10 +198,6 @@ class Marshaller
             } else {
                 $properties[$key] = $value;
             }
-        }
-
-        if (isset($options['fieldList'])) {
-            $options['fields'] = $options['fieldList'];
         }
 
         if (isset($options['fields'])) {
@@ -257,6 +254,11 @@ class Marshaller
     protected function _prepareDataAndOptions($data, $options)
     {
         $options += ['validate' => true];
+
+        if (!isset($options['fields']) && isset($options['fieldList'])) {
+            $options['fields'] = $options['fieldList'];
+            unset($options['fieldList']);
+        }
 
         $tableName = $this->_table->alias();
         if (isset($data[$tableName])) {
@@ -316,7 +318,7 @@ class Marshaller
      * - validate: Set to false to disable validation. Can also be a string of the validator ruleset to be applied.
      *   Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well. Defaults to null.
-     * - fieldList: (deprecated) use fields instead
+     * - fieldList: (deprecated) Since 3.4.0. Use fields instead
      * - fields: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used. Defaults to null.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields. Defaults to null
@@ -328,6 +330,7 @@ class Marshaller
      * @param array $options List of options
      * @return array An array of hydrated records.
      * @see \Cake\ORM\Table::newEntities()
+     * @see \Cake\ORM\Entity::$_accessible
      */
     public function many(array $data, array $options = [])
     {
@@ -496,7 +499,7 @@ class Marshaller
      * - associated: Associations listed here will be marshalled as well.
      * - validate: Whether or not to validate data before hydrating the entities. Can
      *   also be set to a string to use a specific validator. Defaults to true/default.
-     * - fieldList: (deprecated) use fields instead
+     * - fieldList: (deprecated) Since 3.4.0. Use fields instead
      * - fields: A whitelist of fields to be assigned to the entity. If not present
      *   the accessible fields list in the entity will be used.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
@@ -516,6 +519,7 @@ class Marshaller
      * @param array $data key value list of fields to be merged into the entity
      * @param array $options List of options.
      * @return \Cake\Datasource\EntityInterface
+     * @see \Cake\ORM\Entity::$_accessible
      */
     public function merge(EntityInterface $entity, array $data, array $options = [])
     {
@@ -565,10 +569,6 @@ class Marshaller
             $properties[$key] = $value;
         }
 
-        if (isset($options['fieldList'])) {
-            $options['fields'] = $options['fieldList'];
-        }
-
         $entity->errors($errors);
         if (!isset($options['fields'])) {
             $entity->set($properties);
@@ -614,7 +614,7 @@ class Marshaller
      * - validate: Whether or not to validate data before hydrating the entities. Can
      *   also be set to a string to use a specific validator. Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well.
-     * - fieldList: (deprecated) use fields instead
+     * - fieldList: (deprecated) Since 3.4.0. Use fields instead
      * - fields: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
@@ -624,6 +624,7 @@ class Marshaller
      * @param array $data list of arrays to be merged into the entities
      * @param array $options List of options.
      * @return array
+     * @see \Cake\ORM\Entity::$_accessible
      */
     public function mergeMany($entities, array $data, array $options = [])
     {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -20,7 +20,6 @@ use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Type;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\InvalidPropertyInterface;
-use Cake\ORM\PropertyMarshalInterface;
 use RuntimeException;
 
 /**
@@ -139,7 +138,8 @@ class Marshaller
      * - validate: Set to false to disable validation. Can also be a string of the validator ruleset to be applied.
      *   Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well. Defaults to null.
-     * - fieldList: A whitelist of fields to be assigned to the entity. If not present,
+     * - fieldList: (deprecated) use fields instead.
+     * - fields: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used. Defaults to null.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields. Defaults to null
      * - forceNew: When enabled, belongsToMany associations will have 'new' entities created
@@ -167,6 +167,7 @@ class Marshaller
 
         $primaryKey = (array)$this->_table->primaryKey();
         $entityClass = $this->_table->entityClass();
+        /* @var Entity $entity */
         $entity = new $entityClass();
         $entity->source($this->_table->registryAlias());
 
@@ -198,17 +199,18 @@ class Marshaller
             }
         }
 
-        if (!isset($options['fieldList'])) {
-            $entity->set($properties);
-            $entity->errors($errors);
-
-            return $entity;
+        if (isset($options['fieldList'])) {
+            $options['fields'] = $options['fieldList'];
         }
 
-        foreach ((array)$options['fieldList'] as $field) {
-            if (array_key_exists($field, $properties)) {
-                $entity->set($field, $properties[$field]);
+        if (isset($options['fields'])) {
+            foreach ((array)$options['fields'] as $field) {
+                if (array_key_exists($field, $properties)) {
+                    $entity->set($field, $properties[$field]);
+                }
             }
+        } else {
+            $entity->set($properties);
         }
 
         $entity->errors($errors);
@@ -314,7 +316,8 @@ class Marshaller
      * - validate: Set to false to disable validation. Can also be a string of the validator ruleset to be applied.
      *   Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well. Defaults to null.
-     * - fieldList: A whitelist of fields to be assigned to the entity. If not present,
+     * - fieldList: (deprecated) use fields instead
+     * - fields: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used. Defaults to null.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields. Defaults to null
      * - forceNew: When enabled, belongsToMany associations will have 'new' entities created
@@ -493,7 +496,8 @@ class Marshaller
      * - associated: Associations listed here will be marshalled as well.
      * - validate: Whether or not to validate data before hydrating the entities. Can
      *   also be set to a string to use a specific validator. Defaults to true/default.
-     * - fieldList: A whitelist of fields to be assigned to the entity. If not present
+     * - fieldList: (deprecated) use fields instead
+     * - fields: A whitelist of fields to be assigned to the entity. If not present
      *   the accessible fields list in the entity will be used.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
      *
@@ -561,8 +565,12 @@ class Marshaller
             $properties[$key] = $value;
         }
 
+        if (isset($options['fieldList'])) {
+            $options['fields'] = $options['fieldList'];
+        }
+
         $entity->errors($errors);
-        if (!isset($options['fieldList'])) {
+        if (!isset($options['fields'])) {
             $entity->set($properties);
 
             foreach ($properties as $field => $value) {
@@ -574,7 +582,7 @@ class Marshaller
             return $entity;
         }
 
-        foreach ((array)$options['fieldList'] as $field) {
+        foreach ((array)$options['fields'] as $field) {
             if (array_key_exists($field, $properties)) {
                 $entity->set($field, $properties[$field]);
                 if ($properties[$field] instanceof EntityInterface) {
@@ -606,7 +614,8 @@ class Marshaller
      * - validate: Whether or not to validate data before hydrating the entities. Can
      *   also be set to a string to use a specific validator. Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well.
-     * - fieldList: A whitelist of fields to be assigned to the entity. If not present,
+     * - fieldList: (deprecated) use fields instead
+     * - fields: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used.
      * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
      *


### PR DESCRIPTION
The `fieldList` option for `newEntity` isn't consistent with other parts of the ORM. Where `fields` is used to select what fields will be used (queries as an example).

This PR deprecates `fieldList` and changes it to `fields`. With `fieldList` support working as before and to be removed at a later date.
