### PR TITLE
Using variadic instead of func_* functions

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -891,8 +891,8 @@ interface CollectionInterface extends Iterator, JsonSerializable
      *
      * ```
      * $collection = new Collection([1, 2]);
-     * $zipped = $collection->zipWith([3, 4], [5, 6], function () {
-     *   return array_sum(func_get_args());
+     * $zipped = $collection->zipWith([3, 4], [5, 6], function (...$args) {
+     *   return array_sum($args);
      * });
      * $zipped->toList(); // returns [9, 12]; [(1 + 3 + 5), (2 + 4 + 6)]
      * ```

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -443,13 +443,13 @@ class Shell
             array_shift($this->args);
             $this->startup();
 
-            return call_user_func_array([$this, $method], $this->args);
+            return $this->$method(...$this->args);
         }
 
         if ($isMethod && isset($subcommands[$command])) {
             $this->startup();
 
-            return call_user_func_array([$this, $method], $this->args);
+            return $this->$method(...$this->args);
         }
 
         if ($this->hasTask($command) && isset($subcommands[$command])) {
@@ -463,7 +463,7 @@ class Shell
             $this->command = 'main';
             $this->startup();
 
-            return call_user_func_array([$this, 'main'], $this->args);
+            return $this->main(...$this->args);
         }
 
         $this->out($this->OptionParser->help($command));

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -206,7 +206,7 @@ class RequestHandlerComponent extends Component
                 throw new RuntimeException(sprintf("Invalid callable for '%s' type.", $type));
             }
             if ($this->requestedWith($type)) {
-                $input = call_user_func_array([$request, 'input'], $handler);
+                $input = $request->input(...$handler);
                 $request->data = (array)$input;
             }
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -432,7 +432,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
         $callable = [$this, $request->param('action')];
 
-        return call_user_func_array($callable, $request->param('pass'));
+        return $callable(...$request->param('pass'));
     }
 
     /**
@@ -577,7 +577,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         $this->request = $this->request->withParam('action', $action);
 
-        return call_user_func_array([&$this, $action], $args);
+        return $this->$action(...$args);
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -570,13 +570,12 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @param string $action The new action to be 'redirected' to.
      *   Any other parameters passed to this method will be passed as parameters to the new action.
+     * @param array ...$args Arguments passed to the action
      * @return mixed Returns the return value of the called action
      */
-    public function setAction($action)
+    public function setAction($action, ...$args)
     {
         $this->request = $this->request->withParam('action', $action);
-        $args = func_get_args();
-        unset($args[0]);
 
         return call_user_func_array([&$this, $action], $args);
     }

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -456,7 +456,7 @@ trait QueryTrait
         if (in_array($method, get_class_methods($resultSetClass))) {
             $results = $this->all();
 
-            return call_user_func_array([$results, $method], $arguments);
+            return $results->$method(...$arguments);
         }
         throw new BadMethodCallException(
             sprintf('Unknown method "%s"', $method)

--- a/src/Event/Decorator/AbstractDecorator.php
+++ b/src/Event/Decorator/AbstractDecorator.php
@@ -66,17 +66,7 @@ abstract class AbstractDecorator
     protected function _call($args)
     {
         $callable = $this->_callable;
-        switch (count($args)) {
-            case 0:
-                return $callable();
-            case 1:
-                return $callable($args[0]);
-            case 2:
-                return $callable($args[0], $args[1]);
-            case 3:
-                return $callable($args[0], $args[1], $args[2]);
-            default:
-                return call_user_func_array($callable, $args);
-        }
+
+        return $callable(...$args);
     }
 }

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -403,9 +403,6 @@ class EventManager
     /**
      * Calls a listener.
      *
-     * Direct callback invocation is up to 30% faster than using call_user_func_array.
-     * Optimize the common cases to provide improved performance.
-     *
      * @param callable $listener The listener to trigger.
      * @param \Cake\Event\Event $event Event instance.
      * @return mixed The result of the $listener function.
@@ -413,24 +410,8 @@ class EventManager
     protected function _callListener(callable $listener, Event $event)
     {
         $data = $event->data();
-        $length = count($data);
-        if ($length) {
-            $data = array_values($data);
-        }
-        switch ($length) {
-            case 0:
-                return $listener($event);
-            case 1:
-                return $listener($event, $data[0]);
-            case 2:
-                return $listener($event, $data[0], $data[1]);
-            case 3:
-                return $listener($event, $data[0], $data[1], $data[2]);
-            default:
-                array_unshift($data, $event);
 
-                return call_user_func_array($listener, $data);
-        }
+        return $listener($event, ...array_values($data));
     }
 
     /**

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -238,11 +238,11 @@ class Folder
         }
 
         if ($dirs) {
-            $dirs = call_user_func_array('array_merge', $dirs);
+            $dirs = array_merge(...array_values($dirs));
         }
 
         if ($files) {
-            $files = call_user_func_array('array_merge', $files);
+            $files = array_merge(...array_values($files));
         }
 
         return [$dirs, $files];

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -634,17 +634,16 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|array $type The type of request you want to check. If an array
      *   this method will return true if the request matches any type.
+     * @param array ...$args List of arguments
      * @return bool Whether or not the request is the type you are checking.
      */
-    public function is($type)
+    public function is($type, ...$args)
     {
         if (is_array($type)) {
             $result = array_map([$this, 'is'], $type);
 
             return count(array_filter($result)) > 0;
         }
-        $args = func_get_args();
-        array_shift($args);
 
         $type = strtolower($type);
         if (!isset(static::$_detectors[$type])) {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -587,7 +587,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
 
             array_unshift($params, $type);
 
-            return call_user_func_array([$this, 'is'], $params);
+            return $this->is(...$params);
         }
         throw new BadMethodCallException(sprintf('Method %s does not exist', $name));
     }
@@ -683,7 +683,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         if (is_callable($detect)) {
             array_unshift($args, $this);
 
-            return call_user_func_array($detect, $args);
+            return $detect(...$args);
         }
         if (isset($detect['env']) && $this->_environmentDetector($detect)) {
             return true;

--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -19,17 +19,17 @@ if (!function_exists('__')) {
      * Returns a translated string if one is found; Otherwise, the submitted message.
      *
      * @param string $singular Text to translate.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null The translated text, or null if invalid.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__
      */
-    function __($singular, $args = null)
+    function __($singular, ...$args)
     {
         if (!$singular) {
             return null;
         }
 
-        $arguments = func_num_args() === 2 ? (array)$args : array_slice(func_get_args(), 1);
+        $arguments = func_num_args() === 2 ? (array)$args[0] : $args;
 
         return I18n::translator()->translate($singular, $arguments);
     }
@@ -44,17 +44,17 @@ if (!function_exists('__n')) {
      * @param string $singular Singular text to translate.
      * @param string $plural Plural text.
      * @param int $count Count.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Plural form of translated string, or null if invalid.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__n
      */
-    function __n($singular, $plural, $count, $args = null)
+    function __n($singular, $plural, $count, ...$args)
     {
         if (!$singular) {
             return null;
         }
 
-        $arguments = func_num_args() === 4 ? (array)$args : array_slice(func_get_args(), 3);
+        $arguments = func_num_args() === 4 ? (array)$args[0] : $args;
 
         return I18n::translator()->translate(
             $plural,
@@ -70,16 +70,16 @@ if (!function_exists('__d')) {
      *
      * @param string $domain Domain.
      * @param string $msg String to translate.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__d
      */
-    function __d($domain, $msg, $args = null)
+    function __d($domain, $msg, ...$args)
     {
         if (!$msg) {
             return null;
         }
-        $arguments = func_num_args() === 3 ? (array)$args : array_slice(func_get_args(), 2);
+        $arguments = func_num_args() === 3 ? (array)$args[0] : $args;
 
         return I18n::translator($domain)->translate($msg, $arguments);
     }
@@ -96,17 +96,17 @@ if (!function_exists('__dn')) {
      * @param string $singular Singular string to translate.
      * @param string $plural Plural.
      * @param int $count Count.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Plural form of translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dn
      */
-    function __dn($domain, $singular, $plural, $count, $args = null)
+    function __dn($domain, $singular, $plural, $count, ...$args)
     {
         if (!$singular) {
             return null;
         }
 
-        $arguments = func_num_args() === 5 ? (array)$args : array_slice(func_get_args(), 4);
+        $arguments = func_num_args() === 5 ? (array)$args[0] : $args;
 
         return I18n::translator($domain)->translate(
             $plural,
@@ -124,17 +124,17 @@ if (!function_exists('__x')) {
      *
      * @param string $context Context of the text.
      * @param string $singular Text to translate.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__x
      */
-    function __x($context, $singular, $args = null)
+    function __x($context, $singular, ...$args)
     {
         if (!$singular) {
             return null;
         }
 
-        $arguments = func_num_args() === 3 ? (array)$args : array_slice(func_get_args(), 2);
+        $arguments = func_num_args() === 3 ? (array)$args[0] : $args;
 
         return I18n::translator()->translate($singular, ['_context' => $context] + $arguments);
     }
@@ -152,17 +152,17 @@ if (!function_exists('__xn')) {
      * @param string $singular Singular text to translate.
      * @param string $plural Plural text.
      * @param int $count Count.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Plural form of translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__xn
      */
-    function __xn($context, $singular, $plural, $count, $args = null)
+    function __xn($context, $singular, $plural, $count, ...$args)
     {
         if (!$singular) {
             return null;
         }
 
-        $arguments = func_num_args() === 5 ? (array)$args : array_slice(func_get_args(), 4);
+        $arguments = func_num_args() === 5 ? (array)$args[0] : $args;
 
         return I18n::translator()->translate(
             $plural,
@@ -181,17 +181,17 @@ if (!function_exists('__dx')) {
      * @param string $domain Domain.
      * @param string $context Context of the text.
      * @param string $msg String to translate.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dx
      */
-    function __dx($domain, $context, $msg, $args = null)
+    function __dx($domain, $context, $msg, ...$args)
     {
         if (!$msg) {
             return null;
         }
 
-        $arguments = func_num_args() === 4 ? (array)$args : array_slice(func_get_args(), 3);
+        $arguments = func_num_args() === 4 ? (array)$args[0] : $args;
 
         return I18n::translator($domain)->translate(
             $msg,
@@ -213,17 +213,17 @@ if (!function_exists('__dxn')) {
      * @param string $singular Singular text to translate.
      * @param string $plural Plural text.
      * @param int $count Count.
-     * @param mixed $args Array with arguments or multiple arguments in function.
+     * @param array ...$args Array with arguments or multiple arguments in function.
      * @return string|null Plural form of translated string.
      * @link http://book.cakephp.org/3.0/en/core-libraries/global-constants-and-functions.html#__dxn
      */
-    function __dxn($domain, $context, $singular, $plural, $count, $args = null)
+    function __dxn($domain, $context, $singular, $plural, $count, ...$args)
     {
         if (!$singular) {
             return null;
         }
 
-        $arguments = func_num_args() === 6 ? (array)$args : array_slice(func_get_args(), 5);
+        $arguments = func_num_args() === 6 ? (array)$args[0] : $args;
 
         return I18n::translator($domain)->translate(
             $plural,

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -202,7 +202,7 @@ abstract class Mailer implements EventListenerInterface
      */
     public function __call($method, $args)
     {
-        call_user_func_array([$this->_email, $method], $args);
+        $this->_email->$method(...$args);
 
         return $this;
     }
@@ -245,7 +245,7 @@ abstract class Mailer implements EventListenerInterface
             $this->_email->viewBuilder()->template($action);
         }
 
-        call_user_func_array([$this, $action], $args);
+        $this->$action(...$args);
 
         $result = $this->_email->send();
         $this->reset();

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1309,7 +1309,7 @@ abstract class Association
      */
     public function __call($method, $argument)
     {
-        return call_user_func_array([$this->target(), $method], $argument);
+        return $this->target()->$method(...$argument);
     }
 
     /**

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -163,6 +163,6 @@ class TableRegistry
      */
     public static function __callStatic($name, $arguments)
     {
-        return call_user_func_array([static::locator(), $name], $arguments);
+        return static::locator()->$name(...$arguments);
     }
 }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -928,7 +928,7 @@ class Validation
             E_USER_DEPRECATED
         );
 
-        return call_user_func_array([$object, $method], [$check, $args]);
+        return $object->$method($check, $args);
     }
 
     /**

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -135,7 +135,7 @@ class ValidationRule
 
         if ($this->_pass) {
             $args = array_merge([$value], $this->_pass, [$context]);
-            $result = call_user_func_array($callable, $args);
+            $result = $callable(...$args);
         } else {
             $result = $callable($value, $context);
         }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1553,8 +1553,8 @@ class CollectionTest extends TestCase
         });
         $this->assertEquals([3, 8], $zipped->toList());
 
-        $zipped = $collection->zipWith([3, 4], [5, 6, 7], function () {
-            return array_sum(func_get_args());
+        $zipped = $collection->zipWith([3, 4], [5, 6, 7], function (...$args) {
+            return array_sum($args);
         });
         $this->assertEquals([9, 12], $zipped->toList());
     }

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -307,7 +307,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
 
-        call_user_func_array(['Cake\Routing\Router', 'extensions'], [$extensions, false]);
+        Router::extensions($extensions, false);
     }
 
     /**


### PR DESCRIPTION
This PR replaces the use of some of the `func_*` functions by variadic. It reduces the function calls and consequently improves the performance, especially on the `EventManager`, which is very often called.

The signature of few methods were changed, so people extending the method can get a strict error from php, but the functionality is the same. I don't think people extend it very often, but I can revert it to the original. These methods are not often called.
PS: The i18n functions won't matter for this BC since they need to be completely redefined instead of extended.