### PR TITLE
False positives and conflicts list for shells

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -280,8 +280,8 @@ class ShellDispatcher
                         "command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",
                         ['shell-dispatcher']
                     );
-                    continue;
                 }
+                continue;
             }
             
             if (isset($others[$shell])) {

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -274,7 +274,7 @@ class ShellDispatcher
             $other = static::alias($shell);
             if ($other) {
                 $other = $aliases[$shell];
-                if ($other != $plugin) {
+                if ($other !== $plugin) {
                     Log::write(
                         'debug',
                         "command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -244,7 +244,7 @@ class ShellDispatcher
         $io->setLoggers(false);
         $list = $task->getShellList() + ['app' => []];
         $fixed = array_flip($list['app']) + array_flip($list['CORE']);
-        $aliases = [];
+        $aliases = $others = [];
 
         foreach ($plugins as $plugin) {
             if (!isset($list[$plugin])) {
@@ -253,6 +253,11 @@ class ShellDispatcher
 
             foreach ($list[$plugin] as $shell) {
                 $aliases += [$shell => $plugin];
+                if (!isset($others[$shell])) {
+                    $others[$shell] = [$plugin];
+                } else {
+                    $others[$shell] = array_merge($others[$shell], [$plugin]);
+                }
             }
         }
 
@@ -269,12 +274,26 @@ class ShellDispatcher
             $other = static::alias($shell);
             if ($other) {
                 $other = $aliases[$shell];
-                Log::write(
-                    'debug',
-                    "command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",
-                    ['shell-dispatcher']
-                );
-                continue;
+                if ($other != $plugin) {
+                    Log::write(
+                        'debug',
+                        "command '$shell' in plugin '$plugin' was not aliased, conflicts with '$other'",
+                        ['shell-dispatcher']
+                    );
+                    continue;
+                }
+            }
+            
+            if (isset($others[$shell])) {
+                $conflicts = array_diff($others[$shell], [$plugin]);
+                if (count($conflicts) > 0) {
+                    $conflictList = implode("', '", $conflicts);
+                    Log::write(
+                        'debug',
+                        "command '$shell' in plugin '$plugin' was not aliased, conflicts with '$conflictList'",
+                        ['shell-dispatcher']
+                    );
+                }
             }
 
             static::alias($shell, "$plugin.$shell");

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -284,6 +284,7 @@ class ShellDispatcher
                 continue;
             }
             
+
             if (isset($others[$shell])) {
                 $conflicts = array_diff($others[$shell], [$plugin]);
                 if (count($conflicts) > 0) {

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -283,7 +283,6 @@ class ShellDispatcher
                 }
                 continue;
             }
-            
 
             if (isset($others[$shell])) {
                 $conflicts = array_diff($others[$shell], [$plugin]);


### PR DESCRIPTION
As discussed in #9728 this will fix shell naming conflicts between plugins:

- [x] Avoid reporting that shall name of PluginName conflicts with PluginName
- [x] List all plugins that conflicts for a specific shall command