### PR TITLE
Fix docblocks of the ORM `deleteAll()` method

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -96,8 +96,6 @@ interface RepositoryInterface
     public function updateAll($fields, $conditions);
 
     /**
-     * Delete all matching records.
-     *
      * Deletes all records matching the provided conditions.
      *
      * This method will *not* trigger beforeDelete/afterDelete events. If you
@@ -109,7 +107,7 @@ interface RepositoryInterface
      *
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.
-     * @return int Count Returns the affected rows.
+     * @return int Returns the number of affected rows.
      * @see \Cake\Datasource\RepositoryInterface::delete()
      */
     public function deleteAll($conditions);

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -736,7 +736,7 @@ abstract class Association
      *
      * @param mixed $conditions Conditions to be used, accepts anything Query::where()
      * can take.
-     * @return bool Success Returns true if one or more rows are affected.
+     * @return int Returns the number of affected rows.
      * @see \Cake\ORM\Table::deleteAll()
      */
     public function deleteAll($conditions)


### PR DESCRIPTION
Stumbled upon a case where I was testing the result of a `deleteAll()` as a bool, which was problematic when no records where affected.