### PR TITLE
Improved thrown MissingElementException message

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -505,7 +505,9 @@ class View implements EventDispatcherInterface
             list ($plugin, $name) = pluginSplit($name, true);
             $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
             $file = $plugin . 'Element' . DIRECTORY_SEPARATOR . $name . $this->_ext;
-            throw new MissingElementException($file);
+            throw new MissingElementException(
+                sprintf('Element file "%s" is missing', $file)
+            );
         }
     }
 


### PR DESCRIPTION
Currently, the exception message is just the file location.name ($file). Added some context.