### PR TITLE
Corrected psr/log version constraint to everything in 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-mbstring": "*",
         "cakephp/chronos": "~1.0",
         "aura/intl": "1.1.*",
-        "psr/log": "1.0",
+        "psr/log": "^1.0",
         "zendframework/zend-diactoros": "~1.0"
     },
     "suggest": {

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -15,6 +15,6 @@
     },
     "require": {
         "cakephp/core": "~3.0",
-        "psr/log": "1.0"
+        "psr/log": "^1.0"
     }
 }


### PR DESCRIPTION
Currently `psr/log` `1.0` is targeted hard with the current version constraints. But there have been [two releases](https://github.com/php-fig/log/releases) to it since `1.0`. Thus making `^1.0` the more logical version constraint allowing those new versions to be used as well.