### PR TITLE
Improve consistency of docblocks

### DIFF
--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -143,6 +143,8 @@ class SecurityComponentTest extends TestCase
     /**
      * setUp method
      *
+     * Initializes environment state.
+     *
      * @return void
      */
     public function setUp()
@@ -169,7 +171,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Tear-down method. Resets environment state.
+     * tearDown method
+     *
+     * Resets environment state.
      *
      * @return void
      */
@@ -195,8 +199,10 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testBlackholeWithBrokenCallback method
+     *
      * Test that requests are still blackholed when controller has incorrect
-     * visibility keyword in the blackhole callback
+     * visibility keyword in the blackhole callback.
      *
      * @expectedException \Cake\Network\Exception\BadRequestException
      * @return void
@@ -221,6 +227,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testExceptionWhenActionIsBlackholeCallback method
+     *
      * Ensure that directly requesting the blackholeCallback as the controller
      * action results in an exception.
      *
@@ -240,7 +248,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test that initialize can set properties.
+     * testConstructorSettingProperties method
+     *
+     * Test that initialize can set properties.
      *
      * @return void
      */
@@ -404,6 +414,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePost method
+     *
      * Simple hash validation test
      *
      * @return void
@@ -426,6 +438,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePostOnGetWithData method
+     *
      * Test that validatePost fires on GET with request data.
      * This could happen when method overriding is used.
      *
@@ -455,6 +469,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePostNoSession method
+     *
      * Test that validatePost fails if you are missing the session information.
      *
      * @return void
@@ -482,6 +498,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePostNoUnlockedInRequestData method
+     *
      * Test that validatePost fails if you are missing unlocked in request data.
      *
      * @return void
@@ -503,7 +521,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test that validatePost fails if any of its required fields are missing.
+     * testValidatePostFormHacking method
+     *
+     * Test that validatePost fails if any of its required fields are missing.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -523,6 +543,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePostObjectDeserialize
+     *
      * Test that objects can't be passed into the serialized string. This was a vector for RFI and LFI
      * attacks. Thanks to Felix Wilhelm
      *
@@ -554,6 +576,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePostIgnoresCsrfToken method
+     *
      * Tests validation post data ignores `_csrfToken`.
      *
      * @return void
@@ -577,7 +601,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Tests validation of checkbox arrays
+     * testValidatePostArray method
+     *
+     * Tests validation of checkbox arrays.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -609,6 +635,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidateIntFieldName method
+     *
      * Tests validation of integer field names.
      *
      * @return void
@@ -682,7 +710,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Tests hash validation for multiple records, including locked fields
+     * testValidatePostComplex method
+     *
+     * Tests hash validation for multiple records, including locked fields.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -714,7 +744,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test ValidatePost with multiple select elements.
+     * testValidatePostMultipleSelect method
+     *
+     * Test ValidatePost with multiple select elements.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -858,7 +890,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test validating post data with posted unlocked fields.
+     * testValidatePostDisabledFieldsInData method
+     *
+     * Test validating post data with posted unlocked fields.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -886,7 +920,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test that missing 'unlocked' input causes failure
+     * testValidatePostFailNoDisabled method
+     *
+     * Test that missing 'unlocked' input causes failure.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -912,7 +948,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test that missing 'debug' input causes failure
+     * testValidatePostFailNoDebug method
+     *
+     * Test that missing 'debug' input causes failure.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -939,7 +977,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test that missing 'debug' input is not the problem when debug mode disabled
+     * testValidatePostFailNoDebugMode method
+     *
+     * Test that missing 'debug' input is not the problem when debug mode disabled.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -965,6 +1005,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidatePostFailDisabledFieldTampering method
+     *
      * Test that validatePost fails when unlocked fields are changed.
      *
      * @return void
@@ -1102,6 +1144,8 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
+     * testValidateNestedNumericSets method
+     *
      * Test that values like Foo.0.1
      *
      * @return void
@@ -1233,7 +1277,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test validatePost with radio buttons
+     * testValidatePostRadio method
+     *
+     * Test validatePost with radio buttons.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1279,7 +1325,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test validatePost uses here() as a hash input.
+     * testValidatePostUrlAsHashInput method
+     *
+     * Test validatePost uses here() as a hash input.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1321,7 +1369,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test that blackhole doesn't delete the _Token session key so repeat data submissions
+     * testBlackHoleNotDeletingSessionInformation method
+     *
+     * Test that blackhole doesn't delete the _Token session key so repeat data submissions
      * stay blackholed.
      *
      * @return void
@@ -1337,7 +1387,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Test generateToken()
+     * testGenerateToken method
+     *
+     * Test generateToken().
      *
      * @return void
      */
@@ -1351,7 +1403,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Test unlocked actions
+     * testUnlockedActions method
+     *
+     * Test unlocked actions.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1368,7 +1422,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Test that debug token format is right
+     * testValidatePostDebugFormat method
+     *
+     * Test that debug token format is right.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1405,7 +1461,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test blackhole will now throw passed exception if debug enabled
+     * testBlackholeThrowsException method
+     *
+     * Test blackhole will now throw passed exception if debug enabled.
      *
      * @expectedException \Cake\Controller\Exception\SecurityException
      * @expectedExceptionMessage error description
@@ -1418,7 +1476,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * test blackhole will throw BadRequest if debug disabled
+     * testBlackholeThrowsBadRequest method
+     *
+     * Test blackhole will throw BadRequest if debug disabled.
      *
      * @return void
      */
@@ -1439,7 +1499,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Test that validatePost fails with tampered fields and explanation
+     * testValidatePostFailTampering method
+     *
+     * Test that validatePost fails with tampered fields and explanation.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1470,7 +1532,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Test that validatePost fails with tampered fields and explanation
+     * testValidatePostFailTamperingMutatedIntoArray method
+     *
+     * Test that validatePost fails with tampered fields and explanation.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1501,7 +1565,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Test that debug token should not be sent if debug is disabled
+     * testValidatePostUnexpectedDebugToken method
+     *
+     * Test that debug token should not be sent if debug is disabled.
      *
      * @return void
      * @triggers Controller.startup $this->Controller
@@ -1532,7 +1598,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Auth required throws exception token not found
+     * testAuthRequiredThrowsExceptionTokenNotFoundPost method
+     *
+     * Auth required throws exception token not found.
      *
      * @return void
      * @expectedException \Cake\Controller\Exception\AuthSecurityException
@@ -1548,7 +1616,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Auth required throws exception token not found in Session
+     * testAuthRequiredThrowsExceptionTokenNotFoundSession method
+     *
+     * Auth required throws exception token not found in Session.
      *
      * @return void
      * @expectedException \Cake\Controller\Exception\AuthSecurityException
@@ -1564,7 +1634,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Auth required throws exception controller not allowed
+     * testAuthRequiredThrowsExceptionControllerNotAllowed method
+     *
+     * Auth required throws exception controller not allowed.
      *
      * @return void
      * @expectedException \Cake\Controller\Exception\AuthSecurityException
@@ -1584,7 +1656,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Auth required throws exception controller not allowed
+     * testAuthRequiredThrowsExceptionActionNotAllowed method
+     *
+     * Auth required throws exception controller not allowed.
      *
      * @return void
      * @expectedException \Cake\Controller\Exception\AuthSecurityException
@@ -1604,7 +1678,9 @@ class SecurityComponentTest extends TestCase
     }
 
     /**
-     * Auth required throws exception controller not allowed
+     * testAuthRequired method
+     *
+     * Auth required throws exception controller not allowed.
      *
      * @return void
      * @triggers Controller.startup $this->Controller

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1580,7 +1580,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test form security with Model.field.0 style inputs
+     * testFormSecurityArrayFields method
+     *
+     * Test form security with Model.field.0 style inputs.
      *
      * @return void
      */
@@ -1599,7 +1601,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormSecurityMultipleInputDisabledFields method
      *
-     * test secure form generation with multiple records and disabled fields.
+     * Test secure form generation with multiple records and disabled fields.
      *
      * @return void
      */
@@ -1918,7 +1920,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test securing inputs with custom name attributes.
+     * testFormSecureWithCustomNameAttribute method
+     *
+     * Test securing inputs with custom name attributes.
      *
      * @return void
      */
@@ -2096,6 +2100,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSecuredInputCustomName method
+     *
      * Test secured inputs with custom names.
      *
      * @return void
@@ -2123,6 +2129,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSecuredInputDuplicate method
+     *
      * Test that a hidden field followed by a visible field
      * undoes the hidden field locking.
      *
@@ -2148,7 +2156,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Tests that the correct keys are added to the field hash index
+     * testFormSecuredFileInput method
+     *
+     * Tests that the correct keys are added to the field hash index.
      *
      * @return void
      */
@@ -2166,7 +2176,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that multiple selects keys are added to field hash
+     * testFormSecuredMultipleSelect method
+     *
+     * Test that multiple selects keys are added to field hash.
      *
      * @return void
      */
@@ -2215,6 +2227,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testFormSecuredAndDisabledNotAssoc method
+     *
      * Test that when disabled is in a list based attribute array it works.
      *
      * @return void
@@ -2237,7 +2251,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that forms with disabled inputs + secured forms leave off the inputs from the form
+     * testFormSecuredAndDisabled method
+     *
+     * Test that forms with disabled inputs + secured forms leave off the inputs from the form
      * hashing.
      *
      * @return void
@@ -2291,7 +2307,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test disableField
+     * testUnlockFieldAddsToList method
+     *
+     * Test disableField.
      *
      * @return void
      */
@@ -2308,7 +2326,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test unlockField removing from fields array.
+     * testUnlockFieldRemovingFromFields method
+     *
+     * Test unlockField removing from fields array.
      *
      * @return void
      */
@@ -2330,7 +2350,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test reset unlockFields, when create new form.
+     * testResetUnlockFields method
+     *
+     * Test reset unlockFields, when create new form.
      *
      * @return void
      */
@@ -2353,6 +2375,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSecuredFormUrlIgnoresHost method
+     *
      * Test that only the path + query elements of a form's URL show up in their hash.
      *
      * @return void
@@ -2382,6 +2406,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSecuredFormUrlHasHtmlAndIdentifer method
+     *
      * Test that URL, HTML and identifer show up in their hashs.
      *
      * @return void
@@ -2420,7 +2446,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test error message display
+     * testErrorMessageDisplay method
+     *
+     * Test error message display.
      *
      * @return void
      */
@@ -2524,6 +2552,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testEmptyErrorValidation method
+     *
      * Test validation errors, when validation message is an empty string.
      *
      * @return void
@@ -2554,6 +2584,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testEmptyInputErrorValidation method
+     *
      * Test validation errors, when calling input() overriding validation message by an empty string.
      *
      * @return void
@@ -2584,7 +2616,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test validation errors, when calling input() overriding validation messages
+     * testInputErrorMessage method
+     *
+     * Test validation errors, when calling input() overriding validation messages.
      *
      * @return void
      */
@@ -2639,7 +2673,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Tests displaying errors for nested entities
+     * testFormValidationAssociated method
+     *
+     * Tests displaying errors for nested entities.
      *
      * @return void
      */
@@ -2657,7 +2693,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormValidationAssociatedSecondLevel method
      *
-     * test form error display with associated model.
+     * Test form error display with associated model.
      *
      * @return void
      */
@@ -2675,7 +2711,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormValidationMultiRecord method
      *
-     * test form error display with multiple records.
+     * Test form error display with multiple records.
      *
      * @return void
      */
@@ -2776,7 +2812,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Tests the input method and passing custom options
+     * testInputCustomization method
+     *
+     * Tests the input method and passing custom options.
      *
      * @return void
      */
@@ -2990,6 +3028,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputWithTemplateFile method
+     *
      * Test that input() accepts a template file.
      *
      * @return void
@@ -3012,7 +3052,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that nested inputs end with brackets
+     * testNestedInputsEndWithBrackets method
+     *
+     * Test that nested inputs end with brackets.
      *
      * @return void
      */
@@ -3035,7 +3077,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test id prefix
+     * testCreateIdPrefix method
+     *
+     * Test id prefix.
      *
      * @return void
      */
@@ -3130,6 +3174,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputZero method
+     *
      * Test that inputs with 0 can be created.
      *
      * @return void
@@ -3151,7 +3197,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test input() with checkbox creation
+     * testInputCheckbox method
+     *
+     * Test input() with checkbox creation.
      *
      * @return void
      */
@@ -3229,7 +3277,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that input() does not create wrapping div and label tag for hidden fields
+     * testInputHidden method
+     *
+     * Test that input() does not create wrapping div and label tag for hidden fields.
      *
      * @return void
      */
@@ -3254,7 +3304,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test form->input() with datetime
+     * testInputDatetime method
+     *
+     * Test form->input() with datetime.
      *
      * @return void
      */
@@ -3294,7 +3346,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test form->input() with datetime with id prefix
+     * testInputDatetimeIdPrefix method
+     *
+     * Test form->input() with datetime with id prefix.
      *
      * @return void
      */
@@ -3337,6 +3391,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputCheckboxWithDisabledElements method
+     *
      * Test generating checkboxes with disabled elements.
      *
      * @return void
@@ -3407,7 +3463,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test input name with leading integer, ensure attributes are generated correctly.
+     * testInputWithLeadingInteger method
+     *
+     * Test input name with leading integer, ensure attributes are generated correctly.
      *
      * @return void
      */
@@ -3421,7 +3479,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test form->input() with select type inputs.
+     * testInputSelectType method
+     *
+     * Test form->input() with select type inputs.
      *
      * @return void
      */
@@ -3582,7 +3642,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that input() and a non standard primary key makes a hidden input by default.
+     * testInputWithNonStandardPrimaryKeyMakesHidden method
+     *
+     * Test that input() and a non standard primary key makes a hidden input by default.
      *
      * @return void
      */
@@ -3612,7 +3674,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that overriding the magic select type widget is possible
+     * testInputOverridingMagicSelectType method
+     *
+     * Test that overriding the magic select type widget is possible.
      *
      * @return void
      */
@@ -3644,7 +3708,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that inferred types do not override developer input
+     * testInputMagicTypeDoesNotOverride method
+     *
+     * Test that inferred types do not override developer input.
      *
      * @return void
      */
@@ -3711,7 +3777,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that magic input() selects are created for type=number
+     * testInputMagicSelectForTypeNumber method
+     *
+     * Test that magic input() selects are created for type=number.
      *
      * @return void
      */
@@ -3746,6 +3814,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInvalidInputTypeOption method
+     *
      * Test invalid 'input' type option to input() function.
      *
      * @expectedException \RuntimeException
@@ -3758,6 +3828,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputMagicSelectChangeToRadio method
+     *
      * Test that magic input() selects can easily be converted into radio types without error.
      *
      * @return void
@@ -3772,7 +3844,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormInputSubmit method
      *
-     * test correct results for form::input() and type submit.
+     * Test correct results for form::input() and type submit.
      *
      * @return void
      */
@@ -3790,7 +3862,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormInputs method
      *
-     * test correct results from form::inputs().
+     * Test correct results from form::inputs().
      *
      * @return void
      */
@@ -3864,6 +3936,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testFormInputs method
+     *
      * Test the inputs() method.
      *
      * @return void
@@ -3946,7 +4020,7 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormInputsBlacklist
+     * testFormInputsBlacklist method
      *
      * @return void
      */
@@ -3995,7 +4069,7 @@ class FormHelperTest extends TestCase
     /**
      * testSelectAsCheckbox method
      *
-     * test multi-select widget with checkbox formatting.
+     * Test multi-select widget with checkbox formatting.
      *
      * @return void
      */
@@ -4049,7 +4123,7 @@ class FormHelperTest extends TestCase
     /**
      * testLabel method
      *
-     * test label generation.
+     * Test label generation.
      *
      * @return void
      */
@@ -4089,6 +4163,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testLabelContainInput method
+     *
      * Test that label() can accept an input with the correct template vars.
      *
      * @return void
@@ -4113,7 +4189,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextbox method
      *
-     * test textbox element generation
+     * Test textbox element generation.
      *
      * @return void
      */
@@ -4133,6 +4209,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testTextBoxDataAndError method
+     *
      * Test that text() hooks up with request data and error fields.
      *
      * @return void
@@ -4172,7 +4250,7 @@ class FormHelperTest extends TestCase
     /**
      * testDefaultValue method
      *
-     * Test default value setting
+     * Test default value setting.
      *
      * @return void
      */
@@ -4223,7 +4301,7 @@ class FormHelperTest extends TestCase
     /**
      * testError method
      *
-     * Test field error generation
+     * Test field error generation.
      *
      * @return void
      */
@@ -4260,7 +4338,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test error translation can use rule names for translating.
+     * testErrorRuleName method
+     *
+     * Test error translation can use rule names for translating.
      *
      * @return void
      */
@@ -4310,6 +4390,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testErrorMessages method
+     *
      * Test error with nested lists.
      *
      * @return void
@@ -4333,7 +4415,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test error() with multiple messages.
+     * testErrorMultipleMessages method
+     *
+     * Test error() with multiple messages.
      *
      * @return void
      */
@@ -4363,7 +4447,7 @@ class FormHelperTest extends TestCase
     /**
      * testPassword method
      *
-     * Test password element generation
+     * Test password element generation.
      *
      * @return void
      */
@@ -4389,7 +4473,7 @@ class FormHelperTest extends TestCase
     /**
      * testRadio method
      *
-     * Test radio element set generation
+     * Test radio element set generation.
      *
      * @return void
      */
@@ -4478,7 +4562,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test default value setting on radio() method
+     * testRadioDefaultValue method
+     *
+     * Test default value setting on radio() method.
      *
      * @return void
      */
@@ -4509,7 +4595,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that input works with radio types
+     * testInputRadio method
+     *
+     * Test that input works with radio types.
      *
      * @return void
      */
@@ -4582,7 +4670,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that radio() works with label = false
+     * testRadioNoLabel method
+     *
+     * Test that radio() works with label = false.
      *
      * @return void
      */
@@ -4598,7 +4688,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test generating radio input inside label ala twitter bootstrap
+     * testRadioInputInsideLabel method
+     *
+     * Test generating radio input inside label ala twitter bootstrap.
      *
      * @return void
      */
@@ -4641,7 +4733,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test disabling the hidden input for radio buttons
+     * testRadioHiddenInputDisabling method
+     *
+     * Test disabling the hidden input for radio buttons.
      *
      * @return void
      */
@@ -4658,9 +4752,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testRadio method
+     * testRadioOutOfRange method
      *
-     * Test radio element set generation
+     * Test radio element set generation.
      *
      * @return void
      */
@@ -4774,6 +4868,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSelectEscapeHtml method
+     *
      * Test that select() escapes HTML.
      *
      * @return void
@@ -4816,7 +4912,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test select() with required and disabled attributes.
+     * testSelectRequired method
+     *
+     * Test select() with required and disabled attributes.
      *
      * @return void
      */
@@ -4852,7 +4950,7 @@ class FormHelperTest extends TestCase
     /**
      * testNestedSelect method
      *
-     * test select element generation with optgroups
+     * Test select element generation with optgroups.
      *
      * @return void
      */
@@ -4892,7 +4990,7 @@ class FormHelperTest extends TestCase
     /**
      * testSelectMultiple method
      *
-     * test generation of multiple select elements
+     * Test generation of multiple select elements.
      *
      * @return void
      */
@@ -4938,6 +5036,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testCheckboxZeroValue method
+     *
      * Test that a checkbox can have 0 for the value and 1 for the hidden input.
      *
      * @return void
@@ -4968,7 +5068,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test generation of habtm select boxes.
+     * testHabtmSelectBox method
+     *
+     * Test generation of habtm select boxes.
      *
      * @return void
      */
@@ -5078,6 +5180,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testErrorsForBelongsToManySelect method
+     *
      * Tests that errors for belongsToMany select fields are being
      * picked up properly.
      *
@@ -5123,7 +5227,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test generation of multi select elements in checkbox format
+     * testSelectMultipleCheckboxes method
+     *
+     * Test generation of multi select elements in checkbox format.
      *
      * @return void
      */
@@ -5249,6 +5355,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSelectMultipleCheckboxRequestData method
+     *
      * Ensure that multiCheckbox reads from the request data.
      *
      * @return void
@@ -5289,7 +5397,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Checks the security hash array generated for multiple-input checkbox elements
+     * testSelectMultipleCheckboxSecurity method
+     *
+     * Checks the security hash array generated for multiple-input checkbox elements.
      *
      * @return void
      */
@@ -5311,6 +5421,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSelectMultipleSecureWithNoOptions method
+     *
      * Multiple select elements should always be secured as they always participate
      * in the POST data.
      *
@@ -5329,6 +5441,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSelectNoSecureWithNoOptions method
+     *
      * When a select box has no options it should not be added to the fields list
      * as it always fail post validation.
      *
@@ -5356,7 +5470,7 @@ class FormHelperTest extends TestCase
     /**
      * testInputMultipleCheckboxes method
      *
-     * test input() resulting in multi select elements being generated.
+     * Test input() resulting in multi select elements being generated.
      *
      * @return void
      */
@@ -5430,7 +5544,7 @@ class FormHelperTest extends TestCase
     /**
      * testSelectHiddenFieldOmission method
      *
-     * test that select() with 'hiddenField' => false omits the hidden field
+     * Test that select() with 'hiddenField' => false omits the hidden field.
      *
      * @return void
      */
@@ -5445,7 +5559,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that select() with multiple = checkbox works with overriding name attribute.
+     * testSelectCheckboxMultipleOverrideName method
+     *
+     * Test that select() with multiple = checkbox works with overriding name attribute.
      *
      * @return void
      */
@@ -5484,6 +5600,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputMultiCheckbox method
+     *
      * Test that input() works with multicheckbox.
      *
      * @return void
@@ -5520,7 +5638,7 @@ class FormHelperTest extends TestCase
     /**
      * testCheckbox method
      *
-     * Test generation of checkboxes
+     * Test generation of checkboxes.
      *
      * @return void
      */
@@ -5552,7 +5670,7 @@ class FormHelperTest extends TestCase
     /**
      * testCheckboxDefaultValue method
      *
-     * Test default value setting on checkbox() method
+     * Test default value setting on checkbox() method.
      *
      * @return void
      */
@@ -5591,6 +5709,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testCheckboxCheckedAndError method
+     *
      * Test checkbox being checked or having errors.
      *
      * @return void
@@ -5627,7 +5747,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test checkbox() with a custom name attribute
+     * testCheckboxCustomNameAttribute method
+     *
+     * Test checkbox() with a custom name attribute.
      *
      * @return void
      */
@@ -5642,6 +5764,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testCheckboxHiddenField method
+     *
      * Test that the hidden input for checkboxes can be omitted or set to a
      * specific value.
      *
@@ -5679,6 +5803,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testTime method
+     *
      * Test the time type.
      *
      * @return void
@@ -5711,6 +5837,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testTimeFormat24NoMeridian method
+     *
      * Ensure that timeFormat=24 has no merdian.
      *
      * @return void.
@@ -5732,6 +5860,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testDate method
+     *
      * Test the date type.
      *
      * @return void
@@ -5753,7 +5883,7 @@ class FormHelperTest extends TestCase
     /**
      * testDateTime method
      *
-     * Test generation of date/time select elements
+     * Test generation of date/time select elements.
      *
      * @return void
      */
@@ -5854,6 +5984,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testDateTimeSecured method
+     *
      * Test that datetime fields are added to protected fields list.
      *
      * @return void
@@ -5882,6 +6014,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testDateTimeSecuredDisabled method
+     *
      * Test that datetime fields are added to protected fields list.
      *
      * @return void
@@ -5900,6 +6034,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testDatetimeEmpty method
+     *
      * Test empty defaulting to true for datetime.
      *
      * @return void
@@ -5956,6 +6092,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testDatetimeMinuteInterval method
+     *
      * Test datetime with interval option.
      *
      * @return void
@@ -6013,7 +6151,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test dateTime with rounding
+     * testDateTimeRounding method
+     *
+     * Test dateTime with rounding.
      *
      * @return void
      */
@@ -6041,7 +6181,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that datetime() and default values work.
+     * testDatetimeWithDefault method
+     *
+     * Test that datetime() and default values work.
      *
      * @return void
      */
@@ -6061,7 +6203,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testDateTime all zeros
+     * testDateTimeAllZeros method
+     *
+     * Test datetime() with all zeros.
      *
      * @return void
      */
@@ -6078,7 +6222,7 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testDateTimeEmptyAsArray
+     * testDateTimeEmptyAsArray method
      *
      * @return void
      */
@@ -6116,7 +6260,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormDateTimeMulti method
      *
-     * test multiple datetime element generation
+     * Test multiple datetime element generation.
      *
      * @return void
      */
@@ -6133,6 +6277,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testDateTimeLabelIdMatchesFirstInput method
+     *
      * When changing the date format, the label should always focus the first select box when
      * clicked.
      *
@@ -6151,7 +6297,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test datetime second=true
+     * testDateTimeSecondOptions method
+     *
+     * Test datetime second=true.
      *
      * @return void
      */
@@ -6172,6 +6320,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testMonth method
+     *
+     * Test generation of a month input.
      *
      * @return void
      */
@@ -6266,6 +6416,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testDay method
+     *
+     * Test generation of a day input.
      *
      * @return void
      */
@@ -6362,6 +6514,8 @@ class FormHelperTest extends TestCase
     /**
      * testMinute method
      *
+     * Test generation of a minute input.
+     *
      * @return void
      */
     public function testMinute()
@@ -6453,6 +6607,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testMeridian method
+     *
      * Test generating an input for the meridian.
      *
      * @return void
@@ -6478,6 +6634,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testHour method
+     *
+     * Test generation of an hour input.
      *
      * @return void
      */
@@ -6578,6 +6736,8 @@ class FormHelperTest extends TestCase
     /**
      * testYear method
      *
+     * Test generation of a year input.
+     *
      * @return void
      */
     public function testYear()
@@ -6642,7 +6802,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test minYear being prior to the unix epoch
+     * testInputDatetimePreEpoch method
+     *
+     * Test minYear being prior to the unix epoch.
      *
      * @return void
      */
@@ -6699,6 +6861,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputDate method
+     *
      * Test that input() accepts the type of date and passes options in.
      *
      * @return void
@@ -6720,6 +6884,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputLabelFalse method
+     *
      * Test the label option being set to false.
      *
      * @return void
@@ -6740,7 +6906,7 @@ class FormHelperTest extends TestCase
      * testInputDateMaxYear method
      *
      * Let's say we want to only allow users born from 2006 to 2008 to register
-     * This being the first signup page, we still don't have any data
+     * This being the first signup page, we still don't have any data.
      *
      * @return void
      */
@@ -6763,6 +6929,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testTextArea method
+     *
+     * Test generation of a textarea input.
      *
      * @return void
      */
@@ -6815,7 +6983,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextAreaWithStupidCharacters method
      *
-     * test text area with non-ascii characters
+     * Test text area with non-ascii characters.
      *
      * @return void
      */
@@ -6835,7 +7003,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test textareas waxlength read from schema.
+     * testTextAreaMaxLength method
+     *
+     * Test textareas maxlength read from schema.
      *
      * @return void
      */
@@ -6874,6 +7044,8 @@ class FormHelperTest extends TestCase
     /**
      * testHiddenField method
      *
+     * Test generation of a hidden input.
+     *
      * @return void
      */
     public function testHiddenField()
@@ -6898,6 +7070,8 @@ class FormHelperTest extends TestCase
     /**
      * testFileUploadField method
      *
+     * Test generation of a file upload input.
+     *
      * @return void
      */
     public function testFileUploadField()
@@ -6920,7 +7094,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test File upload input on a model not used in create();
+     * testFileUploadOnOtherModel method
+     *
+     * Test File upload input on a model not used in create().
      *
      * @return void
      */
@@ -6936,6 +7112,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testButton method
+     *
+     * Test generation of a form button.
      *
      * @return void
      */
@@ -6969,6 +7147,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testButtonUnlockedByDefault method
+     *
      * Test that button() makes unlocked fields by default.
      *
      * @return void
@@ -7007,6 +7187,11 @@ class FormHelperTest extends TestCase
         $this->assertTrue(strpos($result, '<input type="hidden" name="extra" value="value"') !== false);
     }
 
+    /**
+     * testPostButtonMethodType method
+     *
+     * @return void
+     */
     public function testPostButtonMethodType()
     {
         $result = $this->Form->postButton('Hi', '/controller/action', ['method' => 'patch']);
@@ -7023,6 +7208,11 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
+    /**
+     * testPostButtonFormOptions method
+     *
+     * @return void
+     */
     public function testPostButtonFormOptions()
     {
         $result = $this->Form->postButton('Hi', '/controller/action', ['form' => ['class' => 'inline']]);
@@ -7040,6 +7230,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testPostButtonNestedData method
+     *
      * Test using postButton with N dimensional data.
      *
      * @return void
@@ -7060,6 +7252,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSecurePostButton method
+     *
      * Test that postButton adds _Token fields.
      *
      * @return void
@@ -7155,7 +7349,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test the confirm option for postLink()
+     * testPostLinkWithConfirm method
+     *
+     * Test the confirm option for postLink().
      *
      * @return void
      */
@@ -7195,7 +7391,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test postLink() with query string args.
+     * testPostLinkWithQuery method
+     *
+     * Test postLink() with query string args.
      *
      * @return void
      */
@@ -7220,6 +7418,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testPostLinkWithData method
+     *
      * Test postLink with additional data.
      *
      * @return void
@@ -7241,6 +7441,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testPostLinkSecurityHash method
+     *
      * Test that security hashes for postLink include the url.
      *
      * @return void
@@ -7292,6 +7494,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testPostLinkSecurityHashBlockMode method
+     *
      * Test that postLink doesn't modify the fields in the containing form.
      *
      * postLink() calls inside open forms should not modify the field list
@@ -7321,6 +7525,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testPostLinkSecurityHashNoDebugMode method
+     *
      * Test that security does not include debug token if debug is false.
      *
      * @return void
@@ -7362,6 +7568,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testPostLinkNestedData method
+     *
      * Test using postLink with N dimensional data.
      *
      * @return void
@@ -7382,7 +7590,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test creating postLinks after a GET form.
+     * testPostLinkAfterGetForm method
+     *
+     * Test creating postLinks after a GET form.
      *
      * @return void
      */
@@ -7424,7 +7634,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test that postLink adds form tags to view block
+     * testPostLinkFormBuffer method
+     *
+     * Test that postLink adds form tags to view block.
      *
      * @return void
      */
@@ -7549,7 +7761,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test image submit types.
+     * testSubmitImage method
+     *
+     * Test image submit types.
      *
      * @return void
      */
@@ -7589,6 +7803,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSubmitUnlockedByDefault method
+     *
      * Submit buttons should be unlocked by default as there could be multiples, and only one will
      * be submitted at a time.
      *
@@ -7605,6 +7821,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSubmitImageTimestamp method
+     *
      * Test submit image with timestamps.
      *
      * @return void
@@ -7623,7 +7841,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that datetime() works with GET style forms.
+     * testDateTimeWithGetForms method
+     *
+     * Test that datetime() works with GET style forms.
      *
      * @return void
      */
@@ -7788,6 +8008,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testMultiRecordForm method
+     *
      * Test the generation of fields for a multi record form.
      *
      * @return void
@@ -7886,7 +8108,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * test that some html5 inputs + FormHelper::__call() work
+     * testHtml5Inputs method
+     *
+     * Test that some html5 inputs + FormHelper::__call() work.
      *
      * @return void
      */
@@ -7918,6 +8142,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testHtml5InputWithInput method
+     *
      * Test accessing html5 inputs through input().
      *
      * @return void
@@ -7938,6 +8164,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testHtml5InputException method
+     *
      * Test errors when field name is missing.
      *
      * @expectedException \Cake\Core\Exception\Exception
@@ -7949,6 +8177,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testRequiredAttribute method
+     *
      * Tests that formhelper sets required attributes.
      *
      * @return void
@@ -8000,7 +8230,9 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Tests that it is possible to put inputs outside of the label
+     * testInputsNotNested method
+     *
+     * Tests that it is possible to put inputs outside of the label.
      *
      * @return void
      */
@@ -8076,6 +8308,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testInputContainerTemplates method
+     *
      * Test that *Container templates are used by input.
      *
      * @return void
@@ -8127,6 +8361,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testFormGroupTemplates method
+     *
      * Test that *Container templates are used by input.
      *
      * @return void
@@ -8147,6 +8383,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testResetTemplates method
+     *
      * Test resetting templates.
      *
      * @return void
@@ -8161,6 +8399,8 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testContext method
+     *
      * Test the context method.
      *
      * @return void
@@ -8176,7 +8416,7 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testAutoDomId
+     * testAutoDomId method
      *
      * @return void
      */


### PR DESCRIPTION
Just generally improving the consistency of docblocks in these files: method lines, capitalization, punctuation, added a few obvious comments.