### PR TITLE
Split up more $this|other mixed methods into separate getter/setter m…

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -271,25 +271,75 @@ class ConsoleOptionParser
     }
 
     /**
+     * Sets the command name for shell/task.
+     *
+     * @param string $text The text to set.
+     * @return $this
+     */
+    public function setCommand($text)
+    {
+        $this->_command = Inflector::underscore($text);
+
+        return $this;
+    }
+
+    /**
+     * Gets the command name for shell/task.
+     *
+     * @return string The value of the command.
+     */
+    public function getCommand()
+    {
+        return $this->_command;
+    }
+
+    /**
      * Gets or sets the command name for shell/task.
      *
+     * @deprecated 3.4.0 Use setCommand()/getCommand() instead.
      * @param string|null $text The text to set, or null if you want to read
      * @return string|$this If reading, the value of the command. If setting $this will be returned.
      */
     public function command($text = null)
     {
         if ($text !== null) {
-            $this->_command = Inflector::underscore($text);
-
-            return $this;
+            return $this->setCommand($text);
         }
 
-        return $this->_command;
+        return $this->getCommand();
+    }
+
+    /**
+     * Sets the description text for shell/task.
+     *
+     * @param string|array $text The text to set. If an array the
+     *   text will be imploded with "\n".
+     * @return $this
+     */
+    public function setDescription($text)
+    {
+        if (is_array($text)) {
+            $text = implode("\n", $text);
+        }
+        $this->_description = $text;
+
+        return $this;
+    }
+
+    /**
+     * Gets the description text for shell/task.
+     *
+     * @return string The value of the description
+     */
+    public function getDescription()
+    {
+        return $this->_description;
     }
 
     /**
      * Get or set the description text for shell/task.
      *
+     * @deprecated 3.4.0 Use setDescription()/getDescription() instead.
      * @param string|array|null $text The text to set, or null if you want to read. If an array the
      *   text will be imploded with "\n".
      * @return string|$this If reading, the value of the description. If setting $this will be returned.
@@ -297,21 +347,45 @@ class ConsoleOptionParser
     public function description($text = null)
     {
         if ($text !== null) {
-            if (is_array($text)) {
-                $text = implode("\n", $text);
-            }
-            $this->_description = $text;
-
-            return $this;
+            return $this->setDescription($text);
         }
 
-        return $this->_description;
+        return $this->getDescription();
     }
 
     /**
-     * Get or set an epilog to the parser. The epilog is added to the end of
+     * Sets an epilog to the parser. The epilog is added to the end of
      * the options and arguments listing when help is generated.
      *
+     * @param string|array $text The text to set. If an array the text will
+     *   be imploded with "\n".
+     * @return $this
+     */
+    public function setEpilog($text)
+    {
+        if (is_array($text)) {
+            $text = implode("\n", $text);
+        }
+        $this->_epilog = $text;
+
+        return $this;
+    }
+
+    /**
+     * Gets the epilog.
+     *
+     * @return string The value of the epilog.
+     */
+    public function getEpilog()
+    {
+        return $this->_epilog;
+    }
+
+    /**
+     * Gets or sets an epilog to the parser. The epilog is added to the end of
+     * the options and arguments listing when help is generated.
+     *
+     * @deprecated 3.4.0 Use setEpilog()/getEpilog() instead.
      * @param string|array|null $text Text when setting or null when reading. If an array the text will
      *   be imploded with "\n".
      * @return string|$this If reading, the value of the epilog. If setting $this will be returned.
@@ -319,15 +393,10 @@ class ConsoleOptionParser
     public function epilog($text = null)
     {
         if ($text !== null) {
-            if (is_array($text)) {
-                $text = implode("\n", $text);
-            }
-            $this->_epilog = $text;
-
-            return $this;
+            return $this->setEpilog($text);
         }
 
-        return $this->_epilog;
+        return $this->getEpilog();
     }
 
     /**

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -179,28 +179,58 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * deciding whether a validation rule can be applied. All validation methods,
      * when called will receive the full list of providers stored in this validator.
      *
+     * @param string $name The name under which the provider should be set.
+     * @param object|string $object Provider object or class name.
+     * @return $this
+     */
+    public function setProvider($name, $object)
+    {
+        $this->_providers[$name] = $object;
+
+        return $this;
+    }
+
+    /**
+     * Returns the provider stored under that name if it exists.
+     *
+     * @param string $name The name under which the provider should be set.
+     * @return object|string|null
+     */
+    public function getProvider($name)
+    {
+        if (isset($this->_providers[$name])) {
+            return $this->_providers[$name];
+        }
+        if ($name !== 'default') {
+            return null;
+        }
+
+        $this->_providers[$name] = new RulesProvider();
+
+        return $this->_providers[$name];
+    }
+
+    /**
+     * Associates an object to a name so it can be used as a provider. Providers are
+     * objects or class names that can contain methods used during validation of for
+     * deciding whether a validation rule can be applied. All validation methods,
+     * when called will receive the full list of providers stored in this validator.
+     *
      * If called with no arguments, it will return the provider stored under that name if
      * it exists, otherwise it returns this instance of chaining.
      *
+     * @deprecated 3.4.0 Use setProvider()/getProvider() instead.
      * @param string $name The name under which the provider should be set.
      * @param null|object|string $object Provider object or class name.
      * @return $this|object|string|null
      */
     public function provider($name, $object = null)
     {
-        if ($object === null) {
-            if (isset($this->_providers[$name])) {
-                return $this->_providers[$name];
-            }
-            if ($name === 'default') {
-                return $this->_providers[$name] = new RulesProvider();
-            }
-
-            return null;
+        if ($object !== null) {
+            return $this->setProvider($name, $object);
         }
-        $this->_providers[$name] = $object;
 
-        return $this;
+        return $this->getProvider($name);
     }
 
     /**

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -29,8 +29,33 @@ trait StringTemplateTrait
     protected $_templater;
 
     /**
-     * Get/set templates to use.
+     * Sets templates to use.
      *
+     * @param array $templates Templates to be added.
+     * @return $this
+     */
+    public function setTemplates(array $templates)
+    {
+        $this->templater()->add($templates);
+
+        return $this;
+    }
+
+    /**
+     * Gets templates to use or a specific template.
+     *
+     * @param string|null $template String for reading a specific template, null for all.
+     * @return string|array
+     */
+    public function getTemplates($template = null)
+    {
+        return $this->templater()->get($template);
+    }
+
+    /**
+     * Gets/sets templates to use.
+     *
+     * @deprecated 3.4.0 Use setTemplates()/getTemplates() instead.
      * @param string|null|array $templates null or string allow reading templates. An array
      *   allows templates to be added.
      * @return $this|string|array
@@ -47,7 +72,7 @@ trait StringTemplateTrait
     }
 
     /**
-     * Format a template string with $data
+     * Formats a template string with $data
      *
      * @param string $name The template name.
      * @param array $data The data to insert.
@@ -59,13 +84,13 @@ trait StringTemplateTrait
     }
 
     /**
-     * templater
+     * Returns the templater instance.
      *
      * @return \Cake\View\StringTemplate
      */
     public function templater()
     {
-        if (empty($this->_templater)) {
+        if ($this->_templater === null) {
             $class = $this->config('templateClass') ?: 'Cake\View\StringTemplate';
             $this->_templater = new $class();
 


### PR DESCRIPTION
Following https://github.com/cakephp/cakephp/pull/9701 and Http, Orm and other layers already getting addressed.

So far the only classes left out yet are
- Email (not too important at this time and a lot of methods)
- ViewBuilder (a lot of work still coming)
- and a strange TranslateTrait which seems to consist of a strange mix-method (cannot easily be split) and can probably only be addressed in 4.0 directly.