### PR TITLE
[2.x] Fix TreeBehavior does access property/method via model

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -112,11 +112,12 @@ class TreeBehavior extends ModelBehavior {
  * @return void
  */
 	protected function _setChildrenLevel(Model $Model, $id) {
-		$settings = $Model->Behaviors->Tree->settings[$Model->alias];
+		$settings = $this->settings[$Model->alias];
 		$primaryKey = $Model->primaryKey;
 		$depths = array($id => (int)$Model->data[$Model->alias][$settings['level']]);
 
-		$children = $Model->children(
+		$children = $this->children(
+			$Model,
 			$id,
 			false,
 			array($primaryKey, $settings['parent'], $settings['level']),


### PR DESCRIPTION
This change would allow people to extend TreeBehavior.

Although I didn't add additional test cases, this change is tested by [TreeBehaviorNumberTest::testLevel()](https://github.com/cakephp/cakephp/blob/4ad001b9ca7021b951ceefec89fc28f0b1bdba0f/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php#L1555).
