### PR TITLE
Fix missing HTML encoding in Debugger

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -733,6 +733,7 @@ class Debugger
 
         if (!empty($tpl['escapeContext'])) {
             $context = h($context);
+            $data['description'] = h($data['description']);
         }
 
         $infoData = compact('code', 'context', 'trace');

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -149,6 +149,30 @@ class DebuggerTest extends TestCase
     }
 
     /**
+     * Test outputError with description encoding
+     *
+     * @return void
+     */
+    public function testOutputErrorDescriptionEncoding()
+    {
+        Debugger::outputAs('html');
+
+        ob_start();
+        $debugger = Debugger::getInstance();
+        $debugger->outputError([
+            'error' => 'Notice',
+            'code' => E_NOTICE,
+            'level' => E_NOTICE,
+            'description' => 'Undefined index <script>alert(1)</script>',
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]);
+        $result = ob_get_clean();
+        $this->assertContains('&lt;script&gt;', $result);
+        $this->assertNotContains('<script>', $result);
+    }
+
+    /**
      * Tests that changes in output formats using Debugger::output() change the templates used.
      *
      * @return void


### PR DESCRIPTION
Fix missing HTML encoding when error messages contain HTML. This can happen when user data is used as an offset in an array in an unchecked way.

Thanks to Teppei Fukuda for reporting this issue via the responsible security disclosure process.