### PR TITLE
Fix up doblocks to be of more concrete type arrays

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -102,7 +102,8 @@ class Cache
     /**
      * Whether to reset the settings with the next call to Cache::set();
      *
-     * @var array
+     * @deprecated Not used anymore
+     * @var bool
      */
     protected static $_reset = false;
 

--- a/src/Cache/Engine/ApcEngine.php
+++ b/src/Cache/Engine/ApcEngine.php
@@ -27,7 +27,7 @@ class ApcEngine extends CacheEngine
      * Contains the compiled group names
      * (prefixed with the global configuration prefix)
      *
-     * @var array
+     * @var string[]
      */
     protected $_compiledGroupNames = [];
 

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -45,15 +45,15 @@ class Configure
     /**
      * Configured engine classes, used to load config files from resources
      *
-     * @var array
      * @see \Cake\Core\Configure::load()
+     * @var \Cake\Core\Configure\ConfigEngineInterface[]
      */
     protected static $_engines = [];
 
     /**
      * Flag to track whether or not ini_set exists.
      *
-     * @return void
+     * @var bool|null
      */
     protected static $_hasIniSet = null;
 
@@ -238,7 +238,7 @@ class Configure
      * Gets the names of the configured Engine objects.
      *
      * @param string|null $name Engine name.
-     * @return array Array of the configured Engine objects.
+     * @return array|bool Array of the configured Engine objects, bool for specific name.
      */
     public static function configured($name = null)
     {

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -38,7 +38,7 @@ class Exception extends RuntimeException
     /**
      * Array of headers to be passed to Cake\Network\Response::header()
      *
-     * @var array
+     * @var array|null
      */
     protected $_responseHeaders = null;
 

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -40,7 +40,7 @@ abstract class ObjectRegistry
     /**
      * Map of loaded objects.
      *
-     * @var array
+     * @var object[]
      */
     protected $_loaded = [];
 

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -64,7 +64,7 @@ class Comparison implements ExpressionInterface, FieldInterface
      * A cached list of ExpressionInterface objects that were
      * found in the value for this expression.
      *
-     * @var array
+     * @var \Cake\Database\ExpressionInterface[]
      */
     protected $_valueExpressions = [];
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -54,7 +54,7 @@ trait QueryTrait
      * List of formatter classes or callbacks that will post-process the
      * results when fetched
      *
-     * @var array
+     * @var callable[]
      */
     protected $_formatters = [];
 

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -63,28 +63,28 @@ class RulesChecker
     /**
      * The list of rules to be checked on both create and update operations
      *
-     * @var array
+     * @var callable[]
      */
     protected $_rules = [];
 
     /**
      * The list of rules to check during create operations
      *
-     * @var array
+     * @var callable[]
      */
     protected $_createRules = [];
 
     /**
      * The list of rules to check during update operations
      *
-     * @var array
+     * @var callable[]
      */
     protected $_updateRules = [];
 
     /**
      * The list of rules to check during delete operations
      *
-     * @var array
+     * @var callable[]
      */
     protected $_deleteRules = [];
 

--- a/src/Event/EventList.php
+++ b/src/Event/EventList.php
@@ -56,7 +56,7 @@ class EventList implements ArrayAccess, Countable
      *
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
      * @param mixed $offset An offset to check for.
-     * @return boole True on success or false on failure.
+     * @return bool True on success or false on failure.
      */
     public function offsetExists($offset)
     {

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -37,7 +37,7 @@ class ActionDispatcher
     /**
      * Attached routing filters
      *
-     * @var array
+     * @var \Cake\Event\EventListenerInterface[]
      */
     protected $filters = [];
 
@@ -53,7 +53,7 @@ class ActionDispatcher
      *
      * @param \Cake\Http\ControllerFactory|null $factory A controller factory instance.
      * @param \Cake\Event\EventManager|null $eventManager An event manager if you want to inject one.
-     * @param array $filters The list of filters to include.
+     * @param \Cake\Event\EventListenerInterface[] $filters The list of filters to include.
      */
     public function __construct($factory = null, $eventManager = null, array $filters = [])
     {
@@ -71,7 +71,7 @@ class ActionDispatcher
      *
      * @param \Cake\Network\Request $request The request to dispatch.
      * @param \Cake\Network\Response $response The response to dispatch.
-     * @return \Cake\Network\Response a modified/replaced response.
+     * @return \Cake\Network\Response A modified/replaced response.
      */
     public function dispatch(Request $request, Response $response)
     {

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -50,7 +50,7 @@ class FormData implements Countable
     /**
      * The parts in the form data.
      *
-     * @var array
+     * @var \Cake\Http\Client\FormDataPart[]
      */
     protected $_parts = [];
 

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -505,7 +505,7 @@ class Response extends Message implements ResponseInterface
      */
     protected function _getJson()
     {
-        if (!empty($this->_json)) {
+        if ($this->_json) {
             return $this->_json;
         }
 
@@ -519,7 +519,7 @@ class Response extends Message implements ResponseInterface
      */
     protected function _getXml()
     {
-        if (!empty($this->_xml)) {
+        if ($this->_xml) {
             return $this->_xml;
         }
         libxml_use_internal_errors();

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -35,7 +35,7 @@ class MiddlewareQueue implements Countable
     /**
      * The queue of middleware callables.
      *
-     * @var array
+     * @var callable[]
      */
     protected $callables = [];
 

--- a/src/I18n/ChainMessagesLoader.php
+++ b/src/I18n/ChainMessagesLoader.php
@@ -27,7 +27,7 @@ class ChainMessagesLoader
     /**
      * The list of callables to execute one after another for loading messages
      *
-     * @var array
+     * @var callable[]
      */
     protected $_loaders = [];
 
@@ -35,7 +35,7 @@ class ChainMessagesLoader
      * Receives a list of callable functions or objects that will be executed
      * one after another until one of them returns a non-empty translations package
      *
-     * @param array $loaders List of callables to execute
+     * @param callable[] $loaders List of callables to execute
      */
     public function __construct(array $loaders)
     {

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -34,9 +34,9 @@ class TranslatorRegistry extends TranslatorLocator
      * packages where none can be found for the combination of translator
      * name and locale.
      *
-     * @var array
+     * @var callable[]
      */
-    protected $_loaders;
+    protected $_loaders = [];
 
     /**
      * Fallback loader name

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -60,7 +60,7 @@ class SyslogLog extends BaseLog
     /**
      * Used to map the string names back to their LOG_* constants
      *
-     * @var array
+     * @var int[]
      */
     protected $_levelMap = [
         'emergency' => LOG_EMERG,

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -187,7 +187,11 @@ abstract class Association
      *
      * @var array
      */
-    protected $_validStrategies = [self::STRATEGY_JOIN, self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
+    protected $_validStrategies = [
+        self::STRATEGY_JOIN,
+        self::STRATEGY_SELECT,
+        self::STRATEGY_SUBQUERY
+    ];
 
     /**
      * Constructor. Subclasses can override _options function to get the original
@@ -702,7 +706,7 @@ abstract class Association
      */
     public function exists($conditions)
     {
-        if (!empty($this->_conditions)) {
+        if ($this->_conditions) {
             $conditions = $this
                 ->find('all', ['conditions' => $conditions])
                 ->clause('where');
@@ -805,7 +809,7 @@ abstract class Association
             $fields = array_merge((array)$fields, $target->schema()->columns());
         }
 
-        if (!empty($fields)) {
+        if ($fields) {
             $query->select($query->aliasFields($fields, $target->alias()));
         }
         $query->addDefaultTypes($target);

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -36,7 +36,10 @@ class BelongsTo extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [self::STRATEGY_JOIN, self::STRATEGY_SELECT];
+    protected $_validStrategies = [
+        self::STRATEGY_JOIN,
+        self::STRATEGY_SELECT
+    ];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -120,7 +120,10 @@ class BelongsToMany extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
+    protected $_validStrategies = [
+        self::STRATEGY_SELECT,
+        self::STRATEGY_SUBQUERY
+    ];
 
     /**
      * Whether the records on the joint table should be removed when a record

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -62,7 +62,10 @@ class HasMany extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [self::STRATEGY_SELECT, self::STRATEGY_SUBQUERY];
+    protected $_validStrategies = [
+        self::STRATEGY_SELECT,
+        self::STRATEGY_SUBQUERY
+    ];
 
     /**
      * Saving strategy that will only append to the links set

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -36,7 +36,10 @@ class HasOne extends Association
      *
      * @var array
      */
-    protected $_validStrategies = [self::STRATEGY_JOIN, self::STRATEGY_SELECT];
+    protected $_validStrategies = [
+        self::STRATEGY_JOIN,
+        self::STRATEGY_SELECT
+    ];
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -36,7 +36,7 @@ class TableLocator implements LocatorInterface
     /**
      * Instances that belong to the registry.
      *
-     * @var array
+     * @var \Cake\ORM\Table[]
      */
     protected $_instances = [];
 
@@ -44,7 +44,7 @@ class TableLocator implements LocatorInterface
      * Contains a list of Table objects that were created out of the
      * built-in Table class. The list is indexed by table alias
      *
-     * @var array
+     * @var \Cake\ORM\Table[]
      */
     protected $_fallbacked = [];
 
@@ -244,7 +244,7 @@ class TableLocator implements LocatorInterface
      * debugging common mistakes when setting up associations or created new table
      * classes.
      *
-     * @return array
+     * @return \Cake\ORM\Table[]
      */
     public function genericInstances()
     {

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -33,7 +33,7 @@ class Dispatcher
     /**
      * Connected filter objects
      *
-     * @var array
+     * @var \Cake\Event\EventListenerInterface[]
      */
     protected $_filters = [];
 
@@ -83,7 +83,7 @@ class Dispatcher
     /**
      * Get the list of connected filters.
      *
-     * @return array
+     * @return \Cake\Event\EventListenerInterface[]
      */
     public function filters()
     {

--- a/src/Routing/DispatcherFactory.php
+++ b/src/Routing/DispatcherFactory.php
@@ -27,7 +27,7 @@ class DispatcherFactory
     /**
      * Stack of middleware to apply to dispatchers.
      *
-     * @var array
+     * @var \Cake\Routing\DispatcherFilter[]
      */
     protected static $_stack = [];
 
@@ -91,7 +91,7 @@ class DispatcherFactory
     /**
      * Get the connected dispatcher filters.
      *
-     * @return array
+     * @return \Cake\Routing\DispatcherFilter[]
      */
     public static function filters()
     {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -148,7 +148,7 @@ class Router
      * The stack of URL filters to apply against routing URLs before passing the
      * parameters to the route collection.
      *
-     * @var array
+     * @var callable[]
      */
     protected static $_urlFilters = [];
 

--- a/src/Shell/Task/ExtractTask.php
+++ b/src/Shell/Task/ExtractTask.php
@@ -51,7 +51,7 @@ class ExtractTask extends Shell
     /**
      * Current file being processed
      *
-     * @var string
+     * @var string|null
      */
     protected $_file = null;
 
@@ -79,7 +79,7 @@ class ExtractTask extends Shell
     /**
      * Destination path
      *
-     * @var string
+     * @var string|null
      */
     protected $_output = null;
 

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -29,7 +29,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Holds the ValidationRule objects
      *
-     * @var array
+     * @var \Cake\Validation\ValidationRule[]
      */
     protected $_rules = [];
 
@@ -98,7 +98,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns all rules for this validation set
      *
-     * @return array
+     * @return \Cake\Validation\ValidationRule[]
      */
     public function rules()
     {

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -47,7 +47,7 @@ trait ValidatorAwareTrait
     /**
      * A list of validation objects indexed by name
      *
-     * @var array
+     * @var \Cake\Validation\Validator[]
      */
     protected $_validators = [];
 


### PR DESCRIPTION
Needed for autocomplete on those to work inside foreach loops and alike.
In general we should be more strict, also with

```
int[]
string[]
```

etc.

PS: Could we also just delete `protected static $_reset = false;`?
