### PR TITLE
Remove an invalid option for json_encode.

### DIFF
--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -136,7 +136,7 @@ class JsonView extends SerializedView
         $data = $this->_dataToSerialize($serialize);
 
         $jsonOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT |
-            JSON_ERROR_INF_OR_NAN | JSON_PARTIAL_OUTPUT_ON_ERROR;
+            JSON_PARTIAL_OUTPUT_ON_ERROR;
 
         if (isset($this->viewVars['_jsonOptions'])) {
             if ($this->viewVars['_jsonOptions'] === false) {


### PR DESCRIPTION
`JSON_ERROR_INF_OR_NAN` is a constant returned by `json_last_error()`.

(This issue was reported by @nojimage)