### PR TITLE
Allows the Fixture system to use the aliases created

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -360,7 +360,7 @@ class FixtureManager
     {
         $dbs = $this->_fixtureConnections($fixtures);
         foreach ($dbs as $connection => $fixtures) {
-            $db = ConnectionManager::get($connection, false);
+            $db = ConnectionManager::get($connection);
             $logQueries = $db->logQueries();
             if ($logQueries && !$this->_debug) {
                 $db->logQueries(false);


### PR DESCRIPTION
This makes sure the FixtureManager uses the prefix aliases it creates. This isn't so much a problem for Fixtures that extend TestFixture as it enforces connections to be `test` prefixed. However for Fixtures that implement FixtureInterface like `cakephp/elastic-search`. Also this isn't a problem for connections that either `test` or `default` as an alias is auto created for this. However if you have a connection of `elastic` for example it creates `test_elastic`.  This isn't used because of the `false` on 357 of FixtureManager.

All current tests still pass

Sorry its a difficult one to complain, I have spoke to Mark Story at length about this ;-)