### PR TITLE
Fix AclNode constructor.

### DIFF
--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -39,6 +39,11 @@ class AclNode extends Model {
 
 /**
  * Constructor
+ *
+ * @param bool|int|string|array $id Set this ID for this model on startup,
+ *   can also be an array of options, see above.
+ * @param string $table Name of database table to use.
+ * @param string $ds DataSource connection name.
  */
 	public function __construct($id = false, $table = null, $ds = null) {
 		$config = Configure::read('Acl.database');

--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -40,12 +40,12 @@ class AclNode extends Model {
 /**
  * Constructor
  */
-	public function __construct() {
+	public function __construct($id = false, $table = null, $ds = null) {
 		$config = Configure::read('Acl.database');
 		if (isset($config)) {
 			$this->useDbConfig = $config;
 		}
-		parent::__construct();
+		parent::__construct($id, $table, $ds);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -201,6 +201,19 @@ class ClassRegistryTest extends CakeTestCase {
 	}
 
 /**
+ * Test that init() can make the Aco models with alias set properly
+ *
+ * @return void
+ */
+	public function testAddModelWithAliasAco()
+	{
+		$aco = ClassRegistry::init(array('class' => 'Aco', 'alias' => 'CustomAco'));
+		$this->assertInstanceOf('Aco', $aco);
+		$this->assertSame('Aco', $aco->name);
+		$this->assertSame('CustomAco', $aco->alias);
+	}
+
+/**
  * testClassRegistryFlush method
  *
  * @return void

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -187,8 +187,7 @@ class ClassRegistryTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testAddModelWithAlias()
-	{
+	public function testAddModelWithAlias() {
 		$tag = ClassRegistry::init(array('class' => 'RegisterArticleTag', 'alias' => 'NewTag'));
 		$this->assertInstanceOf('RegisterArticleTag', $tag);
 		$this->assertSame('NewTag', $tag->alias);
@@ -205,8 +204,7 @@ class ClassRegistryTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testAddModelWithAliasAco()
-	{
+	public function testAddModelWithAliasAco() {
 		$aco = ClassRegistry::init(array('class' => 'Aco', 'alias' => 'CustomAco'));
 		$this->assertInstanceOf('Aco', $aco);
 		$this->assertSame('Aco', $aco->name);


### PR DESCRIPTION
It should forward the settings from ClassRegistry::init() so that aliases can be customized as needed.

Refs #9766