### PR TITLE
Improve error message on belongsToMany associations

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -900,8 +900,9 @@ abstract class Association
 
         if (count($foreignKey) !== count($bindingKey)) {
             if (empty($bindingKey)) {
-                $msg = 'The "%s" table does not define a primary key. Please set one.';
-                throw new RuntimeException(sprintf($msg, $this->target()->table()));
+                $table = $this->isOwningSide($this->source()) ? $this->source()->table() : $this->target()->table();
+                $msg = 'The "%s" table does not define a primary key, and cannot have join conditions generated.';
+                throw new RuntimeException(sprintf($msg, $table));
             }
 
             $msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1039,6 +1039,23 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that eager loading requires association keys
+     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The "tags" table does not define a primary key
+     * @return void
+     */
+    public function testEagerLoadingRequiresPrimaryKey()
+    {
+        $table = TableRegistry::get('Articles');
+        $tags = TableRegistry::get('Tags');
+        $tags->schema()->dropConstraint('primary');
+
+        $table->belongsToMany('Tags');
+        $table->find()->contain('Tags')->first();
+    }
+
+    /**
      * Tests that fetching belongsToMany association will not force
      * all fields being returned, but intead will honor the select() clause
      *


### PR DESCRIPTION
Name the correct table when bindingKey() is empty.

Refs #10054