### PR TITLE
Issue 7324 paginator sort multiple fields

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -336,9 +336,10 @@ class PaginatorComponent extends Component
             if (!in_array($direction, ['asc', 'desc'])) {
                 $direction = 'asc';
             }
-            
+
             // Union the sort option from URL and default sort option to allow sorting by multiple fields
-            $options['order'] = [$options['sort'] => $direction] + (isset($options['order']) ? $options['order'] : []);
+            $options['order'] = [$options['sort'] => $direction]
+                + (isset($options['order']) ? $options['order'] : []);
         }
         unset($options['sort'], $options['direction']);
 

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -222,6 +222,7 @@ class PaginatorComponent extends Component
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,
             'scope' => $options['scope'],
+            'totalOrder' => $order
         ];
 
         if (!$request->param('paging')) {
@@ -335,7 +336,9 @@ class PaginatorComponent extends Component
             if (!in_array($direction, ['asc', 'desc'])) {
                 $direction = 'asc';
             }
-            $options['order'] = [$options['sort'] => $direction];
+            
+            // Union the sort option from URL and default sort option to allow sorting by multiple fields
+            $options['order'] = [$options['sort'] => $direction] + (isset($options['order']) ? $options['order'] : []);
         }
         unset($options['sort'], $options['direction']);
 

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -222,7 +222,7 @@ class PaginatorComponent extends Component
             'sortDefault' => $sortDefault,
             'directionDefault' => $directionDefault,
             'scope' => $options['scope'],
-            'totalOrder' => $order
+            'completeSort' => $order
         ];
 
         if (!$request->param('paging')) {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -781,6 +781,7 @@ class PaginatorComponentTest extends TestCase
             foreach ($result as $record) {
                 $ids[] = $record->title;
             }
+
             return $ids;
         };
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -800,7 +800,7 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['First Post', 'Third Post', 'Second Post'], $titleExtractor($result));
         $this->assertEquals(
             ['PaginatorPosts.author_id' => 'asc', 'PaginatorPosts.title' => 'asc'],
-            $this->request->params['paging']['PaginatorPosts']['totalOrder']
+            $this->request->params['paging']['PaginatorPosts']['completeSort']
         );
 
         // Test overwriting a sort field defined in the settings
@@ -813,7 +813,7 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['Second Post', 'First Post', 'Third Post'], $titleExtractor($result));
         $this->assertEquals(
             ['PaginatorPosts.author_id' => 'desc', 'PaginatorPosts.title' => 'asc'],
-            $this->request->params['paging']['PaginatorPosts']['totalOrder']
+            $this->request->params['paging']['PaginatorPosts']['completeSort']
         );
 
         // Test sorting by a field not defined in the settings
@@ -826,7 +826,7 @@ class PaginatorComponentTest extends TestCase
         $this->assertEquals(['First Post', 'Second Post', 'Third Post'], $titleExtractor($result));
         $this->assertEquals(
             ['PaginatorPosts.id' => 'asc', 'PaginatorPosts.author_id' => 'asc', 'PaginatorPosts.title' => 'asc'],
-            $this->request->params['paging']['PaginatorPosts']['totalOrder']
+            $this->request->params['paging']['PaginatorPosts']['completeSort']
         );
     }
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -765,7 +765,7 @@ class PaginatorComponentTest extends TestCase
 
         $this->assertEquals($expected, $result['order']);
     }
-    
+
     /**
      * test that multiple sort works in combination with query.
      *


### PR DESCRIPTION
This resolves issue #7324 as described in my comment there.

You can define the sort order of pagination in pagination settings array.  
These settings are unioned with the request query parameters, request query always comes first.  

Due to the union, if the sort field of the request query is already defined by the settings array, the settings array will not overwrite the request query sort field.  

If no request query sort field is set (e.g. initial page 1), the pagination URL is created with the first settings entry, which has the same effect than ommiting it in the URL.
