### PR TITLE
Switch `types` for `levels` in the LogTest

### DIFF
--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -255,6 +255,54 @@ class LogTest extends TestCase
         Log::config('spam', [
             'engine' => 'File',
             'path' => LOGS,
+            'levels' => 'debug',
+            'file' => 'spam',
+        ]);
+        Log::config('eggs', [
+            'engine' => 'File',
+            'path' => LOGS,
+            'levels' => ['eggs', 'debug', 'error', 'warning'],
+            'file' => 'eggs',
+        ]);
+
+        $testMessage = 'selective logging';
+        Log::write('warning', $testMessage);
+
+        $this->assertFileExists(LOGS . 'eggs.log');
+        $this->assertFileNotExists(LOGS . 'spam.log');
+
+        Log::write('debug', $testMessage);
+        $this->assertFileExists(LOGS . 'spam.log');
+
+        $contents = file_get_contents(LOGS . 'spam.log');
+        $this->assertContains('Debug: ' . $testMessage, $contents);
+        $contents = file_get_contents(LOGS . 'eggs.log');
+        $this->assertContains('Debug: ' . $testMessage, $contents);
+
+        if (file_exists(LOGS . 'spam.log')) {
+            unlink(LOGS . 'spam.log');
+        }
+        if (file_exists(LOGS . 'eggs.log')) {
+            unlink(LOGS . 'eggs.log');
+        }
+    }
+
+    /**
+     * test selective logging by level using the `types` attribute
+     *
+     * @return void
+     */
+    public function testSelectiveLoggingByLevelUsingTypes()
+    {
+        if (file_exists(LOGS . 'spam.log')) {
+            unlink(LOGS . 'spam.log');
+        }
+        if (file_exists(LOGS . 'eggs.log')) {
+            unlink(LOGS . 'eggs.log');
+        }
+        Log::config('spam', [
+            'engine' => 'File',
+            'path' => LOGS,
             'types' => 'debug',
             'file' => 'spam',
         ]);
@@ -292,13 +340,13 @@ class LogTest extends TestCase
         Log::config('debug', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['notice', 'info', 'debug'],
+            'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
         ]);
         Log::config('error', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['warning', 'error', 'critical', 'alert', 'emergency'],
+            'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
             'file' => 'error',
         ]);
     }
@@ -337,7 +385,7 @@ class LogTest extends TestCase
         Log::config('shops', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['info', 'debug', 'warning'],
+            'levels' => ['info', 'debug', 'warning'],
             'scopes' => ['transactions', 'orders'],
             'file' => 'shops',
         ]);
@@ -378,14 +426,14 @@ class LogTest extends TestCase
         Log::config('debug', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['notice', 'info', 'debug'],
+            'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
             'scopes' => false
         ]);
         Log::config('shops', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['info', 'debug', 'warning'],
+            'levels' => ['info', 'debug', 'warning'],
             'file' => 'shops',
             'scopes' => ['transactions', 'orders'],
         ]);
@@ -424,7 +472,7 @@ class LogTest extends TestCase
         Log::config('shops', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['info', 'debug', 'notice', 'warning'],
+            'levels' => ['info', 'debug', 'notice', 'warning'],
             'scopes' => ['transactions', 'orders'],
             'file' => 'shops',
         ]);
@@ -465,14 +513,14 @@ class LogTest extends TestCase
         Log::config('shops', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['debug', 'notice', 'warning'],
+            'levels' => ['debug', 'notice', 'warning'],
             'scopes' => ['transactions', 'orders'],
             'file' => 'shops.log',
         ]);
         Log::config('eggs', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['debug', 'notice', 'warning'],
+            'levels' => ['debug', 'notice', 'warning'],
             'scopes' => ['eggs'],
             'file' => 'eggs.log',
         ]);
@@ -500,7 +548,7 @@ class LogTest extends TestCase
         Log::config('scope_test', [
             'engine' => 'TestApp',
             'path' => LOGS,
-            'types' => ['notice', 'info', 'debug'],
+            'levels' => ['notice', 'info', 'debug'],
             'scopes' => ['foo', 'bar'],
         ]);
 
@@ -527,13 +575,13 @@ class LogTest extends TestCase
         Log::config('debug', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['notice', 'info', 'debug'],
+            'levels' => ['notice', 'info', 'debug'],
             'file' => 'debug',
         ]);
         Log::config('error', [
             'engine' => 'File',
             'path' => LOGS,
-            'types' => ['emergency', 'alert', 'critical', 'error', 'warning'],
+            'levels' => ['emergency', 'alert', 'critical', 'error', 'warning'],
             'file' => 'error',
         ]);
 


### PR DESCRIPTION
Not a major issue, but in the `LogTest` tests file, a property `types` is "promoted" but there is no mention of it anywhere in the docs. It is just an alias to `levels` (done in the `BaseLog::__construct()`).

The tests should use the documented way of doing things.

I added a test to make sure the `types` attributes is still taken into account.

Is it here because of backward compatibility ?