### PR TITLE
Fix double error tags when option parsing fails.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -417,7 +417,7 @@ class Shell
         try {
             list($this->params, $this->args) = $this->OptionParser->parse($argv);
         } catch (ConsoleException $e) {
-            $this->err('<error>Error: ' . $e->getMessage() . '</error>');
+            $this->err('Error: ' . $e->getMessage());
             $this->out($this->OptionParser->help($command));
 
             return false;

--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -41,8 +41,8 @@ class LoadTask extends Shell
         $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
         if (empty($plugin)) {
-            $this->err('<error>You must provide a plugin name in CamelCase format.</error>');
-            $this->err('To load an "Example" plugin, run <info>`cake plugin load Example`</info>.');
+            $this->err('You must provide a plugin name in CamelCase format.');
+            $this->err('To load an "Example" plugin, run `cake plugin load Example`.');
 
             return false;
         }

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -41,8 +41,8 @@ class UnloadTask extends Shell
         $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
         if (empty($plugin)) {
-            $this->err('<error>You must provide a plugin name in CamelCase format.</error>');
-            $this->err('To unload an "Example" plugin, run <info>`cake plugin unload Example`</info>.');
+            $this->err('You must provide a plugin name in CamelCase format.');
+            $this->err('To unload an "Example" plugin, run `cake plugin unload Example`.');
 
             return false;
         }

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1174,6 +1174,36 @@ TEXT;
     }
 
     /**
+     * test run command missing parameters
+     *
+     * @return void
+     */
+    public function testRunCommandMainMissingArgument()
+    {
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+        $shell = $this->getMockBuilder('Cake\Console\Shell')
+            ->setMethods(['main', 'startup', 'getOptionParser'])
+            ->setConstructorArgs([$io])
+            ->getMock();
+
+        $parser = new ConsoleOptionParser('test');
+        $parser->addArgument('filename', [
+            'required' => true,
+            'help' => 'a file',
+        ]);
+        $shell->expects($this->once())
+            ->method('getOptionParser')
+            ->will($this->returnValue($parser));
+        $shell->expects($this->never())->method('main');
+
+        $io->expects($this->once())
+            ->method('err')
+            ->with('<error>Error: Missing required arguments. filename is required.</error>');
+        $result = $shell->runCommand([]);
+        $this->assertFalse($result, 'Shell should fail');
+    }
+
+    /**
      * test wrapBlock wrapping text.
      *
      * @return void


### PR DESCRIPTION
When err() started adding formatting for us, we forgot to remove the formatting added when handling option parser errors.

Refs #9394