### PR TITLE
Make it possible to have single character route keys.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -173,7 +173,7 @@ class Route
         $names = $routeParams = [];
         $parsed = preg_quote($this->template, '#');
 
-        preg_match_all('#:([A-Za-z0-9_-]+[A-Z0-9a-z])#', $route, $namedElements);
+        preg_match_all('/:([a-z0-9-_]+(?<![-_]))/i', $route, $namedElements);
         foreach ($namedElements[1] as $i => $name) {
             $search = '\\' . $namedElements[0][$i];
             if (isset($this->options[$name])) {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -91,6 +91,31 @@ class RouteTest extends TestCase
     }
 
     /**
+     * Test that single letter placeholders work.
+     *
+     * @return void
+     */
+    public function testRouteBuildingSmallPlaceholders()
+    {
+        $route = new Route(
+            '/fighters/:id/move/:x/:y',
+            ['controller' => 'Fighters', 'action' => 'move'],
+            ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']]
+        );
+        $pattern = $route->compile();
+        $this->assertRegExp($pattern, '/fighters/123/move/8/42');
+
+        $result = $route->match([
+            'controller' => 'Fighters',
+            'action' => 'move',
+            'id' => 123,
+            'x' => 8,
+            'y' => 42
+        ]);
+        $this->assertEquals('/fighters/123/move/8/42', $result);
+    }
+
+    /**
      * Test parsing routes with extensions.
      *
      * @return void


### PR DESCRIPTION
The template parsing pattern required placeholders be at least 2 characters. Using a negative lookbehind allows us to capture single character patterns without causing issues where placeholders are separated by `-` or `_`.

Refs #9777