### PR TITLE
CacheShellTest uses a TMP subdirectory

### DIFF
--- a/tests/TestCase/Shell/CacheShellTest.php
+++ b/tests/TestCase/Shell/CacheShellTest.php
@@ -34,7 +34,7 @@ class CacheShellTest extends TestCase
         parent::setUp();
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->shell = new CacheShell($this->io);
-        Cache::config('test', ['engine' => 'File', 'path' => TMP . 'cache']);
+        Cache::config('test', ['engine' => 'File', 'path' => CACHE]);
     }
 
     /**

--- a/tests/TestCase/Shell/CacheShellTest.php
+++ b/tests/TestCase/Shell/CacheShellTest.php
@@ -34,7 +34,7 @@ class CacheShellTest extends TestCase
         parent::setUp();
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $this->shell = new CacheShell($this->io);
-        Cache::config('test', ['engine' => 'File', 'path' => TMP]);
+        Cache::config('test', ['engine' => 'File', 'path' => TMP . 'cache']);
     }
 
     /**


### PR DESCRIPTION
It's a bad idea to write tests that delete files in the TMP:

```
$ phpunit tests/TestCase/Shell/CacheShellTest.php
PHPUnit 5.5.4 by Sebastian Bergmann and contributors.

..E.E                                                               5 / 5 (100%)

Time: 33 ms, Memory: 6.00MB

There were 2 errors:

1) Cake\Test\TestCase\Shell\CacheShellTest::testClearValidPrefix
dir(/tmp/pulse-PKdhtXMmr18n/): failed to open dir: Permission denied

/home/mirko/Libs/cakephp/src/Cache/Engine/FileEngine.php:309
/home/mirko/Libs/cakephp/src/Cache/Engine/FileEngine.php:286
/home/mirko/Libs/cakephp/src/Cache/Cache.php:458
/home/mirko/Libs/cakephp/src/Shell/CacheShell.php:77
/home/mirko/Libs/cakephp/tests/TestCase/Shell/CacheShellTest.php:82
/usr/share/php/PHPUnit/TextUI/Command.php:162
/usr/share/php/PHPUnit/TextUI/Command.php:113

2) Cake\Test\TestCase\Shell\CacheShellTest::testClearAll
dir(/tmp/pulse-PKdhtXMmr18n/): failed to open dir: Permission denied

/home/mirko/Libs/cakephp/src/Cache/Engine/FileEngine.php:309
/home/mirko/Libs/cakephp/src/Cache/Engine/FileEngine.php:286
/home/mirko/Libs/cakephp/src/Cache/Cache.php:458
/home/mirko/Libs/cakephp/src/Shell/CacheShell.php:77
/home/mirko/Libs/cakephp/src/Shell/CacheShell.php:101
/home/mirko/Libs/cakephp/tests/TestCase/Shell/CacheShellTest.php:107
/usr/share/php/PHPUnit/TextUI/Command.php:162
/usr/share/php/PHPUnit/TextUI/Command.php:113

ERRORS!
Tests: 5, Assertions: 3, Errors: 2.

```