### PR TITLE
Make use of built-in message template of MissingElementException

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -505,9 +505,7 @@ class View implements EventDispatcherInterface
             list ($plugin, $name) = pluginSplit($name, true);
             $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
             $file = $plugin . 'Element' . DIRECTORY_SEPARATOR . $name . $this->_ext;
-            throw new MissingElementException(
-                sprintf('Element file "%s" is missing', $file)
-            );
+            throw new MissingElementException([$file]);
         }
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -897,9 +897,10 @@ class ViewTest extends TestCase
     }
 
     /**
-     * Test elementInexistent method
+     * Test loading inexistent view element
      *
      * @expectedException \Cake\View\Exception\MissingElementException
+     * @expectedExceptionMessage Element file "Element\non_existent_element.ctp" is missing
      * @return void
      */
     public function testElementInexistent()
@@ -908,12 +909,13 @@ class ViewTest extends TestCase
     }
 
     /**
-     * Test elementInexistent3 method
+     * Test loading inexistent plugin view element
      *
      * @expectedException \Cake\View\Exception\MissingElementException
+     * @expectedExceptionMessage Element file "test_plugin.Element\plugin_element.ctp" is missing
      * @return void
      */
-    public function testElementInexistent3()
+    public function testElementInexistentPluginElement()
     {
         $this->View->element('test_plugin.plugin_element');
     }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -900,7 +900,7 @@ class ViewTest extends TestCase
      * Test loading inexistent view element
      *
      * @expectedException \Cake\View\Exception\MissingElementException
-     * @expectedExceptionMessage Element file "Element\non_existent_element.ctp" is missing
+     * @expectedExceptionMessageRegExp $Element file \"Element[\\|/]non_existent_element\.ctp\" is missing$
      * @return void
      */
     public function testElementInexistent()
@@ -912,7 +912,7 @@ class ViewTest extends TestCase
      * Test loading inexistent plugin view element
      *
      * @expectedException \Cake\View\Exception\MissingElementException
-     * @expectedExceptionMessage Element file "test_plugin.Element\plugin_element.ctp" is missing
+     * @expectedExceptionMessageRegExp $Element file "test_plugin\.Element[\\|/]plugin_element\.ctp\" is missing$
      * @return void
      */
     public function testElementInexistentPluginElement()


### PR DESCRIPTION
Reverts #9854 as it copy & pasted the built-in message only.

Makes use of:
https://github.com/cakephp/cakephp/blob/3.3.10/src/View/Exception/MissingElementException.php#L28

Improved tests to prevent that, too.
