### PR TITLE
Remove redundant setLoggers() call.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -184,7 +184,6 @@ class Shell
             ['tasks'],
             ['associative' => ['tasks']]
         );
-        $this->_io->setLoggers(true);
 
         if (isset($this->modelClass)) {
             $this->loadModel();

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1318,7 +1318,7 @@ TEXT;
         $io->expects($this->at(0))
             ->method('setLoggers')
             ->with(true);
-        $io->expects($this->at(3))
+        $io->expects($this->at(2))
             ->method('setLoggers')
             ->with(ConsoleIo::QUIET);
 


### PR DESCRIPTION
This call is no longer necessary as the logging levels are set in ShellDispatcher.

Refs #10001