### PR TITLE
Prevent IDE from reporting an error here.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -430,6 +430,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
                 'plugin' => $request->getParam('plugin'),
             ]);
         }
+        /* @var callable $callable */
         $callable = [$this, $request->getParam('action')];
 
         return $callable(...$request->getParam('pass'));


### PR DESCRIPTION
This prevents the IDE from rendering this file as "error".

It thinks it is an array, and not a callable.