### PR TITLE
Rename Schema/Table to Schema/TableSchema via class_alias()

### DIFF
--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -54,19 +54,19 @@ abstract class BaseSchema
      */
     protected function _foreignOnClause($on)
     {
-        if ($on === Table::ACTION_SET_NULL) {
+        if ($on === TableSchema::ACTION_SET_NULL) {
             return 'SET NULL';
         }
-        if ($on === Table::ACTION_SET_DEFAULT) {
+        if ($on === TableSchema::ACTION_SET_DEFAULT) {
             return 'SET DEFAULT';
         }
-        if ($on === Table::ACTION_CASCADE) {
+        if ($on === TableSchema::ACTION_CASCADE) {
             return 'CASCADE';
         }
-        if ($on === Table::ACTION_RESTRICT) {
+        if ($on === TableSchema::ACTION_RESTRICT) {
             return 'RESTRICT';
         }
-        if ($on === Table::ACTION_NO_ACTION) {
+        if ($on === TableSchema::ACTION_NO_ACTION) {
             return 'NO ACTION';
         }
     }
@@ -83,10 +83,10 @@ abstract class BaseSchema
             return strtolower($clause);
         }
         if ($clause === 'NO ACTION') {
-            return Table::ACTION_NO_ACTION;
+            return TableSchema::ACTION_NO_ACTION;
         }
 
-        return Table::ACTION_SET_NULL;
+        return TableSchema::ACTION_SET_NULL;
     }
 
     /**
@@ -111,14 +111,14 @@ abstract class BaseSchema
     /**
      * Generate the SQL to drop a table.
      *
-     * @param \Cake\Database\Schema\Table $table Table instance
+     * @param \Cake\Database\Schema\TableSchema $schema Schema instance
      * @return array SQL statements to drop a table.
      */
-    public function dropTableSql(Table $table)
+    public function dropTableSql(TableSchema $schema)
     {
         $sql = sprintf(
             'DROP TABLE %s',
-            $this->_driver->quoteIdentifier($table->name())
+            $this->_driver->quoteIdentifier($schema->name())
         );
 
         return [$sql];
@@ -175,102 +175,102 @@ abstract class BaseSchema
     /**
      * Convert field description results into abstract schema fields.
      *
-     * @param \Cake\Database\Schema\Table $table The table object to append fields to.
+     * @param \Cake\Database\Schema\TableSchema $schema The table object to append fields to.
      * @param array $row The row data from `describeColumnSql`.
      * @return void
      */
-    abstract public function convertColumnDescription(Table $table, $row);
+    abstract public function convertColumnDescription(TableSchema $schema, $row);
 
     /**
      * Convert an index description results into abstract schema indexes or constraints.
      *
-     * @param \Cake\Database\Schema\Table $table The table object to append
+     * @param \Cake\Database\Schema\TableSchema $schema The table object to append
      *    an index or constraint to.
      * @param array $row The row data from `describeIndexSql`.
      * @return void
      */
-    abstract public function convertIndexDescription(Table $table, $row);
+    abstract public function convertIndexDescription(TableSchema $schema, $row);
 
     /**
      * Convert a foreign key description into constraints on the Table object.
      *
-     * @param \Cake\Database\Schema\Table $table The table object to append
+     * @param \Cake\Database\Schema\TableSchema $schema The table object to append
      *    a constraint to.
      * @param array $row The row data from `describeForeignKeySql`.
      * @return void
      */
-    abstract public function convertForeignKeyDescription(Table $table, $row);
+    abstract public function convertForeignKeyDescription(TableSchema $schema, $row);
 
     /**
      * Convert options data into table options.
      *
-     * @param \Cake\Database\Schema\Table $table Table instance.
+     * @param \Cake\Database\Schema\TableSchema $schema Table instance.
      * @param array $row The row of data.
      * @return void
      */
-    public function convertOptionsDescription(Table $table, $row)
+    public function convertOptionsDescription(TableSchema $schema, $row)
     {
     }
 
     /**
      * Generate the SQL to create a table.
      *
-     * @param \Cake\Database\Schema\Table $table Table instance.
+     * @param \Cake\Database\Schema\TableSchema $schema Table instance.
      * @param array $columns The columns to go inside the table.
      * @param array $constraints The constraints for the table.
      * @param array $indexes The indexes for the table.
      * @return array SQL statements to create a table.
      */
-    abstract public function createTableSql(Table $table, $columns, $constraints, $indexes);
+    abstract public function createTableSql(TableSchema $schema, $columns, $constraints, $indexes);
 
     /**
      * Generate the SQL fragment for a single column in a table.
      *
-     * @param \Cake\Database\Schema\Table $table The table instance the column is in.
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
      * @param string $name The name of the column.
      * @return string SQL fragment.
      */
-    abstract public function columnSql(Table $table, $name);
+    abstract public function columnSql(TableSchema $schema, $name);
 
     /**
      * Generate the SQL queries needed to add foreign key constraints to the table
      *
-     * @param \Cake\Database\Schema\Table $table The table instance the foreign key constraints are.
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
      * @return array SQL fragment.
      */
-    abstract public function addConstraintSql(Table $table);
+    abstract public function addConstraintSql(TableSchema $schema);
 
     /**
      * Generate the SQL queries needed to drop foreign key constraints from the table
      *
-     * @param \Cake\Database\Schema\Table $table The table instance the foreign key constraints are.
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
      * @return array SQL fragment.
      */
-    abstract public function dropConstraintSql(Table $table);
+    abstract public function dropConstraintSql(TableSchema $schema);
 
     /**
      * Generate the SQL fragments for defining table constraints.
      *
-     * @param \Cake\Database\Schema\Table $table The table instance the column is in.
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
      * @param string $name The name of the column.
      * @return string SQL fragment.
      */
-    abstract public function constraintSql(Table $table, $name);
+    abstract public function constraintSql(TableSchema $schema, $name);
 
     /**
      * Generate the SQL fragment for a single index in a table.
      *
-     * @param \Cake\Database\Schema\Table $table The table object the column is in.
+     * @param \Cake\Database\Schema\TableSchema $schema The table object the column is in.
      * @param string $name The name of the column.
      * @return string SQL fragment.
      */
-    abstract public function indexSql(Table $table, $name);
+    abstract public function indexSql(TableSchema $schema, $name);
 
     /**
      * Generate the SQL to truncate a table.
      *
-     * @param \Cake\Database\Schema\Table $table Table instance.
+     * @param \Cake\Database\Schema\TableSchema $schema Table instance.
      * @return array SQL statements to truncate a table.
      */
-    abstract public function truncateTableSql(Table $table);
+    abstract public function truncateTableSql(TableSchema $schema);
 }

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -83,7 +83,7 @@ class Collection
      *
      * @param string $name The name of the table to describe.
      * @param array $options The options to use, see above.
-     * @return \Cake\Database\Schema\Table Object with column metadata.
+     * @return \Cake\Database\Schema\TableSchema Object with column metadata.
      * @throws \Cake\Database\Exception when table cannot be described.
      */
     public function describe($name, array $options = [])
@@ -92,7 +92,7 @@ class Collection
         if (strpos($name, '.')) {
             list($config['schema'], $name) = explode('.', $name);
         }
-        $table = new Table($name);
+        $table = new TableSchema($name);
 
         $this->_reflect('Column', $name, $config, $table);
         if (count($table->columns()) === 0) {
@@ -112,11 +112,11 @@ class Collection
      * @param string $stage The stage name.
      * @param string $name The table name.
      * @param array $config The config data.
-     * @param \Cake\Database\Schema\Table $table The table instance
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance
      * @return void
      * @throws \Cake\Database\Exception on query failure.
      */
-    protected function _reflect($stage, $name, $config, $table)
+    protected function _reflect($stage, $name, $config, $schema)
     {
         $describeMethod = "describe{$stage}Sql";
         $convertMethod = "convert{$stage}Description";
@@ -131,7 +131,7 @@ class Collection
             throw new Exception($e->getMessage(), 500, $e);
         }
         foreach ($statement->fetchAll('assoc') as $row) {
-            $this->_dialect->{$convertMethod}($table, $row);
+            $this->_dialect->{$convertMethod}($schema, $row);
         }
         $statement->closeCursor();
     }

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -268,12 +268,12 @@ class MysqlSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function createTableSql(Table $table, $columns, $constraints, $indexes)
+    public function createTableSql(Table $schema, $columns, $constraints, $indexes)
     {
         $content = implode(",\n", array_merge($columns, $constraints, $indexes));
-        $temporary = $table->temporary() ? ' TEMPORARY ' : ' ';
-        $content = sprintf("CREATE%sTABLE `%s` (\n%s\n)", $temporary, $table->name(), $content);
-        $options = $table->options();
+        $temporary = $schema->temporary() ? ' TEMPORARY ' : ' ';
+        $content = sprintf("CREATE%sTABLE `%s` (\n%s\n)", $temporary, $schema->name(), $content);
+        $options = $schema->options();
         if (isset($options['engine'])) {
             $content .= sprintf(' ENGINE=%s', $options['engine']);
         }
@@ -290,9 +290,9 @@ class MysqlSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function columnSql(Table $table, $name)
+    public function columnSql(Table $schema, $name)
     {
-        $data = $table->column($name);
+        $data = $schema->column($name);
         $out = $this->_driver->quoteIdentifier($name);
         $nativeJson = $this->_driver->supportsNativeJson();
 
@@ -381,8 +381,8 @@ class MysqlSchema extends BaseSchema
             $out .= ' NOT NULL';
         }
         $addAutoIncrement = (
-            [$name] == (array)$table->primaryKey() &&
-            !$table->hasAutoIncrement()
+            [$name] == (array)$schema->primaryKey() &&
+            !$schema->hasAutoIncrement()
         );
         if (in_array($data['type'], ['integer', 'biginteger']) &&
             ($data['autoIncrement'] === true || $addAutoIncrement)
@@ -414,9 +414,9 @@ class MysqlSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function constraintSql(Table $table, $name)
+    public function constraintSql(Table $schema, $name)
     {
-        $data = $table->constraint($name);
+        $data = $schema->constraint($name);
         if ($data['type'] === Table::CONSTRAINT_PRIMARY) {
             $columns = array_map(
                 [$this->_driver, 'quoteIdentifier'],
@@ -441,16 +441,16 @@ class MysqlSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function addConstraintSql(Table $table)
+    public function addConstraintSql(Table $schema)
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s;';
         $sql = [];
 
-        foreach ($table->constraints() as $name) {
-            $constraint = $table->constraint($name);
+        foreach ($schema->constraints() as $name) {
+            $constraint = $schema->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $tableName = $this->_driver->quoteIdentifier($table->name());
-                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($table, $name));
+                $tableName = $this->_driver->quoteIdentifier($schema->name());
+                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($schema, $name));
             }
         }
 

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -143,7 +143,7 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function convertColumnDescription(Table $table, $row)
+    public function convertColumnDescription(TableSchema $schema, $row)
     {
         $field = $this->_convertColumn($row['type']);
 
@@ -165,7 +165,7 @@ class PostgresSchema extends BaseSchema
             'comment' => $row['comment']
         ];
         $field['length'] = $row['char_length'] ?: $field['length'];
-        $table->addColumn($row['name'], $field);
+        $schema->addColumn($row['name'], $field);
     }
 
     /**
@@ -226,22 +226,22 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function convertIndexDescription(Table $table, $row)
+    public function convertIndexDescription(TableSchema $schema, $row)
     {
-        $type = Table::INDEX_INDEX;
+        $type = TableSchema::INDEX_INDEX;
         $name = $row['relname'];
         if ($row['indisprimary']) {
-            $name = $type = Table::CONSTRAINT_PRIMARY;
+            $name = $type = TableSchema::CONSTRAINT_PRIMARY;
         }
-        if ($row['indisunique'] && $type === Table::INDEX_INDEX) {
-            $type = Table::CONSTRAINT_UNIQUE;
+        if ($row['indisunique'] && $type === TableSchema::INDEX_INDEX) {
+            $type = TableSchema::CONSTRAINT_UNIQUE;
         }
-        if ($type === Table::CONSTRAINT_PRIMARY || $type === Table::CONSTRAINT_UNIQUE) {
-            $this->_convertConstraint($table, $name, $type, $row);
+        if ($type === TableSchema::CONSTRAINT_PRIMARY || $type === TableSchema::CONSTRAINT_UNIQUE) {
+            $this->_convertConstraint($schema, $name, $type, $row);
 
             return;
         }
-        $index = $table->index($name);
+        $index = $schema->index($name);
         if (!$index) {
             $index = [
                 'type' => $type,
@@ -249,21 +249,21 @@ class PostgresSchema extends BaseSchema
             ];
         }
         $index['columns'][] = $row['attname'];
-        $table->addIndex($name, $index);
+        $schema->addIndex($name, $index);
     }
 
     /**
      * Add/update a constraint into the schema object.
      *
-     * @param \Cake\Database\Schema\Table $table The table to update.
+     * @param \Cake\Database\Schema\TableSchema $schema The table to update.
      * @param string $name The index name.
      * @param string $type The index type.
      * @param array $row The metadata record to update with.
      * @return void
      */
-    protected function _convertConstraint($table, $name, $type, $row)
+    protected function _convertConstraint($schema, $name, $type, $row)
     {
-        $constraint = $table->constraint($name);
+        $constraint = $schema->constraint($name);
         if (!$constraint) {
             $constraint = [
                 'type' => $type,
@@ -271,7 +271,7 @@ class PostgresSchema extends BaseSchema
             ];
         }
         $constraint['columns'][] = $row['attname'];
-        $table->addConstraint($name, $constraint);
+        $schema->addConstraint($name, $constraint);
     }
 
     /**
@@ -305,16 +305,16 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function convertForeignKeyDescription(Table $table, $row)
+    public function convertForeignKeyDescription(TableSchema $schema, $row)
     {
         $data = [
-            'type' => Table::CONSTRAINT_FOREIGN,
+            'type' => TableSchema::CONSTRAINT_FOREIGN,
             'columns' => $row['column_name'],
             'references' => [$row['references_table'], $row['references_field']],
             'update' => $this->_convertOnClause($row['on_update']),
             'delete' => $this->_convertOnClause($row['on_delete']),
         ];
-        $table->addConstraint($row['name'], $data);
+        $schema->addConstraint($row['name'], $data);
     }
 
     /**
@@ -323,24 +323,24 @@ class PostgresSchema extends BaseSchema
     protected function _convertOnClause($clause)
     {
         if ($clause === 'r') {
-            return Table::ACTION_RESTRICT;
+            return TableSchema::ACTION_RESTRICT;
         }
         if ($clause === 'a') {
-            return Table::ACTION_NO_ACTION;
+            return TableSchema::ACTION_NO_ACTION;
         }
         if ($clause === 'c') {
-            return Table::ACTION_CASCADE;
+            return TableSchema::ACTION_CASCADE;
         }
 
-        return Table::ACTION_SET_NULL;
+        return TableSchema::ACTION_SET_NULL;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function columnSql(Table $table, $name)
+    public function columnSql(Table $schema, $name)
     {
-        $data = $table->column($name);
+        $data = $schema->column($name);
         $out = $this->_driver->quoteIdentifier($name);
         $typeMap = [
             'boolean' => ' BOOLEAN',
@@ -361,18 +361,18 @@ class PostgresSchema extends BaseSchema
 
         if ($data['type'] === 'integer' || $data['type'] === 'biginteger') {
             $type = $data['type'] === 'integer' ? ' INTEGER' : ' BIGINT';
-            if ([$name] === $table->primaryKey() || $data['autoIncrement'] === true) {
+            if ([$name] === $schema->primaryKey() || $data['autoIncrement'] === true) {
                 $type = $data['type'] === 'integer' ? ' SERIAL' : ' BIGSERIAL';
                 unset($data['null'], $data['default']);
             }
             $out .= $type;
         }
 
-        if ($data['type'] === 'text' && $data['length'] !== Table::LENGTH_TINY) {
+        if ($data['type'] === 'text' && $data['length'] !== TableSchema::LENGTH_TINY) {
             $out .= ' TEXT';
         }
 
-        if ($data['type'] === 'string' || ($data['type'] === 'text' && $data['length'] === Table::LENGTH_TINY)) {
+        if ($data['type'] === 'string' || ($data['type'] === 'text' && $data['length'] === TableSchema::LENGTH_TINY)) {
             $isFixed = !empty($data['fixed']);
             $type = ' VARCHAR';
             if ($isFixed) {
@@ -420,16 +420,16 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function addConstraintSql(Table $table)
+    public function addConstraintSql(Table $schema)
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s;';
         $sql = [];
 
-        foreach ($table->constraints() as $name) {
-            $constraint = $table->constraint($name);
-            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $tableName = $this->_driver->quoteIdentifier($table->name());
-                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($table, $name));
+        foreach ($schema->constraints() as $name) {
+            $constraint = $schema->constraint($name);
+            if ($constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
+                $tableName = $this->_driver->quoteIdentifier($schema->name());
+                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($schema, $name));
             }
         }
 
@@ -439,15 +439,15 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function dropConstraintSql(Table $table)
+    public function dropConstraintSql(TableSchema $schema)
     {
         $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s;';
         $sql = [];
 
-        foreach ($table->constraints() as $name) {
-            $constraint = $table->constraint($name);
-            if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $tableName = $this->_driver->quoteIdentifier($table->name());
+        foreach ($schema->constraints() as $name) {
+            $constraint = $schema->constraint($name);
+            if ($constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
+                $tableName = $this->_driver->quoteIdentifier($schema->name());
                 $constraintName = $this->_driver->quoteIdentifier($name);
                 $sql[] = sprintf($sqlPattern, $tableName, $constraintName);
             }
@@ -459,9 +459,9 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function indexSql(Table $table, $name)
+    public function indexSql(TableSchema $schema, $name)
     {
-        $data = $table->index($name);
+        $data = $schema->index($name);
         $columns = array_map(
             [$this->_driver, 'quoteIdentifier'],
             $data['columns']
@@ -470,7 +470,7 @@ class PostgresSchema extends BaseSchema
         return sprintf(
             'CREATE INDEX %s ON %s (%s)',
             $this->_driver->quoteIdentifier($name),
-            $this->_driver->quoteIdentifier($table->name()),
+            $this->_driver->quoteIdentifier($schema->name()),
             implode(', ', $columns)
         );
     }
@@ -478,14 +478,14 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function constraintSql(Table $table, $name)
+    public function constraintSql(Table $schema, $name)
     {
-        $data = $table->constraint($name);
+        $data = $schema->constraint($name);
         $out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
-        if ($data['type'] === Table::CONSTRAINT_PRIMARY) {
+        if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {
             $out = 'PRIMARY KEY';
         }
-        if ($data['type'] === Table::CONSTRAINT_UNIQUE) {
+        if ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
             $out .= ' UNIQUE';
         }
 
@@ -505,7 +505,7 @@ class PostgresSchema extends BaseSchema
             [$this->_driver, 'quoteIdentifier'],
             $data['columns']
         );
-        if ($data['type'] === Table::CONSTRAINT_FOREIGN) {
+        if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             return $prefix . sprintf(
                 ' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s DEFERRABLE INITIALLY IMMEDIATE',
                 implode(', ', $columns),
@@ -522,19 +522,19 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function createTableSql(Table $table, $columns, $constraints, $indexes)
+    public function createTableSql(TableSchema $schema, $columns, $constraints, $indexes)
     {
         $content = array_merge($columns, $constraints);
         $content = implode(",\n", array_filter($content));
-        $tableName = $this->_driver->quoteIdentifier($table->name());
-        $temporary = $table->temporary() ? ' TEMPORARY ' : ' ';
+        $tableName = $this->_driver->quoteIdentifier($schema->name());
+        $temporary = $schema->temporary() ? ' TEMPORARY ' : ' ';
         $out = [];
         $out[] = sprintf("CREATE%sTABLE %s (\n%s\n)", $temporary, $tableName, $content);
         foreach ($indexes as $index) {
             $out[] = $index;
         }
-        foreach ($table->columns() as $column) {
-            $columnData = $table->column($column);
+        foreach ($schema->columns() as $column) {
+            $columnData = $schema->column($column);
             if (isset($columnData['comment'])) {
                 $out[] = sprintf(
                     'COMMENT ON COLUMN %s.%s IS %s',
@@ -551,9 +551,9 @@ class PostgresSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function truncateTableSql(Table $table)
+    public function truncateTableSql(TableSchema $schema)
     {
-        $name = $this->_driver->quoteIdentifier($table->name());
+        $name = $this->_driver->quoteIdentifier($schema->name());
 
         return [
             sprintf('TRUNCATE %s RESTART IDENTITY CASCADE', $name)
@@ -563,14 +563,14 @@ class PostgresSchema extends BaseSchema
     /**
      * Generate the SQL to drop a table.
      *
-     * @param \Cake\Database\Schema\Table $table Table instance
+     * @param \Cake\Database\Schema\TableSchema $schema Table instance
      * @return array SQL statements to drop a table.
      */
-    public function dropTableSql(Table $table)
+    public function dropTableSql(TableSchema $schema)
     {
         $sql = sprintf(
             'DROP TABLE %s CASCADE',
-            $this->_driver->quoteIdentifier($table->name())
+            $this->_driver->quoteIdentifier($schema->name())
         );
 
         return [$sql];

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -123,14 +123,14 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function convertColumnDescription(Table $table, $row)
+    public function convertColumnDescription(TableSchema $schema, $row)
     {
         $field = $this->_convertColumn($row['type']);
         $field += [
             'null' => !$row['notnull'],
             'default' => $this->_defaultValue($row['dflt_value']),
         ];
-        $primary = $table->constraint('primary');
+        $primary = $schema->constraint('primary');
 
         if ($row['pk'] && empty($primary)) {
             $field['null'] = false;
@@ -140,17 +140,17 @@ class SqliteSchema extends BaseSchema
         // SQLite does not support autoincrement on composite keys.
         if ($row['pk'] && !empty($primary)) {
             $existingColumn = $primary['columns'][0];
-            $table->addColumn($existingColumn, ['autoIncrement' => null] + $table->column($existingColumn));
+            $schema->addColumn($existingColumn, ['autoIncrement' => null] + $schema->column($existingColumn));
         }
 
-        $table->addColumn($row['name'], $field);
+        $schema->addColumn($row['name'], $field);
         if ($row['pk']) {
-            $constraint = (array)$table->constraint('primary') + [
-                'type' => Table::CONSTRAINT_PRIMARY,
+            $constraint = (array)$schema->constraint('primary') + [
+                'type' => TableSchema::CONSTRAINT_PRIMARY,
                 'columns' => []
             ];
             $constraint['columns'] = array_merge($constraint['columns'], [$row['name']]);
-            $table->addConstraint('primary', $constraint);
+            $schema->addConstraint('primary', $constraint);
         }
     }
 
@@ -199,7 +199,7 @@ class SqliteSchema extends BaseSchema
      * the table. This is a limitation in Sqlite's metadata features.
      *
      */
-    public function convertIndexDescription(Table $table, $row)
+    public function convertIndexDescription(TableSchema $schema, $row)
     {
         $sql = sprintf(
             'PRAGMA index_info(%s)',
@@ -213,13 +213,13 @@ class SqliteSchema extends BaseSchema
         }
         $statement->closeCursor();
         if ($row['unique']) {
-            $table->addConstraint($row['name'], [
-                'type' => Table::CONSTRAINT_UNIQUE,
+            $schema->addConstraint($row['name'], [
+                'type' => TableSchema::CONSTRAINT_UNIQUE,
                 'columns' => $columns
             ]);
         } else {
-            $table->addIndex($row['name'], [
-                'type' => Table::INDEX_INDEX,
+            $schema->addIndex($row['name'], [
+                'type' => TableSchema::INDEX_INDEX,
                 'columns' => $columns
             ]);
         }
@@ -238,27 +238,27 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function convertForeignKeyDescription(Table $table, $row)
+    public function convertForeignKeyDescription(TableSchema $schema, $row)
     {
         $name = $row['from'] . '_fk';
 
         $update = isset($row['on_update']) ? $row['on_update'] : '';
         $delete = isset($row['on_delete']) ? $row['on_delete'] : '';
         $data = [
-            'type' => Table::CONSTRAINT_FOREIGN,
+            'type' => TableSchema::CONSTRAINT_FOREIGN,
             'columns' => [$row['from']],
             'references' => [$row['table'], $row['to']],
             'update' => $this->_convertOnClause($update),
             'delete' => $this->_convertOnClause($delete),
         ];
 
-        if (isset($this->_constraintsIdMap[$table->name()][$row['id']])) {
-            $name = $this->_constraintsIdMap[$table->name()][$row['id']];
+        if (isset($this->_constraintsIdMap[$schema->name()][$row['id']])) {
+            $name = $this->_constraintsIdMap[$schema->name()][$row['id']];
         } else {
-            $this->_constraintsIdMap[$table->name()][$row['id']] = $name;
+            $this->_constraintsIdMap[$schema->name()][$row['id']] = $name;
         }
 
-        $table->addConstraint($name, $data);
+        $schema->addConstraint($name, $data);
     }
 
     /**
@@ -266,9 +266,9 @@ class SqliteSchema extends BaseSchema
      *
      * @throws \Cake\Database\Exception when the column type is unknown
      */
-    public function columnSql(Table $table, $name)
+    public function columnSql(TableSchema $schema, $name)
     {
-        $data = $table->column($name);
+        $data = $schema->column($name);
         $typeMap = [
             'uuid' => ' CHAR(36)',
             'biginteger' => ' BIGINT',
@@ -289,7 +289,7 @@ class SqliteSchema extends BaseSchema
         if (in_array($data['type'], $hasUnsigned, true) &&
             isset($data['unsigned']) && $data['unsigned'] === true
         ) {
-            if ($data['type'] !== 'integer' || [$name] !== (array)$table->primaryKey()) {
+            if ($data['type'] !== 'integer' || [$name] !== (array)$schema->primaryKey()) {
                 $out .= ' UNSIGNED';
             }
         }
@@ -298,11 +298,11 @@ class SqliteSchema extends BaseSchema
             $out .= $typeMap[$data['type']];
         }
 
-        if ($data['type'] === 'text' && $data['length'] !== Table::LENGTH_TINY) {
+        if ($data['type'] === 'text' && $data['length'] !== TableSchema::LENGTH_TINY) {
             $out .= ' TEXT';
         }
 
-        if ($data['type'] === 'string' || ($data['type'] === 'text' && $data['length'] === Table::LENGTH_TINY)) {
+        if ($data['type'] === 'string' || ($data['type'] === 'text' && $data['length'] === TableSchema::LENGTH_TINY)) {
             $out .= ' VARCHAR';
 
             if (isset($data['length'])) {
@@ -312,7 +312,7 @@ class SqliteSchema extends BaseSchema
 
         if ($data['type'] === 'integer') {
             $out .= ' INTEGER';
-            if (isset($data['length']) && [$name] !== (array)$table->primaryKey()) {
+            if (isset($data['length']) && [$name] !== (array)$schema->primaryKey()) {
                 $out .= '(' . (int)$data['length'] . ')';
             }
         }
@@ -328,7 +328,7 @@ class SqliteSchema extends BaseSchema
             $out .= ' NOT NULL';
         }
 
-        if ($data['type'] === 'integer' && [$name] === (array)$table->primaryKey()) {
+        if ($data['type'] === 'integer' && [$name] === (array)$schema->primaryKey()) {
             $out .= ' PRIMARY KEY AUTOINCREMENT';
         }
 
@@ -350,23 +350,23 @@ class SqliteSchema extends BaseSchema
      * that integer primary keys be defined in the column definition.
      *
      */
-    public function constraintSql(Table $table, $name)
+    public function constraintSql(TableSchema $schema, $name)
     {
-        $data = $table->constraint($name);
-        if ($data['type'] === Table::CONSTRAINT_PRIMARY &&
+        $data = $schema->constraint($name);
+        if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY &&
             count($data['columns']) === 1 &&
-            $table->column($data['columns'][0])['type'] === 'integer'
+            $schema->column($data['columns'][0])['type'] === 'integer'
         ) {
             return '';
         }
         $clause = '';
-        if ($data['type'] === Table::CONSTRAINT_PRIMARY) {
+        if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {
             $type = 'PRIMARY KEY';
         }
-        if ($data['type'] === Table::CONSTRAINT_UNIQUE) {
+        if ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
             $type = 'UNIQUE';
         }
-        if ($data['type'] === Table::CONSTRAINT_FOREIGN) {
+        if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             $type = 'FOREIGN KEY';
 
             $clause = sprintf(
@@ -397,7 +397,7 @@ class SqliteSchema extends BaseSchema
      * SQLite can not properly handle adding a constraint to an existing table.
      * This method is no-op
      */
-    public function addConstraintSql(Table $table)
+    public function addConstraintSql(TableSchema $schema)
     {
         return [];
     }
@@ -408,7 +408,7 @@ class SqliteSchema extends BaseSchema
      * SQLite can not properly handle dropping a constraint to an existing table.
      * This method is no-op
      */
-    public function dropConstraintSql(Table $table)
+    public function dropConstraintSql(TableSchema $schema)
     {
         return [];
     }
@@ -416,9 +416,9 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function indexSql(Table $table, $name)
+    public function indexSql(TableSchema $schema, $name)
     {
-        $data = $table->index($name);
+        $data = $schema->index($name);
         $columns = array_map(
             [$this->_driver, 'quoteIdentifier'],
             $data['columns']
@@ -427,7 +427,7 @@ class SqliteSchema extends BaseSchema
         return sprintf(
             'CREATE INDEX %s ON %s (%s)',
             $this->_driver->quoteIdentifier($name),
-            $this->_driver->quoteIdentifier($table->name()),
+            $this->_driver->quoteIdentifier($schema->name()),
             implode(', ', $columns)
         );
     }
@@ -435,12 +435,12 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function createTableSql(Table $table, $columns, $constraints, $indexes)
+    public function createTableSql(TableSchema $schema, $columns, $constraints, $indexes)
     {
         $lines = array_merge($columns, $constraints);
         $content = implode(",\n", array_filter($lines));
-        $temporary = $table->temporary() ? ' TEMPORARY ' : ' ';
-        $table = sprintf("CREATE%sTABLE \"%s\" (\n%s\n)", $temporary, $table->name(), $content);
+        $temporary = $schema->temporary() ? ' TEMPORARY ' : ' ';
+        $table = sprintf("CREATE%sTABLE \"%s\" (\n%s\n)", $temporary, $schema->name(), $content);
         $out = [$table];
         foreach ($indexes as $index) {
             $out[] = $index;
@@ -452,9 +452,9 @@ class SqliteSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function truncateTableSql(Table $table)
+    public function truncateTableSql(TableSchema $schema)
     {
-        $name = $table->name();
+        $name = $schema->name();
         $sql = [];
         if ($this->hasSequences()) {
             $sql[] = sprintf('DELETE FROM sqlite_sequence WHERE name="%s"', $name);

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -326,9 +326,9 @@ class SqlserverSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function columnSql(Table $table, $name)
+    public function columnSql(Table $schema, $name)
     {
-        $data = $table->column($name);
+        $data = $schema->column($name);
         $out = $this->_driver->quoteIdentifier($name);
         $typeMap = [
             'integer' => ' INTEGER',
@@ -349,7 +349,7 @@ class SqlserverSchema extends BaseSchema
         }
 
         if ($data['type'] === 'integer' || $data['type'] === 'biginteger') {
-            if ([$name] === $table->primaryKey() || $data['autoIncrement'] === true) {
+            if ([$name] === $schema->primaryKey() || $data['autoIncrement'] === true) {
                 unset($data['null'], $data['default']);
                 $out .= ' IDENTITY(1, 1)';
             }
@@ -418,16 +418,16 @@ class SqlserverSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function addConstraintSql(Table $table)
+    public function addConstraintSql(Table $schema)
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s;';
         $sql = [];
 
-        foreach ($table->constraints() as $name) {
-            $constraint = $table->constraint($name);
+        foreach ($schema->constraints() as $name) {
+            $constraint = $schema->constraint($name);
             if ($constraint['type'] === Table::CONSTRAINT_FOREIGN) {
-                $tableName = $this->_driver->quoteIdentifier($table->name());
-                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($table, $name));
+                $tableName = $this->_driver->quoteIdentifier($schema->name());
+                $sql[] = sprintf($sqlPattern, $tableName, $this->constraintSql($schema, $name));
             }
         }
 
@@ -476,9 +476,9 @@ class SqlserverSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function constraintSql(Table $table, $name)
+    public function constraintSql(Table $schema, $name)
     {
-        $data = $table->constraint($name);
+        $data = $schema->constraint($name);
         $out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
         if ($data['type'] === Table::CONSTRAINT_PRIMARY) {
             $out = 'PRIMARY KEY';
@@ -520,11 +520,11 @@ class SqlserverSchema extends BaseSchema
     /**
      * {@inheritDoc}
      */
-    public function createTableSql(Table $table, $columns, $constraints, $indexes)
+    public function createTableSql(Table $schema, $columns, $constraints, $indexes)
     {
         $content = array_merge($columns, $constraints);
         $content = implode(",\n", array_filter($content));
-        $tableName = $this->_driver->quoteIdentifier($table->name());
+        $tableName = $this->_driver->quoteIdentifier($schema->name());
         $out = [];
         $out[] = sprintf("CREATE TABLE %s (\n%s\n)", $tableName, $content);
         foreach ($indexes as $index) {

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -1,3 +1,3 @@
 <?php
 // @deprecated Backwards compatibility with earlier 3.x versions.
-class_alias('Cake\Database\Schema\Schema', 'Cake\Database\Schema\Table');
+class_alias('Cake\Database\Schema\TableSchema', 'Cake\Database\Schema\Table');

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -29,7 +29,7 @@ use Cake\Datasource\ConnectionInterface;
  * Schema\Collection objects. They can also be converted into SQL using the
  * createSql(), dropSql() and truncateSql() methods.
  */
-class Schema
+class TableSchema
 {
 
     /**

--- a/src/Datasource/TableSchemaInterface.php
+++ b/src/Datasource/TableSchemaInterface.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Datasource;
 
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 
 /**
  * Defines the interface for getting the schema.
@@ -25,8 +25,8 @@ interface TableSchemaInterface
     /**
      * Get and set the schema for this fixture.
      *
-     * @param \Cake\Database\Schema\Table|null $schema The table to set.
-     * @return \Cake\Database\Schema\Table|null
+     * @param \Cake\Database\Schema\TableSchema|null $schema The table to set.
+     * @return \Cake\Database\Schema\TableSchema|null
      */
-    public function schema(Table $schema = null);
+    public function schema(TableSchema $schema = null);
 }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -17,7 +17,7 @@ namespace Cake\ORM;
 use ArrayObject;
 use BadMethodCallException;
 use Cake\Core\App;
-use Cake\Database\Schema\Schema;
+use Cake\Database\Schema\TableSchema;
 use Cake\Database\Type;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\EntityInterface;
@@ -176,7 +176,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * The schema object containing a description of this table fields
      *
-     * @var \Cake\Database\Schema\Schema
+     * @var \Cake\Database\Schema\TableSchema
      */
     protected $_schema;
 
@@ -232,7 +232,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * - connection: The connection instance to use
      * - entityClass: The fully namespaced class name of the entity class that will
      *   represent rows in this table.
-     * - schema: A \Cake\Database\Schema\Table object or an array that can be
+     * - schema: A \Cake\Database\Schema\TableSchema object or an array that can be
      *   passed to it.
      * - eventManager: An instance of an event manager to use for internal events
      * - behaviors: A BehaviorRegistry. Generally not used outside of tests.
@@ -421,14 +421,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the schema table object describing this table's properties.
      *
-     * If an \Cake\Database\Schema\Table is passed, it will be used for this table
+     * If a TableSchema is passed, it will be used for this table
      * instead of the default one.
      *
-     * If an array is passed, a new \Cake\Database\Schema\Table will be constructed
+     * If an array is passed, a new TableSchema will be constructed
      * out of it and used as the schema for this table.
      *
-     * @param array|\Cake\Database\Schema\Schema|null $schema New schema to be used for this table
-     * @return \Cake\Database\Schema\Schema
+     * @param array|\Cake\Database\Schema\TableSchema|null $schema New schema to be used for this table
+     * @return \Cake\Database\Schema\TableSchema
      */
     public function schema($schema = null)
     {
@@ -452,7 +452,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 unset($schema['_constraints']);
             }
 
-            $schema = new Schema($this->table(), $schema);
+            $schema = new TableSchema($this->table(), $schema);
 
             foreach ($constraints as $name => $value) {
                 $schema->addConstraint($name, $value);
@@ -478,11 +478,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * }
      * ```
      *
-     * @param \Cake\Database\Schema\Schema $schema The table definition fetched from database.
-     * @return \Cake\Database\Schema\Schema the altered schema
+     * @param \Cake\Database\Schema\TableSchema $schema The table definition fetched from database.
+     * @return \Cake\Database\Schema\TableSchema the altered schema
      * @api
      */
-    protected function _initializeSchema(Schema $schema)
+    protected function _initializeSchema(TableSchema $schema)
     {
         return $schema;
     }

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -16,7 +16,7 @@ namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\TableSchemaInterface;
 use Cake\Utility\Inflector;
@@ -243,7 +243,7 @@ class FixtureManager
         $exists = in_array($table, $sources);
 
         if (($drop && $exists) ||
-            ($exists && !$isFixtureSetup && $fixture instanceof TableSchemaInterface && $fixture->schema() instanceof Table)
+            ($exists && !$isFixtureSetup && $fixture instanceof TableSchemaInterface && $fixture->schema() instanceof TableSchema)
         ) {
             $fixture->drop($db);
             $fixture->create($db);

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -14,7 +14,7 @@
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\Exception as CakeException;
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\FixtureInterface;
@@ -48,7 +48,7 @@ class TestFixture implements FixtureInterface, TableSchemaInterface
     /**
      * Fields / Schema for the fixture.
      *
-     * This array should be compatible with Cake\Database\Schema\Table.
+     * This array should be compatible with Cake\Database\Schema\Schema.
      * The `_constraints`, `_options` and `_indexes` keys are reserved for defining
      * constraints, options and indexes respectively.
      *
@@ -75,9 +75,9 @@ class TestFixture implements FixtureInterface, TableSchemaInterface
     public $records = [];
 
     /**
-     * The Cake\Database\Schema\Table for this fixture.
+     * The schema for this fixture.
      *
-     * @var \Cake\Database\Schema\Table
+     * @var \Cake\Database\Schema\TableSchema
      */
     protected $_schema;
 
@@ -176,7 +176,7 @@ class TestFixture implements FixtureInterface, TableSchemaInterface
     protected function _schemaFromFields()
     {
         $connection = ConnectionManager::get($this->connection());
-        $this->_schema = new Table($this->table);
+        $this->_schema = new TableSchema($this->table);
         foreach ($this->fields as $field => $data) {
             if ($field === '_constraints' || $field === '_indexes' || $field === '_options') {
                 continue;
@@ -185,7 +185,7 @@ class TestFixture implements FixtureInterface, TableSchemaInterface
         }
         if (!empty($this->fields['_constraints'])) {
             foreach ($this->fields['_constraints'] as $name => $data) {
-                if (!$connection->supportsDynamicConstraints() || $data['type'] !== Table::CONSTRAINT_FOREIGN) {
+                if (!$connection->supportsDynamicConstraints() || $data['type'] !== TableSchema::CONSTRAINT_FOREIGN) {
                     $this->_schema->addConstraint($name, $data);
                 } else {
                     $this->_constraints[$name] = $data;
@@ -260,12 +260,12 @@ class TestFixture implements FixtureInterface, TableSchemaInterface
     }
 
     /**
-     * Get/Set the Cake\Database\Schema\Table instance used by this fixture.
+     * Gets/Sets the TableSchema instance used by this fixture.
      *
-     * @param \Cake\Database\Schema\Table|null $schema The table to set.
-     * @return \Cake\Database\Schema\Table|null
+     * @param \Cake\Database\Schema\TableSchema|null $schema The table to set.
+     * @return \Cake\Database\Schema\TableSchema|null
      */
-    public function schema(Table $schema = null)
+    public function schema(TableSchema $schema = null)
     {
         if ($schema) {
             $this->_schema = $schema;

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -31,7 +31,7 @@ use Cake\Utility\Hash;
  * - `required` A nested array of fields, relationships and boolean
  *   flags to indicate a field is required.
  * - `schema` An array of data that emulate the column structures that
- *   Cake\Database\Schema\Table uses. This array allows you to control
+ *   Cake\Database\Schema\Schema uses. This array allows you to control
  *   the inferred type for fields and allows auto generation of attributes
  *   like maxlength, step and other HTML attributes. If you want
  *   primary key/id detection to work. Make sure you have provided a `_constraints`

--- a/tests/Fixture/SessionsFixture.php
+++ b/tests/Fixture/SessionsFixture.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Test\Fixture;
 
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
@@ -30,7 +30,7 @@ class SessionsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'string', 'length' => 128],
-        'data' => ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM, 'null' => true],
+        'data' => ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM, 'null' => true],
         'expires' => ['type' => 'integer', 'length' => 11, 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Test\Fixture;
 
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
@@ -31,7 +31,7 @@ class TagsFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer', 'null' => false],
         'name' => ['type' => 'string', 'null' => false],
-        'description' => ['type' => 'text', 'length' => Table::LENGTH_MEDIUM],
+        'description' => ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM],
         'created' => ['type' => 'datetime', 'null' => true, 'default' => null],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\MysqlSchema;
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -105,19 +105,19 @@ class MysqlSchemaTest extends TestCase
             ],
             [
                 'TINYTEXT',
-                ['type' => 'text', 'length' => Table::LENGTH_TINY]
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY]
             ],
             [
                 'MEDIUMTEXT',
-                ['type' => 'text', 'length' => Table::LENGTH_MEDIUM]
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM]
             ],
             [
                 'LONGTEXT',
-                ['type' => 'text', 'length' => Table::LENGTH_LONG]
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG]
             ],
             [
                 'TINYBLOB',
-                ['type' => 'binary', 'length' => Table::LENGTH_TINY]
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_TINY]
             ],
             [
                 'BLOB',
@@ -125,11 +125,11 @@ class MysqlSchemaTest extends TestCase
             ],
             [
                 'MEDIUMBLOB',
-                ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM]
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM]
             ],
             [
                 'LONGBLOB',
-                ['type' => 'binary', 'length' => Table::LENGTH_LONG]
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG]
             ],
             [
                 'FLOAT',
@@ -200,7 +200,7 @@ class MysqlSchemaTest extends TestCase
         $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')->getMock();
         $dialect = new MysqlSchema($driver);
 
-        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+        $table = $this->getMockBuilder(TableSchema::class)
             ->setConstructorArgs(['table'])
             ->getMock();
         $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
@@ -513,17 +513,17 @@ SQL;
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_TINY, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY, 'null' => false],
                 '`body` TINYTEXT NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_MEDIUM, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM, 'null' => false],
                 '`body` MEDIUMTEXT NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_LONG, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG, 'null' => false],
                 '`body` LONGTEXT NOT NULL'
             ],
             [
@@ -539,17 +539,17 @@ SQL;
             ],
             [
                 'body',
-                ['type' => 'binary', 'length' => Table::LENGTH_TINY, 'null' => false],
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_TINY, 'null' => false],
                 '`body` TINYBLOB NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM, 'null' => false],
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM, 'null' => false],
                 '`body` MEDIUMBLOB NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'binary', 'length' => Table::LENGTH_LONG, 'null' => false],
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG, 'null' => false],
                 '`body` LONGBLOB NOT NULL'
             ],
             // Integers
@@ -673,7 +673,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchema($driver);
 
-        $table = (new Table('articles'))->addColumn($name, $data);
+        $table = (new TableSchema('articles'))->addColumn($name, $data);
         $this->assertEquals($expected, $schema->columnSql($table, $name));
     }
 
@@ -747,7 +747,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchema($driver);
 
-        $table = (new Table('articles'))->addColumn('title', [
+        $table = (new TableSchema('articles'))->addColumn('title', [
             'type' => 'string',
             'length' => 255
         ])->addColumn('author_id', [
@@ -788,7 +788,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchema($driver);
 
-        $table = (new Table('articles'))->addColumn('title', [
+        $table = (new TableSchema('articles'))->addColumn('title', [
             'type' => 'string',
             'length' => 255
         ])->addColumn('author_id', [
@@ -812,7 +812,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
+        $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
                 'type' => 'integer',
                 'null' => false
@@ -863,7 +863,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
+        $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
                 'type' => 'integer',
                 'null' => false
@@ -910,7 +910,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchema($driver);
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $table->addColumn('id', [
                 'type' => 'integer',
                 'null' => false,
@@ -922,7 +922,7 @@ SQL;
         $result = $schema->columnSql($table, 'id');
         $this->assertEquals($result, '`id` INTEGER NOT NULL AUTO_INCREMENT');
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $table->addColumn('id', [
                 'type' => 'biginteger',
                 'null' => false
@@ -954,7 +954,7 @@ SQL;
             ->method('getAttribute')
             ->will($this->returnValue('5.6.0'));
 
-        $table = (new Table('posts'))->addColumn('id', [
+        $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
                 'null' => false
             ])
@@ -1024,7 +1024,7 @@ SQL;
             ->method('getAttribute')
             ->will($this->returnValue('5.7.0'));
 
-        $table = (new Table('posts'))->addColumn('id', [
+        $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
                 'null' => false
             ])
@@ -1066,7 +1066,7 @@ SQL;
             ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
-        $table = (new Table('schema_articles'))->addColumn('id', [
+        $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false
         ]);
@@ -1089,7 +1089,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('articles_tags'))
+        $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
                 'type' => 'integer',
                 'null' => false
@@ -1114,7 +1114,7 @@ SQL;
         $this->assertCount(1, $result);
         $this->assertTextEquals($expected, $result[0]);
 
-        $table = (new Table('composite_key'))
+        $table = (new TableSchema('composite_key'))
             ->addColumn('id', [
                 'type' => 'integer',
                 'null' => false,
@@ -1155,7 +1155,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
         $this->assertEquals('DROP TABLE `articles`', $result[0]);
@@ -1175,7 +1175,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
         $this->assertCount(1, $result);
         $this->assertEquals('TRUNCATE TABLE `articles`', $result[0]);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -18,6 +18,7 @@ use Cake\Database\Driver\Postgres;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\PostgresSchema;
 use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -240,7 +241,7 @@ SQL;
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')->getMock();
         $dialect = new PostgresSchema($driver);
 
-        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+        $table = $this->getMockBuilder(TableSchema::class)
             ->setConstructorArgs(['table'])
             ->getMock();
         $table->expects($this->at(0))->method('addColumn')->with('field', $expected);
@@ -660,17 +661,17 @@ SQL;
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_TINY, 'null' => false],
-                sprintf('"body" VARCHAR(%s) NOT NULL', Table::LENGTH_TINY)
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY, 'null' => false],
+                sprintf('"body" VARCHAR(%s) NOT NULL', TableSchema::LENGTH_TINY)
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_MEDIUM, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM, 'null' => false],
                 '"body" TEXT NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_LONG, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG, 'null' => false],
                 '"body" TEXT NOT NULL'
             ],
             [
@@ -791,7 +792,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new PostgresSchema($driver);
 
-        $table = (new Table('schema_articles'))->addColumn($name, $data);
+        $table = (new TableSchema('schema_articles'))->addColumn($name, $data);
         $this->assertEquals($expected, $schema->columnSql($table, $name));
     }
 
@@ -805,7 +806,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new PostgresSchema($driver);
 
-        $table = new Table('schema_articles');
+        $table = new TableSchema('schema_articles');
         $table->addColumn('id', [
                 'type' => 'integer',
                 'null' => false
@@ -879,7 +880,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new PostgresSchema($driver);
 
-        $table = (new Table('schema_articles'))->addColumn('title', [
+        $table = (new TableSchema('schema_articles'))->addColumn('title', [
             'type' => 'string',
             'length' => 255
         ])->addColumn('author_id', [
@@ -903,7 +904,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
+        $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
                 'type' => 'integer',
                 'null' => false
@@ -954,7 +955,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
+        $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
                 'type' => 'integer',
                 'null' => false
@@ -1005,7 +1006,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('schema_articles'))->addColumn('id', [
+        $table = (new TableSchema('schema_articles'))->addColumn('id', [
                 'type' => 'integer',
                 'null' => false
             ])
@@ -1071,7 +1072,7 @@ SQL;
             ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
-        $table = (new Table('schema_articles'))->addColumn('id', [
+        $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false
         ]);
@@ -1094,7 +1095,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('articles_tags'))
+        $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
                 'type' => 'integer',
                 'null' => false
@@ -1119,7 +1120,7 @@ SQL;
         $this->assertCount(1, $result);
         $this->assertTextEquals($expected, $result[0]);
 
-        $table = (new Table('composite_key'))
+        $table = (new TableSchema('composite_key'))
             ->addColumn('id', [
                 'type' => 'integer',
                 'null' => false,
@@ -1160,7 +1161,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('schema_articles');
+        $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
         $this->assertEquals('DROP TABLE "schema_articles" CASCADE', $result[0]);
@@ -1180,7 +1181,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('schema_articles');
+        $table = new TableSchema('schema_articles');
         $table->addColumn('id', 'integer')
             ->addConstraint('primary', [
                 'type' => 'primary',

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqliteSchema;
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -153,7 +153,7 @@ class SqliteSchemaTest extends TestCase
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')->getMock();
         $dialect = new SqliteSchema($driver);
 
-        $table = $this->getMockBuilder('Cake\Database\Schema\Table')
+        $table = $this->getMockBuilder(TableSchema::class)
             ->setConstructorArgs(['table'])
             ->getMock();
         $table->expects($this->at(1))->method('addColumn')->with('field', $expected);
@@ -187,7 +187,7 @@ class SqliteSchemaTest extends TestCase
             'dflt_value' => 1,
         ];
 
-        $table = new \Cake\Database\Schema\Table('table');
+        $table = new TableSchema('table');
         $dialect->convertColumnDescription($table, $field1);
         $dialect->convertColumnDescription($table, $field2);
         $this->assertEquals(['field1', 'field2'], $table->primaryKey());
@@ -483,17 +483,17 @@ SQL;
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_TINY, 'null' => false],
-                '"body" VARCHAR(' . Table::LENGTH_TINY . ') NOT NULL'
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY, 'null' => false],
+                '"body" VARCHAR(' . TableSchema::LENGTH_TINY . ') NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_MEDIUM, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM, 'null' => false],
                 '"body" TEXT NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_LONG, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG, 'null' => false],
                 '"body" TEXT NOT NULL'
             ],
             // Integers
@@ -600,7 +600,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('posts');
+        $table = new TableSchema('posts');
 
         $result = $table->addConstraintSql($connection);
         $this->assertEmpty($result);
@@ -620,7 +620,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('posts');
+        $table = new TableSchema('posts');
         $result = $table->dropConstraintSql($connection);
         $this->assertEmpty($result);
     }
@@ -636,7 +636,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchema($driver);
 
-        $table = (new Table('articles'))->addColumn($name, $data);
+        $table = (new TableSchema('articles'))->addColumn($name, $data);
         $this->assertEquals($expected, $schema->columnSql($table, $name));
     }
 
@@ -650,7 +650,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchema($driver);
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $table->addColumn('id', [
                 'type' => 'integer',
                 'null' => false,
@@ -678,7 +678,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchema($driver);
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $table->addColumn('id', [
                 'type' => 'biginteger',
                 'null' => false
@@ -755,7 +755,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchema($driver);
 
-        $table = (new Table('articles'))->addColumn('title', [
+        $table = (new TableSchema('articles'))->addColumn('title', [
             'type' => 'string',
             'length' => 255
         ])->addColumn('author_id', [
@@ -791,7 +791,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchema($driver);
 
-        $table = (new Table('articles'))->addColumn('title', [
+        $table = (new TableSchema('articles'))->addColumn('title', [
             'type' => 'string',
             'length' => 255
         ])->addColumn('author_id', [
@@ -815,7 +815,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('articles'))->addColumn('id', [
+        $table = (new TableSchema('articles'))->addColumn('id', [
                 'type' => 'integer',
                 'null' => false
             ])
@@ -866,7 +866,7 @@ SQL;
             ->getMock();
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
-        $table = (new Table('schema_articles'))->addColumn('id', [
+        $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false
         ]);
@@ -889,7 +889,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('articles_tags'))
+        $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
                 'type' => 'integer',
                 'null' => false
@@ -916,7 +916,7 @@ SQL;
 
         // Sqlite only supports AUTO_INCREMENT on single column primary
         // keys. Ensure that schema data follows the limitations of Sqlite.
-        $table = (new Table('composite_key'))
+        $table = (new TableSchema('composite_key'))
             ->addColumn('id', [
                 'type' => 'integer',
                 'null' => false,
@@ -957,7 +957,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
         $this->assertEquals('DROP TABLE "articles"', $result[0]);
@@ -988,7 +988,7 @@ SQL;
         $statement->expects($this->at(2))->method('fetch')
             ->will($this->returnValue(false));
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
         $this->assertCount(2, $result);
         $this->assertEquals('DELETE FROM sqlite_sequence WHERE name="articles"', $result[0]);
@@ -1018,7 +1018,7 @@ SQL;
         $statement->expects($this->once())->method('fetch')
             ->will($this->returnValue(false));
 
-        $table = new Table('articles');
+        $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
         $this->assertCount(1, $result);
         $this->assertEquals('DELETE FROM "articles"', $result[0]);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqlserverSchema;
-use Cake\Database\Schema\Table;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -534,17 +534,17 @@ SQL;
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_TINY, 'null' => false],
-                sprintf('[body] NVARCHAR(%s) NOT NULL', Table::LENGTH_TINY)
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY, 'null' => false],
+                sprintf('[body] NVARCHAR(%s) NOT NULL', TableSchema::LENGTH_TINY)
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_MEDIUM, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM, 'null' => false],
                 '[body] NVARCHAR(MAX) NOT NULL'
             ],
             [
                 'body',
-                ['type' => 'text', 'length' => Table::LENGTH_LONG, 'null' => false],
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG, 'null' => false],
                 '[body] NVARCHAR(MAX) NOT NULL'
             ],
             [
@@ -598,17 +598,17 @@ SQL;
             ],
             [
                 'img',
-                ['type' => 'binary', 'length' => Table::LENGTH_TINY],
-                sprintf('[img] VARBINARY(%s)', Table::LENGTH_TINY)
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_TINY],
+                sprintf('[img] VARBINARY(%s)', TableSchema::LENGTH_TINY)
             ],
             [
                 'img',
-                ['type' => 'binary', 'length' => Table::LENGTH_MEDIUM],
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM],
                 '[img] VARBINARY(MAX)'
             ],
             [
                 'img',
-                ['type' => 'binary', 'length' => Table::LENGTH_LONG],
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
                 '[img] VARBINARY(MAX)'
             ],
             // Boolean
@@ -659,7 +659,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqlserverSchema($driver);
 
-        $table = (new Table('schema_articles'))->addColumn($name, $data);
+        $table = (new TableSchema('schema_articles'))->addColumn($name, $data);
         $this->assertEquals($expected, $schema->columnSql($table, $name));
     }
 
@@ -724,7 +724,7 @@ SQL;
         $driver = $this->_getMockedDriver();
         $schema = new SqlserverSchema($driver);
 
-        $table = (new Table('schema_articles'))->addColumn('title', [
+        $table = (new TableSchema('schema_articles'))->addColumn('title', [
             'type' => 'string',
             'length' => 255
         ])->addColumn('author_id', [
@@ -748,7 +748,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
+        $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
                 'type' => 'integer',
                 'null' => false
@@ -799,7 +799,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('posts'))
+        $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
                 'type' => 'integer',
                 'null' => false
@@ -850,7 +850,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = (new Table('schema_articles'))->addColumn('id', [
+        $table = (new TableSchema('schema_articles'))->addColumn('id', [
                 'type' => 'integer',
                 'null' => false
             ])
@@ -912,7 +912,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('schema_articles');
+        $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
         $this->assertCount(1, $result);
         $this->assertEquals('DROP TABLE [schema_articles]', $result[0]);
@@ -932,7 +932,7 @@ SQL;
         $connection->expects($this->any())->method('driver')
             ->will($this->returnValue($driver));
 
-        $table = new Table('schema_articles');
+        $table = new TableSchema('schema_articles');
         $table->addColumn('id', 'integer')
             ->addConstraint('primary', [
                 'type' => 'primary',

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Database\Exception;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
@@ -325,7 +326,7 @@ class TableTest extends TestCase
         $schema = ['id' => ['type' => 'integer']];
         $table->schema($schema);
         $this->assertEquals(
-            new \Cake\Database\Schema\Table('another', $schema),
+            new TableSchema('another', $schema),
             $table->schema()
         );
     }


### PR DESCRIPTION
This PR completes https://github.com/cakephp/cakephp/pull/9685
The feedback was that Schema should better be TableSchema

Everything is changed expect for a few BC checks in tests and in the subclasses of BaseSchema - to proof that even extension with swapping the alias does not trigger any notices.