### PR TITLE
Allow SecurityComponent to check fields that are optional, but must have a specific value if included

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -506,6 +506,7 @@ class SecurityComponent extends Component
         if (empty($data['_Token']['optional'])) {
             return [];
         }
+
         return json_decode(urldecode($data['_Token']['optional']), true);
     }
 
@@ -519,6 +520,7 @@ class SecurityComponent extends Component
     {
         $optional = $this->_optional($data);
         ksort($optional, SORT_STRING);
+
         return implode('|', array_keys($optional));
     }
 

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -328,7 +328,7 @@ class SecurityComponent extends Component
         $hashParts = $this->_hashParts($controller);
         $check = Security::hash(implode('', $hashParts), 'sha1');
 
-        if ($token === $check) {
+        if ($token === $check && $this->_validateOptionalFields($controller, $token)) {
             return true;
         }
 
@@ -386,11 +386,13 @@ class SecurityComponent extends Component
     {
         $fieldList = $this->_fieldsList($controller->request->data);
         $unlocked = $this->_sortedUnlocked($controller->request->data);
+        $optional = $this->_sortedOptional($controller->request->data);
 
         return [
             $controller->request->here(),
             serialize($fieldList),
             $unlocked,
+            $optional,
             Security::salt()
         ];
     }
@@ -406,6 +408,7 @@ class SecurityComponent extends Component
         $locked = '';
         $token = urldecode($check['_Token']['fields']);
         $unlocked = $this->_unlocked($check);
+        $optional = $this->_optional($check);
 
         if (strpos($token, ':')) {
             list($token, $locked) = explode(':', $token, 2);
@@ -438,6 +441,7 @@ class SecurityComponent extends Component
 
         foreach ($fieldList as $i => $key) {
             $isLocked = (is_array($locked) && in_array($key, $locked));
+            $isOptional = (array_key_exists($key, $optional));
 
             if (!empty($unlockedFields)) {
                 foreach ($unlockedFields as $off) {
@@ -450,7 +454,7 @@ class SecurityComponent extends Component
                 }
             }
 
-            if ($isUnlocked || $isLocked) {
+            if ($isUnlocked || $isLocked || $isOptional) {
                 unset($fieldList[$i]);
                 if ($isLocked) {
                     $lockedFields[$key] = $fields[$key];
@@ -492,6 +496,56 @@ class SecurityComponent extends Component
     }
 
     /**
+     * Get the optional string
+     *
+     * @param array $data Data array
+     * @return array Optional fields and the values they must have if present
+     */
+    protected function _optional(array $data)
+    {
+        if (empty($data['_Token']['optional'])) {
+            return [];
+        }
+        return json_decode(urldecode($data['_Token']['optional']), true);
+    }
+
+    /**
+     * Get the sorted optional string
+     *
+     * @param array $data Data array
+     * @return string
+     */
+    protected function _sortedOptional($data)
+    {
+        $optional = $this->_optional($data);
+        ksort($optional, SORT_STRING);
+        return implode('|', array_keys($optional));
+    }
+
+    /**
+     * Validate that any optional fields are either not present or the value matches
+     *
+     * @param \Cake\Controller\Controller $controller Instantiating controller
+     * @param string $token The token string used in hashing
+     * @return bool true if no errors are found
+     */
+    protected function _validateOptionalFields(Controller $controller, $token)
+    {
+        $fields = $controller->request->data;
+        unset($fields['_Token'], $fields['_csrfToken']);
+        $fields = Hash::flatten($fields);
+        $optional = $this->_optional($controller->request->data);
+        foreach ($optional as $name => $hash) {
+            if (array_key_exists($name, $fields)) {
+                if ($hash !== Security::hash($name . $fields[$name] . $token, 'sha1')) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Create a message for humans to understand why Security token is not matching
      *
      * @param \Cake\Controller\Controller $controller Instantiating controller
@@ -502,7 +556,7 @@ class SecurityComponent extends Component
     {
         $messages = [];
         $expectedParts = json_decode(urldecode($controller->request->data['_Token']['debug']), true);
-        if (!is_array($expectedParts) || count($expectedParts) !== 3) {
+        if (!is_array($expectedParts) || count($expectedParts) !== 4) {
             return 'Invalid security debug token.';
         }
         $expectedUrl = Hash::get($expectedParts, 0);
@@ -535,7 +589,17 @@ class SecurityComponent extends Component
             'Missing unlocked field: \'%s\''
         );
 
-        $messages = array_merge($messages, $fieldsMessages, $unlockFieldsMessages);
+        $optionalFields = Hash::get($expectedParts, 3);
+        $check = $controller->request->data;
+        unset($check['_Token'], $check['_csrfToken']);
+        $fields = Hash::flatten($check);
+        $optionalMessages = $this->_matchOptionalFields(
+            $fields,
+            $optionalFields,
+            'Tampered optional field \'%s\' in POST data (expected value \'%s\' but found \'%s\')'
+        );
+
+        $messages = array_merge($messages, $fieldsMessages, $unlockFieldsMessages, $optionalMessages);
 
         return implode(', ', $messages);
     }
@@ -664,5 +728,24 @@ class SecurityComponent extends Component
         }
 
         return sprintf($missingMessage, implode(', ', $expectedFieldNames));
+    }
+
+    /**
+     * Generate array of messages for the optional fields in POST data
+     *
+     * @param array $dataFields Fields array, containing the POST data fields
+     * @param array $optionalFields Fields array, containing the optional fields and their required values, if present
+     * @param string $stringKeyMessage Message string if tampered found in data fields indexed by string (protected)
+     * @return array Error messages
+     */
+    protected function _matchOptionalFields($dataFields, $optionalFields, $stringKeyMessage)
+    {
+        $messages = [];
+        foreach ((array)$optionalFields as $key => $value) {
+            if (isset($dataFields[$key]) && $value !== $dataFields[$key]) {
+                $messages[] = sprintf($stringKeyMessage, $key, $value, $dataFields[$key]);
+            }
+        }
+        return $messages;
     }
 }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -544,6 +544,7 @@ class SecurityComponent extends Component
                 }
             }
         }
+
         return true;
     }
 
@@ -748,6 +749,7 @@ class SecurityComponent extends Component
                 $messages[] = sprintf($stringKeyMessage, $key, $value, $dataFields[$key]);
             }
         }
+
         return $messages;
     }
 }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -732,6 +732,7 @@ class FormHelper extends Helper
             if (!in_array($field, $this->fields)) {
                 if ($value !== null) {
                     $this->fields[$field] = $value;
+
                     return;
                 }
                 if (isset($this->fields[$field]) && $value === null) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -159,6 +159,14 @@ class FormHelper extends Helper
     const SECURE_SKIP = 'skip';
 
     /**
+     * Constant used internally to indicate optional fields in the
+     * securing process.
+     *
+     * @var string
+     */
+    const SECURE_OPTIONAL = 'optional';
+
+    /**
      * Defines the type of form being created. Set by FormHelper::create().
      *
      * @var string
@@ -174,6 +182,17 @@ class FormHelper extends Helper
      * @var array
      */
     protected $_unlockedFields = [];
+
+    /**
+     * An array of field names that have been excluded from
+     * the Token hash used by SecurityComponent's validatePost method,
+     * but which must maintain their values *if* they are present
+     *
+     * @see FormHelper::_secure()
+     * @see SecurityComponent::validatePost()
+     * @var array
+     */
+    protected $_optionalFields = [];
 
     /**
      * Registry for input widgets.
@@ -434,7 +453,7 @@ class FormHelper extends Helper
 
         $htmlAttributes += $options;
 
-        $this->fields = [];
+        $this->fields = $this->_optionalFields = [];
         if ($this->requestType !== 'get') {
             $append .= $this->_csrfField();
         }
@@ -550,6 +569,7 @@ class FormHelper extends Helper
             $out .= $this->secure($this->fields, $secureAttributes);
             $this->fields = [];
             $this->_unlockedFields = [];
+            $this->_optionalFields = [];
         }
         $out .= $this->formatTemplate('formEnd', []);
 
@@ -591,7 +611,8 @@ class FormHelper extends Helper
         $tokenData = $this->_buildFieldToken(
             $this->_lastAction,
             $fields,
-            $this->_unlockedFields
+            $this->_unlockedFields,
+            $this->_optionalFields
         );
         $tokenFields = array_merge($secureAttributes, [
             'value' => $tokenData['fields'],
@@ -601,12 +622,19 @@ class FormHelper extends Helper
             'value' => $tokenData['unlocked'],
         ]);
         $out .= $this->hidden('_Token.unlocked', $tokenUnlocked);
+        if (!empty($tokenData['optional'])) {
+            $tokenOptional = array_merge($secureAttributes, [
+                'value' => $tokenData['optional'],
+            ]);
+            $out .= $this->hidden('_Token.optional', $tokenOptional);
+        }
         if ($debugSecurity) {
             $tokenDebug = array_merge($secureAttributes, [
                 'value' => urlencode(json_encode([
                     $this->_lastAction,
                     $fields,
-                    $this->_unlockedFields
+                    $this->_unlockedFields,
+                    $this->_optionalFields
                 ])),
             ]);
             $out .= $this->hidden('_Token.debug', $tokenDebug);
@@ -641,10 +669,37 @@ class FormHelper extends Helper
     }
 
     /**
+     * Add to or get the list of fields that are currently optional.
+     * Optional fields are not included in the field hash used by SecurityComponent,
+     * but their value must be retained *if* the field is present in the data.
+     * Making a field optional once its been added to the list of secured fields will
+     * remove it from the list of fields.
+     *
+     * @param string|null $name The dot separated name for the field.
+     * @param string|null $value The value required for the field.
+     * @return mixed Either null, or the list of fields.
+     * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#working-with-securitycomponent
+     */
+    public function optionalField($name = null, $value = null)
+    {
+        if ($name === null) {
+            return $this->_optionalFields;
+        }
+        $this->_optionalFields[$name] = $value;
+
+        // Optional fields must also not be locked
+        $index = array_search($name, $this->fields);
+        if ($index !== false) {
+            unset($this->fields[$index]);
+        }
+        unset($this->fields[$name]);
+    }
+
+    /**
      * Determine which fields of a form should be used for hash.
      * Populates $this->fields
      *
-     * @param bool $lock Whether this field should be part of the validation
+     * @param mixed $lock Whether this field should be part of the validation
      *   or excluded as part of the unlockedFields.
      * @param string|array $field Reference to field to be secured. Can be dot
      *   separated string to indicate nesting or array of fieldname parts.
@@ -671,10 +726,13 @@ class FormHelper extends Helper
         $field = implode('.', $field);
         $field = preg_replace('/(\.\d+)+$/', '', $field);
 
-        if ($lock) {
+        if ($lock === self::SECURE_OPTIONAL) {
+            $this->optionalField($field, $value);
+        } elseif ($lock) {
             if (!in_array($field, $this->fields)) {
                 if ($value !== null) {
-                    return $this->fields[$field] = $value;
+                    $this->fields[$field] = $value;
+                    return;
                 }
                 if (isset($this->fields[$field]) && $value === null) {
                     unset($this->fields[$field]);
@@ -1597,8 +1655,8 @@ class FormHelper extends Helper
             ['secure' => static::SECURE_SKIP]
         ));
 
-        if ($secure === true) {
-            $this->_secure(true, $this->_secureFieldName($options['name']), (string)$options['val']);
+        if ($secure === true || $secure === self::SECURE_OPTIONAL) {
+            $this->_secure($secure, $this->_secureFieldName($options['name']), (string)$options['val']);
         }
 
         $options['type'] = 'hidden';
@@ -2666,7 +2724,11 @@ class FormHelper extends Helper
         $out = $widget->render($data, $this->context());
         if (isset($data['name']) && $secure !== null && $secure !== self::SECURE_SKIP) {
             foreach ($widget->secureFields($data) as $field) {
-                $this->_secure($secure, $this->_secureFieldName($field));
+                if ($secure === self::SECURE_OPTIONAL && array_key_exists('val', $data)) {
+                    $this->_secure($secure, $this->_secureFieldName($field), $data['val']);
+                } else {
+                    $this->_secure($secure, $this->_secureFieldName($field));
+                }
             }
         }
 

--- a/src/View/Helper/SecureFieldTokenTrait.php
+++ b/src/View/Helper/SecureFieldTokenTrait.php
@@ -30,9 +30,11 @@ trait SecureFieldTokenTrait
      *    generating the hash.
      * @param array $unlockedFields The list of fields that are excluded from
      *    field validation.
+     * @param array $optionalFields The list of fields that are not required
+     *    but must retain their value if they are present.
      * @return array The token data.
      */
-    protected function _buildFieldToken($url, $fields, $unlockedFields = [])
+    protected function _buildFieldToken($url, $fields, $unlockedFields = [], $optionalFields = [])
     {
         $locked = [];
         foreach ($fields as $key => $value) {
@@ -46,23 +48,33 @@ trait SecureFieldTokenTrait
         }
 
         sort($unlockedFields, SORT_STRING);
+        ksort($optionalFields, SORT_STRING);
         sort($fields, SORT_STRING);
         ksort($locked, SORT_STRING);
         $fields += $locked;
 
-        $locked = implode(array_keys($locked), '|');
-        $unlocked = implode($unlockedFields, '|');
+        $locked = implode('|', array_keys($locked));
+        $unlocked = implode('|', $unlockedFields);
+        $optional = implode('|', array_keys($optionalFields));
         $hashParts = [
             $url,
             serialize($fields),
             $unlocked,
+            $optional,
             Security::salt()
         ];
         $fields = Security::hash(implode('', $hashParts), 'sha1');
 
+        foreach ($optionalFields as $name => $value) {
+            // Include more than just the value and salt in the string we hash,
+            // because that would be easily subject to replay attacks.
+            $optionalFields[$name] = Security::hash($name . $value . $fields, 'sha1');
+        }
+
         return [
             'fields' => urlencode($fields . ':' . $locked),
             'unlocked' => urlencode($unlocked),
+            'optional' => empty($optionalFields) ? '' : urlencode(json_encode($optionalFields)),
         ];
     }
 }


### PR DESCRIPTION
See issue #7848 for discussion. This PR supersedes PR #8558, which got messed up due to incorrect git management, and was never checked with v3.3.

I haven't yet made any changes in the documentation, pending acceptance of general implementation of this PR. If these changes look good but you want the docs updated before merging, let me know and I can take care of that.