### PR TITLE
Fix CookieComponent erroring on corrupted data.

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -283,8 +283,11 @@ class CookieComponent extends Component {
 			return null;
 		}
 
-		if (!empty($names[1]) && is_array($this->_values[$this->name][$key])) {
-			return Hash::get($this->_values[$this->name][$key], $names[1]);
+		if (!empty($names[1])) {
+			if (is_array($this->_values[$this->name][$key])) {
+				return Hash::get($this->_values[$this->name][$key], $names[1]);
+			}
+			return null;
 		}
 		return $this->_values[$this->name][$key];
 	}
@@ -336,7 +339,7 @@ class CookieComponent extends Component {
 			return;
 		}
 		$names = explode('.', $key, 2);
-		if (isset($this->_values[$this->name][$names[0]])) {
+		if (isset($this->_values[$this->name][$names[0]]) && is_array($this->_values[$this->name][$names[0]])) {
 			$this->_values[$this->name][$names[0]] = Hash::remove($this->_values[$this->name][$names[0]], $names[1]);
 		}
 		$this->_delete('[' . implode('][', $names) . ']');

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -452,6 +452,25 @@ class CookieComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test delete() on corrupted/truncated cookie data.
+ *
+ * @return void
+ */
+	public function testDeleteCorruptedCookieData() {
+		$this->Cookie->type('aes');
+		$this->Cookie->key = sha1('some bad key');
+
+		$data = $this->_implode(array('name' => 'jill', 'age' => 24));
+		// Corrupt the cookie data by slicing some bytes off.
+		$_COOKIE['CakeTestCookie'] = array(
+			'BadData' => substr(Security::encrypt($data, $this->Cookie->key), 0, -5)
+		);
+
+		$this->assertNull($this->Cookie->delete('BadData.name'));
+		$this->assertNull($this->Cookie->read('BadData.name'));
+	}
+
+/**
  * testReadingCookieArray
  *
  * @return void

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -154,6 +154,24 @@ class CookieComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test read operations on corrupted cookie data.
+ *
+ * @return void
+ */
+	public function testReadCorruptedCookieData() {
+		$this->Cookie->type('aes');
+		$this->Cookie->key = sha1('some bad key');
+
+		$data = $this->_implode(array('name' => 'jill', 'age' => 24));
+		// Corrupt the cookie data by slicing some bytes off.
+		$_COOKIE['CakeTestCookie'] = array(
+			'BadData' => substr(Security::encrypt($data, $this->Cookie->key), 0, -5)
+		);
+		$this->assertFalse($this->Cookie->check('BadData.name'), 'Key does not exist');
+		$this->assertNull($this->Cookie->read('BadData.name'), 'Key does not exist');
+	}
+
+/**
  * testReadPlainCookieData
  *
  * @return void
@@ -167,6 +185,19 @@ class CookieComponentTest extends CakeTestCase {
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
 		$this->assertEquals($expected, $data);
+	}
+
+/**
+ * test read array keys from string data.
+ *
+ * @return void
+ */
+	public function testReadNestedDataFromStrings() {
+		$_COOKIE['CakeTestCookie'] = array(
+			'User' => 'bad data'
+		);
+		$this->assertFalse($this->Cookie->check('User.name'), 'No key');
+		$this->assertNull($this->Cookie->read('User.name'), 'No key');
 	}
 
 /**


### PR DESCRIPTION
* Fix CookieComponent emitting errors on corrupted encrypted data.
* Fix reading nested paths out of string data. These scenarios should return `null` as the key does not exist.

Refs #9779, #9784 