### PR TITLE
Fix for incorrect @return phpdoccomment

### DIFF
--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -40,7 +40,7 @@ class PagesController extends AppController {
 /**
  * Displays a view
  *
- * @return void
+ * @return \Cake\Network\Response|null
  * @throws ForbiddenException When a directory traversal attempt.
  * @throws NotFoundException When the view file could not be found
  *   or MissingViewException in debug mode.


### PR DESCRIPTION
During our PHP 7 upgrade I encountered this incorrect `@return` comment.

Found using [etsy/phan](https://github.com/etsy/phan) ([see](https://github.com/cloudflare/docker-phan#getting-docker-phan)). There are probably more in `lib`, but I only scanned `app` (for now).