### PR TITLE
Adding composeField method for making field names with postfixes

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -404,6 +404,24 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
+     * Compose field based on name and operator.
+     *
+     * If `$operator` is already found in `$field` it will result in no-op.
+     *
+     * @param string $field The field to compose
+     * @param string|null $operator Operator to use as postfix
+     * @return string
+     */
+    public function composeField($field, $operator = null)
+    {
+        if ($operator === null || strpos($field, $operator) !== false) {
+            return $this->aliasField($field);
+        }
+
+        return sprintf('%s %s', $this->aliasField($field), $operator);
+    }
+
+    /**
      * Returns the connection instance or sets a new one
      *
      * @param \Cake\Datasource\ConnectionInterface|null $conn The new connection instance

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -197,6 +197,24 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test that composeField() works.
+     *
+     * @return void
+     */
+    public function testComposeField()
+    {
+        $table = new Table(['alias' => 'Users']);
+        $this->assertEquals('Users.id', $table->composeField('id'));
+        $this->assertEquals('Users.id', $table->composeField('Users.id'));
+
+        $this->assertEquals('Users.id <', $table->composeField('id', '<'));
+        $this->assertEquals('Users.id <', $table->composeField('Users.id', '<'));
+
+        $this->assertEquals('Users.id <', $table->composeField('id <', '<'));
+        $this->assertEquals('Users.id <', $table->composeField('Users.id <', '<'));
+    }
+
+    /**
      * Tests connection method
      *
      * @return void


### PR DESCRIPTION
Suggestion for adding a `composeField` method. It's similar to `aliasField` but takes an extra argument; `$operator`.

Here is what we currently have to do:
```
$query->where([$this->aliasField('foo') . '<=' => $bar]);
```

Using `composeField` we can now do
```
$query->where([$this->composeField('foo', '<=') => $bar]);
```

The name `composeField` is in lack of a better name, I'm very open to suggestions.