### PR TITLE
Let Composer decide which tool path to use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,8 +75,8 @@
             "@cs-check",
             "@test"
         ],
-        "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "test": "vendor/bin/phpunit --colors=always"
+        "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
+        "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
+        "test": "phpunit --colors=always"
     }
 }


### PR DESCRIPTION
https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands

> Note: Composer's bin-dir is pushed on top of the PATH so that binaries of dependencies are easily accessible as CLI commands when writing scripts.

This fixes the execution of these scripts on Windows, where it would throw a ``Command "vendor`" not found`` error otherwise.