### PR TITLE
Provide BC typehinting for TableSchema.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,6 @@
             "src/Core/functions.php",
             "src/Collection/functions.php",
             "src/I18n/functions.php",
-            "src/Database/backwards_compat.php",
-            "src/Http/backwards_compat.php",
             "src/Utility/bootstrap.php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
             "src/Core/functions.php",
             "src/Collection/functions.php",
             "src/I18n/functions.php",
+            "src/Database/backwards_compat.php",
             "src/Http/backwards_compat.php",
             "src/Utility/bootstrap.php"
         ]

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Core">
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml"/>
+ <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml"/>
+
+ <!-- Necessary for class aliases used for backwards compat -->
+ <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+  <severity>0</severity>
+ </rule>
 </ruleset>

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earlier 3.x versions.
-class_alias('Cake\Database\Schema\TableSchema', 'Cake\Database\Schema\Table');
+// @deprecated Load new class and alias
+class_exists('Cake\Database\Schema\TableSchema');

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -879,3 +879,6 @@ class TableSchema
         return $dialect->dropConstraintSql($this);
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Database\Schema\TableSchema', 'Cake\Database\Schema\Table');

--- a/src/Database/backwards_compat.php
+++ b/src/Database/backwards_compat.php
@@ -1,0 +1,3 @@
+<?php
+// Ensure backwards compat aliases exists.
+class_exists('Cake\Database\Schema\Table');

--- a/src/Database/backwards_compat.php
+++ b/src/Database/backwards_compat.php
@@ -1,3 +1,0 @@
-<?php
-// Ensure backwards compat aliases exists.
-class_exists('Cake\Database\Schema\Table');

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -549,3 +549,5 @@ class Client
         return new $class($this, $options);
     }
 }
+// @deprecated Backwards compatibility with earler 3.x versions.
+class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -320,3 +320,6 @@ class Stream
         return array_merge($this->_contextOptions, $this->_sslContextOptions);
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -72,3 +72,6 @@ class Basic
         return 'Basic ' . base64_encode($user . ':' . $pass);
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -142,3 +142,6 @@ class Digest
         return $authHeader;
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -350,3 +350,6 @@ class Oauth
         );
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -117,3 +117,6 @@ class CookieCollection
         return array_values($this->_cookies);
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -268,3 +268,6 @@ class FormData implements Countable
         return http_build_query($data);
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -221,3 +221,6 @@ class FormDataPart
         return $out;
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');

--- a/src/Http/Client/Message.php
+++ b/src/Http/Client/Message.php
@@ -171,3 +171,6 @@ class Message
         return $this;
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -254,3 +254,6 @@ class Request extends Message implements RequestInterface
         return $this;
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -601,3 +601,6 @@ class Response extends Message implements ResponseInterface
         return isset($this->{$key});
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2439,3 +2439,6 @@ class Response implements ResponseInterface
         ];
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\Response', 'Cake\Network\Response');

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -2132,3 +2132,6 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
         unset($this->params[$name]);
     }
 }
+
+// @deprecated Add backwards compat alias.
+class_alias('Cake\Http\ServerRequest', 'Cake\Network\Request');

--- a/src/Http/backwards_compat.php
+++ b/src/Http/backwards_compat.php
@@ -1,4 +1,0 @@
-<?php
-// Ensure backwards compat aliases exists.
-class_exists('Cake\Network\Request');
-class_exists('Cake\Network\Response');

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Adapter\Stream', 'Cake\Network\Http\Adapter\Stream');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Adapter\Stream');

--- a/src/Network/Http/Auth/Basic.php
+++ b/src/Network/Http/Auth/Basic.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Auth\Basic', 'Cake\Network\Http\Auth\Basic');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Auth\Basic');

--- a/src/Network/Http/Auth/Digest.php
+++ b/src/Network/Http/Auth/Digest.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Auth\Digest', 'Cake\Network\Http\Auth\Digest');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Auth\Digest');

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Auth\Oauth', 'Cake\Network\Http\Auth\Oauth');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Auth\Oauth');

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client', 'Cake\Network\Http\Client');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client');

--- a/src/Network/Http/CookieCollection.php
+++ b/src/Network/Http/CookieCollection.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\CookieCollection', 'Cake\Network\Http\CookieCollection');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\CookieCollection');

--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\FormData', 'Cake\Network\Http\FormData');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\FormData');

--- a/src/Network/Http/FormData/Part.php
+++ b/src/Network/Http/FormData/Part.php
@@ -1,2 +1,3 @@
 <?php
-class_alias('Cake\Http\Client\FormDataPart', 'Cake\Network\Http\FormData\Part');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\FormDataPart');

--- a/src/Network/Http/Message.php
+++ b/src/Network/Http/Message.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Message', 'Cake\Network\Http\Message');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Message');

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Request', 'Cake\Network\Http\Request');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Request');

--- a/src/Network/Http/Response.php
+++ b/src/Network/Http/Response.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Client\Response', 'Cake\Network\Http\Response');
+// @deprecated Load new class and alias.
+class_exists('Cake\Http\Client\Response');

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\ServerRequest', 'Cake\Network\Request');
+// @deprecated Load new class and alias
+class_exists('Cake\Http\ServerRequest');

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1,3 +1,3 @@
 <?php
-// @deprecated Backwards compatibility with earler 3.x versions.
-class_alias('Cake\Http\Response', 'Cake\Network\Response');
+// @deprecated Load new class and alias
+class_exists('Cake\Http\Response');


### PR DESCRIPTION
When running migrations, or running tests on bake plugin right now:
```
1) Bake\Test\TestCase\Shell\Task\FixtureTaskTest::testImportOptionsAlternateConnection
TypeError: Argument 1 passed to Bake\Shell\Task\FixtureTask::_generateRecords() must be an instance of
Cake\Database\Schema\Table, instance of Cake\Database\Schema\TableSchema given, called in
D:\...\Apps\sandbox.local\vendor\cakephp\bake\src\Shell\Task\FixtureTask.php on line 194

D:\...\Apps\sandbox.local\vendor\cakephp\bake\src\Shell\Task\FixtureTask.php:322
D:\...\Apps\sandbox.local\vendor\cakephp\bake\src\Shell\Task\FixtureTask.php:194
D:\...\Apps\sandbox.local\vendor\cakephp\bake\tests\TestCase\Shell\Task\FixtureTaskTest.php:132
```

This should resolve it. //cc @markstory 