### PR TITLE
Clean up ServerRequest in non-test-code to be consistent.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -16,7 +16,7 @@ namespace Cake\Auth;
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Event\EventListenerInterface;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
 
@@ -193,20 +193,20 @@ abstract class BaseAuthenticate implements EventListenerInterface
     /**
      * Authenticate a user based on the request information.
      *
-     * @param \Cake\Network\Request $request Request to get authentication information from.
+     * @param \Cake\Http\ServerRequest $request Request to get authentication information from.
      * @param \Cake\Network\Response $response A response object that can have headers added.
      * @return mixed Either false on failure, or an array of user data on success.
      */
-    abstract public function authenticate(Request $request, Response $response);
+    abstract public function authenticate(ServerRequest $request, Response $response);
 
     /**
      * Get a user based on information in the request. Primarily used by stateless authentication
      * systems like basic and digest auth.
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Cake\Http\ServerRequest $request Request object.
      * @return mixed Either false or an array of user information
      */
-    public function getUser(Request $request)
+    public function getUser(ServerRequest $request)
     {
         return false;
     }
@@ -219,11 +219,11 @@ abstract class BaseAuthenticate implements EventListenerInterface
      * - Cake\Network\Response - A response object, which will cause AuthComponent to
      *   simply return that response.
      *
-     * @param \Cake\Network\Request $request A request object.
+     * @param \Cake\Http\ServerRequest $request A request object.
      * @param \Cake\Network\Response $response A response object.
      * @return void
      */
-    public function unauthenticated(Request $request, Response $response)
+    public function unauthenticated(ServerRequest $request, Response $response)
     {
     }
 

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -16,7 +16,7 @@ namespace Cake\Auth;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 
 /**
  * Abstract base authorization adapter for AuthComponent.
@@ -58,8 +58,8 @@ abstract class BaseAuthorize
      * Checks user authorization.
      *
      * @param array|\ArrayAccess $user Active user data
-     * @param \Cake\Network\Request $request Request instance.
+     * @param \Cake\Http\ServerRequest $request Request instance.
      * @return bool
      */
-    abstract public function authorize($user, Request $request);
+    abstract public function authorize($user, ServerRequest $request);
 }

--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Auth;
 
+use Cake\Http\ServerRequest;
 use Cake\Network\Exception\UnauthorizedException;
-use Cake\Network\Request;
 use Cake\Network\Response;
 
 /**
@@ -56,11 +56,11 @@ class BasicAuthenticate extends BaseAuthenticate
      * Authenticate a user using HTTP auth. Will use the configured User model and attempt a
      * login using HTTP auth.
      *
-     * @param \Cake\Network\Request $request The request to authenticate with.
+     * @param \Cake\Http\ServerRequest $request The request to authenticate with.
      * @param \Cake\Network\Response $response The response to add headers to.
      * @return mixed Either false on failure, or an array of user data on success.
      */
-    public function authenticate(Request $request, Response $response)
+    public function authenticate(ServerRequest $request, Response $response)
     {
         return $this->getUser($request);
     }
@@ -68,10 +68,10 @@ class BasicAuthenticate extends BaseAuthenticate
     /**
      * Get a user based on information in the request. Used by cookie-less auth for stateless clients.
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Cake\Http\ServerRequest $request Request object.
      * @return mixed Either false or an array of user information
      */
-    public function getUser(Request $request)
+    public function getUser(ServerRequest $request)
     {
         $username = $request->env('PHP_AUTH_USER');
         $pass = $request->env('PHP_AUTH_PW');
@@ -86,12 +86,12 @@ class BasicAuthenticate extends BaseAuthenticate
     /**
      * Handles an unauthenticated access attempt by sending appropriate login headers
      *
-     * @param \Cake\Network\Request $request A request object.
+     * @param \Cake\Http\ServerRequest $request A request object.
      * @param \Cake\Network\Response $response A response object.
      * @return void
      * @throws \Cake\Network\Exception\UnauthorizedException
      */
-    public function unauthenticated(Request $request, Response $response)
+    public function unauthenticated(ServerRequest $request, Response $response)
     {
         $Exception = new UnauthorizedException();
         $Exception->responseHeader([$this->loginHeaders($request)]);
@@ -101,10 +101,10 @@ class BasicAuthenticate extends BaseAuthenticate
     /**
      * Generate the login headers
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Cake\Http\ServerRequest $request Request object.
      * @return string Headers for logging in.
      */
-    public function loginHeaders(Request $request)
+    public function loginHeaders(ServerRequest $request)
     {
         $realm = $this->config('realm') ?: $request->env('SERVER_NAME');
 

--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -17,7 +17,7 @@ namespace Cake\Auth;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\Exception\Exception;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 
 /**
  * An authorization adapter for AuthComponent. Provides the ability to authorize
@@ -85,10 +85,10 @@ class ControllerAuthorize extends BaseAuthorize
      * Checks user authorization using a controller callback.
      *
      * @param array|\ArrayAccess $user Active user data
-     * @param \Cake\Network\Request $request Request instance.
+     * @param \Cake\Http\ServerRequest $request Request instance.
      * @return bool
      */
-    public function authorize($user, Request $request)
+    public function authorize($user, ServerRequest $request)
     {
         return (bool)$this->_Controller->isAuthorized($user);
     }

--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -16,8 +16,7 @@ namespace Cake\Auth;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
-use Cake\Network\Exception\UnauthorizedException;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 
 /**
  * Digest Authentication adapter for AuthComponent.
@@ -100,10 +99,10 @@ class DigestAuthenticate extends BasicAuthenticate
     /**
      * Get a user based on information in the request. Used by cookie-less auth for stateless clients.
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Cake\Http\ServerRequest $request Request object.
      * @return mixed Either false or an array of user information
      */
-    public function getUser(Request $request)
+    public function getUser(ServerRequest $request)
     {
         $digest = $this->_getDigest($request);
         if (empty($digest)) {
@@ -134,10 +133,10 @@ class DigestAuthenticate extends BasicAuthenticate
     /**
      * Gets the digest headers from the request/environment.
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Cake\Http\ServerRequest $request Request object.
      * @return array Array of digest information.
      */
-    protected function _getDigest(Request $request)
+    protected function _getDigest(ServerRequest $request)
     {
         $digest = $request->env('PHP_AUTH_DIGEST');
         if (empty($digest) && function_exists('apache_request_headers')) {
@@ -213,10 +212,10 @@ class DigestAuthenticate extends BasicAuthenticate
     /**
      * Generate the login headers
      *
-     * @param \Cake\Network\Request $request Request object.
+     * @param \Cake\Http\ServerRequest $request Request object.
      * @return string Headers for logging in.
      */
-    public function loginHeaders(Request $request)
+    public function loginHeaders(ServerRequest $request)
     {
         $realm = $this->_config['realm'] ?: $request->env('SERVER_NAME');
 

--- a/src/Auth/FormAuthenticate.php
+++ b/src/Auth/FormAuthenticate.php
@@ -15,7 +15,7 @@
  */
 namespace Cake\Auth;
 
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 
 /**
@@ -41,11 +41,11 @@ class FormAuthenticate extends BaseAuthenticate
     /**
      * Checks the fields to ensure they are supplied.
      *
-     * @param \Cake\Network\Request $request The request that contains login information.
+     * @param \Cake\Http\ServerRequest $request The request that contains login information.
      * @param array $fields The fields to be checked.
      * @return bool False if the fields have not been supplied. True if they exist.
      */
-    protected function _checkFields(Request $request, array $fields)
+    protected function _checkFields(ServerRequest $request, array $fields)
     {
         foreach ([$fields['username'], $fields['password']] as $field) {
             $value = $request->data($field);
@@ -62,11 +62,11 @@ class FormAuthenticate extends BaseAuthenticate
      * to find POST data that is used to find a matching record in the `config.userModel`. Will return false if
      * there is no post data, either username or password is missing, or if the scope conditions have not been met.
      *
-     * @param \Cake\Network\Request $request The request that contains login information.
+     * @param \Cake\Http\ServerRequest $request The request that contains login information.
      * @param \Cake\Network\Response $response Unused response object.
      * @return mixed False on login failure.  An array of User data on success.
      */
-    public function authenticate(Request $request, Response $response)
+    public function authenticate(ServerRequest $request, Response $response)
     {
         $fields = $this->_config['fields'];
         if (!$this->_checkFields($request, $fields)) {

--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -15,7 +15,7 @@
 namespace Cake\Auth\Storage;
 
 use Cake\Core\InstanceConfigTrait;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 
 /**
@@ -61,11 +61,11 @@ class SessionStorage implements StorageInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request Request instance.
+     * @param \Cake\Http\ServerRequest $request Request instance.
      * @param \Cake\Network\Response $response Response instance.
      * @param array $config Configuration list.
      */
-    public function __construct(Request $request, Response $response, array $config = [])
+    public function __construct(ServerRequest $request, Response $response, array $config = [])
     {
         $this->_session = $request->session();
         $this->config($config);

--- a/src/Auth/WeakPasswordHasher.php
+++ b/src/Auth/WeakPasswordHasher.php
@@ -43,7 +43,8 @@ class WeakPasswordHasher extends AbstractPasswordHasher
         if (Configure::read('debug')) {
             Debugger::checkSecurityKeys();
         }
-        parent::config($config);
+
+        parent::__construct($config);
     }
 
     /**

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -21,8 +21,8 @@ use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Http\ServerRequest;
 use Cake\Network\Exception\ForbiddenException;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -511,7 +511,7 @@ class AuthComponent extends Component
      *   If empty, the current request will be used.
      * @return bool True if $user is authorized, otherwise false
      */
-    public function isAuthorized($user = null, Request $request = null)
+    public function isAuthorized($user = null, ServerRequest $request = null)
     {
         if (empty($user) && !$this->user()) {
             return false;

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -15,8 +15,8 @@
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Http\ServerRequest;
 use Cake\I18n\Time;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\CookieCryptTrait;
 use Cake\Utility\Hash;
@@ -126,7 +126,7 @@ class CookieComponent extends Component
         }
 
         if ($controller === null) {
-            $this->request = Request::createFromGlobals();
+            $this->request = ServerRequest::createFromGlobals();
             $this->_response = new Response();
         }
 

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -16,9 +16,9 @@ namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Event\Event;
+use Cake\Http\ServerRequest;
 use Cake\I18n\Time;
 use Cake\Network\Exception\InvalidCsrfTokenException;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Security;
 
@@ -117,11 +117,11 @@ class CsrfComponent extends Component
      * Also sets the request->params['_csrfToken'] so the newly minted
      * token is available in the request data.
      *
-     * @param \Cake\Network\Request $request The request object.
+     * @param \Cake\Http\ServerRequest $request The request object.
      * @param \Cake\Network\Response $response The response object.
      * @return void
      */
-    protected function _setCookie(Request $request, Response $response)
+    protected function _setCookie(ServerRequest $request, Response $response)
     {
         $expiry = new Time($this->_config['expiry']);
         $value = hash('sha512', Security::randomBytes(16), false);
@@ -140,11 +140,11 @@ class CsrfComponent extends Component
     /**
      * Validate the request data against the cookie token.
      *
-     * @param \Cake\Network\Request $request The request to validate against.
+     * @param \Cake\Http\ServerRequest $request The request to validate against.
      * @throws \Cake\Network\Exception\InvalidCsrfTokenException when the CSRF token is invalid or missing.
      * @return void
      */
-    protected function _validateToken(Request $request)
+    protected function _validateToken(ServerRequest $request)
     {
         $cookie = $request->cookie($this->_config['cookieName']);
         $post = $request->data($this->_config['field']);

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -155,7 +155,7 @@ class RequestHandlerComponent extends Component
      * If html is one of the preferred types, no content type will be set, this
      * is to avoid issues with browsers that prefer HTML and several other content types.
      *
-     * @param \Cake\Network\Request $request The request instance.
+     * @param \Cake\Http\ServerRequest $request The request instance.
      * @param \Cake\Network\Response $response The response instance.
      * @return void
      */
@@ -323,7 +323,9 @@ class RequestHandlerComponent extends Component
         );
 
         if ($this->ext && $isRecognized) {
-            $this->renderAs($event->subject(), $this->ext);
+            /* @var \Cake\Controller\Controller $controller */
+            $controller = $event->subject();
+            $this->renderAs($controller, $this->ext);
         } else {
             $this->response->charset(Configure::read('App.encoding'));
         }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -20,8 +20,8 @@ use Cake\Controller\Exception\AuthSecurityException;
 use Cake\Controller\Exception\SecurityException;
 use Cake\Core\Configure;
 use Cake\Event\Event;
+use Cake\Http\ServerRequest;
 use Cake\Network\Exception\BadRequestException;
-use Cake\Network\Request;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
 
@@ -562,10 +562,10 @@ class SecurityComponent extends Component
      * Manually add form tampering prevention token information into the provided
      * request object.
      *
-     * @param \Cake\Network\Request $request The request object to add into.
+     * @param \Cake\Http\ServerRequest $request The request object to add into.
      * @return bool
      */
-    public function generateToken(Request $request)
+    public function generateToken(ServerRequest $request)
     {
         if ($request->is('requested')) {
             if ($this->session->check('_Token')) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -20,8 +20,8 @@ use Cake\Event\Event;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventListenerInterface;
+use Cake\Http\ServerRequest;
 use Cake\Log\LogTrait;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Routing\RequestActionTrait;
@@ -222,14 +222,14 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Sets a number of properties based on conventions if they are empty. To override the
      * conventions CakePHP uses you can define properties in your class declaration.
      *
-     * @param \Cake\Network\Request|null $request Request object for this controller. Can be null for testing,
+     * @param \Cake\Http\ServerRequest|null $request Request object for this controller. Can be null for testing,
      *   but expect that features that use the request parameters will not work.
      * @param \Cake\Network\Response|null $response Response object for this controller.
      * @param string|null $name Override the name useful in testing when using mocks.
      * @param \Cake\Event\EventManager|null $eventManager The event manager. Defaults to a new instance.
      * @param \Cake\Controller\ComponentRegistry|null $components The component registry. Defaults to a new instance.
      */
-    public function __construct(Request $request = null, Response $response = null, $name = null, $eventManager = null, $components = null)
+    public function __construct(ServerRequest $request = null, Response $response = null, $name = null, $eventManager = null, $components = null)
     {
         if ($name !== null) {
             $this->name = $name;
@@ -244,8 +244,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $this->name = substr($name, 0, -10);
         }
 
-        $this->setRequest($request !== null ? $request : new Request);
-        $this->response = $response !== null ? $response : new Response;
+        $this->setRequest($request !== null ? $request : new ServerRequest());
+        $this->response = $response !== null ? $response : new Response();
 
         if ($eventManager !== null) {
             $this->eventManager($eventManager);
@@ -395,10 +395,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * - $this->passedArgs - Same as $request->params['pass]
      * - View::$plugin - $this->plugin
      *
-     * @param \Cake\Network\Request $request Request instance.
+     * @param \Cake\Http\ServerRequest $request Request instance.
      * @return void
      */
-    public function setRequest(Request $request)
+    public function setRequest(ServerRequest $request)
     {
         $this->request = $request;
         $this->plugin = $request->param('plugin') ?: null;

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -315,7 +315,7 @@ abstract class BaseErrorHandler
     /**
      * Get the request context for an error/exception trace.
      *
-     * @param \Cake\Network\Request $request The request to read from.
+     * @param \Cake\Http\ServerRequest $request The request to read from.
      * @return string
      */
     protected function _requestContext($request)

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -20,8 +20,8 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\Exception as CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Event\Event;
+use Cake\Http\ServerRequest;
 use Cake\Network\Exception\HttpException;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
@@ -115,7 +115,7 @@ class ExceptionRenderer
     protected function _getController()
     {
         if (!$request = Router::getRequest(true)) {
-            $request = Request::createFromGlobals();
+            $request = ServerRequest::createFromGlobals();
         }
         $response = new Response();
 

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -17,8 +17,6 @@ namespace Cake\Http;
 use Cake\Controller\Controller;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventListenerInterface;
-use Cake\Http\ControllerFactory;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
 use LogicException;
@@ -69,11 +67,11 @@ class ActionDispatcher
     /**
      * Dispatches a Request & Response
      *
-     * @param \Cake\Network\Request $request The request to dispatch.
+     * @param \Cake\Http\ServerRequest $request The request to dispatch.
      * @param \Cake\Network\Response $response The response to dispatch.
      * @return \Cake\Network\Response A modified/replaced response.
      */
-    public function dispatch(Request $request, Response $response)
+    public function dispatch(ServerRequest $request, Response $response)
     {
         if (Router::getRequest(true) !== $request) {
             Router::pushRequest($request);

--- a/src/Http/ControllerFactory.php
+++ b/src/Http/ControllerFactory.php
@@ -15,7 +15,6 @@
 namespace Cake\Http;
 
 use Cake\Core\App;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Exception\MissingControllerException;
 use Cake\Utility\Inflector;
@@ -29,11 +28,11 @@ class ControllerFactory
     /**
      * Create a controller for a given request/response
      *
-     * @param \Cake\Network\Request $request The request to build a controller for.
+     * @param \Cake\Http\ServerRequest $request The request to build a controller for.
      * @param \Cake\Network\Response $response The response to use.
      * @return \Cake\Controller\Controller
      */
-    public function create(Request $request, Response $response)
+    public function create(ServerRequest $request, Response $response)
     {
         $pluginPath = $controller = null;
         $namespace = 'Controller';
@@ -82,7 +81,7 @@ class ControllerFactory
     /**
      * Throws an exception when a controller is missing.
      *
-     * @param \Cake\Network\Request $request The request.
+     * @param \Cake\Http\ServerRequest $request The request.
      * @throws \Cake\Routing\Exception\MissingControllerException
      * @return void
      */

--- a/src/Http/RequestTransformer.php
+++ b/src/Http/RequestTransformer.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Http;
 
-use Cake\Network\Request as CakeRequest;
 use Cake\Utility\Hash;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 
@@ -35,7 +34,7 @@ class RequestTransformer
      * Transform a PSR7 request into a CakePHP one.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The PSR7 request.
-     * @return \Cake\Network\Request The transformed request.
+     * @return \Cake\Http\ServerRequest The transformed request.
      */
     public static function toCake(PsrRequest $request)
     {
@@ -50,7 +49,7 @@ class RequestTransformer
         $input = $request->getBody()->getContents();
         $input = $input === '' ? null : $input;
 
-        return new CakeRequest([
+        return new ServerRequest([
             'query' => $request->getQueryParams(),
             'post' => $post,
             'cookies' => $request->getCookieParams(),

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -127,7 +127,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * The built in detectors used with `is()` can be modified with `addDetector()`.
      *
-     * There are several ways to specify a detector, see Cake\Network\Request::addDetector() for the
+     * There are several ways to specify a detector, see \Cake\Http\ServerRequest::addDetector() for the
      * various formats and ways to define detectors.
      *
      * @var array
@@ -217,7 +217,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
      * the request.
      *
-     * @return \Cake\Network\Request
+     * @return \Cake\Http\ServerRequest
      * @deprecated 3.4.0 Use `Cake\Http\ServerRequestFactory` instead.
      */
     public static function createFromGlobals()

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1441,7 +1441,7 @@ class Response implements ResponseInterface
      * the Last-Modified etag response header before calling this method. Otherwise
      * a comparison will not be possible.
      *
-     * @param \Cake\Network\Request $request Request object
+     * @param \Cake\Http\ServerRequest $request Request object
      * @return bool Whether the response was marked as not modified or not.
      */
     public function checkNotModified(Request $request)
@@ -1580,7 +1580,7 @@ class Response implements ResponseInterface
      * *Note* The `$allowedDomains`, `$allowedMethods`, `$allowedHeaders` parameters are deprecated.
      * Instead the builder object should be used.
      *
-     * @param \Cake\Network\Request $request Request object
+     * @param \Cake\Http\ServerRequest $request Request object
      * @param string|array $allowedDomains List of allowed domains, see method description for more details
      * @param string|array $allowedMethods List of HTTP verbs allowed
      * @param string|array $allowedHeaders List of HTTP headers allowed

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -17,7 +17,7 @@ namespace Cake\Routing;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventListenerInterface;
 use Cake\Http\ActionDispatcher;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 
 /**
@@ -49,12 +49,12 @@ class Dispatcher
      * If no controller of given name can be found, invoke() will throw an exception.
      * If the controller is found, and the action is not found an exception will be thrown.
      *
-     * @param \Cake\Network\Request $request Request object to dispatch.
+     * @param \Cake\Http\ServerRequest $request Request object to dispatch.
      * @param \Cake\Network\Response $response Response object to put the results of the dispatch into.
      * @return string|null if `$request['return']` is set then it returns response body, null otherwise
      * @throws \LogicException When the controller did not get created in the Dispatcher.beforeDispatch event.
      */
-    public function dispatch(Request $request, Response $response)
+    public function dispatch(ServerRequest $request, Response $response)
     {
         $actionDispatcher = new ActionDispatcher(null, $this->eventManager(), $this->_filters);
         $response = $actionDispatcher->dispatch($request, $response);

--- a/src/Routing/Filter/AssetFilter.php
+++ b/src/Routing/Filter/AssetFilter.php
@@ -16,7 +16,7 @@ namespace Cake\Routing\Filter;
 
 use Cake\Core\Plugin;
 use Cake\Event\Event;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use Cake\Routing\DispatcherFilter;
 use Cake\Utility\Inflector;
@@ -120,13 +120,13 @@ class AssetFilter extends DispatcherFilter
     /**
      * Sends an asset file to the client
      *
-     * @param \Cake\Network\Request $request The request object to use.
+     * @param \Cake\Http\ServerRequest $request The request object to use.
      * @param \Cake\Network\Response $response The response object to use.
      * @param string $assetFile Path to the asset file in the file system
      * @param string $ext The extension of the file to determine its mime type
      * @return \Cake\Network\Response The updated response.
      */
-    protected function _deliverAsset(Request $request, Response $response, $assetFile, $ext)
+    protected function _deliverAsset(ServerRequest $request, Response $response, $assetFile, $ext)
     {
         $compressionEnabled = $response->compress();
         if ($response->type($ext) === $ext) {

--- a/src/Routing/Filter/ControllerFactoryFilter.php
+++ b/src/Routing/Filter/ControllerFactoryFilter.php
@@ -52,7 +52,7 @@ class ControllerFactoryFilter extends DispatcherFilter
     /**
      * Gets controller to use, either plugin or application controller.
      *
-     * @param \Cake\Network\Request $request Request object
+     * @param \Cake\Http\ServerRequest $request Request object
      * @param \Cake\Network\Response $response Response for the controller.
      * @return \Cake\Controller\Controller
      */

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -14,7 +14,7 @@
 namespace Cake\Routing;
 
 use Cake\Core\Configure;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use Cake\Network\Session;
 use Cake\Routing\Filter\ControllerFactoryFilter;
@@ -153,7 +153,7 @@ trait RequestActionTrait
 
         $params['session'] = isset($extra['session']) ? $extra['session'] : new Session();
 
-        $request = new Request($params);
+        $request = new ServerRequest($params);
         $request->addParams($extra);
         $dispatcher = DispatcherFactory::create();
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Routing\Route;
 
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 
 /**
@@ -280,7 +280,7 @@ class Route
         if (isset($this->defaults['_method'])) {
             if (empty($method)) {
                 // Deprecated reading the global state is deprecated and will be removed in 4.x
-                $request = Router::getRequest(true) ?: Request::createFromGlobals();
+                $request = Router::getRequest(true) ?: ServerRequest::createFromGlobals();
                 $method = $request->env('REQUEST_METHOD');
             }
             if (!in_array($method, (array)$this->defaults['_method'], true)) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -15,7 +15,7 @@
 namespace Cake\Routing;
 
 use Cake\Core\Configure;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -362,12 +362,12 @@ class Router
      * Will accept either a Cake\Network\Request object or an array of arrays. Support for
      * accepting arrays may be removed in the future.
      *
-     * @param \Cake\Network\Request|array $request Parameters and path information or a Cake\Network\Request object.
+     * @param \Cake\Http\ServerRequest|array $request Parameters and path information or a Cake\Network\Request object.
      * @return void
      */
     public static function setRequestInfo($request)
     {
-        if ($request instanceof Request) {
+        if ($request instanceof ServerRequest) {
             static::pushRequest($request);
         } else {
             $requestData = $request;
@@ -377,7 +377,7 @@ class Router
                 'action' => false,
                 'plugin' => null
             ];
-            $request = new Request();
+            $request = new ServerRequest();
             $request->addParams($requestData[0])->addPaths($requestData[1]);
             static::pushRequest($request);
         }
@@ -387,10 +387,10 @@ class Router
      * Push a request onto the request stack. Pushing a request
      * sets the request context used when generating URLs.
      *
-     * @param \Cake\Network\Request $request Request instance.
+     * @param \Cake\Http\ServerRequest $request Request instance.
      * @return void
      */
-    public static function pushRequest(Request $request)
+    public static function pushRequest(ServerRequest $request)
     {
         static::$_requests[] = $request;
         static::setRequestContext($request);
@@ -399,13 +399,13 @@ class Router
     /**
      * Store the request context for a given request.
      *
-     * @param \Cake\Network\Request|\Psr\Http\Message\ServerRequestInterface $request The request instance.
+     * @param \Cake\Http\ServerRequest|\Psr\Http\Message\ServerRequestInterface $request The request instance.
      * @return void
      * @throws InvalidArgumentException When parameter is an incorrect type.
      */
     public static function setRequestContext($request)
     {
-        if ($request instanceof Request) {
+        if ($request instanceof ServerRequest) {
             static::$_requestContext = [
                 '_base' => $request->base,
                 '_port' => $request->port(),
@@ -433,7 +433,7 @@ class Router
     /**
      * Pops a request off of the request stack.  Used when doing requestAction
      *
-     * @return \Cake\Network\Request The request removed from the stack.
+     * @return \Cake\Http\ServerRequest The request removed from the stack.
      * @see \Cake\Routing\Router::pushRequest()
      * @see \Cake\Routing\RequestActionTrait::requestAction()
      */
@@ -453,7 +453,7 @@ class Router
      * Get the current request object, or the first one.
      *
      * @param bool $current True to get the current request, or false to get the first one.
-     * @return \Cake\Network\Request|null
+     * @return \Cake\Http\ServerRequest|null
      */
     public static function getRequest($current = false)
     {
@@ -715,7 +715,7 @@ class Router
      * This will strip out 'autoRender', 'bare', 'requested', and 'return' param names as those
      * are used for CakePHP internals and should not normally be part of an output URL.
      *
-     * @param \Cake\Network\Request|array $params The params array or
+     * @param \Cake\Http\ServerRequest|array $params The params array or
      *     Cake\Network\Request object that needs to be reversed.
      * @param bool $full Set to true to include the full URL including the
      *     protocol when reversing the URL.
@@ -724,7 +724,7 @@ class Router
     public static function reverse($params, $full = false)
     {
         $url = [];
-        if ($params instanceof Request) {
+        if ($params instanceof ServerRequest) {
             $url = $params->query;
             $params = $params->params;
         } elseif (isset($params['url'])) {
@@ -839,12 +839,12 @@ class Router
      *
      * - `separator` The string to use as a separator.  Defaults to `:`.
      *
-     * @param \Cake\Network\Request $request The request object to modify.
+     * @param \Cake\Http\ServerRequest $request The request object to modify.
      * @param array $options The array of options.
-     * @return \Cake\Network\Request The modified request
+     * @return \Cake\Http\ServerRequest The modified request
      * @deprecated 3.3.0 Named parameter backwards compatibility will be removed in 4.0.
      */
-    public static function parseNamedParams(Request $request, array $options = [])
+    public static function parseNamedParams(ServerRequest $request, array $options = [])
     {
         $options += ['separator' => ':'];
         if (empty($request->params['pass'])) {

--- a/src/TestSuite/LegacyRequestDispatcher.php
+++ b/src/TestSuite/LegacyRequestDispatcher.php
@@ -13,7 +13,7 @@
  */
 namespace Cake\TestSuite;
 
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Routing\DispatcherFactory;
 use Cake\TestSuite\Stub\Response;
 
@@ -39,11 +39,11 @@ class LegacyRequestDispatcher
      * Run a request and get the response.
      *
      * @param array $request The request context to execute.
-     * @return \Cake\Network\Response The generated response.
+     * @return string|null The generated response.
      */
     public function execute($request)
     {
-        $request = new Request($request);
+        $request = new ServerRequest($request);
         $response = new Response();
         $dispatcher = DispatcherFactory::create();
         $dispatcher->eventManager()->on(

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -70,7 +70,7 @@ class MiddlewareDispatcher
     /**
      * Run a request and get the response.
      *
-     * @param \Cake\Network\Request $request The request to execute.
+     * @param \Cake\Http\ServerRequest $request The request to execute.
      * @return \Cake\Network\Response The generated response.
      */
     public function execute($request)

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -15,7 +15,7 @@
 namespace Cake\View;
 
 use Cake\Event\EventManager;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 
 /**
@@ -35,13 +35,13 @@ class AjaxView extends View
     /**
      * Constructor
      *
-     * @param \Cake\Network\Request|null $request The request object.
+     * @param \Cake\Http\ServerRequest|null $request The request object.
      * @param \Cake\Network\Response|null $response The response object.
      * @param \Cake\Event\EventManager|null $eventManager Event manager object.
      * @param array $viewOptions View options.
      */
     public function __construct(
-        Request $request = null,
+        ServerRequest $request = null,
         Response $response = null,
         EventManager $eventManager = null,
         array $viewOptions = []

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -19,7 +19,7 @@ use Cake\Cache\Cache;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
@@ -133,13 +133,13 @@ abstract class Cell
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request|null $request The request to use in the cell.
+     * @param \Cake\Http\ServerRequest|null $request The request to use in the cell.
      * @param \Cake\Network\Response|null $response The response to use in the cell.
      * @param \Cake\Event\EventManager|null $eventManager The eventManager to bind events to.
      * @param array $cellOptions Cell options to apply.
      */
     public function __construct(
-        Request $request = null,
+        ServerRequest $request = null,
         Response $response = null,
         EventManager $eventManager = null,
         array $cellOptions = []

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -88,10 +88,11 @@ trait CellTrait
      * @param string $action The action name.
      * @param string $plugin The plugin name.
      * @param array $options The constructor options for the cell.
-     * @return \Cake\View\Cell;
+     * @return \Cake\View\Cell
      */
     protected function _createCell($className, $action, $plugin, $options)
     {
+        /* @var \Cake\View\Cell $instance */
         $instance = new $className($this->request, $this->response, $this->eventManager(), $options);
         $instance->template = Inflector::underscore($action);
 

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Form;
 
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Utility\Hash;
 
 /**
@@ -77,10 +77,10 @@ class ArrayContext implements ContextInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request The request object.
+     * @param \Cake\Http\ServerRequest $request The request object.
      * @param array $context Context info.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(ServerRequest $request, array $context)
     {
         $this->_request = $request;
         $context += [

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -16,7 +16,7 @@ namespace Cake\View\Form;
 
 use Cake\Collection\Collection;
 use Cake\Datasource\EntityInterface;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use RuntimeException;
@@ -84,10 +84,10 @@ class EntityContext implements ContextInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request The request object.
+     * @param \Cake\Http\ServerRequest $request The request object.
      * @param array $context Context info.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(ServerRequest $request, array $context)
     {
         $this->_request = $request;
         $context += [

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Form;
 
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Utility\Hash;
 
 /**
@@ -36,10 +36,10 @@ class FormContext implements ContextInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request The request object.
+     * @param \Cake\Http\ServerRequest $request The request object.
      * @param array $context Context info.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(ServerRequest $request, array $context)
     {
         $this->_request = $request;
         $context += [

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Form;
 
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 
 /**
  * Provides a context provider that does nothing.
@@ -35,10 +35,10 @@ class NullContext implements ContextInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Network\Request $request The request object.
+     * @param \Cake\Http\ServerRequest $request The request object.
      * @param array $context Context info.
      */
-    public function __construct(Request $request, array $context)
+    public function __construct(ServerRequest $request, array $context)
     {
         $this->_request = $request;
     }

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -15,7 +15,7 @@
 namespace Cake\View;
 
 use Cake\Event\EventManager;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use RuntimeException;
 
@@ -35,13 +35,13 @@ class SerializedView extends View
     /**
      * Constructor
      *
-     * @param \Cake\Network\Request|null $request Request instance.
+     * @param \Cake\Http\ServerRequest|null $request Request instance.
      * @param \Cake\Network\Response|null $response Response instance.
      * @param \Cake\Event\EventManager|null $eventManager EventManager instance.
      * @param array $viewOptions An array of view options
      */
     public function __construct(
-        Request $request = null,
+        ServerRequest $request = null,
         Response $response = null,
         EventManager $eventManager = null,
         array $viewOptions = []

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -20,8 +20,8 @@ use Cake\Core\Plugin;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
+use Cake\Http\ServerRequest;
 use Cake\Log\LogTrait;
-use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
@@ -198,7 +198,7 @@ class View implements EventDispatcherInterface
     public $uuids = [];
 
     /**
-     * An instance of a Cake\Network\Request object that contains information about the current request.
+     * An instance of a \Cake\Http\ServerRequest object that contains information about the current request.
      * This object contains all the information about a request and several methods for reading
      * additional information about the request.
      *
@@ -308,14 +308,14 @@ class View implements EventDispatcherInterface
     /**
      * Constructor
      *
-     * @param \Cake\Network\Request|null $request Request instance.
+     * @param \Cake\Http\ServerRequest|null $request Request instance.
      * @param \Cake\Network\Response|null $response Response instance.
      * @param \Cake\Event\EventManager|null $eventManager Event manager instance.
      * @param array $viewOptions View options. See View::$_passedVars for list of
      *   options which get set as class properties.
      */
     public function __construct(
-        Request $request = null,
+        ServerRequest $request = null,
         Response $response = null,
         EventManager $eventManager = null,
         array $viewOptions = []
@@ -335,7 +335,7 @@ class View implements EventDispatcherInterface
         $this->request = $request ?: Router::getRequest(true);
         $this->response = $response ?: new Response();
         if (empty($this->request)) {
-            $this->request = new Request([
+            $this->request = new ServerRequest([
                 'base' => '',
                 'url' => '',
                 'webroot' => '/'
@@ -487,7 +487,7 @@ class View implements EventDispatcherInterface
         }
 
         $pluginCheck = $options['plugin'] === false ? false : true;
-        $file = $this->_getElementFilename($name, $pluginCheck);
+        $file = $this->_getElementFileName($name, $pluginCheck);
         if ($file && $options['cache']) {
             return $this->cache(function () use ($file, $data, $options) {
                 echo $this->_renderElement($file, $data, $options);

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -16,7 +16,7 @@ namespace Cake\View;
 
 use Cake\Core\App;
 use Cake\Event\EventManager;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use Cake\View\Exception\MissingViewException;
 use JsonSerializable;
@@ -325,13 +325,13 @@ class ViewBuilder implements JsonSerializable, Serializable
      * If that class does not exist, then Cake\View\View will be used.
      *
      * @param array $vars The view variables/context to use.
-     * @param \Cake\Network\Request|null $request The request to use.
+     * @param \Cake\Http\ServerRequest|null $request The request to use.
      * @param \Cake\Network\Response|null $response The response to use.
      * @param \Cake\Event\EventManager|null $events The event manager to use.
      * @return \Cake\View\View
      * @throws \Cake\View\Exception\MissingViewException
      */
-    public function build($vars = [], Request $request = null, Response $response = null, EventManager $events = null)
+    public function build($vars = [], ServerRequest $request = null, Response $response = null, EventManager $events = null)
     {
         $className = $this->_className;
         if ($className === null) {

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -36,11 +36,21 @@ class TestAuthenticate extends BaseAuthenticate
         ];
     }
 
+    /**
+     * @param \Cake\Http\ServerRequest $request
+     * @param \Cake\Network\Response $response
+     * @return array
+     */
     public function authenticate(Request $request, Response $response)
     {
         return ['id' => 1, 'username' => 'admad'];
     }
 
+    /**
+     * @param \Cake\Event\Event $event
+     * @param array $user
+     * @return array
+     */
     public function afterIdentify(Event $event, array $user)
     {
         $this->callStack[] = __FUNCTION__;
@@ -51,6 +61,10 @@ class TestAuthenticate extends BaseAuthenticate
         }
     }
 
+    /**
+     * @param \Cake\Event\Event $event
+     * @param array $user
+     */
     public function logout(Event $event, array $user)
     {
         $this->callStack[] = __FUNCTION__;


### PR DESCRIPTION
IDEs really don't like class aliases.
They completely break two advantages of IDEs: auto complete and typehinting.
Also, with the latest changes it seems now proven that class aliases can be changed inside method signatures without causing BC breaks. A test case to proof it is still available (see test_app/TestApp/Auth/TestAuthenticate.php in this PR).

So in short: The new 3.4 should be consistent in itself in the functional part. Tests are still using the old Request class, which is fine.