### PR TITLE
Fix MemcachedEngineTest::testConfigurationConflict() rarely fails

### DIFF
--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -771,12 +771,12 @@ class MemcachedEngineTest extends TestCase
     {
         Cache::config('long_memcached', [
             'engine' => 'Memcached',
-            'duration' => '+2 seconds',
+            'duration' => '+3 seconds',
             'servers' => ['127.0.0.1:11211'],
         ]);
         Cache::config('short_memcached', [
             'engine' => 'Memcached',
-            'duration' => '+1 seconds',
+            'duration' => '+2 seconds',
             'servers' => ['127.0.0.1:11211'],
         ]);
 
@@ -786,10 +786,10 @@ class MemcachedEngineTest extends TestCase
         $this->assertEquals('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
         $this->assertEquals('boo', Cache::read('short_duration_test', 'short_memcached'), 'Value was not read %s');
 
-        sleep(1);
+        usleep(500000);
         $this->assertEquals('yay', Cache::read('duration_test', 'long_memcached'), 'Value was not read %s');
 
-        sleep(2);
+        usleep(3000000);
         $this->assertFalse(Cache::read('short_duration_test', 'short_memcached'), 'Cache was not invalidated %s');
         $this->assertFalse(Cache::read('duration_test', 'long_memcached'), 'Value did not expire %s');
 


### PR DESCRIPTION
This is a unit test's bug.

* CakePHP Version: 3.3.10
* Platform and Target: Travis CI (Environment I found)

I added a PR #9899. After checking the build result of Travis-CI, [`MemcachedEngineTest::testConfigurationConflict()`](https://github.com/cakephp/cakephp/blob/master/tests/TestCase/Cache/Engine/MemcachedEngineTest.php#L770) failed with only one of all the jobs. (It seems that it was manually rebuilt immediately.)

Probably the same case: [testConfigurationConflict site:travis-ci.org - Google](https://www.google.co.jp/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=testConfigurationConflict+site%3Atravis-ci.org)

It seems that the test fails because the cache can not be read for a time shorter than the specified expiration date (maximum 1 second).

For example, in the following tests, It's only have 200 milliseconds waiting for a cache write, but sometimes the test fails. (Cache can't be read.)

```php
<?php
namespace App\Test\TestCase;

use Cake\Cache\Cache;
use Cake\TestSuite\TestCase;

class ErraticMemcachedEngineTest extends TestCase
{
    public function testSomeTimeFail()
    {
        usleep(rand(1, 1000000)); // start timing randomize
        Cache::config('short_memcached', [
            'engine' => 'Memcached',
            'duration' => '+1 seconds',
            'servers' => ['127.0.0.1:11211'],
        ]);

        $this->assertTrue(Cache::write('short_duration_test', 'boo', 'short_memcached'));
        usleep(200000);
        $this->assertEquals('boo', Cache::read('short_duration_test', 'short_memcached'), 'Value was not read %s');
        Cache::drop('short_memcached');
    }
}
```

In this PR, I adjusted the time according to the behavior of Memcached.

By the way, I checked [the commit with the test method added](https://github.com/cakephp/cakephp/commit/4425743bcd2c83431c8a500505e63cfcf4fb34ff#diff-f7b6371d1efb5cf5cd03dd8e1f3ff305) and [the commit on migration to Cake 3](https://github.com/cakephp/cakephp/pull/1606/commits/c2171e80e8aee91c1478cde21cde6ef53a67a635#diff-deb56b8077f4d5332e67d075877b3efdL444).

At the time of migration of Cake 3, the following code which seemed necessary was deleted, is not it a problem?

`testConfigurationConflict()` DocComment is <q>test that configurations don't conflict, when a file engine is declared after a memcached one.</q>

```php
Cache::config('some_file', array('engine' => 'File'));
```