### PR TITLE
RFC - Allow routes to restrict the hosts they should match on

### DIFF
--- a/src/Routing/Filter/RoutingFilter.php
+++ b/src/Routing/Filter/RoutingFilter.php
@@ -55,7 +55,7 @@ class RoutingFilter extends DispatcherFilter
 
         try {
             if (empty($request->params['controller'])) {
-                $params = Router::parse($request->url, $request->method());
+                $params = Router::parseRequest($request);
                 $request->addParams($params);
             }
 

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -45,10 +45,7 @@ class RoutingMiddleware
                 }
                 $request = $request->withAttribute(
                     'params',
-                    Router::parse(
-                        $request->getUri()->getPath(),
-                        $request->getMethod()
-                    )
+                    Router::parseRequest($request)
                 );
             }
         } catch (RedirectException $e) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -92,6 +92,9 @@ class Route
      *
      * - `_ext` - Defines the extensions used for this route.
      * - `pass` - Copies the listed parameters into params['pass'].
+     * - `_host` - Define the host name pattern if you want this route to only match
+     *   specific host names. You can use `.*` and to create wildcard subdomains/hosts
+     *   e.g. `*.example.com` matches all subdomains on `example.com`.
      *
      * @param string $template Template string with parameter placeholders
      * @param array|string $defaults Defaults for the route.

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -360,6 +360,18 @@ class Route
     }
 
     /**
+     * Check to see if the host matches the route requirements
+     */
+    public function hostMatches($host)
+    {
+        if (!isset($this->options['_host'])) {
+            return true;
+        }
+        // TODO implement
+        return true;
+    }
+
+    /**
      * Removes the extension from $url if it contains a registered extension.
      * If no registered extension is found, no extension is returned and the URL is returned unmodified.
      *

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -367,8 +367,11 @@ class Route
      */
     public function hostMatches($host)
     {
-        // Will be implemented later
-        return true;
+        if (!isset($this->options['_host'])) {
+            return true;
+        }
+        $pattern = '@^' . str_replace('\*', '.*', preg_quote($this->options['_host'], '@')) . '$@';
+        return preg_match($pattern, $host) !== 0;
     }
 
     /**

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -361,13 +361,13 @@ class Route
 
     /**
      * Check to see if the host matches the route requirements
+     *
+     * @param string $host The request's host name
+     * @return bool Whether or not the host matches any conditions set in for this route.
      */
     public function hostMatches($host)
     {
-        if (!isset($this->options['_host'])) {
-            return true;
-        }
-        // TODO implement
+        // Will be implemented later
         return true;
     }
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -374,6 +374,7 @@ class Route
             return true;
         }
         $pattern = '@^' . str_replace('\*', '.*', preg_quote($this->options['_host'], '@')) . '$@';
+
         return preg_match($pattern, $host) !== 0;
     }
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -15,8 +15,8 @@
 namespace Cake\Routing\Route;
 
 use Cake\Http\ServerRequest;
-use Psr\Http\Message\ServerRequestInterface;
 use Cake\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * A single Route used by the Router to connect requests to
@@ -297,6 +297,7 @@ class Route
         if (isset($this->options['_host']) && !$this->hostMatches($uri->getHost())) {
             return false;
         }
+
         return $this->parse($uri->getPath(), $request->getMethod());
     }
 

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -158,9 +158,7 @@ class RouteCollection
     public function parseRequest(ServerRequestInterface $request)
     {
         $uri = $request->getUri();
-        $method = $request->getMethod();
         $urlPath = $uri->getPath();
-        $host = $uri->getHost();
         foreach (array_keys($this->_paths) as $path) {
             if (strpos($urlPath, $path) !== 0) {
                 continue;
@@ -168,11 +166,7 @@ class RouteCollection
 
             /* @var \Cake\Routing\Route\Route $route */
             foreach ($this->_paths[$path] as $route) {
-                if (!$route->hostMatches($host)) {
-                    continue;
-                }
-
-                $r = $route->parse($urlPath, $method);
+                $r = $route->parseRequest($request);
                 if ($r === false) {
                     continue;
                 }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -157,8 +157,8 @@ class RouteCollection
      */
     public function parseRequest(ServerRequestInterface $request)
     {
-        $method = $request->getMethod();
         $uri = $request->getUri();
+        $method = $request->getMethod();
         $urlPath = $uri->getPath();
         foreach (array_keys($this->_paths) as $path) {
             if (strpos($urlPath, $path) !== 0) {
@@ -184,7 +184,7 @@ class RouteCollection
                 return $r;
             }
         }
-        throw new MissingRouteException(['url' => $url]);
+        throw new MissingRouteException(['url' => $uri]);
     }
 
     /**

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -184,7 +184,7 @@ class RouteCollection
                 return $r;
             }
         }
-        throw new MissingRouteException(['url' => $uri]);
+        throw new MissingRouteException(['url' => $urlPath]);
     }
 
     /**

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -160,12 +160,12 @@ class RouteCollection
         $uri = $request->getUri();
         $method = $request->getMethod();
         $urlPath = $uri->getPath();
+        $host = $uri->getHost();
         foreach (array_keys($this->_paths) as $path) {
             if (strpos($urlPath, $path) !== 0) {
                 continue;
             }
 
-            $host = $uri->getHost();
             /* @var \Cake\Routing\Route\Route $route */
             foreach ($this->_paths[$path] as $route) {
                 if (!$route->hostMatches($host)) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -17,6 +17,7 @@ namespace Cake\Routing;
 use Cake\Routing\Exception\DuplicateNamedRouteException;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Contains a collection of routes.
@@ -138,6 +139,45 @@ class RouteCollection
                     continue;
                 }
                 if ($queryParameters) {
+                    $r['?'] = $queryParameters;
+                }
+
+                return $r;
+            }
+        }
+        throw new MissingRouteException(['url' => $url]);
+    }
+
+    /**
+     * Takes the ServerRequestInterface, iterates the routes until one is able to parse the route.
+     *
+     * @param \Psr\Http\Messages\ServerRequestInterface $request The request to parse route data from.
+     * @return array An array of request parameters parsed from the URL.
+     * @throws \Cake\Routing\Exception\MissingRouteException When a URL has no matching route.
+     */
+    public function parseRequest(ServerRequestInterface $request)
+    {
+        $method = $request->getMethod();
+        $uri = $request->getUri();
+        $urlPath = $uri->getPath();
+        foreach (array_keys($this->_paths) as $path) {
+            if (strpos($urlPath, $path) !== 0) {
+                continue;
+            }
+
+            $host = $uri->getHost();
+            /* @var \Cake\Routing\Route\Route $route */
+            foreach ($this->_paths[$path] as $route) {
+                if (!$route->hostMatches($host)) {
+                    continue;
+                }
+
+                $r = $route->parse($urlPath, $method);
+                if ($r === false) {
+                    continue;
+                }
+                if ($uri->getQuery()) {
+                    parse_str($uri->getQuery(), $queryParameters);
                     $r['?'] = $queryParameters;
                 }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -338,6 +338,7 @@ class Router
      * @param string $method The HTTP method being used.
      * @return array Parsed elements from URL.
      * @throws \Cake\Routing\Exception\MissingRouteException When a route cannot be handled
+     * @deprecated 3.4.0 Use Router::parseRequest() instead.
      */
     public static function parse($url, $method = '')
     {
@@ -349,6 +350,22 @@ class Router
         }
 
         return static::$_collection->parse($url, $method);
+    }
+
+    /**
+     * Get the routing parameters for the request is possible.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request to parse request data from.
+     * @return array Parsed elements from URL.
+     * @throws \Cake\Routing\Exception\MissingRouteException When a route cannot be handled
+     */
+    public static function parseRequest(ServerRequestInterface $request)
+    {
+        if (!static::$initialized) {
+            static::_loadRoutes();
+        }
+
+        return static::$_collection->parseRequest($request);
     }
 
     /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Routing;
 
+use Cake\Http\ServerRequest;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Route\Route;
@@ -154,6 +155,86 @@ class RouteCollectionTest extends TestCase
             'pass' => [],
             '_matchedRoute' => '/:controller/:action',
 
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test parseRequest() throws an error on unknown routes.
+     *
+     * @expectedException \Cake\Routing\Exception\MissingRouteException
+     * @expectedExceptionMessage A route matching "/" could not be found
+     */
+    public function testParseRequestMissingRoute()
+    {
+        $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
+        $routes->connect('/', ['controller' => 'Articles']);
+        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+
+        $request = new ServerRequest(['url' => '/']);
+        $result = $this->collection->parseRequest($request);
+        $this->assertEquals([], $result, 'Should not match, missing /b');
+    }
+
+    /**
+     * Test parsing routes.
+     *
+     * @return void
+     */
+    public function testParseRequest()
+    {
+        $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
+        $routes->connect('/', ['controller' => 'Articles']);
+        $routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
+
+        $request = new ServerRequest(['url' => '/b/']);
+        $result = $this->collection->parseRequest($request);
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'pass' => [],
+            'plugin' => null,
+            'key' => 'value',
+            '_matchedRoute' => '/b',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $request = new ServerRequest(['url' => '/b/the-thing?one=two']);
+        $result = $this->collection->parseRequest($request);
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'id' => 'the-thing',
+            'pass' => [],
+            'plugin' => null,
+            'key' => 'value',
+            '?' => ['one' => 'two'],
+            '_matchedRoute' => '/b/:id',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $request = new ServerRequest(['url' => '/b/media/search']);
+        $result = $this->collection->parseRequest($request);
+        $expected = [
+            'key' => 'value',
+            'pass' => [],
+            'plugin' => null,
+            'controller' => 'Media',
+            'action' => 'search',
+            '_matchedRoute' => '/b/media/search/*',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $request = new ServerRequest(['url' => '/b/media/search/thing']);
+        $result = $this->collection->parseRequest($request);
+        $expected = [
+            'key' => 'value',
+            'pass' => ['thing'],
+            'plugin' => null,
+            'controller' => 'Media',
+            'action' => 'search',
+            '_matchedRoute' => '/b/media/search/*',
         ];
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -330,7 +330,6 @@ class RouteCollectionTest extends TestCase
             '_matchedRoute' => '/b/:id',
         ];
         $this->assertEquals($expected, $result);
-
     }
 
     /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -185,7 +185,11 @@ class RouteCollectionTest extends TestCase
     public function testParseRequestCheckHostCondition()
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->connect('/fallback', ['controller' => 'Articles', 'action' => 'index'], ['_host' => '*.example.com']);
+        $routes->connect(
+            '/fallback',
+            ['controller' => 'Articles', 'action' => 'index'],
+            ['_host' => '*.example.com']
+        );
 
         $request = new ServerRequest([
             'environment' => [
@@ -250,7 +254,11 @@ class RouteCollectionTest extends TestCase
     public function testParseRequestCheckHostConditionFail($host)
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->connect('/fallback', ['controller' => 'Articles', 'action' => 'index'], ['_host' => '*.example.com']);
+        $routes->connect(
+            '/fallback',
+            ['controller' => 'Articles', 'action' => 'index'],
+            ['_host' => '*.example.com']
+        );
 
         $request = new ServerRequest([
             'environment' => [

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -200,20 +200,6 @@ class RouteCollectionTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
 
-        $request = new ServerRequest(['url' => '/b/the-thing?one=two']);
-        $result = $this->collection->parseRequest($request);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'view',
-            'id' => 'the-thing',
-            'pass' => [],
-            'plugin' => null,
-            'key' => 'value',
-            '?' => ['one' => 'two'],
-            '_matchedRoute' => '/b/:id',
-        ];
-        $this->assertEquals($expected, $result);
-
         $request = new ServerRequest(['url' => '/b/media/search']);
         $result = $this->collection->parseRequest($request);
         $expected = [
@@ -237,6 +223,21 @@ class RouteCollectionTest extends TestCase
             '_matchedRoute' => '/b/media/search/*',
         ];
         $this->assertEquals($expected, $result);
+
+        $request = new ServerRequest(['url' => '/b/the-thing?one=two']);
+        $result = $this->collection->parseRequest($request);
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'id' => 'the-thing',
+            'pass' => [],
+            'plugin' => null,
+            'key' => 'value',
+            '?' => ['one' => 'two'],
+            '_matchedRoute' => '/b/:id',
+        ];
+        $this->assertEquals($expected, $result);
+
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1596,6 +1596,26 @@ class RouterTest extends TestCase
     }
 
     /**
+     * test parseRequest
+     *
+     * @return void
+     */
+    public function testParseRequest()
+    {
+        Router::connect('/articles/:action/*', ['controller' => 'Articles']);
+        $request = new Request(['url' => '/articles/view/1']);
+        $result = Router::parseRequest($request);
+        $expected = [
+            'pass' => ['1'],
+            'plugin' => null,
+            'controller' => 'Articles',
+            'action' => 'view',
+            '_matchedRoute' => '/articles/:action/*',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * testUuidRoutes method
      *
      * @return void


### PR DESCRIPTION
By passing the request we can make it possible to add route conditions for more than just the URL. I've had to add new methods onto Router and RouteCollection to make this possible, but I feel that passing the object around is better long term anyways.

This requires deprecating `Router::parse()` which makes me a bit sad, but I feel this makes the code simpler/better long term.

This is currently an RFC as I want to see if people think the addition of the `_host` option is worth the churn in code. Also if there are any other similar types of conditions/matchers we should add.

Refs #9917