### PR TITLE
Make it possible to filter values per method in DboSource::cacheMethod

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -797,6 +797,37 @@ class DboSource extends DataSource {
  * Filters to apply to the results of `name` and `fields`. When the filter for a given method does not return `true`
  * then the result is not added to the memory cache.
  *
+ * Some examples:
+ *
+ * ```
+ * // For method fields, do not cache values that contain floats
+ * if ($method === 'fields') {
+ * 	$hasFloat = preg_grep('/(\d+)?\.\d+/', $value);
+ *
+ * 	return count($hasFloat) === 0;
+ * }
+ *
+ * return true;
+ * ```
+ *
+ * ```
+ * // For method name, do not cache values that have the name created
+ * if ($method === 'name') {
+ * 	return preg_match('/^`created`$/', $value) !== 1;
+ * }
+ *
+ * return true;
+ * ```
+ *
+ * ```
+ * // For method name, do not cache values that have the key 472551d38e1f8bbc78d7dfd28106166f
+ * if ($key === '472551d38e1f8bbc78d7dfd28106166f') {
+ * 	return false;
+ * }
+ *
+ * return true;
+ * ```
+ *
  * @param string $method Name of the method being cached.
  * @param string $key The key name for the cache operation.
  * @param mixed $value The value to cache into memory.

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -60,48 +60,12 @@ class DboSource extends DataSource {
 	public static $methodCache = array();
 
 /**
- * Whether or not to cache the results of DboSource::name(), DboSource::fields() and DboSource::conditions()
+ * Whether or not to cache the results of DboSource::name() and DboSource::conditions()
  * into the memory cache. Set to false to disable the use of the memory cache.
  *
  * @var bool
  */
 	public $cacheMethods = true;
-
-/**
- * Filters to apply to the results of DboSource::name(), DboSource::fields() and DboSource::conditions().
- * When the filter function for a given method does not return true then the result is not added to the memory cache.
- *
- * For instance:
- *
- * ```
- * array(
- * 	// For method fields, do not cache values that contain floats
- * 	'fields' => function ($value) {
- * 		$hasFloat = preg_grep('/(\d+)?\.\d+/', $value);
- *
- * 		return count($hasFloat) === 0;
- * 	},
- * 	// For method name, do not cache values that have the name floats
- * 	'name' => function ($value) {
- * 		return preg_match('/^`rating_diff`$/', $value) !== 1;
- * 	}
- * )
- * ```
- *
- * or
- *
- * ```
- * array(
- * 	// For method fields, do not cache any values
- * 	'fields' => function () {
- * 		return false;
- * 	},
- * )
- * ```
- *
- * @var array
- */
-	public $cacheMethodFilters = array();
 
 /**
  * Flag to support nested transactions. If it is set to false, you will be able to use
@@ -822,16 +786,24 @@ class DboSource extends DataSource {
 		if ($value === null) {
 			return (isset(static::$methodCache[$method][$key])) ? static::$methodCache[$method][$key] : null;
 		}
-
-		$methodFilterExists = (
-			isset($this->cacheMethodFilters[$method]) && is_callable($this->cacheMethodFilters[$method])
-		);
-		if ($methodFilterExists && !call_user_func($this->cacheMethodFilters[$method], $value)) {
+		if (!$this->cacheMethodFilter($method, $key, $value)) {
 			return $value;
 		}
-
 		$this->_methodCacheChange = true;
 		return static::$methodCache[$method][$key] = $value;
+	}
+
+/**
+ * Filters to apply to the results of `name` and `fields`. When the filter for a given method does not return `true`
+ * then the result is not added to the memory cache.
+ *
+ * @param string $method Name of the method being cached.
+ * @param string $key The key name for the cache operation.
+ * @param mixed $value The value to cache into memory.
+ * @return bool Whether or not to cache
+ */
+	public function cacheMethodFilter($method, $key, $value) {
+		return true;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -738,6 +738,34 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * Test that cacheMethodFilter does not filter by default.
+ *
+ * @return void
+ */
+	public function testCacheMethodFilter() {
+		$method = 'name';
+		$key = '49d9207adfce6df1dd3ee8c30c434414';
+		$value = '`menus`';
+		$actual = $this->testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertTrue($actual);
+
+		$method = 'fields';
+		$key = '2b57253ab1fffb3e95fa4f95299220b1';
+		$value = ["`Menu`.`id`", "`Menu`.`name`"];
+		$actual = $this->testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertTrue($actual);
+
+		$method = 'non-existing';
+		$key = '';
+		$value = '``';
+		$actual = $this->testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertTrue($actual);
+	}
+
+/**
  * Test that rare collisions do not happen with method caching
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -110,6 +110,35 @@ class DboSecondTestSource extends DboSource {
 }
 
 /**
+ * DboFourthTestSource
+ *
+ * @package       Cake.Test.Case.Model.Datasource
+ */
+class DboFourthTestSource extends DboSource {
+
+	public function connect($config = array()) {
+		$this->connected = true;
+	}
+
+	public function cacheMethodFilter($method, $key, $value) {
+		if ($method === 'name') {
+			if ($value === '`menus`') {
+				return false;
+			} elseif ($key === '1fca740733997f1ebbedacfc7678592a') {
+				return false;
+			}
+		} elseif ($method === 'fields') {
+			$endsWithName = preg_grep('/`name`$/', $value);
+
+			return count($endsWithName) === 0;
+		}
+
+		return true;
+	}
+
+}
+
+/**
  * DboSourceTest class
  *
  * @package       Cake.Test.Case.Model.Datasource
@@ -752,7 +781,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$method = 'fields';
 		$key = '2b57253ab1fffb3e95fa4f95299220b1';
-		$value = ["`Menu`.`id`", "`Menu`.`name`"];
+		$value = array("`Menu`.`id`", "`Menu`.`name`");
 		$actual = $this->testDb->cacheMethodFilter($method, $key, $value);
 
 		$this->assertTrue($actual);
@@ -761,6 +790,50 @@ class DboSourceTest extends CakeTestCase {
 		$key = '';
 		$value = '``';
 		$actual = $this->testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertTrue($actual);
+	}
+
+/**
+ * Test that cacheMethodFilter can be overridden to do actual filtering.
+ *
+ * @return void
+ */
+	public function testCacheMethodFilterOverridden() {
+		$testDb = new DboFourthTestSource();
+
+		$method = 'name';
+		$key = '49d9207adfce6df1dd3ee8c30c434414';
+		$value = '`menus`';
+		$actual = $testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertFalse($actual);
+
+		$method = 'name';
+		$key = '1fca740733997f1ebbedacfc7678592a';
+		$value = '`Menu`.`id`';
+		$actual = $testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertFalse($actual);
+
+		$method = 'fields';
+		$key = '2b57253ab1fffb3e95fa4f95299220b1';
+		$value = array("`Menu`.`id`", "`Menu`.`name`");
+		$actual = $testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertFalse($actual);
+
+		$method = 'name';
+		$key = 'd2bc458620afb092c61ab4383b7475e0';
+		$value = '`Menu`';
+		$actual = $testDb->cacheMethodFilter($method, $key, $value);
+
+		$this->assertTrue($actual);
+
+		$method = 'non-existing';
+		$key = '';
+		$value = '``';
+		$actual = $testDb->cacheMethodFilter($method, $key, $value);
 
 		$this->assertTrue($actual);
 	}


### PR DESCRIPTION
In the past we had issues with the default setting of `$cacheMethods = true;`, To solve our memory leak we had to set it to `false`. Although the performance hit of this is not really an issue for us, we've had all sorts of issues (e.g. #8225, #9466) with running unit tests and loading fixtures and what not :-(

Therefore I propose to make it possible to filter values per `method` in `DboSource::cacheMethod`. This way it's not needed to completely disable cacheMethod, but you can just filter out certain values (with floats for instance).

If you like the feature I can add some unit tests.

Thanks in advance