### PR TITLE
Replace `%` in templates with `%%`

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -86,8 +86,7 @@ class StringTemplate
      *
      * @var array
      */
-    protected $_defaultConfig = [
-    ];
+    protected $_defaultConfig = [];
 
     /**
      * A stack of template sets that have been stashed temporarily.
@@ -179,6 +178,7 @@ class StringTemplate
                 $this->_compiled[$name] = [null, null];
             }
 
+            $template = str_replace('%', '%%', $template);
             preg_match_all('#\{\{([\w\d\._]+)\}\}#', $template, $matches);
             $this->_compiled[$name] = [
                 str_replace($matches[0], '%s', $template),

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -115,6 +115,22 @@ class StringTemplateTest extends TestCase
     }
 
     /**
+     * Test formatting strings with URL encoding
+     *
+     * @return void
+     */
+    public function testFormatUrlEncoding()
+    {
+        $templates = [
+            'test' => '<img src="/img/foo%20bar.jpg">{{text}}',
+        ];
+        $this->template->add($templates);
+
+        $result = $this->template->format('test', ['text' => 'stuff!']);
+        $this->assertSame('<img src="/img/foo%20bar.jpg">stuff!', $result);
+    }
+
+    /**
      * Formatting array data should not trigger errors.
      *
      * @return void


### PR DESCRIPTION
We don't want people getting errors when they inadvertantly use % style placeholders. Instead people should be using the `{{var}}` style replacements.

Refs #9722