### PR TITLE
Fixing a broken error message in MailTransport

### DIFF
--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -72,12 +72,12 @@ class MailTransport extends AbstractTransport {
 			//@codingStandardsIgnoreStart
 			if (!@mail($to, $subject, $message, $headers)) {
 				$error = error_get_last();
-				$msg = 'Could not send email: ' . isset($error['message']) ? $error['message'] : 'unknown';
+				$msg = 'Could not send email: ' . (isset($error['message']) ? $error['message'] : 'unknown');
 				throw new SocketException($msg);
 			}
 		} elseif (!@mail($to, $subject, $message, $headers, $params)) {
 			$error = error_get_last();
-			$msg = 'Could not send email: ' . isset($error['message']) ? $error['message'] : 'unknown';
+			$msg = 'Could not send email: ' . (isset($error['message']) ? $error['message'] : 'unknown');
 			//@codingStandardsIgnoreEnd
 			throw new SocketException($msg);
 		}


### PR DESCRIPTION
When sending a mail using MailTransport fails, CakePHP does not create the correct error message. 
In lines 75 and 80, `.` binds stronger than `?`, so the condition is always true, and the string `'Could not send email'` is never contained in the output (which is an obvious mistake). 