### PR TITLE
Add support for the parseHuge option.

### DIFF
--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -168,6 +168,18 @@ class XmlTest extends CakeTestCase {
 	}
 
 /**
+ * test build() method with huge option
+ *
+ * @return void
+ */
+	public function testBuildHuge() {
+		$xml = '<tag>value</tag>';
+		$obj = Xml::build($xml, array('parseHuge' => true));
+		$this->assertEquals('tag', $obj->getName());
+		$this->assertEquals('value', (string)$obj);
+	}
+
+/**
  * Test that the readFile option disables local file parsing.
  *
  * @expectedException XmlException

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -80,7 +80,9 @@ class Xml {
  * - `readFile` Set to false to disable file reading. This is important to disable when
  *   putting user data into Xml::build(). If enabled local & remote files will be read if they exist.
  *   Defaults to true for backwards compatibility reasons.
- * - If using array as input, you can pass `options` from Xml::fromArray.
+ * - `parseHuge` Enable the `LIBXML_PARSEHUGE`
+ *
+ * If using array as input, you can pass `options` from Xml::fromArray.
  *
  * @param string|array $input XML string, a path to a file, a URL or an array
  * @param array $options The options to use
@@ -94,7 +96,8 @@ class Xml {
 		$defaults = array(
 			'return' => 'simplexml',
 			'loadEntities' => false,
-			'readFile' => true
+			'readFile' => true,
+			'parseHuge' => true
 		);
 		$options += $defaults;
 
@@ -134,6 +137,10 @@ class Xml {
 		$internalErrors = libxml_use_internal_errors(true);
 		if ($hasDisable && !$options['loadEntities']) {
 			libxml_disable_entity_loader(true);
+		}
+		$flags = LIBXML_NOCDATA;
+		if (!empty($options['parseHuge'])) {
+			$flags |= LIBXML_PARSEHUGE;
 		}
 		try {
 			if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {


### PR DESCRIPTION
Sometimes people need to load huge XML files. Add an option to enable people to enable this flag.

Refs #10031