### PR TITLE
Allow loading and unloading plugins for bootstrap_cli

### DIFF
--- a/src/Shell/Task/LoadTask.php
+++ b/src/Shell/Task/LoadTask.php
@@ -38,9 +38,14 @@ class LoadTask extends Shell
      */
     public function main($plugin = null)
     {
-        $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+        $filename = 'bootstrap';
+        if ($this->params['cli']) {
+            $filename .= '_cli';
+        }
 
-        if (empty($plugin)) {
+        $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . $filename . '.php';
+
+        if (!$plugin) {
             $this->err('You must provide a plugin name in CamelCase format.');
             $this->err('To load an "Example" plugin, run `cake plugin load Example`.');
 
@@ -109,8 +114,13 @@ class LoadTask extends Shell
                     'default' => false,
                 ])
                 ->addOption('autoload', [
-                    'help' => 'Will autoload the plugin using CakePHP. ' .
+                    'help' => 'Will autoload the plugin using CakePHP.' .
                         'Set to true if you are not using composer to autoload your plugin.',
+                    'boolean' => true,
+                    'default' => false,
+                ])
+                ->addOption('cli', [
+                    'help' => 'Use the bootstrap_cli file.',
                     'boolean' => true,
                     'default' => false,
                 ])

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -38,9 +38,14 @@ class UnloadTask extends Shell
      */
     public function main($plugin = null)
     {
-        $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+        $filename = 'bootstrap';
+        if ($this->params['cli']) {
+            $filename .= '_cli';
+        }
 
-        if (empty($plugin)) {
+        $this->bootstrap = ROOT . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . $filename . '.php';
+
+        if (!$plugin) {
             $this->err('You must provide a plugin name in CamelCase format.');
             $this->err('To unload an "Example" plugin, run `cake plugin unload Example`.');
 
@@ -58,7 +63,7 @@ class UnloadTask extends Shell
      */
     protected function _modifyBootstrap($plugin)
     {
-        $finder = "/\nPlugin::load\((.|.\n|\n\s\s|\n\t|)+'$plugin'(.|.\n|)+\);\n/";
+        $finder = "@\nPlugin::load\((.|.\n|\n\s\s|\n\t|)+'$plugin'(.|.\n|)+\);\n@";
 
         $bootstrap = new File($this->bootstrap, false);
         $contents = $bootstrap->read();
@@ -86,9 +91,14 @@ class UnloadTask extends Shell
     {
         $parser = parent::getOptionParser();
 
-        $parser->addArgument('plugin', [
-            'help' => 'Name of the plugin to load.',
-        ]);
+        $parser->addOption('cli', [
+                'help' => 'Use the bootstrap_cli file.',
+                'boolean' => true,
+                'default' => false,
+            ])
+            ->addArgument('plugin', [
+                'help' => 'Name of the plugin to load.',
+            ]);
 
         return $parser;
     }

--- a/src/Shell/Task/UnloadTask.php
+++ b/src/Shell/Task/UnloadTask.php
@@ -66,12 +66,16 @@ class UnloadTask extends Shell
         $finder = "@\nPlugin::load\((.|.\n|\n\s\s|\n\t|)+'$plugin'(.|.\n|)+\);\n@";
 
         $bootstrap = new File($this->bootstrap, false);
-        $contents = $bootstrap->read();
+        $content = $bootstrap->read();
 
-        if (!preg_match("@\n\s*Plugin::loadAll@", $contents)) {
-            $contents = preg_replace($finder, "", $contents);
+        if (!preg_match("@\n\s*Plugin::loadAll@", $content)) {
+            $newContent = preg_replace($finder, "", $content);
 
-            $bootstrap->write($contents);
+            if ($newContent === $content) {
+                return false;
+            }
+
+            $bootstrap->write($newContent);
 
             $this->out('');
             $this->out(sprintf('%s modified', $this->bootstrap));

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -46,6 +46,8 @@ class LoadTaskTest extends TestCase
             ->getMock();
 
         $this->bootstrap = ROOT . DS . 'config' . DS . 'bootstrap.php';
+        $this->bootstrapCli = ROOT . DS . 'config' . DS . 'bootstrap_cli.php';
+        copy($this->bootstrap, $this->bootstrapCli);
 
         $bootstrap = new File($this->bootstrap, false);
         $this->originalBootstrapContent = $bootstrap->read();
@@ -64,6 +66,7 @@ class LoadTaskTest extends TestCase
 
         $bootstrap = new File($this->bootstrap, false);
         $bootstrap->write($this->originalBootstrapContent);
+        unlink($this->bootstrapCli);
     }
 
     /**
@@ -109,6 +112,29 @@ class LoadTaskTest extends TestCase
 
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => true]);";
         $bootstrap = new File($this->bootstrap, false);
+        $this->assertContains($expected, $bootstrap->read());
+    }
+
+    /**
+     * Tests that loading with bootstrap_cli works.
+     *
+     * @return void
+     */
+    public function testLoadBootstrapCli()
+    {
+        $this->Task->params = [
+            'bootstrap' => false,
+            'routes' => false,
+            'autoload' => false,
+            'cli' => true
+        ];
+
+        $action = $this->Task->main('CliPlugin');
+
+        $this->assertTrue($action);
+
+        $expected = "Plugin::load('CliPlugin');";
+        $bootstrap = new File($this->bootstrapCli, false);
         $this->assertContains($expected, $bootstrap->read());
     }
 

--- a/tests/TestCase/Shell/Task/LoadTaskTest.php
+++ b/tests/TestCase/Shell/Task/LoadTaskTest.php
@@ -22,6 +22,10 @@ use Cake\TestSuite\TestCase;
  */
 class LoadTaskTest extends TestCase
 {
+    /**
+     * @var \Cake\Shell\Task\LoadTask|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $Task;
 
     /**
      * setUp method
@@ -73,6 +77,7 @@ class LoadTaskTest extends TestCase
             'bootstrap' => false,
             'routes' => false,
             'autoload' => true,
+            'cli' => false
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -95,6 +100,7 @@ class LoadTaskTest extends TestCase
             'bootstrap' => true,
             'routes' => false,
             'autoload' => true,
+            'cli' => false
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -117,6 +123,7 @@ class LoadTaskTest extends TestCase
             'bootstrap' => false,
             'routes' => true,
             'autoload' => true,
+            'cli' => false
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -139,6 +146,7 @@ class LoadTaskTest extends TestCase
             'bootstrap' => false,
             'routes' => true,
             'autoload' => false,
+            'cli' => false
         ];
 
         $action = $this->Task->main('TestPlugin');
@@ -161,6 +169,7 @@ class LoadTaskTest extends TestCase
             'bootstrap' => false,
             'routes' => false,
             'autoload' => false,
+            'cli' => false
         ];
 
         $action = $this->Task->main('TestPlugin');

--- a/tests/TestCase/Shell/Task/UnloadTaskTest.php
+++ b/tests/TestCase/Shell/Task/UnloadTaskTest.php
@@ -22,6 +22,10 @@ use Cake\TestSuite\TestCase;
  */
 class UnloadTaskTest extends TestCase
 {
+    /**
+     * @var \Cake\Shell\Task\UnloadTask|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $Task;
 
     /**
      * setUp method
@@ -80,6 +84,10 @@ class UnloadTaskTest extends TestCase
         $expected = "Plugin::load('TestPlugin', ['autoload' => true, 'bootstrap' => false, 'routes' => false]);";
         $this->assertContains($expected, $bootstrap->read());
 
+        $this->Task->params = [
+            'cli' => false
+        ];
+
         $action = $this->Task->main('TestPlugin');
 
         $this->assertTrue($action);
@@ -97,6 +105,10 @@ class UnloadTaskTest extends TestCase
     public function testRegularExpressions()
     {
         $bootstrap = new File($this->bootstrap, false);
+
+        $this->Task->params = [
+            'cli' => false
+        ];
 
         //  Plugin::load('TestPlugin', [
         //      'boostrap' => false


### PR DESCRIPTION
Implements https://github.com/cakephp/cakephp/issues/9150

      bin/cake plugin load Foo --cli

Note that the regexp in unload task has to be fixed because / as delimiter won't work with plugin load calls like
    
     Plugin::load('ADmad/HybridAuth', ['routes' => true]);

I found that out when testing it.