### PR TITLE
Use View class when rendering error page for nested errors.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -352,7 +352,7 @@ class ExceptionRenderer
         $builder->helpers($helpers, false)
             ->layoutPath('')
             ->templatePath('Error');
-        $view = $this->controller->createView();
+        $view = $this->controller->createView('View');
 
         $this->controller->response->body($view->render($template, 'error'));
         $this->controller->response->type('html');


### PR DESCRIPTION
Fixes #9830