### PR TITLE
Fixes request input

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1539,6 +1539,7 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
      */
     public function input($callback = null, ...$args)
     {
+        $this->stream->rewind();
         $input = $this->stream->getContents();
         if ($callback) {
             array_unshift($args, $input);


### PR DESCRIPTION
Currently `ServerRequest::input()` doesn't always return the correct result (especially if it's called multiple times, or if the body stream is read elsewhere). This is obviously not BC with 3.3, simple fix is to rewind the stream before trying to read from it.