### PR TITLE
3.next - Add more response helper methods

### DIFF
--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1150,6 +1150,7 @@ class Response implements ResponseInterface
      *
      * @param string|null $charset Character set string.
      * @return string Current charset
+     * @deprecated 3.4.0 Use withCharset() instead.
      */
     public function charset($charset = null)
     {
@@ -1160,6 +1161,21 @@ class Response implements ResponseInterface
         $this->_setContentType();
 
         return $this->_charset;
+    }
+
+    /**
+     * Get a new instance with an updated charset.
+     *
+     * @param string $charset Character set string.
+     * @return static
+     */
+    public function withCharset($charset)
+    {
+        $new = clone $this;
+        $new->_charset = $charset;
+        $new->_setContentType();
+
+        return $new;
     }
 
     /**

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1541,6 +1541,7 @@ class Response implements ResponseInterface
      *
      * @param int|null $bytes Number of bytes
      * @return int|null
+     * @deprecated 3.4.0 Use withLength() to set length instead.
      */
     public function length($bytes = null)
     {
@@ -1553,6 +1554,17 @@ class Response implements ResponseInterface
         }
 
         return null;
+    }
+
+    /**
+     * Create a new response with the Content-Length header set.
+     *
+     * @param int|string $bytes Number of bytes
+     * @return static
+     */
+    public function withLength($bytes)
+    {
+        return $this->withHeader('Content-Length', (string)$bytes);
     }
 
     /**

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1166,12 +1166,25 @@ class Response implements ResponseInterface
      * Sets the correct headers to instruct the client to not cache the response
      *
      * @return void
+     * @deprected 3.4.0 Use withDisabledCache() instead.
      */
     public function disableCache()
     {
         $this->_setHeader('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT');
         $this->_setHeader('Last-Modified', gmdate("D, d M Y H:i:s") . " GMT");
         $this->_setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+    }
+
+    /**
+     * Create a new instance with headers to instruct the client to not cache the response
+     *
+     * @return static
+     */
+    public function withDisabledCache()
+    {
+        return $this->withHeader('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT')
+            ->withHeader('Last-Modified', gmdate("D, d M Y H:i:s") . " GMT")
+            ->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
     }
 
     /**

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -472,6 +472,26 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Tests the withDisabledCache method
+     *
+     * @return void
+     */
+    public function testWithDisabledCache()
+    {
+        $response = new Response();
+        $expected = [
+            'Expires' => ['Mon, 26 Jul 1997 05:00:00 GMT'],
+            'Last-Modified' => [gmdate("D, d M Y H:i:s") . " GMT"],
+            'Cache-Control' => ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0'],
+            'Content-Type' => ['text/html; charset=UTF-8'],
+        ];
+        $new = $response->withDisabledCache();
+        $this->assertFalse($response->hasHeader('Expires'), 'Old instance not mutated.');
+
+        $this->assertEquals($expected, $new->getHeaders());
+    }
+
+    /**
      * Tests the cache method
      *
      * @return void

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -131,6 +131,22 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Tests withCharset method
+     *
+     * @return void
+     */
+    public function testWithCharset()
+    {
+        $response = new Response();
+        $this->assertEquals('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+
+        $new = $response->withCharset('iso-8859-1');
+        $this->assertNotContains('iso', $response->getHeaderLine('Content-Type'), 'Old instance not changed');
+
+        $this->assertEquals('text/html; charset=iso-8859-1', $new->getHeaderLine('Content-Type'));
+    }
+
+    /**
      * Tests the statusCode method
      *
      * @expectedException \InvalidArgumentException

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -696,6 +696,23 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Tests settings the content length
+     *
+     * @return void
+     */
+    public function testWithLength()
+    {
+        $response = new Response();
+        $this->assertFalse($response->hasHeader('Content-Length'));
+
+        $new = $response->withLength(100);
+        $this->assertFalse($response->hasHeader('Content-Length'), 'Old instance not modified');
+
+        $this->assertSame('100', $new->getHeaderLine('Content-Length'));
+        $this->assertSame('100', $new->length(), 'new method is compat with old.');
+    }
+
+    /**
      * Tests setting the expiration date
      *
      * @return void


### PR DESCRIPTION
Add a few more immutable flavour helper methods for modifying responses. There are still a few more that need to be built, but I wanted to keep each pull request small and easier to review.

Refs #9636 