### PR TITLE
Connection manager config

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -30,7 +30,7 @@ class ConnectionManager
 {
 
     use StaticConfigTrait {
-        config as protected _config;
+        setConfig as protected _setConfig;
         parseDsn as protected _parseDsn;
     }
 
@@ -71,13 +71,13 @@ class ConnectionManager
      * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
      * @see \Cake\Core\StaticConfigTrait::config()
      */
-    public static function config($key, $config = null)
+    public static function setConfig($key, $config = null)
     {
         if (is_array($config)) {
             $config['name'] = $key;
         }
 
-        return static::_config($key, $config);
+        return static::_setConfig($key, $config);
     }
 
     /**

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -17,6 +17,41 @@ use Cake\TestSuite\TestCase;
 
 class FakeConnection
 {
+    protected $_config = [];
+
+    /**
+     * Constructor.
+     *
+     * @param array $config configuration for connecting to database
+     */
+    public function __construct($config)
+    {
+        $this->_config = $config;
+    }
+
+    /**
+     * Returns the set config
+     *
+     * @return array
+     */
+    public function config()
+    {
+        return $this->_config;
+    }
+
+    /**
+     * Returns the set name
+     *
+     * @return string
+     */
+    public function configName()
+    {
+        if (empty($this->_config['name'])) {
+            return '';
+        }
+
+        return $this->_config['name'];
+    }
 }
 
 /**
@@ -278,5 +313,31 @@ class ConnectionManagerTest extends TestCase
 
         ConnectionManager::config('test_variant', $callable);
         $this->assertSame($connection, ConnectionManager::get('test_variant'));
+    }
+
+    /**
+     * Tests that setting a config will also correctly set the name for the connection
+     *
+     * @return void
+     */
+    public function testSetConfigName()
+    {
+        //Set with explicit name
+        ConnectionManager::config('test_variant', [
+            'className' => __NAMESPACE__ . '\FakeConnection',
+            'database' => ':memory:'
+        ]);
+        $result = ConnectionManager::get('test_variant');
+        $this->assertSame('test_variant', $result->configName());
+
+        ConnectionManager::drop('test_variant');
+        ConnectionManager::config([
+            'test_variant' => [
+                'className' => __NAMESPACE__ . '\FakeConnection',
+                'database' => ':memory:'
+            ]
+        ]);
+        $result = ConnectionManager::get('test_variant');
+        $this->assertSame('test_variant', $result->configName());
     }
 }

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -24,7 +24,7 @@ class FakeConnection
      *
      * @param array $config configuration for connecting to database
      */
-    public function __construct($config)
+    public function __construct($config = [])
     {
         $this->_config = $config;
     }


### PR DESCRIPTION
Fixes an issue where the name for connections was no longer set after the config getter/setting split.

`$connection->configName()` would return an empty string. Also added a test case for this to ensure that it doesn't happen again.