### PR TITLE
Link HasMany associations using a single transaction

### DIFF
--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -231,7 +231,9 @@ class HasMany extends Association
 
         $sourceEntity->set($property, $currentEntities);
 
-        $savedEntity = $this->saveAssociated($sourceEntity, $options);
+        $savedEntity = $this->connection()->transactional(function () use ($sourceEntity, $options) {
+            return $this->saveAssociated($sourceEntity, $options);
+        });
 
         $ok = ($savedEntity instanceof EntityInterface);
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -714,12 +714,12 @@ class HasManyTest extends TestCase
 
         // Ensure that after each model is saved, we are still within a transaction.
         $listenerAfterSave = function ($e, $entity, $options) use ($articles) {
-            $debugInfo = $articles->connection()->__debugInfo();
-            $transactionLevel = $debugInfo['transactionLevel'];
-            $this->assertGreaterThan(0, $transactionLevel);
+            $this->assertTrue($articles->connection()->inTransaction(), 'Multiple transactions used to save associated models.');
         };
         $articles->eventManager()->on('Model.afterSave', $listenerAfterSave);
-        $assoc->link($entity, $articles->find('all')->toArray());
+
+        $options = ['atomic' => false];
+        $assoc->link($entity, $articles->find('all')->toArray(), $options);
 
         // Ensure that link was successful.
         $new = $this->author->get(2, ['contain' => 'Articles']);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -693,4 +693,36 @@ class HasManyTest extends TestCase
         $this->assertSame(4, $this->author->find()->count(), 'Authors should still exist');
         $this->assertSame(3, $articles->find()->count(), 'Articles should still exist');
     }
+
+    /**
+     * Tests that link only uses a single database transaction
+     *
+     * @return void
+     */
+    public function testLinkUsesSingleTransaction()
+    {
+        $articles = TableRegistry::get('Articles');
+        $assoc = $this->author->hasMany('Articles', [
+            'sourceTable' => $this->author,
+            'targetTable' => $articles
+        ]);
+
+        // Ensure author in fixture has zero associated articles
+        $entity = $this->author->get(2, ['contain' => 'Articles']);
+        $initial = $entity->articles;
+        $this->assertCount(0, $initial);
+
+        // Ensure that after each model is saved, we are still within a transaction.
+        $listenerAfterSave = function ($e, $entity, $options) use ($articles) {
+            $debugInfo = $articles->connection()->__debugInfo();
+            $transactionLevel = $debugInfo['transactionLevel'];
+            $this->assertGreaterThan(0, $transactionLevel);
+        };
+        $articles->eventManager()->on('Model.afterSave', $listenerAfterSave);
+        $assoc->link($entity, $articles->find('all')->toArray());
+
+        // Ensure that link was successful.
+        $new = $this->author->get(2, ['contain' => 'Articles']);
+        $this->assertCount(3, $new->articles);
+    }
 }


### PR DESCRIPTION
HasMany->link is now using a single database transaction instead of multiple transactions.
BelongsToMany->link already was using a single transaction.

HasMany->unlink uses the updateAll function therefore I do not believe any changes are required.

Ref: #8196