### PR TITLE
Changed Table::findOrCreate to deal with null and array values in search

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1526,7 +1526,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $query = $this->find();
             $search($query);
         } elseif (is_array($search)) {
-            $query = $this->find()->where($search);
+            $where = [];
+            foreach ($search as $property => $value) {
+                if (is_array($value)) {
+                    $property = $property . ' in';
+                } else {
+                    $property = $property . ' is';
+                }
+                $where[$property] = $value;
+            }
+            $query = $this->find()->where($where);
         } elseif ($search instanceof Query) {
             $query = $search;
         } else {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5607,13 +5607,13 @@ class TableTest extends TestCase
         $this->assertNotNull($fifthArticle->id);
         $this->assertEquals('Some', $fifthArticle->title);
 
-        $sixtArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function ($article) {
+        $sixthArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function ($article) {
             $this->fail('Should not be called for existing entities.');
         });
-        $this->assertFalse($sixtArticle->isNew());
-        $this->assertNotNull($sixtArticle->id);
-        $this->assertEquals('Some', $sixtArticle->title);
-        $this->assertEquals($fifthArticle->id, $sixtArticle->id);
+        $this->assertFalse($sixthArticle->isNew());
+        $this->assertNotNull($sixthArticle->id);
+        $this->assertEquals('Some', $sixthArticle->title);
+        $this->assertEquals($fifthArticle->id, $sixthArticle->id);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5600,14 +5600,14 @@ class TableTest extends TestCase
         $this->assertEquals($thirdArticle->id, $fourthArticle->id);
 
         // Test if findOrCreate can handle IN statements
-        $fifthArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function($article) {
+        $fifthArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function ($article) {
             $article->title = 'Some';
         });
         $this->assertFalse($fifthArticle->isNew());
         $this->assertNotNull($fifthArticle->id);
         $this->assertEquals('Some', $fifthArticle->title);
 
-        $sixtArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function($article) {
+        $sixtArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function ($article) {
             $this->fail('Should not be called for existing entities.');
         });
         $this->assertFalse($sixtArticle->isNew());

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5584,6 +5584,36 @@ class TableTest extends TestCase
         $this->assertNotNull($secondArticle->id);
         $this->assertEquals('Not there', $secondArticle->title);
         $this->assertEquals($firstArticle->id, $secondArticle->id);
+
+        // Test if findOrCreate is null-safe
+        $thirdArticle = $articles->findOrCreate(['title' => 'Not Existing Article', 'body' => null]);
+        $this->assertFalse($thirdArticle->isNew());
+        $this->assertNotNull($thirdArticle->id);
+        $this->assertEquals('Not Existing Article', $thirdArticle->title);
+        $this->assertNull($thirdArticle->body);
+
+        $fourthArticle = $articles->findOrCreate(['title' => 'Not Existing Article', 'body' => null]);
+        $this->assertFalse($fourthArticle->isNew());
+        $this->assertNotNull($fourthArticle->id);
+        $this->assertEquals('Not Existing Article', $fourthArticle->title);
+        $this->assertNull($fourthArticle->body);
+        $this->assertEquals($thirdArticle->id, $fourthArticle->id);
+
+        // Test if findOrCreate can handle IN statements
+        $fifthArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function($article) {
+            $article->title = 'Some';
+        });
+        $this->assertFalse($fifthArticle->isNew());
+        $this->assertNotNull($fifthArticle->id);
+        $this->assertEquals('Some', $fifthArticle->title);
+
+        $sixtArticle = $articles->findOrCreate(['title' => ['Some', 'Values']], function($article) {
+            $this->fail('Should not be called for existing entities.');
+        });
+        $this->assertFalse($sixtArticle->isNew());
+        $this->assertNotNull($sixtArticle->id);
+        $this->assertEquals('Some', $sixtArticle->title);
+        $this->assertEquals($fifthArticle->id, $sixtArticle->id);
     }
 
     /**


### PR DESCRIPTION
Closes #9857 

Makes the Table::findOrCreate method null-safe and enables checking for array values in $search.