### PR TITLE
Use array conditions for joins.

### DIFF
--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -102,7 +102,7 @@ class AclNode extends Model {
 					'alias' => "{$type}{$i}",
 					'type' => 'INNER',
 					'conditions' => array(
-						$db->name("{$type}{$i}.alias") . ' = ' . $db->value($alias, 'string')
+						"{$type}{$i}.alias" => $alias
 					)
 				);
 


### PR DESCRIPTION
Use array style conditions instead of using lower-level DboSource API methods to create safe SQL.

Refs #9927
