### PR TITLE
Merge in defaults from subcommand for the parser description.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -601,7 +601,7 @@ class ConsoleOptionParser
             return $options;
         }
 
-        if ($options['parser'] && is_object($options['parser'])) {
+        if ($options['parser'] instanceof self) {
             if ($options['parser']->getDescription() !== null) {
                 return $options;
             }
@@ -611,7 +611,7 @@ class ConsoleOptionParser
             return $options;
         }
 
-        if ($options['parser'] && is_array($options['parser'])) {
+        if (is_array($options['parser'])) {
             if (isset($options['parser']['description'])) {
                 return $options;
             }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -580,12 +580,48 @@ class ConsoleOptionParser
                 'parser' => null
             ];
             $options += $defaults;
+
+            $options = $this->_mergeSubcommandHelpToParserDescription($options);
+
             $command = new ConsoleInputSubcommand($options);
         }
         $this->_subcommands[$name] = $command;
         asort($this->_subcommands);
 
         return $this;
+    }
+
+    /**
+     * @param array $options Options
+     * @return array
+     */
+    protected function _mergeSubcommandHelpToParserDescription($options)
+    {
+        if (!$options['help']) {
+            return $options;
+        }
+
+        if ($options['parser'] && is_object($options['parser'])) {
+            if ($options['parser']->getDescription() !== null) {
+                return $options;
+            }
+
+            $options['parser']->setDescription($options['help']);
+
+            return $options;
+        }
+
+        if ($options['parser'] && is_array($options['parser'])) {
+            if (isset($options['parser']['description'])) {
+                return $options;
+            }
+        }
+
+        $options['parser'] = [
+            'description' => $options['help']
+        ] + (array)$options['parser'];
+
+        return $options;
     }
 
     /**

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -611,12 +611,6 @@ class ConsoleOptionParser
             return $options;
         }
 
-        if (is_array($options['parser'])) {
-            if (isset($options['parser']['description'])) {
-                return $options;
-            }
-        }
-
         $options['parser'] = [
             'description' => $options['help']
         ] + (array)$options['parser'];

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -603,6 +603,8 @@ class ConsoleOptionParserTest extends TestCase
 
         $result = $parser->help('method');
         $expected = <<<TEXT
+This is another command
+
 <info>Usage:</info>
 cake mycommand method [--connection] [-h] [-0]
 
@@ -611,6 +613,48 @@ cake mycommand method [--connection] [-h] [-0]
 --connection      Db connection.
 --help, -h        Display this help.
 --zero, -0        Zero.
+
+TEXT;
+        $this->assertTextEquals($expected, $result, 'Help is not correct.');
+    }
+
+    /**
+     * test that help() with a command param shows the help for a subcommand
+     *
+     * @return void
+     */
+    public function testHelpSubcommandHelpArray()
+    {
+        $subParser = [
+            'options' => [
+                'foo' => [
+                    'short' => 'f',
+                    'help' => 'Foo.',
+                    'boolean' => true,
+                ]
+            ],
+        ];
+
+        $parser = new ConsoleOptionParser('mycommand', false);
+        $parser->addSubcommand('method', [
+            'help' => 'This is a subcommand',
+            'parser' => $subParser
+        ])
+            ->addOption('test', ['help' => 'A test option.']);
+
+        $result = $parser->help('method');
+        $expected = <<<TEXT
+This is a subcommand
+
+<info>Usage:</info>
+cake mycommand method [-f] [-h] [-q] [-v]
+
+<info>Options:</info>
+
+--foo, -f      Foo.
+--help, -h     Display this help.
+--quiet, -q    Enable quiet output.
+--verbose, -v  Enable verbose output.
 
 TEXT;
         $this->assertTextEquals($expected, $result, 'Help is not correct.');


### PR DESCRIPTION
### Before
```php
        $parser->addSubcommand('infos', [
            'help' => 'Get some GitHub infos',
            'parser' => [
                //'description' => 'Get some GitHub infos' // Without declaring this again
            ],
        ]);
```

results in no --help output (displaying main page again) and
```
Usage:
cake release [subcommand] [-d] [-h] [-q] [-v]

Subcommands:

infos  Get some GitHub infos
pr     Release PR

To see help on a subcommand use `cake release [subcommand] --help`
```

It only works if you manually copy and paste the help text into the parser description (unDRY).

### After
The above results in expected

```
Get some GitHub infos

Usage:
cake release infos [-h] [-q] [-v]

Options:

--help, -h     Display this help.
--quiet, -q    Enable quiet output.
--verbose, -v  Enable verbose output.
```

