### PR TITLE
2.x - Debugger encoding

### DIFF
--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -161,6 +161,7 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function testOutputEncodeDescription() {
+		$this->skipIf(version_compare(PHP_VERSION, '5.4.0', '<'), 'Index errors are different in PHP 5.3');
 		set_error_handler('Debugger::showError');
 		$this->_restoreError = true;
 

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -161,12 +161,11 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function testOutputEncodeDescription() {
-		$this->skipIf(version_compare(PHP_VERSION, '5.4.0', '<'), 'Index errors are different in PHP 5.3');
 		set_error_handler('Debugger::showError');
 		$this->_restoreError = true;
 
 		ob_start();
-		$a = 'things';
+		$a = array();
 		$b = $a['<script>alert(1)</script>'];
 		$result = ob_get_clean();
 

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -156,6 +156,24 @@ class DebuggerTest extends CakeTestCase {
 	}
 
 /**
+ * test encodes error messages
+ *
+ * @return void
+ */
+	public function testOutputEncodeDescription() {
+		set_error_handler('Debugger::showError');
+		$this->_restoreError = true;
+
+		ob_start();
+		$a = 'things';
+		$b = $a['<script>alert(1)</script>'];
+		$result = ob_get_clean();
+
+		$this->assertNotContains('<script>alert(1)', $result);
+		$this->assertContains('&lt;script&gt;alert(1)', $result);
+	}
+
+/**
  * Tests that changes in output formats using Debugger::output() change the templates used.
  *
  * @return void

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -774,6 +774,7 @@ class Debugger {
 
 		if (!empty($tpl['escapeContext'])) {
 			$context = h($context);
+			$data['description'] = h($data['description']);
 		}
 
 		$infoData = compact('code', 'context', 'trace');


### PR DESCRIPTION
Fix missing HTML encoding when error messages contain HTML. This can happen when user data is used as an offset in an array in an unchecked way.

Thanks to Teppei Fukuda for reporting this issue via the responsible security disclosure process.