### PR TITLE
Fix cookies sending by ResponseEmitter.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -402,9 +402,9 @@ class Response implements ResponseInterface
     /**
      * Reason Phrase
      *
-     * @var string|null
+     * @var string
      */
-    protected $_reasonPhrase = null;
+    protected $_reasonPhrase = 'OK';
 
     /**
      * Stream mode options.
@@ -877,7 +877,9 @@ class Response implements ResponseInterface
         if (!isset($this->_statusCodes[$code])) {
             throw new InvalidArgumentException('Unknown status code');
         }
-
+        if (isset($this->_statusCodes[$code])) {
+            $this->_reasonPhrase = $this->_statusCodes[$code];
+        }
         $this->_status = $code;
         $this->_setContentType();
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1925,7 +1925,7 @@ class Response implements ResponseInterface
      * @param array|null $options Either null to get all cookies, string for a specific cookie
      *  or array to set cookie.
      * @return mixed
-     * @deprecated 3.4.0 Use getCookie() and withCookie() instead.
+     * @deprecated 3.4.0 Use getCookie(), getCookies() and withCookie() instead.
      */
     public function cookie($options = null)
     {
@@ -2020,6 +2020,18 @@ class Response implements ResponseInterface
         }
 
         return null;
+    }
+
+    /**
+     * Get all cookies in the response.
+     *
+     * Returns an associative array of cookie name => cookie data.
+     *
+     * @return array
+     */
+    public function getCookies()
+    {
+        return $this->_cookies;
     }
 
     /**

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -162,9 +162,14 @@ class ResponseEmitter implements EmitterInterface
      */
     protected function emitHeaders(ResponseInterface $response)
     {
+        $cookies = [];
+        if (method_exists($response, 'cookie')) {
+            $cookies = $response->cookie();
+        }
+
         foreach ($response->getHeaders() as $name => $values) {
             if (strtolower($name) === 'set-cookie') {
-                $this->emitCookies($values);
+                $cookies = array_merge($cookies, $values);
                 continue;
             }
             $first = true;
@@ -177,6 +182,8 @@ class ResponseEmitter implements EmitterInterface
                 $first = false;
             }
         }
+
+        $this->emitCookies($cookies);
     }
 
     /**
@@ -187,7 +194,20 @@ class ResponseEmitter implements EmitterInterface
      */
     protected function emitCookies(array $cookies)
     {
-        foreach ((array)$cookies as $cookie) {
+        foreach ($cookies as $cookie) {
+            if (is_array($cookie)) {
+                setcookie(
+                    $cookie['name'],
+                    $cookie['value'],
+                    $cookie['expire'],
+                    $cookie['path'],
+                    $cookie['domain'],
+                    $cookie['secure'],
+                    $cookie['httpOnly']
+                );
+                continue;
+            }
+
             if (strpos($cookie, '";"') !== false) {
                 $cookie = str_replace('";"', "{__cookie_replace__}", $cookie);
                 $parts = str_replace("{__cookie_replace__}", '";"', explode(';', $cookie));

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -163,8 +163,8 @@ class ResponseEmitter implements EmitterInterface
     protected function emitHeaders(ResponseInterface $response)
     {
         $cookies = [];
-        if (method_exists($response, 'cookie')) {
-            $cookies = $response->cookie();
+        if (method_exists($response, 'getCookies')) {
+            $cookies = $response->getCookies();
         }
 
         foreach ($response->getHeaders() as $name => $values) {

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -15,9 +15,9 @@
 namespace Cake\Test\TestCase;
 
 use Cake\Http\CallbackStream;
+use Cake\Http\Response;
 use Cake\Http\ResponseEmitter;
 use Cake\TestSuite\TestCase;
-use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
 use Zend\Diactoros\Stream;
 
@@ -85,6 +85,52 @@ class ResponseEmitterTest extends TestCase
             'X-testing: value',
         ];
         $this->assertEquals($expected, $GLOBALS['mockedHeaders']);
+    }
+
+    /**
+     * Test emitting responses with array cookes
+     *
+     * @return void
+     */
+    public function testEmitResponseArrayCookies()
+    {
+        $response = (new Response())
+            ->withCookie('simple', ['value' => 'val', 'secure' => true])
+            ->withAddedHeader('Set-Cookie', 'google=not=nice;Path=/accounts; HttpOnly')
+            ->withHeader('Content-Type', 'text/plain');
+        $response->getBody()->write('ok');
+
+        ob_start();
+        $this->emitter->emit($response);
+        $out = ob_get_clean();
+
+        $this->assertEquals('ok', $out);
+        $expected = [
+            'HTTP/1.1 200 OK',
+            'Content-Type: text/plain'
+        ];
+        $this->assertEquals($expected, $GLOBALS['mockedHeaders']);
+        $expected = [
+            [
+                'name' => 'simple',
+                'value' => 'val',
+                'path' => '/',
+                'expire' => 0,
+                'domain' => '',
+                'secure' => true,
+                'httponly' => false
+            ],
+            [
+                'name' => 'google',
+                'value' => 'not=nice',
+                'path' => '/accounts',
+                'expire' => 0,
+                'domain' => '',
+                'secure' => false,
+                'httponly' => true
+            ],
+        ];
+        $this->assertEquals($expected, $GLOBALS['mockedCookies']);
     }
 
     /**

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -1430,6 +1430,46 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Test getCookies() and array data.
+     *
+     * @return void
+     */
+    public function testGetCookies()
+    {
+        $response = new Response();
+        $cookie = [
+            'name' => 'ignored key',
+            'value' => '[a,b,c]',
+            'expire' => 1000,
+            'path' => '/test',
+            'secure' => true
+        ];
+        $new = $response->withCookie('testing', 'a')
+            ->withCookie('test2', ['value' => 'b', 'path' => '/test', 'secure' => true]);
+        $expected = [
+            'testing' => [
+                'name' => 'testing',
+                'value' => 'a',
+                'expire' => null,
+                'path' => '/',
+                'domain' => '',
+                'secure' => false,
+                'httpOnly' => false
+            ],
+            'test2' => [
+                'name' => 'test2',
+                'value' => 'b',
+                'expire' => null,
+                'path' => '/test',
+                'domain' => '',
+                'secure' => true,
+                'httpOnly' => false
+            ]
+        ];
+        $this->assertEquals($expected, $new->getCookies());
+    }
+
+    /**
      * Test CORS
      *
      * @dataProvider corsData

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -2742,8 +2742,8 @@ class ResponseTest extends TestCase
     public function testGetReasonPhrase()
     {
         $response = new Response();
-        $reasonPhrase = $response->getReasonPhrase();
-        $this->assertNull($reasonPhrase);
+        $this->assertSame('OK', $response->getReasonPhrase());
+
         $response = $response->withStatus(404);
         $reasonPhrase = $response->getReasonPhrase();
         $this->assertEquals('Not Found', $reasonPhrase);

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -130,18 +130,30 @@ class ResponseTest extends TestCase
     /**
      * Tests the statusCode method
      *
-     * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testStatusCode()
     {
         $response = new Response();
         $this->assertEquals(200, $response->statusCode());
-        $response->statusCode(404);
-        $this->assertEquals(404, $response->statusCode());
-        $this->assertEquals(500, $response->statusCode(500));
 
-        //Throws exception
+        $response->statusCode(404);
+        $this->assertEquals(404, $response->getStatusCode(), 'Sets shared state.');
+        $this->assertEquals(404, $response->statusCode());
+        $this->assertEquals('Not Found', $response->getReasonPhrase());
+
+        $this->assertEquals(500, $response->statusCode(500));
+    }
+
+    /**
+     * Test invalid status codes
+     *
+     * @expectedException \InvalidArgumentException
+     * @return void
+     */
+    public function testStatusCodeInvalid()
+    {
+        $response = new Response();
         $response->statusCode(1001);
     }
 


### PR DESCRIPTION
Before this fix the cookies info in `Response::$_cookies` was never used to actually set cookies.

I haven't added/updated tests as I am not 100% sure this is the correct way to fix this problem but testing in an actual app it does seem to fix the problem.