### PR TITLE
Fix class name typo

### DIFF
--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -234,7 +234,7 @@ class MiddlewareQueueTest extends TestCase
         };
         $two = function () {
         };
-        $three = new SampleMiddleWare();
+        $three = new SampleMiddleware();
 
         $queue = new MiddlewareQueue();
         $queue->add($one)->insertAt(-1, $two)->insertAt(-1, $three);


### PR DESCRIPTION
Just noticed this earlier, fairly trivial.

It still worked but was camel cased incorrectly.