### PR TITLE
Incorrect Request-URI when using HttpClient with proxy

### DIFF
--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -202,6 +202,7 @@ class Stream
             $this->_contextOptions['max_redirects'] = (int)$options['redirect'];
         }
         if (isset($options['proxy']['proxy'])) {
+            $this->_contextOptions['request_fulluri'] = true;
             $this->_contextOptions['proxy'] = $options['proxy']['proxy'];
         }
     }


### PR DESCRIPTION
According to RFC2616 when sending a request to a proxy request URI MUST be sent in an absolute form.

Closes #10038 .