### PR TITLE
Flash messages stack and in cases can result in duplicate messages

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -108,11 +108,11 @@ class FlashComponent extends Component
         }
 
         $messages = [];
-        if ($options['clear'] === false) {
+        if (!$options['clear']) {
             $messages = (array)$this->_session->read('Flash.' . $options['key']);
         }
 
-        if ($options['duplicate'] === false) {
+        if (!$options['duplicate']) {
             foreach ($messages as $existingMessage) {
                 if ($existingMessage['message'] === $message) {
                     return;

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -47,7 +47,8 @@ class FlashComponent extends Component
         'key' => 'flash',
         'element' => 'default',
         'params' => [],
-        'clear' => false
+        'clear' => false,
+        'duplicate' => true
     ];
 
     /**
@@ -109,6 +110,14 @@ class FlashComponent extends Component
         $messages = [];
         if ($options['clear'] === false) {
             $messages = (array)$this->_session->read('Flash.' . $options['key']);
+        }
+
+        if ($options['duplicate'] === false) {
+            foreach ($messages as $existingMessage) {
+                if ($existingMessage['message'] == $message) {
+                    return;
+                }
+            }
         }
 
         $messages[] = [

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -114,7 +114,7 @@ class FlashComponent extends Component
 
         if ($options['duplicate'] === false) {
             foreach ($messages as $existingMessage) {
-                if ($existingMessage['message'] == $message) {
+                if ($existingMessage['message'] === $message) {
                     return;
                 }
             }

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -108,6 +108,13 @@ class FlashComponentTest extends TestCase
         ];
         $result = $this->Session->read('Flash.foobar');
         $this->assertEquals($expected, $result);
+
+
+        $this->Flash->config('duplicate', false);
+        $this->Flash->set('This test message should appear once only');
+        $this->Flash->set('This test message should appear once only');
+        $result = array_slice($this->Session->read('Flash.flash'), -2);
+        $this->assertNotEquals($result[0], $result[1]);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -109,12 +109,17 @@ class FlashComponentTest extends TestCase
         $result = $this->Session->read('Flash.foobar');
         $this->assertEquals($expected, $result);
 
+    }
+
+    public function testDuplicateIgnored()
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
 
         $this->Flash->config('duplicate', false);
         $this->Flash->set('This test message should appear once only');
         $this->Flash->set('This test message should appear once only');
-        $result = array_slice($this->Session->read('Flash.flash'), -2);
-        $this->assertNotEquals($result[0], $result[1]);
+        $result = $this->Session->read('Flash.flash');
+        $this->assertCount(1, $result);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -108,7 +108,6 @@ class FlashComponentTest extends TestCase
         ];
         $result = $this->Session->read('Flash.foobar');
         $this->assertEquals($expected, $result);
-
     }
 
     public function testDuplicateIgnored()


### PR DESCRIPTION
Hi, 
I didn't make an issue for this as it seemed too simple. 

Stacking of Flash messages is a really nice feature, but when doing the following:
client_posts_data -> appcontroller_sets_flash -> a_controller_receives_post_and_redirects -> 
appcontroller_sets_flash =
view rendered with duplicate flash messages. 

I added a configuration key "duplicate", when set to false, skips adding messages that are already in the stack. 

