### PR TITLE
Add debugInfo to Response for better debugging.

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1666,4 +1666,24 @@ class Response
     {
         exit($status);
     }
+
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'status' => $this->_status,
+            'contentType' => $this->_contentType,
+            'headers' => $this->_headers,
+            'file' => $this->_file,
+            'fileRange' => $this->_fileRange,
+            'cookies' => $this->_cookies,
+            'cacheDirectives' => $this->_cacheDirectives,
+            'body' => $this->_body,
+        ];
+    }
 }

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -2096,4 +2096,27 @@ class ResponseTest extends TestCase
         $this->assertNull($response->location('http://example.org'), 'Setting a location should return null');
         $this->assertEquals('http://example.org', $response->location(), 'Reading a location should return the value.');
     }
+
+    /**
+     * Tests __debugInfo
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $response = new Response();
+        $result = $response->__debugInfo();
+
+        $expected = [
+            'status' => (int) 200,
+            'contentType' => 'text/html',
+            'headers' => [],
+            'file' => null,
+            'fileRange' => [],
+            'cookies' => [],
+            'cacheDirectives' => [],
+            'body' => null
+        ];
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -2108,7 +2108,7 @@ class ResponseTest extends TestCase
         $result = $response->__debugInfo();
 
         $expected = [
-            'status' => (int) 200,
+            'status' => 200,
             'contentType' => 'text/html',
             'headers' => [],
             'file' => null,


### PR DESCRIPTION
Doing debug($response) anywhere so far is always quite painful, especially in CLI.
It first outputs the whole internal property stack, including irrelevant long list [protected] _statusCodes as as well as [protected] _mimeTypes

With __debugInfo() it now focuses on the actual data.