### PR TITLE
3.next - Add more consistent request getters

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1459,11 +1459,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
 
             return $this;
         }
-        if (!isset($this->params[$name])) {
-            return Hash::get($this->params, $name, false);
-        }
-
-        return $this->params[$name];
+        return $this->getParam($name);
     }
 
     /**
@@ -1740,6 +1736,22 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         $copy->params = Hash::insert($copy->params, $name, $value);
 
         return $copy;
+    }
+
+    /**
+     * Safely access the values in $this->params.
+     *
+     * @param string $name The name of the parameter to get.
+     * @param mixed $default The default value if $name is not set.
+     * @return mixed
+     */
+    public function getParam($name, $default = false)
+    {
+        if (!isset($this->params[$name])) {
+            return Hash::get($this->params, $name, $default);
+        }
+
+        return $this->params[$name];
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1396,6 +1396,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         if ($name === null) {
             return $this->query;
         }
+
         return $this->getQuery($name);
     }
 
@@ -1470,7 +1471,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * When reading values you will get `null` for keys/values that do not exist.
      *
-     * @param string $name|null Dot separated name of the value to read. Or null to read all data.
+     * @param string|null $name Dot separated name of the value to read. Or null to read all data.
      * @param mixed $default The default data.
      * @return mixed The value being read.
      */
@@ -1479,6 +1480,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         if ($name === null) {
             return $this->data;
         }
+
         return Hash::get($this->data, $name, $default);
     }
 
@@ -1498,6 +1500,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
 
             return $this;
         }
+
         return $this->getParam($name);
     }
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1405,7 +1405,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string $name The name or dotted path to the query param.
      * @param mixed $default The default value if the named parameter is not set.
-     * @return mixed Query data.
+     * @return null|string|array Query data.
      */
     public function getQuery($name, $default = null)
     {
@@ -1473,7 +1473,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|null $name Dot separated name of the value to read. Or null to read all data.
      * @param mixed $default The default data.
-     * @return mixed The value being read.
+     * @return null|string|array The value being read.
      */
     public function getData($name = null, $default = null)
     {
@@ -1561,7 +1561,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string $key The key or dotted path you want to read.
      * @param string $default The default value if the cookie is not set.
-     * @return null|string Either the cookie value, or null if the value doesn't exist.
+     * @return null|array|string Either the cookie value, or null if the value doesn't exist.
      */
     public function getCookie($key, $default = null)
     {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1429,15 +1429,13 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * $request->data('Post.title', 'New post!');
      * ```
      *
-     * As of 3.4.0, the setter mode of this method is *deprecated*.
-     * Use `withData` instead.
-     *
      * You can write to any value, even paths/keys that do not exist, and the arrays
      * will be created for you.
      *
      * @param string|null $name Dot separated name of the value to read/write
      * @param mixed ...$args The data to set (deprecated)
      * @return mixed|$this Either the value being read, or this so you can chain consecutive writes.
+     * @deprecated 3.4.0 Use withData() and getData() or getParsedBody() instead.
      */
     public function data($name = null, ...$args)
     {
@@ -1451,6 +1449,37 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return $this->data;
+    }
+
+    /**
+     * Provides a safe accessor for request data. Allows
+     * you to use Hash::get() compatible paths.
+     *
+     * ### Reading values.
+     *
+     * ```
+     * // get all data
+     * $request->getData();
+     *
+     * // Read a specific field.
+     * $request->data('Post.title');
+     *
+     * // With a default value.
+     * $request->data('Post.not there', 'default value);
+     * ```
+     *
+     * When reading values you will get `null` for keys/values that do not exist.
+     *
+     * @param string $name|null Dot separated name of the value to read. Or null to read all data.
+     * @param mixed $default The default data.
+     * @return mixed The value being read.
+     */
+    public function getData($name = null, $default = null)
+    {
+        if ($name === null) {
+            return $this->data;
+        }
+        return Hash::get($this->data, $name, $default);
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1389,7 +1389,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|null $name Query string variable name or null to read all.
      * @return string|array|null The value being read
-     * @deprecated 3.4.0 Use getQuery() instead.
+     * @deprecated 3.4.0 Use getQuery() and withQueryParams() instead.
      */
     public function query($name = null)
     {
@@ -1542,6 +1542,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string $key The key you want to read.
      * @return null|string Either the cookie value, or null if the value doesn't exist.
+     * @deprecated 3.4.0 Use getCookie() instead.
      */
     public function cookie($key)
     {
@@ -1550,6 +1551,18 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         }
 
         return null;
+    }
+
+    /**
+     * Read cookie data from the request's cookie data.
+     *
+     * @param string $key The key you want to read.
+     * @param string $default The default value if the cookie is not set.
+     * @return null|string Either the cookie value, or null if the value doesn't exist.
+     */
+    public function getCookie($key, $default = null)
+    {
+        return Hash::get($this->cookies, $key, $default);
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1402,7 +1402,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Read a specific query value or dotted path.
      *
-     * @param string $name The name of the query arg or a dotted path.
+     * @param string $name The name or dotted path to the query param.
      * @param mixed $default The default value if the named parameter is not set.
      * @return mixed Query data.
      */
@@ -1556,7 +1556,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Read cookie data from the request's cookie data.
      *
-     * @param string $key The key you want to read.
+     * @param string $key The key or dotted path you want to read.
      * @param string $default The default value if the cookie is not set.
      * @return null|string Either the cookie value, or null if the value doesn't exist.
      */
@@ -1793,17 +1793,13 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Safely access the values in $this->params.
      *
-     * @param string $name The name of the parameter to get.
+     * @param string $name The name or dotted path to parameter.
      * @param mixed $default The default value if $name is not set.
      * @return mixed
      */
     public function getParam($name, $default = false)
     {
-        if (!isset($this->params[$name])) {
-            return Hash::get($this->params, $name, $default);
-        }
-
-        return $this->params[$name];
+        return Hash::get($this->params, $name, $default);
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1389,14 +1389,26 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|null $name Query string variable name or null to read all.
      * @return string|array|null The value being read
+     * @deprecated 3.4.0 Use getQuery() instead.
      */
     public function query($name = null)
     {
         if ($name === null) {
             return $this->query;
         }
+        return $this->getQuery($name);
+    }
 
-        return Hash::get($this->query, $name);
+    /**
+     * Read a specific query value or dotted path.
+     *
+     * @param string $name The name of the query arg or a dotted path.
+     * @param mixed $default The default value if the named parameter is not set.
+     * @return mixed Query data.
+     */
+    public function getQuery($name, $default = null)
+    {
+        return Hash::get($this->query, $name, $default);
     }
 
     /**
@@ -1444,13 +1456,11 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     /**
      * Safely access the values in $this->params.
      *
-     * As of 3.4.0, the setter mode of this method is *deprecated*.
-     * Use `withParam` instead.
-     *
      * @param string $name The name of the parameter to get.
      * @param mixed ...$args Value to set (deprecated).
      * @return mixed|$this The value of the provided parameter. Will
      *   return false if the parameter doesn't exist or is falsey.
+     * @deprecated 3.4.0 Use getParam() and withParam() instead.
      */
     public function param($name, ...$args)
     {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -3009,18 +3009,26 @@ XML;
      *
      * @return void
      */
-    public function testCookie()
+    public function testGetCookie()
     {
         $request = new Request([
             'cookies' => [
-                'testing' => 'A value in the cookie'
+                'testing' => 'A value in the cookie',
+                'user' => [
+                    'remember' => '1'
+                ]
             ]
         ]);
-        $result = $request->cookie('testing');
-        $this->assertEquals('A value in the cookie', $result);
+        $this->assertEquals('A value in the cookie', $request->cookie('testing'));
+        $this->assertEquals('A value in the cookie', $request->getCookie('testing'));
 
-        $result = $request->cookie('not there');
-        $this->assertNull($result);
+        $this->assertNull($request->cookie('not there'));
+        $this->assertNull($request->getCookie('not there'));
+        $this->assertSame('default', $request->getCookie('not there', 'default'));
+
+        $this->assertSame('1', $request->getCookie('user.remember'));
+        $this->assertSame('1', $request->getCookie('user.remember', 'default'));
+        $this->assertSame('default', $request->getCookie('user.not there', 'default'));
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2396,40 +2396,40 @@ class RequestTest extends TestCase
         ];
         $request = new Request($array);
 
-        $result = $request->query('foo');
-        $this->assertSame('bar', $result);
-
-        $result = $request->query('zero');
-        $this->assertSame('0', $result);
-
-        $result = $request->query('imaginary');
-        $this->assertNull($result);
-
-        $result = $request->query();
-        $this->assertSame($array['query'], $result);
+        $this->assertSame('bar', $request->query('foo'));
+        $this->assertSame('0', $request->query('zero'));
+        $this->assertNull($request->query('imaginary'));
+        $this->assertSame($array['query'], $request->query());
     }
 
     /**
-     * Test the query() method with arrays passed via $_GET
+     * Test the getQuery() method
      *
      * @return void
      */
-    public function testQueryWithArray()
+    public function testGetQuery()
     {
-        $get['test'] = ['foo', 'bar'];
+        $array = [
+            'query' => [
+                'foo' => 'bar',
+                'zero' => '0',
+                'test' => [
+                    'foo', 'bar'
+                ]
+            ]
+        ];
+        $request = new Request($array);
 
-        $request = new Request([
-            'query' => $get
-        ]);
+        $this->assertSame('bar', $request->getQuery('foo'));
+        $this->assertSame('0', $request->getQuery('zero'));
+        $this->assertNull($request->getQuery('imaginary'));
+        $this->assertSame('default', $request->getQuery('imaginary', 'default'));
+        $this->assertFalse($request->getQuery('imaginary', false));
 
-        $result = $request->query('test');
-        $this->assertEquals(['foo', 'bar'], $result);
-
-        $result = $request->query('test.1');
-        $this->assertEquals('bar', $result);
-
-        $result = $request->query('test.2');
-        $this->assertNull($result);
+        $this->assertSame(['foo', 'bar'], $request->getQuery('test'));
+        $this->assertSame('bar', $request->getQuery('test.1'));
+        $this->assertNull($request->getQuery('test.2'));
+        $this->assertSame('default', $request->getQuery('test.2', 'default'));
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2587,7 +2587,7 @@ class RequestTest extends TestCase
      *
      * @dataProvider paramReadingDataProvider
      */
-    public function testParamReading($toRead, $expected)
+    public function testGetParam($toRead, $expected)
     {
         $request = new Request('/');
         $request->addParams([
@@ -2603,6 +2603,26 @@ class RequestTest extends TestCase
             'zero' => '0',
         ]);
         $this->assertSame($expected, $request->param($toRead));
+        $this->assertSame($expected, $request->getParam($toRead));
+    }
+
+    /**
+     * Test getParam returning a default value.
+     *
+     * @return void
+     */
+    public function testGetParamDefault()
+    {
+        $request = new Request([
+            'params' => [
+                'controller' => 'Articles',
+                'null' => null,
+            ]
+        ]);
+        $this->assertSame('Articles', $request->getParam('controller', 'default'));
+        $this->assertSame('default', $request->getParam('null', 'default'));
+        $this->assertNull($request->getParam('unset', null));
+        $this->assertFalse($request->getParam('unset'));
     }
 
     /**

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2527,14 +2527,17 @@ class RequestTest extends TestCase
             ]
         ];
         $request = new Request(compact('post'));
-        $result = $request->data('Model');
-        $this->assertEquals($post['Model'], $result);
+        $this->assertEquals($post['Model'], $request->data('Model'));
+        $this->assertEquals($post['Model'], $request->getData('Model'));
 
-        $result = $request->data();
-        $this->assertEquals($post, $result);
+        $this->assertEquals($post, $request->data());
+        $this->assertEquals($post, $request->getData());
 
-        $result = $request->data('Model.imaginary');
-        $this->assertNull($result);
+        $this->assertNull($request->data('Model.imaginary'));
+        $this->assertNull($request->getData('Model.imaginary'));
+
+        $this->assertSame('value', $request->getData('Model.field', 'default'));
+        $this->assertSame('default', $request->getData('Model.imaginary', 'default'));
     }
 
     /**


### PR DESCRIPTION
Implement several `get*` methods on `ServerRequest`. These methods are more consistent with the PSR7 methods and each other as they all support dotted paths and default arguments now.

I've left `getData()` able to return all data to help migration/upgrades be easier. `request->data()` is frequently used and I wanted the upgrade path to be a simple search/replace.

Refs #9670