### PR TITLE
Correctly generate IN clause placeholders.

### DIFF
--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -90,7 +90,7 @@ class ValueBinder
             $this->_bindings[$param] = [
                 'value' => $value,
                 'type' => $type,
-                'placeholder' => $param
+                'placeholder' => substr($param, 1),
             ];
             $placeholders[$k] = $param;
             $this->_bindingsCount++;

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -72,7 +72,7 @@ class QueryLoggerTest extends TestCase
      *
      * @return void
      */
-    public function testStringInterpolation2()
+    public function testStringInterpolationNotNamed()
     {
         $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])
@@ -92,7 +92,7 @@ class QueryLoggerTest extends TestCase
      *
      * @return void
      */
-    public function testStringInterpolation3()
+    public function testStringInterpolationDuplicate()
     {
         $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
             ->setMethods(['_log'])

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1368,6 +1368,26 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Tests that IN clauses generate correct placeholders
+     *
+     * @return void
+     */
+    public function testInClausePlaceholderGeneration()
+    {
+        $this->loadFixtures('Comments');
+        $query = new Query($this->connection);
+        $query->select(['id'])
+            ->from('comments')
+            ->where(['id IN' => [1, 2]])
+            ->sql();
+        $bindings = $query->valueBinder()->bindings();
+        $this->assertArrayHasKey(':c0', $bindings);
+        $this->assertEquals('c0', $bindings[':c0']['placeholder']);
+        $this->assertArrayHasKey(':c1', $bindings);
+        $this->assertEquals('c1', $bindings[':c1']['placeholder']);
+    }
+
+    /**
      * Tests where() with callable types.
      *
      * @return void


### PR DESCRIPTION
This fixes logged queries not having placeholders replaced for IN clause placeholders.

Refs cakephp/debug_kit#445