### PR TITLE
Fix a bug in Xml::fromArray()

### DIFF
--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -312,7 +312,7 @@ class Xml {
 				$childNS = $value['xmlns:'];
 				unset($value['xmlns:']);
 			}
-		} elseif (!empty($value) || $value === 0) {
+		} elseif (!empty($value) || $value === 0 || $value === '0') {
 			$childValue = (string)$value;
 		}
 


### PR DESCRIPTION
When creating a XML from an array with elements like this `[ "a" => [ 0 ] ]` or `[ "a" => [ '0' ] ]` it fails and produces XML like this `<a/>` instant of `<a>0</a>`.

The problem is that in PHP `empty('0')` is true, so an exception to this case is needed.

This bug affect all versions of CakePHP.