### PR TITLE
Fix nullable field with default value in various db platforms.

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -389,8 +389,8 @@ class MysqlSchema extends BaseSchema
         ) {
             $out .= ' AUTO_INCREMENT';
         }
-        if (isset($data['null']) && $data['null'] === true) {
-            $out .= $data['type'] === 'timestamp' ? ' NULL' : ' DEFAULT NULL';
+        if (isset($data['null']) && $data['null'] === true && $data['type'] === 'timestamp') {
+            $out .= ' NULL';
             unset($data['default']);
         }
         if (isset($data['default']) && !in_array($data['type'], ['timestamp', 'datetime'])) {

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -402,7 +402,7 @@ class PostgresSchema extends BaseSchema
         if (isset($data['null']) && $data['null'] === false) {
             $out .= ' NOT NULL';
         }
-        if (isset($data['null']) && $data['null'] === true) {
+        if (isset($data['null']) && $data['null'] === true && $data['type'] === 'timestamp') {
             $out .= ' DEFAULT NULL';
             unset($data['default']);
         }

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -332,9 +332,8 @@ class SqliteSchema extends BaseSchema
             $out .= ' PRIMARY KEY AUTOINCREMENT';
         }
 
-        if (isset($data['null']) && $data['null'] === true) {
+        if (isset($data['null']) && $data['null'] === true && $data['type'] === 'timestamp') {
             $out .= ' DEFAULT NULL';
-            unset($data['default']);
         }
         if (isset($data['default'])) {
             $out .= ' DEFAULT ' . $this->_driver->schemaValue($data['default']);

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -472,23 +472,33 @@ SQL;
             // strings
             [
                 'title',
+                ['type' => 'string', 'length' => 25, 'null' => true, 'default' => null],
+                '`title` VARCHAR(25)',
+            ],
+            [
+                'title',
                 ['type' => 'string', 'length' => 25, 'null' => false],
                 '`title` VARCHAR(25) NOT NULL'
             ],
             [
                 'title',
                 ['type' => 'string', 'length' => 25, 'null' => true, 'default' => 'ignored'],
-                '`title` VARCHAR(25) DEFAULT NULL'
+                '`title` VARCHAR(25) DEFAULT \'ignored\'',
             ],
             [
-                'id',
-                ['type' => 'string', 'length' => 32, 'fixed' => true, 'null' => false],
-                '`id` CHAR(32) NOT NULL'
+                'title',
+                ['type' => 'string', 'length' => 25, 'null' => true, 'default' => ''],
+                '`title` VARCHAR(25) DEFAULT \'\'',
             ],
             [
                 'role',
                 ['type' => 'string', 'length' => 10, 'null' => false, 'default' => 'admin'],
                 '`role` VARCHAR(10) NOT NULL DEFAULT \'admin\''
+            ],
+            [
+                'id',
+                ['type' => 'string', 'length' => 32, 'fixed' => true, 'null' => false],
+                '`id` CHAR(32) NOT NULL'
             ],
             [
                 'title',

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -625,7 +625,7 @@ SQL;
             [
                 'title',
                 ['type' => 'string', 'length' => 25, 'null' => true, 'default' => 'ignored'],
-                '"title" VARCHAR(25) DEFAULT NULL'
+                '"title" VARCHAR(25) DEFAULT \'ignored\'',
             ],
             [
                 'id',

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -453,7 +453,7 @@ SQL;
             [
                 'title',
                 ['type' => 'string', 'length' => 25, 'null' => true, 'default' => 'ignored'],
-                '"title" VARCHAR(25) DEFAULT NULL'
+                '"title" VARCHAR(25) DEFAULT "ignored"',
             ],
             [
                 'id',


### PR DESCRIPTION
null => true and a default value should create a nullable column with a default value not `DEFAULT NULL`.

Refs #9686 