### PR TITLE
Query update type check

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -19,6 +19,7 @@ use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\ValuesExpression;
 use Cake\Database\Statement\CallbackStatement;
+use InvalidArgumentException;
 use IteratorAggregate;
 use RuntimeException;
 
@@ -1412,11 +1413,17 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * Can be combined with set() and where() methods to create update queries.
      *
-     * @param string $table The table you want to update.
+     * @param string|\Cake\Database\ExpressionInterface $table The table you want to update.
      * @return $this
      */
     public function update($table)
     {
+        if (!is_string($table) && !($table instanceof ExpressionInterface)) {
+            $text = 'Table must be of type string or "%s", got "%s"';
+            $message = sprintf($text, ExpressionInterface::class, gettype($table));
+            throw new InvalidArgumentException($message);
+        }
+
         $this->_dirty();
         $this->_type = 'update';
         $this->_parts['update'][0] = $table;

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2732,6 +2732,20 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test update with type checking
+     * by passing an array as table arg
+     *
+     * @expectedException \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function testUpdateArgTypeChecking()
+    {
+        $query = new Query($this->connection);
+        $query->update(['Articles']);
+    }
+
+    /**
      * Test update with multiple fields.
      *
      * @return void


### PR DESCRIPTION
Add type checking to update method. This prevents setting `$this->_parts['update'][0]` with a value which can't be processed by _buildUpdatePart and causes an "Array to string conversion" error on [this line](https://github.com/cakephp/cakephp/blob/master/src/Database/QueryCompiler.php#L343)

This is possibly related to #9735 

Thanks