### PR TITLE
Improve .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -22,111 +22,75 @@ Mark Scherer <euromark@web.de> mscherer <mark.scherer@spryker.com>
 Mark Scherer <euromark@web.de> mark <mark.scherer@spryker.com>
 Mark Scherer <euromark@web.de> Mark S. <dereuromark@users.noreply.github.com>
 phpnut <phpnut@cakephp.org>
-phpnut <phpnut@cakephp.org> Larry E. Masters <phpnut@cakephp.org>
+phpnut <phpnut@cakephp.org> <phpnut@gmail.com>
 AD7six <andydawson76@gmail.com>
-AD7six <andydawson76@gmail.com> Andy Dawson <andydawson76@gmail.com>
+AD7six <andydawson76@gmail.com> <andydawson76@yahoo.co.uk>
 predominant <graham@grahamweldon.com>
-predominant <graham@grahamweldon.com> Graham Weldon <graham@grahamweldon.com>
+mariano.iglesias <mariano.iglesias@3807eeeb-6ff5-0310-8944-8be069107fe0>
+mariano.iglesias <mariano.iglesias@3807eeeb-6ff5-0310-8944-8be069107fe0> <mariano@cricava.com>
 antograssiot <antograssiot@free.fr>
-antograssiot <antograssiot@free.fr> Anthony GRASSIOT <antograssiot@free.fr>
-antograssiot <antograssiot@free.fr> Anto <antograssiot@free.fr>
 Florian Krämer <florian.kraemer@cakedc.com>
-Florian Krämer <florian.kraemer@cakedc.com> burzum <florian.kraemer@cakedc.com>
-Florian Krämer <florian.kraemer@cakedc.com> Florian Krämer <florian.kraemer@cakedc.com>
+Florian Krämer <florian.kraemer@cakedc.com> <florian.kraemer@kreative-design.net>
+Florian Krämer <florian.kraemer@cakedc.com> <burzum@users.noreply.github.com>
 Rachman Chavik <rchavik@xintesa.com>
-Rachman Chavik <rchavik@xintesa.com> rchavik <rchavik@xintesa.com>
+Rachman Chavik <rchavik@xintesa.com> <rchavik@gmail.com>
 jperras <joel.perras@gmail.com>
-jperras <joel.perras@gmail.com> Joël Perras <joel.perras@gmail.com>
 renan.saddam <renan.saddam@gmail.com>
-renan.saddam <renan.saddam@gmail.com> Renan Gonçalves <renan.saddam@gmail.com>
-renan.saddam <renan.saddam@gmail.com> Renan Gonçalves <renan.saddam@gmail.com>
-renan.saddam <renan.saddam@gmail.com> Renan Gonçalves aka renan.saddam <renan.saddam@gmail.com>
 Ber Clausen <crashcookie@gmail.com>
-Ber Clausen <crashcookie@gmail.com> ber clausen <crashcookie@gmail.com>
 Marc Würth <ravage@bluewin.ch>
-Marc Würth <ravage@bluewin.ch> ravage84 <ravage@bluewin.ch>
-Marc Würth <ravage@bluewin.ch> Ravage84 <ravage@bluewin.ch>
 Jad Bitar <jadbitar@mac.com>
-Jad Bitar <jadbitar@mac.com> jadb <jadbitar@mac.com>
-Jad Bitar <jadbitar@mac.com> Jad BITAR <jadbitar@mac.com>
+Jad Bitar <jadbitar@mac.com> <jadb@users.noreply.github.com>
+Jad Bitar <jadbitar@mac.com> <bitarjad@gmail.com>
 Yves P <havokinspiration@gmail.com>
-Yves P <havokinspiration@gmail.com> Yves <havokinspiration@gmail.com>
-Yves P <havokinspiration@gmail.com> Yves P. <havokinspiration@gmail.com>
 dogmatic69 <dogmatic69@gmail.com>
-dogmatic69 <dogmatic69@gmail.com> dogmatic <dogmatic69@gmail.com>
-dogmatic69 <dogmatic69@gmail.com> Carl Sutton <dogmatic69@gmail.com>
 Majna <majnaggz@gmail.com>
-Majna <majnaggz@gmail.com> Ivan Majnaric <majnaggz@gmail.com>
-Robert <robert.pustulka@gmail.com>
-Robert <robert.pustulka@gmail.com> Robert Pustułka <robert.pustulka@gmail.com>
+Robert Pustułka <robert.pustulka@gmail.com>
+Robert Pustułka <robert.pustulka@gmail.com> <r.pustulka@zano.pl>
 Thomas Ploch <t.ploch@reizwerk.com>
-Thomas Ploch <t.ploch@reizwerk.com> tPl0ch <t.ploch@reizwerk.com>
 Tigran Gabrielyan <tigrangab@gmail.com>
-Tigran Gabrielyan <tigrangab@gmail.com> tigrang <tigrangab@gmail.com>
 Bryan Crowe <bryan@zapsolutions.com>
-Bryan Crowe <bryan@zapsolutions.com> bcrowe <bryan@zapsolutions.com>
 Phally <info@frankdegraaf.net>
-Phally <info@frankdegraaf.net> Frank de Graaf <info@frankdegraaf.net>
 Sam <sgpinkus@gmail.com>
-Sam <sgpinkus@gmail.com> sam-at-github <sgpinkus@gmail.com>
 Jorge González <steinkel@gmail.com>
-Jorge González <steinkel@gmail.com> Jorge M. González Martín <steinkel@gmail.com>
 Saleh Souzanchi <saleh.souzanchi@gmail.com>
-Saleh Souzanchi <saleh.souzanchi@gmail.com> zoghal <saleh.souzanchi@gmail.com>
 Yevgeny Tomenko <skie@mail.ru>
-Yevgeny Tomenko <skie@mail.ru> SkieDr <skie@mail.ru>
 Ricardo Arturo Cabral <ricardo.arturo.cabral@gmail.com>
-Ricardo Arturo Cabral <ricardo.arturo.cabral@gmail.com> Cameri <ricardo.arturo.cabral@gmail.com>
-Robert <r.pustulka@zano.pl>
-Robert <r.pustulka@zano.pl> Robert Pustułka <r.pustulka@zano.pl>
 Jonas <jh@ht-studios.de>
-Jonas <jh@ht-studios.de> ionas <jh@ht-studios.de>
-Jonas <jh@ht-studios.de> Jonas Hartmann <jh@ht-studios.de>
 Cauan Cabral <cauan@radig.com.br>
-Cauan Cabral <cauan@radig.com.br> CauanCabral <cauan@radig.com.br>
 pirouet <pirouet@me.com>
-pirouet <pirouet@me.com> Michael Pirouet <pirouet@me.com>
 davidsteinsland <david@davidsteinsland.net>
-davidsteinsland <david@davidsteinsland.net> David Steinsland <david@davidsteinsland.net>
 jamiemill <jamiermill@gmail.com>
-jamiemill <jamiermill@gmail.com> Jamie Mill <jamiermill@gmail.com>
 Stefan Dickmann <stefan@php-engineer.de>
-Stefan Dickmann <stefan@php-engineer.de> Stefan D <stefan@php-engineer.de>
 Benjamin Tamási <h@lfto.me>
-Benjamin Tamási <h@lfto.me> Tamási Benjamin <h@lfto.me>
 Gordon Pettey (petteyg) <petteyg359@gmail.com>
-Gordon Pettey (petteyg) <petteyg359@gmail.com> Gordon Pettey <petteyg359@gmail.com>
 Mathieu de Ruiter <mathieu@fellicht.nl>
-Mathieu de Ruiter <mathieu@fellicht.nl> Mathieu <mathieu@fellicht.nl>
 Cees-Jan Kiewiet <ceesjank@gmail.com>
-Cees-Jan Kiewiet <ceesjank@gmail.com> wyrihaximus <ceesjank@gmail.com>
 Fiblan <fib@ingegnosamente.com>
-Fiblan <fib@ingegnosamente.com> fiblan <fib@ingegnosamente.com>
 Haithem BEN GHORBAL <haithem.benghorbal@gmail.com>
-Haithem BEN GHORBAL <haithem.benghorbal@gmail.com> Haithem Ben Ghorbal <haithem.benghorbal@gmail.com>
 Pedro Perejón <pperejon@proavan.com>
-Pedro Perejón <pperejon@proavan.com> Pedro Perejon <pperejon@proavan.com>
 Algirdas Gurevicius <a.gurevicius@gmail.com>
-Algirdas Gurevicius <a.gurevicius@gmail.com> uniquexor <a.gurevicius@gmail.com>
 Calin <calinseciu@gmail.com>
-Calin <calinseciu@gmail.com> calinseciu <calinseciu@gmail.com>
 Mikaël Capelle <capelle.mikael@gmail.com>
-Mikaël Capelle <capelle.mikael@gmail.com> mcapelle <capelle.mikael@gmail.com>
-Mikaël Capelle <capelle.mikael@gmail.com> Holt59 <capelle.mikael@gmail.com>
 OKINAKA Kenshin <okinakak@yahoo.co.jp>
-OKINAKA Kenshin <okinakak@yahoo.co.jp> Kenshin Okinaka <okinakak@yahoo.co.jp>
-OKINAKA Kenshin <okinakak@yahoo.co.jp> okinaka <okinakak@yahoo.co.jp>
 Walter Nasich <wnasich@gmail.com>
-Walter Nasich <wnasich@gmail.com> wnasich <wnasich@gmail.com>
 mstra001 <ms@creemedia.com>
-mstra001 <ms@creemedia.com> mathieu strauch <ms@creemedia.com>
 Aymeric Derbois <aymeric@derbois.com>
-Aymeric Derbois <aymeric@derbois.com> Derbois Aymeric <aymeric@derbois.com>
 Daniel <wrightdaniel86@gmail.com>
-Daniel <wrightdaniel86@gmail.com> dangerdan <wrightdaniel86@gmail.com>
 James Michael DuPont <JamesMikeDuPont@gmail.com>
-James Michael DuPont <JamesMikeDuPont@gmail.com> James Michael DuPont <jamesmikedupont@gmail.com>
 Jan Dorsman <oldskool@fluxbb.org>
-Jan Dorsman <oldskool@fluxbb.org> oldskool <oldskool@fluxbb.org>
 Pierre Martin <contact@pierre-martin.fr>
-Pierre Martin <contact@pierre-martin.fr> real34 <contact@pierre-martin.fr>
+Jeremy Harris <jeremy@42pixels.com>
+Jeremy Harris <jeremy@42pixels.com> <jeremy@someguyjeremy.com>
+Christian Winther <jippignu@gmail.com>
+Christian Winther <jippignu@gmail.com> <cw@bownty.com>
+Christian Winther <jippignu@gmail.com> <cw@nodes.dk>
+Jose Diaz-Gonzalez <email@josediazgonzalez.com>
+Jose Diaz-Gonzalez <email@josediazgonzalez.com> <josegonzalez@users.noreply.github.com>
+Jose Diaz-Gonzalez <email@josediazgonzalez.com> <myaccounts@savant.be>
+Frank de Graaf <frank@fdeg.nl>
+Frank de Graaf <frank@fdeg.nl> <Phally@users.noreply.github.com>
+Marlin Cremers <m.cremers@cvo-technologies.com>
+Marlin Cremers <m.cremers@cvo-technologies.com> <m.cremers@mms-projects.net>
+Marlin Cremers <m.cremers@cvo-technologies.com> <marlin.cremers@gmail.com>
+David Yell <neon1024@gmail.com> <dyell@ukwebmedia.com>
+James Watts <james.watts@cakephp.org> <jameswatts@solfenix.com>

--- a/.mailmap
+++ b/.mailmap
@@ -49,7 +49,6 @@ Jorge González <steinkel@gmail.com>
 Saleh Souzanchi <saleh.souzanchi@gmail.com>
 Yevgeny Tomenko <skie@mail.ru>
 Ricardo Arturo Cabral <ricardo.arturo.cabral@gmail.com>
-Jonas <jh@ht-studios.de>
 Cauan Cabral <cauan@radig.com.br>
 pirouet <pirouet@me.com>
 davidsteinsland <david@davidsteinsland.net>

--- a/.mailmap
+++ b/.mailmap
@@ -44,7 +44,6 @@ Robert Pustułka <robert.pustulka@gmail.com> <r.pustulka@zano.pl>
 Thomas Ploch <t.ploch@reizwerk.com>
 Tigran Gabrielyan <tigrangab@gmail.com>
 Bryan Crowe <bryan@zapsolutions.com>
-Phally <info@frankdegraaf.net>
 Sam <sgpinkus@gmail.com>
 Jorge González <steinkel@gmail.com>
 Saleh Souzanchi <saleh.souzanchi@gmail.com>
@@ -82,8 +81,9 @@ Christian Winther <jippignu@gmail.com> <cw@nodes.dk>
 Jose Diaz-Gonzalez <email@josediazgonzalez.com>
 Jose Diaz-Gonzalez <email@josediazgonzalez.com> <josegonzalez@users.noreply.github.com>
 Jose Diaz-Gonzalez <email@josediazgonzalez.com> <myaccounts@savant.be>
-Frank de Graaf <frank@fdeg.nl>
-Frank de Graaf <frank@fdeg.nl> <Phally@users.noreply.github.com>
+Frank de Graaf <info@frankdegraaf.net>
+Frank de Graaf <info@frankdegraaf.net> Frank de Graaf <frank@fdeg.nl>
+Frank de Graaf <info@frankdegraaf.net> <Phally@users.noreply.github.com>
 Marlin Cremers <m.cremers@cvo-technologies.com>
 Marlin Cremers <m.cremers@cvo-technologies.com> <m.cremers@mms-projects.net>
 Marlin Cremers <m.cremers@cvo-technologies.com> <marlin.cremers@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -69,7 +69,8 @@ Walter Nasich <wnasich@gmail.com>
 mstra001 <ms@creemedia.com>
 Aymeric Derbois <aymeric@derbois.com>
 Daniel <wrightdaniel86@gmail.com>
-James Michael DuPont <JamesMikeDuPont@gmail.com>
+James Michael DuPont <jamesmikedupont@gmail.com>
+James Michael DuPont <jamesmikedupont@gmail.com> <JamesMikeDuPont@gmail.com>
 Jan Dorsman <oldskool@fluxbb.org>
 Pierre Martin <contact@pierre-martin.fr>
 Jeremy Harris <jeremy@42pixels.com>

--- a/.mailmap
+++ b/.mailmap
@@ -14,13 +14,8 @@ Walther Lalk <emailme@waltherlalk.com> <waltherlalk@gmail.com>
 Walther Lalk <emailme@waltherlalk.com> <dakota@users.noreply.github.com>
 Walther Lalk <emailme@waltherlalk.com> <walther@uafrica.com>
 Mark Scherer <euromark@web.de>
-Mark Scherer <euromark@web.de> euromark <euromark@web.de>
-Mark Scherer <euromark@web.de> Mark Sch <dereuromark@users.noreply.github.com>
-Mark Scherer <euromark@web.de> Mark S <dereuromark@users.noreply.github.com>
-Mark Scherer <euromark@web.de> Mark S. <euromark@web.de>
-Mark Scherer <euromark@web.de> mscherer <mark.scherer@spryker.com>
-Mark Scherer <euromark@web.de> mark <mark.scherer@spryker.com>
-Mark Scherer <euromark@web.de> Mark S. <dereuromark@users.noreply.github.com>
+Mark Scherer <euromark@web.de> <dereuromark@users.noreply.github.com>
+Mark Scherer <euromark@web.de> <mark.scherer@spryker.com>
 phpnut <phpnut@cakephp.org>
 phpnut <phpnut@cakephp.org> <phpnut@gmail.com>
 AD7six <andydawson76@gmail.com>
@@ -94,3 +89,16 @@ Marlin Cremers <m.cremers@cvo-technologies.com> <m.cremers@mms-projects.net>
 Marlin Cremers <m.cremers@cvo-technologies.com> <marlin.cremers@gmail.com>
 David Yell <neon1024@gmail.com> <dyell@ukwebmedia.com>
 James Watts <james.watts@cakephp.org> <jameswatts@solfenix.com>
+Jonas Hartmann <jh@ht-studios.de>
+Jonas Hartmann <jh@ht-studios.de> <github@ht-studios.de>
+Jonas Hartmann <jh@ht-studios.de> <fwd_github@jonas-hartmann.com>
+Thom Seddon <thom@seddonmedia.co.uk>
+Thom Seddon <thom@seddonmedia.co.uk> <thom@nightworld.com>
+Robbert Noordzij <robbert@xseeding.com>
+Robbert Noordzij <robbert@xseeding.com> <robbert@xseeding.nl>
+Simon East <me@simoneast.net>
+Simon East <me@simoneast.net> <simon@surfacemedia.com.au>
+Matt Alexander <alexandma@advisory.com>
+Matt Alexander <alexandma@advisory.com> <mattalexx@gmail.com>
+Mark van Driel <mvdriel@mvdriel-EP35-DS3R>
+Mark van Driel <mvdriel@mvdriel-EP35-DS3R> <mvdriel@mvdriel-UL30>


### PR DESCRIPTION
Simplified existing mappings and added few more.

`git shortlog -sne` now returns **591** lines.