### PR TITLE
2.x: Built-in server doesn't accept query string parameters for the base path

### DIFF
--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -82,7 +82,7 @@ if (!defined('WWW_ROOT')) {
 
 // For the built-in server
 if (PHP_SAPI === 'cli-server') {
-	if ($_SERVER['REQUEST_URI'] !== '/' && file_exists(WWW_ROOT . $_SERVER['PHP_SELF'])) {
+	if ($_SERVER['PHP_SELF'] !== '/' . basename(__FILE__) && file_exists(WWW_ROOT . $_SERVER['PHP_SELF'])) {
 		return false;
 	}
 	$_SERVER['PHP_SELF'] = '/' . basename(__FILE__);


### PR DESCRIPTION
This is a minor problem only affecting the built-in server but I had to fix it and I'm sharing this fix in case it helps anyone.

In case you want to use query string parameters in the base path while developing your app you won't be able to because the webroot/index.php will stop. I've changed the condition that makes the script stop.

Fixes #10067 