### PR TITLE
Split combined into separate getter setter for cleaner API.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -447,7 +447,7 @@ class Connection implements ConnectionInterface
         }
 
         $this->_transactionLevel++;
-        if ($this->isEnabledSavePoints()) {
+        if ($this->isSavePointsEnabled()) {
             $this->createSavePoint($this->_transactionLevel);
         }
     }
@@ -471,7 +471,7 @@ class Connection implements ConnectionInterface
 
             return $this->_driver->commitTransaction();
         }
-        if ($this->isEnabledSavePoints()) {
+        if ($this->isSavePointsEnabled()) {
             $this->releaseSavePoint($this->_transactionLevel);
         }
 
@@ -491,7 +491,7 @@ class Connection implements ConnectionInterface
             return false;
         }
 
-        $useSavePoint = $this->isEnabledSavePoints();
+        $useSavePoint = $this->isSavePointsEnabled();
         if ($this->_transactionLevel === 0 || !$useSavePoint) {
             $this->_transactionLevel = 0;
             $this->_transactionStarted = false;
@@ -540,7 +540,7 @@ class Connection implements ConnectionInterface
      *
      * @return bool true if enabled, false otherwise
      */
-    public function isEnabledSavePoints()
+    public function isSavePointsEnabled()
     {
         return $this->_useSavePoints;
     }
@@ -559,7 +559,7 @@ class Connection implements ConnectionInterface
      * `$connection->useSavePoints(false)` Disables usage of savepoints and returns false
      * `$connection->useSavePoints()` Returns current status
      *
-     * @deprecated 3.4.0 Use enableSavePoints()/isEnabledSavePoints() instead.
+     * @deprecated 3.4.0 Use enableSavePoints()/isSavePointsEnabled() instead.
      * @param bool|null $enable Whether or not save points should be used.
      * @return bool true if enabled, false otherwise
      */
@@ -569,7 +569,7 @@ class Connection implements ConnectionInterface
             $this->enableSavePoints($enable);
         }
 
-        return $this->isEnabledSavePoints();
+        return $this->isSavePointsEnabled();
     }
 
     /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -81,7 +81,7 @@ class Connection implements ConnectionInterface
     /**
      * Logger object instance.
      *
-     * @var \Cake\Database\Log\QueryLogger
+     * @var \Cake\Database\Log\QueryLogger|null
      */
     protected $_logger = null;
 
@@ -105,7 +105,7 @@ class Connection implements ConnectionInterface
         if (!empty($config['driver'])) {
             $driver = $config['driver'];
         }
-        $this->driver($driver, $config);
+        $this->setDriver($driver, $config);
 
         if (!empty($config['log'])) {
             $this->logQueries($config['log']);
@@ -146,19 +146,14 @@ class Connection implements ConnectionInterface
      * Sets the driver instance. If a string is passed it will be treated
      * as a class name and will be instantiated.
      *
-     * If no params are passed it will return the current driver instance.
-     *
-     * @param \Cake\Database\Driver|string|null $driver The driver instance to use.
-     * @param array $config Either config for a new driver or null.
+     * @param \Cake\Database\Driver|string $driver The driver instance to use.
+     * @param array $config Config for a new driver.
      * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
      * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
-     * @return \Cake\Database\Driver
+     * @return $this
      */
-    public function driver($driver = null, $config = [])
+    public function setDriver($driver, $config = [])
     {
-        if ($driver === null) {
-            return $this->_driver;
-        }
         if (is_string($driver)) {
             $className = App::className($driver, 'Database/Driver');
             if (!$className || !class_exists($className)) {
@@ -170,7 +165,41 @@ class Connection implements ConnectionInterface
             throw new MissingExtensionException(['driver' => get_class($driver)]);
         }
 
-        return $this->_driver = $driver;
+        $this->_driver = $driver;
+
+        return $this;
+    }
+
+    /**
+     * Gets the driver instance.
+     *
+     * @return \Cake\Database\Driver
+     */
+    public function getDriver()
+    {
+        return $this->_driver;
+    }
+
+    /**
+     * Sets the driver instance. If a string is passed it will be treated
+     * as a class name and will be instantiated.
+     *
+     * If no params are passed it will return the current driver instance.
+     *
+     * @deprecated 3.4.0 Use setDriver()/getDriver() instead.
+     * @param \Cake\Database\Driver|string|null $driver The driver instance to use.
+     * @param array $config Either config for a new driver or null.
+     * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
+     * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
+     * @return \Cake\Database\Driver
+     */
+    public function driver($driver = null, $config = [])
+    {
+        if ($driver !== null) {
+            $this->setDriver($driver, $config);
+        }
+
+        return $this->getDriver();
     }
 
     /**
@@ -259,7 +288,7 @@ class Connection implements ConnectionInterface
      */
     public function compileQuery(Query $query, ValueBinder $generator)
     {
-        return $this->driver()->compileQuery($query, $generator)[1];
+        return $this->getDriver()->compileQuery($query, $generator)[1];
     }
 
     /**
@@ -303,17 +332,25 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Gets or sets a Schema\Collection object for this connection.
+     * Sets a Schema\Collection object for this connection.
      *
-     * @param \Cake\Database\Schema\Collection|null $collection The schema collection object
+     * @param \Cake\Database\Schema\Collection $collection The schema collection object
+     * @return $this
+     */
+    public function setSchemaCollection(SchemaCollection $collection)
+    {
+        $this->_schemaCollection = $collection;
+
+        return $this;
+    }
+
+    /**
+     * Gets a Schema\Collection object for this connection.
+     *
      * @return \Cake\Database\Schema\Collection
      */
-    public function schemaCollection(SchemaCollection $collection = null)
+    public function getSchemaCollection()
     {
-        if ($collection !== null) {
-            return $this->_schemaCollection = $collection;
-        }
-
         if ($this->_schemaCollection !== null) {
             return $this->_schemaCollection;
         }
@@ -323,6 +360,22 @@ class Connection implements ConnectionInterface
         }
 
         return $this->_schemaCollection = new SchemaCollection($this);
+    }
+
+    /**
+     * Gets or sets a Schema\Collection object for this connection.
+     *
+     * @deprecated 3.4.0 Use setSchemaCollection()/getSchemaCollection()
+     * @param \Cake\Database\Schema\Collection|null $collection The schema collection object
+     * @return \Cake\Database\Schema\Collection
+     */
+    public function schemaCollection(SchemaCollection $collection = null)
+    {
+        if ($collection !== null) {
+            $this->setSchemaCollection($collection);
+        }
+
+        return $this->getSchemaCollection();
     }
 
     /**
@@ -394,7 +447,7 @@ class Connection implements ConnectionInterface
         }
 
         $this->_transactionLevel++;
-        if ($this->useSavePoints()) {
+        if ($this->isEnabledSavePoints()) {
             $this->createSavePoint($this->_transactionLevel);
         }
     }
@@ -418,7 +471,7 @@ class Connection implements ConnectionInterface
 
             return $this->_driver->commitTransaction();
         }
-        if ($this->useSavePoints()) {
+        if ($this->isEnabledSavePoints()) {
             $this->releaseSavePoint($this->_transactionLevel);
         }
 
@@ -438,7 +491,7 @@ class Connection implements ConnectionInterface
             return false;
         }
 
-        $useSavePoint = $this->useSavePoints();
+        $useSavePoint = $this->isEnabledSavePoints();
         if ($this->_transactionLevel === 0 || !$useSavePoint) {
             $this->_transactionLevel = 0;
             $this->_transactionStarted = false;
@@ -458,6 +511,41 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Enables/disables the usage of savepoints, enables only if driver the allows it.
+     *
+     * If you are trying to enable this feature, make sure you check the return value of this
+     * function to verify it was enabled successfully.
+     *
+     * ### Example:
+     *
+     * `$connection->useSavePoints(true)` Returns true if drivers supports save points, false otherwise
+     * `$connection->useSavePoints(false)` Disables usage of savepoints and returns false
+     *
+     * @param bool $enable Whether or not save points should be used.
+     * @return $this
+     */
+    public function enableSavePoints($enable)
+    {
+        if ($enable === false) {
+            $this->_useSavePoints = false;
+        } else {
+            $this->_useSavePoints = $this->_driver->supportsSavePoints();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns whether this connection is using savepoints for nested transactions
+     *
+     * @return bool true if enabled, false otherwise
+     */
+    public function isEnabledSavePoints()
+    {
+        return $this->_useSavePoints;
+    }
+
+    /**
      * Returns whether this connection is using savepoints for nested transactions
      * If a boolean is passed as argument it will enable/disable the usage of savepoints
      * only if driver the allows it.
@@ -471,20 +559,17 @@ class Connection implements ConnectionInterface
      * `$connection->useSavePoints(false)` Disables usage of savepoints and returns false
      * `$connection->useSavePoints()` Returns current status
      *
+     * @deprecated 3.4.0 Use enableSavePoints()/isEnabledSavePoints() instead.
      * @param bool|null $enable Whether or not save points should be used.
      * @return bool true if enabled, false otherwise
      */
     public function useSavePoints($enable = null)
     {
-        if ($enable === null) {
-            return $this->_useSavePoints;
+        if ($enable !== null) {
+            $this->enableSavePoints($enable);
         }
 
-        if ($enable === false) {
-            return $this->_useSavePoints = false;
-        }
-
-        return $this->_useSavePoints = $this->_driver->supportsSavePoints();
+        return $this->isEnabledSavePoints();
     }
 
     /**
@@ -720,7 +805,7 @@ class Connection implements ConnectionInterface
      */
     protected function _newLogger(StatementInterface $statement)
     {
-        $log = new LoggingStatement($statement, $this->driver());
+        $log = new LoggingStatement($statement, $this->getDriver());
         $log->logger($this->logger());
 
         return $log;

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -518,8 +518,8 @@ class Connection implements ConnectionInterface
      *
      * ### Example:
      *
-     * `$connection->useSavePoints(true)` Returns true if drivers supports save points, false otherwise
-     * `$connection->useSavePoints(false)` Disables usage of savepoints and returns false
+     * `$connection->enableSavePoints(true)` Returns true if drivers supports save points, false otherwise
+     * `$connection->enableSavePoints(false)` Disables usage of savepoints and returns false
      *
      * @param bool $enable Whether or not save points should be used.
      * @return $this

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -316,7 +316,7 @@ abstract class Driver
      *
      * @return bool
      */
-    public function isEnabledAutoQuoting()
+    public function isAutoQuotingEnabled()
     {
         return $this->_autoQuoting;
     }
@@ -328,7 +328,7 @@ abstract class Driver
      * If called with a boolean argument, it will toggle the auto quoting setting
      * to the passed value
      *
-     * @deprecated 3.4.0 use enableAutoQuoting()/isEnabledAutoQuoting() instead.
+     * @deprecated 3.4.0 use enableAutoQuoting()/isAutoQuotingEnabled() instead.
      * @param bool|null $enable Whether to enable auto quoting
      * @return bool
      */
@@ -338,7 +338,7 @@ abstract class Driver
             $this->enableAutoQuoting($enable);
         }
 
-        return $this->isEnabledAutoQuoting();
+        return $this->isAutoQuotingEnabled();
     }
 
     /**

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -297,22 +297,48 @@ abstract class Driver
     }
 
     /**
+     * Sets whether or not this driver should automatically quote identifiers
+     * in queries.
+     *
+     * @param bool $enable Whether to enable auto quoting
+     * @return $this
+     */
+    public function enableAutoQuoting($enable)
+    {
+        $this->_autoQuoting = (bool)$enable;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether or not this driver should automatically quote identifiers
+     * in queries
+     *
+     * @return bool
+     */
+    public function isEnabledAutoQuoting()
+    {
+        return $this->_autoQuoting;
+    }
+
+    /**
      * Returns whether or not this driver should automatically quote identifiers
      * in queries
      *
      * If called with a boolean argument, it will toggle the auto quoting setting
      * to the passed value
      *
-     * @param bool|null $enable whether to enable auto quoting
+     * @deprecated 3.4.0 use enableAutoQuoting()/isEnabledAutoQuoting() instead.
+     * @param bool|null $enable Whether to enable auto quoting
      * @return bool
      */
     public function autoQuoting($enable = null)
     {
-        if ($enable === null) {
-            return $this->_autoQuoting;
+        if ($enable !== null) {
+            $this->enableAutoQuoting($enable);
         }
 
-        return $this->_autoQuoting = (bool)$enable;
+        return $this->isEnabledAutoQuoting();
     }
 
     /**

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -74,20 +74,43 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
     }
 
     /**
+     * Sets the name of the SQL function to be invoke in this expression.
+     *
+     * @param string $name The name of the function
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->_name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name of the SQL function to be invoke in this expression.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->_name;
+    }
+
+    /**
      * Sets the name of the SQL function to be invoke in this expression,
      * if no value is passed it will return current name
      *
+     * @deprecated 3.4.0 Use setName()/getName() instead.
      * @param string|null $name The name of the function
      * @return string|$this
      */
     public function name($name = null)
     {
-        if ($name === null) {
-            return $this->_name;
+        if ($name !== null) {
+            return $this->setName($name);
         }
-        $this->_name = $name;
 
-        return $this;
+        return $this->getName();
     }
 
     /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -75,19 +75,43 @@ class QueryExpression implements ExpressionInterface, Countable
      * Changes the conjunction for the conditions at this level of the expression tree.
      * If called with no arguments it will return the currently configured value.
      *
+     * @param string $conjunction Value to be used for joining conditions. If null it
+     * will not set any value, but return the currently stored one
+     * @return $this
+     */
+    public function setConjunction($conjunction)
+    {
+        $this->_conjunction = strtoupper($conjunction);
+
+        return $this;
+    }
+
+    /**
+     * Gets the currently configured conjunction for the conditions at this level of the expression tree.
+     *
+     * @return string
+     */
+    public function getConjunction()
+    {
+        return $this->_conjunction;
+    }
+
+    /**
+     * Changes the conjunction for the conditions at this level of the expression tree.
+     * If called with no arguments it will return the currently configured value.
+     *
+     * @deprecated 3.4.0 Use setConjunction()/getConjunction() instead.
      * @param string|null $conjunction value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
      * @return string|$this
      */
     public function tieWith($conjunction = null)
     {
-        if ($conjunction === null) {
-            return $this->_conjunction;
+        if ($conjunction !== null) {
+            return $this->setConjunction($conjunction);
         }
 
-        $this->_conjunction = strtoupper($conjunction);
-
-        return $this;
+        return $this->getConjunction();
     }
 
     /**

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -103,21 +103,44 @@ class ValuesExpression implements ExpressionInterface
     }
 
     /**
-     * Sets the columns to be inserted. If no params are passed, then it returns
-     * the currently stored columns
+     * Sets the columns to be inserted.
      *
-     * @param array|null $cols arrays with columns to be inserted
-     * @return array|$this
+     * @param array $cols Array with columns to be inserted.
+     * @return $this
      */
-    public function columns($cols = null)
+    public function setColumns($cols)
     {
-        if ($cols === null) {
-            return $this->_columns;
-        }
         $this->_columns = $cols;
         $this->_castedExpressions = false;
 
         return $this;
+    }
+
+    /**
+     * Gets the columns to be inserted.
+     *
+     * @return array
+     */
+    public function getColumns()
+    {
+        return $this->_columns;
+    }
+
+    /**
+     * Sets the columns to be inserted. If no params are passed, then it returns
+     * the currently stored columns.
+     *
+     * @deprecated 3.4.0 Use setColumns()/getColumns() instead.
+     * @param array|null $cols Array with columns to be inserted.
+     * @return array|$this
+     */
+    public function columns($cols = null)
+    {
+        if ($cols !== null) {
+            return $this->setColumns($cols);
+        }
+
+        return $this->getColumns();
     }
 
     /**
@@ -142,21 +165,13 @@ class ValuesExpression implements ExpressionInterface
     }
 
     /**
-     * Sets the values to be inserted. If no params are passed, then it returns
-     * the currently stored values
+     * Sets the values to be inserted.
      *
-     * @param array|null $values arrays with values to be inserted
-     * @return array|$this
+     * @param array $values Array with values to be inserted.
+     * @return $this
      */
-    public function values($values = null)
+    public function setValues($values)
     {
-        if ($values === null) {
-            if (!$this->_castedExpressions) {
-                $this->_processExpressions();
-            }
-
-            return $this->_values;
-        }
         $this->_values = $values;
         $this->_castedExpressions = false;
 
@@ -164,19 +179,76 @@ class ValuesExpression implements ExpressionInterface
     }
 
     /**
+     * Gets the values to be inserted.
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        if (!$this->_castedExpressions) {
+            $this->_processExpressions();
+        }
+
+        return $this->_values;
+    }
+
+    /**
+     * Sets the values to be inserted. If no params are passed, then it returns
+     * the currently stored values
+     *
+     * @param array|null $values Array with values to be inserted.
+     * @return array|$this
+     */
+    public function values($values = null)
+    {
+        if ($values !== null) {
+            return $this->setValues($values);
+        }
+
+        return $this->getValues();
+    }
+
+    /**
+     * Sets the query object to be used as the values expression to be evaluated
+     * to insert records in the table.
+     *
+     * @param \Cake\Database\Query $query The query to set
+     * @return $this
+     */
+    public function setQuery(Query $query)
+    {
+        $this->_query = $query;
+
+        return $this;
+    }
+
+    /**
+     * Gets the query object to be used as the values expression to be evaluated
+     * to insert records in the table.
+     *
+     * @return \Cake\Database\Query
+     */
+    public function getQuery()
+    {
+        return $this->_query;
+    }
+
+    /**
      * Sets the query object to be used as the values expression to be evaluated
      * to insert records in the table. If no params are passed, then it returns
      * the currently stored query
      *
-     * @param \Cake\Database\Query|null $query The query to set/get
-     * @return \Cake\Database\Query|null
+     * @deprecated 3.4.0 Use setQuery()/getQuery() instead.
+     * @param \Cake\Database\Query|null $query The query to set
+     * @return \Cake\Database\Query|null|$this
      */
     public function query(Query $query = null)
     {
-        if ($query === null) {
-            return $this->_query;
+        if ($query !== null) {
+            return $this->setQuery($query);
         }
-        $this->_query = $query;
+
+        return $this->getQuery();
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -147,21 +147,44 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
-     * Sets the connection instance to be used for executing and transforming this query
-     * When called with a null argument, it will return the current connection instance.
+     * Sets the connection instance to be used for executing and transforming this query.
      *
-     * @param \Cake\Datasource\ConnectionInterface|null $connection instance
-     * @return $this|\Cake\Datasource\ConnectionInterface
+     * @param \Cake\Datasource\ConnectionInterface $connection Connection instance
+     * @return $this
      */
-    public function connection($connection = null)
+    public function setConnection($connection)
     {
-        if ($connection === null) {
-            return $this->_connection;
-        }
         $this->_dirty();
         $this->_connection = $connection;
 
         return $this;
+    }
+
+    /**
+     * Gets the connection instance to be used for executing and transforming this query.
+     *
+     * @return \Cake\Datasource\ConnectionInterface
+     */
+    public function getConnection()
+    {
+        return $this->_connection;
+    }
+
+    /**
+     * Sets the connection instance to be used for executing and transforming this query
+     * When called with a null argument, it will return the current connection instance.
+     *
+     * @deprecated 3.4.0 Use setConnection()/getConnection() instead.
+     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance
+     * @return $this|\Cake\Datasource\ConnectionInterface
+     */
+    public function connection($connection = null)
+    {
+        if ($connection !== null) {
+            return $this->setConnection($connection);
+        }
+
+        return $this->getConnection();
     }
 
     /**
@@ -1774,6 +1797,45 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
+     * Enables/Disables buffered results.
+     *
+     * When enabled the results returned by this Query will be
+     * buffered. This enables you to iterate a result set multiple times, or
+     * both cache and iterate it.
+     *
+     * When disabled it will consume less memory as fetched results are not
+     * remembered for future iterations.
+     *
+     * @param bool $enable Whether or not to enable buffering
+     * @return $this
+     */
+    public function enableBufferedResults($enable)
+    {
+        $this->_dirty();
+        $this->_useBufferedResults = (bool)$enable;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether buffered results are enabled/disabled.
+     *
+     * When enabled the results returned by this Query will be
+     * buffered. This enables you to iterate a result set multiple times, or
+     * both cache and iterate it.
+     *
+     * When disabled it will consume less memory as fetched results are not
+     * remembered for future iterations.
+     *
+     * @return bool
+     */
+    public function isEnabledBufferedResults()
+    {
+        return $this->_useBufferedResults;
+    }
+
+
+    /**
      * Enable/Disable buffered results.
      *
      * When enabled the results returned by this Query will be
@@ -1786,19 +1848,45 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If called with no arguments, it will return whether or not buffering is
      * enabled.
      *
-     * @param bool|null $enable whether or not to enable buffering
+     * @deprecated 3.4.0 Use enableBufferedResults()/isEnabledBufferedResults() instead.
+     * @param bool|null $enable Whether or not to enable buffering
      * @return bool|$this
      */
     public function bufferResults($enable = null)
     {
-        if ($enable === null) {
-            return $this->_useBufferedResults;
+        if ($enable !== null) {
+            return $this->enableBufferedResults($enable);
         }
 
-        $this->_dirty();
-        $this->_useBufferedResults = (bool)$enable;
+        return $this->isEnabledBufferedResults();
+    }
+
+    /**
+     * Sets the TypeMap class where the types for each of the fields in the
+     * select clause are stored.
+     *
+     * @param \Cake\Database\TypeMap $typeMap The map object to use
+     * @return $this
+     */
+    public function setSelectTypeMap(TypeMap $typeMap)
+    {
+        $this->_selectTypeMap = $typeMap;
 
         return $this;
+    }
+    /**
+     * Gets the TypeMap class where the types for each of the fields in the
+     * select clause are stored.
+     *
+     * @return \Cake\Database\TypeMap
+     */
+    public function getSelectTypeMap()
+    {
+        if ($this->_selectTypeMap === null) {
+            $this->_selectTypeMap = new TypeMap();
+        }
+
+        return $this->_selectTypeMap;
     }
 
     /**
@@ -1807,22 +1895,17 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * When called with no arguments, the current TypeMap object is returned.
      *
+     * @deprecated 3.4.0 Use setSelectTypeMap()/getSelectTypeMap() instead.
      * @param \Cake\Database\TypeMap|null $typeMap The map object to use
      * @return $this|\Cake\Database\TypeMap
      */
     public function selectTypeMap(TypeMap $typeMap = null)
     {
-        if ($typeMap === null && $this->_selectTypeMap === null) {
-            $this->_selectTypeMap = new TypeMap();
+        if ($typeMap !== null) {
+            return $this->setSelectTypeMap($typeMap);
         }
 
-        if ($typeMap === null) {
-            return $this->_selectTypeMap;
-        }
-
-        $this->_selectTypeMap = $typeMap;
-
-        return $this;
+        return $this->getSelectTypeMap();
     }
 
     /**
@@ -1835,7 +1918,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     protected function _decorateStatement($statement)
     {
         foreach ($this->_resultDecorators as $f) {
-            $statement = new CallbackStatement($statement, $this->connection()->driver(), $f);
+            $statement = new CallbackStatement($statement, $this->getConnection()->driver(), $f);
         }
 
         return $statement;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1829,11 +1829,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @return bool
      */
-    public function isEnabledBufferedResults()
+    public function isBufferedResultsEnabled()
     {
         return $this->_useBufferedResults;
     }
-
 
     /**
      * Enable/Disable buffered results.
@@ -1848,7 +1847,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If called with no arguments, it will return whether or not buffering is
      * enabled.
      *
-     * @deprecated 3.4.0 Use enableBufferedResults()/isEnabledBufferedResults() instead.
+     * @deprecated 3.4.0 Use enableBufferedResults()/isBufferedResultsEnabled() instead.
      * @param bool|null $enable Whether or not to enable buffering
      * @return bool|$this
      */
@@ -1858,7 +1857,7 @@ class Query implements ExpressionInterface, IteratorAggregate
             return $this->enableBufferedResults($enable);
         }
 
-        return $this->isEnabledBufferedResults();
+        return $this->isBufferedResultsEnabled();
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -83,20 +83,47 @@ class CachedCollection extends Collection
     /**
      * Sets the cache config name to use for caching table metadata, or
      * disables it if false is passed.
-     * If called with no arguments it returns the current configuration name.
      *
-     * @param bool|null $enable whether or not to enable caching
-     * @return string|bool
+     * @param bool $enable Whether or not to enable caching
+     * @return $this
      */
-    public function cacheMetadata($enable = null)
+    public function setCacheMetadata($enable)
     {
-        if ($enable === null) {
-            return $this->_cache;
-        }
         if ($enable === true) {
             $enable = '_cake_model_';
         }
 
-        return $this->_cache = $enable;
+        $this->_cache = $enable;
+
+        return $this;
+    }
+
+    /**
+     * Gets the cache config name to use for caching table metadata, false means disabled.
+     *
+     * @return string|bool
+     */
+    public function getCacheMetadata()
+    {
+        return $this->_cache;
+    }
+
+
+    /**
+     * Sets the cache config name to use for caching table metadata, or
+     * disables it if false is passed.
+     * If called with no arguments it returns the current configuration name.
+     *
+     * @deprecated 3.4.0 Use setCacheMetadata()/getCacheMetadata()
+     * @param bool|null $enable Whether or not to enable caching
+     * @return string|bool
+     */
+    public function cacheMetadata($enable = null)
+    {
+        if ($enable !== null) {
+            $this->setCacheMetadata($enable);
+        }
+
+        return $this->getCacheMetadata();
     }
 }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -25,7 +25,7 @@ use Cake\Datasource\ConnectionInterface;
  * or by incrementally building an instance using
  * methods.
  *
- * Once created Table instances can be added to
+ * Once created TableSchema instances can be added to
  * Schema\Collection objects. They can also be converted into SQL using the
  * createSql(), dropSql() and truncateSql() methods.
  */
@@ -711,20 +711,62 @@ class TableSchema
     }
 
     /**
+     * Sets the options for a table.
+     *
+     * Table options allow you to set platform specific table level options.
+     * For example the engine type in MySQL.
+     *
+     * @param array $options The options to set, or null to read options.
+     * @return $this TableSchema instance
+     */
+    public function setOptions($options)
+    {
+        $this->_options = array_merge($this->_options, $options);
+
+        return $this;
+    }
+
+    /**
+     * Gets the options for a table.
+     *
+     * Table options allow you to set platform specific table level options.
+     * For example the engine type in MySQL.
+     *
+     * @return array An array of options.
+     */
+    public function getOptions()
+    {
+        return $this->_options;
+    }
+
+    /**
      * Get/set the options for a table.
      *
      * Table options allow you to set platform specific table level options.
      * For example the engine type in MySQL.
      *
+     * @deprecated 3.4.0 Use setOptions()/getOptions() instead.
      * @param array|null $options The options to set, or null to read options.
-     * @return $this|array Either the table instance, or an array of options when reading.
+     * @return $this|array Either the TableSchema instance, or an array of options when reading.
      */
     public function options($options = null)
     {
-        if ($options === null) {
-            return $this->_options;
+        if ($options !== null) {
+            return $this->setOptions($options);
         }
-        $this->_options = array_merge($this->_options, $options);
+
+        return $this->getOptions();
+    }
+
+    /**
+     * Get/Set whether the table is temporary in the database
+     *
+     * @param bool $temporary Whether or not the table is to be temporary
+     * @return $this TableSchema instance.
+     */
+    public function setTemporary($temporary)
+    {
+        $this->_temporary = (bool)$temporary;
 
         return $this;
     }
@@ -732,17 +774,27 @@ class TableSchema
     /**
      * Get/Set whether the table is temporary in the database
      *
-     * @param bool|null $set whether or not the table is to be temporary
-     * @return $this|bool Either the table instance, the current temporary setting
+     * @return bool The current temporary setting
      */
-    public function temporary($set = null)
+    public function getTemporary()
     {
-        if ($set === null) {
-            return $this->_temporary;
-        }
-        $this->_temporary = (bool)$set;
+        return $this->_temporary;
+    }
 
-        return $this;
+    /**
+     * Get/Set whether the table is temporary in the database
+     *
+     * @deprecated 3.4.0 Use setTemporary()/getTemporary() instead.
+     * @param bool|null $temporary whether or not the table is to be temporary
+     * @return $this|bool Either the TableSchema instance, the current temporary setting
+     */
+    public function temporary($temporary = null)
+    {
+        if ($temporary !== null) {
+            return $this->setTemporary($temporary);
+        }
+
+        return $this->getTemporary();
     }
 
     /**

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -759,10 +759,10 @@ class TableSchema
     }
 
     /**
-     * Get/Set whether the table is temporary in the database
+     * Sets whether the table is temporary in the database.
      *
-     * @param bool $temporary Whether or not the table is to be temporary
-     * @return $this TableSchema instance.
+     * @param bool $temporary Whether or not the table is to be temporary.
+     * @return $this Instance.
      */
     public function setTemporary($temporary)
     {
@@ -772,11 +772,11 @@ class TableSchema
     }
 
     /**
-     * Get/Set whether the table is temporary in the database
+     * Gets whether the table is temporary in the database.
      *
-     * @return bool The current temporary setting
+     * @return bool The current temporary setting.
      */
-    public function getTemporary()
+    public function isTemporary()
     {
         return $this->_temporary;
     }
@@ -784,7 +784,7 @@ class TableSchema
     /**
      * Get/Set whether the table is temporary in the database
      *
-     * @deprecated 3.4.0 Use setTemporary()/getTemporary() instead.
+     * @deprecated 3.4.0 Use setTemporary()/isTemporary() instead.
      * @param bool|null $temporary whether or not the table is to be temporary
      * @return $this|bool Either the TableSchema instance, the current temporary setting
      */
@@ -794,7 +794,7 @@ class TableSchema
             return $this->setTemporary($temporary);
         }
 
-        return $this->getTemporary();
+        return $this->isTemporary();
     }
 
     /**

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -47,8 +47,44 @@ class TypeMap
      */
     public function __construct(array $defaults = [])
     {
-        $this->defaults($defaults);
+        $this->setDefaults($defaults);
     }
+
+    /**
+     * Configures a map of default fields and their associated types to be
+     * used as the default list of types for every function in this class
+     * with a $types param. Useful to avoid repetition when calling the same
+     * functions using the same fields and types.
+     *
+     * ### Example
+     *
+     * ```
+     * $query->setDefaults(['created' => 'datetime', 'is_visible' => 'boolean']);
+     * ```
+     *
+     * This method will replace all the existing type maps with the ones provided.
+     *
+     * @param array $defaults Associative array where keys are field names and values
+     * are the correspondent type.
+     * @return $this
+     */
+    public function setDefaults(array $defaults)
+    {
+        $this->_defaults = $defaults;
+
+        return $this;
+    }
+
+    /**
+     * Returns the currently configured types.
+     *
+     * @return $this|array
+     */
+    public function getDefaults()
+    {
+        return $this->_defaults;
+    }
+
 
     /**
      * Configures a map of default fields and their associated types to be
@@ -66,18 +102,18 @@ class TypeMap
      *
      * This method will replace all the existing type maps with the ones provided.
      *
+     * @deprecated 3.4.0 Use setDefaults()/getDefaults() instead.
      * @param array|null $defaults associative array where keys are field names and values
      * are the correspondent type.
      * @return $this|array
      */
     public function defaults(array $defaults = null)
     {
-        if ($defaults === null) {
-            return $this->_defaults;
+        if ($defaults !== null) {
+            return $this->setDefaults($defaults);
         }
-        $this->_defaults = $defaults;
 
-        return $this;
+        return $this->getDefaults();
     }
 
     /**
@@ -96,6 +132,38 @@ class TypeMap
     /**
      * Sets a map of fields and their associated types for single-use.
      *
+     * ### Example
+     *
+     * ```
+     * $query->setTypes(['created' => 'time']);
+     * ```
+     *
+     * This method will replace all the existing type maps with the ones provided.
+     *
+     * @param array $types Associative array where keys are field names and values
+     * are the correspondent type.
+     * @return $this
+     */
+    public function setTypes(array $types)
+    {
+        $this->_types = $types;
+
+        return $this;
+    }
+
+    /**
+     * Gets a map of fields and their associated types for single-use.
+     *
+     * @return array
+     */
+    public function getTypes()
+    {
+        return $this->_types;
+    }
+
+    /**
+     * Sets a map of fields and their associated types for single-use.
+     *
      * If called with no arguments it will return the currently configured types.
      *
      * ### Example
@@ -106,18 +174,18 @@ class TypeMap
      *
      * This method will replace all the existing type maps with the ones provided.
      *
+     * @deprecated 3.4.0 Use setTypes()/getTypes() instead.
      * @param array|null $types associative array where keys are field names and values
      * are the correspondent type.
      * @return $this|array
      */
     public function types(array $types = null)
     {
-        if ($types === null) {
-            return $this->_types;
+        if ($types !== null) {
+            return $this->setTypes($types);
         }
-        $this->_types = $types;
 
-        return $this;
+        return $this->getTypes();
     }
 
     /**

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -26,38 +26,85 @@ trait TypeMapTrait
     protected $_typeMap;
 
     /**
-     * Creates a new TypeMap if $typeMap is an array, otherwise returns the existing type map
-     * or exchanges it for the given one.
+     * Creates a new TypeMap if $typeMap is an array, otherwise exchanges it for the given one.
      *
-     * @param array|\Cake\Database\TypeMap|null $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
-     * @return $this|\Cake\Database\TypeMap
+     * @param array|\Cake\Database\TypeMap $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
+     * @return $this
      */
-    public function typeMap($typeMap = null)
+    public function setTypeMap($typeMap)
     {
-        if ($this->_typeMap === null) {
-            $this->_typeMap = new TypeMap();
-        }
-        if ($typeMap === null) {
-            return $this->_typeMap;
-        }
         $this->_typeMap = is_array($typeMap) ? new TypeMap($typeMap) : $typeMap;
 
         return $this;
     }
 
     /**
+     * Returns the existing type map.
+     *
+     * @return \Cake\Database\TypeMap
+     */
+    public function getTypeMap()
+    {
+        if ($this->_typeMap === null) {
+            $this->_typeMap = new TypeMap();
+        }
+
+        return $this->_typeMap;
+    }
+
+    /**
+     * Creates a new TypeMap if $typeMap is an array, otherwise returns the existing type map
+     * or exchanges it for the given one.
+     *
+     * @deprecated 3.4.0 Use setTypeMap()/getTypeMap() instead.
+     * @param array|\Cake\Database\TypeMap|null $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
+     * @return $this|\Cake\Database\TypeMap
+     */
+    public function typeMap($typeMap = null)
+    {
+        if ($typeMap !== null) {
+            return $this->setTypeMap($typeMap);
+        }
+
+        return $this->getTypeMap();
+    }
+
+    /**
+     * Allows setting default types when chaining query.
+     *
+     * @param array $types The array of types to set.
+     * @return $this
+     */
+    public function setDefaultTypes(array $types)
+    {
+        $this->getTypeMap()->setDefaults($types);
+
+        return $this;
+    }
+
+    /**
+     * Gets default types of current type map.
+     *
+     * @return array
+     */
+    public function getDefaultTypes()
+    {
+        return $this->getTypeMap()->getDefaults();
+    }
+
+    /**
      * Allows setting default types when chaining query
      *
+     * @deprecated 3.4.0 Use setDefaultTypes()/getDefaultTypes() instead.
      * @param array|null $types The array of types to set.
      * @return $this|array
      */
     public function defaultTypes(array $types = null)
     {
-        if ($types === null) {
-            return $this->typeMap()->defaults();
+        if ($types !== null) {
+            return $this->setDefaultTypes($types);
         }
-        $this->typeMap()->defaults($types);
 
-        return $this;
+        return $this->getDefaultTypes();
     }
 }

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -183,7 +183,7 @@ class ConnectionManager
      *
      * @param string $name The connection name.
      * @param bool $useAliases Set to false to not use aliased connections.
-     * @return \Cake\\ConnectionInterface A connection object.
+     * @return \Cake\Datasource\ConnectionInterface A connection object.
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When config
      * data is missing.
      */

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -183,7 +183,7 @@ class ConnectionManager
      *
      * @param string $name The connection name.
      * @param bool $useAliases Set to false to not use aliased connections.
-     * @return \Cake\Datasource\ConnectionInterface A connection object.
+     * @return \Cake\\ConnectionInterface A connection object.
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When config
      * data is missing.
      */

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -217,21 +217,12 @@ class EagerLoadable
     }
 
     /**
-     * Gets whether or not this level can be fetched using a join.
-     *
-     * @return bool
-     */
-    public function getCanBeJoined()
-    {
-        return $this->_canBeJoined;
-    }
-
-    /**
      * Sets whether or not this level can be fetched using a join.
      *
      * If called with no arguments it returns the current value.
      *
-     * @deprecated 3.4.0 Use setCanBeJoined()/getCanBeJoined() instead.
+     * As of 3.4.0 the setter part is deprecated, use setCanBeJoined() instead.
+     *
      * @param bool|null $possible The value to set.
      * @return bool
      */

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -211,16 +211,15 @@ class EagerLoadable
      */
     public function setCanBeJoined($possible)
     {
-        $this->_canBeJoined = $possible;
+        $this->_canBeJoined = (bool)$possible;
 
         return $this;
     }
 
     /**
-     * Sets whether or not this level can be fetched using a join.
+     * Gets whether or not this level can be fetched using a join.
      *
-     * If called with no arguments it returns the current value.
-     *
+     * If called with arguments it sets the value.
      * As of 3.4.0 the setter part is deprecated, use setCanBeJoined() instead.
      *
      * @param bool|null $possible The value to set.
@@ -232,7 +231,7 @@ class EagerLoadable
             $this->setCanBeJoined($possible);
         }
 
-        return $this->getCanBeJoined();
+        return $this->_canBeJoined;
     }
 
     /**

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -206,17 +206,67 @@ class EagerLoadable
     /**
      * Sets whether or not this level can be fetched using a join.
      *
+     * @param bool $possible The value to set.
+     * @return $this
+     */
+    public function setCanBeJoined($possible)
+    {
+        $this->_canBeJoined = $possible;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether or not this level can be fetched using a join.
+     *
+     * @return bool
+     */
+    public function getCanBeJoined()
+    {
+        return $this->_canBeJoined;
+    }
+
+    /**
+     * Sets whether or not this level can be fetched using a join.
+     *
      * If called with no arguments it returns the current value.
      *
+     * @deprecated 3.4.0 Use setCanBeJoined()/getCanBeJoined() instead.
      * @param bool|null $possible The value to set.
      * @return bool
      */
     public function canBeJoined($possible = null)
     {
-        if ($possible === null) {
-            return $this->_canBeJoined;
+        if ($possible !== null) {
+            $this->setCanBeJoined($possible);
         }
-        $this->_canBeJoined = $possible;
+
+        return $this->getCanBeJoined();
+    }
+
+    /**
+     * Sets the list of options to pass to the association object for loading
+     * the records.
+     *
+     * @param array $config The value to set.
+     * @return $this
+     */
+    public function setConfig(array $config)
+    {
+        $this->_config = $config;
+
+        return $this;
+    }
+
+    /**
+     * Gets the list of options to pass to the association object for loading
+     * the records.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->_config;
     }
 
     /**
@@ -226,15 +276,17 @@ class EagerLoadable
      * If called with no arguments it returns the current
      * value.
      *
+     * @deprecated 3.4.0 Use setConfig()/getConfig() instead.
      * @param array|null $config The value to set.
      * @return array
      */
     public function config(array $config = null)
     {
-        if ($config === null) {
-            return $this->_config;
+        if ($config !== null) {
+            $this->setConfig($config);
         }
-        $this->_config = $config;
+
+        return $this->getConfig();
     }
 
     /**

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -177,7 +177,7 @@ class EagerLoader
      *
      * @return bool The current value.
      */
-    public function isEnabledAutoFields()
+    public function isAutoFieldsEnabled()
     {
         return $this->_autoFields;
     }
@@ -185,7 +185,7 @@ class EagerLoader
     /**
      * Sets/Gets whether or not contained associations will load fields automatically.
      *
-     * @deprecated 3.4.0 Use enableAutoFields()/isEnabledAutoFields() instead.
+     * @deprecated 3.4.0 Use enableAutoFields()/isAutoFieldsEnabled() instead.
      * @param bool|null $enable The value to set.
      * @return bool The current value.
      */
@@ -195,7 +195,7 @@ class EagerLoader
             $this->enableAutoFields($enable);
         }
 
-        return $this->isEnabledAutoFields();
+        return $this->isAutoFieldsEnabled();
     }
 
     /**

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -160,18 +160,42 @@ class EagerLoader
     }
 
     /**
-     * Set whether or not contained associations will load fields automatically.
+     * Sets whether or not contained associations will load fields automatically.
      *
-     * @param bool|null $value The value to set.
+     * @param bool $enable The value to set.
+     * @return $this
+     */
+    public function enableAutoFields($enable)
+    {
+        $this->_autoFields = (bool)$enable;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether or not contained associations will load fields automatically.
+     *
      * @return bool The current value.
      */
-    public function autoFields($value = null)
+    public function isEnabledAutoFields()
     {
-        if ($value !== null) {
-            $this->_autoFields = (bool)$value;
+        return $this->_autoFields;
+    }
+
+    /**
+     * Sets/Gets whether or not contained associations will load fields automatically.
+     *
+     * @deprecated 3.4.0 Use enableAutoFields()/isEnabledAutoFields() instead.
+     * @param bool|null $enable The value to set.
+     * @return bool The current value.
+     */
+    public function autoFields($enable = null)
+    {
+        if ($enable !== null) {
+            $this->enableAutoFields($enable);
         }
 
-        return $this->_autoFields;
+        return $this->isEnabledAutoFields();
     }
 
     /**
@@ -181,25 +205,22 @@ class EagerLoader
      * parameter, this will translate in setting all those associations with the
      * `matching` option.
      *
-     * If called with no arguments it will return the current tree of associations to
-     * be matched.
+     *  ### Options
+     *  - 'joinType': INNER, OUTER, ...
+     *  - 'fields': Fields to contain
      *
-     * @param string|null $assoc A single association or a dot separated path of associations.
+     * @param string $assoc A single association or a dot separated path of associations.
      * @param callable|null $builder the callback function to be used for setting extra
      * options to the filtering query
-     * @param array $options Extra options for the association matching, such as 'joinType'
-     * and 'fields'
-     * @return array The resulting containments array
+     * @param array $options Extra options for the association matching.
+     * @return $this
      */
-    public function matching($assoc = null, callable $builder = null, $options = [])
+    public function setMatching($assoc, callable $builder = null, $options = [])
     {
         if ($this->_matching === null) {
             $this->_matching = new self();
         }
 
-        if ($assoc === null) {
-            return $this->_matching->contain();
-        }
         if (!isset($options['joinType'])) {
             $options['joinType'] = 'INNER';
         }
@@ -218,7 +239,50 @@ class EagerLoader
 
         $pointer[$last] = ['queryBuilder' => $builder, 'matching' => true] + $options;
 
-        return $this->_matching->contain($containments);
+        $this->_matching->contain($containments);
+
+        return $this;
+    }
+
+    /**
+     * Returns the current tree of associations to be matched.
+     *
+     * @return array The resulting containments array
+     */
+    public function getMatching()
+    {
+        if ($this->_matching === null) {
+            $this->_matching = new self();
+        }
+
+        return $this->_matching->contain();
+    }
+
+    /**
+     * Adds a new association to the list that will be used to filter the results of
+     * any given query based on the results of finding records for that association.
+     * You can pass a dot separated path of associations to this method as its first
+     * parameter, this will translate in setting all those associations with the
+     * `matching` option.
+     *
+     * If called with no arguments it will return the current tree of associations to
+     * be matched.
+     *
+     * @deprecated 3.4.0 Use setMatching()/getMatching() instead.
+     * @param string|null $assoc A single association or a dot separated path of associations.
+     * @param callable|null $builder the callback function to be used for setting extra
+     * options to the filtering query
+     * @param array $options Extra options for the association matching, such as 'joinType'
+     * and 'fields'
+     * @return array The resulting containments array
+     */
+    public function matching($assoc = null, callable $builder = null, $options = [])
+    {
+        if ($assoc !== null) {
+            $this->setMatching($assoc, $builder, $options);
+        }
+
+        return $this->getMatching();
     }
 
     /**

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -59,29 +59,19 @@ class TableLocator implements LocatorInterface
      * Stores a list of options to be used when instantiating an object
      * with a matching alias.
      *
-     * The options that can be stored are those that are recognized by `get()`
-     * If second argument is omitted, it will return the current settings
-     * for $alias.
-     *
-     * If no arguments are passed it will return the full configuration array for
-     * all aliases
-     *
-     * @param string|null $alias Name of the alias
+     * @param string|array $alias Name of the alias or array to completely overwrite current config.
      * @param array|null $options list of options for the alias
-     * @return array The config data.
+     * @return $this
      * @throws \RuntimeException When you attempt to configure an existing table instance.
      */
-    public function config($alias = null, $options = null)
+    public function setConfig($alias, $options = null)
     {
-        if ($alias === null) {
-            return $this->_config;
-        }
         if (!is_string($alias)) {
-            return $this->_config = $alias;
+            $this->_config = $alias;
+
+            return $this;
         }
-        if ($options === null) {
-            return isset($this->_config[$alias]) ? $this->_config[$alias] : [];
-        }
+
         if (isset($this->_instances[$alias])) {
             throw new RuntimeException(sprintf(
                 'You cannot configure "%s", it has already been constructed.',
@@ -89,7 +79,54 @@ class TableLocator implements LocatorInterface
             ));
         }
 
-        return $this->_config[$alias] = $options;
+        $this->_config[$alias] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Returns configuration for an alias or the full configuration array for all aliases.
+     *
+     * @param string|null $alias Alias to get config for, null for complete config.
+     * @return array The config data.
+     */
+    public function getConfig($alias = null)
+    {
+        if ($alias === null) {
+            return $this->_config;
+        }
+
+        return isset($this->_config[$alias]) ? $this->_config[$alias] : [];
+    }
+
+    /**
+     * Stores a list of options to be used when instantiating an object
+     * with a matching alias.
+     *
+     * The options that can be stored are those that are recognized by `get()`
+     * If second argument is omitted, it will return the current settings
+     * for $alias.
+     *
+     * If no arguments are passed it will return the full configuration array for
+     * all aliases
+     *
+     * @deprecated 3.4.0 Use setConfig()/getConfig() instead.
+     * @param string|array|null $alias Name of the alias
+     * @param array|null $options list of options for the alias
+     * @return array The config data.
+     * @throws \RuntimeException When you attempt to configure an existing table instance.
+     */
+    public function config($alias = null, $options = null)
+    {
+        if ($alias !== null) {
+            if (is_string($alias) && $options === null) {
+                return $this->getConfig($alias);
+            }
+
+            $this->setConfig($alias, $options);
+        }
+
+        return $this->getConfig($alias);
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -220,25 +220,49 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
 
     /**
      * Sets the instance of the eager loader class to use for loading associations
+     * and storing containments.
+     *
+     * @param \Cake\ORM\EagerLoader $instance The eager loader to use.
+     * @return $this
+     */
+    public function setEagerLoader(EagerLoader $instance)
+    {
+        $this->_eagerLoader = $instance;
+
+        return $this;
+    }
+
+    /**
+     * Returns the currently configured instance.
+     *
+     * @return \Cake\ORM\EagerLoader
+     */
+    public function getEagerLoader()
+    {
+        if ($this->_eagerLoader === null) {
+            $this->_eagerLoader = new EagerLoader();
+        }
+
+        return $this->_eagerLoader;
+    }
+
+    /**
+     * Sets the instance of the eager loader class to use for loading associations
      * and storing containments. If called with no arguments, it will return the
      * currently configured instance.
      *
+     * @deprecated 3.4.0 Use setEagerLoader()/getEagerLoader() instead.
      * @param \Cake\ORM\EagerLoader|null $instance The eager loader to use. Pass null
      *   to get the current eagerloader.
      * @return \Cake\ORM\EagerLoader|$this
      */
     public function eagerLoader(EagerLoader $instance = null)
     {
-        if ($instance === null) {
-            if ($this->_eagerLoader === null) {
-                $this->_eagerLoader = new EagerLoader();
-            }
-
-            return $this->_eagerLoader;
+        if ($instance !== null) {
+            return $this->setEagerLoader($instance);
         }
-        $this->_eagerLoader = $instance;
 
-        return $this;
+        return $this->getEagerLoader();
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -329,20 +329,29 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Returns the database table name or sets a new one
+     * Sets the database table name.
      *
-     * @param string|null $table the new table name
+     * @param string $table Table name.
+     * @return $this
+     */
+    public function setTable($table)
+    {
+        $this->_table = $table;
+
+        return $this;
+    }
+
+    /**
+     * Returns the database table name.
+     *
      * @return string
      */
-    public function table($table = null)
+    public function getTable()
     {
-        if ($table !== null) {
-            $this->_table = $table;
-        }
         if ($this->_table === null) {
             $table = namespaceSplit(get_class($this));
             $table = substr(end($table), 0, -5);
-            if (empty($table)) {
+            if (!$table) {
                 $table = $this->alias();
             }
             $this->_table = Inflector::underscore($table);
@@ -352,13 +361,41 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the database table name or sets a new one.
+     *
+     * @deprecated 3.4.0 Use setTable()/getTable() instead.
+     * @param string|null $table the new table name
+     * @return string
      */
-    public function alias($alias = null)
+    public function table($table = null)
     {
-        if ($alias !== null) {
-            $this->_alias = $alias;
+        if ($table !== null) {
+            $this->setTable($table);
         }
+
+        return $this->getTable();
+    }
+
+    /**
+     * Sets the table alias.
+     *
+     * @param string $alias Table alias
+     * @return $this
+     */
+    public function setAlias($alias)
+    {
+        $this->_alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * Returns the table alias.
+     *
+     * @return string
+     */
+    public function getAlias()
+    {
         if ($this->_alias === null) {
             $alias = namespaceSplit(get_class($this));
             $alias = substr(end($alias), 0, -5) ?: $this->_table;
@@ -366,6 +403,20 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         return $this->_alias;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * @deprecated 3.4.0 Use setAlias()/getAlias() instead.
+     */
+    public function alias($alias = null)
+    {
+        if ($alias !== null) {
+            $this->setAlias($alias);
+        }
+
+        return $this->getAlias();
     }
 
     /**
@@ -382,68 +433,121 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $field;
         }
 
-        return $this->alias() . '.' . $field;
+        return $this->getAlias() . '.' . $field;
     }
 
     /**
-     * Returns the table registry key used to create this table instance
+     * Sets the table registry key used to create this table instance.
      *
-     * @param string|null $registryAlias the key used to access this object
+     * @param string $registryAlias The key used to access this object.
+     * @return $this
+     */
+    public function setRegistryAlias($registryAlias)
+    {
+        $this->_registryAlias = $registryAlias;
+
+        return $this;
+    }
+
+
+    /**
+     * Returns the table registry key used to create this table instance.
+     *
      * @return string
      */
-    public function registryAlias($registryAlias = null)
+    public function getRegistryAlias()
     {
-        if ($registryAlias !== null) {
-            $this->_registryAlias = $registryAlias;
-        }
         if ($this->_registryAlias === null) {
-            $this->_registryAlias = $this->alias();
+            $this->_registryAlias = $this->getAlias();
         }
 
         return $this->_registryAlias;
     }
 
     /**
-     * Returns the connection instance or sets a new one
+     * Returns the table registry key used to create this table instance or sets one.
      *
-     * @param \Cake\Datasource\ConnectionInterface|null $conn The new connection instance
-     * @return \Cake\Datasource\ConnectionInterface
+     * @deprecated 3.4.0 Use setRegistryAlias()/getRegistryAlias() instead.
+     * @param string|null $registryAlias the key used to access this object
+     * @return string
      */
-    public function connection(ConnectionInterface $conn = null)
+    public function registryAlias($registryAlias = null)
     {
-        if ($conn === null) {
-            return $this->_connection;
+        if ($registryAlias !== null) {
+            $this->setRegistryAlias($registryAlias);
         }
 
-        return $this->_connection = $conn;
+        return $this->getRegistryAlias();
+    }
+
+    /**
+     * Sets the connection instance.
+     *
+     * @param \Cake\Datasource\ConnectionInterface $connection The connection instance
+     * @return $this
+     */
+    public function setConnection(ConnectionInterface $connection)
+    {
+        $this->_connection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * Returns the connection instance.
+     *
+     * @return \Cake\Datasource\ConnectionInterface
+     */
+    public function getConnection()
+    {
+        return $this->_connection;
+    }
+
+    /**
+     * Returns the connection instance or sets a new one
+     *
+     * @deprecated 3.4.0 Use setConnection()/getConnection() instead.
+     * @param \Cake\Datasource\ConnectionInterface|null $connection The new connection instance
+     * @return \Cake\Datasource\ConnectionInterface
+     */
+    public function connection(ConnectionInterface $connection = null)
+    {
+        if ($connection !== null) {
+            $this->setConnection($connection);
+        }
+
+        return $this->getConnection();
     }
 
     /**
      * Returns the schema table object describing this table's properties.
      *
-     * If a TableSchema is passed, it will be used for this table
-     * instead of the default one.
+     * @return \Cake\Database\Schema\TableSchema
+     */
+    public function getSchema()
+    {
+        if ($this->_schema === null) {
+            $this->_schema = $this->_initializeSchema(
+                $this->connection()
+                    ->getSchemaCollection()
+                    ->describe($this->getTable())
+            );
+        }
+
+        return $this->_schema;
+    }
+
+    /**
+     * Sets the schema table object describing this table's properties.
      *
      * If an array is passed, a new TableSchema will be constructed
      * out of it and used as the schema for this table.
      *
-     * @param array|\Cake\Database\Schema\TableSchema|null $schema New schema to be used for this table
-     * @return \Cake\Database\Schema\TableSchema
+     * @param array|\Cake\Database\Schema\TableSchema $schema Schema to be used for this table
+     * @return $this
      */
-    public function schema($schema = null)
+    public function setSchema($schema)
     {
-        if ($schema === null) {
-            if ($this->_schema === null) {
-                $this->_schema = $this->_initializeSchema(
-                    $this->connection()
-                        ->schemaCollection()
-                        ->describe($this->table())
-                );
-            }
-
-            return $this->_schema;
-        }
-
         if (is_array($schema)) {
             $constraints = [];
 
@@ -459,7 +563,31 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
 
-        return $this->_schema = $schema;
+        $this->_schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Returns the schema table object describing this table's properties.
+     *
+     * If a TableSchema is passed, it will be used for this table
+     * instead of the default one.
+     *
+     * If an array is passed, a new TableSchema will be constructed
+     * out of it and used as the schema for this table.
+     *
+     * @deprecated 3.4.0 Use setSchema()/getSchema() instead.
+     * @param array|\Cake\Database\Schema\TableSchema|null $schema New schema to be used for this table
+     * @return \Cake\Database\Schema\TableSchema
+     */
+    public function schema($schema = null)
+    {
+        if ($schema !== null) {
+            $this->setSchema($schema);
+        }
+
+        return $this->getSchema();
     }
 
     /**
@@ -498,24 +626,33 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function hasField($field)
     {
-        $schema = $this->schema();
+        $schema = $this->getSchema();
 
         return $schema->column($field) !== null;
     }
 
     /**
-     * Returns the primary key field name or sets a new one
+     * Sets the primary key field name.
      *
-     * @param string|array|null $key sets a new name to be used as primary key
+     * @param string|array $key Sets a new name to be used as primary key
+     * @return $this
+     */
+    public function setPrimaryKey($key)
+    {
+        $this->_primaryKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Returns the primary key field name.
+     *
      * @return string|array
      */
-    public function primaryKey($key = null)
+    public function getPrimaryKey()
     {
-        if ($key !== null) {
-            $this->_primaryKey = $key;
-        }
         if ($this->_primaryKey === null) {
-            $key = (array)$this->schema()->primaryKey();
+            $key = (array)$this->getSchema()->primaryKey();
             if (count($key) === 1) {
                 $key = $key[0];
             }
@@ -526,16 +663,41 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Returns the display field or sets a new one
+     * Returns the primary key field name or sets a new one
      *
-     * @param string|null $key sets a new name to be used as display field
-     * @return string
+     * @deprecated 3.4.0 Use setPrimaryKey()/getPrimaryKey() instead.
+     * @param string|array|null $key Sets a new name to be used as primary key
+     * @return string|array
      */
-    public function displayField($key = null)
+    public function primaryKey($key = null)
     {
         if ($key !== null) {
-            $this->_displayField = $key;
+            $this->setPrimaryKey($key);
         }
+
+        return $this->getPrimaryKey();
+    }
+
+    /**
+     * Sets the display field.
+     *
+     * @param string $key Name to be used as display field.
+     * @return $this
+     */
+    public function setDisplayField($key)
+    {
+        $this->_displayField = $key;
+
+        return $this;
+    }
+
+    /**
+     * Returns the display field.
+     *
+     * @return string
+     */
+    public function getDisplayField()
+    {
         if ($this->_displayField === null) {
             $schema = $this->schema();
             $primary = (array)$this->primaryKey();
@@ -552,16 +714,29 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Returns the class used to hydrate rows for this table or sets
-     * a new one
+     * Returns the display field or sets a new one
      *
-     * @param string|null $name the name of the class to use
-     * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
+     * @deprecated 3.4.0 Use setDisplayField()/getDisplayField() instead.
+     * @param string|null $key sets a new name to be used as display field
      * @return string
      */
-    public function entityClass($name = null)
+    public function displayField($key = null)
     {
-        if ($name === null && !$this->_entityClass) {
+        if ($key !== null) {
+            return $this->setDisplayField($key);
+        }
+
+        return $this->getDisplayField();
+    }
+
+    /**
+     * Returns the class used to hydrate rows for this table.
+     *
+     * @return string
+     */
+    public function getEntityClass()
+    {
+        if (!$this->_entityClass) {
             $default = '\Cake\ORM\Entity';
             $self = get_called_class();
             $parts = explode('\\', $self);
@@ -575,18 +750,53 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             if (!class_exists($name)) {
                 return $this->_entityClass = $default;
             }
-        }
 
-        if ($name !== null) {
             $class = App::className($name, 'Model/Entity');
+            if (!$class) {
+                throw new MissingEntityException([$name]);
+            }
+
             $this->_entityClass = $class;
         }
 
-        if (!$this->_entityClass) {
+        return $this->_entityClass;
+    }
+
+    /**
+     * Sets the class used to hydrate rows for this table.
+     *
+     * @param string $name The name of the class to use
+     * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
+     * @return $this
+     */
+    public function setEntityClass($name)
+    {
+        $class = App::className($name, 'Model/Entity');
+        if (!$class) {
             throw new MissingEntityException([$name]);
         }
 
-        return $this->_entityClass;
+        $this->_entityClass = $class;
+
+        return $this;
+    }
+
+    /**
+     * Returns the class used to hydrate rows for this table or sets
+     * a new one
+     *
+     * @deprecated 3.4.0 Use setEntityClass()/getEntityClass() instead.
+     * @param string|null $name The name of the class to use
+     * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
+     * @return string
+     */
+    public function entityClass($name = null)
+    {
+        if ($name !== null) {
+            $this->setEntityClass($name);
+        }
+
+        return $this->getEntityClass();
     }
 
     /**

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -102,7 +102,7 @@ class SqlserverTest extends TestCase
     public function testSelectLimitVersion12()
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->setMethods(['_connect', 'connection', '_version'])
+            ->setMethods(['_connect', 'getConnection', '_version'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver
@@ -111,12 +111,12 @@ class SqlserverTest extends TestCase
             ->will($this->returnValue(12));
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->setMethods(['connect', 'driver'])
+            ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();
         $connection
             ->expects($this->any())
-            ->method('driver')
+            ->method('getDriver')
             ->will($this->returnValue($driver));
 
         $query = new Query($connection);
@@ -155,7 +155,7 @@ class SqlserverTest extends TestCase
     public function testSelectLimitOldServer()
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->setMethods(['_connect', 'connection', '_version'])
+            ->setMethods(['_connect', 'getConnection', '_version'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver
@@ -164,12 +164,12 @@ class SqlserverTest extends TestCase
             ->will($this->returnValue(8));
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->setMethods(['connect', 'driver'])
+            ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();
         $connection
             ->expects($this->any())
-            ->method('driver')
+            ->method('getDriver')
             ->will($this->returnValue($driver));
 
         $query = new Query($connection);
@@ -219,16 +219,16 @@ class SqlserverTest extends TestCase
     public function testInsertUsesOutput()
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->setMethods(['_connect', 'connection'])
+            ->setMethods(['_connect', 'getConnection'])
             ->setConstructorArgs([[]])
             ->getMock();
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->setMethods(['connect', 'driver'])
+            ->setMethods(['connect', 'getDriver', 'setDriver'])
             ->setConstructorArgs([['log' => false]])
             ->getMock();
         $connection
             ->expects($this->any())
-            ->method('driver')
+            ->method('getDriver')
             ->will($this->returnValue($driver));
         $query = new Query($connection);
         $query->insert(['title'])

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -25,7 +25,14 @@ use Cake\TestSuite\TestCase;
  */
 class CollectionTest extends TestCase
 {
+    /**
+     * @var \Cake\Database\Connection
+     */
+    public $connection;
 
+    /**
+     * @var array
+     */
     public $fixtures = [
         'core.users'
     ];
@@ -77,7 +84,7 @@ class CollectionTest extends TestCase
     public function testDescribeCache()
     {
         $schema = $this->connection->schemaCollection();
-        $table = $this->connection->schemaCollection()->describe('users');
+        $table = $schema->describe('users');
 
         Cache::delete('test_users', '_cake_model_');
         $this->connection->cacheMetadata(true);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -181,7 +181,7 @@ class BelongsToManyTest extends TestCase
     public function testJunctionConnection()
     {
         $mock = $this->getMockBuilder('Cake\Database\Connection')
-                ->setMethods(['driver'])
+                ->setMethods(['setDriver'])
                 ->setConstructorArgs(['name' => 'other_source'])
                 ->getMock();
         ConnectionManager::config('other_source', $mock);
@@ -192,7 +192,7 @@ class BelongsToManyTest extends TestCase
             'targetTable' => $this->tag
         ]);
         $junction = $assoc->junction();
-        $this->assertSame($mock, $junction->connection());
+        $this->assertSame($mock, $junction->getConnection());
         ConnectionManager::drop('other_source');
     }
 

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -17,7 +17,6 @@ namespace Cake\Test\TestCase\Routing;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
-use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\Route\RedirectRoute;
 use Cake\Routing\Route\Route;


### PR DESCRIPTION
Start the splitting of combined to separate setter/getter.
Scope is only the important ORM layers:
- Database
- Datasource
- ORM

Key features:
- No more fatal errors or accidents will $null input that triggers the get instead of set call
- Remove method complexity, allow stronger typehinting in the future, better IDE support
- Better speaking API, booleans are more clear from the method name (`autoQuoting()` to `enableAutoQuoting()`/`isEnabledAutoQuoting` etc)
- Chainable setters where it makes sense
- Doc blocks (and therefore API doc) more readable as per their "single responsibility" now
- Methods should never return `$this|otherType`

E.g it removes the confusion around `selectTypeMap()` which does not mean "to select a typeMap" but to "set the typeMap for the select clause" by using `setSelectTypeMap()` and `getSelectTypeMap()`.

Everything is BC, cleanup in 4.0 will be easy, also upgrading will be super easy as people have enough time in 3.x to slowly adjust to the new API.

Methods are still used the old way a lot, to provide BC check and to keep diff readable. Can be done later.

Worth mentioning:

- `Query::bufferResults($enablel)` is now `enableBufferedResults()`/`isEnabledBufferedResults()`.
- `Connection::useSavePoints($enable)` is now `enableSavePoints()`/`isEnabledSavePoints()`.

Better ideas for names welcome. This way it would be consistent, though - and `is...` shows that this is of bool result.

---

Remark for the future:
- We must more declare properties in the tests, just `$this->foo = new Foo()` provides no typehinting etc. This makes the tests and refactoring very difficult. Each `$this->...` assignment must have a property defined IMO.