### PR TITLE
Allow help to also display 0 as short type and fix some cloaking nons…

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -100,14 +100,6 @@ class Cache
     protected static $_groups = [];
 
     /**
-     * Whether to reset the settings with the next call to Cache::set();
-     *
-     * @deprecated Not used anymore
-     * @var bool
-     */
-    protected static $_reset = false;
-
-    /**
      * Cache Registry used for creating and using cache adapters.
      *
      * @var \Cake\Cache\CacheRegistry
@@ -127,7 +119,7 @@ class Cache
             static::$_registry = $registry;
         }
 
-        if (empty(static::$_registry)) {
+        if (!static::$_registry) {
             static::$_registry = new CacheRegistry();
         }
 

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -245,12 +245,12 @@ abstract class CacheEngine
      */
     public function key($key)
     {
-        if (empty($key)) {
+        if (!$key) {
             return false;
         }
 
         $prefix = '';
-        if (!empty($this->_groupPrefix)) {
+        if ($this->_groupPrefix) {
             $prefix = vsprintf($this->_groupPrefix, $this->groups());
         }
 

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -98,7 +98,7 @@ class FileEngine extends CacheEngine
         if (substr($this->_config['path'], -1) !== DIRECTORY_SEPARATOR) {
             $this->_config['path'] .= DIRECTORY_SEPARATOR;
         }
-        if (!empty($this->_groupPrefix)) {
+        if ($this->_groupPrefix) {
             $this->_groupPrefix = str_replace('_', DIRECTORY_SEPARATOR, $this->_groupPrefix);
         }
 
@@ -377,7 +377,7 @@ class FileEngine extends CacheEngine
     protected function _setKey($key, $createKey = false)
     {
         $groups = null;
-        if (!empty($this->_groupPrefix)) {
+        if ($this->_groupPrefix) {
             $groups = vsprintf($this->_groupPrefix, $this->groups());
         }
         $dir = $this->_config['path'] . $groups;

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -113,7 +113,7 @@ class ConsoleInputArgument
         if (!$this->isRequired()) {
             $optional = ' <comment>(optional)</comment>';
         }
-        if (!empty($this->_choices)) {
+        if ($this->_choices) {
             $optional .= sprintf(' <comment>(choices: %s)</comment>', implode('|', $this->_choices));
         }
 
@@ -128,7 +128,7 @@ class ConsoleInputArgument
     public function usage()
     {
         $name = $this->_name;
-        if (!empty($this->_choices)) {
+        if ($this->_choices) {
             $name = implode('|', $this->_choices);
         }
         $name = '<' . $name . '>';

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -129,13 +129,13 @@ class ConsoleInputOption
     public function help($width = 0)
     {
         $default = $short = '';
-        if (!empty($this->_default) && $this->_default !== true) {
+        if ($this->_default && $this->_default !== true) {
             $default = sprintf(' <comment>(default: %s)</comment>', $this->_default);
         }
-        if (!empty($this->_choices)) {
+        if ($this->_choices) {
             $default .= sprintf(' <comment>(choices: %s)</comment>', implode('|', $this->_choices));
         }
-        if (!empty($this->_short)) {
+        if (strlen($this->_short) > 0) {
             $short = ', -' . $this->_short;
         }
         $name = sprintf('--%s%s', $this->_name, $short);
@@ -158,7 +158,7 @@ class ConsoleInputOption
         if (strlen($this->_default) > 0 && $this->_default !== true) {
             $default = ' ' . $this->_default;
         }
-        if (!empty($this->_choices)) {
+        if ($this->_choices) {
             $default = ' ' . implode('|', $this->_choices);
         }
 

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -123,7 +123,7 @@ class Component implements EventListenerInterface
 
         $this->config($config);
 
-        if (!empty($this->components)) {
+        if ($this->components) {
             $this->_componentMap = $registry->normalizeArray($this->components);
         }
         $this->initialize($config);

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -57,7 +57,7 @@ class RequestHandlerComponent extends Component
     /**
      * Contains the file extension parsed out by the Router
      *
-     * @var string
+     * @var string|null
      * @see \Cake\Routing\Router::extensions()
      */
     public $ext = null;
@@ -65,7 +65,7 @@ class RequestHandlerComponent extends Component
     /**
      * The template to use when rendering the given content type.
      *
-     * @var string
+     * @var string|null
      */
     protected $_renderType = null;
 
@@ -177,7 +177,7 @@ class RequestHandlerComponent extends Component
         );
         foreach ($accepts as $types) {
             $ext = array_intersect($extensions, $types);
-            if (!empty($ext)) {
+            if ($ext) {
                 $this->ext = current($ext);
                 break;
             }
@@ -202,13 +202,13 @@ class RequestHandlerComponent extends Component
         if ($request->param('_ext')) {
             $this->ext = $request->param('_ext');
         }
-        if (empty($this->ext) || in_array($this->ext, ['html', 'htm'])) {
+        if (!$this->ext || in_array($this->ext, ['html', 'htm'])) {
             $this->_setExtension($request, $this->response);
         }
 
         $request->params['isAjax'] = $request->is('ajax');
 
-        if (empty($this->ext) && $request->is('ajax')) {
+        if (!$this->ext && $request->is('ajax')) {
             $this->ext = 'ajax';
         }
 
@@ -323,7 +323,7 @@ class RequestHandlerComponent extends Component
             $this->response->getMimeType($this->ext)
         );
 
-        if (!empty($this->ext) && $isRecognized) {
+        if ($this->ext && $isRecognized) {
             $this->renderAs($event->subject(), $this->ext);
         } else {
             $this->response->charset(Configure::read('App.encoding'));
@@ -517,7 +517,7 @@ class RequestHandlerComponent extends Component
         $types = (array)$type;
 
         if (count($types) === 1) {
-            if (!empty($this->ext)) {
+            if ($this->ext) {
                 return in_array($this->ext, $types);
             }
 
@@ -525,7 +525,7 @@ class RequestHandlerComponent extends Component
         }
 
         $intersect = array_values(array_intersect($accepts, $types));
-        if (empty($intersect)) {
+        if (!$intersect) {
             return false;
         }
 
@@ -582,7 +582,7 @@ class RequestHandlerComponent extends Component
             $controller->viewClass = $viewClass;
             $builder->className($viewClass);
         } else {
-            if (empty($this->_renderType)) {
+            if (!$this->_renderType) {
                 $builder->templatePath($builder->templatePath() . DIRECTORY_SEPARATOR . $type);
             } else {
                 $builder->templatePath(preg_replace(

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -66,7 +66,7 @@ class IniConfig implements ConfigEngineInterface
     /**
      * The section to read, if null all sections will be read.
      *
-     * @var string
+     * @var string|null
      */
     protected $_section;
 
@@ -101,7 +101,7 @@ class IniConfig implements ConfigEngineInterface
         $file = $this->_getFilePath($key, true);
 
         $contents = parse_ini_file($file, true);
-        if (!empty($this->_section) && isset($contents[$this->_section])) {
+        if ($this->_section && isset($contents[$this->_section])) {
             $values = $this->_parseNestedValues($contents[$this->_section]);
         } else {
             $values = [];

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -56,21 +56,21 @@ class FileLog extends BaseLog
     /**
      * Path to save log files on.
      *
-     * @var string
+     * @var string|null
      */
     protected $_path = null;
 
     /**
      * The name of the file to save logs into.
      *
-     * @var string
+     * @var string|null
      */
     protected $_file = null;
 
     /**
      * Max file size, used for log file rotation.
      *
-     * @var int
+     * @var int|null
      */
     protected $_size = null;
 
@@ -123,13 +123,13 @@ class FileLog extends BaseLog
         $message = $this->_format($message, $context);
         $output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
         $filename = $this->_getFilename($level);
-        if (!empty($this->_size)) {
+        if ($this->_size) {
             $this->_rotateFile($filename);
         }
 
         $pathname = $this->_path . $filename;
         $mask = $this->_config['mask'];
-        if (empty($mask)) {
+        if (!$mask) {
             return file_put_contents($pathname, $output, FILE_APPEND);
         }
 
@@ -159,7 +159,7 @@ class FileLog extends BaseLog
     {
         $debugTypes = ['notice', 'info', 'debug'];
 
-        if (!empty($this->_file)) {
+        if ($this->_file) {
             $filename = $this->_file;
         } elseif ($level === 'error' || $level === 'warning') {
             $filename = 'error.log';

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -828,7 +828,7 @@ class Email implements JsonSerializable, Serializable
         }
 
         $headers['MIME-Version'] = '1.0';
-        if (!empty($this->_attachments)) {
+        if ($this->_attachments) {
             $headers['Content-Type'] = 'multipart/mixed; boundary="' . $this->_boundary . '"';
         } elseif ($this->_emailFormat === 'both') {
             $headers['Content-Type'] = 'multipart/alternative; boundary="' . $this->_boundary . '"';
@@ -1680,7 +1680,7 @@ class Email implements JsonSerializable, Serializable
      */
     protected function _createBoundary()
     {
-        if (!empty($this->_attachments) || $this->_emailFormat === 'both') {
+        if ($this->_attachments || $this->_emailFormat === 'both') {
             $this->_boundary = md5(Security::randomBytes(16));
         }
     }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -98,7 +98,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        if (empty($this->_configure)) {
+        if (!$this->_configure) {
             $this->_configure = Configure::read();
         }
         if (class_exists('Cake\Routing\Router', false)) {
@@ -116,7 +116,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         parent::tearDown();
-        if (!empty($this->_configure)) {
+        if ($this->_configure) {
             Configure::clear();
             Configure::write($this->_configure);
         }

--- a/src/View/Helper/IdGeneratorTrait.php
+++ b/src/View/Helper/IdGeneratorTrait.php
@@ -26,7 +26,7 @@ trait IdGeneratorTrait
     /**
      * Prefix for id attribute.
      *
-     * @var string
+     * @var string|null
      */
     protected $_idPrefix = null;
 
@@ -80,7 +80,7 @@ trait IdGeneratorTrait
     protected function _domId($value)
     {
         $domId = mb_strtolower(Inflector::slug($value, '-'));
-        if (!empty($this->_idPrefix)) {
+        if ($this->_idPrefix) {
             $domId = $this->_idPrefix . '-' . $domId;
         }
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -592,6 +592,7 @@ class ConsoleOptionParserTest extends TestCase
     {
         $subParser = new ConsoleOptionParser('method', false);
         $subParser->addOption('connection', ['help' => 'Db connection.']);
+        $subParser->addOption('zero', ['short' => '0', 'help' => 'Zero.']);
 
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addSubcommand('method', [
@@ -603,12 +604,13 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->help('method');
         $expected = <<<TEXT
 <info>Usage:</info>
-cake mycommand method [--connection] [-h]
+cake mycommand method [--connection] [-h] [-0]
 
 <info>Options:</info>
 
 --connection      Db connection.
 --help, -h        Display this help.
+--zero, -0        Zero.
 
 TEXT;
         $this->assertTextEquals($expected, $result, 'Help is not correct.');


### PR DESCRIPTION
- Fixed `0` output for short option on help() to be in line with the other methods
- Removed dead $_reset var
- Removed some cloaking empty() checks in favor of the same nonstrict noncloaking check.
- Minor doc block fixes
