### PR TITLE
SQL JSON expression in virtual field and conditions

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2958,10 +2958,11 @@ class DboSource extends DataSource {
 		if (!empty($this->endQuote)) {
 			$end = preg_quote($this->endQuote);
 		}
+
 		// Remove quotes and requote all the Model.field names.
 		$conditions = str_replace(array($start, $end), '', $conditions);
 		$conditions = preg_replace_callback(
-			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*[a-z0-9_])/i',
+			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*[a-z0-9_])|([a-z0-9_][a-z0-9_\\-]*)(?=->)/i',
 			array(&$this, '_quoteMatchedField'),
 			$conditions
 		);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2884,7 +2884,7 @@ class DboSource extends DataSource {
 		// Remove quotes and requote all the Model.field names.
 		$conditions = str_replace(array($start, $end), '', $conditions);
 		$conditions = preg_replace_callback(
-			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*)/i',
+			'/(?:[\'\"][^\'\"\\\]*(?:\\\.[^\'\"\\\]*)*[\'\"])|([a-z0-9_][a-z0-9\\-_]*\\.[a-z0-9_][a-z0-9_\\-]*[a-z0-9_])/i',
 			array(&$this, '_quoteMatchedField'),
 			$conditions
 		);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2897,7 +2897,8 @@ class DboSource extends DataSource {
 			$isKey = (
 				strpos($key, '(') !== false ||
 				strpos($key, ')') !== false ||
-				strpos($key, '|') !== false
+				strpos($key, '|') !== false ||
+				strpos($key, '->') !== false
 			);
 			$key = $isKey ? $this->_quoteFields($key) : $this->name($key);
 		}

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -198,6 +198,18 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * test that PostgreSQL json operators can be used.
+ *
+ * @return void
+ */
+	public function testColumnHyphenOperator() {
+		$result = $this->testDb->conditions(array('Foo.bar->>\'fieldName\'' => 42));
+		echo "Result is: ";
+		echo $result;
+		$this->assertEquals(' WHERE `Foo`.`bar`->>\'fieldName\' = 42', $result, 'pgsql json operator failed');
+	}
+
+/**
  * test that order() will accept objects made from DboSource::expression
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -244,15 +244,16 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
- * test that PostgreSQL json operators can be used.
+ * test that SQL JSON operators can be used.
  *
  * @return void
  */
 	public function testColumnHyphenOperator() {
 		$result = $this->testDb->conditions(array('Foo.bar->>\'fieldName\'' => 42));
-		echo "Result is: ";
-		echo $result;
-		$this->assertEquals(' WHERE `Foo`.`bar`->>\'fieldName\' = 42', $result, 'pgsql json operator failed');
+		$this->assertEquals(' WHERE `Foo`.`bar`->>\'fieldName\' = 42', $result, 'SQL JSON operator failed');
+
+		$result = $this->testDb->conditions(array('Foo.bar->\'fieldName\'' => 42));
+		$this->assertEquals(' WHERE `Foo`.`bar`->\'fieldName\' = 42', $result, 'SQL JSON operator failed');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -249,12 +249,20 @@ class DboSourceTest extends CakeTestCase {
  * @return void
  */
 	public function testColumnHyphenOperator() {
+		//PostgreSQL style
 		$result = $this->testDb->conditions(array('Foo.bar->>\'fieldName\'' => 42));
 		$this->assertEquals(' WHERE `Foo`.`bar`->>\'fieldName\' = 42', $result, 'SQL JSON operator failed');
-
 		$result = $this->testDb->conditions(array('Foo.bar->\'fieldName\'' => 42));
 		$this->assertEquals(' WHERE `Foo`.`bar`->\'fieldName\' = 42', $result, 'SQL JSON operator failed');
-	}
+
+		// MYSQL style
+		$result = $this->testDb->conditions(array('Foo.bar->>\'$.fieldName\'' => 42));
+		$this->assertEquals(' WHERE `Foo`.`bar`->>\'$.fieldName\' = 42', $result, 'SQL JSON operator failed');
+
+		//Without defining table name.
+		$result = $this->testDb->conditions(array('bar->>\'$.fieldName\'' => 42));
+		$this->assertEquals(' WHERE `bar`->>\'$.fieldName\' = 42', $result, 'SQL JSON operator failed');
+    }
 
 /**
  * test that order() will accept objects made from DboSource::expression

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -262,7 +262,7 @@ class DboSourceTest extends CakeTestCase {
 		//Without defining table name.
 		$result = $this->testDb->conditions(array('bar->>\'$.fieldName\'' => 42));
 		$this->assertEquals(' WHERE `bar`->>\'$.fieldName\' = 42', $result, 'SQL JSON operator failed');
-    }
+	}
 
 /**
  * test that order() will accept objects made from DboSource::expression


### PR DESCRIPTION
Continuing from previous pull request started by @erjiang. 

Fixes unit tests and ability for SQL JSON expression like "Foo"."bar"->>'prop' to be handled by data layer. 

Previous PR: #8872
Issue: #8856
