### PR TITLE
Add reset method to BreadcrumbsHelper

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -224,6 +224,18 @@ class BreadcrumbsHelper extends Helper
     }
 
     /**
+     * Removes all existing crumbs.
+     *
+     * @return $this
+     */
+    public function reset()
+    {
+        $this->crumbs = [];
+
+        return $this;
+    }
+
+    /**
      * Renders the breadcrumbs trail.
      *
      * @param array $attributes Array of attributes applied to the `wrapper` template. Accepts the `templateVars` key to

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -201,6 +201,24 @@ class BreadcrumbsHelperTest extends TestCase
     }
 
     /**
+     * Test ability to empty crumbs list.
+     *
+     * @return void
+     */
+    public function testReset()
+    {
+        $this->breadcrumbs->add('Home', '/');
+        $this->breadcrumbs->add('Products', '/products');
+
+        $crumbs = $this->breadcrumbs->getCrumbs();
+        $this->assertEquals(count($crumbs), 2);
+
+        $this->breadcrumbs->reset();
+        $actual = $this->breadcrumbs->getCrumbs();
+        $this->assertEquals($actual, []);
+    }
+
+    /**
      * Test adding crumbs to a specific index
      *
      * @return void


### PR DESCRIPTION
Added a reset method to clear the crumbs list in BreadcrumbsHelper. Useful to modify the crumbs list manually. 
eg.

    $crumbs = $this->Breadcrumbs->getCrumbs();
    $crumbs = collection($crumbs)->map(function ($crumb) {
        $crumb['options']['class'] = 'breadcrumb-item';
        return $crumb;
    })->toArray();

    $this->Breadcrumbs->reset()->add($crumbs);


Discussed in ticket #9829.
