### PR TITLE
Shift subcommand propagation to be at help generation.

### DIFF
--- a/src/Console/ConsoleInputSubcommand.php
+++ b/src/Console/ConsoleInputSubcommand.php
@@ -32,14 +32,14 @@ class ConsoleInputSubcommand
      *
      * @var string
      */
-    protected $_name;
+    protected $_name = '';
 
     /**
      * Help string for the subcommand
      *
      * @var string
      */
-    protected $_help;
+    protected $_help = '';
 
     /**
      * The ConsoleOptionParser for this subcommand.
@@ -81,6 +81,16 @@ class ConsoleInputSubcommand
     public function name()
     {
         return $this->_name;
+    }
+
+    /**
+     * Get the raw help string for this command
+     *
+     * @return string
+     */
+    public function getRawHelp()
+    {
+        return $this->_help;
     }
 
     /**

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -819,7 +819,7 @@ class ConsoleOptionParser
         if ($option->validChoice($value)) {
             if ($option->acceptsMultiple($value)) {
                 $params[$name][] = $value;
-fi            } else {
+            } else {
                 $params[$name] = $value;
             }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -731,6 +731,7 @@ class ConsoleOptionParser
                 $subparser->setDescription($command->getRawHelp());
             }
             $subparser->setCommand($this->getCommand() . ' ' . $subcommand);
+
             return $subparser->help(null, $format, $width);
         }
 
@@ -818,7 +819,7 @@ class ConsoleOptionParser
         if ($option->validChoice($value)) {
             if ($option->acceptsMultiple($value)) {
                 $params[$name][] = $value;
-            } else {
+fi            } else {
                 $params[$name] = $value;
             }
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -592,6 +592,30 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * Test addSubcommand inherits options as no
+     * parser is created.
+     *
+     * @return void
+     */
+    public function testAddSubcommandInheritOptions()
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addSubcommand('build', [
+            'help' => 'Build things'
+        ])->addOption('connection', [
+            'short' => 'c',
+            'default' => 'default'
+        ])->addArgument('name', ['required' => false]);
+
+        $result = $parser->parse(['build']);
+        $this->assertEquals('default', $result[0]['connection']);
+
+        $result = $parser->subcommands();
+        $this->assertArrayHasKey('build', $result);
+        $this->assertFalse($result['build']->parser(), 'No parser should be created');
+    }
+
+    /**
      * test addSubcommand with an object.
      *
      * @return void


### PR DESCRIPTION
The old approach created a parser for every command that didn't have an explict option parser. This broke automatic option inheritance for subcommands. While there weren't any tests for this behavior many console tools rely on this behavior. eg. `orm_cache`

cc @dereuromark 