### PR TITLE
3.next - Deprecate Component response/request

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -66,6 +66,8 @@ class Component implements EventListenerInterface
      * Request object
      *
      * @var \Cake\Http\ServerRequest
+     * @deprecated 3.4.0 Storing references to the request is deprecated. Use Component::getController()
+     *   or callback $event->subject() to access the controller & request instead.
      */
     public $request;
 
@@ -73,6 +75,8 @@ class Component implements EventListenerInterface
      * Response object
      *
      * @var \Cake\Network\Response
+     * @deprecated 3.4.0 Storing references to the response is deprecated. Use Component::getController()
+     *   or callback $event->subject() to access the controller & response instead.
      */
     public $response;
 
@@ -127,6 +131,16 @@ class Component implements EventListenerInterface
             $this->_componentMap = $registry->normalizeArray($this->components);
         }
         $this->initialize($config);
+    }
+
+    /**
+     * Get the controller this component is bound to.
+     *
+     * @return \Cake\Controller\Controller The bound controller.
+     */
+    public function getController()
+    {
+        return $this->_registry->getController();
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -650,16 +650,16 @@ class RequestHandlerComponentTest extends TestCase
             ->method('parseAccept')
             ->will($this->returnValue(['1.0' => ['application/xml']]));
 
-        $this->RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['type', 'download', 'charset'])
             ->getMock();
-        $this->RequestHandler->response->expects($this->at(0))
+        $this->Controller->response->expects($this->at(0))
             ->method('type')
             ->with('application/xml');
-        $this->RequestHandler->response->expects($this->at(1))
+        $this->Controller->response->expects($this->at(1))
             ->method('charset')
             ->with('UTF-8');
-        $this->RequestHandler->response->expects($this->at(2))
+        $this->Controller->response->expects($this->at(2))
             ->method('download')
             ->with('myfile.xml');
 
@@ -675,12 +675,12 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testRespondAs()
     {
-        $this->RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['type'])
             ->getMock();
-        $this->RequestHandler->response->expects($this->at(0))->method('type')
+        $this->Controller->response->expects($this->at(0))->method('type')
             ->with('application/json');
-        $this->RequestHandler->response->expects($this->at(1))->method('type')
+        $this->Controller->response->expects($this->at(1))->method('type')
             ->with('text/xml');
 
         $result = $this->RequestHandler->respondAs('json');
@@ -700,20 +700,20 @@ class RequestHandlerComponentTest extends TestCase
             ->setMethods(['_header'])
             ->setConstructorArgs([$this->Controller->components()])
             ->getMock();
-        $this->RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['type', 'download'])
             ->getMock();
-        $this->RequestHandler->request = $this->getMockBuilder('Cake\Network\Request')
+        $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['parseAccept'])
             ->getMock();
 
-        $this->RequestHandler->request->expects($this->once())
+        $this->Controller->request->expects($this->once())
             ->method('parseAccept')
             ->will($this->returnValue(['1.0' => ['application/xml']]));
 
-        $this->RequestHandler->response->expects($this->once())->method('download')
+        $this->Controller->response->expects($this->once())->method('download')
             ->with('myfile.xml');
-        $this->RequestHandler->response->expects($this->once())->method('type')
+        $this->Controller->response->expects($this->once())->method('type')
             ->with('application/xml');
 
         $result = $this->RequestHandler->respondAs('xml', ['attachment' => 'myfile.xml']);
@@ -821,7 +821,7 @@ class RequestHandlerComponentTest extends TestCase
             ->with('mobile')
             ->will($this->returnValue(true));
 
-        $this->RequestHandler->request = $request;
+        $this->Controller->request = $request;
         $this->assertTrue($this->RequestHandler->isMobile());
     }
 
@@ -906,18 +906,18 @@ class RequestHandlerComponentTest extends TestCase
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
         $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['is'])
             ->getMock();
         $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();
-        $this->Controller->RequestHandler->request = $this->Controller->request;
-        $this->Controller->RequestHandler->response = $this->Controller->response;
-        $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
+        $this->Controller->request->expects($this->any())
+            ->method('is')
+            ->will($this->returnValue(true));
 
-        $response = $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->RequestHandler->beforeRedirect(
             $event,
             ['controller' => 'RequestHandlerTest', 'action' => 'destination'],
             $this->Controller->response
@@ -935,23 +935,21 @@ class RequestHandlerComponentTest extends TestCase
     {
         Configure::write('App.namespace', 'TestApp');
         Router::connect('/:controller/:action');
-        $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
         $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['is'])
             ->getMock();
         $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();
-        $this->Controller->RequestHandler->request = $this->Controller->request;
-        $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())
             ->method('is')
             ->with('ajax')
             ->will($this->returnValue(true));
+        $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $response = $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->RequestHandler->beforeRedirect(
             $event,
             '/request_action/params_pass?a=b&x=y?ish',
             $this->Controller->response
@@ -959,7 +957,7 @@ class RequestHandlerComponentTest extends TestCase
         $data = json_decode($response, true);
         $this->assertEquals('/request_action/params_pass', $data['here']);
 
-        $response = $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->RequestHandler->beforeRedirect(
             $event,
             '/request_action/query_pass?a=b&x=y?ish',
             $this->Controller->response
@@ -980,15 +978,13 @@ class RequestHandlerComponentTest extends TestCase
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
         $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['is'])
             ->getMock();
         $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();
-        $this->Controller->RequestHandler->request = $this->Controller->request;
-        $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
 
         $cookies = [
@@ -996,7 +992,7 @@ class RequestHandlerComponentTest extends TestCase
         ];
         $this->Controller->request->cookies = $cookies;
 
-        $response = $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->RequestHandler->beforeRedirect(
             $event,
             '/request_action/cookie_pass',
             $this->Controller->response
@@ -1017,7 +1013,7 @@ class RequestHandlerComponentTest extends TestCase
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
         $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['is'])
             ->getMock();
@@ -1025,11 +1021,9 @@ class RequestHandlerComponentTest extends TestCase
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();
         $this->Controller->response->statusCode(302);
-        $this->Controller->RequestHandler->request = $this->Controller->request;
-        $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
 
-        $response = $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->RequestHandler->beforeRedirect(
             $event,
             ['controller' => 'RequestHandlerTest', 'action' => 'destination'],
             $this->Controller->response
@@ -1051,18 +1045,16 @@ class RequestHandlerComponentTest extends TestCase
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
-        $this->Controller->RequestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
         $this->Controller->request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['is'])
             ->getMock();
         $this->Controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['_sendHeader', 'stop'])
             ->getMock();
-        $this->Controller->RequestHandler->request = $this->Controller->request;
-        $this->Controller->RequestHandler->response = $this->Controller->response;
         $this->Controller->request->expects($this->any())->method('is')->will($this->returnValue(true));
 
-        $response = $this->Controller->RequestHandler->beforeRedirect(
+        $response = $this->RequestHandler->beforeRedirect(
             $event,
             ['controller' => 'RequestHandlerTest', 'action' => 'ajax2_layout'],
             $this->Controller->response
@@ -1092,8 +1084,7 @@ class RequestHandlerComponentTest extends TestCase
         ]);
 
         $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->request = new Request('posts/index');
-        $RequestHandler->response = $this->Controller->response;
+        $this->Controller->request = new Request('posts/index');
 
         ob_start();
         $RequestHandler->beforeRedirect(
@@ -1127,14 +1118,16 @@ class RequestHandlerComponentTest extends TestCase
     public function testCheckNotModifiedByEtagStar()
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = '*';
-        $event = new Event('Controller.beforeRender', $this->Controller);
-        $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['notModified', 'stop'])
             ->getMock();
-        $RequestHandler->response->etag('something');
-        $RequestHandler->response->expects($this->once())->method('notModified');
-        $this->assertFalse($RequestHandler->beforeRender($event));
+        $response->etag('something');
+        $response->expects($this->once())->method('notModified');
+        $this->Controller->response = $response;
+
+        $event = new Event('Controller.beforeRender', $this->Controller);
+        $requestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->assertFalse($requestHandler->beforeRender($event));
     }
 
     /**
@@ -1146,14 +1139,16 @@ class RequestHandlerComponentTest extends TestCase
     public function testCheckNotModifiedByEtagExact()
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
-        $event = new Event('Controller.beforeRender');
-        $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['notModified', 'stop'])
             ->getMock();
-        $RequestHandler->response->etag('something', true);
-        $RequestHandler->response->expects($this->once())->method('notModified');
-        $this->assertFalse($RequestHandler->beforeRender($event));
+        $response->etag('something', true);
+        $response->expects($this->once())->method('notModified');
+        $this->Controller->response = $response;
+        $event = new Event('Controller.beforeRender', $this->Controller);
+
+        $requestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->assertFalse($requestHandler->beforeRender($event));
     }
 
     /**
@@ -1166,15 +1161,17 @@ class RequestHandlerComponentTest extends TestCase
     {
         $_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
         $_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-        $event = new Event('Controller.beforeRender', $this->Controller);
-        $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['notModified', 'stop'])
             ->getMock();
-        $RequestHandler->response->etag('something', true);
-        $RequestHandler->response->modified('2012-01-01 00:00:00');
-        $RequestHandler->response->expects($this->once())->method('notModified');
-        $this->assertFalse($RequestHandler->beforeRender($event));
+        $response->etag('something', true);
+        $response->modified('2012-01-01 00:00:00');
+        $response->expects($this->once())->method('notModified');
+        $this->Controller->response = $response;
+
+        $event = new Event('Controller.beforeRender', $this->Controller);
+        $requestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->assertFalse($requestHandler->beforeRender($event));
     }
 
     /**
@@ -1185,13 +1182,15 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testCheckNotModifiedNoInfo()
     {
-        $event = new Event('Controller.beforeRender', $this->Controller);
-        $RequestHandler = new RequestHandlerComponent($this->Controller->components());
-        $RequestHandler->response = $this->getMockBuilder('Cake\Network\Response')
+        $response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['notModified', 'stop'])
             ->getMock();
-        $RequestHandler->response->expects($this->never())->method('notModified');
-        $this->assertNull($RequestHandler->beforeRender($event));
+        $response->expects($this->never())->method('notModified');
+        $this->Controller->response = $response;
+
+        $event = new Event('Controller.beforeRender', $this->Controller);
+        $requestHandler = new RequestHandlerComponent($this->Controller->components());
+        $this->assertNull($requestHandler->beforeRender($event));
     }
 
     /**

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -347,15 +347,15 @@ class SecurityComponentTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'AUTH';
         $this->Controller->request['action'] = 'posted';
         $this->Controller->request->data = ['username' => 'willy', 'password' => 'somePass'];
-        $this->Controller->Security->requireAuth(['posted']);
-        $this->Controller->Security->startup($event);
+        $this->Security->requireAuth(['posted']);
+        $this->Security->startup($event);
         $this->assertTrue($this->Controller->failed);
 
         $this->Security->session->write('_Token', ['allowedControllers' => []]);
         $this->Controller->request->data = ['username' => 'willy', 'password' => 'somePass'];
         $this->Controller->request['action'] = 'posted';
-        $this->Controller->Security->requireAuth('posted');
-        $this->Controller->Security->startup($event);
+        $this->Security->requireAuth('posted');
+        $this->Security->startup($event);
         $this->assertTrue($this->Controller->failed);
 
         $this->Security->session->write('_Token', [
@@ -363,8 +363,8 @@ class SecurityComponentTest extends TestCase
         ]);
         $this->Controller->request->data = ['username' => 'willy', 'password' => 'somePass'];
         $this->Controller->request['action'] = 'posted';
-        $this->Controller->Security->requireAuth('posted');
-        $this->Controller->Security->startup($event);
+        $this->Security->requireAuth('posted');
+        $this->Security->startup($event);
         $this->assertTrue($this->Controller->failed);
     }
 
@@ -380,17 +380,21 @@ class SecurityComponentTest extends TestCase
         $this->Controller->Security->config('validatePost', false);
 
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->request['action'] = 'posted';
-        $this->Controller->Security->requireAuth('posted');
-        $this->Controller->Security->startup($event);
+        $this->Controller->request->addParams([
+            'action' => 'posted'
+        ]);
+        $this->Security->requireAuth('posted');
+        $this->Security->startup($event);
         $this->assertFalse($this->Controller->failed);
 
         $this->Controller->Security->session->write('_Token', [
             'allowedControllers' => ['SecurityTest'],
             'allowedActions' => ['posted'],
         ]);
-        $this->Controller->request['controller'] = 'SecurityTest';
-        $this->Controller->request['action'] = 'posted';
+        $this->Controller->request->addParams([
+            'controller' => 'SecurityTest',
+            'action' => 'posted'
+        ]);
 
         $this->Controller->request->data = [
             'username' => 'willy',
@@ -412,7 +416,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePost()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = '68730b0747d4889ec2766f9117405f9635f5fd5e%3AModel.valid';
         $unlocked = '';
@@ -435,7 +439,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostOnGetWithData()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = 'an-invalid-token';
         $unlocked = '';
@@ -450,7 +454,7 @@ class SecurityComponentTest extends TestCase
             'Model' => ['username' => 'nate', 'password' => 'foo', 'valid' => '0'],
             '_Token' => compact('fields', 'unlocked', 'debug')
         ];
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $this->assertTrue($this->Controller->failed);
     }
 
@@ -463,7 +467,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostNoSession()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $this->Security->session->delete('_Token');
         $unlocked = '';
         $debug = urlencode(json_encode([
@@ -490,7 +494,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostNoUnlockedInRequestData()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $this->Security->session->delete('_Token');
 
         $fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877%3AModel.valid';
@@ -511,7 +515,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFormHacking()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = '';
 
         $this->Controller->request->data = [
@@ -532,7 +536,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostObjectDeserialize()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877';
         $unlocked = '';
         $debug = urlencode(json_encode([
@@ -562,7 +566,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostIgnoresCsrfToken()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = '8e26ef05379e5402c2c619f37ee91152333a0264%3A';
         $unlocked = '';
@@ -585,7 +589,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostArray()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = '8e26ef05379e5402c2c619f37ee91152333a0264%3A';
         $unlocked = '';
@@ -616,7 +620,7 @@ class SecurityComponentTest extends TestCase
     public function testValidateIntFieldName()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = '4a221010dd7a23f7166cb10c38bc21d81341c387%3A';
         $unlocked = '';
@@ -642,7 +646,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostNoModel()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = 'a1c3724b7ba85e7022413611e30ba2c6181d5aba%3A';
         $unlocked = '';
@@ -666,7 +670,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostSimple()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = 'b0914d06dfb04abf1fada53e16810e87d157950b%3A';
         $unlocked = '';
@@ -690,7 +694,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostComplex()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = 'b65c7463e44a61d8d2eaecce2c265b406c9c4742%3AAddresses.0.id%7CAddresses.1.id';
         $unlocked = '';
@@ -722,7 +726,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostMultipleSelect()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $fields = '8d8da68ba03b3d6e7e145b948abfe26741422169%3A';
         $unlocked = '';
@@ -771,7 +775,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostCheckbox()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '68730b0747d4889ec2766f9117405f9635f5fd5e%3AModel.valid';
         $unlocked = '';
         $debug = 'not used';
@@ -795,7 +799,7 @@ class SecurityComponentTest extends TestCase
         $this->assertTrue($result);
 
         $this->Controller->request->data = [];
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
         $this->Controller->request->data = [
             'Model' => ['username' => '', 'password' => '', 'valid' => '0'],
@@ -815,7 +819,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostHidden()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '973a8939a68ac014cc6f7666cec9aa6268507350%3AModel.hidden%7CModel.other_hidden';
         $unlocked = '';
         $debug = 'not used';
@@ -840,8 +844,8 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostWithDisabledFields()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->config('disabledFields', ['Model.username', 'Model.password']);
-        $this->Controller->Security->startup($event);
+        $this->Security->config('disabledFields', ['Model.username', 'Model.password']);
+        $this->Security->startup($event);
         $fields = '1c59acfbca98bd870c11fb544d545cbf23215880%3AModel.hidden';
         $unlocked = '';
         $debug = 'not used';
@@ -866,7 +870,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostDisabledFieldsInData()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
         $fields = urlencode(Security::hash('/articles/index' . serialize($fields) . $unlocked . Security::salt()));
@@ -894,7 +898,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFailNoDisabled()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
         $fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
 
@@ -920,7 +924,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFailNoDebug()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
         $fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
         $unlocked = '';
@@ -947,7 +951,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFailNoDebugMode()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
         $fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
         $unlocked = '';
@@ -973,7 +977,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFailDisabledFieldTampering()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
         $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
@@ -1008,7 +1012,7 @@ class SecurityComponentTest extends TestCase
     public function testValidateHiddenMultipleModel()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '075ca6c26c38a09a78d871201df89faf52cbbeb8%3AModel.valid%7CModel2.valid%7CModel3.valid';
         $unlocked = '';
         $debug = 'not used';
@@ -1032,7 +1036,7 @@ class SecurityComponentTest extends TestCase
     public function testValidateHasManyModel()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '24a753fb62ef7839389987b58e3f7108f564e529%3AModel.0.hidden%7CModel.0.valid';
         $fields .= '%7CModel.1.hidden%7CModel.1.valid';
         $unlocked = '';
@@ -1065,7 +1069,7 @@ class SecurityComponentTest extends TestCase
     public function testValidateHasManyRecordsPass()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '8f7d82bf7656cf068822d9bdab109ebed1be1825%3AAddress.0.id%7CAddress.0.primary%7C';
         $fields .= 'Address.1.id%7CAddress.1.primary';
         $unlocked = '';
@@ -1110,7 +1114,7 @@ class SecurityComponentTest extends TestCase
     public function testValidateNestedNumericSets()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = '';
         $hashFields = ['TaxonomyData'];
         $fields = urlencode(Security::hash('/articles/index' . serialize($hashFields) . $unlocked . Security::salt()));
@@ -1138,7 +1142,7 @@ class SecurityComponentTest extends TestCase
     public function testValidateHasManyRecordsFail()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '7a203edb3d345bbf38fe0dccae960da8842e11d7%3AAddress.0.id%7CAddress.0.primary%7C';
         $fields .= 'Address.1.id%7CAddress.1.primary';
         $unlocked = '';
@@ -1204,7 +1208,7 @@ class SecurityComponentTest extends TestCase
     {
         $event = new Event('Controller.startup', $this->Controller);
 
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = '9da2b3fa2b5b8ac0bfbc1bbce145e58059629125%3An%3A0%3A%7B%7D';
         $unlocked = '';
         $debug = urlencode(json_encode([
@@ -1220,8 +1224,8 @@ class SecurityComponentTest extends TestCase
         $result = $this->validatePost('SecurityException', 'Unexpected field \'MyModel.name\' in POST data');
         $this->assertFalse($result);
 
-        $this->Controller->Security->startup($event);
-        $this->Controller->Security->config('disabledFields', ['MyModel.name']);
+        $this->Security->startup($event);
+        $this->Security->config('disabledFields', ['MyModel.name']);
 
         $this->Controller->request->data = [
             'MyModel' => ['name' => 'some data'],
@@ -1241,7 +1245,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostRadio()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $fields = 'c2226a8879c3f4b513691295fc2519a29c44c8bb%3An%3A0%3A%7B%7D';
         $unlocked = '';
         $debug = urlencode(json_encode([
@@ -1330,9 +1334,9 @@ class SecurityComponentTest extends TestCase
     public function testBlackHoleNotDeletingSessionInformation()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
 
-        $this->Controller->Security->blackHole($this->Controller, 'auth');
+        $this->Security->blackHole($this->Controller, 'auth');
         $this->assertTrue($this->Controller->Security->session->check('_Token'), '_Token was deleted by blackHole %s');
     }
 
@@ -1361,8 +1365,8 @@ class SecurityComponentTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $event = new Event('Controller.startup', $this->Controller);
         $this->Controller->request->data = ['data'];
-        $this->Controller->Security->unlockedActions = 'index';
-        $this->Controller->Security->blackHoleCallback = null;
+        $this->Security->unlockedActions = 'index';
+        $this->Security->blackHoleCallback = null;
         $result = $this->Controller->Security->startup($event);
         $this->assertNull($result);
     }
@@ -1376,7 +1380,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostDebugFormat()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
         $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
@@ -1447,7 +1451,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFailTampering()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = '';
         $fields = ['Model.hidden' => 'value', 'Model.id' => '1'];
         $debug = urlencode(json_encode([
@@ -1478,7 +1482,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostFailTamperingMutatedIntoArray()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = '';
         $fields = ['Model.hidden' => 'value', 'Model.id' => '1'];
         $debug = urlencode(json_encode([
@@ -1509,7 +1513,7 @@ class SecurityComponentTest extends TestCase
     public function testValidatePostUnexpectedDebugToken()
     {
         $event = new Event('Controller.startup', $this->Controller);
-        $this->Controller->Security->startup($event);
+        $this->Security->startup($event);
         $unlocked = '';
         $fields = ['Model.hidden' => 'value', 'Model.id' => '1'];
         $debug = urlencode(json_encode([
@@ -1541,10 +1545,10 @@ class SecurityComponentTest extends TestCase
      */
     public function testAuthRequiredThrowsExceptionTokenNotFoundPost()
     {
-        $this->Controller->Security->config('requireAuth', ['protected']);
+        $this->Security->config('requireAuth', ['protected']);
         $this->Controller->request->params['action'] = 'protected';
         $this->Controller->request->data = 'notEmpty';
-        $this->Controller->Security->authRequired($this->Controller);
+        $this->Security->authRequired($this->Controller);
     }
 
     /**
@@ -1557,10 +1561,10 @@ class SecurityComponentTest extends TestCase
      */
     public function testAuthRequiredThrowsExceptionTokenNotFoundSession()
     {
-        $this->Controller->Security->config('requireAuth', ['protected']);
+        $this->Security->config('requireAuth', ['protected']);
         $this->Controller->request->params['action'] = 'protected';
         $this->Controller->request->data = ['_Token' => 'not empty'];
-        $this->Controller->Security->authRequired($this->Controller);
+        $this->Security->authRequired($this->Controller);
     }
 
     /**
@@ -1573,14 +1577,14 @@ class SecurityComponentTest extends TestCase
      */
     public function testAuthRequiredThrowsExceptionControllerNotAllowed()
     {
-        $this->Controller->Security->config('requireAuth', ['protected']);
+        $this->Security->config('requireAuth', ['protected']);
         $this->Controller->request->params['controller'] = 'NotAllowed';
         $this->Controller->request->params['action'] = 'protected';
         $this->Controller->request->data = ['_Token' => 'not empty'];
         $this->Controller->request->session()->write('_Token', [
             'allowedControllers' => ['Allowed', 'AnotherAllowed']
         ]);
-        $this->Controller->Security->authRequired($this->Controller);
+        $this->Security->authRequired($this->Controller);
     }
 
     /**
@@ -1593,14 +1597,14 @@ class SecurityComponentTest extends TestCase
      */
     public function testAuthRequiredThrowsExceptionActionNotAllowed()
     {
-        $this->Controller->Security->config('requireAuth', ['protected']);
+        $this->Security->config('requireAuth', ['protected']);
         $this->Controller->request->params['controller'] = 'NotAllowed';
         $this->Controller->request->params['action'] = 'protected';
         $this->Controller->request->data = ['_Token' => 'not empty'];
         $this->Controller->request->session()->write('_Token', [
             'allowedActions' => ['index', 'view']
         ]);
-        $this->Controller->Security->authRequired($this->Controller);
+        $this->Security->authRequired($this->Controller);
     }
 
     /**
@@ -1611,7 +1615,7 @@ class SecurityComponentTest extends TestCase
      */
     public function testAuthRequired()
     {
-        $this->Controller->Security->config('requireAuth', ['protected']);
+        $this->Security->config('requireAuth', ['protected']);
         $this->Controller->request->params['controller'] = 'Allowed';
         $this->Controller->request->params['action'] = 'protected';
         $this->Controller->request->data = ['_Token' => 'not empty'];
@@ -1619,6 +1623,6 @@ class SecurityComponentTest extends TestCase
             'allowedActions' => ['protected'],
             'allowedControllers' => ['Allowed'],
         ]);
-        $this->assertTrue($this->Controller->Security->authRequired($this->Controller));
+        $this->assertTrue($this->Security->authRequired($this->Controller));
     }
 }


### PR DESCRIPTION
Start deprecating the request/response properties on components. By not storing references to PSR7 objects all over the place, we can migrate to using immutable methods more easily in the future. I don't think it will be easy to start using the immutable methods _now_ as user-land components could easily be referencing old public properties.

Refs #9636 