### PR TITLE
Replace broken link inside of CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,5 +88,5 @@ If you've found a security related issue in CakePHP, please don't open an issue 
 * [Existing issues](https://github.com/cakephp/cakephp/issues)
 * [Development Roadmaps](https://github.com/cakephp/cakephp/wiki#roadmaps)
 * [General GitHub documentation](https://help.github.com/)
-* [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
+* [GitHub pull request documentation](https://help.github.com/articles/creating-a-pull-request/)
 * `#cakephp` IRC channel on freenode.org


### PR DESCRIPTION
The old GitHub pull request documentation link didn't works anymore.