### PR TITLE
Don't populate Controller::$helpers in RequestHandler.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -594,15 +594,6 @@ class RequestHandlerComponent extends Component
         if ($response->getMimeType($type)) {
             $this->respondAs($type, $options);
         }
-
-        $helper = ucfirst($type);
-
-        if (!in_array($helper, $controller->helpers) && empty($controller->helpers[$helper])) {
-            $helperClass = App::className($helper, 'View/Helper', 'Helper');
-            if ($helperClass !== false) {
-                $controller->helpers[] = $helper;
-            }
-        }
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -627,9 +627,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testRenderAs()
     {
-        $this->assertFalse(in_array('Rss', $this->Controller->helpers));
         $this->RequestHandler->renderAs($this->Controller, 'rss');
-        $this->assertTrue(in_array('Rss', $this->Controller->helpers));
 
         $this->Controller->viewBuilder()->templatePath('request_handler_test\\rss');
         $this->RequestHandler->renderAs($this->Controller, 'js');


### PR DESCRIPTION
Since app/core helpers can be autoloaded with defaults upon use in templates,
pre-populating Controller::$helpers is not required.
