### PR TITLE
3.next - Start adding Response helpers and fix some issues.

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -670,6 +670,7 @@ class Response implements ResponseInterface
      *  - an array of string headers is also accepted
      * @param string|array|null $value The header value(s)
      * @return array List of headers to be sent
+     * @deprecated 3.4.0 Use `withHeader()`, `getHeaderLine()` and `getHeaders()` instead.
      */
     public function header($header = null, $value = null)
     {
@@ -705,7 +706,9 @@ class Response implements ResponseInterface
      *
      * @param null|string $url Either null to get the current location, or a string to set one.
      * @return string|null When setting the location null will be returned. When reading the location
-     *    a string of the current location header value (if any) will be returned.
+     *   a string of the current location header value (if any) will be returned.
+     * @deprecated 3.4.0 Mutable responses are deprecated. Use `withLocation()` and `getHeaderLine()`
+     *   instead.
      */
     public function location($url = null)
     {
@@ -753,6 +756,7 @@ class Response implements ResponseInterface
      *
      * @param string|callable|null $content the string or callable message to be sent
      * @return string Current message buffer if $content param is passed as null
+     * @deprecated 3.4.0 Mutable response methods are deprecated. Use `withBody()` and `getBody()` instead.
      */
     public function body($content = null)
     {
@@ -806,7 +810,7 @@ class Response implements ResponseInterface
      * @param int|null $code the HTTP status code
      * @return int Current status code
      * @throws \InvalidArgumentException When an unknown status code is reached.
-     * @deprecated 3.4.0 Use getStatusCode() to read the status code instead.
+     * @deprecated 3.4.0 Use `getStatusCode()` and `withStatusCode()` instead.
      */
     public function statusCode($code = null)
     {

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1025,9 +1025,9 @@ class Response implements ResponseInterface
         if (strpos($contentType, '/') === false) {
             return false;
         }
-
         $this->_contentType = $contentType;
         $this->_setContentType();
+
         return $contentType;
     }
 
@@ -1121,9 +1121,9 @@ class Response implements ResponseInterface
         if ($charset === null) {
             return $this->_charset;
         }
-
         $this->_charset = $charset;
         $this->_setContentType();
+
         return $this->_charset;
     }
 

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -723,6 +723,17 @@ class Response implements ResponseInterface
     }
 
     /**
+     * Return an instance with an updated location header
+     *
+     * @param string $url The location to redirect to.
+     * @return static A new response with the Location header set.
+     */
+    public function withLocation($url)
+    {
+        return $this->withHeader('Location', $url);
+    }
+
+    /**
      * Sets a header.
      *
      * @param string $header Header key.

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -714,7 +714,10 @@ class Response implements ResponseInterface
         $out = [];
         foreach ($this->headers as $key => $values) {
             $header = $this->headerNames[strtolower($key)];
-            $out[$header] = implode(',', $values);
+            if (count($values) === 1) {
+                $values = $values[0];
+            }
+            $out[$header] = $values;
         }
 
         return $out;

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -521,7 +521,7 @@ class Response implements ResponseInterface
         $this->_setCookies();
         $this->_sendHeader("{$this->_protocol} {$this->_status} {$codeMessage}");
 
-        if (in_array($this->_status, [304, 204])) {
+        if (!in_array($this->_status, [304, 204])) {
             $this->_setContentType();
         }
 

--- a/tests/TestCase/Http/ResponseTransformerTest.php
+++ b/tests/TestCase/Http/ResponseTransformerTest.php
@@ -92,7 +92,11 @@ class ResponseTransformerTest extends TestCase
     {
         $psr = new PsrResponse('php://memory', 200, ['X-testing' => 'value']);
         $result = ResponseTransformer::toCake($psr);
-        $this->assertSame(['X-testing' => 'value'], $result->header());
+        $expected = [
+            'Content-Type' => 'text/html; charset=UTF-8',
+            'X-testing' => 'value'
+        ];
+        $this->assertSame($expected, $result->header());
     }
 
     /**
@@ -104,7 +108,11 @@ class ResponseTransformerTest extends TestCase
     {
         $psr = new PsrResponse('php://memory', 200, ['X-testing' => ['value', 'value2']]);
         $result = ResponseTransformer::toCake($psr);
-        $this->assertSame(['X-testing' => ['value', 'value2']], $result->header());
+        $expected = [
+            'Content-Type' => 'text/html; charset=UTF-8',
+            'X-testing' => ['value', 'value2'],
+        ];
+        $this->assertSame($expected, $result->header());
     }
 
     /**
@@ -270,24 +278,6 @@ class ResponseTransformerTest extends TestCase
      *
      * @return void
      */
-    public function testToPsrContentTypeStatusOmission()
-    {
-        $cake = new CakeResponse();
-        $cake->type('html');
-        $cake->statusCode(304);
-        $result = ResponseTransformer::toPsr($cake);
-        $this->assertSame('', $result->getHeaderLine('Content-Type'));
-
-        $cake->statusCode(204);
-        $result = ResponseTransformer::toPsr($cake);
-        $this->assertSame('', $result->getHeaderLine('Content-Type'));
-    }
-
-    /**
-     * Test conversion omitting content-type on 304 and 204 status codes
-     *
-     * @return void
-     */
     public function testToPsrContentTypeCharsetIsTypeSpecific()
     {
         $cake = new CakeResponse();
@@ -320,9 +310,9 @@ class ResponseTransformerTest extends TestCase
         ]);
         $result = ResponseTransformer::toPsr($cake);
         $expected = [
+            'Content-Type' => ['text/html; charset=UTF-8'],
             'X-testing' => ['one', 'two'],
             'Location' => ['http://example.com/testing'],
-            'Content-Type' => ['text/html; charset=UTF-8'],
         ];
         $this->assertSame($expected, $result->getHeaders());
     }

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -2111,6 +2111,22 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Test the withLocation method.
+     *
+     * @return void
+     */
+    public function testWithLocation()
+    {
+        $response = new Response();
+        $this->assertSame('', $response->getHeaderLine('Location'), 'No header should be set.');
+        $new = $response->withLocation('http://example.org');
+
+        $this->assertNotSame($new, $response);
+        $this->assertSame('', $response->getHeaderLine('Location'), 'No header should be set');
+        $this->assertSame('http://example.org', $new->getHeaderLine('Location'), 'Header should be set');
+    }
+
+    /**
      * Test get protocol version.
      *
      * @return void

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -285,7 +285,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($headers, $response->header());
 
         $response->header('Access-Control-Allow-Origin', ['domain1', 'domain2']);
-        $headers += ['Access-Control-Allow-Origin' => 'domain1,domain2'];
+        $headers += ['Access-Control-Allow-Origin' => ['domain1', 'domain2']];
         $this->assertEquals($headers, $response->header());
     }
 

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -712,7 +712,7 @@ class ResponseTest extends TestCase
         $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
         $response->modified('+1 day');
         $this->assertEquals($time->format($format) . ' GMT', $response->modified());
-        $this->assertEquals($time->format($format). ' GMT', $response->getHeaderLine('Last-Modified'));
+        $this->assertEquals($time->format($format) . ' GMT', $response->getHeaderLine('Last-Modified'));
     }
 
     /**


### PR DESCRIPTION
Add `withLocation()` and `withType()`. These are immutable versions of `type()` and `location()`. Unfortunately this spiraled a bit out of control as I wanted to keep the tests passing. However, I've:

* Fixed getHeaders() not always following PSR7 interface requirements  when headers are set with `header()`.
* Restored behavior where the status code is set to 302 when a location  header is set and the current status is 200.
* Eagerly set the 'Content-Type' header so that charset(), type() and  withType() all result in the content-type header being correctly set.   This also fixes an issue where the content type would not be correctly  set when the response was emitted.

Refs #9636