### PR TITLE
3.4 Fix setMatching return type

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -213,7 +213,7 @@ class EagerLoader
      * @param callable|null $builder the callback function to be used for setting extra
      * options to the filtering query
      * @param array $options Extra options for the association matching.
-     * @return array Containments.
+     * @return $this
      */
     public function setMatching($assoc, callable $builder = null, $options = [])
     {
@@ -239,7 +239,9 @@ class EagerLoader
 
         $pointer[$last] = ['queryBuilder' => $builder, 'matching' => true] + $options;
 
-        return $this->_matching->contain($containments);
+        $this->_matching->contain($containments);
+
+        return $this;
     }
 
     /**

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -213,7 +213,7 @@ class EagerLoader
      * @param callable|null $builder the callback function to be used for setting extra
      * options to the filtering query
      * @param array $options Extra options for the association matching.
-     * @return self
+     * @return array Containments.
      */
     public function setMatching($assoc, callable $builder = null, $options = [])
     {
@@ -239,9 +239,7 @@ class EagerLoader
 
         $pointer[$last] = ['queryBuilder' => $builder, 'matching' => true] + $options;
 
-        $this->_matching->contain($containments);
-
-        return $this;
+        return $this->_matching->contain($containments);
     }
 
     /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -473,7 +473,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function matching($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->setMatching($assoc, $builder);
+        $result = $this->getEagerLoader()->setMatching($assoc, $builder)->getMatching();
         $this->_addAssociationsToTypeMap($this->repository(), $this->typeMap(), $result);
         $this->_dirty();
 
@@ -545,10 +545,12 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function leftJoinWith($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->setMatching($assoc, $builder, [
-            'joinType' => 'LEFT',
-            'fields' => false
-        ]);
+        $result = $this->getEagerLoader()
+            ->setMatching($assoc, $builder, [
+                'joinType' => 'LEFT',
+                'fields' => false
+            ])
+            ->getMatching();
         $this->_addAssociationsToTypeMap($this->repository(), $this->typeMap(), $result);
         $this->_dirty();
 
@@ -592,10 +594,12 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function innerJoinWith($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->setMatching($assoc, $builder, [
-            'joinType' => 'INNER',
-            'fields' => false
-        ]);
+        $result = $this->getEagerLoader()
+            ->setMatching($assoc, $builder, [
+                'joinType' => 'INNER',
+                'fields' => false
+            ])
+            ->getMatching();
         $this->_addAssociationsToTypeMap($this->repository(), $this->typeMap(), $result);
         $this->_dirty();
 
@@ -654,11 +658,13 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function notMatching($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->setMatching($assoc, $builder, [
-            'joinType' => 'LEFT',
-            'fields' => false,
-            'negateMatch' => true
-        ]);
+        $result = $this->getEagerLoader()
+            ->setMatching($assoc, $builder, [
+                'joinType' => 'LEFT',
+                'fields' => false,
+                'negateMatch' => true
+            ])
+            ->getMatching();
         $this->_addAssociationsToTypeMap($this->repository(), $this->typeMap(), $result);
         $this->_dirty();
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -473,7 +473,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function matching($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->matching($assoc, $builder);
+        $result = $this->getEagerLoader()->setMatching($assoc, $builder);
         $this->_addAssociationsToTypeMap($this->repository(), $this->typeMap(), $result);
         $this->_dirty();
 
@@ -545,7 +545,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function leftJoinWith($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->matching($assoc, $builder, [
+        $result = $this->getEagerLoader()->setMatching($assoc, $builder, [
             'joinType' => 'LEFT',
             'fields' => false
         ]);
@@ -592,7 +592,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function innerJoinWith($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->matching($assoc, $builder, [
+        $result = $this->getEagerLoader()->setMatching($assoc, $builder, [
             'joinType' => 'INNER',
             'fields' => false
         ]);
@@ -654,7 +654,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function notMatching($assoc, callable $builder = null)
     {
-        $result = $this->getEagerLoader()->matching($assoc, $builder, [
+        $result = $this->getEagerLoader()->setMatching($assoc, $builder, [
             'joinType' => 'LEFT',
             'fields' => false,
             'negateMatch' => true

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -530,4 +530,19 @@ class EagerLoaderTest extends TestCase
 
         return $elements;
     }
+
+    /**
+     * Assert that matching('something') and SetMatching('something') return consistent type
+     */
+    public function testSetMatchingReturnType()
+    {
+        $loader = new EagerLoader();
+        $result = $loader->setMatching('clients');
+        $this->assertArrayHasKey('clients', $result);
+        $this->assertArrayHasKey('clients', $loader->getMatching());
+
+        $result = $loader->matching('customers');
+        $this->assertArrayHasKey('customers', $result);
+        $this->assertArrayHasKey('customers', $loader->getMatching());
+    }
 }

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -538,7 +538,7 @@ class EagerLoaderTest extends TestCase
     {
         $loader = new EagerLoader();
         $result = $loader->setMatching('clients');
-        $this->assertArrayHasKey('clients', $result);
+        $this->assertInstanceOf(EagerLoader::class, $result);
         $this->assertArrayHasKey('clients', $loader->getMatching());
 
         $result = $loader->matching('customers');

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -532,7 +532,9 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
-     * Assert that matching('something') and SetMatching('something') return consistent type
+     * Asserts that matching('something') and setMatching('something') return consistent type.
+     *
+     * @return void
      */
     public function testSetMatchingReturnType()
     {


### PR DESCRIPTION
`EagerLoader::contain()` does return an array of Containments.

the old code of matching is
```php
public function matching($assoc = null, callable $builder = null, $options = [])
    {
        if ($this->_matching === null) {
            $this->_matching = new self();
        }

        if ($assoc === null) {
            return $this->_matching->contain();
        }
        if (!isset($options['joinType'])) {
            $options['joinType'] = 'INNER';
        }

        $assocs = explode('.', $assoc);
        $last = array_pop($assocs);
        $containments = [];
        $pointer =& $containments;
        $opts = ['matching' => true] + $options;
        unset($opts['negateMatch']);

        foreach ($assocs as $name) {
            $pointer[$name] = $opts;
            $pointer =& $pointer[$name];
        }

        $pointer[$last] = ['queryBuilder' => $builder, 'matching' => true] + $options;

        return $this->_matching->contain($containments);
    }
```

so it can't be replace by a return $this in a setter if I'm not mistaken.
Does `setMatching` is an appropriate name here ?