### PR TITLE
3.next Stop using ResponseTransformer

### DIFF
--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -64,9 +64,6 @@ class ActionDispatcher
             $this->addFilter($filter);
         }
         $this->factory = $factory ?: new ControllerFactory();
-
-        // Force aliases to be autoloaded.
-        class_exists('Cake\Network\Request');
     }
 
     /**

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -64,16 +64,19 @@ class ActionDispatcher
             $this->addFilter($filter);
         }
         $this->factory = $factory ?: new ControllerFactory();
+
+        // Force aliases to be autoloaded.
+        class_exists('Cake\Network\Request');
     }
 
     /**
      * Dispatches a Request & Response
      *
-     * @param \Cake\Network\Request $request The request to dispatch.
+     * @param \Cake\Http\ServerRequest $request The request to dispatch.
      * @param \Cake\Network\Response $response The response to dispatch.
      * @return \Cake\Network\Response A modified/replaced response.
      */
-    public function dispatch(Request $request, Response $response)
+    public function dispatch(ServerRequest $request, Response $response)
     {
         if (Router::getRequest(true) !== $request) {
             Router::pushRequest($request);

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -75,13 +75,7 @@ abstract class BaseApplication
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
-        $cakeResponse = ResponseTransformer::toCake($response);
-
-        // Dispatch the request/response to CakePHP
-        $cakeResponse = $this->getDispatcher()->dispatch($request, $cakeResponse);
-
-        // Convert the response back into a PSR7 object.
-        return ResponseTransformer::toPsr($cakeResponse);
+        return $this->getDispatcher()->dispatch($request, $response);
     }
 
     /**

--- a/src/Http/RequestTransformer.php
+++ b/src/Http/RequestTransformer.php
@@ -28,6 +28,7 @@ use Psr\Http\Message\ServerRequestInterface as PsrRequest;
  * request object.
  *
  * @internal
+ * @deprecated 3.4.0 No longer used. Will be removed in 4.0.0
  */
 class RequestTransformer
 {

--- a/src/Http/ResponseTransformer.php
+++ b/src/Http/ResponseTransformer.php
@@ -27,6 +27,7 @@ use Zend\Diactoros\Stream;
  * can be embedded as PSR7 middleware in a fully compatible way.
  *
  * @internal
+ * @deprecated 3.4.0 No longer used. Will be removed in 4.0.0
  */
 class ResponseTransformer
 {

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -15,11 +15,11 @@
 namespace Cake\Http;
 
 use Cake\Event\EventDispatcherTrait;
+use Cake\Network\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use UnexpectedValueException;
-use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Diactoros\Response\SapiStreamEmitter;

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -700,16 +700,16 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert location header. ' . $message);
         }
-        $result = $this->_response->header();
+        $result = $this->_response->getHeaderLine('Location');
         if ($url === null) {
-            $this->assertTrue(!empty($result['Location']), $message);
+            $this->assertTrue(!empty($result), $message);
 
             return;
         }
-        if (empty($result['Location'])) {
+        if (empty($result)) {
             $this->fail('No location header set. ' . $message);
         }
-        $this->assertEquals(Router::url($url, ['_full' => true]), $result['Location'], $message);
+        $this->assertEquals(Router::url($url, ['_full' => true]), $result, $message);
     }
 
     /**
@@ -724,11 +724,11 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert location header. ' . $message);
         }
-        $result = $this->_response->header();
-        if (empty($result['Location'])) {
+        $result = $this->_response->getHeaderLine('Location');
+        if (empty($result)) {
             $this->fail('No location header set. ' . $message);
         }
-        $this->assertContains($url, $result['Location'], $message);
+        $this->assertContains($url, $result, $message);
     }
 
     /**
@@ -742,14 +742,14 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert location header. ' . $message);
         }
-        $result = $this->_response->header();
+        $result = $this->_response->getHeaderLine('Location');
         if (!$message) {
             $message = 'Redirect header set';
         }
-        if (!empty($result['Location'])) {
-            $message .= ': ' . $result['Location'];
+        if (!empty($result)) {
+            $message .= ': ' . $result;
         }
-        $this->assertTrue(empty($result['Location']), $message);
+        $this->assertTrue(empty($result), $message);
     }
 
     /**
@@ -765,11 +765,11 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert headers. ' . $message);
         }
-        $headers = $this->_response->header();
-        if (!isset($headers[$header])) {
+        if (!$this->_response->hasHeader($header)) {
             $this->fail("The '$header' header is not set. " . $message);
         }
-        $this->assertEquals($headers[$header], $content, $message);
+        $actual = $this->_response->getHeaderLine($header);
+        $this->assertEquals($content, $actual, $message);
     }
 
     /**
@@ -785,11 +785,11 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert headers. ' . $message);
         }
-        $headers = $this->_response->header();
-        if (!isset($headers[$header])) {
+        if (!$this->_response->hasHeader($header)) {
             $this->fail("The '$header' header is not set. " . $message);
         }
-        $this->assertContains($content, $headers[$header], $message);
+        $actual = $this->_response->getHeaderLine($header);
+        $this->assertContains($content, $actual, $message);
     }
 
     /**

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -94,6 +94,7 @@ class MiddlewareDispatcher
 
         $server = new Server($app);
         $psrRequest = $this->_createRequest($request);
+
         return $server->run($psrRequest);
     }
 

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -94,9 +94,7 @@ class MiddlewareDispatcher
 
         $server = new Server($app);
         $psrRequest = $this->_createRequest($request);
-        $response = $server->run($psrRequest);
-
-        return ResponseTransformer::toCake($response);
+        return $server->run($psrRequest);
     }
 
     /**

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -4,8 +4,8 @@ namespace Cake\Test\TestCase;
 use Cake\Core\Configure;
 use Cake\Http\BaseApplication;
 use Cake\Http\ServerRequestFactory;
+use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
-use Zend\Diactoros\Response;
 
 /**
  * Base application test.


### PR DESCRIPTION
Now that `Cake\Network\Response` implements the PSR7 interfaces we don't need the `ResponseTransformer` any more. This saves us some time and complexity as responses aren't transformed before being emitted.

Refs #9636 