### PR TITLE
Revert #9577

### DIFF
--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -139,7 +139,7 @@ class ShellDispatcher {
 		if (!defined('TMP') && !is_dir(APP . 'tmp')) {
 			define('TMP', CAKE_CORE_INCLUDE_PATH . DS . 'Cake' . DS . 'Console' . DS . 'Templates' . DS . 'skel' . DS . 'tmp' . DS);
 		}
-
+		$boot = file_exists(ROOT . DS . APP_DIR . DS . 'Config' . DS . 'bootstrap.php');
 		require CORE_PATH . 'Cake' . DS . 'bootstrap.php';
 
 		if (!file_exists(APP . 'Config' . DS . 'core.php')) {


### PR DESCRIPTION
The change in #9577 breaks bake. Because the removed variable `$boot` is used apparently. See https://github.com/cakephp/cakephp/blob/57bc0f9c457974378b708c79752a4ee1de26c389/lib/Cake/bootstrap.php#L432

### CakepPHP <= 2.9.0

```
C:\var\www\localhost\webroot\demo>Vendor\cakephp\cakephp\app\Console\cake bake project .


Welcome to CakePHP v2.9.0 Console
---------------------------------------------------------------
App : demo
Path: C:\var\www\localhost\webroot\demo\
---------------------------------------------------------------
Skel Directory: C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\Console\Templates\skel
Will be copied to: .
---------------------------------------------------------------
Look okay? (y/n/q)
```

### CakePHP >= 2.9.1
```
C:\var\www\localhost\webroot\demo>Vendor\cakephp\cakephp\app\Console\cake bake project .

PHP Warning:  include(C:\var\www\localhost\webroot\demo\Config\core.php): failed to open stream: No such file or directory in C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\Core\Configure.php on line 72
PHP Stack trace:
PHP   1. {main}() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\app\Console\cake.php:0
PHP   2. ShellDispatcher::run() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\app\Console\cake.php:47
PHP   3. ShellDispatcher->__construct() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\Console\ShellDispatcher.php:65
PHP   4. ShellDispatcher->_initEnvironment() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\Console\ShellDispatcher.php:54
PHP   5. ShellDispatcher->_bootstrap() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\Console\ShellDispatcher.php:100
PHP   6. require() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\Console\ShellDispatcher.php:138
PHP   7. Configure::bootstrap() C:\var\www\localhost\webroot\demo\Vendor\cakephp\cakephp\lib\Cake\bootstrap.php:432
```