### PR TITLE
Fix expression doc blocks.

### DIFF
--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -53,7 +53,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
     /**
      * Constructor
      *
-     * @param mixed $field The field name to compare for values in between the range.
+     * @param string|\Cake\Database\ExpressionInterface $field The field name to compare for values in between the range.
      * @param mixed $from The initial value of the range.
      * @param mixed $to The ending value in the comparison range.
      * @param string|null $type The data type name to bind the values with.

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -71,7 +71,7 @@ class Comparison implements ExpressionInterface, FieldInterface
     /**
      * Constructor
      *
-     * @param string $field the field name to compare to a value
+     * @param string|\Cake\Database\ExpressionInterface $field the field name to compare to a value
      * @param mixed $value The value to be used in comparison
      * @param string $type the type name used to cast the value
      * @param string $operator the operator used for comparing field and value

--- a/src/Database/Expression/FieldInterface.php
+++ b/src/Database/Expression/FieldInterface.php
@@ -26,7 +26,7 @@ interface FieldInterface
     /**
      * Sets the field name
      *
-     * @param string $field The field to compare with.
+     * @param string|\Cake\Database\ExpressionInterface $field The field to compare with.
      * @return void
      */
     public function setField($field);

--- a/src/Database/Expression/FieldTrait.php
+++ b/src/Database/Expression/FieldTrait.php
@@ -25,14 +25,14 @@ trait FieldTrait
     /**
      * The field name or expression to be used in the left hand side of the operator
      *
-     * @var string
+     * @var string|\Cake\Database\ExpressionInterface
      */
     protected $_field;
 
     /**
      * Sets the field name
      *
-     * @param string $field The field to compare with.
+     * @param string|\Cake\Database\ExpressionInterface $field The field to compare with.
      * @return void
      */
     public function setField($field)

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -28,8 +28,8 @@ class OrderByExpression extends QueryExpression
     /**
      * Constructor
      *
-     * @param array $conditions The sort columns
-     * @param array $types The types for each column.
+     * @param string|array|\Cake\Database\ExpressionInterface $conditions The sort columns
+     * @param array|\Cake\Database\TypeMap $types The types for each column.
      * @param string $conjunction The glue used to join conditions together.
      */
     public function __construct($conditions = [], $types = [], $conjunction = '')

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -54,7 +54,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * expression objects. Optionally, you can set the conjunction keyword to be used
      * for joining each part of this level of the expression tree.
      *
-     * @param string|array|\Cake\Database\Expression\QueryExpression $conditions tree-like array structure containing all the conditions
+     * @param string|array|\Cake\Database\ExpressionInterface $conditions tree-like array structure containing all the conditions
      * to be added or nested inside this expression object.
      * @param array|\Cake\Database\TypeMap $types associative array of types to be associated with the values
      * passed in $conditions.
@@ -145,7 +145,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field = value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * If it is suffixed with "[]" and the value is an array then multiple placeholders
@@ -164,7 +164,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field != value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * If it is suffixed with "[]" and the value is an array then multiple placeholders
@@ -183,7 +183,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field > value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -200,7 +200,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field < value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -217,7 +217,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field >= value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -234,7 +234,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field <= value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -283,7 +283,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field LIKE value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -300,7 +300,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Adds a new condition to the expression object in the form "field NOT LIKE value".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param mixed $value The value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -318,7 +318,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Adds a new condition to the expression object in the form
      * "field IN (value1, value2)".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param string|array $values the value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -355,7 +355,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Adds a new condition to the expression object in the form
      * "field NOT IN (value1, value2)".
      *
-     * @param string $field Database field to be compared against value
+     * @param string|\Cake\Database\ExpressionInterface $field Database field to be compared against value
      * @param array $values the value to be bound to $field for comparison
      * @param string|null $type the type name for $value as configured using the Type map.
      * @return $this
@@ -398,7 +398,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Adds a new condition to the expression object in the form
      * "field BETWEEN from AND to".
      *
-     * @param mixed $field The field name to compare for values in between the range.
+     * @param string|\Cake\Database\ExpressionInterface $field The field name to compare for values in between the range.
      * @param mixed $from The initial value of the range.
      * @param mixed $to The ending value in the comparison range.
      * @param string|null $type the type name for $value as configured using the Type map.
@@ -418,7 +418,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
      *
-     * @param string|array|QueryExpression $conditions to be joined with AND
+     * @param string|array|\Cake\Database\ExpressionInterface $conditions to be joined with AND
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
@@ -436,7 +436,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "OR"
      *
-     * @param string|array|QueryExpression $conditions to be joined with OR
+     * @param string|array|\Cake\Database\ExpressionInterface $conditions to be joined with OR
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
@@ -457,7 +457,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * "NOT ( (condition1) AND (conditions2) )" conjunction depends on the one
      * currently configured for this object.
      *
-     * @param string|array|\Cake\Database\Expression\QueryExpression $conditions to be added and negated
+     * @param string|array|\Cake\Database\ExpressionInterface $conditions to be added and negated
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return $this
@@ -763,7 +763,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Returns the type name for the passed field if it was stored in the typeMap
      *
-     * @param string|\Cake\Database\Expression\QueryExpression $field The field name to get a type for.
+     * @param string|\Cake\Database\Expression\IdentifierExpression $field The field name to get a type for.
      * @return string|null The computed type or null, if the type is unknown.
      */
     protected function _calculateType($field)

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -29,7 +29,7 @@ class TupleComparison extends Comparison
     /**
      * Constructor
      *
-     * @param string|array $fields the fields to use to form a tuple
+     * @param string|array|\Cake\Database\ExpressionInterface $fields the fields to use to form a tuple
      * @param array|\Cake\Database\ExpressionInterface $values the values to use to form a tuple
      * @param array $types the types names to use for casting each of the values, only
      * one type per position in the value array in needed


### PR DESCRIPTION
Most of the expression class' methods do accept expression objects,
and/or actually use the same signature as the overridden methods.