### PR TITLE
Defensive check before trying to access empty string.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1073,7 +1073,7 @@ class View implements EventDispatcherInterface
         list($plugin, $name) = $this->pluginSplit($name);
         $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
 
-        if (strpos($name, DIRECTORY_SEPARATOR) === false && $name[0] !== '.') {
+        if (strpos($name, DIRECTORY_SEPARATOR) === false && $name !== '' && $name[0] !== '.') {
             $name = $templatePath . $subDir . $this->_inflectViewFileName($name);
         } elseif (strpos($name, DIRECTORY_SEPARATOR) !== false) {
             if ($name[0] === DIRECTORY_SEPARATOR || $name[1] === ':') {


### PR DESCRIPTION
Fixes

    Notice (8): Uninitialized string offset: 0 [CORE/src/View/View.php, line 1076]

when $name was still empty and

    if (strpos($name, DIRECTORY_SEPARATOR) === false && $name[0] !== '.') {

tries to access the empty string as array (`[0]`).