### PR TITLE
use array_key_exists() instead of isset() in \Hash::get()

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -59,7 +59,7 @@ class Hash {
 		}
 
 		foreach ($parts as $key) {
-			if (is_array($data) && isset($data[$key])) {
+			if ( is_array($data) && array_key_exists($key,$data) ) {
 				$data =& $data[$key];
 			} else {
 				return $default;


### PR DESCRIPTION
if `$data['a_key']` exists and it is equal to `null` the `\Hash::get()` returns `false`, it should return `null`
\Hash::get($data,'a_key',false);