### PR TITLE
Update thrown message to indicate missing method/route combination, addressing #9994.

### DIFF
--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -27,12 +27,23 @@ class MissingRouteException extends Exception
     protected $_messageTemplate = 'A route matching "%s" could not be found.';
 
     /**
+     * Message template to use when the requested method is included.
+     *
+     * @var  string
+     */
+    protected $_messageTemplateWithMethod = 'A "%s" route matching "%s" could not be found.';
+
+    /**
      * {@inheritDoc}
      */
     public function __construct($message, $code = 404)
     {
-        if (is_array($message) && isset($message['message'])) {
-            $this->_messageTemplate = $message['message'];
+        if (is_array($message)) {
+            if (isset($message['message'])) {
+                $this->_messageTemplate = $message['message'];
+            } elseif (isset($message['method']) && $message['method']) {
+                $this->_messageTemplate = $this->_messageTemplateWithMethod;
+            }
         }
         parent::__construct($message, $code);
     }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -144,7 +144,11 @@ class RouteCollection
                 return $r;
             }
         }
-        throw new MissingRouteException(['url' => $url]);
+        throw new MissingRouteException([
+            'method' => $method,
+            'url' => $url,
+            'message' => 'A "%s" route matching "%s" could not be found.',
+        ]);
     }
 
     /**

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -144,11 +144,15 @@ class RouteCollection
                 return $r;
             }
         }
-        throw new MissingRouteException([
-            'method' => $method,
-            'url' => $url,
-            'message' => 'A "%s" route matching "%s" could not be found.',
-        ]);
+
+        $exceptionProperties = ['url' => $url];
+        if ($method !== '') {
+            // Ensure that if the method is included, it is the first element of
+            // the array, to match the order that the strings are printed in the
+            // MissingRouteException error message, $_messageTemplateWithMethod.
+            $exceptionProperties = array_merge(['method' => $method], $exceptionProperties);
+        }
+        throw new MissingRouteException($exceptionProperties);
     }
 
     /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -37,7 +37,7 @@ class RouteCollectionTest extends TestCase
      * Test parse() throws an error on unknown routes.
      *
      * @expectedException \Cake\Routing\Exception\MissingRouteException
-     * @expectedExceptionMessage A "" route matching "/" could not be found
+     * @expectedExceptionMessage A route matching "/" could not be found
      */
     public function testParseMissingRoute()
     {

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -37,7 +37,7 @@ class RouteCollectionTest extends TestCase
      * Test parse() throws an error on unknown routes.
      *
      * @expectedException \Cake\Routing\Exception\MissingRouteException
-     * @expectedExceptionMessage A route matching "/" could not be found
+     * @expectedExceptionMessage A "" route matching "/" could not be found
      */
     public function testParseMissingRoute()
     {
@@ -47,6 +47,23 @@ class RouteCollectionTest extends TestCase
 
         $result = $this->collection->parse('/');
         $this->assertEquals([], $result, 'Should not match, missing /b');
+    }
+
+    /**
+     * Test parse() throws an error on known routes called with unknown methods.
+     *
+     * @expectedException \Cake\Routing\Exception\MissingRouteException
+     * @expectedExceptionMessage A "POST" route matching "/b" could not be found
+     */
+    public function testParseMissingRouteMethod()
+    {
+        $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
+        $routes->connect('/', ['controller' => 'Articles', '_method' => ['GET']]);
+
+        $result = $this->collection->parse('/b', 'GET');
+        $this->assertNotEmpty($result, 'Route should be found');
+        $result = $this->collection->parse('/b', 'POST');
+        $this->assertEquals([], $result, 'Should not match with missing method');
     }
 
     /**


### PR DESCRIPTION
The message of the `MissingRouteException` thrown when a route cannot be found now includes the method used to (attempt to) access the route, as well as the path of the route. This addresses a problem where the user (developer) could be presented with a message such as "A route matching 'x' could not be found. List of available routes: 'x'". It is now made explicit that e.g. "A 'POST' route matching 'x' could not be found."