### PR TITLE
ValueBinder->placeholder method fixes

### DIFF
--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -195,9 +195,6 @@ class ValuesExpression implements ExpressionInterface
             $this->_processExpressions();
         }
 
-        $i = 0;
-        $columns = [];
-
         $columns = $this->_columnNames();
         $defaults = array_fill_keys($columns, null);
         $placeholders = [];
@@ -220,7 +217,7 @@ class ValuesExpression implements ExpressionInterface
                     continue;
                 }
 
-                $placeholder = $generator->placeholder($i);
+                $placeholder = $generator->placeholder('c');
                 $rowPlaceholders[] = $placeholder;
                 $generator->bind($placeholder, $value, $types[$column]);
             }

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -143,7 +143,7 @@ class ValueBinder
         if (empty($bindings)) {
             return;
         }
-        $params = $types = [];
+
         foreach ($bindings as $b) {
             $statement->bindValue($b['placeholder'], $b['value'], $b['type']);
         }

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -86,14 +86,13 @@ class ValueBinder
     {
         $placeholders = [];
         foreach ($values as $k => $value) {
-            $param = ":c" . $this->_bindingsCount;
+            $param = $this->placeholder('c');
             $this->_bindings[$param] = [
                 'value' => $value,
                 'type' => $type,
                 'placeholder' => substr($param, 1),
             ];
             $placeholders[$k] = $param;
-            $this->_bindingsCount++;
         }
 
         return $placeholders;

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -67,8 +67,8 @@ class ValueBinder
     public function placeholder($token)
     {
         $number = $this->_bindingsCount++;
-        if ($token[0] !== ':' || $token !== '?') {
-            $token = sprintf(':c%s', $number);
+        if ($token[0] !== ':' && $token !== '?') {
+            $token = sprintf(':%s%s', $token, $number);
         }
 
         return $token;

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -37,19 +37,19 @@ class CaseExpressionTest extends TestCase
         $expr2->eq('test2', 'false');
 
         $caseExpression = new CaseExpression($expr, 'foobar');
-        $expected = 'CASE WHEN test = :c0 THEN :c1 END';
+        $expected = 'CASE WHEN test = :c0 THEN :param1 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
         $caseExpression->add($expr2);
-        $expected = 'CASE WHEN test = :c0 THEN :c1 WHEN test2 = :c2 THEN :c3 END';
+        $expected = 'CASE WHEN test = :c0 THEN :param1 WHEN test2 = :c2 THEN :param3 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
         $caseExpression = new CaseExpression([$expr], ['foobar', 'else']);
-        $expected = 'CASE WHEN test = :c0 THEN :c1 ELSE :c2 END';
+        $expected = 'CASE WHEN test = :c0 THEN :param1 ELSE :param2 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
         $caseExpression = new CaseExpression([$expr], ['foobar' => 'literal', 'else']);
-        $expected = 'CASE WHEN test = :c0 THEN foobar ELSE :c1 END';
+        $expected = 'CASE WHEN test = :c0 THEN foobar ELSE :param1 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
     }
 
@@ -63,12 +63,12 @@ class CaseExpressionTest extends TestCase
         $expression = new QueryExpression();
         $expression->add(['id' => 'test']);
         $caseExpression = new CaseExpression([$expression], [0], ['integer']);
-        $expected = 'CASE WHEN id = :c0 THEN :c1 END';
+        $expected = 'CASE WHEN id = :c0 THEN :param1 END';
         $binder = new ValueBinder();
         $this->assertSame($expected, $caseExpression->sql($binder));
         $expected = [
             ':c0' => ['value' => 'test', 'type' => null, 'placeholder' => 'c0'],
-            ':c1' => ['value' => 0, 'type' => 'integer', 'placeholder' => 'c1'],
+            ':param1' => ['value' => 0, 'type' => 'integer', 'placeholder' => 'param1'],
         ];
         $this->assertEquals($expected, $binder->bindings());
     }

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -44,15 +44,15 @@ class FunctionExpressionTest extends TestCase
     {
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $binder = new ValueBinder;
-        $this->assertEquals("MyFunction(:c0, :c1)", $f->sql($binder));
+        $this->assertEquals("MyFunction(:param0, :param1)", $f->sql($binder));
 
-        $this->assertEquals('foo', $binder->bindings()[':c0']['value']);
-        $this->assertEquals('bar', $binder->bindings()[':c1']['value']);
+        $this->assertEquals('foo', $binder->bindings()[':param0']['value']);
+        $this->assertEquals('bar', $binder->bindings()[':param1']['value']);
 
         $binder = new ValueBinder;
         $f = new FunctionExpression('MyFunction', ['bar']);
-        $this->assertEquals("MyFunction(:c0)", $f->sql($binder));
-        $this->assertEquals('bar', $binder->bindings()[':c0']['value']);
+        $this->assertEquals("MyFunction(:param0)", $f->sql($binder));
+        $this->assertEquals('bar', $binder->bindings()[':param0']['value']);
     }
 
     /**
@@ -64,7 +64,7 @@ class FunctionExpressionTest extends TestCase
     {
         $binder = new ValueBinder;
         $f = new FunctionExpression('MyFunction', ['foo' => 'literal', 'bar']);
-        $this->assertEquals("MyFunction(foo, :c0)", $f->sql($binder));
+        $this->assertEquals("MyFunction(foo, :param0)", $f->sql($binder));
     }
 
     /**
@@ -78,7 +78,7 @@ class FunctionExpressionTest extends TestCase
         $binder = new ValueBinder;
         $f = new FunctionExpression('MyFunction', ['foo', 'bar']);
         $g = new FunctionExpression('Wrapper', ['bar' => 'literal', $f]);
-        $this->assertEquals("Wrapper(bar, (MyFunction(:c0, :c1)))", $g->sql($binder));
+        $this->assertEquals("Wrapper(bar, (MyFunction(:param0, :param1)))", $g->sql($binder));
     }
 
     /**

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -34,11 +34,11 @@ class TupleComparisonTest extends TestCase
     {
         $f = new TupleComparison(['field1', 'field2'], [1, 2], ['integer', 'integer'], '=');
         $binder = new ValueBinder;
-        $this->assertEquals('(field1, field2) = (:c0, :c1)', $f->sql($binder));
-        $this->assertSame(1, $binder->bindings()[':c0']['value']);
-        $this->assertSame(2, $binder->bindings()[':c1']['value']);
-        $this->assertSame('integer', $binder->bindings()[':c0']['type']);
-        $this->assertSame('integer', $binder->bindings()[':c1']['type']);
+        $this->assertEquals('(field1, field2) = (:tuple0, :tuple1)', $f->sql($binder));
+        $this->assertSame(1, $binder->bindings()[':tuple0']['value']);
+        $this->assertSame(2, $binder->bindings()[':tuple1']['value']);
+        $this->assertSame('integer', $binder->bindings()[':tuple0']['type']);
+        $this->assertSame('integer', $binder->bindings()[':tuple1']['type']);
     }
 
     /**
@@ -51,10 +51,10 @@ class TupleComparisonTest extends TestCase
         $field1 = new QueryExpression(['a' => 1]);
         $f = new TupleComparison([$field1, 'field2'], [4, 5], ['integer', 'integer'], '>');
         $binder = new ValueBinder;
-        $this->assertEquals('(a = :c0, field2) > (:c1, :c2)', $f->sql($binder));
+        $this->assertEquals('(a = :c0, field2) > (:tuple1, :tuple2)', $f->sql($binder));
         $this->assertSame(1, $binder->bindings()[':c0']['value']);
-        $this->assertSame(4, $binder->bindings()[':c1']['value']);
-        $this->assertSame(5, $binder->bindings()[':c2']['value']);
+        $this->assertSame(4, $binder->bindings()[':tuple1']['value']);
+        $this->assertSame(5, $binder->bindings()[':tuple2']['value']);
     }
 
     /**
@@ -67,9 +67,9 @@ class TupleComparisonTest extends TestCase
         $value1 = new QueryExpression(['a' => 1]);
         $f = new TupleComparison(['field1', 'field2'], [$value1, 2], ['integer', 'integer'], '=');
         $binder = new ValueBinder;
-        $this->assertEquals('(field1, field2) = (a = :c0, :c1)', $f->sql($binder));
+        $this->assertEquals('(field1, field2) = (a = :c0, :tuple1)', $f->sql($binder));
         $this->assertSame(1, $binder->bindings()[':c0']['value']);
-        $this->assertSame(2, $binder->bindings()[':c1']['value']);
+        $this->assertSame(2, $binder->bindings()[':tuple1']['value']);
     }
 
     /**
@@ -86,11 +86,11 @@ class TupleComparisonTest extends TestCase
             'IN'
         );
         $binder = new ValueBinder;
-        $this->assertEquals('(field1, field2) IN ((:c0,:c1), (:c2,:c3))', $f->sql($binder));
-        $this->assertSame(1, $binder->bindings()[':c0']['value']);
-        $this->assertSame(2, $binder->bindings()[':c1']['value']);
-        $this->assertSame(3, $binder->bindings()[':c2']['value']);
-        $this->assertSame(4, $binder->bindings()[':c3']['value']);
+        $this->assertEquals('(field1, field2) IN ((:tuple0,:tuple1), (:tuple2,:tuple3))', $f->sql($binder));
+        $this->assertSame(1, $binder->bindings()[':tuple0']['value']);
+        $this->assertSame(2, $binder->bindings()[':tuple1']['value']);
+        $this->assertSame(3, $binder->bindings()[':tuple2']['value']);
+        $this->assertSame(4, $binder->bindings()[':tuple3']['value']);
     }
 
     /**
@@ -153,6 +153,6 @@ class TupleComparisonTest extends TestCase
         $value = [1, 1];
         $f = new TupleComparison(new QueryExpression('a, b'), $value);
         $binder = new ValueBinder;
-        $this->assertEquals('(a, b) = (:c0, :c1)', $f->sql($binder));
+        $this->assertEquals('(a, b) = (:tuple0, :tuple1)', $f->sql($binder));
     }
 }

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -63,8 +63,8 @@ class ExpressionTypeCastingTest extends TestCase
         $comparison = new Comparison('field', 'the thing', 'test', '=');
         $binder = new ValueBinder;
         $sql = $comparison->sql($binder);
-        $this->assertEquals('field = (CONCAT(:c0, :c1))', $sql);
-        $this->assertEquals('the thing', $binder->bindings()[':c0']['value']);
+        $this->assertEquals('field = (CONCAT(:param0, :param1))', $sql);
+        $this->assertEquals('the thing', $binder->bindings()[':param0']['value']);
 
         $found = false;
         $comparison->traverse(function ($exp) use (&$found) {
@@ -84,9 +84,9 @@ class ExpressionTypeCastingTest extends TestCase
         $comparison = new Comparison('field', ['2', '3'], 'test[]', 'IN');
         $binder = new ValueBinder;
         $sql = $comparison->sql($binder);
-        $this->assertEquals('field IN (CONCAT(:c0, :c1),CONCAT(:c2, :c3))', $sql);
-        $this->assertEquals('2', $binder->bindings()[':c0']['value']);
-        $this->assertEquals('3', $binder->bindings()[':c2']['value']);
+        $this->assertEquals('field IN (CONCAT(:param0, :param1),CONCAT(:param2, :param3))', $sql);
+        $this->assertEquals('2', $binder->bindings()[':param0']['value']);
+        $this->assertEquals('3', $binder->bindings()[':param2']['value']);
 
         $found = false;
         $comparison->traverse(function ($exp) use (&$found) {
@@ -105,9 +105,9 @@ class ExpressionTypeCastingTest extends TestCase
         $between = new BetweenExpression('field', 'from', 'to', 'test');
         $binder = new ValueBinder;
         $sql = $between->sql($binder);
-        $this->assertEquals('field BETWEEN CONCAT(:c0, :c1) AND CONCAT(:c2, :c3)', $sql);
-        $this->assertEquals('from', $binder->bindings()[':c0']['value']);
-        $this->assertEquals('to', $binder->bindings()[':c2']['value']);
+        $this->assertEquals('field BETWEEN CONCAT(:param0, :param1) AND CONCAT(:param2, :param3)', $sql);
+        $this->assertEquals('from', $binder->bindings()[':param0']['value']);
+        $this->assertEquals('to', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
         $between->traverse(function ($exp) use (&$expressions) {
@@ -133,11 +133,11 @@ class ExpressionTypeCastingTest extends TestCase
 
         $binder = new ValueBinder;
         $sql = $case->sql($binder);
-        $this->assertEquals('CASE WHEN foo = :c0 THEN CONCAT(:c1, :c2) ELSE CONCAT(:c3, :c4) END', $sql);
+        $this->assertEquals('CASE WHEN foo = :c0 THEN CONCAT(:param1, :param2) ELSE CONCAT(:param3, :param4) END', $sql);
 
         $this->assertEquals('1', $binder->bindings()[':c0']['value']);
-        $this->assertEquals('value1', $binder->bindings()[':c1']['value']);
-        $this->assertEquals('value2', $binder->bindings()[':c3']['value']);
+        $this->assertEquals('value1', $binder->bindings()[':param1']['value']);
+        $this->assertEquals('value2', $binder->bindings()[':param3']['value']);
 
         $expressions = [];
         $case->traverse(function ($exp) use (&$expressions) {
@@ -158,8 +158,8 @@ class ExpressionTypeCastingTest extends TestCase
         $function = new FunctionExpression('DATE', ['2016-01'], ['test']);
         $binder = new ValueBinder;
         $sql = $function->sql($binder);
-        $this->assertEquals('DATE((CONCAT(:c0, :c1)))', $sql);
-        $this->assertEquals('2016-01', $binder->bindings()[':c0']['value']);
+        $this->assertEquals('DATE((CONCAT(:param0, :param1)))', $sql);
+        $this->assertEquals('2016-01', $binder->bindings()[':param0']['value']);
 
         $expressions = [];
         $function->traverse(function ($exp) use (&$expressions) {
@@ -184,11 +184,11 @@ class ExpressionTypeCastingTest extends TestCase
         $binder = new ValueBinder;
         $sql = $values->sql($binder);
         $this->assertEquals(
-            ' VALUES ((CONCAT(:c0, :c1))), ((CONCAT(:c2, :c3)))',
+            ' VALUES ((CONCAT(:param0, :param1))), ((CONCAT(:param2, :param3)))',
             $sql
         );
-        $this->assertEquals('foo', $binder->bindings()[':c0']['value']);
-        $this->assertEquals('bar', $binder->bindings()[':c2']['value']);
+        $this->assertEquals('foo', $binder->bindings()[':param0']['value']);
+        $this->assertEquals('bar', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
         $values->traverse(function ($exp) use (&$expressions) {

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -129,7 +129,7 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->concat(['title' => 'literal', ' is a string']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals("CONCAT(title, :c0)", $function->sql(new ValueBinder));
+        $this->assertEquals("CONCAT(title, :param0)", $function->sql(new ValueBinder));
         $this->assertEquals('string', $function->returnType());
     }
 
@@ -142,7 +142,7 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->coalesce(['NULL' => 'literal', '1', 'a'], ['a' => 'date']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals("COALESCE(NULL, :c0, :c1)", $function->sql(new ValueBinder));
+        $this->assertEquals("COALESCE(NULL, :param0, :param1)", $function->sql(new ValueBinder));
         $this->assertEquals('date', $function->returnType());
     }
 

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.12
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database;
+
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests ValueBinder class
+ */
+class ValueBinderTest extends TestCase
+{
+    /**
+     * test the placeholder method
+     */
+    public function testPlaceholder()
+    {
+        $valueBinder = new ValueBinder();
+        $result = $valueBinder->placeholder('?');
+        $this->assertEquals('?', $result);
+
+        $valueBinder = new ValueBinder();
+        $result = $valueBinder->placeholder(':param');
+        $this->assertEquals(':param', $result);
+
+        $valueBinder = new ValueBinder();
+        $result = $valueBinder->placeholder('p');
+        $this->assertEquals(':p0', $result);
+        $result = $valueBinder->placeholder('p');
+        $this->assertEquals(':p1', $result);
+        $result = $valueBinder->placeholder('c');
+        $this->assertEquals(':c2', $result);
+    }
+}

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -124,15 +124,15 @@ class ValueBinderTest extends TestCase
         $this->assertCount(2, $valueBinder->bindings());
 
         // Ensure the placeholder generation IS affected by resetCount
-        $valueBinder->placeholder('c');
-        $valueBinder->placeholder('c');
-        $result = $valueBinder->placeholder('c');
-        $this->assertEquals(':c2', $result);
+        $valueBinder->placeholder('param');
+        $valueBinder->placeholder('param');
+        $result = $valueBinder->placeholder('param');
+        $this->assertEquals(':param2', $result);
 
         $valueBinder->resetCount();
 
-        $placeholder = $valueBinder->placeholder('c');
-        $this->assertEquals(':c0', $placeholder);
+        $placeholder = $valueBinder->placeholder('param');
+        $this->assertEquals(':param0', $placeholder);
         $this->assertCount(2, $valueBinder->bindings());
     }
 

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -23,6 +23,40 @@ use Cake\TestSuite\TestCase;
 class ValueBinderTest extends TestCase
 {
     /**
+     * test the bind method
+     */
+    public function testBind()
+    {
+        $valueBinder = new ValueBinder();
+        $valueBinder->bind(':c0', 'value0');
+        $valueBinder->bind(':c1', 1, 'int');
+        $valueBinder->bind(':c2', 'value2');
+
+        $this->assertCount(3, $valueBinder->bindings());
+
+        $expected = [
+            ':c0' => [
+                'value' => 'value0',
+                'type' => 'string',
+                'placeholder' => 'c0'
+            ],
+            ':c1' => [
+                'value' => 1,
+                'type' => 'int',
+                'placeholder' => 'c1'
+            ],
+            ':c2' => [
+                'value' => 'value2',
+                'type' => 'string',
+                'placeholder' => 'c2'
+            ]
+        ];
+
+        $bindings = $valueBinder->bindings();
+        $this->assertEquals($expected, $bindings);
+    }
+
+    /**
      * test the placeholder method
      */
     public function testPlaceholder()
@@ -42,5 +76,84 @@ class ValueBinderTest extends TestCase
         $this->assertEquals(':p1', $result);
         $result = $valueBinder->placeholder('c');
         $this->assertEquals(':c2', $result);
+    }
+
+    public function testGenerateManyNamed()
+    {
+        $valueBinder = new ValueBinder();
+        $values = [
+            'value0',
+            'value1'
+        ];
+
+        $expected = [
+            ':c0',
+            ':c1'
+        ];
+        $placeholders = $valueBinder->generateManyNamed($values);
+        $this->assertEquals($expected, $placeholders);
+    }
+
+    /**
+     * test the reset method
+     */
+    public function testReset()
+    {
+        $valueBinder = new ValueBinder();
+        $valueBinder->bind(':c0', 'value0');
+        $valueBinder->bind(':c1', 'value1');
+
+        $this->assertCount(2, $valueBinder->bindings());
+        $valueBinder->reset();
+        $this->assertCount(0, $valueBinder->bindings());
+
+        $placeholder = $valueBinder->placeholder('c');
+        $this->assertEquals(':c0', $placeholder);
+    }
+
+    /**
+     * test the resetCount method
+     */
+    public function testResetCount()
+    {
+        $valueBinder = new ValueBinder();
+
+        // Ensure the _bindings array IS NOT affected by resetCount
+        $valueBinder->bind(':c0', 'value0');
+        $valueBinder->bind(':c1', 'value1');
+        $this->assertCount(2, $valueBinder->bindings());
+
+        // Ensure the placeholder generation IS affected by resetCount
+        $valueBinder->placeholder('c');
+        $valueBinder->placeholder('c');
+        $result = $valueBinder->placeholder('c');
+        $this->assertEquals(':c2', $result);
+
+        $valueBinder->resetCount();
+
+        $placeholder = $valueBinder->placeholder('c');
+        $this->assertEquals(':c0', $placeholder);
+        $this->assertCount(2, $valueBinder->bindings());
+    }
+
+    /**
+     * tests the attachTo method
+     */
+    public function testAttachTo()
+    {
+        $valueBinder = new ValueBinder();
+        $statementMock = $this->getMockBuilder('Cake\Database\Statement\StatementDecorator')
+            ->disableOriginalConstructor()
+            ->setMethods(['bindValue'])
+            ->getMock();
+
+        $statementMock->expects($this->at(0))->method('bindValue')->with('c0', 'value0', 'string');
+        $statementMock->expects($this->at(1))->method('bindValue')->with('c1', 'value1', 'string');
+
+        $valueBinder->attachTo($statementMock); //empty array shouldn't call statement
+
+        $valueBinder->bind(':c0', 'value0', 'string');
+        $valueBinder->bind(':c1', 'value1', 'string');
+        $valueBinder->attachTo($statementMock);
     }
 }


### PR DESCRIPTION
I was learning how the ORM in CakePHP works and found the ValueBinder class that had some behaviour I believe to be incorrect (please correct me if i'm wrong).

$valueBinder->placeholder describes itself as taking a token and returning a SQL param based based on that token. The PHPDOC block also mentions that '?' should return '?' and ':value' should return ':value'.

What happened 
-----------------
$valueBinder->placeholder('param');
> ':c0'

$valueBinder->placeholder('?')
> ':c1'

$valueBinder->placeholder(':param')
> ':c2'

What I expected to happen:
----------------------------
$valueBinder->placeholder('param')
> ':param0'

$valueBinder->placeholder('?')
> '?'

$valueBinder->placeholder(':param')
> ':param'

After further investigation I found that around ~33 tests were written assuming this bug so I updated those tests.

I found some small code improvements (removing unused variables, reduce logic duplication, etc) 

I also created unit tests for the class in question.

I will comment the main change to logic using github code review tools. 