### PR TITLE
Doc block types.

### DIFF
--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -64,7 +64,7 @@ class Translator implements TranslatorInterface
      * @param string $locale The locale being used.
      * @param array $messages The message keys and translations.
      * @param \Aura\Intl\FormatterInterface $formatter A message formatter.
-     * @param \Aura\Intl\TranslatorInterface $fallback A fallback translator.
+     * @param \Aura\Intl\TranslatorInterface|null $fallback A fallback translator.
      */
     public function __construct(
         $locale,
@@ -82,7 +82,7 @@ class Translator implements TranslatorInterface
      * Gets the message translation by its key.
      *
      * @param string $key The message key.
-     * @return mixed The message translation string, or false if not found.
+     * @return string|bool The message translation string, or false if not found.
      */
     protected function getMessage($key)
     {

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -76,7 +76,7 @@ class TranslatorRegistry extends TranslatorLocator
      * @param string $name The translator package to retrieve.
      * @param string|null $locale The locale to use; if empty, uses the default
      * locale.
-     * @return \Aura\Intl\TranslatorInterface A translator object.
+     * @return \Aura\Intl\TranslatorInterface|null A translator object.
      * @throws \Aura\Intl\Exception If no translator with that name could be found
      * for the given locale.
      */
@@ -255,6 +255,7 @@ class TranslatorRegistry extends TranslatorLocator
             return $loader;
         }
         $loader = function () use ($loader, $fallbackDomain) {
+            /* @var \Aura\Intl\Package $package */
             $package = $loader();
             if (!$package->getFallback()) {
                 $package->setFallback($fallbackDomain);


### PR DESCRIPTION
Small follow up on https://github.com/cakephp/cakephp/pull/10004

One question about `Translator::_fallbackLoader()`:
Is the return type here really `\Aura\Intl\Translator`? It looks to me it is a ChainMessagesLoader, even after the callable.
```php
    /**
     * Returns a new translator instance for the given name and locale
     * based of conventions.
     *
     * @param string $name The translation package name.
     * @param string $locale The locale to create the translator for.
     * @return \Aura\Intl\Translator
     */
    protected function _fallbackLoader($name, $locale)
    {
        $chain = new ChainMessagesLoader([
            new MessagesFileLoader($name, $locale, 'mo'),
            new MessagesFileLoader($name, $locale, 'po')
        ]);

        // \Aura\Intl\Package by default uses formatter configured with key "basic".
        // and we want to make sure the cake domain always uses the default formatter
        $formatter = $name === 'cake' ? 'default' : $this->_defaultFormatter;
        $chain = function () use ($formatter, $chain) {
            $package = $chain();
            $package->setFormatter($formatter);

            return $package;
        };

        return $chain;
    }
```