### PR TITLE
Update Log usage of StaticConfigTrait

### DIFF
--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -105,7 +105,7 @@ class Log
 {
 
     use StaticConfigTrait {
-        config as protected _config;
+        setConfig as protected _setConfig;
     }
 
     /**
@@ -276,9 +276,9 @@ class Log
      * @return array|null Null when adding configuration and an array of configuration data when reading.
      * @throws \BadMethodCallException When trying to modify an existing config.
      */
-    public static function config($key, $config = null)
+    public static function setConfig($key, $config = null)
     {
-        $return = static::_config($key, $config);
+        $return = static::_setConfig($key, $config);
         if ($return !== null) {
             return $return;
         }

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -172,6 +172,20 @@ class LogTest extends TestCase
     }
 
     /**
+     * Test the various setConfig call signatures.
+     *
+     * @dataProvider configProvider
+     * @return void
+     */
+    public function testSetConfigVariants($settings)
+    {
+        Log::setConfig('test', $settings);
+        $this->assertContains('test', Log::configured());
+        $this->assertInstanceOf('Cake\Log\Engine\FileLog', Log::engine('test'));
+        Log::drop('test');
+    }
+
+    /**
      * Test that config() throws an exception when adding an
      * adapter with the wrong type.
      *
@@ -181,6 +195,19 @@ class LogTest extends TestCase
     public function testConfigInjectErrorOnWrongType()
     {
         Log::config('test', new \StdClass);
+        Log::info('testing');
+    }
+
+    /**
+     * Test that setConfig() throws an exception when adding an
+     * adapter with the wrong type.
+     *
+     * @expectedException \RuntimeException
+     * @return void
+     */
+    public function testSetConfigInjectErrorOnWrongType()
+    {
+        Log::setConfig('test', new \StdClass);
         Log::info('testing');
     }
 


### PR DESCRIPTION
If people were to start using `Log::setConfig()` the `Log` class would misbehave. By overriding the new method we avoid that potential breakage.