### PR TITLE
Make datetime validation objects.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -390,7 +390,9 @@ class Validation
         if ($check instanceof DateTimeInterface) {
             return true;
         }
-
+        if (is_object($check)) {
+            return false;
+        }
         if (is_array($check)) {
             $check = static::_getDateString($check);
             $format = 'ymd';
@@ -456,6 +458,9 @@ class Validation
         if ($check instanceof DateTimeInterface) {
             return true;
         }
+        if (is_object($check)) {
+            return false;
+        }
         $valid = false;
         if (is_array($check)) {
             $check = static::_getDateString($check);
@@ -506,6 +511,9 @@ class Validation
     {
         if ($check instanceof DateTimeInterface) {
             return true;
+        }
+        if (is_object($check)) {
+            return false;
         }
         static $methods = [
             'date' => 'parseDate',

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -22,6 +22,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
 use Cake\Validation\Validator;
 use Locale;
+use stdClass;
 
 require_once __DIR__ . '/stubs.php';
 
@@ -929,6 +930,11 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::time($dateTime));
         $this->assertTrue(Validation::dateTime($dateTime));
         $this->assertTrue(Validation::localizedTime($dateTime));
+
+        $this->assertFalse(Validation::time(new stdClass()));
+        $this->assertFalse(Validation::date(new stdClass()));
+        $this->assertFalse(Validation::dateTime(new stdClass()));
+        $this->assertFalse(Validation::localizedTime(new stdClass()));
     }
 
     /**


### PR DESCRIPTION
Don't fail hard on objects getting into datetime validators. This helps prevent errors downstream when expression objects are fed into `newEntity()`

Refs #10017