### PR TITLE
Master fix docblocks

### DIFF
--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -1407,7 +1407,7 @@ class SecurityComponentTest extends TestCase
     /**
      * test blackhole will now throw passed exception if debug enabled
      *
-     * @expectedException Cake\Controller\Exception\SecurityException
+     * @expectedException \Cake\Controller\Exception\SecurityException
      * @expectedExceptionMessage error description
      * @return void
      */
@@ -1535,7 +1535,7 @@ class SecurityComponentTest extends TestCase
      * Auth required throws exception token not found
      *
      * @return void
-     * @expectedException Cake\Controller\Exception\AuthSecurityException
+     * @expectedException \Cake\Controller\Exception\AuthSecurityException
      * @expectedExceptionMessage '_Token' was not found in request data.
      * @triggers Controller.startup $this->Controller
      */
@@ -1551,7 +1551,7 @@ class SecurityComponentTest extends TestCase
      * Auth required throws exception token not found in Session
      *
      * @return void
-     * @expectedException Cake\Controller\Exception\AuthSecurityException
+     * @expectedException \Cake\Controller\Exception\AuthSecurityException
      * @expectedExceptionMessage '_Token' was not found in session.
      * @triggers Controller.startup $this->Controller
      */
@@ -1567,7 +1567,7 @@ class SecurityComponentTest extends TestCase
      * Auth required throws exception controller not allowed
      *
      * @return void
-     * @expectedException Cake\Controller\Exception\AuthSecurityException
+     * @expectedException \Cake\Controller\Exception\AuthSecurityException
      * @expectedExceptionMessage Controller 'NotAllowed' was not found in allowed controllers: 'Allowed, AnotherAllowed'.
      * @triggers Controller.startup $this->Controller
      */
@@ -1587,7 +1587,7 @@ class SecurityComponentTest extends TestCase
      * Auth required throws exception controller not allowed
      *
      * @return void
-     * @expectedException Cake\Controller\Exception\AuthSecurityException
+     * @expectedException \Cake\Controller\Exception\AuthSecurityException
      * @expectedExceptionMessage Action 'NotAllowed::protected' was not found in allowed actions: 'index, view'.
      * @triggers Controller.startup $this->Controller
      */

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -82,7 +82,7 @@ class ConfigureTest extends TestCase
     /**
      * testReadOrFail method
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Expected configuration key "This.Key.Does.Not.exist" not found
      * @return void
      */

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -756,7 +756,7 @@ class QueryTest extends TestCase
      * Tests that passing an empty array type to any where condition will not
      * result in a SQL error, but an internal exception
      *
-     * @expectedException Cake\Database\Exception
+     * @expectedException \Cake\Database\Exception
      * @expectedExceptionMessage Impossible to generate condition with empty list of values for field
      * @return void
      */
@@ -773,7 +773,7 @@ class QueryTest extends TestCase
 
     /**
      * Tests exception message for impossible condition when using an expression
-     * @expectedException Cake\Database\Exception
+     * @expectedException \Cake\Database\Exception
      * @expectedExceptionMessage with empty list of values for field (SELECT 1)
      * @return void
      */

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -23,6 +23,15 @@ use \PDO;
  */
 class BinaryTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\BinaryType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -55,7 +55,7 @@ class BoolTypeTest extends TestCase
     /**
      * Test converting an array to boolean results in an exception
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testToDatabaseInvalid()
@@ -67,7 +67,7 @@ class BoolTypeTest extends TestCase
     /**
      * Tests that passing an invalid value will throw an exception
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testToDatabaseInvalidArray()

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -23,6 +23,15 @@ use \PDO;
  */
 class BoolTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\BoolType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -23,6 +23,15 @@ use Cake\TestSuite\TestCase;
  */
 class DateTimeTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\DateTimeType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Original type map

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -24,6 +24,15 @@ use Cake\TestSuite\TestCase;
  */
 class DateTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\DateType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup
@@ -203,10 +212,10 @@ class DateTypeTest extends TestCase
     {
         $this->type->useImmutable();
         $this->assertInstanceOf('DateTimeImmutable', $this->type->marshal('2015-11-01'));
-        $this->assertInstanceOf('DateTimeImmutable', $this->type->toPhp('2015-11-01', $this->driver));
+        $this->assertInstanceOf('DateTimeImmutable', $this->type->toPHP('2015-11-01', $this->driver));
 
         $this->type->useMutable();
         $this->assertInstanceOf('DateTime', $this->type->marshal('2015-11-01'));
-        $this->assertInstanceOf('DateTime', $this->type->toPhp('2015-11-01', $this->driver));
+        $this->assertInstanceOf('DateTime', $this->type->toPHP('2015-11-01', $this->driver));
     }
 }

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -25,6 +25,25 @@ use \PDO;
  */
 class DecimalTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\DecimalType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
+
+    /**
+     * @var string
+     */
+    public $numberClass;
+
+    /**
+     * @var string
+     */
+    public $localeString;
 
     /**
      * Setup
@@ -36,10 +55,10 @@ class DecimalTypeTest extends TestCase
         parent::setUp();
         $this->type = Type::build('decimal');
         $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
-        $this->locale = I18n::locale();
+        $this->localeString = I18n::locale();
         $this->numberClass = DecimalType::$numberClass;
 
-        I18n::locale($this->locale);
+        I18n::locale($this->localeString);
     }
 
     /**
@@ -50,7 +69,7 @@ class DecimalTypeTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        I18n::locale($this->locale);
+        I18n::locale($this->localeString);
         DecimalType::$numberClass = $this->numberClass;
     }
 
@@ -120,19 +139,19 @@ class DecimalTypeTest extends TestCase
      */
     public function testMarshal()
     {
-        $result = $this->type->marshal('some data', $this->driver);
+        $result = $this->type->marshal('some data');
         $this->assertSame('some data', $result);
 
-        $result = $this->type->marshal('', $this->driver);
+        $result = $this->type->marshal('');
         $this->assertNull($result);
 
-        $result = $this->type->marshal('2.51', $this->driver);
+        $result = $this->type->marshal('2.51');
         $this->assertSame(2.51, $result);
 
-        $result = $this->type->marshal('3.5 bears', $this->driver);
+        $result = $this->type->marshal('3.5 bears');
         $this->assertSame('3.5 bears', $result);
 
-        $result = $this->type->marshal(['3', '4'], $this->driver);
+        $result = $this->type->marshal(['3', '4']);
         $this->assertSame(1, $result);
     }
 

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -105,7 +105,7 @@ class DecimalTypeTest extends TestCase
     /**
      * Arrays are invalid.
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testToDatabaseInvalid()
@@ -165,7 +165,7 @@ class DecimalTypeTest extends TestCase
     /**
      * Test that exceptions are raised on invalid parsers.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @return void
      */
     public function testUseLocaleParsingInvalid()

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -25,6 +25,25 @@ use \PDO;
  */
 class FloatTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\FloatType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
+
+    /**
+     * @var string
+     */
+    public $numberClass;
+
+    /**
+     * @var string
+     */
+    public $localeString;
 
     /**
      * Setup
@@ -36,10 +55,10 @@ class FloatTypeTest extends TestCase
         parent::setUp();
         $this->type = Type::build('float');
         $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
-        $this->locale = I18n::locale();
+        $this->localeString = I18n::locale();
         $this->numberClass = FloatType::$numberClass;
 
-        I18n::locale($this->locale);
+        I18n::locale($this->localeString);
     }
 
     /**
@@ -50,7 +69,7 @@ class FloatTypeTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        I18n::locale($this->locale);
+        I18n::locale($this->localeString);
         FloatType::$numberClass = $this->numberClass;
     }
 
@@ -109,19 +128,19 @@ class FloatTypeTest extends TestCase
      */
     public function testMarshal()
     {
-        $result = $this->type->marshal('some data', $this->driver);
+        $result = $this->type->marshal('some data');
         $this->assertSame('some data', $result);
 
-        $result = $this->type->marshal('', $this->driver);
+        $result = $this->type->marshal('');
         $this->assertNull($result);
 
-        $result = $this->type->marshal('2.51', $this->driver);
+        $result = $this->type->marshal('2.51');
         $this->assertSame(2.51, $result);
 
-        $result = $this->type->marshal('3.5 bears', $this->driver);
+        $result = $this->type->marshal('3.5 bears');
         $this->assertSame('3.5 bears', $result);
 
-        $result = $this->type->marshal(['3', '4'], $this->driver);
+        $result = $this->type->marshal(['3', '4']);
         $this->assertSame(1, $result);
     }
 

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -154,7 +154,7 @@ class FloatTypeTest extends TestCase
     /**
      * Test that exceptions are raised on invalid parsers.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @return void
      */
     public function testUseLocaleParsingInvalid()

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -23,6 +23,15 @@ use \PDO;
  */
 class IntegerTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\IntegerType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup
@@ -98,34 +107,34 @@ class IntegerTypeTest extends TestCase
      */
     public function testMarshal()
     {
-        $result = $this->type->marshal('some data', $this->driver);
+        $result = $this->type->marshal('some data');
         $this->assertNull($result);
 
-        $result = $this->type->marshal('', $this->driver);
+        $result = $this->type->marshal('');
         $this->assertNull($result);
 
-        $result = $this->type->marshal('0', $this->driver);
+        $result = $this->type->marshal('0');
         $this->assertSame(0, $result);
 
-        $result = $this->type->marshal('105', $this->driver);
+        $result = $this->type->marshal('105');
         $this->assertSame(105, $result);
 
-        $result = $this->type->marshal(105, $this->driver);
+        $result = $this->type->marshal(105);
         $this->assertSame(105, $result);
 
-        $result = $this->type->marshal('-105', $this->driver);
+        $result = $this->type->marshal('-105');
         $this->assertSame(-105, $result);
 
-        $result = $this->type->marshal(-105, $this->driver);
+        $result = $this->type->marshal(-105);
         $this->assertSame(-105, $result);
 
-        $result = $this->type->marshal('1.25', $this->driver);
+        $result = $this->type->marshal('1.25');
         $this->assertSame(1, $result);
 
-        $result = $this->type->marshal('2 monkeys', $this->driver);
+        $result = $this->type->marshal('2 monkeys');
         $this->assertNull($result);
 
-        $result = $this->type->marshal(['3', '4'], $this->driver);
+        $result = $this->type->marshal(['3', '4']);
         $this->assertSame(1, $result);
     }
 

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -83,7 +83,7 @@ class IntegerTypeTest extends TestCase
     /**
      * Tests that passing an invalid value will throw an exception
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testToDatabseInvalid()

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -64,7 +64,7 @@ class JsonTypeTest extends TestCase
     /**
      * Tests that passing an invalid value will throw an exception
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testToDatabaseInvalid()

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -23,6 +23,15 @@ use PDO;
  */
 class JsonTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\JsonType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -69,7 +69,7 @@ class StringTypeTest extends TestCase
     /**
      * Tests that passing an invalid value will throw an exception
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testToDatabaseInvalidArray()

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -23,6 +23,15 @@ use Cake\TestSuite\TestCase;
  */
 class TimeTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\TimeType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup
@@ -195,10 +204,10 @@ class TimeTypeTest extends TestCase
     {
         $this->type->useImmutable();
         $this->assertInstanceOf('DateTimeImmutable', $this->type->marshal('11:23:12'));
-        $this->assertInstanceOf('DateTimeImmutable', $this->type->toPhp('11:23:12', $this->driver));
+        $this->assertInstanceOf('DateTimeImmutable', $this->type->toPHP('11:23:12', $this->driver));
 
         $this->type->useMutable();
         $this->assertInstanceOf('DateTime', $this->type->marshal('11:23:12'));
-        $this->assertInstanceOf('DateTime', $this->type->toPhp('11:23:12', $this->driver));
+        $this->assertInstanceOf('DateTime', $this->type->toPHP('11:23:12', $this->driver));
     }
 }

--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -23,6 +23,15 @@ use \PDO;
  */
 class UuidTypeTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Type\UuidType
+     */
+    public $type;
+
+    /**
+     * @var \Cake\Database\Driver
+     */
+    public $driver;
 
     /**
      * Setup

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -84,7 +84,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     /**
      * Test an invalid rendering class.
      *
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessage The 'TotallyInvalid' renderer class could not be found
      */
     public function testInvalidRenderer()

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -284,7 +284,7 @@ class MiddlewareQueueTest extends TestCase
     /**
      * Test insertBefore an invalid classname
      *
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage No middleware matching 'InvalidClassName' could be found.
      * @return void
      */

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -125,7 +125,7 @@ class RunnerTest extends TestCase
     /**
      * Test that exceptions bubble up.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage A bad thing
      */
     public function testRunExceptionInMiddleware()

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -136,7 +136,7 @@ class ServerTest extends TestCase
     /**
      * Test an application failing to build middleware properly
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The application `middleware` method
      */
     public function testRunWithApplicationNotMakingMiddleware()
@@ -163,7 +163,7 @@ class ServerTest extends TestCase
     /**
      * Test middleware not creating a response.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Application did not create a response. Got "Not a response" instead.
      */
     public function testRunMiddlewareNoResponse()

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -49,7 +49,7 @@ class MailerAwareTraitTest extends TestCase
     /**
      * Test exception thrown by getMailer.
      *
-     * @expectedException Cake\Mailer\Exception\MissingMailerException
+     * @expectedException \Cake\Mailer\Exception\MissingMailerException
      * @expectedExceptionMessage Mailer class "Test" could not be found.
      */
     public function testGetMailerThrowsException()

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -165,7 +165,7 @@ class MailerTest extends TestCase
     }
 
     /**
-     * @expectedException Cake\Mailer\Exception\MissingActionException
+     * @expectedException \Cake\Mailer\Exception\MissingActionException
      * @expectedExceptionMessage Mail TestMailer::test() could not be found, or is not accessible.
      */
     public function testMissingActionThrowsException()

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -740,7 +740,7 @@ class BelongsToManyTest extends TestCase
     /**
      * Test that saveAssociated() fails on non-empty, non-iterable value
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Could not save tags, it cannot be traversed
      * @return void
      */

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -44,6 +44,11 @@ class AssociationTest extends TestCase
 {
 
     /**
+     * @var \Cake\ORM\Association|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public $association;
+
+    /**
      * Set up
      *
      * @return void
@@ -328,7 +333,7 @@ class AssociationTest extends TestCase
      * Test that warning is shown if property name clashes with table field.
      *
      * @return void
-     * @expectedException PHPUnit_Framework_Error_Warning
+     * @expectedException \PHPUnit_Framework_Error_Warning
      * @expectedExceptionMessageRegExp /^Association property name "foo" clashes with field of same name of table "test"/
      */
     public function testPropertyNameClash()

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -889,7 +889,7 @@ class TreeBehaviorTest extends TestCase
     /**
      * Tests making a node its own parent as an existing entity
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Cannot set a node's parent as itself
      * @return void
      */
@@ -903,7 +903,7 @@ class TreeBehaviorTest extends TestCase
     /**
      * Tests making a node its own parent as a new entity.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Cannot set a node's parent as itself
      * @return void
      */

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -326,7 +326,7 @@ class MarshallerTest extends TestCase
     /**
      * Test one() with an invalid association
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot marshal data for "Derp" association. It is not associated with "Articles".
      * @return void
      */
@@ -1394,7 +1394,7 @@ class MarshallerTest extends TestCase
     /**
      * Test merge() with an invalid association
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot marshal data for "Derp" association. It is not associated with "Articles".
      * @return void
      */

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -861,7 +861,7 @@ class QueryRegressionTest extends TestCase
      * Tests that trying to contain an inexistent association
      * throws an exception and not a fatal error.
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testQueryNotFatalError()

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -633,7 +633,7 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests existsIn with invalid associations
      *
      * @group save
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage ExistsIn rule for 'author_id' is invalid. 'NotValid' is not associated with 'Cake\ORM\Table'.
      * @return void
      */

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -51,7 +51,7 @@ class TableRegressionTest extends TestCase
      * in the afterSave callback
      *
      * @see https://github.com/cakephp/cakephp/issues/9079
-     * @expectedException Cake\ORM\Exception\RolledbackTransactionException
+     * @expectedException \Cake\ORM\Exception\RolledbackTransactionException
      * @return void
      */
     public function testAfterSaveRollbackTransaction()

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -65,7 +65,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test the parsing of routes.
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/posts
      * @expectedExceptionCode 301
      * @return void
@@ -79,7 +79,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test the parsing of routes.
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/posts
      * @expectedExceptionCode 301
      * @return void
@@ -93,7 +93,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test the parsing of routes.
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/posts
      * @expectedExceptionCode 301
      * @return void
@@ -107,7 +107,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting to an external url
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://google.com
      * @expectedExceptionCode 301
      * @return void
@@ -121,7 +121,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting with a status code
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/posts/view
      * @expectedExceptionCode 302
      * @return void
@@ -135,7 +135,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting with the persist option
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/posts/view/2
      * @expectedExceptionCode 301
      * @return void
@@ -149,7 +149,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting with persist and string target URLs
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/test
      * @expectedExceptionCode 301
      * @return void
@@ -163,7 +163,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting with persist and passed args
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/tags/add/passme
      * @expectedExceptionCode 301
      * @return void
@@ -177,7 +177,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting without persist and passed args
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/tags/add
      * @expectedExceptionCode 301
      * @return void
@@ -191,7 +191,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting with patterns
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/tags/add?lang=nl
      * @expectedExceptionCode 301
      * @return void
@@ -205,7 +205,7 @@ class RedirectRouteTest extends TestCase
     /**
      * test redirecting with patterns and a routed target
      *
-     * @expectedException Cake\Routing\Exception\RedirectException
+     * @expectedException \Cake\Routing\Exception\RedirectException
      * @expectedExceptionMessage http://localhost/nl/preferred_controllers
      * @expectedExceptionCode 301
      * @return void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -37,7 +37,7 @@ class RouterTest extends TestCase
     {
         parent::setUp();
         Configure::write('Routing', ['admin' => null, 'prefixes' => []]);
-        Router::fullbaseUrl('');
+        Router::fullBaseUrl('');
         Configure::write('App.fullBaseUrl', 'http://localhost');
     }
 
@@ -73,7 +73,7 @@ class RouterTest extends TestCase
      */
     public function testfullBaseURL()
     {
-        Router::fullbaseUrl('http://example.com');
+        Router::fullBaseUrl('http://example.com');
         $this->assertEquals('http://example.com/', Router::url('/', true));
         $this->assertEquals('http://example.com', Configure::read('App.fullBaseUrl'));
         Router::fullBaseUrl('https://example.com');
@@ -3210,7 +3210,7 @@ class RouterTest extends TestCase
     /**
      * Test setting the request context.
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testSetRequestContextInvalid()

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -185,7 +185,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     /**
      * Test customizing the app class.
      *
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage Cannot load "TestApp\MissingApp" for use in integration
      * @return void
      */
@@ -390,7 +390,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     /**
      * Tests the failure message for assertCookieNotSet
      *
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
      * @expectedExceptionMessage Cookie 'remember_me' has been set
      * @return void
      */
@@ -404,7 +404,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
      * Tests the failure message for assertCookieNotSet when no
      * response whas generated
      *
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
      * @expectedExceptionMessage No response set, cannot assert cookies.
      * @return void
      */
@@ -523,7 +523,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     /**
      * Test that exceptions being thrown are handled correctly.
      *
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
      * @return void
      */
     public function testWithUnexpectedException()
@@ -799,7 +799,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     /**
      * Test that assertFile requires a response
      *
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
      * @expectedExceptionMessage No response set, cannot assert file
      * @return void
      */
@@ -811,7 +811,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     /**
      * Test that assertFile requires a file
      *
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
      * @expectedExceptionMessage No file was sent in this response
      * @return void
      */

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -917,7 +917,7 @@ class HashTest extends TestCase
     /**
      * Test passing invalid argument type
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid data type, must be an array or \ArrayAccess instance.
      * @return void
      */

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -221,7 +221,7 @@ class ValidatorTest extends TestCase
     /**
      * Tests the requirePresence failure case
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testRequirePresenceAsArrayFailure()
@@ -599,7 +599,7 @@ class ValidatorTest extends TestCase
     /**
      * Tests the allowEmpty failure case
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testAllowEmptyAsArrayFailure()
@@ -678,7 +678,7 @@ class ValidatorTest extends TestCase
     /**
      * Tests the notEmpty failure case
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testNotEmptyAsArrayFailure()
@@ -1301,7 +1301,7 @@ class ValidatorTest extends TestCase
     /**
      * Tests the lengthBetween proxy method
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testLengthBetweenFailure()
@@ -1587,7 +1587,7 @@ class ValidatorTest extends TestCase
     /**
      * Tests the range failure case
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testRangeFailure()

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -39,6 +39,11 @@ class HelperRegistryTest extends TestCase
 {
 
     /**
+     * @var \Cake\View\HelperRegistry
+     */
+    public $Helpers;
+
+    /**
      * setUp
      *
      * @return void
@@ -308,7 +313,7 @@ class HelperRegistryTest extends TestCase
     /**
      * Loading a helper with different config, should throw an exception
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The "Html" alias has already been loaded with the following
      * @return void
      */
@@ -321,7 +326,7 @@ class HelperRegistryTest extends TestCase
     /**
      * Loading a helper with different config, should throw an exception
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The "Html" alias has already been loaded with the following
      * @return void
      */

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -142,7 +142,7 @@ class StringTemplateTest extends TestCase
     /**
      * Test formatting a missing template.
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Cannot find template named 'missing'
      * @return void
      */

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -401,7 +401,7 @@ class ViewTest extends TestCase
      * Test that plugin files with absolute file paths are scoped
      * to the plugin and do now allow any file path.
      *
-     * @expectedException Cake\View\Exception\MissingTemplateException
+     * @expectedException \Cake\View\Exception\MissingTemplateException
      * @return void
      */
     public function testPluginGetTemplateAbsoluteFail()


### PR DESCRIPTION
- Fix up FQCN doc blocks to be not red-alert in IDEs.
- Fix up tests to properly typehint test case attributes to help detect errors => found unused arguments for marshal(), wrong method name casing etc.