### PR TITLE
Rename FormHelper methods to be less confusing.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -857,20 +857,20 @@ class FormHelper extends Helper
     }
 
     /**
-     * Generate a set of inputs for `$fields`. If $fields is empty the fields of current model
-     * will be used.
+     * Generate a set of controls for `$fields`. If $fields is empty the fields
+     * of current model will be used.
      *
-     * You can customize individual inputs through `$fields`.
+     * You can customize individual controls through `$fields`.
      * ```
-     * $this->Form->allInputs([
+     * $this->Form->allControls([
      *   'name' => ['label' => 'custom label']
      * ]);
      * ```
      *
-     * You can exclude fields by specifying them as false:
+     * You can exclude fields by specifying them as `false`:
      *
      * ```
-     * $this->Form->allInputs(['title' => false]);
+     * $this->Form->allControls(['title' => false]);
      * ```
      *
      * In the above example, no field would be generated for the title field.
@@ -881,12 +881,12 @@ class FormHelper extends Helper
      * - `fieldset` Set to false to disable the fieldset. You can also pass an array of params to be
      *    applied as HTML attributes to the fieldset tag. If you pass an empty array, the fieldset will
      *    be enabled
-     * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
+     * - `legend` Set to false to disable the legend for the generated control set. Or supply a string
      *    to customize the legend text.
-     * @return string Completed form inputs.
+     * @return string Completed form controls.
      * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#generating-entire-forms
      */
-    public function allInputs(array $fields = [], array $options = [])
+    public function allControls(array $fields = [], array $options = [])
     {
         $context = $this->_getContext();
 
@@ -897,32 +897,53 @@ class FormHelper extends Helper
             Hash::normalize($fields)
         );
 
-        return $this->inputs($fields, $options);
+        return $this->controls($fields, $options);
     }
 
     /**
-     * Generate a set of inputs for `$fields` wrapped in a fieldset element.
+     * Generate a set of controls for `$fields`. If $fields is empty the fields
+     * of current model will be used.
      *
-     * You can customize individual inputs through `$fields`.
+     * @param array $fields An array of customizations for the fields that will be
+     *   generated. This array allows you to set custom types, labels, or other options.
+     * @param array $options Options array. Valid keys are:
+     * - `fieldset` Set to false to disable the fieldset. You can also pass an array of params to be
+     *    applied as HTML attributes to the fieldset tag. If you pass an empty array, the fieldset will
+     *    be enabled
+     * - `legend` Set to false to disable the legend for the generated control set. Or supply a string
+     *    to customize the legend text.
+     * @return string Completed form controls.
+     * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#generating-entire-forms
+     * @deprecated 3.4.0 Use FormHelper::allControls() instead.
+     */
+    public function allInputs(array $fields = [], array $options = [])
+    {
+        return $this->allControls($fields, $options);
+    }
+
+    /**
+     * Generate a set of controls for `$fields` wrapped in a fieldset element.
+     *
+     * You can customize individual controls through `$fields`.
      * ```
-     * $this->Form->inputs([
+     * $this->Form->controls([
      *   'name' => ['label' => 'custom label'],
      *   'email'
      * ]);
      * ```
      *
-     * @param array $fields An array of the fields to generate. This array allows you to set custom
-     *   types, labels, or other options.
+     * @param array $fields An array of the fields to generate. This array allows
+     *   you to set custom types, labels, or other options.
      * @param array $options Options array. Valid keys are:
-     * - `fieldset` Set to false to disable the fieldset. You can also pass an array of params to be
-     *    applied as HTML attributes to the fieldset tag. If you pass an empty array, the fieldset will
-     *    be enabled
-     * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
-     *    to customize the legend text.
+     * - `fieldset` Set to false to disable the fieldset. You can also pass an
+     *    array of params to be applied as HTML attributes to the fieldset tag.
+     *    If you pass an empty array, the fieldset will be enabled.
+     * - `legend` Set to false to disable the legend for the generated input set.
+     *    Or supply a string to customize the legend text.
      * @return string Completed form inputs.
      * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#generating-entire-forms
      */
-    public function inputs(array $fields, array $options = [])
+    public function controls(array $fields, array $options = [])
     {
         $fields = Hash::normalize($fields);
 
@@ -932,10 +953,30 @@ class FormHelper extends Helper
                 continue;
             }
 
-            $out .= $this->input($name, (array)$opts);
+            $out .= $this->control($name, (array)$opts);
         }
 
         return $this->fieldset($out, $options);
+    }
+
+    /**
+     * Generate a set of controls for `$fields` wrapped in a fieldset element.
+     *
+     * @param array $fields An array of the fields to generate. This array allows
+     *   you to set custom types, labels, or other options.
+     * @param array $options Options array. Valid keys are:
+     * - `fieldset` Set to false to disable the fieldset. You can also pass an
+     *    array of params to be applied as HTML attributes to the fieldset tag.
+     *    If you pass an empty array, the fieldset will be enabled.
+     * - `legend` Set to false to disable the legend for the generated input set.
+     *    Or supply a string to customize the legend text.
+     * @return string Completed form inputs.
+     * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#generating-entire-forms
+     * @deprecated 3.4.0 Use FormHelper::controls() instead.
+     */
+    public function inputs(array $fields, array $options = [])
+    {
+        return $this->controls($fields, $options);
     }
 
     /**
@@ -989,7 +1030,7 @@ class FormHelper extends Helper
     }
 
     /**
-     * Generates a form input element complete with label and wrapper div
+     * Generates a form control element complete with label and wrapper div.
      *
      * ### Options
      *
@@ -1016,7 +1057,7 @@ class FormHelper extends Helper
      * @return string Completed form widget.
      * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#creating-form-inputs
      */
-    public function input($fieldName, array $options = [])
+    public function control($fieldName, array $options = [])
     {
         $options += [
             'type' => null,
@@ -1088,6 +1129,20 @@ class FormHelper extends Helper
         }
 
         return $result;
+    }
+
+    /**
+     * Generates a form control element complete with label and wrapper div.
+     *
+     * @param string $fieldName This should be "modelname.fieldname"
+     * @param array $options Each type of input takes different options.
+     * @return string Completed form widget.
+     * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#creating-form-inputs
+     * @deprecated 3.4.0 Use FormHelper::control() instead.
+     */
+    public function input($fieldName, array $options = [])
+    {
+        return $this->control($fieldName, $options);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -204,7 +204,7 @@ class FormHelperTest extends TestCase
         $helper = new FormHelper($this->View, [
             'templates' => 'htmlhelper_tags'
         ]);
-        $result = $helper->input('name');
+        $result = $helper->control('name');
         $this->assertContains('<input', $result);
     }
 
@@ -570,13 +570,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * Test using template vars in various templates used by input() method.
+     * Test using template vars in various templates used by control() method.
      *
      * @return void
      */
-    public function testInputTemplateVars()
+    public function testControlTemplateVars()
     {
-        $result = $this->Form->input('text', [
+        $result = $this->Form->control('text', [
             'templates' => [
                 'input' => '<input custom="{{forinput}}" type="{{type}}" name="{{name}}"{{attrs}}/>',
                 'label' => '<label{{attrs}}>{{text}} {{forlabel}}</label>',
@@ -605,13 +605,13 @@ class FormHelperTest extends TestCase
 
     /**
      * Test ensuring template variables work in template files loaded
-     * during input().
+     * during control().
      *
      * @return void
      */
-    public function testInputTemplatesFromFile()
+    public function testControlTemplatesFromFile()
     {
-        $result = $this->Form->input('title', [
+        $result = $this->Form->control('title', [
             'templates' => 'test_templates',
             'templateVars' => [
                 'forcontainer' => 'container-data'
@@ -1237,7 +1237,7 @@ class FormHelperTest extends TestCase
         ];
 
         $this->Form->create($this->article);
-        $result = $this->Form->input('foo');
+        $result = $this->Form->control('foo');
         $expected = [
             'div' => ['class' => 'input number'],
             'label' => ['for' => 'foo'],
@@ -1253,7 +1253,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('foo', ['step' => 0.5]);
+        $result = $this->Form->control('foo', ['step' => 0.5]);
         $expected = [
             'div' => ['class' => 'input number'],
             'label' => ['for' => 'foo'],
@@ -1281,7 +1281,7 @@ class FormHelperTest extends TestCase
             'className' => __NAMESPACE__ . '\ContactsTable'
         ]);
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
-        $result = $this->Form->input('age');
+        $result = $this->Form->control('age');
         $expected = [
             'div' => ['class' => 'input number'],
             'label' => ['for' => 'age'],
@@ -1314,7 +1314,7 @@ class FormHelperTest extends TestCase
         ]]);
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
 
-        $result = $this->Form->input('foo');
+        $result = $this->Form->control('foo');
         $expected = [
             'div' => ['class' => 'input file'],
             'label' => ['for' => 'foo'],
@@ -1509,34 +1509,34 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecurityMultipleInputFields method
+     * testFormSecurityMultipleControlFields method
      *
      * Test secure form creation with multiple row creation. Checks hidden, text, checkbox field types
      *
      * @return void
      */
-    public function testFormSecurityMultipleInputFields()
+    public function testFormSecurityMultipleControlFields()
     {
         $this->Form->request->params['_Token'] = 'testKey';
         $this->Form->create();
 
         $this->Form->hidden('Addresses.0.id', ['value' => '123456']);
-        $this->Form->input('Addresses.0.title');
-        $this->Form->input('Addresses.0.first_name');
-        $this->Form->input('Addresses.0.last_name');
-        $this->Form->input('Addresses.0.address');
-        $this->Form->input('Addresses.0.city');
-        $this->Form->input('Addresses.0.phone');
-        $this->Form->input('Addresses.0.primary', ['type' => 'checkbox']);
+        $this->Form->control('Addresses.0.title');
+        $this->Form->control('Addresses.0.first_name');
+        $this->Form->control('Addresses.0.last_name');
+        $this->Form->control('Addresses.0.address');
+        $this->Form->control('Addresses.0.city');
+        $this->Form->control('Addresses.0.phone');
+        $this->Form->control('Addresses.0.primary', ['type' => 'checkbox']);
 
         $this->Form->hidden('Addresses.1.id', ['value' => '654321']);
-        $this->Form->input('Addresses.1.title');
-        $this->Form->input('Addresses.1.first_name');
-        $this->Form->input('Addresses.1.last_name');
-        $this->Form->input('Addresses.1.address');
-        $this->Form->input('Addresses.1.city');
-        $this->Form->input('Addresses.1.phone');
-        $this->Form->input('Addresses.1.primary', ['type' => 'checkbox']);
+        $this->Form->control('Addresses.1.title');
+        $this->Form->control('Addresses.1.first_name');
+        $this->Form->control('Addresses.1.last_name');
+        $this->Form->control('Addresses.1.address');
+        $this->Form->control('Addresses.1.city');
+        $this->Form->control('Addresses.1.phone');
+        $this->Form->control('Addresses.1.primary', ['type' => 'checkbox']);
 
         $result = $this->Form->secure($this->Form->fields);
 
@@ -1602,13 +1602,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecurityMultipleInputDisabledFields method
+     * testFormSecurityMultipleControlDisabledFields method
      *
      * Test secure form generation with multiple records and disabled fields.
      *
      * @return void
      */
-    public function testFormSecurityMultipleInputDisabledFields()
+    public function testFormSecurityMultipleControlDisabledFields()
     {
         $this->Form->request->params['_Token'] = [
             'unlockedFields' => ['first_name', 'address']
@@ -1674,13 +1674,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecurityInputDisabledFields method
+     * testFormSecurityControlDisabledFields method
      *
      * Test single record form with disabled fields.
      *
      * @return void
      */
-    public function testFormSecurityInputUnlockedFields()
+    public function testFormSecurityControlUnlockedFields()
     {
         $this->Form->request->params['_Token'] = [
             'unlockedFields' => ['first_name', 'address']
@@ -1746,13 +1746,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecurityInputUnlockedFieldsDebugSecurityTrue method
+     * testFormSecurityControlUnlockedFieldsDebugSecurityTrue method
      *
      * Test single record form with debugSecurity param.
      *
      * @return void
      */
-    public function testFormSecurityInputUnlockedFieldsDebugSecurityTrue()
+    public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue()
     {
         $this->Form->request->params['_Token'] = [
             'unlockedFields' => ['first_name', 'address']
@@ -1817,13 +1817,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecurityInputUnlockedFieldsDebugSecurityFalse method
+     * testFormSecurityControlUnlockedFieldsDebugSecurityFalse method
      *
      * Debug is false, debugSecurity is true -> no debug
      *
      * @return void
      */
-    public function testFormSecurityInputUnlockedFieldsDebugSecurityDebugFalse()
+    public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse()
     {
         $this->Form->request->params['_Token'] = [
             'unlockedFields' => ['first_name', 'address']
@@ -1869,13 +1869,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecurityInputUnlockedFieldsDebugSecurityFalse method
+     * testFormSecurityControlUnlockedFieldsDebugSecurityFalse method
      *
      * Test single record form with debugSecurity param.
      *
      * @return void
      */
-    public function testFormSecurityInputUnlockedFieldsDebugSecurityFalse()
+    public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse()
     {
         $this->Form->request->params['_Token'] = [
             'unlockedFields' => ['first_name', 'address']
@@ -1941,13 +1941,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecuredInput method
+     * testFormSecuredControl method
      *
-     * Test generation of entire secure form, assertions made on input() output.
+     * Test generation of entire secure form, assertions made on control() output.
      *
      * @return void
      */
-    public function testFormSecuredInput()
+    public function testFormSecuredControl()
     {
         $this->Form->request->params['_csrfToken'] = 'testKey';
         $this->Form->request->params['_Token'] = 'stuff';
@@ -1971,7 +1971,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('ratio');
+        $result = $this->Form->control('ratio');
         $expected = [
             'div' => ['class'],
             'label' => ['for'],
@@ -1982,7 +1982,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('population');
+        $result = $this->Form->control('population');
         $expected = [
             'div' => ['class'],
             'label' => ['for'],
@@ -1993,7 +1993,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('published', ['type' => 'text']);
+        $result = $this->Form->control('published', ['type' => 'text']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'published'],
@@ -2008,7 +2008,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('other', ['type' => 'text']);
+        $result = $this->Form->control('other', ['type' => 'text']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'other'],
@@ -2041,7 +2041,7 @@ class FormHelperTest extends TestCase
         ]];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('something', ['type' => 'checkbox']);
+        $result = $this->Form->control('something', ['type' => 'checkbox']);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             ['input' => [
@@ -2103,13 +2103,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testSecuredInputCustomName method
+     * testSecuredControlCustomName method
      *
      * Test secured inputs with custom names.
      *
      * @return void
      */
-    public function testSecuredInputCustomName()
+    public function testSecuredControlCustomName()
     {
         $this->Form->request->params['_Token'] = 'testKey';
         $this->assertEquals([], $this->Form->fields);
@@ -2132,26 +2132,26 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testSecuredInputDuplicate method
+     * testSecuredControlDuplicate method
      *
      * Test that a hidden field followed by a visible field
      * undoes the hidden field locking.
      *
      * @return void
      */
-    public function testSecuredInputDuplicate()
+    public function testSecuredControlDuplicate()
     {
         $this->Form->request->params['_Token'] = ['key' => 'testKey'];
         $this->assertEquals([], $this->Form->fields);
 
-        $this->Form->input('text_val', [
+        $this->Form->control('text_val', [
                 'type' => 'hidden',
                 'value' => 'some text',
         ]);
         $expected = ['text_val' => 'some text'];
         $this->assertEquals($expected, $this->Form->fields);
 
-        $this->Form->input('text_val', [
+        $this->Form->control('text_val', [
                 'type' => 'text',
         ]);
         $expected = ['text_val'];
@@ -2159,13 +2159,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormSecuredFileInput method
+     * testFormSecuredFileControl method
      *
      * Tests that the correct keys are added to the field hash index.
      *
      * @return void
      */
-    public function testFormSecuredFileInput()
+    public function testFormSecuredFileControl()
     {
         $this->assertEquals([], $this->Form->fields);
 
@@ -2465,7 +2465,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('Article.title');
+        $result = $this->Form->control('Article.title');
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-title'],
@@ -2482,7 +2482,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Article.title', [
+        $result = $this->Form->control('Article.title', [
             'templates' => [
                 'inputContainerError' => '<div class="input {{type}}{{required}} error">{{content}}</div>'
             ]
@@ -2502,7 +2502,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
 
-        $result = $this->Form->input('Article.content');
+        $result = $this->Form->control('Article.content');
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-content'],
@@ -2519,7 +2519,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Article.content', ['error' => ['escape' => true]]);
+        $result = $this->Form->control('Article.content', ['error' => ['escape' => true]]);
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-content'],
@@ -2536,7 +2536,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Article.content', ['error' => ['escape' => false]]);
+        $result = $this->Form->control('Article.content', ['error' => ['escape' => false]]);
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-content'],
@@ -2568,7 +2568,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('Article.title');
+        $result = $this->Form->control('Article.title');
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-title'],
@@ -2587,20 +2587,20 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testEmptyInputErrorValidation method
+     * testEmptyControlErrorValidation method
      *
-     * Test validation errors, when calling input() overriding validation message by an empty string.
+     * Test validation errors, when calling control() overriding validation message by an empty string.
      *
      * @return void
      */
-    public function testEmptyInputErrorValidation()
+    public function testEmptyControlErrorValidation()
     {
         $this->article['errors'] = [
             'Article' => ['title' => 'error message']
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('Article.title', ['error' => '']);
+        $result = $this->Form->control('Article.title', ['error' => '']);
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'article-title'],
@@ -2619,20 +2619,20 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputErrorMessage method
+     * testControlErrorMessage method
      *
-     * Test validation errors, when calling input() overriding validation messages.
+     * Test validation errors, when calling control() overriding validation messages.
      *
      * @return void
      */
-    public function testInputErrorMessage()
+    public function testControlErrorMessage()
     {
         $this->article['errors'] = [
             'title' => ['error message']
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title', [
+        $result = $this->Form->control('title', [
             'error' => 'Custom error!'
         ]);
         $expected = [
@@ -2652,7 +2652,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('title', [
+        $result = $this->Form->control('title', [
             'error' => ['error message' => 'Custom error!']
         ]);
         $expected = [
@@ -2732,7 +2732,7 @@ class FormHelperTest extends TestCase
         $two->errors('name', ['This is wrong']);
         $this->Form->create([$one, $two], ['context' => ['table' => 'Contacts']]);
 
-        $result = $this->Form->input('0.email');
+        $result = $this->Form->control('0.email');
         $expected = [
             'div' => ['class' => 'input email error'],
             'label' => ['for' => '0-email'],
@@ -2749,7 +2749,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('1.name');
+        $result = $this->Form->control('1.name');
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => '1-name'],
@@ -2768,19 +2768,19 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInput method
+     * testControl method
      *
-     * Test various incarnations of input().
+     * Test various incarnations of control().
      *
      * @return void
      */
-    public function testInput()
+    public function testControl()
     {
         TableRegistry::get('ValidateUsers', [
             'className' => __NAMESPACE__ . '\ValidateUsersTable'
         ]);
         $this->Form->create([], ['context' => ['table' => 'ValidateUsers']]);
-        $result = $this->Form->input('ValidateUsers.balance');
+        $result = $this->Form->control('ValidateUsers.balance');
         $expected = [
             'div' => ['class'],
             'label' => ['for'],
@@ -2791,7 +2791,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('ValidateUser.cost_decimal');
+        $result = $this->Form->control('ValidateUser.cost_decimal');
         $expected = [
             'div' => ['class'],
             'label' => ['for'],
@@ -2802,7 +2802,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('ValidateUser.null_decimal');
+        $result = $this->Form->control('ValidateUser.null_decimal');
         $expected = [
             'div' => ['class'],
             'label' => ['for'],
@@ -2815,19 +2815,19 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputCustomization method
+     * testControlCustomization method
      *
      * Tests the input method and passing custom options.
      *
      * @return void
      */
-    public function testInputCustomization()
+    public function testControlCustomization()
     {
         TableRegistry::get('Contacts', [
             'className' => __NAMESPACE__ . '\ContactsTable'
         ]);
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
-        $result = $this->Form->input('Contact.email', ['id' => 'custom']);
+        $result = $this->Form->control('Contact.email', ['id' => 'custom']);
         $expected = [
             'div' => ['class' => 'input email'],
             'label' => ['for' => 'custom'],
@@ -2841,7 +2841,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Contact.email', [
+        $result = $this->Form->control('Contact.email', [
             'templates' => ['inputContainer' => '<div>{{content}}</div>']
         ]);
         $expected = [
@@ -2857,7 +2857,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Contact.email', ['type' => 'text']);
+        $result = $this->Form->control('Contact.email', ['type' => 'text']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'contact-email'],
@@ -2871,7 +2871,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Contact.5.email', ['type' => 'text']);
+        $result = $this->Form->control('Contact.5.email', ['type' => 'text']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'contact-5-email'],
@@ -2885,7 +2885,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Contact.password');
+        $result = $this->Form->control('Contact.password');
         $expected = [
             'div' => ['class' => 'input password'],
             'label' => ['for' => 'contact-password'],
@@ -2899,7 +2899,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Contact.email', [
+        $result = $this->Form->control('Contact.email', [
             'type' => 'file', 'class' => 'textbox'
         ]);
         $expected = [
@@ -2917,7 +2917,7 @@ class FormHelperTest extends TestCase
 
         $entity = new Entity(['phone' => 'Hello & World > weird chars']);
         $this->Form->create($entity, ['context' => ['table' => 'Contacts']]);
-        $result = $this->Form->input('phone');
+        $result = $this->Form->control('phone');
         $expected = [
             'div' => ['class' => 'input tel'],
             'label' => ['for' => 'phone'],
@@ -2934,7 +2934,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->request->data['Model']['0']['OtherModel']['field'] = 'My value';
         $this->Form->create();
-        $result = $this->Form->input('Model.0.OtherModel.field', ['id' => 'myId']);
+        $result = $this->Form->control('Model.0.OtherModel.field', ['id' => 'myId']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'myId'],
@@ -2952,7 +2952,7 @@ class FormHelperTest extends TestCase
 
         $entity->errors('field', 'Badness!');
         $this->Form->create($entity, ['context' => ['table' => 'Contacts']]);
-        $result = $this->Form->input('field');
+        $result = $this->Form->control('field');
         $expected = [
             'div' => ['class' => 'input text error'],
             'label' => ['for' => 'field'],
@@ -2969,7 +2969,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('field', [
+        $result = $this->Form->control('field', [
             'templates' => [
                 'inputContainerError' => '{{content}}{{error}}',
                 'error' => '<span class="error-message">{{content}}</span>'
@@ -2990,7 +2990,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $entity->errors('field', ['minLength'], true);
-        $result = $this->Form->input('field', [
+        $result = $this->Form->control('field', [
             'error' => [
                 'minLength' => 'Le login doit contenir au moins 2 caractères',
                 'maxLength' => 'login too large'
@@ -3010,7 +3010,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $entity->errors('field', ['maxLength'], true);
-        $result = $this->Form->input('field', [
+        $result = $this->Form->control('field', [
             'error' => [
                 'minLength' => 'Le login doit contenir au moins 2 caractères',
                 'maxLength' => 'login too large',
@@ -3031,15 +3031,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputWithTemplateFile method
+     * testControlWithTemplateFile method
      *
-     * Test that input() accepts a template file.
+     * Test that control() accepts a template file.
      *
      * @return void
      */
-    public function testInputWithTemplateFile()
+    public function testControlWithTemplateFile()
     {
-        $result = $this->Form->input('field', [
+        $result = $this->Form->control('field', [
             'templates' => 'htmlhelper_tags'
         ]);
         $expected = [
@@ -3055,13 +3055,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testNestedInputsEndWithBrackets method
+     * testNestedControlsEndWithBrackets method
      *
      * Test that nested inputs end with brackets.
      *
      * @return void
      */
-    public function testNestedInputsEndWithBrackets()
+    public function testNestedControlsEndWithBrackets()
     {
         $result = $this->Form->text('nested.text[]');
         $expected = [
@@ -3090,7 +3090,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->create(false, ['idPrefix' => 'prefix']);
 
-        $result = $this->Form->input('field');
+        $result = $this->Form->control('field');
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'prefix-field'],
@@ -3101,7 +3101,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('field', ['id' => 'custom-id']);
+        $result = $this->Form->control('field', ['id' => 'custom-id']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'custom-id'],
@@ -3164,7 +3164,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->end();
-        $result = $this->Form->input('field');
+        $result = $this->Form->control('field');
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'field'],
@@ -3177,19 +3177,19 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputZero method
+     * testControlZero method
      *
      * Test that inputs with 0 can be created.
      *
      * @return void
      */
-    public function testInputZero()
+    public function testControlZero()
     {
         TableRegistry::get('Contacts', [
             'className' => __NAMESPACE__ . '\ContactsTable'
         ]);
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
-        $result = $this->Form->input('0');
+        $result = $this->Form->control('0');
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => '0'], '/label',
@@ -3200,15 +3200,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputCheckbox method
+     * testControlCheckbox method
      *
-     * Test input() with checkbox creation.
+     * Test control() with checkbox creation.
      *
      * @return void
      */
-    public function testInputCheckbox()
+    public function testControlCheckbox()
     {
-        $result = $this->Form->input('User.active', ['label' => false, 'checked' => true]);
+        $result = $this->Form->control('User.active', ['label' => false, 'checked' => true]);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             'input' => ['type' => 'hidden', 'name' => 'User[active]', 'value' => '0'],
@@ -3217,7 +3217,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('User.active', ['label' => false, 'checked' => 1]);
+        $result = $this->Form->control('User.active', ['label' => false, 'checked' => 1]);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             'input' => ['type' => 'hidden', 'name' => 'User[active]', 'value' => '0'],
@@ -3226,7 +3226,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('User.active', ['label' => false, 'checked' => '1']);
+        $result = $this->Form->control('User.active', ['label' => false, 'checked' => '1']);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             'input' => ['type' => 'hidden', 'name' => 'User[active]', 'value' => '0'],
@@ -3235,7 +3235,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('User.disabled', [
+        $result = $this->Form->control('User.disabled', [
             'label' => 'Disabled',
             'type' => 'checkbox',
             'data-foo' => 'disabled'
@@ -3257,7 +3257,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('User.confirm', [
+        $result = $this->Form->control('User.confirm', [
             'label' => 'Confirm <b>me</b>!',
             'type' => 'checkbox',
             'escape' => false
@@ -3280,26 +3280,26 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputHidden method
+     * testControlHidden method
      *
-     * Test that input() does not create wrapping div and label tag for hidden fields.
+     * Test that control() does not create wrapping div and label tag for hidden fields.
      *
      * @return void
      */
-    public function testInputHidden()
+    public function testControlHidden()
     {
         TableRegistry::get('ValidateUsers', [
             'className' => __NAMESPACE__ . '\ValidateUsersTable'
         ]);
         $this->Form->create([], ['context' => ['table' => 'ValidateUsers']]);
 
-        $result = $this->Form->input('ValidateUser.id');
+        $result = $this->Form->control('ValidateUser.id');
         $expected = [
             'input' => ['name', 'type' => 'hidden', 'id']
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('ValidateUser.custom', ['type' => 'hidden']);
+        $result = $this->Form->control('ValidateUser.custom', ['type' => 'hidden']);
         $expected = [
             'input' => ['name', 'type' => 'hidden', 'id']
         ];
@@ -3307,13 +3307,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputDatetime method
+     * testControlDatetime method
      *
-     * Test form->input() with datetime.
+     * Test form->control() with datetime.
      *
      * @return void
      */
-    public function testInputDatetime()
+    public function testControlDatetime()
     {
         $this->Form = $this->getMockBuilder('Cake\View\Helper\FormHelper')
             ->setMethods(['datetime'])
@@ -3333,7 +3333,7 @@ class FormHelperTest extends TestCase
                 'templateVars' => []
             ])
             ->will($this->returnValue('This is it!'));
-        $result = $this->Form->input('prueba', [
+        $result = $this->Form->control('prueba', [
             'type' => 'datetime', 'timeFormat' => 24, 'minYear' => 2008,
             'maxYear' => 2011, 'interval' => 15
         ]);
@@ -3349,13 +3349,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputDatetimeIdPrefix method
+     * testControlDatetimeIdPrefix method
      *
-     * Test form->input() with datetime with id prefix.
+     * Test form->control() with datetime with id prefix.
      *
      * @return void
      */
-    public function testInputDatetimeIdPrefix()
+    public function testControlDatetimeIdPrefix()
     {
         $this->Form = $this->getMockBuilder('Cake\View\Helper\FormHelper')
             ->setMethods(['datetime'])
@@ -3378,7 +3378,7 @@ class FormHelperTest extends TestCase
                 'templateVars' => []
             ])
             ->will($this->returnValue('This is it!'));
-        $result = $this->Form->input('prueba', [
+        $result = $this->Form->control('prueba', [
             'type' => 'datetime', 'timeFormat' => 24, 'minYear' => 2008,
             'maxYear' => 2011, 'interval' => 15
         ]);
@@ -3394,16 +3394,16 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputCheckboxWithDisabledElements method
+     * testControlCheckboxWithDisabledElements method
      *
      * Test generating checkboxes with disabled elements.
      *
      * @return void
      */
-    public function testInputCheckboxWithDisabledElements()
+    public function testControlCheckboxWithDisabledElements()
     {
         $options = [1 => 'One', 2 => 'Two', '3' => 'Three'];
-        $result = $this->Form->input('Contact.multiple', [
+        $result = $this->Form->control('Contact.multiple', [
             'multiple' => 'checkbox',
             'disabled' => 'disabled',
             'options' => $options
@@ -3461,18 +3461,18 @@ class FormHelperTest extends TestCase
             '/div',
             '/div'
         ];
-        $result = $this->Form->input('Contact.multiple', ['multiple' => 'checkbox', 'disabled' => $disabled, 'options' => $options]);
+        $result = $this->Form->control('Contact.multiple', ['multiple' => 'checkbox', 'disabled' => $disabled, 'options' => $options]);
         $this->assertHtml($expected, $result);
     }
 
     /**
-     * testInputWithLeadingInteger method
+     * testControlWithLeadingInteger method
      *
      * Test input name with leading integer, ensure attributes are generated correctly.
      *
      * @return void
      */
-    public function testInputWithLeadingInteger()
+    public function testControlWithLeadingInteger()
     {
         $result = $this->Form->text('0.Node.title');
         $expected = [
@@ -3482,15 +3482,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputSelectType method
+     * testControlSelectType method
      *
-     * Test form->input() with select type inputs.
+     * Test form->control() with select type inputs.
      *
      * @return void
      */
-    public function testInputSelectType()
+    public function testControlSelectType()
     {
-        $result = $this->Form->input(
+        $result = $this->Form->control(
             'email',
             [
             'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true]
@@ -3514,7 +3514,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input(
+        $result = $this->Form->control(
             'email',
             [
             'options' => ['First', 'Second'], 'empty' => true]
@@ -3538,7 +3538,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('email', [
+        $result = $this->Form->control('email', [
             'type' => 'select',
             'options' => new \ArrayObject(['First', 'Second']),
             'empty' => true
@@ -3548,7 +3548,7 @@ class FormHelperTest extends TestCase
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
         $this->Form->request->data = ['Model' => ['user_id' => 'value']];
 
-        $result = $this->Form->input('Model.user_id', ['empty' => true]);
+        $result = $this->Form->control('Model.user_id', ['empty' => true]);
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'model-user-id'],
@@ -3570,7 +3570,7 @@ class FormHelperTest extends TestCase
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
         $this->Form->request->data = ['Thing' => ['user_id' => null]];
-        $result = $this->Form->input('Thing.user_id', ['empty' => 'Some Empty']);
+        $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'thing-user-id'],
@@ -3593,7 +3593,7 @@ class FormHelperTest extends TestCase
 
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
         $this->Form->request->data = ['Thing' => ['user_id' => 'value']];
-        $result = $this->Form->input('Thing.user_id', ['empty' => 'Some Empty']);
+        $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'thing-user-id'],
@@ -3615,7 +3615,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->data = [];
-        $result = $this->Form->input('Publisher.id', [
+        $result = $this->Form->control('Publisher.id', [
                 'label' => 'Publisher',
                 'type' => 'select',
                 'multiple' => 'checkbox',
@@ -3645,17 +3645,17 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputWithNonStandardPrimaryKeyMakesHidden method
+     * testControlWithNonStandardPrimaryKeyMakesHidden method
      *
-     * Test that input() and a non standard primary key makes a hidden input by default.
+     * Test that control() and a non standard primary key makes a hidden input by default.
      *
      * @return void
      */
-    public function testInputWithNonStandardPrimaryKeyMakesHidden()
+    public function testControlWithNonStandardPrimaryKeyMakesHidden()
     {
         $this->article['schema']['_constraints']['primary']['columns'] = ['title'];
         $this->Form->create($this->article);
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'title', 'id' => 'title'],
         ];
@@ -3663,13 +3663,13 @@ class FormHelperTest extends TestCase
 
         $this->article['schema']['_constraints']['primary']['columns'] = ['title', 'body'];
         $this->Form->create($this->article);
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'title', 'id' => 'title'],
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('body');
+        $result = $this->Form->control('body');
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'body', 'id' => 'body'],
         ];
@@ -3677,16 +3677,16 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputOverridingMagicSelectType method
+     * testControlOverridingMagicSelectType method
      *
      * Test that overriding the magic select type widget is possible.
      *
      * @return void
      */
-    public function testInputOverridingMagicSelectType()
+    public function testControlOverridingMagicSelectType()
     {
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $result = $this->Form->input('Model.user_id', ['type' => 'text']);
+        $result = $this->Form->control('Model.user_id', ['type' => 'text']);
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'model-user-id'], 'User', '/label',
@@ -3697,7 +3697,7 @@ class FormHelperTest extends TestCase
 
         //Check that magic types still work for plural/singular vars
         $this->View->viewVars['types'] = ['value' => 'good', 'other' => 'bad'];
-        $result = $this->Form->input('Model.type');
+        $result = $this->Form->control('Model.type');
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'model-type'], 'Type', '/label',
@@ -3711,16 +3711,16 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputMagicTypeDoesNotOverride method
+     * testControlMagicTypeDoesNotOverride method
      *
      * Test that inferred types do not override developer input.
      *
      * @return void
      */
-    public function testInputMagicTypeDoesNotOverride()
+    public function testControlMagicTypeDoesNotOverride()
     {
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $result = $this->Form->input('Model.user', ['type' => 'checkbox']);
+        $result = $this->Form->control('Model.user', ['type' => 'checkbox']);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             ['input' => [
@@ -3746,7 +3746,7 @@ class FormHelperTest extends TestCase
             1 => 'blue',
             2 => 'red'
         ];
-        $result = $this->Form->input('tags._ids', ['options' => $options, 'multiple' => 'checkbox']);
+        $result = $this->Form->control('tags._ids', ['options' => $options, 'multiple' => 'checkbox']);
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'tags-ids'],
@@ -3780,13 +3780,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputMagicSelectForTypeNumber method
+     * testControlMagicSelectForTypeNumber method
      *
-     * Test that magic input() selects are created for type=number.
+     * Test that magic control() selects are created for type=number.
      *
      * @return void
      */
-    public function testInputMagicSelectForTypeNumber()
+    public function testControlMagicSelectForTypeNumber()
     {
         TableRegistry::get('ValidateUsers', [
             'className' => __NAMESPACE__ . '\ValidateUsersTable'
@@ -3794,7 +3794,7 @@ class FormHelperTest extends TestCase
         $entity = new Entity(['balance' => 1]);
         $this->Form->create($entity, ['context' => ['table' => 'ValidateUsers']]);
         $this->View->viewVars['balances'] = [0 => 'nothing', 1 => 'some', 100 => 'a lot'];
-        $result = $this->Form->input('balance');
+        $result = $this->Form->control('balance');
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'balance'],
@@ -3817,43 +3817,43 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInvalidInputTypeOption method
+     * testInvalidControlTypeOption method
      *
-     * Test invalid 'input' type option to input() function.
+     * Test invalid 'input' type option to control() function.
      *
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Invalid type 'input' used for field 'text'
      * @return void
      */
-    public function testInvalidInputTypeOption()
+    public function testInvalidControlTypeOption()
     {
-        $this->Form->input('text', ['type' => 'input']);
+        $this->Form->control('text', ['type' => 'input']);
     }
 
     /**
-     * testInputMagicSelectChangeToRadio method
+     * testControlMagicSelectChangeToRadio method
      *
-     * Test that magic input() selects can easily be converted into radio types without error.
+     * Test that magic control() selects can easily be converted into radio types without error.
      *
      * @return void
      */
-    public function testInputMagicSelectChangeToRadio()
+    public function testControlMagicSelectChangeToRadio()
     {
         $this->View->viewVars['users'] = ['value' => 'good', 'other' => 'bad'];
-        $result = $this->Form->input('Model.user_id', ['type' => 'radio']);
+        $result = $this->Form->control('Model.user_id', ['type' => 'radio']);
         $this->assertContains('input type="radio"', $result);
     }
 
     /**
-     * testFormInputSubmit method
+     * testFormControlSubmit method
      *
-     * Test correct results for form::input() and type submit.
+     * Test correct results for form::control() and type submit.
      *
      * @return void
      */
-    public function testFormInputSubmit()
+    public function testFormControlSubmit()
     {
-        $result = $this->Form->input('Test Submit', ['type' => 'submit', 'class' => 'foobar']);
+        $result = $this->Form->control('Test Submit', ['type' => 'submit', 'class' => 'foobar']);
         $expected = [
             'div' => ['class' => 'submit'],
             'input' => ['type' => 'submit', 'class' => 'foobar', 'id' => 'test-submit', 'value' => 'Test Submit'],
@@ -3863,16 +3863,16 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormInputs method
+     * testFormControls method
      *
-     * Test correct results from form::inputs().
+     * Test correct results from Form::controls().
      *
      * @return void
      */
-    public function testFormInputsLegendFieldset()
+    public function testFormControlsLegendFieldset()
     {
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs([], ['legend' => 'The Legend']);
+        $result = $this->Form->allControls([], ['legend' => 'The Legend']);
         $expected = [
             '<fieldset',
             '<legend',
@@ -3882,15 +3882,15 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->allInputs([], ['fieldset' => true, 'legend' => 'Field of Dreams']);
+        $result = $this->Form->allControls([], ['fieldset' => true, 'legend' => 'Field of Dreams']);
         $this->assertContains('<legend>Field of Dreams</legend>', $result);
         $this->assertContains('<fieldset>', $result);
 
-        $result = $this->Form->allInputs([], ['fieldset' => false, 'legend' => false]);
+        $result = $this->Form->allControls([], ['fieldset' => false, 'legend' => false]);
         $this->assertNotContains('<legend>', $result);
         $this->assertNotContains('<fieldset>', $result);
 
-        $result = $this->Form->allInputs([], ['fieldset' => false, 'legend' => 'Hello']);
+        $result = $this->Form->allControls([], ['fieldset' => false, 'legend' => 'Hello']);
         $this->assertNotContains('<legend>', $result);
         $this->assertNotContains('<fieldset>', $result);
 
@@ -3898,7 +3898,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->params['prefix'] = 'admin';
         $this->Form->request->params['action'] = 'admin_edit';
         $this->Form->request->params['controller'] = 'articles';
-        $result = $this->Form->allInputs();
+        $result = $this->Form->allControls();
         $expected = [
             '<fieldset',
             '<legend',
@@ -3909,7 +3909,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs([], ['fieldset' => [], 'legend' => 'The Legend']);
+        $result = $this->Form->allControls([], ['fieldset' => [], 'legend' => 'The Legend']);
         $expected = [
             '<fieldset',
             '<legend',
@@ -3920,7 +3920,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs([], [
+        $result = $this->Form->allControls([], [
             'fieldset' => [
                 'class' => 'some-class some-other-class',
                 'disabled' => true,
@@ -3939,16 +3939,16 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormInputs method
+     * testFormControls method
      *
-     * Test the inputs() method.
+     * Test the controls() method.
      *
      * @return void
      */
-    public function testFormInputs()
+    public function testFormControls()
     {
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs();
+        $result = $this->Form->allControls();
         $expected = [
             '<fieldset',
             '<legend', 'New Article', '/legend',
@@ -3965,7 +3965,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->allInputs([
+        $result = $this->Form->allControls([
             'published' => ['type' => 'boolean']
         ]);
         $expected = [
@@ -3985,7 +3985,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs([], ['legend' => 'Hello']);
+        $result = $this->Form->allControls([], ['legend' => 'Hello']);
         $expected = [
             'fieldset' => [],
             'legend' => [],
@@ -4015,7 +4015,7 @@ class FormHelperTest extends TestCase
             '*/div',
             '/fieldset'
         ];
-        $result = $this->Form->allInputs(
+        $result = $this->Form->allControls(
             ['foo' => ['type' => 'text']],
             ['legend' => false]
         );
@@ -4023,14 +4023,14 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormInputsBlacklist method
+     * testFormControlsBlacklist method
      *
      * @return void
      */
-    public function testFormInputsBlacklist()
+    public function testFormControlsBlacklist()
     {
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs([
+        $result = $this->Form->allControls([
             'id' => false
         ]);
         $expected = [
@@ -4049,7 +4049,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->create($this->article);
-        $result = $this->Form->allInputs([
+        $result = $this->Form->allControls([
             'id' => []
         ]);
         $expected = [
@@ -4166,13 +4166,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testLabelContainInput method
+     * testLabelContainControl method
      *
      * Test that label() can accept an input with the correct template vars.
      *
      * @return void
      */
-    public function testLabelContainInput()
+    public function testLabelContainControl()
     {
         $this->Form->templates([
             'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
@@ -4598,15 +4598,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputRadio method
+     * testControlRadio method
      *
      * Test that input works with radio types.
      *
      * @return void
      */
-    public function testInputRadio()
+    public function testControlRadio()
     {
-        $result = $this->Form->input('test', [
+        $result = $this->Form->control('test', [
             'type' => 'radio',
             'options' => ['A', 'B'],
         ]);
@@ -4628,7 +4628,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('test', [
+        $result = $this->Form->control('test', [
             'type' => 'radio',
             'options' => ['A', 'B'],
             'value' => '0'
@@ -4651,7 +4651,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('test', [
+        $result = $this->Form->control('test', [
             'type' => 'radio',
             'options' => ['A', 'B'],
             'label' => false
@@ -4691,13 +4691,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testRadioInputInsideLabel method
+     * testRadioControlInsideLabel method
      *
      * Test generating radio input inside label ala twitter bootstrap.
      *
      * @return void
      */
-    public function testRadioInputInsideLabel()
+    public function testRadioControlInsideLabel()
     {
         $this->Form->templates([
             'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
@@ -4736,13 +4736,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testRadioHiddenInputDisabling method
+     * testRadioHiddenControlDisabling method
      *
      * Test disabling the hidden input for radio buttons.
      *
      * @return void
      */
-    public function testRadioHiddenInputDisabling()
+    public function testRadioHiddenControlDisabling()
     {
         $result = $this->Form->radio('Model.1.field', ['option A'], ['hiddenField' => false]);
         $expected = [
@@ -5047,7 +5047,7 @@ class FormHelperTest extends TestCase
      */
     public function testCheckboxZeroValue()
     {
-        $result = $this->Form->input('User.get_spam', [
+        $result = $this->Form->control('User.get_spam', [
             'type' => 'checkbox',
             'value' => '0',
             'hiddenField' => '1',
@@ -5091,7 +5091,7 @@ class FormHelperTest extends TestCase
         ];
         $article = new Article(['tags' => $tags]);
         $this->Form->create($article);
-        $result = $this->Form->input('tags._ids', ['options' => $options]);
+        $result = $this->Form->control('tags._ids', ['options' => $options]);
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'tags-ids'],
@@ -5128,7 +5128,7 @@ class FormHelperTest extends TestCase
         ];
         $article = new Article(['tags' => $tags]);
         $this->Form->create($article);
-        $result = $this->Form->input('tags._ids', ['options' => $options]);
+        $result = $this->Form->control('tags._ids', ['options' => $options]);
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'tags-ids'],
@@ -5159,7 +5159,7 @@ class FormHelperTest extends TestCase
         ];
         $this->View->viewVars['spacecraft'] = $spacecraft;
         $this->Form->create();
-        $result = $this->Form->input('spacecraft._ids');
+        $result = $this->Form->control('spacecraft._ids');
         $expected = [
             'div' => ['class' => 'input select'],
             'label' => ['for' => 'spacecraft-ids'],
@@ -5202,7 +5202,7 @@ class FormHelperTest extends TestCase
         $article->errors('spacecraft', ['Invalid']);
 
         $this->Form->create($article);
-        $result = $this->Form->input('spacecraft._ids');
+        $result = $this->Form->control('spacecraft._ids');
 
         $expected = [
             ['div' => ['class' => 'input select error']],
@@ -5471,15 +5471,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputMultipleCheckboxes method
+     * testControlMultipleCheckboxes method
      *
-     * Test input() resulting in multi select elements being generated.
+     * Test control() resulting in multi select elements being generated.
      *
      * @return void
      */
-    public function testInputMultipleCheckboxes()
+    public function testControlMultipleCheckboxes()
     {
-        $result = $this->Form->input('Model.multi_field', [
+        $result = $this->Form->control('Model.multi_field', [
             'options' => ['first', 'second', 'third'],
             'multiple' => 'checkbox'
         ]);
@@ -5511,7 +5511,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Model.multi_field', [
+        $result = $this->Form->control('Model.multi_field', [
             'options' => ['a' => 'first', 'b' => 'second', 'c' => 'third'],
             'multiple' => 'checkbox'
         ]);
@@ -5603,15 +5603,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputMultiCheckbox method
+     * testControlMultiCheckbox method
      *
-     * Test that input() works with multicheckbox.
+     * Test that control() works with multicheckbox.
      *
      * @return void
      */
-    public function testInputMultiCheckbox()
+    public function testControlMultiCheckbox()
     {
-        $result = $this->Form->input('category', [
+        $result = $this->Form->control('category', [
             'type' => 'multicheckbox',
             'options' => ['1', '2'],
         ]);
@@ -6280,22 +6280,22 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testDateTimeLabelIdMatchesFirstInput method
+     * testDateTimeLabelIdMatchesFirstControl method
      *
      * When changing the date format, the label should always focus the first select box when
      * clicked.
      *
      * @return void
      */
-    public function testDateTimeLabelIdMatchesFirstInput()
+    public function testDateTimeLabelIdMatchesFirstControl()
     {
-        $result = $this->Form->input('Model.date', ['type' => 'date']);
+        $result = $this->Form->control('Model.date', ['type' => 'date']);
         $this->assertContains('<label>Date</label>', $result);
 
-        $result = $this->Form->input('Model.date', ['type' => 'date', 'dateFormat' => 'DMY']);
+        $result = $this->Form->control('Model.date', ['type' => 'date', 'dateFormat' => 'DMY']);
         $this->assertContains('<label>Date</label>', $result);
 
-        $result = $this->Form->input('Model.date', ['type' => 'date', 'dateFormat' => 'YMD']);
+        $result = $this->Form->control('Model.date', ['type' => 'date', 'dateFormat' => 'YMD']);
         $this->assertContains('<label>Date</label>', $result);
     }
 
@@ -6805,17 +6805,17 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputDatetimePreEpoch method
+     * testControlDatetimePreEpoch method
      *
      * Test minYear being prior to the unix epoch.
      *
      * @return void
      */
-    public function testInputDatetimePreEpoch()
+    public function testControlDatetimePreEpoch()
     {
         $start = date('Y') - 80;
         $end = date('Y') - 18;
-        $result = $this->Form->input('birth_year', [
+        $result = $this->Form->control('birth_year', [
             'type' => 'date',
             'label' => 'Birth Year',
             'minYear' => $start,
@@ -6864,19 +6864,19 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputDate method
+     * testControlDate method
      *
-     * Test that input() accepts the type of date and passes options in.
+     * Test that control() accepts the type of date and passes options in.
      *
      * @return void
      */
-    public function testInputDate()
+    public function testControlDate()
     {
         $this->Form->request->data = [
             'month_year' => ['month' => date('m')],
         ];
         $this->Form->create($this->article);
-        $result = $this->Form->input('month_year', [
+        $result = $this->Form->control('month_year', [
                 'label' => false,
                 'type' => 'date',
                 'minYear' => 2006,
@@ -6887,16 +6887,16 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputLabelFalse method
+     * testControlLabelFalse method
      *
      * Test the label option being set to false.
      *
      * @return void
      */
-    public function testInputLabelFalse()
+    public function testControlLabelFalse()
     {
         $this->Form->create($this->article);
-        $result = $this->Form->input('title', ['label' => false]);
+        $result = $this->Form->control('title', ['label' => false]);
         $expected = [
             'div' => ['class' => 'input text required'],
             'input' => ['type' => 'text', 'required' => 'required', 'id' => 'title', 'name' => 'title'],
@@ -6906,18 +6906,18 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputDateMaxYear method
+     * testControlDateMaxYear method
      *
      * Let's say we want to only allow users born from 2006 to 2008 to register
      * This being the first signup page, we still don't have any data.
      *
      * @return void
      */
-    public function testInputDateMaxYear()
+    public function testControlDateMaxYear()
     {
         $this->Form->request->data = [];
         $this->Form->create($this->article);
-        $result = $this->Form->input('birthday', [
+        $result = $this->Form->control('birthday', [
             'label' => false,
             'type' => 'date',
             'minYear' => 2006,
@@ -7019,7 +7019,7 @@ class FormHelperTest extends TestCase
                 'stuff' => ['type' => 'string', 'length' => 10],
             ]
         ]);
-        $result = $this->Form->input('other', ['type' => 'textarea']);
+        $result = $this->Form->control('other', ['type' => 'textarea']);
         $expected = [
             'div' => ['class' => 'input textarea'],
             'label' => ['for' => 'other'],
@@ -7031,7 +7031,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('stuff', ['type' => 'textarea']);
+        $result = $this->Form->control('stuff', ['type' => 'textarea']);
         $expected = [
             'div' => ['class' => 'input textarea'],
             'label' => ['for' => 'stuff'],
@@ -7518,7 +7518,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->params['_Token']['key'] = 'test';
 
         $this->Form->create('Post', ['url' => ['action' => 'add']]);
-        $this->Form->input('title');
+        $this->Form->control('title');
         $this->Form->postLink('Delete', '/posts/delete/1', ['block' => true]);
         $result = $this->View->fetch('postLink');
 
@@ -7864,15 +7864,15 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testForMagicInputNonExistingNorValidated method
+     * testForMagicControlNonExistingNorValidated method
      *
      * @return void
      */
-    public function testForMagicInputNonExistingNorValidated()
+    public function testForMagicControlNonExistingNorValidated()
     {
         $result = $this->Form->create($this->article);
         $this->Form->templates(['inputContainer' => '{{content}}']);
-        $result = $this->Form->input('non_existing_nor_validated');
+        $result = $this->Form->control('non_existing_nor_validated');
         $expected = [
             'label' => ['for' => 'non-existing-nor-validated'],
             'Non Existing Nor Validated',
@@ -7884,7 +7884,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('non_existing_nor_validated', [
+        $result = $this->Form->control('non_existing_nor_validated', [
             'val' => 'my value'
         ]);
         $expected = [
@@ -7899,7 +7899,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->Form->request->data = ['non_existing_nor_validated' => 'CakePHP magic'];
-        $result = $this->Form->input('non_existing_nor_validated');
+        $result = $this->Form->control('non_existing_nor_validated');
         $expected = [
             'label' => ['for' => 'non-existing-nor-validated'],
             'Non Existing Nor Validated',
@@ -7913,11 +7913,11 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testFormMagicInputLabel method
+     * testFormMagicControlLabel method
      *
      * @return void
      */
-    public function testFormMagicInputLabel()
+    public function testFormMagicControlLabel()
     {
         TableRegistry::get('Contacts', [
             'className' => __NAMESPACE__ . '\ContactsTable'
@@ -7925,7 +7925,7 @@ class FormHelperTest extends TestCase
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
         $this->Form->templates(['inputContainer' => '{{content}}']);
 
-        $result = $this->Form->input('Contacts.name', ['label' => 'My label']);
+        $result = $this->Form->control('Contacts.name', ['label' => 'My label']);
         $expected = [
             'label' => ['for' => 'contacts-name'],
             'My label',
@@ -7937,7 +7937,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('name', [
+        $result = $this->Form->control('name', [
             'label' => ['class' => 'mandatory']
         ]);
         $expected = [
@@ -7951,7 +7951,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('name', [
+        $result = $this->Form->control('name', [
             'div' => false,
             'label' => ['class' => 'mandatory', 'text' => 'My label']
         ]);
@@ -7966,7 +7966,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('Contact.name', [
+        $result = $this->Form->control('Contact.name', [
             'div' => false, 'id' => 'my_id', 'label' => ['for' => 'my_id']
         ]);
         $expected = [
@@ -7980,14 +7980,14 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('1.id');
+        $result = $this->Form->control('1.id');
         $expected = ['input' => [
             'type' => 'hidden', 'name' => '1[id]',
             'id' => '1-id'
         ]];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input("1.name");
+        $result = $this->Form->control("1.name");
         $expected = [
             'label' => ['for' => '1-name'],
             'Name',
@@ -8026,7 +8026,7 @@ class FormHelperTest extends TestCase
         $comment = new Entity(['comment' => 'Value']);
         $article = new Article(['comments' => [$comment]]);
         $this->Form->create([$article]);
-        $result = $this->Form->input('0.comments.1.comment');
+        $result = $this->Form->control('0.comments.1.comment');
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
@@ -8044,7 +8044,7 @@ class FormHelperTest extends TestCase
         //@codingStandardsIgnoreEnd
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('0.comments.0.comment');
+        $result = $this->Form->control('0.comments.0.comment');
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea'],
@@ -8064,7 +8064,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $comment->errors('comment', ['Not valid']);
-        $result = $this->Form->input('0.comments.0.comment');
+        $result = $this->Form->control('0.comments.0.comment');
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea error'],
@@ -8090,7 +8090,7 @@ class FormHelperTest extends TestCase
         TableRegistry::get('Comments')
             ->validator('default')
             ->allowEmpty('comment', false);
-        $result = $this->Form->input('0.comments.1.comment');
+        $result = $this->Form->control('0.comments.1.comment');
         //@codingStandardsIgnoreStart
         $expected = [
             'div' => ['class' => 'input textarea required'],
@@ -8111,13 +8111,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testHtml5Inputs method
+     * testHtml5Controls method
      *
      * Test that some html5 inputs + FormHelper::__call() work.
      *
      * @return void
      */
-    public function testHtml5Inputs()
+    public function testHtml5Controls()
     {
         $result = $this->Form->email('User.email');
         $expected = [
@@ -8145,17 +8145,17 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testHtml5InputWithInput method
+     * testHtml5ControlWithControl method
      *
-     * Test accessing html5 inputs through input().
+     * Test accessing html5 inputs through control().
      *
      * @return void
      */
-    public function testHtml5InputWithInput()
+    public function testHtml5ControlWithControl()
     {
         $this->Form->create();
         $this->Form->templates(['inputContainer' => '{{content}}']);
-        $result = $this->Form->input('website', [
+        $result = $this->Form->control('website', [
             'type' => 'url',
             'val' => 'http://domain.tld',
             'label' => false
@@ -8167,14 +8167,14 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testHtml5InputException method
+     * testHtml5ControlException method
      *
      * Test errors when field name is missing.
      *
      * @expectedException \Cake\Core\Exception\Exception
      * @return void
      */
-    public function testHtml5InputException()
+    public function testHtml5ControlException()
     {
         $this->Form->email();
     }
@@ -8194,7 +8194,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('title');
+        $result = $this->Form->control('title');
         $expected = [
             'div' => ['class' => 'input text required'],
             'label' => ['for' => 'title'],
@@ -8210,10 +8210,10 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('title', ['required' => false]);
+        $result = $this->Form->control('title', ['required' => false]);
         $this->assertNotContains('required', $result);
 
-        $result = $this->Form->input('body');
+        $result = $this->Form->control('body');
         $expected = [
             'div' => ['class' => 'input text'],
             'label' => ['for' => 'body'],
@@ -8228,24 +8228,24 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('body', ['required' => true]);
+        $result = $this->Form->control('body', ['required' => true]);
         $this->assertContains('required', $result);
     }
 
     /**
-     * testInputsNotNested method
+     * testControlsNotNested method
      *
      * Tests that it is possible to put inputs outside of the label.
      *
      * @return void
      */
-    public function testInputsNotNested()
+    public function testControlsNotNested()
     {
         $this->Form->templates([
             'nestingLabel' => '{{hidden}}{{input}}<label{{attrs}}>{{text}}</label>',
             'formGroup' => '{{input}}{{label}}',
         ]);
-        $result = $this->Form->input('foo', ['type' => 'checkbox']);
+        $result = $this->Form->control('foo', ['type' => 'checkbox']);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             ['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
@@ -8257,7 +8257,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('foo', ['type' => 'checkbox', 'label' => false]);
+        $result = $this->Form->control('foo', ['type' => 'checkbox', 'label' => false]);
         $expected = [
             'div' => ['class' => 'input checkbox'],
             ['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
@@ -8266,7 +8266,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('confirm', [
+        $result = $this->Form->control('confirm', [
             'type' => 'radio',
             'options' => ['Y' => 'Yes', 'N' => 'No']
         ]);
@@ -8311,13 +8311,13 @@ class FormHelperTest extends TestCase
     }
 
     /**
-     * testInputContainerTemplates method
+     * testControlContainerTemplates method
      *
      * Test that *Container templates are used by input.
      *
      * @return void
      */
-    public function testInputContainerTemplates()
+    public function testControlContainerTemplates()
     {
         $this->Form->templates([
             'checkboxContainer' => '<div class="check">{{content}}</div>',
@@ -8331,7 +8331,7 @@ class FormHelperTest extends TestCase
         ];
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('accept', [
+        $result = $this->Form->control('accept', [
             'type' => 'checkbox'
         ]);
         $expected = [
@@ -8345,19 +8345,19 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $result = $this->Form->input('accept', [
+        $result = $this->Form->control('accept', [
             'type' => 'radio',
             'options' => ['Y', 'N']
         ]);
         $this->assertContains('<div class="rad">', $result);
 
-        $result = $this->Form->input('Article.published', [
+        $result = $this->Form->control('Article.published', [
             'type' => 'radio',
             'options' => ['Y', 'N']
         ]);
         $this->assertContains('<div class="rad err">', $result);
 
-        $result = $this->Form->input('Article.created', [
+        $result = $this->Form->control('Article.created', [
             'type' => 'datetime',
         ]);
         $this->assertContains('<div class="dt">', $result);
@@ -8378,7 +8378,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($this->article);
 
-        $result = $this->Form->input('accept', [
+        $result = $this->Form->control('accept', [
             'type' => 'radio',
             'options' => ['Y', 'N']
         ]);
@@ -8540,7 +8540,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($article);
         $this->Form->setValueSources(['context']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
         ];
@@ -8548,7 +8548,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->request->query['id'] = '5';
         $this->Form->setValueSources(['query']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
         ];
@@ -8559,7 +8559,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['context']);
         $this->Form->create($article);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5b']],
         ];
@@ -8567,14 +8567,14 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['data']);
         $this->Form->create($article);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5b']],
         ];
         $this->assertHtml($expected, $result);
 
         $this->Form->setValueSources(['query']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5a']],
         ];
@@ -8597,21 +8597,21 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($article);
         $this->Form->setValueSources(['context', 'query']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
         ];
         $this->assertHtml($expected, $result);
 
         $this->Form->setValueSources(['query', 'context']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
         ];
         $this->assertHtml($expected, $result);
 
         $this->Form->setValueSources(['data', 'query', 'context']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
         ];
@@ -8620,7 +8620,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->data['id'] = '8';
         $this->Form->request->query['id'] = '9';
         $this->Form->setValueSources(['data', 'query', 'context']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '8']],
         ];
@@ -8642,7 +8642,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->query['id'] = '5';
 
         $this->Form->create($article, ['valueSources' => 'query']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
         ];
@@ -8652,7 +8652,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['context']);
         $this->Form->create($article, ['valueSources' => 'query']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
         ];
@@ -8662,7 +8662,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['query']);
         $this->Form->create($article, ['valueSources' => 'data']);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '4']],
         ];
@@ -8673,7 +8673,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['query']);
         $this->Form->create($article, ['valueSources' => ['context', 'data']]);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '4']],
         ];
@@ -8699,7 +8699,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->setValueSources(['context'])
             ->create($article, ['valueSources' => ['query', 'data']]);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '11']],
         ];
@@ -8710,7 +8710,7 @@ class FormHelperTest extends TestCase
         unset($this->Form->request->query['id']);
         $this->Form->setValueSources(['context'])
             ->create($article, ['valueSources' => ['query', 'data']]);
-        $result = $this->Form->input('id');
+        $result = $this->Form->control('id');
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '10']],
         ];


### PR DESCRIPTION
input() => control()
inputs() => controls()
allInputs() => allControls()