### PR TITLE
Fix return type to be as expected and documented.

### DIFF
--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -84,7 +84,7 @@ class SessionStorage implements StorageInterface
 
         $this->_user = $this->_session->read($this->_config['key']) ?: false;
 
-        return $this->_user;
+        return $this->_user ?: null;
     }
 
     /**


### PR DESCRIPTION
Internally, the value can be false, but that must not leak outside of the class when reading via read().
As documented and expected it must be either the array or null.