### PR TITLE
Headers should win if they are provided when converting Psr7 request to Cake request.

### DIFF
--- a/src/Http/RequestTransformer.php
+++ b/src/Http/RequestTransformer.php
@@ -41,6 +41,14 @@ class RequestTransformer
     {
         $post = $request->getParsedBody();
         $server = $request->getServerParams();
+        $headers = $request->getHeaders();
+
+        foreach ($headers as $k => $value) {
+            $name = sprintf('HTTP_%s', strtoupper(str_replace('-', '_', $k)));
+            if (isset($server[$name])) {
+                $server[$name] = $value[0];
+            }
+        }
 
         $files = static::getFiles($request);
         if (!empty($files)) {


### PR DESCRIPTION
This PR fixes an issue when we want to test a cake application with middlewares by acceptance tests.

If we create a middleware, that adds some extra headers to the request, then without this patch cake will lookup an old value when we call `$request->header('X-Api-Token')` for example. But with this patch, the following code will work correct:

```php
    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
    {
         $request = $request->withHeader('X-Api-Token', 'FooBar');
 
        return $next($request, $response);
    }

```
