### PR TITLE
Added the method getNames() in AssociationCollection class

### DIFF
--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -327,4 +327,20 @@ class AssociationCollection implements IteratorAggregate
     {
         return new ArrayIterator($this->_items);
     }
+
+    /**
+     * Get the names of all the associations in the collection.
+     *
+     * @return array
+     */
+    public function getNames()
+    {
+        $return = [];
+
+        foreach ($this->_items as $item) {
+            $return[] = $item->name();
+        }
+
+        return $return;
+    }
 }


### PR DESCRIPTION
I created a small function to get the association _name property of all the associations. I needed this to customize the plugin friendsofcake/crud to contain related models on View action. Please, accept if you consider this useful.