### PR TITLE
Supprt Unicode escape sequence in Postgresql

### DIFF
--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Type;
 
 use Cake\Database\Driver;
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Type;
 use Cake\Database\TypeInterface;
 use InvalidArgumentException;
@@ -42,7 +43,12 @@ class JsonType extends Type implements TypeInterface
             throw new InvalidArgumentException('Cannot convert a resource value to JSON');
         }
 
-        return json_encode($value);
+        $options = 0;
+        if ($driver instanceof Postgres) {
+            $options = JSON_UNESCAPED_UNICODE;
+        }
+
+        return json_encode($value, $options);
     }
 
     /**


### PR DESCRIPTION
I,ve fixed my problem on save Unicode JSON in Postgresql with this pull request.

**Error Message:**
```
SQLSTATE[22P05]: Untranslatable character: 7 
ERROR:  unsupported Unicode escape sequence
DETAIL:  Unicode escape values cannot be used for code point values above 007F when the server encoding is not UTF8.
CONTEXT:  JSON data, line 1: {\"first_name\":...
``` 

