### PR TITLE
Fix ServerRequest::input() incorrectly being set to "php://input"

### DIFF
--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -50,7 +50,6 @@ abstract class ServerRequestFactory extends BaseFactory
             'environment' => $server,
             'uri' => $uri,
             'files' => $files,
-            'input' => 'php://input',
             'cookies' => $cookies ?: $_COOKIE,
             'query' => $query ?: $_GET,
             'post' => $body ?: $_POST,

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -46,6 +46,17 @@ class ServerRequestFactoryTest extends TestCase
     }
 
     /**
+     * Test fromGlobals input
+     *
+     * @return void
+     */
+    public function testFromGlobalsInput()
+    {
+        $res = ServerRequestFactory::fromGlobals();
+        $this->assertSame('', $res->input());
+    }
+
+    /**
      * Test fromGlobals includes the session
      *
      * @return void


### PR DESCRIPTION
Closes #9975