### PR TITLE
New translationField method.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -429,13 +429,13 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     public function translationField($field)
     {
         $table = $this->_table;
-        $associationName = $table->alias() . '_' . $field . '_translation';
+        $associationName = $table->getAlias() . '_' . $field . '_translation';
 
         if ($table->associations()->has($associationName)) {
             return $associationName . '.content';
-        } else {
-            return $table->aliasField($field);
         }
+
+        return $table->aliasField($field);
     }
 
     /**

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -75,7 +75,10 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      */
     protected $_defaultConfig = [
         'implementedFinders' => ['translations' => 'findTranslations'],
-        'implementedMethods' => ['locale' => 'locale'],
+        'implementedMethods' => [
+            'locale' => 'locale',
+            'translationField' => 'translationField'
+        ],
         'fields' => [],
         'translationTable' => 'I18n',
         'defaultLocale' => '',
@@ -411,6 +414,28 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         }
 
         return $this->_locale = (string)$locale;
+    }
+
+    /**
+     * Returns a fully aliased field name for translated fields.
+     *
+     * If the requested field is configured as a translation field, the `content`
+     * field with an alias of a corresponding association is returned. Table-aliased
+     * field name is returned for all other fields.
+     *
+     * @param string $field Field name to be aliased.
+     * @return string
+     */
+    public function translationField($field)
+    {
+        $table = $this->_table;
+        $associationName = $table->alias() . '_' . $field . '_translation';
+
+        if ($table->associations()->has($associationName)) {
+            return $associationName . '.content';
+        } else {
+            return $table->aliasField($field);
+        }
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -321,6 +321,36 @@ class TranslateBehaviorTest extends TestCase
     }
 
     /**
+     * Tests translationField method for translated fields.
+     *
+     * @return void
+     */
+    public function testTranslationFieldForTranslatedFields()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+
+        $expected = 'Articles_title_translation.content';
+        $field = $table->translationField('title');
+        $this->assertSame($expected, $field);
+    }
+
+    /**
+     * Tests translationField method for other fields.
+     *
+     * @return void
+     */
+    public function testTranslationFieldForOtherFields()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+
+        $expected = 'Articles.foo';
+        $field = $table->translationField('foo');
+        $this->assertSame($expected, $field);
+    }
+
+    /**
      * Tests that translating fields work when other formatters are used
      *
      * @return void


### PR DESCRIPTION
See #9879

Alias on non-translation fields is enforced to keep alias consistency (contrary to the example shown in #9879).