### PR TITLE
Use absolute autoloader path for better test tools integration.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,11 @@ use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 
-require_once 'vendor/autoload.php';
+if (is_file('vendor/autoload.php')) {
+    require_once 'vendor/autoload.php';
+} else {
+    require_once dirname(__DIR__) . '/vendor/autoload.php';
+}
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);


### PR DESCRIPTION
Using ab absolute path helps with tools that run in environments
where the current working directory does not point to the root of the
project.

For example in my IDE I can do "**Right click > Run test**" in a test method body, on the test class, or even on a folder, in order to run single test methods, single test classes, or specific folders only. However, the CWD will point to the selected folder, respectively the folder that contains the test class file, so including the autoloader will fail.