### PR TITLE
Use self instead of $this for IDE compatibility.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -169,7 +169,7 @@ class ConsoleOptionParser
      *
      * @param string|null $command The command name this parser is for. The command name is used for generating help.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
-     * @return $this
+     * @return self
      */
     public static function create($command, $defaultOptions = true)
     {
@@ -197,7 +197,7 @@ class ConsoleOptionParser
      *
      * @param array $spec The spec to build the OptionParser with.
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
-     * @return $this
+     * @return self
      */
     public static function buildFromArray($spec, $defaultOptions = true)
     {
@@ -244,7 +244,7 @@ class ConsoleOptionParser
      * Get or set the command name for shell/task.
      *
      * @param array|\Cake\Console\ConsoleOptionParser $spec ConsoleOptionParser or spec to merge with.
-     * @return $this
+     * @return self
      */
     public function merge($spec)
     {
@@ -274,7 +274,7 @@ class ConsoleOptionParser
      * Sets the command name for shell/task.
      *
      * @param string $text The text to set.
-     * @return $this
+     * @return self
      */
     public function setCommand($text)
     {
@@ -298,7 +298,7 @@ class ConsoleOptionParser
      *
      * @deprecated 3.4.0 Use setCommand()/getCommand() instead.
      * @param string|null $text The text to set, or null if you want to read
-     * @return string|$this If reading, the value of the command. If setting $this will be returned.
+     * @return string|self If reading, the value of the command. If setting $this will be returned.
      */
     public function command($text = null)
     {
@@ -314,7 +314,7 @@ class ConsoleOptionParser
      *
      * @param string|array $text The text to set. If an array the
      *   text will be imploded with "\n".
-     * @return $this
+     * @return self
      */
     public function setDescription($text)
     {
@@ -342,7 +342,7 @@ class ConsoleOptionParser
      * @deprecated 3.4.0 Use setDescription()/getDescription() instead.
      * @param string|array|null $text The text to set, or null if you want to read. If an array the
      *   text will be imploded with "\n".
-     * @return string|$this If reading, the value of the description. If setting $this will be returned.
+     * @return string|self If reading, the value of the description. If setting $this will be returned.
      */
     public function description($text = null)
     {
@@ -359,7 +359,7 @@ class ConsoleOptionParser
      *
      * @param string|array $text The text to set. If an array the text will
      *   be imploded with "\n".
-     * @return $this
+     * @return self
      */
     public function setEpilog($text)
     {
@@ -388,7 +388,7 @@ class ConsoleOptionParser
      * @deprecated 3.4.0 Use setEpilog()/getEpilog() instead.
      * @param string|array|null $text Text when setting or null when reading. If an array the text will
      *   be imploded with "\n".
-     * @return string|$this If reading, the value of the epilog. If setting $this will be returned.
+     * @return string|self If reading, the value of the epilog. If setting $this will be returned.
      */
     public function epilog($text = null)
     {
@@ -419,7 +419,7 @@ class ConsoleOptionParser
      * @param \Cake\Console\ConsoleInputOption|string $name The long name you want to the value to be parsed out as when options are parsed.
      *   Will also accept an instance of ConsoleInputOption
      * @param array $options An array of parameters that define the behavior of the option
-     * @return $this
+     * @return self
      */
     public function addOption($name, array $options = [])
     {
@@ -452,7 +452,7 @@ class ConsoleOptionParser
      * Remove an option from the option parser.
      *
      * @param string $name The option name to remove.
-     * @return $this
+     * @return self
      */
     public function removeOption($name)
     {
@@ -477,7 +477,7 @@ class ConsoleOptionParser
      * @param \Cake\Console\ConsoleInputArgument|string $name The name of the argument.
      *   Will also accept an instance of ConsoleInputArgument.
      * @param array $params Parameters for the argument, see above.
-     * @return $this
+     * @return self
      */
     public function addArgument($name, array $params = [])
     {
@@ -517,7 +517,7 @@ class ConsoleOptionParser
      *
      * @param array $args Array of arguments to add.
      * @see \Cake\Console\ConsoleOptionParser::addArgument()
-     * @return $this
+     * @return self
      */
     public function addArguments(array $args)
     {
@@ -538,7 +538,7 @@ class ConsoleOptionParser
      *
      * @param array $options Array of options to add.
      * @see \Cake\Console\ConsoleOptionParser::addOption()
-     * @return $this
+     * @return self
      */
     public function addOptions(array $options)
     {
@@ -566,7 +566,7 @@ class ConsoleOptionParser
      *
      * @param \Cake\Console\ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
      * @param array $options Array of params, see above.
-     * @return $this
+     * @return self
      */
     public function addSubcommand($name, array $options = [])
     {
@@ -592,7 +592,7 @@ class ConsoleOptionParser
      * Remove a subcommand from the option parser.
      *
      * @param string $name The subcommand name to remove.
-     * @return $this
+     * @return self
      */
     public function removeSubcommand($name)
     {
@@ -605,7 +605,7 @@ class ConsoleOptionParser
      * Add multiple subcommands at once.
      *
      * @param array $commands Array of subcommands.
-     * @return $this
+     * @return self
      */
     public function addSubcommands(array $commands)
     {

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -124,7 +124,7 @@ trait InstanceConfigTrait
      *
      * @param string|array $key The key to set, or a complete array of configs.
      * @param mixed|null $value The value to set.
-     * @return $this The object itself.
+     * @return self The object itself.
      */
     public function configShallow($key, $value = null)
     {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -150,7 +150,7 @@ class Connection implements ConnectionInterface
      * @param array $config Config for a new driver.
      * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
      * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
-     * @return $this
+     * @return self
      */
     public function setDriver($driver, $config = [])
     {
@@ -335,7 +335,7 @@ class Connection implements ConnectionInterface
      * Sets a Schema\Collection object for this connection.
      *
      * @param \Cake\Database\Schema\Collection $collection The schema collection object
-     * @return $this
+     * @return self
      */
     public function setSchemaCollection(SchemaCollection $collection)
     {
@@ -522,7 +522,7 @@ class Connection implements ConnectionInterface
      * `$connection->enableSavePoints(false)` Disables usage of savepoints and returns false
      *
      * @param bool $enable Whether or not save points should be used.
-     * @return $this
+     * @return self
      */
     public function enableSavePoints($enable)
     {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -301,7 +301,7 @@ abstract class Driver
      * in queries.
      *
      * @param bool $enable Whether to enable auto quoting
-     * @return $this
+     * @return self
      */
     public function enableAutoQuoting($enable)
     {

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -83,7 +83,7 @@ class CaseExpression implements ExpressionInterface
      * @param array|\Cake\Database\ExpressionInterface $values associative array of values of each condition
      * @param array $types associative array of types to be associated with the values
      *
-     * @return $this
+     * @return self
      */
     public function add($conditions = [], $values = [], $types = [])
     {

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -77,7 +77,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      * Sets the name of the SQL function to be invoke in this expression.
      *
      * @param string $name The name of the function
-     * @return $this
+     * @return self
      */
     public function setName($name)
     {
@@ -102,7 +102,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      *
      * @deprecated 3.4.0 Use setName()/getName() instead.
      * @param string|null $name The name of the function
-     * @return string|$this
+     * @return string|self
      */
     public function name($name = null)
     {
@@ -122,7 +122,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      * passed arguments
      * @param bool $prepend Whether to prepend or append to the list of arguments
      * @see \Cake\Database\Expression\FunctionExpression::__construct() for more details.
-     * @return $this
+     * @return self
      */
     public function add($params, $types = [], $prepend = false)
     {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -77,7 +77,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $conjunction Value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
-     * @return $this
+     * @return self
      */
     public function setConjunction($conjunction)
     {
@@ -103,7 +103,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @deprecated 3.4.0 Use setConjunction()/getConjunction() instead.
      * @param string|null $conjunction value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
-     * @return string|$this
+     * @return string|self
      */
     public function tieWith($conjunction = null)
     {
@@ -119,7 +119,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string|null $conjunction value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
-     * @return string|$this
+     * @return string|self
      * @deprecated 3.2.0 Use tieWith() instead
      */
     public function type($conjunction = null)
@@ -145,7 +145,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @see \Cake\Database\Query::where() for examples on conditions
-     * @return $this
+     * @return self
      */
     public function add($conditions, $types = [])
     {
@@ -174,7 +174,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string|null $type the type name for $value as configured using the Type map.
      * If it is suffixed with "[]" and the value is an array then multiple placeholders
      * will be created, one per each value in the array.
-     * @return $this
+     * @return self
      */
     public function eq($field, $value, $type = null)
     {
@@ -193,7 +193,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string|null $type the type name for $value as configured using the Type map.
      * If it is suffixed with "[]" and the value is an array then multiple placeholders
      * will be created, one per each value in the array.
-     * @return $this
+     * @return self
      */
     public function notEq($field, $value, $type = null)
     {
@@ -210,7 +210,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function gt($field, $value, $type = null)
     {
@@ -227,7 +227,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function lt($field, $value, $type = null)
     {
@@ -244,7 +244,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function gte($field, $value, $type = null)
     {
@@ -261,7 +261,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function lte($field, $value, $type = null)
     {
@@ -277,7 +277,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string|\Cake\Database\ExpressionInterface $field database field to be
      * tested for null
-     * @return $this
+     * @return self
      */
     public function isNull($field)
     {
@@ -293,7 +293,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string|\Cake\Database\ExpressionInterface $field database field to be
      * tested for not null
-     * @return $this
+     * @return self
      */
     public function isNotNull($field)
     {
@@ -310,7 +310,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function like($field, $value, $type = null)
     {
@@ -327,7 +327,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function notLike($field, $value, $type = null)
     {
@@ -345,7 +345,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param string|array $values the value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function in($field, $values, $type = null)
     {
@@ -368,7 +368,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * passed in $conditions. If there are more $values than $conditions, the last $value is used as the `ELSE` value
      * @param array $types associative array of types to be associated with the values
      * passed in $values
-     * @return $this
+     * @return self
      */
     public function addCase($conditions, $values = [], $types = [])
     {
@@ -382,7 +382,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field Database field to be compared against value
      * @param array $values the value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function notIn($field, $values, $type = null)
     {
@@ -400,7 +400,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Adds a new condition to the expression object in the form "EXISTS (...)".
      *
      * @param \Cake\Database\ExpressionInterface $query the inner query
-     * @return $this
+     * @return self
      */
     public function exists(ExpressionInterface $query)
     {
@@ -411,7 +411,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Adds a new condition to the expression object in the form "NOT EXISTS (...)".
      *
      * @param \Cake\Database\ExpressionInterface $query the inner query
-     * @return $this
+     * @return self
      */
     public function notExists(ExpressionInterface $query)
     {
@@ -426,7 +426,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param mixed $from The initial value of the range.
      * @param mixed $to The ending value in the comparison range.
      * @param string|null $type the type name for $value as configured using the Type map.
-     * @return $this
+     * @return self
      */
     public function between($field, $from, $to, $type = null)
     {
@@ -484,7 +484,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string|array|\Cake\Database\Expression\QueryExpression $conditions to be added and negated
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
-     * @return $this
+     * @return self
      */
     public function not($conditions, $types = [])
     {
@@ -508,7 +508,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param string $left Left join condition field name.
      * @param string $right Right join condition field name.
-     * @return $this
+     * @return self
      */
     public function equalFields($left, $right)
     {
@@ -589,7 +589,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * modified part is stored.
      *
      * @param callable $callable The callable to apply to each part.
-     * @return $this
+     * @return self
      */
     public function iterateParts(callable $callable)
     {

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -106,7 +106,7 @@ class ValuesExpression implements ExpressionInterface
      * Sets the columns to be inserted.
      *
      * @param array $cols Array with columns to be inserted.
-     * @return $this
+     * @return self
      */
     public function setColumns($cols)
     {
@@ -132,7 +132,7 @@ class ValuesExpression implements ExpressionInterface
      *
      * @deprecated 3.4.0 Use setColumns()/getColumns() instead.
      * @param array|null $cols Array with columns to be inserted.
-     * @return array|$this
+     * @return array|self
      */
     public function columns($cols = null)
     {
@@ -168,7 +168,7 @@ class ValuesExpression implements ExpressionInterface
      * Sets the values to be inserted.
      *
      * @param array $values Array with values to be inserted.
-     * @return $this
+     * @return self
      */
     public function setValues($values)
     {
@@ -197,7 +197,7 @@ class ValuesExpression implements ExpressionInterface
      * the currently stored values
      *
      * @param array|null $values Array with values to be inserted.
-     * @return array|$this
+     * @return array|self
      */
     public function values($values = null)
     {
@@ -213,7 +213,7 @@ class ValuesExpression implements ExpressionInterface
      * to insert records in the table.
      *
      * @param \Cake\Database\Query $query The query to set
-     * @return $this
+     * @return self
      */
     public function setQuery(Query $query)
     {
@@ -240,7 +240,7 @@ class ValuesExpression implements ExpressionInterface
      *
      * @deprecated 3.4.0 Use setQuery()/getQuery() instead.
      * @param \Cake\Database\Query|null $query The query to set
-     * @return \Cake\Database\Query|null|$this
+     * @return \Cake\Database\Query|null|self
      */
     public function query(Query $query = null)
     {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -150,7 +150,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Sets the connection instance to be used for executing and transforming this query.
      *
      * @param \Cake\Datasource\ConnectionInterface $connection Connection instance
-     * @return $this
+     * @return self
      */
     public function setConnection($connection)
     {
@@ -176,7 +176,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @deprecated 3.4.0 Use setConnection()/getConnection() instead.
      * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance
-     * @return $this|\Cake\Datasource\ConnectionInterface
+     * @return self|\Cake\Datasource\ConnectionInterface
      */
     public function connection($connection = null)
     {
@@ -270,7 +270,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param callable $visitor A function or callable to be executed for each part
      * @param array $parts The query clauses to traverse
-     * @return $this
+     * @return self
      */
     public function traverse(callable $visitor, array $parts = [])
     {
@@ -315,7 +315,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param array|\Cake\Database\ExpressionInterface|string|callable $fields fields to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not
-     * @return $this
+     * @return self
      */
     public function select($fields = [], $overwrite = false)
     {
@@ -365,7 +365,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array|\Cake\Database\ExpressionInterface|string|bool $on Enable/disable distinct class
      * or list of fields to be filtered on
      * @param bool $overwrite whether to reset fields with passed list or not
-     * @return $this
+     * @return self
      */
     public function distinct($on = [], $overwrite = false)
     {
@@ -409,7 +409,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param array|\Cake\Database\ExpressionInterface|string $modifiers modifiers to be applied to the query
      * @param bool $overwrite whether to reset order with field list or not
-     * @return $this
+     * @return self
      */
     public function modifier($modifiers, $overwrite = false)
     {
@@ -449,7 +449,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *  passed as an array of strings, array of expression objects, or a single string. See
      *  the examples above for the valid call types.
      * @param bool $overwrite whether to reset tables with passed list or not
-     * @return $this
+     * @return self
      */
     public function from($tables = [], $overwrite = false)
     {
@@ -556,7 +556,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset joins with passed list or not
      * @see \Cake\Database\Type
-     * @return $this
+     * @return self
      */
     public function join($tables = null, $types = [], $overwrite = false)
     {
@@ -604,7 +604,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * the join clauses.
      *
      * @param string $name The alias/name of the join to remove.
-     * @return $this
+     * @return self
      */
     public function removeJoin($name)
     {
@@ -649,7 +649,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
      * values to the corresponding database representation.
-     * @return $this
+     * @return self
      */
     public function leftJoin($table, $conditions = [], $types = [])
     {
@@ -669,7 +669,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
      * values to the corresponding database representation.
-     * @return $this
+     * @return self
      */
     public function rightJoin($table, $conditions = [], $types = [])
     {
@@ -689,7 +689,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
      * values to the corresponding database representation.
-     * @return $this
+     * @return self
      */
     public function innerJoin($table, $conditions = [], $types = [])
     {
@@ -835,7 +835,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Type
      * @see \Cake\Database\Expression\QueryExpression
-     * @return $this
+     * @return self
      */
     public function where($conditions = null, $types = [], $overwrite = false)
     {
@@ -901,7 +901,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::where()
      * @see \Cake\Database\Type
-     * @return $this
+     * @return self
      */
     public function andWhere($conditions, $types = [])
     {
@@ -964,7 +964,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::where()
      * @see \Cake\Database\Type
-     * @return $this
+     * @return self
      */
     public function orWhere($conditions, $types = [])
     {
@@ -1018,7 +1018,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param array|\Cake\Database\ExpressionInterface|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
-     * @return $this
+     * @return self
      */
     public function order($fields, $overwrite = false)
     {
@@ -1046,7 +1046,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param string|\Cake\Database\Expression\QueryExpression $field The field to order on.
      * @param bool $overwrite Whether or not to reset the order clauses.
-     * @return $this
+     * @return self
      */
     public function orderAsc($field, $overwrite = false)
     {
@@ -1073,7 +1073,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param string|\Cake\Database\Expression\QueryExpression $field The field to order on.
      * @param bool $overwrite Whether or not to reset the order clauses.
-     * @return $this
+     * @return self
      */
     public function orderDesc($field, $overwrite = false)
     {
@@ -1112,7 +1112,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param array|\Cake\Database\ExpressionInterface|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset fields with passed list or not
-     * @return $this
+     * @return self
      */
     public function group($fields, $overwrite = false)
     {
@@ -1140,7 +1140,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Query::where()
-     * @return $this
+     * @return self
      */
     public function having($conditions = null, $types = [], $overwrite = false)
     {
@@ -1161,7 +1161,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions The AND conditions for HAVING.
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::andWhere()
-     * @return $this
+     * @return self
      */
     public function andHaving($conditions, $types = [])
     {
@@ -1179,7 +1179,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param string|array|\Cake\Database\ExpressionInterface|callable $conditions The OR conditions for HAVING.
      * @param array $types associative array of type names used to bind values to query.
      * @see \Cake\Database\Query::orWhere()
-     * @return $this
+     * @return self
      */
     public function orHaving($conditions, $types = [])
     {
@@ -1200,7 +1200,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param int $num The page number you want.
      * @param int|null $limit The number of rows you want in the page. If null
      *  the current limit clause will be used.
-     * @return $this
+     * @return self
      */
     public function page($num, $limit = null)
     {
@@ -1235,7 +1235,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ```
      *
      * @param int|\Cake\Database\ExpressionInterface $num number of records to be returned
-     * @return $this
+     * @return self
      */
     public function limit($num)
     {
@@ -1264,7 +1264,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ```
      *
      * @param int|\Cake\Database\ExpressionInterface $num number of records to be skipped
-     * @return $this
+     * @return self
      */
     public function offset($num)
     {
@@ -1299,7 +1299,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param string|\Cake\Database\Query $query full SQL query to be used in UNION operator
      * @param bool $overwrite whether to reset the list of queries to be operated or not
-     * @return $this
+     * @return self
      */
     public function union($query, $overwrite = false)
     {
@@ -1334,7 +1334,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param string|\Cake\Database\Query $query full SQL query to be used in UNION operator
      * @param bool $overwrite whether to reset the list of queries to be operated or not
-     * @return $this
+     * @return self
      */
     public function unionAll($query, $overwrite = false)
     {
@@ -1358,7 +1358,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param array $columns The columns to insert into.
      * @param array $types A map between columns & their datatypes.
-     * @return $this
+     * @return self
      * @throws \RuntimeException When there are 0 columns.
      */
     public function insert(array $columns, array $types = [])
@@ -1382,7 +1382,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Set the table name for insert queries.
      *
      * @param string $table The table name to insert into.
-     * @return $this
+     * @return self
      */
     public function into($table)
     {
@@ -1401,7 +1401,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * instance to insert data from another SELECT statement.
      *
      * @param array|\Cake\Database\Query $data The data to insert.
-     * @return $this
+     * @return self
      * @throws \Cake\Database\Exception if you try to set values before declaring columns.
      *   Or if you try to set values on non-insert queries.
      */
@@ -1436,7 +1436,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Can be combined with set() and where() methods to create update queries.
      *
      * @param string $table The table you want to update.
-     * @return $this
+     * @return self
      */
     public function update($table)
     {
@@ -1479,7 +1479,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *    array or QueryExpression. When $key is an array, this parameter will be
      *    used as $types instead.
      * @param array $types The column types to treat data as.
-     * @return $this
+     * @return self
      */
     public function set($key, $value = null, $types = [])
     {
@@ -1516,7 +1516,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * create delete queries with specific conditions.
      *
      * @param string|null $table The table to use when deleting.
-     * @return $this
+     * @return self
      */
     public function delete($table = null)
     {
@@ -1542,7 +1542,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ```
      *
      * @param string|\Cake\Database\Expression\QueryExpression|null $expression The expression to be appended
-     * @return $this
+     * @return self
      */
     public function epilog($expression = null)
     {
@@ -1691,7 +1691,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param callable|null $callback The callback to invoke when results are fetched.
      * @param bool $overwrite Whether or not this should append or replace all existing decorators.
-     * @return $this
+     * @return self
      */
     public function decorateResults($callback, $overwrite = false)
     {
@@ -1717,7 +1717,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param callable $callback the function to be executed for each ExpressionInterface
      *   found inside this query.
-     * @return $this|null
+     * @return self|null
      */
     public function traverseExpressions(callable $callback)
     {
@@ -1761,7 +1761,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param mixed $value The value to be bound
      * @param string|int $type the mapped type name, used for casting when sending
      *   to database
-     * @return $this
+     * @return self
      */
     public function bind($param, $value, $type = 'string')
     {
@@ -1780,7 +1780,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param \Cake\Database\ValueBinder|null $binder new instance to be set. If no value is passed the
      *   default one will be returned
-     * @return $this|\Cake\Database\ValueBinder
+     * @return self|\Cake\Database\ValueBinder
      */
     public function valueBinder($binder = null)
     {
@@ -1807,7 +1807,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * remembered for future iterations.
      *
      * @param bool $enable Whether or not to enable buffering
-     * @return $this
+     * @return self
      */
     public function enableBufferedResults($enable)
     {
@@ -1849,7 +1849,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @deprecated 3.4.0 Use enableBufferedResults()/isBufferedResultsEnabled() instead.
      * @param bool|null $enable Whether or not to enable buffering
-     * @return bool|$this
+     * @return bool|self
      */
     public function bufferResults($enable = null)
     {
@@ -1865,7 +1865,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * select clause are stored.
      *
      * @param \Cake\Database\TypeMap $typeMap The map object to use
-     * @return $this
+     * @return self
      */
     public function setSelectTypeMap(TypeMap $typeMap)
     {
@@ -1896,7 +1896,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @deprecated 3.4.0 Use setSelectTypeMap()/getSelectTypeMap() instead.
      * @param \Cake\Database\TypeMap|null $typeMap The map object to use
-     * @return $this|\Cake\Database\TypeMap
+     * @return self|\Cake\Database\TypeMap
      */
     public function selectTypeMap(TypeMap $typeMap = null)
     {

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -85,7 +85,7 @@ class CachedCollection extends Collection
      * disables it if false is passed.
      *
      * @param bool $enable Whether or not to enable caching
-     * @return $this
+     * @return self
      */
     public function setCacheMetadata($enable)
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -327,7 +327,7 @@ class TableSchema
      *
      * @param string $name The name of the column
      * @param array $attrs The attributes for the column.
-     * @return $this
+     * @return self
      */
     public function addColumn($name, $attrs)
     {
@@ -482,7 +482,7 @@ class TableSchema
      *
      * @param string $name The name of the index.
      * @param array $attrs The attributes for the index.
-     * @return $this
+     * @return self
      * @throws \Cake\Database\Exception
      */
     public function addIndex($name, $attrs)
@@ -578,7 +578,7 @@ class TableSchema
      *
      * @param string $name The name of the constraint.
      * @param array $attrs The attributes for the constraint.
-     * @return $this
+     * @return self
      * @throws \Cake\Database\Exception
      */
     public function addConstraint($name, $attrs)
@@ -717,7 +717,7 @@ class TableSchema
      * For example the engine type in MySQL.
      *
      * @param array $options The options to set, or null to read options.
-     * @return $this TableSchema instance
+     * @return self TableSchema instance
      */
     public function setOptions($options)
     {
@@ -747,7 +747,7 @@ class TableSchema
      *
      * @deprecated 3.4.0 Use setOptions()/getOptions() instead.
      * @param array|null $options The options to set, or null to read options.
-     * @return $this|array Either the TableSchema instance, or an array of options when reading.
+     * @return self|array Either the TableSchema instance, or an array of options when reading.
      */
     public function options($options = null)
     {
@@ -762,7 +762,7 @@ class TableSchema
      * Sets whether the table is temporary in the database.
      *
      * @param bool $temporary Whether or not the table is to be temporary.
-     * @return $this Instance.
+     * @return self Instance.
      */
     public function setTemporary($temporary)
     {
@@ -786,7 +786,7 @@ class TableSchema
      *
      * @deprecated 3.4.0 Use setTemporary()/isTemporary() instead.
      * @param bool|null $temporary whether or not the table is to be temporary
-     * @return $this|bool Either the TableSchema instance, the current temporary setting
+     * @return self|bool Either the TableSchema instance, the current temporary setting
      */
     public function temporary($temporary = null)
     {

--- a/src/Database/Statement/BufferResultsTrait.php
+++ b/src/Database/Statement/BufferResultsTrait.php
@@ -33,7 +33,7 @@ trait BufferResultsTrait
      * Whether or not to buffer results in php
      *
      * @param bool $buffer Toggle buffering
-     * @return $this
+     * @return self
      */
     public function bufferResults($buffer)
     {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -200,7 +200,7 @@ class DateTimeType extends Type implements TypeInterface
      * by using a locale aware parser.
      *
      * @param bool $enable Whether or not to enable
-     * @return $this
+     * @return self
      */
     public function useLocaleParser($enable = true)
     {
@@ -226,7 +226,7 @@ class DateTimeType extends Type implements TypeInterface
      *
      * @param string|array $format The format in which the string are passed.
      * @see \Cake\I18n\Time::parseDateTime()
-     * @return $this
+     * @return self
      */
     public function setLocaleFormat($format)
     {
@@ -238,7 +238,7 @@ class DateTimeType extends Type implements TypeInterface
     /**
      * Change the preferred class name to the FrozenTime implementation.
      *
-     * @return $this
+     * @return self
      */
     public function useImmutable()
     {
@@ -266,7 +266,7 @@ class DateTimeType extends Type implements TypeInterface
     /**
      * Change the preferred class name to the mutable Time implementation.
      *
-     * @return $this
+     * @return self
      */
     public function useMutable()
     {

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -41,7 +41,7 @@ class DateType extends DateTimeType
     /**
      * Change the preferred class name to the FrozenDate implementation.
      *
-     * @return $this
+     * @return self
      */
     public function useImmutable()
     {
@@ -53,7 +53,7 @@ class DateType extends DateTimeType
     /**
      * Change the preferred class name to the mutable Date implementation.
      *
-     * @return $this
+     * @return self
      */
     public function useMutable()
     {

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -125,7 +125,7 @@ class DecimalType extends Type implements TypeInterface
      * by using a locale aware parser.
      *
      * @param bool $enable Whether or not to enable
-     * @return $this
+     * @return self
      */
     public function useLocaleParser($enable = true)
     {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -120,7 +120,7 @@ class FloatType extends Type implements TypeInterface
      * by using a locale aware parser.
      *
      * @param bool $enable Whether or not to enable
-     * @return $this
+     * @return self
      */
     public function useLocaleParser($enable = true)
     {

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -66,7 +66,7 @@ class TypeMap
      *
      * @param array $defaults Associative array where keys are field names and values
      * are the correspondent type.
-     * @return $this
+     * @return self
      */
     public function setDefaults(array $defaults)
     {
@@ -78,7 +78,7 @@ class TypeMap
     /**
      * Returns the currently configured types.
      *
-     * @return $this|array
+     * @return self|array
      */
     public function getDefaults()
     {
@@ -105,7 +105,7 @@ class TypeMap
      * @deprecated 3.4.0 Use setDefaults()/getDefaults() instead.
      * @param array|null $defaults associative array where keys are field names and values
      * are the correspondent type.
-     * @return $this|array
+     * @return self|array
      */
     public function defaults(array $defaults = null)
     {
@@ -142,7 +142,7 @@ class TypeMap
      *
      * @param array $types Associative array where keys are field names and values
      * are the correspondent type.
-     * @return $this
+     * @return self
      */
     public function setTypes(array $types)
     {
@@ -177,7 +177,7 @@ class TypeMap
      * @deprecated 3.4.0 Use setTypes()/getTypes() instead.
      * @param array|null $types associative array where keys are field names and values
      * are the correspondent type.
-     * @return $this|array
+     * @return self|array
      */
     public function types(array $types = null)
     {

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -29,7 +29,7 @@ trait TypeMapTrait
      * Creates a new TypeMap if $typeMap is an array, otherwise exchanges it for the given one.
      *
      * @param array|\Cake\Database\TypeMap $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
-     * @return $this
+     * @return self
      */
     public function setTypeMap($typeMap)
     {
@@ -58,7 +58,7 @@ trait TypeMapTrait
      *
      * @deprecated 3.4.0 Use setTypeMap()/getTypeMap() instead.
      * @param array|\Cake\Database\TypeMap|null $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
-     * @return $this|\Cake\Database\TypeMap
+     * @return self|\Cake\Database\TypeMap
      */
     public function typeMap($typeMap = null)
     {
@@ -73,7 +73,7 @@ trait TypeMapTrait
      * Allows setting default types when chaining query.
      *
      * @param array $types The array of types to set.
-     * @return $this
+     * @return self
      */
     public function setDefaultTypes(array $types)
     {
@@ -97,7 +97,7 @@ trait TypeMapTrait
      *
      * @deprecated 3.4.0 Use setDefaultTypes()/getDefaultTypes() instead.
      * @param array|null $types The array of types to set.
-     * @return $this|array
+     * @return self|array
      */
     public function defaultTypes(array $types = null)
     {

--- a/src/Database/TypedResultInterface.php
+++ b/src/Database/TypedResultInterface.php
@@ -25,7 +25,7 @@ interface TypedResultInterface
      * If called without arguments, returns the current known type
      *
      * @param string|null $type The name of the type that is to be returned
-     * @return string|$this
+     * @return string|self
      */
     public function returnType($type = null);
 }

--- a/src/Database/TypedResultTrait.php
+++ b/src/Database/TypedResultTrait.php
@@ -32,7 +32,7 @@ trait TypedResultTrait
      * If called without arguments, returns the current known type
      *
      * @param string|null $type The name of the type that is to be returned
-     * @return string|$this
+     * @return string|self
      */
     public function returnType($type = null)
     {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -222,7 +222,7 @@ trait EntityTrait
      * first argument is also an array, in which case will be treated as $options
      * @param array $options options to be used for setting the property. Allowed option
      * keys are `setter` and `guard`
-     * @return $this
+     * @return self
      * @throws \InvalidArgumentException
      */
     public function set($property, $value = null, array $options = [])
@@ -385,7 +385,7 @@ trait EntityTrait
      * ```
      *
      * @param string|array $property The property to unset.
-     * @return $this
+     * @return self
      */
     public function unsetProperty($property)
     {
@@ -405,7 +405,7 @@ trait EntityTrait
      * will be returned. Otherwise the hidden properties will be set.
      *
      * @param null|array $properties Either an array of properties to hide or null to get properties
-     * @return array|$this
+     * @return array|self
      */
     public function hiddenProperties($properties = null)
     {
@@ -424,7 +424,7 @@ trait EntityTrait
      * will be returned. Otherwise the virtual properties will be set.
      *
      * @param null|array $properties Either an array of properties to treat as virtual or null to get properties
-     * @return array|$this
+     * @return array|self
      */
     public function virtualProperties($properties = null)
     {
@@ -757,7 +757,7 @@ trait EntityTrait
      * @param string|array|null $field The field to get errors for, or the array of errors to set.
      * @param string|array|null $errors The errors to be set for $field
      * @param bool $overwrite Whether or not to overwrite pre-existing errors for $field
-     * @return array|$this
+     * @return array|self
      */
     public function errors($field = null, $errors = null, $overwrite = false)
     {
@@ -876,7 +876,7 @@ trait EntityTrait
      * @param string|array|null $field The field to get invalid value for, or the value to set.
      * @param mixed|null $value The invalid value to be set for $field.
      * @param bool $overwrite Whether or not to overwrite pre-existing values for $field.
-     * @return $this|mixed
+     * @return self|mixed
      */
     public function invalid($field = null, $value = null, $overwrite = false)
     {
@@ -936,7 +936,7 @@ trait EntityTrait
      * @param string|array $property single or list of properties to change its accessibility
      * @param bool|null $set true marks the property as accessible, false will
      * mark it as protected.
-     * @return $this|bool
+     * @return self|bool
      */
     public function accessible($property, $set = null)
     {
@@ -971,7 +971,7 @@ trait EntityTrait
      * this entity came from if it is known.
      *
      * @param string|null $alias the alias of the repository
-     * @return string|$this
+     * @return string|self
      */
     public function source($alias = null)
     {

--- a/src/Datasource/InvalidPropertyInterface.php
+++ b/src/Datasource/InvalidPropertyInterface.php
@@ -30,7 +30,7 @@ interface InvalidPropertyInterface
      * @param string|array|null $field The field to get invalid value for, or the value to set.
      * @param mixed|null $value The invalid value to be set for $field.
      * @param bool $overwrite Whether or not to overwrite pre-existing values for $field.
-     * @return $this|mixed
+     * @return self|mixed
      */
     public function invalid($field = null, $value = null, $overwrite = false);
 }

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -134,7 +134,7 @@ trait ModelAwareTrait
      *
      * @param string|null $modelType The model type or null to retrieve the current
      *
-     * @return string|$this
+     * @return string|self
      */
     public function modelType($modelType = null)
     {

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -97,7 +97,7 @@ interface QueryInterface
      * ```
      *
      * @param array $options list of query clauses to apply new parts to.
-     * @return $this
+     * @return self
      */
     public function applyOptions(array $options);
 
@@ -115,7 +115,7 @@ interface QueryInterface
      *
      * @param string $finder The finder method to use.
      * @param array $options The options for the finder.
-     * @return $this Returns a modified query.
+     * @return self Returns a modified query.
      */
     public function find($finder, array $options = []);
 
@@ -154,7 +154,7 @@ interface QueryInterface
      * ```
      *
      * @param int $num number of records to be returned
-     * @return $this
+     * @return self
      */
     public function limit($num);
 
@@ -174,7 +174,7 @@ interface QueryInterface
      * ```
      *
      * @param int $num number of records to be skipped
-     * @return $this
+     * @return self
      */
     public function offset($num);
 
@@ -223,7 +223,7 @@ interface QueryInterface
      *
      * @param array|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
-     * @return $this
+     * @return self
      */
     public function order($fields, $overwrite = false);
 
@@ -239,7 +239,7 @@ interface QueryInterface
      * @param int $num The page number you want.
      * @param int|null $limit The number of rows you want in the page. If null
      *  the current limit clause will be used.
-     * @return $this
+     * @return self
      */
     public function page($num, $limit = null);
 
@@ -255,7 +255,7 @@ interface QueryInterface
      * that is, the repository that will appear in the from clause.
      *
      * @param \Cake\Datasource\RepositoryInterface|null $repository The default repository object to use
-     * @return \Cake\Datasource\RepositoryInterface|$this
+     * @return \Cake\Datasource\RepositoryInterface|self
      */
     public function repository(RepositoryInterface $repository = null);
 
@@ -369,7 +369,7 @@ interface QueryInterface
      * @param string|array|callable|null $conditions The conditions to filter on.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
-     * @return $this
+     * @return self
      */
     public function where($conditions = null, $types = [], $overwrite = false);
 }

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -88,7 +88,7 @@ trait QueryTrait
      * and this query object will be returned for chaining.
      *
      * @param \Cake\Datasource\RepositoryInterface|null $table The default table object to use
-     * @return \Cake\Datasource\RepositoryInterface|$this
+     * @return \Cake\Datasource\RepositoryInterface|self
      */
     public function repository(RepositoryInterface $table = null)
     {
@@ -110,7 +110,7 @@ trait QueryTrait
      * This method is most useful when combined with results stored in a persistent cache.
      *
      * @param \Cake\Datasource\ResultSetInterface $results The results this query should return.
-     * @return $this The query instance.
+     * @return self The query instance.
      */
     public function setResult($results)
     {
@@ -166,7 +166,7 @@ trait QueryTrait
      *   When using a function, this query instance will be supplied as an argument.
      * @param string|\Cake\Cache\CacheEngine $config Either the name of the cache config to use, or
      *   a cache config instance.
-     * @return $this This instance
+     * @return self This instance
      */
     public function cache($key, $config = 'default')
     {
@@ -185,7 +185,7 @@ trait QueryTrait
      * passed, the current configured query `_eagerLoaded` value is returned.
      *
      * @param bool|null $value Whether or not to eager load.
-     * @return $this|\Cake\ORM\Query
+     * @return self|\Cake\ORM\Query
      */
     public function eagerLoaded($value = null)
     {
@@ -309,7 +309,7 @@ trait QueryTrait
      * @param callable|null $mapper The mapper callable.
      * @param callable|null $reducer The reducing function.
      * @param bool $overwrite Set to true to overwrite existing map + reduce functions.
-     * @return $this|array
+     * @return self|array
      * @see \Cake\Collection\Iterator\MapReduce for details on how to use emit data to the map reducer.
      */
     public function mapReduce(callable $mapper = null, callable $reducer = null, $overwrite = false)
@@ -361,7 +361,7 @@ trait QueryTrait
      *
      * @param callable|null $formatter The formatting callable.
      * @param bool|int $mode Whether or not to overwrite, append or prepend the formatter.
-     * @return $this|array
+     * @return self|array
      */
     public function formatResults(callable $formatter = null, $mode = 0)
     {
@@ -468,7 +468,7 @@ trait QueryTrait
      * This is handy for passing all query clauses at once.
      *
      * @param array $options the options to be applied
-     * @return $this This object
+     * @return self This object
      */
     abstract public function applyOptions(array $options);
 

--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -75,7 +75,7 @@ class RuleInvoker
      * Old options will be merged with the new ones.
      *
      * @param array $options The options to set.
-     * @return $this
+     * @return self
      */
     public function setOptions(array $options)
     {
@@ -90,7 +90,7 @@ class RuleInvoker
      * Only truthy names will be set.
      *
      * @param string $name The name to set.
-     * @return $this
+     * @return self
      */
     public function setName($name)
     {

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -130,7 +130,7 @@ class RulesChecker
      * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
-     * @return $this
+     * @return self
      */
     public function add(callable $rule, $name = null, array $options = [])
     {
@@ -155,7 +155,7 @@ class RulesChecker
      * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
-     * @return $this
+     * @return self
      */
     public function addCreate(callable $rule, $name = null, array $options = [])
     {
@@ -180,7 +180,7 @@ class RulesChecker
      * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
-     * @return $this
+     * @return self
      */
     public function addUpdate(callable $rule, $name = null, array $options = [])
     {
@@ -205,7 +205,7 @@ class RulesChecker
      * @param string|null $name The alias for a rule.
      * @param array $options List of extra options to pass to the rule callable as
      * second argument.
-     * @return $this
+     * @return self
      */
     public function addDelete(callable $rule, $name = null, array $options = [])
     {

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -175,7 +175,7 @@ class Event
      * Listeners can attach a result value to the event.
      *
      * @param mixed $value The value to set.
-     * @return $this
+     * @return self
      */
     public function setResult($value = null)
     {
@@ -205,7 +205,7 @@ class Event
      *
      * @param array|string $key An array will replace all payload data, and a key will set just that array item.
      * @param mixed $value The value to set.
-     * @return $this
+     * @return self
      */
     public function setData($key, $value = null)
     {

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -42,7 +42,7 @@ class Schema
      * Add multiple fields to the schema.
      *
      * @param array $fields The fields to add.
-     * @return $this
+     * @return self
      */
     public function addFields(array $fields)
     {
@@ -59,7 +59,7 @@ class Schema
      * @param string $name The field name.
      * @param string|array $attrs The attributes for the field, or the type
      *   as a string.
-     * @return $this
+     * @return self
      */
     public function addField($name, $attrs)
     {
@@ -76,7 +76,7 @@ class Schema
      * Removes a field to the schema.
      *
      * @param string $name The field to remove.
-     * @return $this
+     * @return self
      */
     public function removeField($name)
     {

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -93,7 +93,7 @@ class FormData implements Countable
      * @param string|\Cake\Http\Client\FormData $name The name of the part to add,
      *   or the part data object.
      * @param mixed $value The value for the part.
-     * @return $this
+     * @return self
      */
     public function add($name, $value = null)
     {
@@ -124,7 +124,7 @@ class FormData implements Countable
      * Iterates the parameter and adds all the key/values.
      *
      * @param array $data Array of data to add.
-     * @return $this
+     * @return self
      */
     public function addMany(array $data)
     {

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -60,7 +60,7 @@ class Request extends Message implements RequestInterface
      * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|null $method The method for the request.
-     * @return $this|string Either this or the current method.
+     * @return self|string Either this or the current method.
      * @throws \Cake\Core\Exception\Exception On invalid methods.
      * @deprecated 3.3.0 Use getMethod() and withMethod() instead.
      */
@@ -85,7 +85,7 @@ class Request extends Message implements RequestInterface
      * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|null $url The url for the request. Leave null for get
-     * @return $this|string Either $this or the url value.
+     * @return self|string Either $this or the url value.
      * @deprecated 3.3.0 Use getUri() and withUri() instead.
      */
     public function url($url = null)
@@ -211,7 +211,7 @@ class Request extends Message implements RequestInterface
      * compatibility reasons, and is not part of the PSR7 interface.
      *
      * @param string|null $version The HTTP version.
-     * @return $this|string Either $this or the HTTP version.
+     * @return self|string Either $this or the HTTP version.
      * @deprecated 3.3.0 Use getProtocolVersion() and withProtocolVersion() instead.
      */
     public function version($version = null)

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -89,7 +89,7 @@ class MiddlewareQueue implements Countable
      * Append a middleware callable to the end of the queue.
      *
      * @param callable|string|array $middleware The middleware(s) to append.
-     * @return $this
+     * @return self
      */
     public function add($middleware)
     {
@@ -107,7 +107,7 @@ class MiddlewareQueue implements Countable
      * Alias for MiddlewareQueue::add().
      *
      * @param callable|string|array $middleware The middleware(s) to append.
-     * @return $this
+     * @return self
      * @see MiddlewareQueue::add()
      */
     public function push($middleware)
@@ -119,7 +119,7 @@ class MiddlewareQueue implements Countable
      * Prepend a middleware to the start of the queue.
      *
      * @param callable|string|array $middleware The middleware(s) to prepend.
-     * @return $this
+     * @return self
      */
     public function prepend($middleware)
     {
@@ -141,7 +141,7 @@ class MiddlewareQueue implements Countable
      *
      * @param int $index The index to insert at.
      * @param callable|string $middleware The middleware to insert.
-     * @return $this
+     * @return self
      */
     public function insertAt($index, $middleware)
     {
@@ -158,7 +158,7 @@ class MiddlewareQueue implements Countable
      *
      * @param string $class The classname to insert the middleware before.
      * @param callable|string $middleware The middleware to insert.
-     * @return $this
+     * @return self
      * @throws \LogicException If middleware to insert before is not found.
      */
     public function insertBefore($class, $middleware)
@@ -187,7 +187,7 @@ class MiddlewareQueue implements Countable
      *
      * @param string $class The classname to insert the middleware before.
      * @param callable|string $middleware The middleware to insert.
-     * @return $this
+     * @return self
      */
     public function insertAfter($class, $middleware)
     {

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -112,7 +112,7 @@ class Server
      * Set the application.
      *
      * @param BaseApplication $app The application to set.
-     * @return $this
+     * @return self
      */
     public function setApp(BaseApplication $app)
     {
@@ -135,7 +135,7 @@ class Server
      * Set the runner
      *
      * @param \Cake\Http\Runner $runner The runner to use.
-     * @return $this
+     * @return self
      */
     public function setRunner(Runner $runner)
     {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -885,7 +885,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * This modifies the parameters available through `$request->params`.
      *
      * @param array $params Array of parameters to merge in
-     * @return $this The current object, you can chain this method.
+     * @return self The current object, you can chain this method.
      */
     public function addParams(array $params)
     {
@@ -899,7 +899,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * Provides an easy way to modify, here, webroot and base.
      *
      * @param array $paths Array of paths to merge in
-     * @return $this The current object, you can chain this method.
+     * @return self The current object, you can chain this method.
      */
     public function addPaths(array $paths)
     {
@@ -1441,7 +1441,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string|null $name Dot separated name of the value to read/write
      * @param mixed ...$args The data to set (deprecated)
-     * @return mixed|$this Either the value being read, or this so you can chain consecutive writes.
+     * @return mixed|self Either the value being read, or this so you can chain consecutive writes.
      * @deprecated 3.4.0 Use withData() and getData() or getParsedBody() instead.
      */
     public function data($name = null, ...$args)
@@ -1495,7 +1495,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      *
      * @param string $name The name of the parameter to get.
      * @param mixed ...$args Value to set (deprecated).
-     * @return mixed|$this The value of the provided parameter. Will
+     * @return mixed|self The value of the provided parameter. Will
      *   return false if the parameter doesn't exist or is falsey.
      * @deprecated 3.4.0 Use getParam() and withParam() instead.
      */
@@ -1679,7 +1679,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      * @param string|null $value Value to set. Default null.
      * @param string|null $default Default value when trying to retrieve an environment
      *   variable's value that does not exist. The value parameter must be null.
-     * @return $this|string|null This instance if used as setter,
+     * @return self|string|null This instance if used as setter,
      *   if used as getter either the environment value, or null if the value doesn't exist.
      */
     public function env($key, $value = null, $default = null)

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -365,7 +365,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      * @throws \InvalidArgumentException
      */
     public function from($email = null, $name = null)
@@ -383,7 +383,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      * @throws \InvalidArgumentException
      */
     public function sender($email = null, $name = null)
@@ -401,7 +401,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      * @throws \InvalidArgumentException
      */
     public function replyTo($email = null, $name = null)
@@ -419,7 +419,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      * @throws \InvalidArgumentException
      */
     public function readReceipt($email = null, $name = null)
@@ -437,7 +437,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      * @throws \InvalidArgumentException
      */
     public function returnPath($email = null, $name = null)
@@ -455,7 +455,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      */
     public function to($email = null, $name = null)
     {
@@ -472,7 +472,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return $this
+     * @return self
      */
     public function addTo($email, $name = null)
     {
@@ -485,7 +485,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      */
     public function cc($email = null, $name = null)
     {
@@ -502,7 +502,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return $this
+     * @return self
      */
     public function addCc($email, $name = null)
     {
@@ -515,7 +515,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array|null $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return array|$this
+     * @return array|self
      */
     public function bcc($email = null, $name = null)
     {
@@ -532,7 +532,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array $email Null to get, String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string|null $name Name
-     * @return $this
+     * @return self
      */
     public function addBcc($email, $name = null)
     {
@@ -579,7 +579,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|bool|null $regex The pattern to use for email address validation,
      *   null to unset the pattern and make use of filter_var() instead, false or
      *   nothing to return the current value
-     * @return string|$this
+     * @return string|self
      */
     public function emailPattern($regex = false)
     {
@@ -598,7 +598,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array $email String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string $name Name
-     * @return $this
+     * @return self
      * @throws \InvalidArgumentException
      */
     protected function _setEmail($varName, $email, $name)
@@ -652,7 +652,7 @@ class Email implements JsonSerializable, Serializable
      *   Array with email as key, name as value or email as value (without name)
      * @param string $name Name
      * @param string $throwMessage Exception message
-     * @return $this
+     * @return self
      * @throws \InvalidArgumentException
      */
     protected function _setEmailSingle($varName, $email, $name, $throwMessage)
@@ -674,7 +674,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|array $email String with email,
      *   Array with email as key, name as value or email as value (without name)
      * @param string $name Name
-     * @return $this
+     * @return self
      * @throws \InvalidArgumentException
      */
     protected function _addEmail($varName, $email, $name)
@@ -705,7 +705,7 @@ class Email implements JsonSerializable, Serializable
      * Get/Set Subject.
      *
      * @param string|null $subject Subject string.
-     * @return string|$this
+     * @return string|self
      */
     public function subject($subject = null)
     {
@@ -731,7 +731,7 @@ class Email implements JsonSerializable, Serializable
      * Sets headers for the message
      *
      * @param array $headers Associative array containing headers to be set.
-     * @return $this
+     * @return self
      */
     public function setHeaders(array $headers)
     {
@@ -744,7 +744,7 @@ class Email implements JsonSerializable, Serializable
      * Add header for the message
      *
      * @param array $headers Headers to set.
-     * @return $this
+     * @return self
      */
     public function addHeaders(array $headers)
     {
@@ -875,7 +875,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @param bool|string $template Template name or null to not use
      * @param bool|string $layout Layout name or null to not use
-     * @return array|$this
+     * @return array|self
      */
     public function template($template = false, $layout = false)
     {
@@ -897,7 +897,7 @@ class Email implements JsonSerializable, Serializable
      * View class for render
      *
      * @param string|null $viewClass View class name.
-     * @return string|$this
+     * @return string|self
      */
     public function viewRender($viewClass = null)
     {
@@ -913,7 +913,7 @@ class Email implements JsonSerializable, Serializable
      * Variables to be set on render
      *
      * @param array|null $viewVars Variables to set for view.
-     * @return array|$this
+     * @return array|self
      */
     public function viewVars($viewVars = null)
     {
@@ -929,7 +929,7 @@ class Email implements JsonSerializable, Serializable
      * Theme to use when rendering
      *
      * @param string|null $theme Theme name.
-     * @return string|$this
+     * @return string|self
      */
     public function theme($theme = null)
     {
@@ -945,7 +945,7 @@ class Email implements JsonSerializable, Serializable
      * Helpers to be used in render
      *
      * @param array|null $helpers Helpers list.
-     * @return array|$this
+     * @return array|self
      */
     public function helpers($helpers = null)
     {
@@ -961,7 +961,7 @@ class Email implements JsonSerializable, Serializable
      * Email format
      *
      * @param string|null $format Formatting string.
-     * @return string|$this
+     * @return string|self
      * @throws \InvalidArgumentException
      */
     public function emailFormat($format = null)
@@ -985,7 +985,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @param string|\Cake\Mailer\AbstractTransport|null $name Either the name of a configured
      *   transport, or a transport instance.
-     * @return \Cake\Mailer\AbstractTransport|$this
+     * @return \Cake\Mailer\AbstractTransport|self
      * @throws \LogicException When the chosen transport lacks a send method.
      * @throws \InvalidArgumentException When $name is neither a string nor an object.
      */
@@ -1064,7 +1064,7 @@ class Email implements JsonSerializable, Serializable
      * Message-ID
      *
      * @param bool|string|null $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
-     * @return bool|string|$this
+     * @return bool|string|self
      * @throws \InvalidArgumentException
      */
     public function messageId($message = null)
@@ -1088,7 +1088,7 @@ class Email implements JsonSerializable, Serializable
      * Domain as top level (the part after @)
      *
      * @param string|null $domain Manually set the domain for CLI mailing
-     * @return string|$this
+     * @return string|self
      */
     public function domain($domain = null)
     {
@@ -1146,7 +1146,7 @@ class Email implements JsonSerializable, Serializable
      * attachment compatibility with outlook email clients.
      *
      * @param string|array|null $attachments String with the filename or array with filenames
-     * @return array|$this Either the array of attachments when getting or $this when setting.
+     * @return array|self Either the array of attachments when getting or $this when setting.
      * @throws \InvalidArgumentException
      */
     public function attachments($attachments = null)
@@ -1194,7 +1194,7 @@ class Email implements JsonSerializable, Serializable
      * Add attachments
      *
      * @param string|array $attachments String with the filename or array with filenames
-     * @return $this
+     * @return self
      * @throws \InvalidArgumentException
      * @see \Cake\Mailer\Email::attachments()
      */
@@ -1301,7 +1301,7 @@ class Email implements JsonSerializable, Serializable
      *
      * @param null|string|array $config String with configuration name, or
      *    an array with config or null to return current config.
-     * @return string|array|$this
+     * @return string|array|self
      */
     public function profile($config = null)
     {
@@ -1479,7 +1479,7 @@ class Email implements JsonSerializable, Serializable
     /**
      * Reset all the internal variables to be able to send out a new email.
      *
-     * @return $this
+     * @return self
      */
     public function reset()
     {
@@ -2036,7 +2036,7 @@ class Email implements JsonSerializable, Serializable
      * Configures an email instance object from serialized config.
      *
      * @param array $config Email configuration array.
-     * @return $this Configured email instance.
+     * @return self Configured email instance.
      */
     public function createFromArray($config)
     {

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -174,7 +174,7 @@ abstract class Mailer implements EventListenerInterface
      * Sets layout to use.
      *
      * @param string $layout Name of the layout to use.
-     * @return $this object.
+     * @return self object.
      */
     public function layout($layout)
     {
@@ -198,7 +198,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @param string $method Method name.
      * @param array $args Method arguments
-     * @return $this
+     * @return self
      */
     public function __call($method, $args)
     {
@@ -212,7 +212,7 @@ abstract class Mailer implements EventListenerInterface
      *
      * @param string|array $key Variable name or hash of view variables.
      * @param mixed $value View variable value.
-     * @return $this object.
+     * @return self object.
      */
     public function set($key, $value = null)
     {
@@ -256,7 +256,7 @@ abstract class Mailer implements EventListenerInterface
     /**
      * Reset email instance.
      *
-     * @return $this
+     * @return self
      */
     protected function reset()
     {

--- a/src/Network/CorsBuilder.php
+++ b/src/Network/CorsBuilder.php
@@ -98,7 +98,7 @@ class CorsBuilder
      * You can use `*.example.com` wildcards to accept subdomains, or `*` to allow all domains
      *
      * @param string|array $domain The allowed domains
-     * @return $this
+     * @return self
      */
     public function allowOrigin($domain)
     {
@@ -145,7 +145,7 @@ class CorsBuilder
      * Set the list of allowed HTTP Methods.
      *
      * @param array $methods The allowed HTTP methods
-     * @return $this
+     * @return self
      */
     public function allowMethods(array $methods)
     {
@@ -157,7 +157,7 @@ class CorsBuilder
     /**
      * Enable cookies to be sent in CORS requests.
      *
-     * @return $this
+     * @return self
      */
     public function allowCredentials()
     {
@@ -170,7 +170,7 @@ class CorsBuilder
      * Whitelist headers that can be sent in CORS requests.
      *
      * @param array $headers The list of headers to accept in CORS requests.
-     * @return $this
+     * @return self
      */
     public function allowHeaders(array $headers)
     {
@@ -183,7 +183,7 @@ class CorsBuilder
      * Define the headers a client library/browser can expose to scripting
      *
      * @param array $headers The list of headers to expose CORS responses
-     * @return $this
+     * @return self
      */
     public function exposeHeaders(array $headers)
     {
@@ -196,7 +196,7 @@ class CorsBuilder
      * Define the max-age preflight OPTIONS requests are valid for.
      *
      * @param int $age The max-age for OPTIONS requests in seconds
-     * @return $this
+     * @return self
      */
     public function maxAge($age)
     {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -240,7 +240,7 @@ abstract class Association
      * Sets the name for this association.
      *
      * @param string $name Name to be assigned
-     * @return $this
+     * @return self
      */
     public function setName($name)
     {
@@ -279,7 +279,7 @@ abstract class Association
      * Sets whether or not cascaded deletes should also fire callbacks.
      *
      * @param bool $cascadeCallbacks cascade callbacks switch value
-     * @return $this
+     * @return self
      */
     public function setCascadeCallbacks($cascadeCallbacks)
     {
@@ -329,7 +329,7 @@ abstract class Association
      * Sets the table instance for the source side of the association.
      *
      * @param \Cake\ORM\Table $table the instance to be assigned as source side
-     * @return $this
+     * @return self
      */
     public function setSource(Table $table)
     {
@@ -369,7 +369,7 @@ abstract class Association
      * Sets the table instance for the target side of the association.
      *
      * @param \Cake\ORM\Table $table the instance to be assigned as target side
-     * @return $this
+     * @return self
      */
     public function setTarget(Table $table)
     {
@@ -428,7 +428,7 @@ abstract class Association
      *
      * @param array $conditions list of conditions to be used
      * @see \Cake\Database\Query::where() for examples on the format of the array
-     * @return $this
+     * @return self
      */
     public function setConditions($conditions)
     {
@@ -472,7 +472,7 @@ abstract class Association
      * When not manually specified the primary key of the owning side table is used.
      *
      * @param string $key the table field to be used to link both tables together
-     * @return $this
+     * @return self
      */
     public function setBindingKey($key)
     {
@@ -531,7 +531,7 @@ abstract class Association
      * Sets the name of the field representing the foreign key to the target table.
      *
      * @param string $key the key to be used to link both tables together
-     * @return $this
+     * @return self
      */
     public function setForeignKey($key)
     {
@@ -566,7 +566,7 @@ abstract class Association
      * If no parameters are passed the current setting is returned.
      *
      * @param bool $dependent Set the dependent mode. Use null to read the current state.
-     * @return $this
+     * @return self
      */
     public function setDependent($dependent)
     {
@@ -626,7 +626,7 @@ abstract class Association
      * Sets the type of join to be used when adding the association to a query.
      *
      * @param string $type the join type to be used (e.g. INNER)
-     * @return $this
+     * @return self
      */
     public function setJoinType($type)
     {
@@ -667,7 +667,7 @@ abstract class Association
      * in the source table record.
      *
      * @param string $name The name of the association property. Use null to read the current value.
-     * @return $this
+     * @return self
      */
     public function setProperty($name)
     {
@@ -735,7 +735,7 @@ abstract class Association
      * rendering any changes to this setting void.
      *
      * @param string $name The strategy type. Use null to read the current value.
-     * @return $this
+     * @return self
      * @throws \InvalidArgumentException When an invalid strategy is provided.
      */
     public function setStrategy($name)
@@ -796,7 +796,7 @@ abstract class Association
      * Sets the default finder to use for fetching rows from the target table.
      *
      * @param string $finder the finder name to use
-     * @return $this
+     * @return self
      */
     public function setFinder($finder)
     {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -160,7 +160,7 @@ class BelongsToMany extends Association
      * Sets the name of the field representing the foreign key to the target table.
      *
      * @param string $key the key to be used to link both tables together
-     * @return $this
+     * @return self
      */
     public function setTargetForeignKey($key)
     {
@@ -619,7 +619,7 @@ class BelongsToMany extends Association
      *
      * @param string $strategy the strategy name to be used
      * @throws \InvalidArgumentException if an invalid strategy name is passed
-     * @return $this
+     * @return self
      */
     public function setSaveStrategy($strategy)
     {
@@ -985,7 +985,7 @@ class BelongsToMany extends Association
      * Sets the current join table, either the name of the Table instance or the instance itself.
      *
      * @param string|\Cake\ORM\Table $through Name of the Table instance or the instance itself
-     * @return $this
+     * @return self
      */
     public function setThrough($through)
     {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -106,7 +106,7 @@ class HasMany extends Association
      *
      * @param string $strategy the strategy name to be used
      * @throws \InvalidArgumentException if an invalid strategy name is passed
-     * @return $this
+     * @return self
      */
     public function setSaveStrategy($strategy)
     {
@@ -582,7 +582,7 @@ class HasMany extends Association
      * Sets the sort order in which target records should be returned.
      *
      * @param mixed $sort A find() compatible order clause
-     * @return $this
+     * @return self
      */
     public function setSort($sort)
     {

--- a/src/ORM/Behavior/Translate/TranslateTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateTrait.php
@@ -30,7 +30,7 @@ trait TranslateTrait
      * it.
      *
      * @param string $language Language to return entity for.
-     * @return $this|\Cake\ORM\Entity
+     * @return self|\Cake\ORM\Entity
      */
     public function translation($language)
     {

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -207,7 +207,7 @@ class EagerLoadable
      * Sets whether or not this level can be fetched using a join.
      *
      * @param bool $possible The value to set.
-     * @return $this
+     * @return self
      */
     public function setCanBeJoined($possible)
     {
@@ -239,7 +239,7 @@ class EagerLoadable
      * the records.
      *
      * @param array $config The value to set.
-     * @return $this
+     * @return self
      */
     public function setConfig(array $config)
     {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -163,7 +163,7 @@ class EagerLoader
      * Sets whether or not contained associations will load fields automatically.
      *
      * @param bool $enable The value to set.
-     * @return $this
+     * @return self
      */
     public function enableAutoFields($enable)
     {
@@ -213,7 +213,7 @@ class EagerLoader
      * @param callable|null $builder the callback function to be used for setting extra
      * options to the filtering query
      * @param array $options Extra options for the association matching.
-     * @return $this
+     * @return self
      */
     public function setMatching($assoc, callable $builder = null, $options = [])
     {

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -61,7 +61,7 @@ class TableLocator implements LocatorInterface
      *
      * @param string|array $alias Name of the alias or array to completely overwrite current config.
      * @param array|null $options list of options for the alias
-     * @return $this
+     * @return self
      * @throws \RuntimeException When you attempt to configure an existing table instance.
      */
     public function setConfig($alias, $options = null)

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -178,7 +178,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param array|\Cake\Database\ExpressionInterface|string|\Cake\ORM\Table|\Cake\ORM\Association $fields fields
      * to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not
-     * @return $this
+     * @return self
      */
     public function select($fields = [], $overwrite = false)
     {
@@ -202,7 +202,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * This method returns the same query object for chaining.
      *
      * @param \Cake\ORM\Table $table The table to pull types from
-     * @return $this
+     * @return self
      */
     public function addDefaultTypes(Table $table)
     {
@@ -222,7 +222,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * and storing containments.
      *
      * @param \Cake\ORM\EagerLoader $instance The eager loader to use.
-     * @return $this
+     * @return self
      */
     public function setEagerLoader(EagerLoader $instance)
     {
@@ -253,7 +253,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @deprecated 3.4.0 Use setEagerLoader()/getEagerLoader() instead.
      * @param \Cake\ORM\EagerLoader|null $instance The eager loader to use. Pass null
      *   to get the current eagerloader.
-     * @return \Cake\ORM\EagerLoader|$this
+     * @return \Cake\ORM\EagerLoader|self
      */
     public function eagerLoader(EagerLoader $instance = null)
     {
@@ -373,7 +373,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param array|string|null $associations List of table aliases to be queried.
      * @param bool $override Whether override previous list with the one passed
      * defaults to merging previous list with the new one.
-     * @return array|$this
+     * @return array|self
      */
     public function contain($associations = null, $override = false)
     {
@@ -469,7 +469,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param string $assoc The association to filter by
      * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
-     * @return $this
+     * @return self
      */
     public function matching($assoc, callable $builder = null)
     {
@@ -541,7 +541,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param string $assoc The association to join with
      * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
-     * @return $this
+     * @return self
      */
     public function leftJoinWith($assoc, callable $builder = null)
     {
@@ -587,7 +587,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param string $assoc The association to join with
      * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
-     * @return $this
+     * @return self
      * @see \Cake\ORM\Query::matching()
      */
     public function innerJoinWith($assoc, callable $builder = null)
@@ -650,7 +650,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param string $assoc The association to filter by
      * @param callable|null $builder a function that will receive a pre-made query object
      * that can be used to add custom conditions or selecting some fields
-     * @return $this
+     * @return self
      */
     public function notMatching($assoc, callable $builder = null)
     {
@@ -868,7 +868,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * instead
      *
      * @param callable|null $counter The counter value
-     * @return $this
+     * @return self
      */
     public function counter($counter)
     {
@@ -884,7 +884,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @param bool|null $enable Use a boolean to set the hydration mode.
      *   Null will fetch the current hydration mode.
-     * @return bool|$this A boolean when reading, and $this when setting the mode.
+     * @return bool|self A boolean when reading, and $this when setting the mode.
      */
     public function hydrate($enable = null)
     {
@@ -901,7 +901,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * {@inheritDoc}
      *
-     * @return $this
+     * @return self
      * @throws \RuntimeException When you attempt to cache a non-select query.
      */
     public function cache($key, $config = 'default')
@@ -1086,7 +1086,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Can be combined with set() and where() methods to create update queries.
      *
      * @param string|null $table Unused parameter.
-     * @return $this
+     * @return self
      */
     public function update($table = null)
     {
@@ -1102,7 +1102,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Can be combined with the where() method to create delete queries.
      *
      * @param string|null $table Unused parameter.
-     * @return $this
+     * @return self
      */
     public function delete($table = null)
     {
@@ -1123,7 +1123,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @param array $columns The columns to insert into.
      * @param array $types A map between columns & their datatypes.
-     * @return $this
+     * @return self
      */
     public function insert(array $columns, array $types = [])
     {
@@ -1187,7 +1187,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * auto-fields with this method.
      *
      * @param bool|null $value The value to set or null to read the current value.
-     * @return bool|$this Either the current value or the query object.
+     * @return bool|self Either the current value or the query object.
      */
     public function autoFields($value = null)
     {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -331,7 +331,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Sets the database table name.
      *
      * @param string $table Table name.
-     * @return $this
+     * @return self
      */
     public function setTable($table)
     {
@@ -379,7 +379,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Sets the table alias.
      *
      * @param string $alias Table alias
-     * @return $this
+     * @return self
      */
     public function setAlias($alias)
     {
@@ -439,7 +439,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Sets the table registry key used to create this table instance.
      *
      * @param string $registryAlias The key used to access this object.
-     * @return $this
+     * @return self
      */
     public function setRegistryAlias($registryAlias)
     {
@@ -483,7 +483,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Sets the connection instance.
      *
      * @param \Cake\Datasource\ConnectionInterface $connection The connection instance
-     * @return $this
+     * @return self
      */
     public function setConnection(ConnectionInterface $connection)
     {
@@ -543,7 +543,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * out of it and used as the schema for this table.
      *
      * @param array|\Cake\Database\Schema\TableSchema $schema Schema to be used for this table
-     * @return $this
+     * @return self
      */
     public function setSchema($schema)
     {
@@ -634,7 +634,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Sets the primary key field name.
      *
      * @param string|array $key Sets a new name to be used as primary key
-     * @return $this
+     * @return self
      */
     public function setPrimaryKey($key)
     {
@@ -681,7 +681,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Sets the display field.
      *
      * @param string $key Name to be used as display field.
-     * @return $this
+     * @return self
      */
     public function setDisplayField($key)
     {
@@ -766,7 +766,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $name The name of the class to use
      * @throws \Cake\ORM\Exception\MissingEntityException when the entity class cannot be found
-     * @return $this
+     * @return self
      */
     public function setEntityClass($name)
     {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -128,7 +128,7 @@ class Route
      * Set the supported extensions for this route.
      *
      * @param array $extensions The extensions to set.
-     * @return $this
+     * @return self
      */
     public function setExtensions(array $extensions)
     {

--- a/src/TestSuite/Stub/Response.php
+++ b/src/TestSuite/Stub/Response.php
@@ -24,7 +24,7 @@ class Response extends Base
     /**
      * Stub the send() method so headers and output are not sent.
      *
-     * @return $this
+     * @return self
      */
     public function send()
     {

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -118,7 +118,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $name The name under which the rule should be set
      * @param \Cake\Validation\ValidationRule|array $rule The validation rule to be set
-     * @return $this
+     * @return self
      */
     public function add($name, $rule)
     {
@@ -142,7 +142,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      * ```
      *
      * @param string $name The name under which the rule should be unset
-     * @return $this
+     * @return self
      */
     public function remove($name)
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -181,7 +181,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $name The name under which the provider should be set.
      * @param object|string $object Provider object or class name.
-     * @return $this
+     * @return self
      */
     public function setProvider($name, $object)
     {
@@ -222,7 +222,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @deprecated 3.4.0 Use setProvider()/getProvider() instead.
      * @param string $name The name under which the provider should be set.
      * @param null|object|string $object Provider object or class name.
-     * @return $this|object|string|null
+     * @return self|object|string|null
      */
     public function provider($name, $object = null)
     {
@@ -335,7 +335,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $field The name of the field from which the rule will be added
      * @param array|string $name The alias for a single rule or multiple rules array
      * @param array|\Cake\Validation\ValidationRule $rule the rule to add
-     * @return $this
+     * @return self
      */
     public function add($field, $name, $rule = [])
     {
@@ -369,7 +369,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The root field for the nested validator.
      * @param \Cake\Validation\Validator $validator The nested validator.
-     * @return $this
+     * @return self
      */
     public function addNested($field, Validator $validator)
     {
@@ -404,7 +404,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The root field for the nested validator.
      * @param \Cake\Validation\Validator $validator The nested validator.
-     * @return $this
+     * @return self
      */
     public function addNestedMany($field, Validator $validator)
     {
@@ -446,7 +446,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field from which the rule will be removed
      * @param string|null $rule the name of the rule to be removed
-     * @return $this
+     * @return self
      */
     public function remove($field, $rule = null)
     {
@@ -475,7 +475,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   If a callable is passed then the field will be required only when the callback
      *   returns true.
      * @param string|null $message The message to show if the field presence validation fails.
-     * @return $this
+     * @return self
      */
     public function requirePresence($field, $mode = true, $message = null)
     {
@@ -565,7 +565,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Valid values are true (always), 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @param string|null $message The message to show if the field is not
-     * @return $this
+     * @return self
      */
     public function allowEmpty($field, $when = true, $message = null)
     {
@@ -679,7 +679,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   to be empty. Valid values are true (always), 'create', 'update'. If a
      *   callable is passed then the field will allowed to be empty only when
      *   the callback returns false.
-     * @return $this
+     * @return self
      */
     public function notEmpty($field, $message = null, $when = false)
     {
@@ -722,7 +722,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::notBlank()
-     * @return $this
+     * @return self
      */
     public function notBlank($field, $message = null, $when = null)
     {
@@ -741,7 +741,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::alphaNumeric()
-     * @return $this
+     * @return self
      */
     public function alphaNumeric($field, $message = null, $when = null)
     {
@@ -761,7 +761,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::alphaNumeric()
-     * @return $this
+     * @return self
      */
     public function lengthBetween($field, array $range, $message = null, $when = null)
     {
@@ -785,7 +785,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::cc()
-     * @return $this
+     * @return self
      */
     public function creditCard($field, $type = 'all', $message = null, $when = null)
     {
@@ -805,7 +805,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
-     * @return $this
+     * @return self
      */
     public function greaterThan($field, $value, $message = null, $when = null)
     {
@@ -825,7 +825,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
-     * @return $this
+     * @return self
      */
     public function greaterThanOrEqual($field, $value, $message = null, $when = null)
     {
@@ -845,7 +845,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
-     * @return $this
+     * @return self
      */
     public function lessThan($field, $value, $message = null, $when = null)
     {
@@ -865,7 +865,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
-     * @return $this
+     * @return self
      */
     public function lessThanOrEqual($field, $value, $message = null, $when = null)
     {
@@ -885,7 +885,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
-     * @return $this
+     * @return self
      */
     public function equals($field, $value, $message = null, $when = null)
     {
@@ -905,7 +905,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::comparison()
-     * @return $this
+     * @return self
      */
     public function notEquals($field, $value, $message = null, $when = null)
     {
@@ -927,7 +927,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::compareWith()
-     * @return $this
+     * @return self
      */
     public function sameAs($field, $secondField, $message = null, $when = null)
     {
@@ -947,7 +947,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::containsNonAlphaNumeric()
-     * @return $this
+     * @return self
      */
     public function containsNonAlphaNumeric($field, $limit = 1, $message = null, $when = null)
     {
@@ -967,7 +967,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::date()
-     * @return $this
+     * @return self
      */
     public function date($field, $formats = ['ymd'], $message = null, $when = null)
     {
@@ -987,7 +987,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::datetime()
-     * @return $this
+     * @return self
      */
     public function dateTime($field, $formats = ['ymd'], $message = null, $when = null)
     {
@@ -1006,7 +1006,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::time()
-     * @return $this
+     * @return self
      */
     public function time($field, $message = null, $when = null)
     {
@@ -1026,7 +1026,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::localizedTime()
-     * @return $this
+     * @return self
      */
     public function localizedTime($field, $type = 'datetime', $message = null, $when = null)
     {
@@ -1045,7 +1045,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::boolean()
-     * @return $this
+     * @return self
      */
     public function boolean($field, $message = null, $when = null)
     {
@@ -1065,7 +1065,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::decimal()
-     * @return $this
+     * @return self
      */
     public function decimal($field, $places = null, $message = null, $when = null)
     {
@@ -1085,7 +1085,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::email()
-     * @return $this
+     * @return self
      */
     public function email($field, $checkMX = false, $message = null, $when = null)
     {
@@ -1106,7 +1106,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ip()
-     * @return $this
+     * @return self
      */
     public function ip($field, $message = null, $when = null)
     {
@@ -1125,7 +1125,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ip()
-     * @return $this
+     * @return self
      */
     public function ipv4($field, $message = null, $when = null)
     {
@@ -1144,7 +1144,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ip()
-     * @return $this
+     * @return self
      */
     public function ipv6($field, $message = null, $when = null)
     {
@@ -1164,7 +1164,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::minLength()
-     * @return $this
+     * @return self
      */
     public function minLength($field, $min, $message = null, $when = null)
     {
@@ -1184,7 +1184,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::maxLength()
-     * @return $this
+     * @return self
      */
     public function maxLength($field, $max, $message = null, $when = null)
     {
@@ -1203,7 +1203,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::numeric()
-     * @return $this
+     * @return self
      */
     public function numeric($field, $message = null, $when = null)
     {
@@ -1222,7 +1222,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::naturalNumber()
-     * @return $this
+     * @return self
      */
     public function naturalNumber($field, $message = null, $when = null)
     {
@@ -1241,7 +1241,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::naturalNumber()
-     * @return $this
+     * @return self
      */
     public function nonNegativeInteger($field, $message = null, $when = null)
     {
@@ -1261,7 +1261,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::range()
-     * @return $this
+     * @return self
      */
     public function range($field, array $range, $message = null, $when = null)
     {
@@ -1285,7 +1285,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::url()
-     * @return $this
+     * @return self
      */
     public function url($field, $message = null, $when = null)
     {
@@ -1306,7 +1306,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::url()
-     * @return $this
+     * @return self
      */
     public function urlWithProtocol($field, $message = null, $when = null)
     {
@@ -1326,7 +1326,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::inList()
-     * @return $this
+     * @return self
      */
     public function inList($field, array $list, $message = null, $when = null)
     {
@@ -1345,7 +1345,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::uuid()
-     * @return $this
+     * @return self
      */
     public function uuid($field, $message = null, $when = null)
     {
@@ -1367,7 +1367,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::uploadedFile()
-     * @return $this
+     * @return self
      */
     public function uploadedFile($field, array $options, $message = null, $when = null)
     {
@@ -1388,7 +1388,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::uuid()
-     * @return $this
+     * @return self
      */
     public function latLong($field, $message = null, $when = null)
     {
@@ -1407,7 +1407,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::latitude()
-     * @return $this
+     * @return self
      */
     public function latitude($field, $message = null, $when = null)
     {
@@ -1426,7 +1426,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::longitude()
-     * @return $this
+     * @return self
      */
     public function longitude($field, $message = null, $when = null)
     {
@@ -1445,7 +1445,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::ascii()
-     * @return $this
+     * @return self
      */
     public function ascii($field, $message = null, $when = null)
     {
@@ -1464,7 +1464,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::utf8()
-     * @return $this
+     * @return self
      */
     public function utf8($field, $message = null, $when = null)
     {
@@ -1485,7 +1485,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::utf8()
-     * @return $this
+     * @return self
      */
     public function utf8Extended($field, $message = null, $when = null)
     {
@@ -1504,7 +1504,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::isInteger()
-     * @return $this
+     * @return self
      */
     public function integer($field, $message = null, $when = null)
     {
@@ -1522,7 +1522,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
-     * @return $this
+     * @return self
      */
     public function isArray($field, $message = null, $when = null)
     {
@@ -1543,7 +1543,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::multiple()
-     * @return $this
+     * @return self
      */
     public function multipleOptions($field, array $options = [], $message = null, $when = null)
     {
@@ -1566,7 +1566,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::numElements()
-     * @return $this
+     * @return self
      */
     public function hasAtLeast($field, $count, $message = null, $when = null)
     {
@@ -1593,7 +1593,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
      * @see \Cake\Validation\Validation::numElements()
-     * @return $this
+     * @return self
      */
     public function hasAtMost($field, $count, $message = null, $when = null)
     {

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -72,7 +72,7 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided.
-     * @return $this
+     * @return self
      */
     public function add($title, $url = null, array $options = [])
     {
@@ -105,7 +105,7 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided.
-     * @return $this
+     * @return self
      */
     public function prepend($title, $url = null, array $options = [])
     {
@@ -141,7 +141,7 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided.
-     * @return $this
+     * @return self
      * @throws LogicException In case the index is out of bound
      */
     public function insertAt($index, $title, $url = null, array $options = [])
@@ -170,7 +170,7 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided.
-     * @return $this
+     * @return self
      * @throws LogicException In case the matching crumb can not be found
      */
     public function insertBefore($matchingTitle, $title, $url = null, array $options = [])
@@ -199,7 +199,7 @@ class BreadcrumbsHelper extends Helper
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      * the link)
      * - *templateVars*: Specific template vars in case you override the templates provided.
-     * @return $this
+     * @return self
      * @throws LogicException In case the matching crumb can not be found.
      */
     public function insertAfter($matchingTitle, $title, $url = null, array $options = [])

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2729,7 +2729,7 @@ class FormHelper extends Helper
      * You need to supply one valid context or multiple, as a list of strings. Order sets priority.
      *
      * @param string|array $sources A string or a list of strings identifying a source.
-     * @return $this
+     * @return self
      */
     public function setValueSources($sources)
     {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -151,7 +151,7 @@ class HtmlHelper extends Helper
      * @param string $name Text for link
      * @param string|array|null $link URL for link (if empty it won't be a link)
      * @param string|array $options Link attributes e.g. ['id' => 'selected']
-     * @return $this
+     * @return self
      * @see \Cake\View\Helper\HtmlHelper::link() for details on $options that can be used.
      * @link http://book.cakephp.org/3.0/en/views/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
      * @deprecated 3.3.6 Use the BreadcrumbsHelper instead

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -151,7 +151,7 @@ class StringTemplate
      * ```
      *
      * @param array $templates An associative list of named templates.
-     * @return $this
+     * @return self
      */
     public function add(array $templates)
     {

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -32,7 +32,7 @@ trait StringTemplateTrait
      * Sets templates to use.
      *
      * @param array $templates Templates to be added.
-     * @return $this
+     * @return self
      */
     public function setTemplates(array $templates)
     {
@@ -58,7 +58,7 @@ trait StringTemplateTrait
      * @deprecated 3.4.0 Use setTemplates()/getTemplates() instead.
      * @param string|null|array $templates null or string allow reading templates. An array
      *   allows templates to be added.
-     * @return $this|string|array
+     * @return self|string|array
      */
     public function templates($templates = null)
     {

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -117,7 +117,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Get/set path for template files.
      *
      * @param string|null $path Path for view files. If null returns current path.
-     * @return string|$this
+     * @return string|self
      */
     public function templatePath($path = null)
     {
@@ -134,7 +134,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Get/set path for layout files.
      *
      * @param string|null $path Path for layout files. If null returns current path.
-     * @return string|$this
+     * @return string|self
      */
     public function layoutPath($path = null)
     {
@@ -153,7 +153,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * automatically applied to rendered views.
      *
      * @param bool|null $autoLayout Boolean to turn on/off. If null returns current value.
-     * @return bool|$this
+     * @return bool|self
      */
     public function autoLayout($autoLayout = null)
     {
@@ -171,7 +171,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *
      * @param string|null|false $name Plugin name. If null returns current plugin.
      *   Use false to remove the current plugin name.
-     * @return string|$this
+     * @return string|self
      */
     public function plugin($name = null)
     {
@@ -189,7 +189,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *
      * @param array|null $helpers Helpers to use.
      * @param bool $merge Whether or not to merge existing data with the new data.
-     * @return array|$this
+     * @return array|self
      */
     public function helpers(array $helpers = null, $merge = true)
     {
@@ -209,7 +209,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *
      * @param string|null|false $theme Theme name. If null returns current theme.
      *   Use false to remove the current theme.
-     * @return string|$this
+     * @return string|self
      */
     public function theme($theme = null)
     {
@@ -227,7 +227,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * filename in /src/Template/<SubFolder> without the .ctp extension.
      *
      * @param string|null $name View file name to set. If null returns current name.
-     * @return string|$this
+     * @return string|self
      */
     public function template($name = null)
     {
@@ -246,7 +246,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * without the .ctp extension.
      *
      * @param string|null $name Layout file name to set. If null returns current name.
-     * @return string|$this
+     * @return string|self
      */
     public function layout($name = null)
     {
@@ -266,7 +266,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      *
      * @param array|null $options Either an array of options or null to get current options.
      * @param bool $merge Whether or not to merge existing data with the new data.
-     * @return array|$this
+     * @return array|self
      */
     public function options(array $options = null, $merge = true)
     {
@@ -285,7 +285,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Get/set the view name
      *
      * @param string|null $name The name of the view
-     * @return array|$this
+     * @return array|self
      */
     public function name($name = null)
     {
@@ -306,7 +306,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * @param string|null $name The class name for the view. Can
      *   be a plugin.class name reference, a short alias, or a fully
      *   namespaced name.
-     * @return array|$this
+     * @return array|self
      */
     public function className($name = null)
     {
@@ -391,7 +391,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Configures a view builder instance from serialized config.
      *
      * @param array $config View builder configuration array.
-     * @return $this Configured view builder instance.
+     * @return self Configured view builder instance.
      */
     public function createFromArray($config)
     {
@@ -418,7 +418,7 @@ class ViewBuilder implements JsonSerializable, Serializable
      * Unserializes the view builder object.
      *
      * @param string $data Serialized string.
-     * @return $this Configured view builder instance.
+     * @return self Configured view builder instance.
      */
     public function unserialize($data)
     {

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -125,7 +125,7 @@ trait ViewVarsTrait
      * @param string|array $name A string or an array of data.
      * @param mixed $value Value in case $name is a string (which then works as the key).
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
-     * @return $this
+     * @return self
      */
     public function set($name, $value = null)
     {


### PR DESCRIPTION
`$this` breaks the IDE completely, even in the newest PHPStorm version.
Using `self` actually works fine.

Why did we cling to `$this` again? Can we switch to `self` now when this confirmed to work properly as expected?

Follow up on https://github.com/cakephp/cakephp/pull/9892