### PR TITLE
Fix additional translation records being created for the default locale.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -283,7 +283,10 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         $fields = array_keys($values);
         $noFields = empty($fields);
 
-        if ($noFields && $noBundled) {
+        // If there are no fields and no bundled translations, or both fields
+        // in the default locale and bundled translations we can
+        // skip the remaining logic as its not necessary.
+        if ($noFields && $noBundled || ($fields && $bundled)) {
             return;
         }
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1258,6 +1258,66 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
+     * Tests that default locale saves ok.
+     *
+     * @return void
+     */
+    public function testSaveDefaultLocale()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->hasMany('Comments');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+
+        $article = $table->get(1);
+        $data = [
+            'title' => 'New title',
+            'body' => 'New body',
+        ];
+        $article = $table->patchEntity($article, $data);
+        $table->save($article);
+        $this->assertNull($article->get('_i18n'));
+
+        $article = $table->get(1);
+        $this->assertEquals('New title', $article->get('title'));
+        $this->assertEquals('New body', $article->get('body'));
+    }
+
+    /**
+     * Tests that translations are added to the whitelist of associations to be
+     * saved
+     *
+     * @return void
+     */
+    public function testSaveTranslationDefaultLocale()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->hasMany('Comments');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+
+        $article = $table->get(1);
+        $data = [
+            'title' => 'New title',
+            'body' => 'New body',
+            '_translations' => [
+                'es' => [
+                    'title' => 'ES title',
+                    'body' => 'ES body'
+                ]
+            ]
+        ];
+        $article = $table->patchEntity($article, $data);
+        $table->save($article);
+        $this->assertNull($article->get('_i18n'));
+
+        $article = $table->find('translations')->where(['id' => 1])->first();
+        $this->assertEquals('New title', $article->get('title'));
+        $this->assertEquals('New body', $article->get('body'));
+
+        $this->assertEquals('ES title', $article->_translations['es']->title);
+        $this->assertEquals('ES body', $article->_translations['es']->body);
+    }
+
+    /**
      * Test that no properties are enabled when the translations
      * option is off.
      *


### PR DESCRIPTION
The default locale should be saved onto the host table and not into the translations tables. By returning early when both the default locale and bundled translations are present we can fix the regression introduced in #9640

Refs #9688