### PR TITLE
Handle explict null values in translation functions

### DIFF
--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -28,10 +28,11 @@ if (!function_exists('__')) {
         if (!$singular) {
             return null;
         }
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
-        $arguments = func_num_args() === 2 ? (array)$args[0] : $args;
-
-        return I18n::translator()->translate($singular, $arguments);
+        return I18n::translator()->translate($singular, $args);
     }
 
 }
@@ -53,12 +54,13 @@ if (!function_exists('__n')) {
         if (!$singular) {
             return null;
         }
-
-        $arguments = func_num_args() === 4 ? (array)$args[0] : $args;
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
         return I18n::translator()->translate(
             $plural,
-            ['_count' => $count, '_singular' => $singular] + $arguments
+            ['_count' => $count, '_singular' => $singular] + $args
         );
     }
 
@@ -79,9 +81,11 @@ if (!function_exists('__d')) {
         if (!$msg) {
             return null;
         }
-        $arguments = func_num_args() === 3 ? (array)$args[0] : $args;
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
-        return I18n::translator($domain)->translate($msg, $arguments);
+        return I18n::translator($domain)->translate($msg, $args);
     }
 
 }
@@ -105,12 +109,13 @@ if (!function_exists('__dn')) {
         if (!$singular) {
             return null;
         }
-
-        $arguments = func_num_args() === 5 ? (array)$args[0] : $args;
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
         return I18n::translator($domain)->translate(
             $plural,
-            ['_count' => $count, '_singular' => $singular] + $arguments
+            ['_count' => $count, '_singular' => $singular] + $args
         );
     }
 
@@ -133,10 +138,11 @@ if (!function_exists('__x')) {
         if (!$singular) {
             return null;
         }
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
-        $arguments = func_num_args() === 3 ? (array)$args[0] : $args;
-
-        return I18n::translator()->translate($singular, ['_context' => $context] + $arguments);
+        return I18n::translator()->translate($singular, ['_context' => $context] + $args);
     }
 
 }
@@ -161,12 +167,13 @@ if (!function_exists('__xn')) {
         if (!$singular) {
             return null;
         }
-
-        $arguments = func_num_args() === 5 ? (array)$args[0] : $args;
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
         return I18n::translator()->translate(
             $plural,
-            ['_count' => $count, '_singular' => $singular, '_context' => $context] + $arguments
+            ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args
         );
     }
 
@@ -190,12 +197,13 @@ if (!function_exists('__dx')) {
         if (!$msg) {
             return null;
         }
-
-        $arguments = func_num_args() === 4 ? (array)$args[0] : $args;
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
         return I18n::translator($domain)->translate(
             $msg,
-            ['_context' => $context] + $arguments
+            ['_context' => $context] + $args
         );
     }
 
@@ -222,12 +230,13 @@ if (!function_exists('__dxn')) {
         if (!$singular) {
             return null;
         }
-
-        $arguments = func_num_args() === 6 ? (array)$args[0] : $args;
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
 
         return I18n::translator($domain)->translate(
             $plural,
-            ['_count' => $count, '_singular' => $singular, '_context' => $context] + $arguments
+            ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args
         );
     }
 

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -248,6 +248,38 @@ class I18nTest extends TestCase
     }
 
     /**
+     * Tests the __() functions with explict null params
+     *
+     * @return void
+     */
+    public function testBasicTranslateFunctionsWithNullParam()
+    {
+        $this->assertEquals('text {0}', __('text {0}'));
+        $this->assertEquals('text ', __('text {0}', null));
+
+        $this->assertEquals('text {0}', __n('text {0}', 'texts {0}', 1));
+        $this->assertEquals('text ', __n('text {0}', 'texts {0}', 1, null));
+
+        $this->assertEquals('text {0}', __d('default', 'text {0}'));
+        $this->assertEquals('text ', __d('default', 'text {0}', null));
+
+        $this->assertEquals('text {0}', __dn('default', 'text {0}', 'texts {0}', 1));
+        $this->assertEquals('text ', __dn('default', 'text {0}', 'texts {0}', 1, null));
+
+        $this->assertEquals('text {0}', __x('default', 'text {0}'));
+        $this->assertEquals('text ', __x('default', 'text {0}', null));
+
+        $this->assertEquals('text {0}', __xn('default', 'text {0}', 'texts {0}', 1));
+        $this->assertEquals('text ', __xn('default', 'text {0}', 'texts {0}', 1, null));
+
+        $this->assertEquals('text {0}', __dx('default', 'words', 'text {0}'));
+        $this->assertEquals('text ', __dx('default', 'words', 'text {0}', null));
+
+        $this->assertEquals('text {0}', __dxn('default', 'words', 'text {0}', 'texts {0}', 1));
+        $this->assertEquals('text ', __dxn('default', 'words', 'text {0}', 'texts {0}', 1, null));
+    }
+
+    /**
      * Tests the __() function on a plural key
      *
      * @return void

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -242,6 +242,9 @@ class I18nTest extends TestCase
         I18n::defaultFormatter('sprintf');
         $this->assertEquals('%d is 1 (po translated)', __('%d = 1'));
         $this->assertEquals('1 is 1 (po translated)', __('%d = 1', 1));
+        $this->assertEquals('1 is 1 (po translated)', __('%d = 1', [1]));
+        $this->assertEquals('The red dog, and blue cat', __('The %s dog, and %s cat', ['red', 'blue']));
+        $this->assertEquals('The red dog, and blue cat', __('The %s dog, and %s cat', 'red', 'blue'));
     }
 
     /**
@@ -268,6 +271,12 @@ class I18nTest extends TestCase
 
         $result = __n('singular msg', '%d = 0 or > 1', 2);
         $this->assertEquals('2 is 2-4 (po translated)', $result);
+
+        $result = __n('%s %s and %s are good', '%s and %s are best', 1, ['red', 'blue']);
+        $this->assertEquals('1 red and blue are good', $result);
+
+        $result = __n('%s %s and %s are good', '%s and %s are best', 1, 'red', 'blue');
+        $this->assertEquals('1 red and blue are good', $result);
     }
 
     /**
@@ -290,6 +299,9 @@ class I18nTest extends TestCase
         $this->assertEquals('Le moo', __d('custom', 'Cow'));
 
         $result = __d('custom', 'The {0} is tasty', ['fruit']);
+        $this->assertEquals('The fruit is delicious', $result);
+
+        $result = __d('custom', 'The {0} is tasty', 'fruit');
         $this->assertEquals('The fruit is delicious', $result);
 
         $result = __d('custom', 'Average price {0}', ['9.99']);
@@ -354,6 +366,9 @@ class I18nTest extends TestCase
 
         $this->assertEquals('The letters A and B', __x('character', 'letters', ['A', 'B']));
         $this->assertEquals('The letter A', __x('character', 'letter', ['A']));
+
+        $this->assertEquals('The letters A and B', __x('character', 'letters', 'A', 'B'));
+        $this->assertEquals('The letter A', __x('character', 'letter', 'A'));
 
         $this->assertEquals(
             'She wrote a letter to Thomas and Sara',


### PR DESCRIPTION
When we get an explicit null we should use that as a translation value that is interpolated into the message. This had to be done in 3.4 as we have access to `...` which makes this change simpler to implement.

Refs #10087