### PR TITLE
Dont use magic numbers for success code either.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -49,6 +49,13 @@ class Shell
     const CODE_ERROR = 1;
 
     /**
+     * Default success code
+     *
+     * @var int
+     */
+    const CODE_SUCCESS = 0;
+
+    /**
      * Output constant making verbose shells.
      *
      * @var int
@@ -881,7 +888,7 @@ class Shell
      * @throws \Cake\Console\Exception\StopException
      * @return void
      */
-    protected function _stop($status = 0)
+    protected function _stop($status = self::CODE_SUCCESS)
     {
         throw new StopException('Halting error reached', $status);
     }

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -184,10 +184,10 @@ class ShellDispatcher
             return $e->getCode();
         }
         if ($result === null || $result === true) {
-            return 0;
+            return Shell::CODE_SUCCESS;
         }
 
-        return 1;
+        return Shell::CODE_ERROR;
     }
 
     /**

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Console;
 
+use Cake\Console\Shell;
 use Cake\Console\ShellDispatcher;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -204,12 +205,12 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['mock_with_main'];
         $result = $dispatcher->dispatch();
-        $this->assertSame(0, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
         $this->assertEquals([], $dispatcher->args);
 
         $dispatcher->args = ['mock_with_main'];
         $result = $dispatcher->dispatch();
-        $this->assertSame(0, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
         $this->assertEquals([], $dispatcher->args);
     }
 
@@ -237,7 +238,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['mock_without_main', 'initdb'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(0, $result);
+        $this->assertEquals(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -264,7 +265,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['example'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(0, $result);
+        $this->assertEquals(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -291,7 +292,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['Example'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(0, $result);
+        $this->assertEquals(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -318,7 +319,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['sample'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(0, $result);
+        $this->assertEquals(Shell::CODE_SUCCESS, $result);
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -67,7 +67,7 @@ class ShellTestShell extends Shell
      * @param int $status
      * @return void
      */
-    protected function _stop($status = 0)
+    protected function _stop($status = Shell::CODE_SUCCESS)
     {
         $this->stopped = $status;
     }
@@ -991,7 +991,7 @@ TEXT;
      *
      * @return void
      */
-    public function testRunCommandBaseclassMethod()
+    public function testRunCommandBaseClassMethod()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
             ->setMethods(['startup', 'getOptionParser', 'out', 'hr'])


### PR DESCRIPTION
A while back I fixed the error code, but I forgot to also include the success code.
This rectifies it for clarity.

One should never use the magic numbers here directly as from looking at it they are exactly the opposite of what you would intuitively expect (and their boolean representation).

Resolves also some of the initial confusion that lead to
https://github.com/cakephp/docs/pull/4532