### PR TITLE
Fix default values for datetime columns

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -393,15 +393,15 @@ class MysqlSchema extends BaseSchema
             $out .= ' NULL';
             unset($data['default']);
         }
-        if (isset($data['default']) && !in_array($data['type'], ['timestamp', 'datetime'])) {
-            $out .= ' DEFAULT ' . $this->_driver->schemaValue($data['default']);
-            unset($data['default']);
-        }
         if (isset($data['default']) &&
             in_array($data['type'], ['timestamp', 'datetime']) &&
             strtolower($data['default']) === 'current_timestamp'
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';
+            unset($data['default']);
+        }
+        if (isset($data['default'])) {
+            $out .= ' DEFAULT ' . $this->_driver->schemaValue($data['default']);
             unset($data['default']);
         }
         if (isset($data['comment']) && $data['comment'] !== '') {

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -407,7 +407,14 @@ class SqlserverSchema extends BaseSchema
             unset($data['default']);
         }
 
-        if (isset($data['default']) && $data['type'] !== 'datetime') {
+        if (isset($data['default']) &&
+            in_array($data['type'], ['timestamp', 'datetime']) &&
+            strtolower($data['default']) === 'current_timestamp'
+        ) {
+            $out .= ' DEFAULT CURRENT_TIMESTAMP';
+            unset($data['default']);
+        }
+        if (isset($data['default'])) {
             $default = is_bool($data['default']) ? (int)$data['default'] : $this->_driver->schemaValue($data['default']);
             $out .= ' DEFAULT ' . $default;
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -60,6 +60,10 @@ class MysqlSchemaTest extends TestCase
                 ['type' => 'time', 'length' => null]
             ],
             [
+                'TIMESTAMP',
+                ['type' => 'timestamp', 'length' => null]
+            ],
+            [
                 'TINYINT(1)',
                 ['type' => 'boolean', 'length' => null]
             ],
@@ -652,6 +656,16 @@ SQL;
                 ['type' => 'datetime', 'comment' => 'Created timestamp'],
                 '`created` DATETIME COMMENT \'Created timestamp\''
             ],
+            [
+                'created',
+                ['type' => 'datetime', 'null' => false, 'default' => 'current_timestamp'],
+                '`created` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP'
+            ],
+            [
+                'open_date',
+                ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
+                '`open_date` DATETIME NOT NULL DEFAULT \'2016-12-07 23:04:00\''
+            ],
             // Date & Time
             [
                 'start_date',
@@ -675,9 +689,9 @@ SQL;
                 '`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'
             ],
             [
-                'created',
-                ['type' => 'datetime', 'null' => false, 'default' => 'current_timestamp'],
-                '`created` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP'
+                'open_date',
+                ['type' => 'timestamp', 'null' => false, 'default' => '2016-12-07 23:04:00'],
+                '`open_date` TIMESTAMP NOT NULL DEFAULT \'2016-12-07 23:04:00\''
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -760,6 +760,11 @@ SQL;
                 ['type' => 'datetime'],
                 '"created" TIMESTAMP'
             ],
+            [
+                'open_date',
+                ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
+                '"open_date" TIMESTAMP NOT NULL DEFAULT \'2016-12-07 23:04:00\''
+            ],
             // Date & Time
             [
                 'start_date',

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -566,6 +566,11 @@ SQL;
                 ['type' => 'datetime'],
                 '"created" DATETIME'
             ],
+            [
+                'open_date',
+                ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
+                '"open_date" DATETIME NOT NULL DEFAULT "2016-12-07 23:04:00"'
+            ],
             // Date & Time
             [
                 'start_date',

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -628,6 +628,16 @@ SQL;
                 ['type' => 'datetime'],
                 '[created] DATETIME'
             ],
+            [
+                'open_date',
+                ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
+                '[open_date] DATETIME NOT NULL DEFAULT \'2016-12-07 23:04:00\''
+            ],
+            [
+                'open_date',
+                ['type' => 'datetime', 'null' => false, 'default' => 'current_timestamp'],
+                '[open_date] DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP'
+            ],
             // Date & Time
             [
                 'start_date',


### PR DESCRIPTION
We were generating incorrect SQL for datetime columns that had a default value other than `CURRENT_TIMESTAMP`. I've updated all 4 dialects to be consistent now.

Refs #9850 