### PR TITLE
Normalise dynamic gets

### DIFF
--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -598,6 +598,6 @@ class Response extends Message implements ResponseInterface
             return $val !== null;
         }
 
-        return isset($this->$key);
+        return isset($this->{$key});
     }
 }

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -501,7 +501,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Get the response body as JSON decoded data.
      *
-     * @return mixed
+     * @return array|null
      */
     protected function _getJson()
     {

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -91,7 +91,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         if (isset($this->_loaded[$name])) {
             return $this->_loaded[$name];
         }
-        if (isset($this->$name)) {
+        if (isset($this->{$name})) {
             return $this->_loaded[$name];
         }
 


### PR DESCRIPTION
Fairly trivial changes. After doing a search across the entire repo these were the only occurrences of 
`$this->$something` and I noticed the primary usage throughout cakephp was with braces 
`$this->{$something}`.

So I thought I would clean them up.
