### PR TITLE
Fix Cake\Http\Client\Response::getStatusCode() return value type

### DIFF
--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -195,7 +195,7 @@ class Response extends Message implements ResponseInterface
             if (substr($value, 0, 5) === 'HTTP/') {
                 preg_match('/HTTP\/([\d.]+) ([0-9]+)(.*)/i', $value, $matches);
                 $this->protocol = $matches[1];
-                $this->code = $matches[2];
+                $this->code = (int)$matches[2];
                 $this->reasonPhrase = trim($matches[3]);
                 continue;
             }

--- a/tests/TestCase/Network/Http/ResponseTest.php
+++ b/tests/TestCase/Network/Http/ResponseTest.php
@@ -36,7 +36,7 @@ class ResponseTest extends TestCase
         $response = new Response($headers, 'winner!');
 
         $this->assertEquals('1.0', $response->getProtocolVersion());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
         $this->assertEquals(
             'text/html;charset="UTF-8"',
@@ -63,7 +63,7 @@ class ResponseTest extends TestCase
         ];
         $response = new Response($headers, 'ok');
 
-        $this->assertEquals(200, $response->statusCode());
+        $this->assertSame(200, $response->statusCode());
         $this->assertEquals('1.0', $response->version());
         $this->assertEquals(
             'text/html;charset="UTF-8"',
@@ -86,7 +86,7 @@ class ResponseTest extends TestCase
         $response = new Response($headers, 'ok');
 
         $this->assertEquals('1.0', $response->version());
-        $this->assertEquals(200, $response->statusCode());
+        $this->assertSame(200, $response->statusCode());
     }
 
     /**
@@ -342,10 +342,10 @@ XML;
             'Content-Type: text/html'
         ];
         $response = new Response($headers, '');
-        $this->assertEquals(404, $response->statusCode());
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertSame(404, $response->statusCode());
+        $this->assertSame(404, $response->getStatusCode());
 
-        $this->assertEquals(404, $response->code);
+        $this->assertSame(404, $response->code);
         $this->assertTrue(isset($response->code));
     }
 


### PR DESCRIPTION
This is a bug.

* CakePHP Version: 3.3.10
* Platform and Target: macOS X 10.12 Sierra

### What you did

```php
<?php
$client = new Cake\Http\Client();
$response = $client->get('https://cakephp.org');
var_dump($response->getStatusCode());
// => string(3) "200"
```

### What happened

`Response::getStatusCode()` returns a string type.
This behavior is equivalent to specifying ResponseInterface.
([http-message/ResponseInterface.php at master · php-fig/http-message](https://github.com/php-fig/http-message/blob/master/src/ResponseInterface.php#L30))

### What you expected to happen

return an int type.