### PR TITLE
Use PSR7 response methods where possible.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -366,8 +366,9 @@ class AuthComponent extends Component
         if (empty($this->_authenticateObjects)) {
             $this->constructAuthenticate();
         }
+        $response = $this->response;
         $auth = end($this->_authenticateObjects);
-        $result = $auth->unauthenticated($this->request, $this->response);
+        $result = $auth->unauthenticated($this->request, $response);
         if ($result !== null) {
             return $result;
         }
@@ -384,13 +385,10 @@ class AuthComponent extends Component
                 $this->_config['ajaxLogin'],
                 $this->RequestHandler->ajaxLayout
             );
-            $response->statusCode(403);
-
-            return $response;
+            return $response->withStatus(403);
         }
-        $this->response->statusCode(403);
 
-        return $this->response;
+        return $response->withStatus(403);
     }
 
     /**

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -385,6 +385,7 @@ class AuthComponent extends Component
                 $this->_config['ajaxLogin'],
                 $this->RequestHandler->ajaxLayout
             );
+
             return $response->withStatus(403);
         }
 

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -288,9 +288,8 @@ class RequestHandlerComponent extends Component
             'query' => $query,
             'cookies' => $request->cookies
         ]));
-        $response->statusCode(200);
 
-        return $response;
+        return $response->withStatus(200);
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -540,7 +540,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $response = $this->response;
         if ($status) {
-            $response->statusCode($status);
+            $response = $response->withStatus($status);
         }
 
         $event = $this->dispatchEvent('Controller.beforeRedirect', [$url, $response]);

--- a/src/TestSuite/LegacyRequestDispatcher.php
+++ b/src/TestSuite/LegacyRequestDispatcher.php
@@ -51,8 +51,6 @@ class LegacyRequestDispatcher
             ['priority' => 999],
             [$this->_test, 'controllerSpy']
         );
-        $dispatcher->dispatch($request, $response);
-
-        return $response;
+        return $dispatcher->dispatch($request, $response);
     }
 }

--- a/src/TestSuite/LegacyRequestDispatcher.php
+++ b/src/TestSuite/LegacyRequestDispatcher.php
@@ -51,6 +51,7 @@ class LegacyRequestDispatcher
             ['priority' => 999],
             [$this->_test, 'controllerSpy']
         );
+
         return $dispatcher->dispatch($request, $response);
     }
 }

--- a/src/TestSuite/Stub/Response.php
+++ b/src/TestSuite/Stub/Response.php
@@ -32,6 +32,7 @@ class Response extends Base
             $this->statusCode(302);
         }
         $this->_setContentType();
+
         return $this;
     }
 }

--- a/src/TestSuite/Stub/Response.php
+++ b/src/TestSuite/Stub/Response.php
@@ -24,7 +24,7 @@ class Response extends Base
     /**
      * Stub the send() method so headers and output are not sent.
      *
-     * @return void
+     * @return $this
      */
     public function send()
     {
@@ -32,5 +32,6 @@ class Response extends Base
             $this->statusCode(302);
         }
         $this->_setContentType();
+        return $this;
     }
 }


### PR DESCRIPTION
In Component callbacks that return a response we can start using the PSR7 methods as the event dispatcher passes the returned response up the stack and eventually emits it.

Refs #9636
