### PR TITLE
Allow basic support for MySQL year type

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -92,7 +92,7 @@ class MysqlSchema extends BaseSchema
             $precision = (int)$precision;
         }
 
-        if (in_array($col, ['date', 'time', 'datetime', 'timestamp'])) {
+        if (in_array($col, ['date', 'time', 'datetime', 'timestamp', 'year'])) {
             return ['type' => $col, 'length' => null];
         }
         if (($col === 'tinyint' && $length === 1) || $col === 'boolean') {

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -218,10 +218,12 @@ class DateTimeWidget implements WidgetInterface
                 'meridian' => '',
             ];
         }
+
+        if (is_string($value) && is_numeric($value) && strlen($value) === 4) {
+            $value .= '-01-01';
+        }
+
         try {
-            if (is_string($value) && is_numeric($value) && strlen($value) === 4) {
-                $value .= '-01-01';
-            }
             if (is_string($value) && !is_numeric($value)) {
                 $date = new DateTime($value);
             } elseif (is_bool($value)) {

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -219,7 +219,7 @@ class DateTimeWidget implements WidgetInterface
             ];
         }
         try {
-            if (is_string($value) && strlen($value) === 4) {
+            if (is_string($value) && is_numeric($value) && strlen($value) === 4) {
                 $value .= '-01-01';
             }
             if (is_string($value) && !is_numeric($value)) {

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -219,6 +219,9 @@ class DateTimeWidget implements WidgetInterface
             ];
         }
         try {
+            if (is_string($value) && strlen($value) === 4) {
+                $value .= '-01-01';
+            }
             if (is_string($value) && !is_numeric($value)) {
                 $date = new DateTime($value);
             } elseif (is_bool($value)) {

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -171,6 +171,10 @@ class MysqlSchemaTest extends TestCase
                 'JSON',
                 ['type' => 'json', 'length' => null]
             ],
+            [
+                'YEAR',
+                ['type' => 'year', 'length' => null]
+            ],
         ];
     }
 

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -1198,6 +1198,28 @@ class DateTimeWidgetTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testRenderYear()
+    {
+        $result = $this->DateTime->render([
+            'name' => 'date',
+            'val' => '2009',
+            'month' => false,
+            'day' => false,
+            'hour' => false,
+            'minute' => false,
+            'second' => false,
+        ], $this->context);
+
+        $expected = '<select name="date[year]"><option value="';
+        $this->assertContains($expected, $result);
+
+        $expected = '<option value="2009" selected="selected">2009</option></select>';
+        $this->assertContains($expected, $result);
+    }
+
+    /**
      * Test rendering with templateVars
      *
      * @return void


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/9654

I now confirmed with a real test application that it works together with a custom [YearType](https://github.com/dereuromark/cakephp-shim/blob/master/src/Database/Type/YearType.php).

This patch is required to properly store the values posted on the one side, and to output format it as Year dropdown on the other side for form display.