### PR TITLE
Add support for select multiple=checkbox required=required

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -5768,6 +5768,48 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$result = $this->Form->select(
+			'Model.multi_field',
+			array('a>b' => 'first', 'a<b' => 'second', 'a"b' => 'third'),
+			array('multiple' => 'checkbox', 'required' => 'required')
+		);
+		$expected = array(
+			'input' => array(
+				'type' => 'hidden', 'name' => 'data[Model][multi_field]', 'value' => '', 'id' => 'ModelMultiField'
+			),
+			array('div' => array('class' => 'checkbox')),
+			array('input' => array(
+				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
+				'value' => 'a&gt;b', 'id' => 'ModelMultiFieldAB2',
+				'required' => 'required',
+			)),
+			array('label' => array('for' => 'ModelMultiFieldAB2')),
+			'first',
+			'/label',
+			'/div',
+			array('div' => array('class' => 'checkbox')),
+			array('input' => array(
+				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
+				'value' => 'a&lt;b', 'id' => 'ModelMultiFieldAB1',
+				'required' => 'required',
+			)),
+			array('label' => array('for' => 'ModelMultiFieldAB1')),
+			'second',
+			'/label',
+			'/div',
+			array('div' => array('class' => 'checkbox')),
+			array('input' => array(
+				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
+				'value' => 'a&quot;b', 'id' => 'ModelMultiFieldAB',
+				'required' => 'required',
+			)),
+			array('label' => array('for' => 'ModelMultiFieldAB')),
+			'third',
+			'/label',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2159,10 +2159,6 @@ class FormHelper extends AppHelper {
 			$tag = 'selectstart';
 		}
 
-		if ($tag === 'checkboxmultiplestart') {
-			unset($attributes['required']);
-		}
-
 		if (!empty($tag) || isset($template)) {
 			$hasOptions = (count($options) > 0 || $showEmpty);
 			// Secure the field if there are options, or its a multi select.
@@ -2195,19 +2191,23 @@ class FormHelper extends AppHelper {
 			$attributes['id'] = Inflector::camelize($attributes['id']);
 		}
 
+		$selectAttributes = array(
+			'escape' => $escapeOptions,
+			'style' => $style,
+			'name' => $attributes['name'],
+			'value' => $attributes['value'],
+			'class' => $attributes['class'],
+			'id' => $attributes['id'],
+			'disabled' => $attributes['disabled'],
+		);
+		if (!empty($attributes['required'])) {
+			$selectAttributes['required'] = $attributes['required'];
+		}
 		$select = array_merge($select, $this->_selectOptions(
 			array_reverse($options, true),
 			array(),
 			$showParents,
-			array(
-				'escape' => $escapeOptions,
-				'style' => $style,
-				'name' => $attributes['name'],
-				'value' => $attributes['value'],
-				'class' => $attributes['class'],
-				'id' => $attributes['id'],
-				'disabled' => $attributes['disabled'],
-			)
+			$selectAttributes
 		));
 
 		$template = ($style === 'checkbox') ? 'checkboxmultipleend' : 'selectend';
@@ -2887,6 +2887,9 @@ class FormHelper extends AppHelper {
 					}
 
 					if ($attributes['style'] === 'checkbox') {
+						if (!empty($attributes['required'])) {
+							$htmlOptions['required'] = $attributes['required'];
+						}
 						$htmlOptions['value'] = $name;
 
 						$tagName = $attributes['id'] . $this->domIdSuffix($name);


### PR DESCRIPTION
As far as I can tell, this commit `aa60b8791a213acc1a3ffbc5c6d41e5c12e74727` removed at least some support of the required attribute on multiple=checkbox. I am trying to use input type="select" multiple="checkbox" required="required"

My change places the required attribute in place only for that scenario, because for instance I know doing it for all cases in _selectOptions caused tests to fail on, for example:

```
<select>
<option required="required"></option>
<option required="required"></option>
</select>
```

Please let me know if I'm off base here, or why support for that attribute should not be added. Also let me know if I need to change my base, I wasn't sure which was the best place to base 2.x changes from.