### PR TITLE
Fix query string parsing on requestAction()

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -223,7 +223,7 @@ class CakeRequest implements ArrayAccess {
 		unset($query[$unsetUrl]);
 		unset($query[$this->base . $unsetUrl]);
 		if (strpos($this->url, '?') !== false) {
-			list(, $querystr) = explode('?', $this->url);
+			list($this->url, $querystr) = explode('?', $this->url);
 			parse_str($querystr, $queryArgs);
 			$query += $queryArgs;
 		}

--- a/lib/Cake/Test/Case/Core/CakeObjectTest.php
+++ b/lib/Cake/Test/Case/Core/CakeObjectTest.php
@@ -86,7 +86,7 @@ class RequestActionController extends Controller {
  * @return string $this->here.
  */
 	public function return_here() {
-		return $this->here;
+		return $this->request->here();
 	}
 
 /**
@@ -481,6 +481,17 @@ class ObjectTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$this->assertNull(Router::getRequest(), 'requests were not popped off the stack, this will break url generation');
+	}
+
+/**
+ * Test that here() is calculated correctly in requestAction
+ *
+ * @return void
+ */
+	public function testRequestActionHere() {
+		$url = '/request_action/return_here?key=value';
+		$result = $this->object->requestAction($url);
+		$this->assertStringEndsWith($url, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -193,7 +193,8 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest('some/path?one=something&two=else');
 		$expected = array('one' => 'something', 'two' => 'else');
 		$this->assertEquals($expected, $request->query);
-		$this->assertEquals('some/path?one=something&two=else', $request->url);
+		$this->assertEquals('some/path', $request->url);
+		$this->assertStringEndsWith('/some/path?one=something&two=else', $request->here());
 	}
 
 /**


### PR DESCRIPTION
This also fixes a long standing oddity around string URLs that include a query string where the query string data would be duplicated.

Refs #9962