### PR TITLE
3.next - Error middleware cleanup

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -17,7 +17,6 @@ namespace Cake\Error\Middleware;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Http\ResponseTransformer;
 use Cake\Log\Log;
 use Exception;
 
@@ -99,7 +98,7 @@ class ErrorHandlerMiddleware
             $res = $renderer->render();
             $this->logException($request, $exception);
 
-            return ResponseTransformer::toPsr($res);
+            return $res;
         } catch (\Exception $e) {
             $this->logException($request, $e);
 

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -824,7 +824,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertEquals($content, $this->_response->body(), $message);
+        $this->assertEquals($content, (string)$this->_response->getBody(), $message);
     }
 
     /**
@@ -839,7 +839,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertContains($content, (string)$this->_response->body(), $message);
+        $this->assertContains($content, (string)$this->_response->getBody(), $message);
     }
 
     /**
@@ -854,7 +854,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertNotContains($content, (string)$this->_response->body(), $message);
+        $this->assertNotContains($content, (string)$this->_response->getBody(), $message);
     }
 
     /**
@@ -868,7 +868,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertNotEmpty((string)$this->_response->body(), $message);
+        $this->assertNotEmpty((string)$this->_response->getBody(), $message);
     }
     /**
      * Assert response content is empty.
@@ -881,7 +881,7 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertEmpty((string)$this->_response->body(), $message);
+        $this->assertEmpty((string)$this->_response->getBody(), $message);
     }
 
     /**

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -18,12 +18,11 @@ use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\ServerRequestFactory;
 use Cake\Log\Log;
-use Cake\Network\Response as CakeResponse;
+use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
 use LogicException;
 use Psr\Log\LoggerInterface;
 use Zend\Diactoros\Request;
-use Zend\Diactoros\Response;
 
 /**
  * Test for ErrorHandlerMiddleware
@@ -111,13 +110,13 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
         $factory = function ($exception) {
             $this->assertInstanceOf('LogicException', $exception);
-            $cakeResponse = new CakeResponse;
+            $response = new Response;
             $mock = $this->getMockBuilder('StdClass')
                 ->setMethods(['render'])
                 ->getMock();
             $mock->expects($this->once())
                 ->method('render')
-                ->will($this->returnValue($cakeResponse));
+                ->will($this->returnValue($response));
 
             return $mock;
         };
@@ -142,6 +141,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
             throw new \Cake\Network\Exception\NotFoundException('whoops');
         };
         $result = $middleware($request, $response, $next);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $result);
+        $this->assertInstanceOf('Cake\Network\Response', $result);
         $this->assertNotSame($result, $response);
         $this->assertEquals(404, $result->getStatusCode());
         $this->assertContains("was not found", '' . $result->getBody());


### PR DESCRIPTION
Now that Network\Response is PSR7 compliant we don't need to transform it into a Diactoros\Response. This should also fix the IntegrationTestCase errors people have when testing error responses. 