### PR TITLE
Add missing deprecation annotation on the interface.

### DIFF
--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -26,6 +26,7 @@ interface LocatorInterface
      * Stores a list of options to be used when instantiating an object
      * with a matching alias.
      *
+     * @deprecated 3.4.0 Use setConfig()/getConfig() instead.
      * @param string|null $alias Name of the alias
      * @param array|null $options list of options for the alias
      * @return array The config data.


### PR DESCRIPTION
The implementing classes already have the deprecation line, so the interface should too to signal devs to move to the non deprecated methods.