### PR TITLE
Add functions to test response body against regular expressions

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -860,8 +860,8 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the response body matches a given regular expression.
      *
-     * @param string $pattern
-     * @param string $message
+     * @param string $pattern The pattern to compare against.
+     * @param string $message The failure message that will be appended to the generated message.
      * @return void
      */
     public function assertResponseRegExp($pattern, $message = '')
@@ -875,8 +875,8 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the response body does not match a given regular expression.
      *
-     * @param string $pattern
-     * @param string $message
+     * @param string $pattern The pattern to compare against.
+     * @param string $message The failure message that will be appended to the generated message.
      * @return void
      */
     public function assertResponseNotRegExp($pattern, $message = '')

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -858,6 +858,36 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Asserts that the response body matches a given regular expression.
+     *
+     * @param string $pattern
+     * @param string $message
+     * @return void
+     */
+    public function assertResponseRegExp($pattern, $message = '')
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert content. ' . $message);
+        }
+        $this->assertRegExp($pattern, (string)$this->_response->body(), $message);
+    }
+
+    /**
+     * Asserts that the response body does not match a given regular expression.
+     *
+     * @param string $pattern
+     * @param string $message
+     * @return void
+     */
+    public function assertResponseNotRegExp($pattern, $message = '')
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert content. ' . $message);
+        }
+        $this->assertNotRegExp($pattern, (string)$this->_response->body(), $message);
+    }
+
+    /**
      * Assert response content is not empty.
      *
      * @param string $message The failure message that will be appended to the generated message.

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -747,6 +747,32 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test the content regexp assertion.
+     *
+     * @return void
+     */
+    public function testAssertResponseRegExp()
+    {
+        $this->_response = new Response();
+        $this->_response->body('Some content');
+
+        $this->assertResponseRegExp('/cont/');
+    }
+
+    /**
+     * Test the negated content regexp assertion.
+     *
+     * @return void
+     */
+    public function testAssertResponseNotRegExp()
+    {
+        $this->_response = new Response();
+        $this->_response->body('Some content');
+
+        $this->assertResponseNotRegExp('/cant/');
+    }
+
+    /**
      * Test that works in tandem with testEventManagerReset2 to
      * test the EventManager reset.
      *


### PR DESCRIPTION
Came across a situation where testing the response body for a regular expression would be very useful, and it seemed like trivially easy functions to add.