### PR TITLE
Fix Uri query string not getting set.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -314,6 +314,9 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         if ($config['url']) {
             $uri = $uri->withPath('/' . $config['url']);
         }
+        if (strlen($querystr)) {
+            $uri = $uri->withQuery($querystr);
+        }
 
         $this->uri = $uri;
         $this->base = $config['base'];

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -172,6 +172,7 @@ class RequestTest extends TestCase
         $expected = ['one' => 'something', 'two' => 'else'];
         $this->assertEquals($expected, $request->query);
         $this->assertEquals('some/path', $request->url);
+        $this->assertEquals('one=something&two=else', $request->getUri()->getQuery());
     }
 
     /**


### PR DESCRIPTION
When the `url` option is used, the query string if present should be set into the Uri instance. This makes it match up with the `query` property.