### PR TITLE
Make it possible to configure the cacheMethod hashing algorithm in DboSource

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -51,34 +51,23 @@ class DboSource extends DataSource {
 	public $alias = 'AS ';
 
 /**
- * Caches result from query parsing operations. Cached results for both DboSource::name(), DboSource::fields() and
- * DboSource::conditions() will be stored here.
+ * Caches result from query parsing operations. Cached results for both DboSource::name() and DboSource::fields()
+ * will be stored here.
  *
- * Method caching uses `md5` (by default) to construct cache keys.
- * If you have problems with collisions, try a different hashing algorithm in DboSource::$cacheMethodHashAlgo or
- * set DboSource::$cacheMethods to false.
+ * Method caching uses `md5` (by default) to construct cache keys. If you have problems with collisions,
+ * try a different hashing algorithm by overriding DboSource::cacheMethodHasher or set DboSource::$cacheMethods to false.
  *
  * @var array
  */
 	public static $methodCache = array();
 
 /**
- * Whether or not to cache the results of DboSource::name(), DboSource::fields() and DboSource::conditions()
- * into the memory cache. Set to false to disable the use of the memory cache.
+ * Whether or not to cache the results of DboSource::name() and DboSource::fields() into the memory cache.
+ * Set to false to disable the use of the memory cache.
  *
  * @var bool
  */
 	public $cacheMethods = true;
-
-/**
- * Method caching uses `md5` (by default) to construct cache keys. If you have problems with collisions,
- * try a different hashing algorithm or set DboSource::$cacheMethods to false.
- *
- * @var string
- * @see http://php.net/manual/en/function.hash-algos.php
- * @see http://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
- */
-	public $cacheMethodHashAlgo = 'md5';
 
 /**
  * Flag to support nested transactions. If it is set to false, you will be able to use
@@ -804,6 +793,21 @@ class DboSource extends DataSource {
 	}
 
 /**
+ * Hashes a given value.
+ *
+ * Method caching uses `md5` (by default) to construct cache keys. If you have problems with collisions,
+ * try a different hashing algorithm or set DboSource::$cacheMethods to false.
+ *
+ * @param string $value Value to hash
+ * @return string Hashed value
+ * @see http://php.net/manual/en/function.hash-algos.php
+ * @see http://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
+ */
+	public function cacheMethodHasher($value) {
+		return md5($value);
+	}
+
+/**
  * Returns a quoted name of $data for use in an SQL statement.
  * Strips fields out of SQL functions before quoting.
  *
@@ -828,7 +832,7 @@ class DboSource extends DataSource {
 			}
 			return $data;
 		}
-		$cacheKey = hash($this->cacheMethodHashAlgo, $this->startQuote . $data . $this->endQuote);
+		$cacheKey = $this->cacheMethodHasher($this->startQuote . $data . $this->endQuote);
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}
@@ -2546,7 +2550,7 @@ class DboSource extends DataSource {
 			$Model->schemaName,
 			$Model->table
 		);
-		$cacheKey = hash($this->cacheMethodHashAlgo, serialize($cacheKey));
+		$cacheKey = $this->cacheMethodHasher(serialize($cacheKey));
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -51,21 +51,34 @@ class DboSource extends DataSource {
 	public $alias = 'AS ';
 
 /**
- * Caches result from query parsing operations. Cached results for both DboSource::name() and
- * DboSource::conditions() will be stored here. Method caching uses `md5()`. If you have
- * problems with collisions, set DboSource::$cacheMethods to false.
+ * Caches result from query parsing operations. Cached results for both DboSource::name(), DboSource::fields() and
+ * DboSource::conditions() will be stored here.
+ *
+ * Method caching uses `md5` (by default) to construct cache keys.
+ * If you have problems with collisions, try a different hashing algorithm in DboSource::$cacheMethodHashAlgo or
+ * set DboSource::$cacheMethods to false.
  *
  * @var array
  */
 	public static $methodCache = array();
 
 /**
- * Whether or not to cache the results of DboSource::name() and DboSource::conditions()
+ * Whether or not to cache the results of DboSource::name(), DboSource::fields() and DboSource::conditions()
  * into the memory cache. Set to false to disable the use of the memory cache.
  *
  * @var bool
  */
 	public $cacheMethods = true;
+
+/**
+ * Method caching uses `md5` (by default) to construct cache keys. If you have problems with collisions,
+ * try a different hashing algorithm or set DboSource::$cacheMethods to false.
+ *
+ * @var string
+ * @see http://php.net/manual/en/function.hash-algos.php
+ * @see http://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
+ */
+	public $cacheMethodHashAlgo = 'md5';
 
 /**
  * Flag to support nested transactions. If it is set to false, you will be able to use
@@ -815,7 +828,7 @@ class DboSource extends DataSource {
 			}
 			return $data;
 		}
-		$cacheKey = md5($this->startQuote . $data . $this->endQuote);
+		$cacheKey = hash($this->cacheMethodHashAlgo, $this->startQuote . $data . $this->endQuote);
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}
@@ -2533,7 +2546,7 @@ class DboSource extends DataSource {
 			$Model->schemaName,
 			$Model->table
 		);
-		$cacheKey = md5(serialize($cacheKey));
+		$cacheKey = hash($this->cacheMethodHashAlgo, serialize($cacheKey));
 		if ($return = $this->cacheMethod(__FUNCTION__, $cacheKey)) {
 			return $return;
 		}

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -738,6 +738,34 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * Test that cacheMethodHasher uses md5 by default.
+ *
+ * @return void
+ */
+	public function testCacheMethodHasher() {
+		$name = 'Model.fieldlbqndkezcoapfgirmjsh';
+		$actual = $this->testDb->cacheMethodHasher($name);
+		$expected = '4a45dc9ed52f98c393d04ac424ee5078';
+
+		$this->assertEquals($expected, $actual);
+	}
+
+/**
+ * Test that cacheMethodHasher can be overridden to use a different hashing algorithm.
+ *
+ * @return void
+ */
+	public function testCacheMethodHasherOverridden() {
+		$testDb = new DboThirdTestSource();
+
+		$name = 'Model.fieldlbqndkezcoapfgirmjsh';
+		$actual = $testDb->cacheMethodHasher($name);
+		$expected = 'f4441bb8fcbe0944';
+
+		$this->assertEquals($expected, $actual);
+	}
+
+/**
  * Test that rare collisions do not happen with method caching
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -110,6 +110,23 @@ class DboSecondTestSource extends DboSource {
 }
 
 /**
+ * DboThirdTestSource
+ *
+ * @package       Cake.Test.Case.Model.Datasource
+ */
+class DboThirdTestSource extends DboSource {
+
+	public function connect($config = array()) {
+		$this->connected = true;
+	}
+
+	public function cacheMethodHasher($value) {
+		return hash('sha1', $value);
+	}
+
+}
+
+/**
  * DboSourceTest class
  *
  * @package       Cake.Test.Case.Model.Datasource
@@ -760,7 +777,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$name = 'Model.fieldlbqndkezcoapfgirmjsh';
 		$actual = $testDb->cacheMethodHasher($name);
-		$expected = 'f4441bb8fcbe0944';
+		$expected = 'beb8b6469359285b7c2865dce0ef743feb16cb71';
 
 		$this->assertEquals($expected, $actual);
 	}


### PR DESCRIPTION
> Method caching uses `md5` to construct cache keys. If you have problems with collisions, set DboSource::$cacheMethods to false.

Seems like an easy fix for this problem. If you like this feature I can add some tests.

Thanks in advance