### PR TITLE
Fix FlashHelper::render() cannot render `default` messages

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FlashHelperTest.php
@@ -76,6 +76,12 @@ class FlashHelperTest extends CakeTestCase {
 					'message' => 'Recorded',
 					'element' => 'flash_classy',
 					'params' => array()
+				),
+				'default' => array(
+					'key' => 'default',
+					'message' => 'Default',
+					'element' => 'default',
+					'params' => array()
 				)
 			)
 		));
@@ -152,6 +158,15 @@ class FlashHelperTest extends CakeTestCase {
 
 		$result = $this->Flash->render('flash', array('element' => 'TestPlugin.plugin_element'));
 		$expected = 'this is the plugin element';
+		$this->assertContains($expected, $result);
+	}
+
+/**
+ * Test that the default element fallbacks to the Flash/default element.
+ */
+	public function testFlashFallback() {
+		$result = $this->Flash->render('default');
+		$expected = '<div class="message">Default</div>';
 		$this->assertContains($expected, $result);
 	}
 }

--- a/lib/Cake/View/Helper/FlashHelper.php
+++ b/lib/Cake/View/Helper/FlashHelper.php
@@ -86,6 +86,10 @@ class FlashHelper extends AppHelper {
 		CakeSession::delete("Message.$key");
 		$flash['key'] = $key;
 
+		if ($flash['element'] === 'default') {
+			$flash['element'] = 'Flash/default';
+		}
+
 		return $this->_View->element($flash['element'], $flash);
 	}
 }


### PR DESCRIPTION
Fixes #9910