### PR TITLE
Update Cache.php

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -164,6 +164,10 @@ class Cache {
  * @throws CacheException
  */
 	protected static function _buildEngine($name) {
+		if (Configure::read('Cache.disable')) {
+			return true;
+		}
+
 		$config = static::$_config[$name];
 
 		list($plugin, $class) = pluginSplit($config['engine'], true);


### PR DESCRIPTION
I recently moved to a new dev machine that it misses some modules. So I have set in my CakePHP app to the `core.php` file the following line

    	Configure::write('Cache.disable', true);

On production where all modules are installed everything works fine.
but on my dev I get the following exception:

```
CacheException: Cache engine "_cake_core_" is not properly configured. Ensure required extensions are installed, and credentials/permissions are correct in /vhosts/myhost/lib/Cake/Cache/Cache.php on line 185

Call Stack:
    0.0001     239144   1. {main}() /vhosts/myhost/app/Console/cake.php:0
    0.0007     329344   2. ShellDispatcher::run() /vhosts/myhost/app/Console/cake.php:48
    0.0007     329544   3. ShellDispatcher->__construct() /vhosts/myhost/lib/Cake/Console/ShellDispatcher.php:65
    0.0007     332248   4. ShellDispatcher->_initEnvironment() /vhosts/myhost/lib/Cake/Console/ShellDispatcher.php:54
    0.0007     332688   5. ShellDispatcher->_bootstrap() /vhosts/myhost/lib/Cake/Console/ShellDispatcher.php:100
    0.0010     408888   6. require('/vhosts/myhost/lib/Cake/bootstrap.php') /vhosts/myhost/lib/Cake/Console/ShellDispatcher.php:138
    0.0043    1319520   7. Configure::bootstrap() /vhosts/myhost/lib/Cake/bootstrap.php:432
    0.0044    1333408   8. include('/vhosts/myhost/app/Config/core.php') /vhosts/myhost/lib/Cake/Core/Configure.php:72
    0.0050    1434176   9. Cache::config() /vhosts/myhost/app/Config/core.php:387
    0.0050    1435496  10. Cache::_buildEngine() /vhosts/myhost/lib/Cake/Cache/Cache.php:151
```

I guess there is no reason checking if the module is installed if you have disabled the cache. 
