### PR TITLE
Fix controller->redirect response handling

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -545,17 +545,17 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $event = $this->dispatchEvent('Controller.beforeRedirect', [$url, $response]);
         if ($event->result() instanceof Response) {
-            return $event->result();
+            return $this->response = $event->result();
         }
         if ($event->isStopped()) {
             return null;
         }
 
         if (!$response->location()) {
-            $response->location(Router::url($url, true));
+            $response = $response->withLocation(Router::url($url, true));
         }
 
-        return $response;
+        return $this->response = $response;
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -475,6 +475,7 @@ class ControllerTest extends TestCase
         $Controller = new Controller(null, new Response());
 
         $response = $Controller->redirect('http://cakephp.org', (int)$code);
+        $this->assertSame($response, $Controller->response);
         $this->assertEquals($code, $response->statusCode());
         $this->assertEquals('http://cakephp.org', $response->header()['Location']);
         $this->assertFalse($Controller->autoRender);
@@ -534,6 +535,7 @@ class ControllerTest extends TestCase
 
         $result = $Controller->redirect('http://cakephp.org');
         $this->assertSame($newResponse, $result);
+        $this->assertSame($newResponse, $Controller->response);
     }
 
     /**


### PR DESCRIPTION
Store references to the updated response. Previously controller methods that forgot to `return $this->redirect()` would break in 3.4 as `$this->response` was not correct.