### PR TITLE
Proposed fix for #9634

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1285,7 +1285,11 @@ class BelongsToMany extends Association
         $query
             ->eagerLoader()
             ->addToJoinsMap($tempName, $assoc, false, $this->_junctionProperty);
-        $assoc->attachTo($query, ['aliasPath' => $assoc->alias(), 'includeFields' => false]);
+        $assoc->attachTo($query, [
+            'aliasPath' => $assoc->alias(),
+            'includeFields' => false,
+            'propertyPath' => $this->_junctionProperty
+        ]);
 
         return $query;
     }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1312,6 +1312,7 @@ class QueryTest extends TestCase
             ->eventManager()
             ->attach(function ($event, $query) {
                 $query->formatResults(function ($results) {
+                    $results->beforeFind = true;
                     return $results;
                 });
             }, 'Model.beforeFind');
@@ -1335,6 +1336,7 @@ class QueryTest extends TestCase
             '_joinData' => ['article_id' => 1, 'tag_id' => 1],
             'description' => 'A big description',
             'created' => new Time('2016-01-01 00:00'),
+            'beforeFind' => true,
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
         $this->assertInstanceOf(Time::class, $first->tags[0]->created);
@@ -1345,6 +1347,7 @@ class QueryTest extends TestCase
             '_joinData' => ['article_id' => 1, 'tag_id' => 2],
             'description' => 'Another big description',
             'created' => new Time('2016-01-01 00:00'),
+            'beforeFind' => true,
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
         $this->assertInstanceOf(Time::class, $first->tags[0]->created);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1312,7 +1312,10 @@ class QueryTest extends TestCase
             ->eventManager()
             ->attach(function ($event, $query) {
                 $query->formatResults(function ($results) {
-                    $results->beforeFind = true;
+                    foreach ($results as $result) {
+                        $result->beforeFind = true;
+                    }
+
                     return $results;
                 });
             }, 'Model.beforeFind');
@@ -1333,10 +1336,13 @@ class QueryTest extends TestCase
         $expected = [
             'id' => 1,
             'name' => 'tag1',
-            '_joinData' => ['article_id' => 1, 'tag_id' => 1],
+            '_joinData' => [
+                'article_id' => 1,
+                'tag_id' => 1,
+                'beforeFind' => true,
+            ],
             'description' => 'A big description',
             'created' => new Time('2016-01-01 00:00'),
-            'beforeFind' => true,
         ];
         $this->assertEquals($expected, $first->tags[0]->toArray());
         $this->assertInstanceOf(Time::class, $first->tags[0]->created);
@@ -1344,10 +1350,13 @@ class QueryTest extends TestCase
         $expected = [
             'id' => 2,
             'name' => 'tag2',
-            '_joinData' => ['article_id' => 1, 'tag_id' => 2],
+            '_joinData' => [
+                'article_id' => 1,
+                'tag_id' => 2,
+                'beforeFind' => true,
+            ],
             'description' => 'Another big description',
             'created' => new Time('2016-01-01 00:00'),
-            'beforeFind' => true,
         ];
         $this->assertEquals($expected, $first->tags[1]->toArray());
         $this->assertInstanceOf(Time::class, $first->tags[0]->created);


### PR DESCRIPTION
This fixes #9634, however I have to admit I don't know if this will have any potential side effects I'm not considering. In the `testFormatResultsBelongsToMany` test I added a formatter to the originating table to make sure it gets called still and doesn't get the belongsToMany formatter applied to it, just in case.
