### PR TITLE
Static method to create Mailer instances

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -12,9 +12,11 @@
  */
 namespace Cake\Mailer;
 
+use Cake\Core\App;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventListenerInterface;
 use Cake\Mailer\Exception\MissingActionException;
+use Cake\Mailer\Exception\MissingMailerException;
 
 /**
  * Mailer base class.
@@ -136,6 +138,29 @@ abstract class Mailer implements EventListenerInterface
      * @var string
      */
     protected $_clonedEmail;
+
+    /**
+     * Returns a mailer instance.
+     *
+     * @param string $name Mailer's name.
+     * @param \Cake\Mailer\Email|null $email Email instance.
+     * @return \Cake\Mailer\Mailer
+     * @throws \Cake\Mailer\Exception\MissingMailerException if undefined mailer class.
+     */
+    public static function getMailer($name, Email $email = null)
+    {
+        if ($email === null) {
+            $email = new Email();
+        }
+
+        $className = App::className($name, 'Mailer', 'Mailer');
+
+        if (empty($className)) {
+            throw new MissingMailerException(compact('name'));
+        }
+
+        return (new $className($email));
+    }
 
     /**
      * Constructor.

--- a/src/Mailer/MailerAwareTrait.php
+++ b/src/Mailer/MailerAwareTrait.php
@@ -14,9 +14,6 @@
  */
 namespace Cake\Mailer;
 
-use Cake\Core\App;
-use Cake\Mailer\Exception\MissingMailerException;
-
 /**
  * Provides functionality for loading mailer classes
  * onto properties of the host object.
@@ -37,16 +34,6 @@ trait MailerAwareTrait
      */
     public function getMailer($name, Email $email = null)
     {
-        if ($email === null) {
-            $email = new Email();
-        }
-
-        $className = App::className($name, 'Mailer', 'Mailer');
-
-        if (empty($className)) {
-            throw new MissingMailerException(compact('name'));
-        }
-
-        return (new $className($email));
+        return Mailer::getMailer($name, $email);
     }
 }


### PR DESCRIPTION
I've moved the code that creates a new ```Mailer``` instance in the ```MailerAwareTrait``` to a static method. The trait keeps working the same.

I think it's painful having to import the trait every time I need a ```Mailer``` instance in a different class.

Fixes #10071.