### PR TITLE
Adds test for caching result set with file engine

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -313,6 +313,11 @@ class ResultSet implements ResultSetInterface
      */
     public function serialize()
     {
+        if (!$this->_useBuffering) {
+            $msg = 'You cannot serialize an un-buffered ResultSet. Use Query::bufferResults() to get a buffered ResultSet.';
+            throw new Exception($msg);
+        }
+
         while ($this->valid()) {
             $this->next();
         }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -330,7 +330,8 @@ class ResultSet implements ResultSetInterface
      */
     public function unserialize($serialized)
     {
-        $this->_results = unserialize($serialized);
+        // closes #10111 prevent SqlFixedArray instances
+        $this->_results = (array)unserialize($serialized);
         $this->_useBuffering = true;
         $this->_count = count($this->_results);
     }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -317,7 +317,7 @@ class ResultSet implements ResultSetInterface
             $this->next();
         }
 
-        if($this->_results instanceof SplFixedArray) {
+        if ($this->_results instanceof SplFixedArray) {
             return serialize($this->_results->toArray());
         }
 
@@ -334,9 +334,10 @@ class ResultSet implements ResultSetInterface
      */
     public function unserialize($serialized)
     {
-        $this->_results = (array)(unserialize($serialized) ?: []);
+        $results = (array)(unserialize($serialized) ?: []);
+        $this->_results = SplFixedArray::fromArray($results);
         $this->_useBuffering = true;
-        $this->_count = count($this->_results);
+        $this->_count = $this->_results->count();
     }
 
     /**
@@ -355,7 +356,7 @@ class ResultSet implements ResultSetInterface
             return $this->_count = $this->_statement->rowCount();
         }
 
-        if($this->_results instanceof SplFixedArray) {
+        if ($this->_results instanceof SplFixedArray) {
             $this->_count = $this->_results->count();
         } else {
             $this->_count = count($this->_results);

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -355,7 +355,13 @@ class ResultSet implements ResultSetInterface
             return $this->_count = $this->_statement->rowCount();
         }
 
-        return $this->_count = count($this->_results);
+        if($this->_results instanceof SplFixedArray) {
+            $this->_count = $this->_results->count();
+        } else {
+            $this->_count = count($this->_results);
+        }
+
+        return $this->_count;
     }
 
     /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -317,6 +317,10 @@ class ResultSet implements ResultSetInterface
             $this->next();
         }
 
+        if($this->_results instanceof SplFixedArray) {
+            return serialize($this->_results->toArray());
+        }
+
         return serialize($this->_results);
     }
 
@@ -330,8 +334,7 @@ class ResultSet implements ResultSetInterface
      */
     public function unserialize($serialized)
     {
-        // closes #10111 prevent SqlFixedArray instances
-        $this->_results = (array)unserialize($serialized);
+        $this->_results = (array)(unserialize($serialized) ?: []);
         $this->_useBuffering = true;
         $this->_count = count($this->_results);
     }

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -17,27 +17,13 @@ namespace Cake\Test\TestCase\Cache\Engine;
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Core\Configure;
-use Cake\ORM\ResultSet;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use TestApp\Model\Table\ArticlesTable;
 
 /**
  * FileEngineTest class
  */
 class FileEngineTest extends TestCase
 {
-    /**
-     * @var array
-     */
-    public $fixtures = [
-        'core.articles'
-    ];
-
-    /**
-     * @var bool
-     */
-    public $autoFixtures = false;
 
     /**
      * setUp method
@@ -204,34 +190,6 @@ class FileEngineTest extends TestCase
         $delete = Cache::delete('serialize_test', 'file_test');
         $this->assertSame($read, serialize($data));
         $this->assertSame(unserialize($read), $data);
-    }
-
-    /**
-     * Verify across PHP versions that caching of ResultSet objects works as expected.
-     *
-     * @see https://github.com/cakephp/cakephp/issues/10111
-     * @return void
-     */
-    public function testResultSetCache()
-    {
-        Configure::write('App.namespace', 'TestApp');
-        $this->loadFixtures('Articles');
-
-        /* @var ArticlesTable $articles */
-        $articles = TableRegistry::get('Articles');
-        $query = $articles->find()->all();
-        $this->assertInstanceOf(ResultSet::class, $query);
-        $this->assertSame(3, count($query->toArray()));
-
-        $this->_configCache(['serialize' => true]);
-        $write = Cache::write('articles', $query, 'file_test');
-        $this->assertTrue($write);
-
-        $read = Cache::read('articles', 'file_test');
-        $this->assertInstanceOf(ResultSet::class, $read);
-        $this->assertSame(3, count($read->toArray()));
-
-        TableRegistry::clear();
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -17,13 +17,27 @@ namespace Cake\Test\TestCase\Cache\Engine;
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Core\Configure;
+use Cake\ORM\ResultSet;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use TestApp\Model\Table\ArticlesTable;
 
 /**
  * FileEngineTest class
  */
 class FileEngineTest extends TestCase
 {
+    /**
+     * @var array
+     */
+    public $fixtures = [
+        'core.articles'
+    ];
+
+    /**
+     * @var bool
+     */
+    public $autoFixtures = false;
 
     /**
      * setUp method
@@ -190,6 +204,34 @@ class FileEngineTest extends TestCase
         $delete = Cache::delete('serialize_test', 'file_test');
         $this->assertSame($read, serialize($data));
         $this->assertSame(unserialize($read), $data);
+    }
+
+    /**
+     * Verify across PHP versions that caching of ResultSet objects works as expected.
+     *
+     * @see https://github.com/cakephp/cakephp/issues/10111
+     * @return void
+     */
+    public function testResultSetCache()
+    {
+        Configure::write('App.namespace', 'TestApp');
+        $this->loadFixtures('Articles');
+
+        /* @var ArticlesTable $articles */
+        $articles = TableRegistry::get('Articles');
+        $query = $articles->find()->all();
+        $this->assertInstanceOf(ResultSet::class, $query);
+        $this->assertSame(3, count($query->toArray()));
+
+        $this->_configCache(['serialize' => true]);
+        $write = Cache::write('articles', $query, 'file_test');
+        $this->assertTrue($write);
+
+        $read = Cache::read('articles', 'file_test');
+        $this->assertInstanceOf(ResultSet::class, $read);
+        $this->assertSame(3, count($read->toArray()));
+
+        TableRegistry::clear();
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -713,6 +713,20 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Tests serializing an entity as PHP
+     *
+     * @return void
+     */
+    public function testPhpSerialize()
+    {
+        $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
+        $entity = new Entity($data);
+        $copy = unserialize(serialize($entity));
+        $this->assertInstanceOf(Entity::class, $copy);
+        $this->assertEquals($data, $copy->toArray());
+    }
+
+    /**
      * Tests that jsonSerialize is called recursively for contained entities
      *
      * @return void

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -111,16 +111,6 @@ class ResultSetTest extends TestCase
     }
 
     /**
-     * @expectedException \Cake\Database\Exception
-     * @expectedExceptionMessage You cannot serialize an un-buffered ResultSet. Use Query::bufferResults() to get a buffered ResultSet.
-     */
-    public function testSerializationUnbuffered()
-    {
-        $results = $this->table->find('all')->bufferResults(false)->all();
-        serialize($results);
-    }
-
-    /**
      * Test iteration after serialization
      *
      * @return void

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Entity;
@@ -109,6 +108,16 @@ class ResultSetTest extends TestCase
         $serialized = serialize($results2);
         $outcome = unserialize($serialized);
         $this->assertEquals($expected, $outcome->toArray());
+    }
+
+    /**
+     * @expectedException \Cake\Database\Exception
+     * @expectedExceptionMessage You cannot serialize an un-buffered ResultSet. Use Query::bufferResults() to get a buffered ResultSet.
+     */
+    public function testSerializationUnbuffered()
+    {
+        $results = $this->table->find('all')->bufferResults(false)->all();
+        serialize($results);
     }
 
     /**


### PR DESCRIPTION
Adds a test for verifying that ResultSet objects can be cached with the file engine, and deserialized again with the same data.

New unit test is failing for me on PHP 7.1.1

Relates to issue #10111 