### PR TITLE
BreadcrumbsHelper::render() returns null with no crumbs

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -235,12 +235,12 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs* To provide attributes in case your separator is divided in two elements.
      * All other properties will be converted as HTML attributes and will replace the *attrs* key in the template.
      * If you use the default for this option (empty), it will not render a separator.
-     * @return string|null The breadcrumbs trail
+     * @return string The breadcrumbs trail
      */
     public function render(array $attributes = [], array $separator = [])
     {
-        if (empty($this->crumbs)) {
-            return null;
+        if (!$this->crumbs) {
+            return '';
         }
 
         $crumbs = $this->crumbs;

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -235,10 +235,14 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs* To provide attributes in case your separator is divided in two elements.
      * All other properties will be converted as HTML attributes and will replace the *attrs* key in the template.
      * If you use the default for this option (empty), it will not render a separator.
-     * @return string The breadcrumbs trail
+     * @return string|null The breadcrumbs trail
      */
     public function render(array $attributes = [], array $separator = [])
     {
+        if (empty($this->crumbs)) {
+            return null;
+        }
+
         $crumbs = $this->crumbs;
         $crumbsCount = count($crumbs);
         $templater = $this->templater();

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -357,6 +357,8 @@ class BreadcrumbsHelperTest extends TestCase
      */
     public function testRender()
     {
+        $this->assertEmpty($this->breadcrumbs->render());
+
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first', 'innerAttrs' => ['data-foo' => 'bar']])
             ->add('Some text', ['controller' => 'tests_apps', 'action' => 'some_method'])

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -357,7 +357,7 @@ class BreadcrumbsHelperTest extends TestCase
      */
     public function testRender()
     {
-        $this->assertEmpty($this->breadcrumbs->render());
+        $this->assertSame('', $this->breadcrumbs->render());
 
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first', 'innerAttrs' => ['data-foo' => 'bar']])


### PR DESCRIPTION
See https://github.com/cakephp/cakephp/issues/9798

The `render()` method should return `null` (or a blank string) if empty (now it returns the string `<ul></ul>`), in other words if you have not added any crumb.