### PR TITLE
Static analysis with PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
+    - php: 7.0
+      env: PHPSTAN=1 DEFAULT=0
+
+    - php: 7.1
+      env: PHPSTAN=1 DEFAULT=0
+
     - php: hhvm
       env: HHVM=1 DB=sqlite db_dsn='sqlite:///:memory:'
 
@@ -44,6 +50,10 @@ matrix:
 
   allow_failures:
     - php: hhvm
+    - php: 7.0
+      env: PHPSTAN=1 DEFAULT=0
+    - php: 7.1
+      env: PHPSTAN=1 DEFAULT=0
 
 before_install:
   - if [ $HHVM != 1 && $TRAVIS_PHP_VERSION != 7.* ]; then phpenv config-rm xdebug.ini; fi
@@ -78,6 +88,7 @@ script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
 
   - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
+  - if [[ $PHPSTAN = 1 ]]; then composer require --dev phpstan/phpstan:dev-master && vendor/bin/phpstan analyse -c phpstan.neon -l 0 src; fi
 
 after_success:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+	autoload_files:
+		- %rootDir%/../../../src/basics.php

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -24,7 +24,6 @@ use Cake\Database\Log\QueryLogger;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Datasource\ConnectionInterface;
-use Exception;
 
 /**
  * Represents a connection with a database server.
@@ -214,7 +213,7 @@ class Connection implements ConnectionInterface
             $this->_driver->connect();
 
             return true;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new MissingConnectionException(['reason' => $e->getMessage()]);
         }
     }
@@ -653,7 +652,7 @@ class Connection implements ConnectionInterface
 
         try {
             $result = $callback($this);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->rollback();
             throw $e;
         }
@@ -686,7 +685,7 @@ class Connection implements ConnectionInterface
 
         try {
             $result = $callback($this);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->enableForeignKeys();
             throw $e;
         }


### PR DESCRIPTION
Continuing the work from #9934. This is PR to integrate [PHPStan](https://github.com/phpstan/phpstan) into the CI build of CakePHP.

It's a work in progress since there are quite a lot of errors in the build log. `@property` annotations are already supported by PHPStan, but it still found some undefined properties.

Even after merging this PR, I expect to continue to work with you on increasing the level of strictness of the analysis and also on updating to newer versions of PHPStan :)

I'd like one of the maintainers to go through the error log and fix obvious errors in the code. We can then work together on the other, more questionable, errors.