### PR TITLE
fixed empty string bug

### DIFF
--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -45,7 +45,7 @@ class TableHelper extends Helper
         foreach ($rows as $line) {
             foreach ($line as $k => $v) {
                 $columnLength = mb_strwidth($line[$k]);
-                if ($columnLength > (isset($widths[$k]) ? $widths[$k] : 0)) {
+                if ($columnLength >= (isset($widths[$k]) ? $widths[$k] : 0)) {
                     $widths[$k] = $columnLength;
                 }
             }

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -100,6 +100,28 @@ class TableHelperTest extends TestCase
     }
 
     /**
+     * Test that output works when data contains just empty strings.
+     */
+    public function testNullValues()
+    {
+        $data = [
+            ['Header 1', 'Header', 'Empty'],
+            ['short', 'Longish thing', null],
+            ['Longer thing', 'short', null],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+-------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Empty</info> |',
+            '+--------------+---------------+-------+',
+            '| short        | Longish thing |       |',
+            '| Longer thing | short         |       |',
+            '+--------------+---------------+-------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
      * Test output with multi-byte characters
      *
      * @return void

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -100,7 +100,7 @@ class TableHelperTest extends TestCase
     }
 
     /**
-     * Test that output works when data contains just empty strings.
+     * Test that output works when data contains nulls.
      */
     public function testNullValues()
     {

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -24,6 +24,20 @@ use Cake\TestSuite\TestCase;
  */
 class TableHelperTest extends TestCase
 {
+    /**
+     * @var ConsoleOutput
+     */
+    public $stub;
+
+    /**
+     * @var ConsoleIo
+     */
+    public $io;
+
+    /**
+     * @var TableHelper
+     */
+    public $helper;
 
     /**
      * setUp method
@@ -59,6 +73,28 @@ class TableHelperTest extends TestCase
             '| short        | Longish thing | short         |',
             '| Longer thing | short         | Longest Value |',
             '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test that output works when data contains just empty strings.
+     */
+    public function testEmptyStrings()
+    {
+        $data = [
+            ['Header 1', 'Header', 'Empty'],
+            ['short', 'Longish thing', ''],
+            ['Longer thing', 'short', ''],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+-------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Empty</info> |',
+            '+--------------+---------------+-------+',
+            '| short        | Longish thing |       |',
+            '| Longer thing | short         |       |',
+            '+--------------+---------------+-------+',
         ];
         $this->assertEquals($expected, $this->stub->messages());
     }


### PR DESCRIPTION
Widths for columns that contain an empty string are not added, and
produces a bug where there are fewer headings then columns per row.