### PR TITLE
3.next view builder

### DIFF
--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -114,37 +114,81 @@ class ViewBuilder implements JsonSerializable, Serializable
     protected $_helpers = [];
 
     /**
-     * Get/set path for template files.
+     * Sets path for template files.
      *
-     * @param string|null $path Path for view files. If null returns current path.
-     * @return string|self
+     * @param string $path Path for view files.
+     * @return $this
      */
-    public function templatePath($path = null)
+    public function setTemplatePath($path)
     {
-        if ($path === null) {
-            return $this->_templatePath;
-        }
-
         $this->_templatePath = $path;
 
         return $this;
     }
 
     /**
+     * Gets path for template files.
+     *
+     * @return string
+     */
+    public function getTemplatePath()
+    {
+        return $this->_templatePath;
+    }
+
+    /**
+     * Get/set path for template files.
+     *
+     * @deprecated 3.4.0 Use setTemplatePath()/getTemplatePath() instead.
+     * @param string|null $path Path for view files. If null returns current path.
+     * @return string|self
+     */
+    public function templatePath($path = null)
+    {
+        if ($path !== null) {
+            return $this->setTemplatePath($path);
+        }
+
+        return $this->getTemplatePath();
+    }
+
+    /**
+     * Sets path for layout files.
+     *
+     * @param string $path Path for layout files.
+     * @return $this
+     */
+    public function setLayoutPath($path)
+    {
+        $this->_layoutPath = $path;
+
+        return $this;
+    }
+
+    /**
+     * Gets path for layout files.
+     *
+     * @return string
+     */
+    public function getLayoutPath()
+    {
+        return $this->_layoutPath;
+    }
+
+    /**
      * Get/set path for layout files.
      *
+     * @deprecated 3.4.0 Use setLayoutPath()/getLayoutPath() instead.
      * @param string|null $path Path for layout files. If null returns current path.
      * @return string|self
      */
     public function layoutPath($path = null)
     {
-        if ($path === null) {
-            return $this->_layoutPath;
+        if ($path !== null) {
+            return $this->setLayoutPath($path);
         }
 
-        $this->_layoutPath = $path;
-
-        return $this;
+        return $this->getLayoutPath();
     }
 
     /**
@@ -152,50 +196,97 @@ class ViewBuilder implements JsonSerializable, Serializable
      * On by default. Setting to off means that layouts will not be
      * automatically applied to rendered views.
      *
-     * @param bool|null $autoLayout Boolean to turn on/off. If null returns current value.
-     * @return bool|self
+     * @param bool $enable Boolean to turn on/off.
+     * @return $this
      */
-    public function autoLayout($autoLayout = null)
+    public function enableAutoLayout($enable)
     {
-        if ($autoLayout === null) {
-            return $this->_autoLayout;
-        }
-
-        $this->_autoLayout = (bool)$autoLayout;
+        $this->_autoLayout = (bool)$enable;
 
         return $this;
     }
 
     /**
-     * The plugin name to use
+     * Returns if CakePHP's conventional mode of applying layout files is enabled.
+     * Disabled means that layouts will not be automatically applied to rendered views.
      *
-     * @param string|null|false $name Plugin name. If null returns current plugin.
-     *   Use false to remove the current plugin name.
-     * @return string|self
+     * @return bool
      */
-    public function plugin($name = null)
+    public function isAutoLayoutEnabled()
     {
-        if ($name === null) {
-            return $this->_plugin;
+        return $this->_autoLayout;
+    }
+
+    /**
+     * Turns on or off CakePHP's conventional mode of applying layout files.
+     * On by default. Setting to off means that layouts will not be
+     * automatically applied to rendered views.
+     *
+     * @deprecated 3.4.0 Use enableAutoLayout()/isAutoLayoutEnabled() instead.
+     * @param bool|null $enable Boolean to turn on/off. If null returns current value.
+     * @return bool|self
+     */
+    public function autoLayout($enable = null)
+    {
+        if ($enable !== null) {
+            return $this->enableAutoLayout($enable);
         }
 
+        return $this->isAutoLayoutEnabled();
+    }
+
+    /**
+     * Sets the plugin name to use.
+     *
+     * `False` to remove current plugin name is deprecated as of 3.4.0. Use directly `null` instead.
+     *
+     * @param string|null|false $name Plugin name.
+     *   Use null or false to remove the current plugin name.
+     * @return $this
+     */
+    public function setPlugin($name)
+    {
         $this->_plugin = $name;
 
         return $this;
     }
 
     /**
-     * The helpers to use
+     * Gets the plugin name to use.
      *
-     * @param array|null $helpers Helpers to use.
-     * @param bool $merge Whether or not to merge existing data with the new data.
-     * @return array|self
+     * @return string
      */
-    public function helpers(array $helpers = null, $merge = true)
+    public function getPlugin()
     {
-        if ($helpers === null) {
-            return $this->_helpers;
+        return $this->_plugin;
+    }
+
+    /**
+     * The plugin name to use
+     *
+     * @deprecated 3.4.0 Use setPlugin()/getPlugin() instead.
+     * @param string|null|false $name Plugin name. If null returns current plugin.
+     *   Use false to remove the current plugin name.
+     * @return string|self
+     */
+    public function plugin($name = null)
+    {
+        if ($name !== null) {
+            return $this->setPlugin($name);
         }
+
+        return $this->getPlugin();
+    }
+
+    /**
+     * Sets the helpers to use.
+     *
+     * @param array $helpers Helpers to use.
+     * @param bool $merge Whether or not to merge existing data with the new data.
+     * @return $this
+     */
+    public function setHelpers(array $helpers, $merge = true)
+    {
         if ($merge) {
             $helpers = array_merge($this->_helpers, $helpers);
         }
@@ -205,39 +296,140 @@ class ViewBuilder implements JsonSerializable, Serializable
     }
 
     /**
-     * The view theme to use.
+     * Gets the helpers to use.
      *
-     * @param string|null|false $theme Theme name. If null returns current theme.
-     *   Use false to remove the current theme.
-     * @return string|self
+     * @return array
      */
-    public function theme($theme = null)
+    public function getHelpers()
     {
-        if ($theme === null) {
-            return $this->_theme;
+        return $this->_helpers;
+    }
+
+    /**
+     * The helpers to use
+     *
+     * @deprecated 3.4.0 Use setHelpers()/getHelpers() instead.
+     * @param array|null $helpers Helpers to use.
+     * @param bool $merge Whether or not to merge existing data with the new data.
+     * @return array|self
+     */
+    public function helpers(array $helpers = null, $merge = true)
+    {
+        if ($helpers !== null) {
+            return $this->setHelpers($helpers, $merge);
         }
 
+        return $this->getHelpers();
+    }
+
+    /**
+     * Sets the view theme to use.
+     *
+     * `False` to remove current theme is deprecated as of 3.4.0. Use directly `null` instead.
+     *
+     * @param string|null|false $theme Theme name.
+     *   Use null or false to remove the current theme.
+     * @return $this
+     */
+    public function setTheme($theme)
+    {
         $this->_theme = $theme;
 
         return $this;
     }
 
     /**
+     * Gets the view theme to use.
+     *
+     * @return string
+     */
+    public function getTheme()
+    {
+        return $this->_theme;
+    }
+
+    /**
+     * The view theme to use.
+     *
+     * @deprecated 3.4.0 Use setTheme()/getTheme() instead.
+     * @param string|null|false $theme Theme name. If null returns current theme.
+     *   Use false to remove the current theme.
+     * @return string|self
+     */
+    public function theme($theme = null)
+    {
+        if ($theme !== null) {
+            return $this->setTheme($theme);
+        }
+
+        return $this->getTheme();
+    }
+
+    /**
+     * Sets the name of the view file to render. The name specified is the
+     * filename in /src/Template/<SubFolder> without the .ctp extension.
+     *
+     * @param string $name View file name to set.
+     * @return $this
+     */
+    public function setTemplate($name)
+    {
+        $this->_template = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name of the view file to render. The name specified is the
+     * filename in /src/Template/<SubFolder> without the .ctp extension.
+     *
+     * @return string
+     */
+    public function getTemplate()
+    {
+        return $this->_template;
+    }
+
+    /**
      * Get/set the name of the view file to render. The name specified is the
      * filename in /src/Template/<SubFolder> without the .ctp extension.
      *
+     * @deprecated 3.4.0 Use setTemplate()/getTemplate()
      * @param string|null $name View file name to set. If null returns current name.
      * @return string|self
      */
     public function template($name = null)
     {
-        if ($name === null) {
-            return $this->_template;
+        if ($name !== null) {
+            return $this->setTemplate($name);
         }
 
-        $this->_template = $name;
+        return $this->getTemplate();
+    }
+
+    /**
+     * Sets the name of the layout file to render the view inside of.
+     * The name specified is the filename of the layout in /src/Template/Layout
+     * without the .ctp extension.
+     *
+     * @param string $name Layout file name to set.
+     * @return $this
+     */
+    public function setLayout($name)
+    {
+        $this->_layout = $name;
 
         return $this;
+    }
+
+    /**
+     * Gets the name of the layout file to render the view inside of.
+     *
+     * @return string
+     */
+    public function getLayout()
+    {
+        return $this->_layout;
     }
 
     /**
@@ -245,34 +437,30 @@ class ViewBuilder implements JsonSerializable, Serializable
      * The name specified is the filename of the layout in /src/Template/Layout
      * without the .ctp extension.
      *
+     * @deprecated 3.4.0 Use setLayout()/getLayout() instead.
      * @param string|null $name Layout file name to set. If null returns current name.
      * @return string|self
      */
     public function layout($name = null)
     {
-        if ($name === null) {
-            return $this->_layout;
+        if ($name !== null) {
+            return $this->setLayout($name);
         }
 
-        $this->_layout = $name;
-
-        return $this;
+        return $this->getLayout();
     }
 
     /**
-     * Set additional options for the view.
+     * Sets additional options for the view.
      *
      * This lets you provide custom constructor arguments to application/plugin view classes.
      *
-     * @param array|null $options Either an array of options or null to get current options.
+     * @param array $options An array of options.
      * @param bool $merge Whether or not to merge existing data with the new data.
-     * @return array|self
+     * @return $this
      */
-    public function options(array $options = null, $merge = true)
+    public function setOptions(array $options, $merge = true)
     {
-        if ($options === null) {
-            return $this->_options;
-        }
         if ($merge) {
             $options = array_merge($this->_options, $options);
         }
@@ -282,19 +470,97 @@ class ViewBuilder implements JsonSerializable, Serializable
     }
 
     /**
-     * Get/set the view name
+     * Gets additional options for the view.
      *
-     * @param string|null $name The name of the view
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->_options;
+    }
+
+    /**
+     * Set additional options for the view.
+     *
+     * This lets you provide custom constructor arguments to application/plugin view classes.
+     *
+     * @deprecated 3.4.0 Use setOptions()/getOptions() instead.
+     * @param array|null $options Either an array of options or null to get current options.
+     * @param bool $merge Whether or not to merge existing data with the new data.
      * @return array|self
      */
-    public function name($name = null)
+    public function options(array $options = null, $merge = true)
     {
-        if ($name === null) {
-            return $this->_name;
+        if ($options !== null) {
+            return $this->setOptions($options, $merge);
         }
+
+        return $this->getOptions();
+    }
+
+    /**
+     * Sets the view name.
+     *
+     * @param string $name The name of the view.
+     * @return $this
+     */
+    public function setName($name)
+    {
         $this->_name = $name;
 
         return $this;
+    }
+
+    /**
+     * Gets the view name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->_name;
+    }
+
+    /**
+     * Get/set the view name
+     *
+     * @deprecated 3.4.0 Use setName()/getName() instead.
+     * @param string|null $name The name of the view
+     * @return string|self
+     */
+    public function name($name = null)
+    {
+        if ($name !== null) {
+            return $this->setName($name);
+        }
+
+        return $this->getName();
+    }
+
+    /**
+     * Sets the view classname.
+     *
+     * Accepts either a short name (Ajax) a plugin name (MyPlugin.Ajax)
+     * or a fully namespaced name (App\View\AppView).
+     *
+     * @param string $name The class name for the view.
+     * @return $this
+     */
+    public function setClassName($name)
+    {
+        $this->_className = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets the view classname.
+     *
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->_className;
     }
 
     /**
@@ -303,19 +569,19 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Accepts either a short name (Ajax) a plugin name (MyPlugin.Ajax)
      * or a fully namespaced name (App\View\AppView).
      *
+     * @deprecated 3.4.0 Use setClassName()/getClassName() instead.
      * @param string|null $name The class name for the view. Can
      *   be a plugin.class name reference, a short alias, or a fully
      *   namespaced name.
-     * @return array|self
+     * @return string|self
      */
     public function className($name = null)
     {
-        if ($name === null) {
-            return $this->_className;
+        if ($name !== null) {
+            return $this->setClassName($name);
         }
-        $this->_className = $name;
 
-        return $this;
+        return $this->getClassName();
     }
 
     /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -18,6 +18,7 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use Cake\View\View;
 use TestApp\View\CustomJsonView;
 
 /**
@@ -27,6 +28,11 @@ use TestApp\View\CustomJsonView;
  */
 class CellTest extends TestCase
 {
+
+    /**
+     * @var \Cake\View\View
+     */
+    public $View;
 
     /**
      * setUp method
@@ -40,7 +46,7 @@ class CellTest extends TestCase
         Plugin::load(['TestPlugin', 'TestTheme']);
         $request = $this->getMockBuilder('Cake\Network\Request')->getMock();
         $response = $this->getMockBuilder('Cake\Network\Response')->getMock();
-        $this->View = new \Cake\View\View($request, $response);
+        $this->View = new View($request, $response);
     }
 
     /**
@@ -139,7 +145,7 @@ class CellTest extends TestCase
 
         $this->assertContains('This is the alternate template', "{$appCell}");
         $this->assertEquals('alternate_teaser_list', $appCell->template);
-        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->template());
+        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->getTemplate());
     }
 
     /**
@@ -153,7 +159,7 @@ class CellTest extends TestCase
 
         $this->assertContains('Articles subdir custom_template_path template', "{$appCell}");
         $this->assertEquals('custom_template_path', $appCell->template);
-        $this->assertEquals('Cell/Articles/Subdir', $appCell->viewBuilder()->templatePath());
+        $this->assertEquals('Cell/Articles/Subdir', $appCell->viewBuilder()->getTemplatePath());
     }
 
     /**
@@ -166,7 +172,7 @@ class CellTest extends TestCase
         $appCell = $this->View->cell('Articles::customTemplateViewBuilder');
 
         $this->assertContains('This is the alternate template', "{$appCell}");
-        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->template());
+        $this->assertEquals('alternate_teaser_list', $appCell->viewBuilder()->getTemplate());
     }
 
     /**
@@ -205,9 +211,9 @@ class CellTest extends TestCase
         $this->View->theme = 'TestTheme';
         $cell = $this->View->cell('Articles', ['msg' => 'hello world!']);
 
-        $this->assertEquals($this->View->theme, $cell->viewBuilder()->theme());
+        $this->assertEquals($this->View->theme, $cell->viewBuilder()->getTheme());
         $this->assertContains('Themed cell content.', $cell->render());
-        $this->assertEquals($cell->View->theme, $cell->viewBuilder()->theme());
+        $this->assertEquals($cell->View->theme, $cell->viewBuilder()->getTheme());
     }
 
     /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -156,7 +156,7 @@ class EntityContextTest extends TestCase
      */
     public function testInvalidTable()
     {
-        $row = new \StdClass();
+        $row = new \stdClass();
         $context = new EntityContext($this->request, [
             'entity' => $row,
         ]);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -44,6 +44,11 @@ class HelperRegistryTest extends TestCase
     public $Helpers;
 
     /**
+     * @var \Cake\Event\EventManager
+     */
+    public $Events;
+
+    /**
      * setUp
      *
      * @return void
@@ -241,7 +246,7 @@ class HelperRegistryTest extends TestCase
         );
         $this->assertCount(1, $this->Events->listeners('View.beforeRender'));
 
-        $this->assertNull($this->Helpers->reset(), 'No return expected');
+        $this->Helpers->reset();
         $this->assertCount(0, $this->Events->listeners('View.beforeRender'));
 
         $this->assertNotSame($instance, $this->Helpers->load('EventListenerTest'));

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -43,7 +43,6 @@ class TestHelper extends Helper
      * @var array
      */
     public $helpers = ['Html', 'TestPlugin.OtherHelper'];
-
 }
 
 /**

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -44,19 +44,6 @@ class TestHelper extends Helper
      */
     public $helpers = ['Html', 'TestPlugin.OtherHelper'];
 
-    /**
-     * expose a method as public
-     *
-     * @param string $options
-     * @param string $exclude
-     * @param string $insertBefore
-     * @param string $insertAfter
-     * @return void
-     */
-    public function parseAttributes($options, $exclude = null, $insertBefore = ' ', $insertAfter = null)
-    {
-        return $this->_parseAttributes($options, $exclude, $insertBefore, $insertAfter);
-    }
 }
 
 /**
@@ -64,6 +51,11 @@ class TestHelper extends Helper
  */
 class HelperTest extends TestCase
 {
+
+    /**
+     * @var \Cake\View\View
+     */
+    public $View;
 
     /**
      * setUp method
@@ -76,8 +68,6 @@ class HelperTest extends TestCase
 
         Router::reload();
         $this->View = new View();
-        $this->Helper = new Helper($this->View);
-        $this->Helper->request = new Request();
     }
 
     /**
@@ -91,7 +81,7 @@ class HelperTest extends TestCase
         Configure::delete('Asset');
 
         Plugin::unload();
-        unset($this->Helper, $this->View);
+        unset($this->View);
     }
 
     /**

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -241,7 +241,7 @@ class JsonViewTest extends TestCase
         $Controller->set($data);
         $Controller->set('_serialize', $serialize);
         $Controller->set('_jsonOptions', $jsonOptions);
-        $Controller->viewBuilder()->className('Json');
+        $Controller->viewBuilder()->setClassName('Json');
         $View = $Controller->createView();
         $output = $View->render(false);
 
@@ -264,7 +264,7 @@ class JsonViewTest extends TestCase
             'tags' => ['cakephp', 'framework'],
             '_serialize' => 'tags'
         ]);
-        $Controller->viewBuilder()->className('Json');
+        $Controller->viewBuilder()->setClassName('Json');
         $View = $Controller->createView();
         $View->render();
 
@@ -288,7 +288,7 @@ class JsonViewTest extends TestCase
             '_serialize' => 'data',
             '_jsonp' => true
         ]);
-        $Controller->viewBuilder()->className('Json');
+        $Controller->viewBuilder()->setClassName('Json');
         $View = $Controller->createView();
         $output = $View->render(false);
 
@@ -330,7 +330,7 @@ class JsonViewTest extends TestCase
             ]
         ];
         $Controller->set('user', $data);
-        $Controller->viewBuilder()->className('Json');
+        $Controller->viewBuilder()->setClassName('Json');
         $View = $Controller->createView();
         $View->viewPath = $Controller->name;
         $output = $View->render('index');

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -42,6 +42,11 @@ class StringTemplateTraitTest extends TestCase
 {
 
     /**
+     * @var TestStringTemplate
+     */
+    public $Template;
+
+    /**
      * setUp method
      *
      * @return void
@@ -62,13 +67,13 @@ class StringTemplateTraitTest extends TestCase
         $templates = [
             'text' => '<p>{{text}}</p>',
         ];
-        $this->Template->templates($templates);
+        $this->Template->setTemplates($templates);
 
         $this->assertEquals(
             [
                 'text' => '<p>{{text}}</p>'
             ],
-            $this->Template->templates(),
+            $this->Template->getTemplates(),
             'newly added template should be included in template list'
         );
     }
@@ -89,7 +94,7 @@ class StringTemplateTraitTest extends TestCase
             [
                 'text' => '<p>{{text}}</p>'
             ],
-            $this->Template->templates(),
+            $this->Template->getTemplates(),
             'Configured templates should be included in template list'
         );
     }
@@ -104,7 +109,7 @@ class StringTemplateTraitTest extends TestCase
         $templates = [
             'text' => '<p>{{text}}</p>',
         ];
-        $this->Template->templates($templates);
+        $this->Template->setTemplates($templates);
         $result = $this->Template->formatTemplate('text', [
             'text' => 'CakePHP'
         ]);
@@ -124,7 +129,7 @@ class StringTemplateTraitTest extends TestCase
         $templates = [
             'text' => '<p>{{text}}</p>',
         ];
-        $this->Template->templates($templates);
+        $this->Template->setTemplates($templates);
         $result = $this->Template->templater();
         $this->assertInstanceOf('Cake\View\StringTemplate', $result);
     }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -114,15 +114,15 @@ class ViewBuilderTest extends TestCase
         $events = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
 
         $builder = new ViewBuilder();
-        $builder->name('Articles')
-            ->className('Ajax')
-            ->template('edit')
-            ->layout('default')
-            ->templatePath('Articles/')
-            ->helpers(['Form', 'Html'])
-            ->layoutPath('Admin/')
-            ->theme('TestTheme')
-            ->plugin('TestPlugin');
+        $builder->setName('Articles')
+            ->setClassName('Ajax')
+            ->setTemplate('edit')
+            ->setLayout('default')
+            ->setTemplatePath('Articles/')
+            ->setHelpers(['Form', 'Html'])
+            ->setLayoutPath('Admin/')
+            ->setTheme('TestTheme')
+            ->setPlugin('TestPlugin');
         $view = $builder->build(
             ['one' => 'value'],
             $request,
@@ -180,7 +180,7 @@ class ViewBuilderTest extends TestCase
     public function testBuildMissingViewClass()
     {
         $builder = new ViewBuilder();
-        $builder->className('Foo');
+        $builder->setClassName('Foo');
         $builder->build();
     }
 
@@ -194,10 +194,10 @@ class ViewBuilderTest extends TestCase
         $builder = new ViewBuilder();
 
         $builder
-            ->template('default')
-            ->layout('test')
-            ->helpers(['Html'])
-            ->className('JsonView');
+            ->setTemplate('default')
+            ->setLayout('test')
+            ->setHelpers(['Html'])
+            ->setClassName('JsonView');
 
         $result = json_decode(json_encode($builder), true);
 
@@ -223,19 +223,19 @@ class ViewBuilderTest extends TestCase
         $builder = new ViewBuilder();
 
         $builder
-            ->template('default')
-            ->layout('test')
-            ->helpers(['Html'])
-            ->className('JsonView');
+            ->setTemplate('default')
+            ->setLayout('test')
+            ->setHelpers(['Html'])
+            ->setClassName('JsonView');
 
         $result = json_encode($builder);
 
         $builder = new ViewBuilder();
         $builder->createFromArray(json_decode($result, true));
 
-        $this->assertEquals('default', $builder->template());
-        $this->assertEquals('test', $builder->layout());
-        $this->assertEquals(['Html'], $builder->helpers());
-        $this->assertEquals('JsonView', $builder->className());
+        $this->assertEquals('default', $builder->getTemplate());
+        $this->assertEquals('test', $builder->getLayout());
+        $this->assertEquals(['Html'], $builder->getHelpers());
+        $this->assertEquals('JsonView', $builder->getClassName());
     }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -280,6 +280,16 @@ class ViewTest extends TestCase
     public $fixtures = ['core.posts', 'core.users'];
 
     /**
+     * @var \Cake\View\View
+     */
+    public $View;
+
+    /**
+     * @var ViewPostsController
+     */
+    public $PostsController;
+
+    /**
      * setUp method
      *
      * @return void

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -23,6 +23,11 @@ class ViewVarsTraitTest extends TestCase
 {
 
     /**
+     * @var \Cake\Controller\Controller;
+     */
+    public $subject;
+
+    /**
      * setup
      *
      * @return void
@@ -79,7 +84,7 @@ class ViewVarsTraitTest extends TestCase
      *
      * @return void
      */
-    public function testSetTwoParamCombind()
+    public function testSetTwoParamCombined()
     {
         $keys = ['one', 'key'];
         $vals = ['two', 'val'];
@@ -183,7 +188,7 @@ class ViewVarsTraitTest extends TestCase
     {
         $this->subject->passedArgs = 'test';
         $this->subject->createView();
-        $result = $this->subject->viewbuilder()->options();
+        $result = $this->subject->viewBuilder()->getOptions();
         $this->assertEquals(['passedArgs' => 'test'], $result);
     }
 
@@ -196,7 +201,7 @@ class ViewVarsTraitTest extends TestCase
     {
         $this->subject->viewClass = 'Json';
         $view = $this->subject->createView();
-        $this->assertInstanceof('Cake\View\JsonView', $view);
+        $this->assertInstanceOf('Cake\View\JsonView', $view);
     }
 
     /**
@@ -206,10 +211,10 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testCreateViewViewBuilder()
     {
-        $this->subject->viewBuilder()->className('Xml');
+        $this->subject->viewBuilder()->setClassName('Xml');
         $this->subject->viewClass = 'Json';
         $view = $this->subject->createView();
-        $this->assertInstanceof('Cake\View\XmlView', $view);
+        $this->assertInstanceOf('Cake\View\XmlView', $view);
     }
 
     /**
@@ -219,10 +224,10 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testCreateViewParameter()
     {
-        $this->subject->viewBuilder()->className('View');
+        $this->subject->viewBuilder()->setClassName('View');
         $this->subject->viewClass = 'Json';
         $view = $this->subject->createView('Xml');
-        $this->assertInstanceof('Cake\View\XmlView', $view);
+        $this->assertInstanceOf('Cake\View\XmlView', $view);
     }
 
     /**


### PR DESCRIPTION
- Start fixing up ViewBuilder API. Also fixed a few wrong doc blocks.
- Remove deprecated method usage in tests. Make typehinting possible which reveals coding errors.
