### PR TITLE
Introduce a new deleteEach method for Table

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -17,6 +17,10 @@ namespace Cake\Datasource;
 /**
  * Describes the methods that any class representing a data storage should
  * comply with.
+ *
+ * New methods that will be added in version 4.0.0
+ *
+ * @method int deleteEach($conditions, $options = []);
  */
 interface RepositoryInterface
 {
@@ -114,49 +118,6 @@ interface RepositoryInterface
      */
     public function deleteAll($conditions);
 
-    /**
-     * Deletes records individually by reading batches that match the conditions. For each
-     * matched record Table::delete() is executed providing support for behaviors and events.
-     *
-     * This method will continue execution until all records are deleted, or one of the events is stopped.
-     * If a record fails to be deleted the operation will stop (optional).
-     *
-     * This method will *not* trigger afterDeleteCommit events. The event afterDeleteEachCommit will be
-     * broadcast after each batch is committed.
-     *
-     * This method will *not* accept query options that alter the size of a batch, such as limit, offset
-     * and page.
-     *
-     * ### Options
-     *
-     * - 'finder' string Defaults to 'all'. The customer finder to use when reading batches.
-     * - `atomic` boolean Defaults to true. When true the deletion happens within a transaction.
-     * - 'stopOnFailure' boolean Defaults to true. Stop deleting records when a record fails to be deleted.
-     * - 'batch' integer Defaults to 1. Number of records to read in batches, zero reads all records.
-     * - `checkRules` boolean Defaults to true. Check deletion rules before deleting the record.
-     *
-     * ### Events
-     *
-     * - `Model.beforeDeleteEach` Fired before the batch delete occurs. If stopped the delete
-     *   will be aborted. Receives the event, \Cake\Datasource\ResultSetInterface, and options.
-     * - `Model.afterDeleteEach` Fired after the batch delete has been successful. Receives
-     *   the event, \Cake\Datasource\ResultSetInterface, and options.
-     * - `Model.afterDeleteEachCommit` Fired after the transaction is committed for
-     *   the batch of atomic deletes. Receives the event, \Cake\Datasource\ResultSetInterface, and options.
-     *
-     * ### Example:
-     *
-     * ```
-     * $count = $articles->deleteEach(['published' => true]);
-     * ```
-     *
-     * @param mixed $conditions Conditions to be used, accepts anything Query::where()
-     * can take.
-     * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
-     * @return int Count Returns the affected rows.
-     * @see \Cake\Datasource\RepositoryInterface::delete()
-     */
-    public function deleteEach($conditions, $options = []);
 
     /**
      * Returns true if there is any record in this repository matching the specified

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -115,6 +115,23 @@ interface RepositoryInterface
     public function deleteAll($conditions);
 
     /**
+     * Delete each record individually that matches the conditions. For each
+     * matched record Table::delete() is executed providing support for behaviors
+     * and events.
+     *
+     * This method will continue execution until all records are deleted. You should
+     * be aware of possible long execution times, and side effects of processing
+     * events on a large collection of records.
+     *
+     * @param mixed $conditions Conditions to be used, accepts anything Query::where()
+     * can take.
+     * @param array|\ArrayAccess $options The options for the updates.
+     * @return int Count Returns the affected rows.
+     * @see \Cake\Datasource\RepositoryInterface::deleteAll()
+     */
+    public function deleteEach($conditions, $options = []);
+
+    /**
      * Returns true if there is any record in this repository matching the specified
      * conditions.
      *

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -115,7 +115,7 @@ interface RepositoryInterface
     public function deleteAll($conditions);
 
     /**
-     * Delete each record individually that matches the conditions. For each
+     * Delete each record individually by matches the conditions. For each
      * matched record Table::delete() is executed providing support for behaviors
      * and events.
      *
@@ -125,7 +125,7 @@ interface RepositoryInterface
      *
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.
-     * @param array|\ArrayAccess $options The options for the updates.
+     * @param array $options The options for the updates.
      * @return int Count Returns the affected rows.
      * @see \Cake\Datasource\RepositoryInterface::deleteAll()
      */

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -115,13 +115,20 @@ interface RepositoryInterface
     public function deleteAll($conditions);
 
     /**
-     * Delete each record individually by matches the conditions. For each
+     * Delete each record individually by matching the conditions. For each
      * matched record Table::delete() is executed providing support for behaviors
      * and events.
      *
      * This method will continue execution until all records are deleted. You should
      * be aware of possible long execution times, and side effects of processing
      * events on a large collection of records.
+     *
+     * ### Options
+     *
+     * Options are passed to Table::delete() with the exception of these.
+     *
+     * - 'stopOnFailure' boolean (default True) stop deleting records should one fail to be deleted.
+     * - 'limit' integer (default 0) Limit the number of records to delete, zero means no limit.
      *
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1369,8 +1369,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function deleteEach($conditions, $options = [])
     {
-        $options = $options + [
-                'strict' => true,
+        $options += [
+                'stopOnFailure' => true,
                 'limit' => 0
             ];
 
@@ -1386,7 +1386,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             if ($entity === null) {
                 break;
             }
-            if ($this->delete($entity, $options) === false && $options['strict']) {
+            if ($this->delete($entity, $options) === false && $options['stopOnFailure']) {
                 break;
             }
             $count++;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1579,8 +1579,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function deleteEach($conditions, $options = [])
     {
-        $options = $options + [
-                'strict' => true,
+        $options += [
+                'stopOnFailure' => true,
                 'limit' => 0
             ];
 
@@ -1596,7 +1596,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             if ($entity === null) {
                 break;
             }
-            if ($this->delete($entity, $options) === false && $options['strict']) {
+            if ($this->delete($entity, $options) === false && $options['stopOnFailure']) {
                 break;
             }
             $count++;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -36,6 +36,7 @@ use Cake\ORM\Exception\MissingEntityException;
 use Cake\ORM\Exception\RolledbackTransactionException;
 use Cake\ORM\Rule\IsUnique;
 use Cake\Utility\Inflector;
+use Cake\Validation\Validation;
 use Cake\Validation\ValidatorAwareTrait;
 use InvalidArgumentException;
 use RuntimeException;
@@ -964,7 +965,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new BelongsTo($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**
@@ -1008,7 +1009,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new HasOne($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**
@@ -1058,7 +1059,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new HasMany($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**
@@ -1110,7 +1111,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new BelongsToMany($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -36,7 +36,6 @@ use Cake\ORM\Exception\MissingEntityException;
 use Cake\ORM\Exception\RolledbackTransactionException;
 use Cake\ORM\Rule\IsUnique;
 use Cake\Utility\Inflector;
-use Cake\Validation\Validation;
 use Cake\Validation\ValidatorAwareTrait;
 use InvalidArgumentException;
 use RuntimeException;
@@ -965,7 +964,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new BelongsTo($associated, $options);
 
-        return $this->_associations->add($association->name(), $association);
+        return $this->_associations->add($association->getName(), $association);
     }
 
     /**
@@ -1009,7 +1008,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new HasOne($associated, $options);
 
-        return $this->_associations->add($association->name(), $association);
+        return $this->_associations->add($association->getName(), $association);
     }
 
     /**
@@ -1059,7 +1058,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new HasMany($associated, $options);
 
-        return $this->_associations->add($association->name(), $association);
+        return $this->_associations->add($association->getName(), $association);
     }
 
     /**
@@ -1111,7 +1110,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new BelongsToMany($associated, $options);
 
-        return $this->_associations->add($association->name(), $association);
+        return $this->_associations->add($association->getName(), $association);
     }
 
     /**
@@ -1573,6 +1572,37 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $statement->closeCursor();
 
         return $statement->rowCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteEach($conditions, $options = [])
+    {
+        $options = $options + [
+                'strict' => true,
+                'limit' => 0
+            ];
+
+        $event = $this->dispatchEvent('Model.beforeDeleteEach', compact('conditions', 'options'));
+        if ($event->isStopped()) {
+            return $event->result();
+        }
+        $conditions = $event->data('conditions');
+
+        $count = 0;
+        do {
+            $entity = $this->find()->where($conditions)->first();
+            if ($entity === null) {
+                break;
+            }
+            if ($this->delete($entity, $options) === false && $options['strict']) {
+                break;
+            }
+            $count++;
+        } while ($entity !== null && ($options['limit'] == 0 || $count < $options['limit']));
+
+        return $this->dispatchEvent('Model.afterDeleteEach', compact('count'))->data('count');
     }
 
     /**
@@ -2563,6 +2593,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * - Model.beforeDelete => beforeDelete
      * - Model.afterDelete => afterDelete
      * - Model.afterDeleteCommit => afterDeleteCommit
+     * - Model.beforeDeleteEach => beforeDeleteEach
+     * - Model.afterDeleteEach => afterDeleteEach
      * - Model.beforeRules => beforeRules
      * - Model.afterRules => afterRules
      *
@@ -2580,6 +2612,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             'Model.beforeDelete' => 'beforeDelete',
             'Model.afterDelete' => 'afterDelete',
             'Model.afterDeleteCommit' => 'afterDeleteCommit',
+            'Model.beforeDeleteEach' => 'beforeDeleteEach',
+            'Model.afterDeleteEach' => 'afterDeleteEach',
             'Model.beforeRules' => 'beforeRules',
             'Model.afterRules' => 'afterRules',
         ];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -964,7 +964,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new BelongsTo($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**
@@ -1008,7 +1008,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new HasOne($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**
@@ -1058,7 +1058,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new HasMany($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**
@@ -1110,7 +1110,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options += ['sourceTable' => $this];
         $association = new BelongsToMany($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->add($association->name(), $association);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1576,7 +1576,46 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * {@inheritDoc}
+     * Deletes records individually by reading batches that match the conditions. For each
+     * matched record Table::delete() is executed providing support for behaviors and events.
+     *
+     * This method will continue execution until all records are deleted, or one of the events is stopped.
+     * If a record fails to be deleted the operation will stop (optional).
+     *
+     * This method will *not* trigger afterDeleteCommit events. The event afterDeleteEachCommit will be
+     * broadcast after each batch is committed.
+     *
+     * This method will *not* accept query options that alter the size of a batch, such as limit, offset
+     * and page.
+     *
+     * ### Options
+     *
+     * - 'finder' string Defaults to 'all'. The customer finder to use when reading batches.
+     * - `atomic` boolean Defaults to true. When true the deletion happens within a transaction.
+     * - 'stopOnFailure' boolean Defaults to true. Stop deleting records when a record fails to be deleted.
+     * - 'batch' integer Defaults to 1. Number of records to read in batches, zero reads all records.
+     * - `checkRules` boolean Defaults to true. Check deletion rules before deleting the record.
+     *
+     * ### Events
+     *
+     * - `Model.beforeDeleteEach` Fired before the batch delete occurs. If stopped the delete
+     *   will be aborted. Receives the event, \Cake\Datasource\ResultSetInterface, and options.
+     * - `Model.afterDeleteEach` Fired after the batch delete has been successful. Receives
+     *   the event, \Cake\Datasource\ResultSetInterface, and options.
+     * - `Model.afterDeleteEachCommit` Fired after the transaction is committed for
+     *   the batch of atomic deletes. Receives the event, \Cake\Datasource\ResultSetInterface, and options.
+     *
+     * ### Example:
+     *
+     * ```
+     * $count = $articles->deleteEach(['published' => true]);
+     * ```
+     *
+     * @param mixed $conditions Conditions to be used, accepts anything Query::where()
+     * can take.
+     * @param array|\ArrayAccess $options An array that will be passed to Query::applyOptions()
+     * @return int Count Returns the affected rows.
+     * @see \Cake\Datasource\RepositoryInterface::delete()
      */
     public function deleteEach($conditions, $options = [])
     {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -27,9 +27,9 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\I18n\Time;
-use Cake\ORM\AssociationCollection;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
+use Cake\ORM\AssociationCollection;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -963,6 +963,102 @@ class TableTest extends TestCase
 
         $table->deleteAll(['id >' => 4]);
     }
+
+    /**
+     * @return array
+     */
+    public function dataDeleteEach()
+    {
+        return [
+            [['batch' => 1]],
+            [['batch' => 100]],
+            [['atomic' => false]],
+            [['stopOnFailure' => false]],
+            [['checkRules' => false]]
+        ];
+    }
+
+    /**
+     * @dataProvider dataDeleteEach
+     * @param array $options
+     */
+    public function testDeleteEach(array $options) {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $result = $table->deleteEach(['username !=' => 'mariano'], $options);
+        $this->assertSame(3, $result);
+
+        $result = $table->find('all')->toArray();
+        $this->assertCount(1, $result, 'Only one record should remain');
+        $this->assertEquals('mariano', $result[0]['username']);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataDeleteEachInvalidArgument()
+    {
+        return [
+            [['limit' => 10]],
+            [['offset' => 10]],
+            [['page' => 10]]
+        ];
+    }
+
+    /**
+     * @param array $invalidParams
+     * @dataProvider dataDeleteEachInvalidArgument
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDeleteEachInvalidArgument(array $invalidParams) {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $table->deleteEach(['username !=' => 'mariano'], $invalidParams);
+    }
+
+    /**
+     *
+     */
+    public function testDeleteEachFinder() {
+
+        $table = TableRegistry::get('articles');
+        $result = $table->deleteEach(['username !=' => 'mariano'], ['finder' => 'published']);
+        $this->assertSame(4, $result);
+    }
+
+    /**
+     *
+     */
+    public function testDeleteEachAtomic() {
+
+    }
+
+    /**
+     * Tests failure by having a rule block delete.
+     */
+    public function testDeleteEachStopOnFailure() {
+
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid batch size: 0
+     */
+    public function testDeleteEachZeroBatch() {
+
+    }
+
+    /**
+     *
+     */
+    public function testDeleteEachCheckRules() {
+
+    }
+
 
     /**
      * Tests that array options are passed to the query object using applyOptions


### PR DESCRIPTION
closes #9727

- adds a new deleteEach method to the Table interface
- adds beforeDeleteEach  and afterDeleteEach events

Unit tests are coming. Just wanted early review.