### PR TITLE
Fix tests for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ matrix:
 
   allow_failures:
     - php: hhvm
-    - php: 7.1
 
 before_install:
   - if [ $HHVM != 1 && $TRAVIS_PHP_VERSION != 7.* ]; then phpenv config-rm xdebug.ini; fi

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -395,7 +395,7 @@ class TimestampBehaviorTest extends TestCase
         $row = $table->find('all')->where(['id' => $entity->id])->first();
 
         $now = Time::now();
-        $this->assertEquals($now, $row->created);
-        $this->assertEquals($now, $row->updated);
+        $this->assertEquals($now->toDateTimeString(), $row->created->toDateTimeString());
+        $this->assertEquals($now->toDateTimeString(), $row->updated->toDateTimeString());
     }
 }


### PR DESCRIPTION
PHP7.1 has microseconds on all timestamps, so don't include that as part of the compared values. This got tests to pass on PHP 7.1 RC6 for me locally.