### PR TITLE
Fix missing inflection on prefix value.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -990,9 +990,10 @@ class Router
             $callback = $params;
             $params = [];
         }
+        $name = Inflector::underscore($name);
 
         if (empty($params['path'])) {
-            $path = '/' . Inflector::underscore($name);
+            $path = '/' . $name;
         } else {
             $path = $params['path'];
             unset($params['path']);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3108,7 +3108,7 @@ class RouterTest extends TestCase
         Router::prefix('CustomPath', ['path' => '/custom-path'], function ($routes) {
             $this->assertInstanceOf('Cake\Routing\RouteBuilder', $routes);
             $this->assertEquals('/custom-path', $routes->path());
-            $this->assertEquals(['prefix' => 'CustomPath'], $routes->params());
+            $this->assertEquals(['prefix' => 'custom_path'], $routes->params());
         });
     }
 


### PR DESCRIPTION
Routing prefix value names need to be underscored so that they are
compatible with previous behavior and namespace generation.

Refs #10037