### PR TITLE
Fix notBlank for floats with value of 0.0

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -85,7 +85,7 @@ class Validation
      */
     public static function notBlank($check)
     {
-        if (empty($check) && $check !== '0' && $check !== 0) {
+        if (empty($check) && !is_bool($check) && !is_numeric($check)) {
             return false;
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1715,7 +1715,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     protected function _fieldIsEmpty($data)
     {
-        if (empty($data) && $data !== '0' && $data !== false && $data !== 0 && $data !== 0.0) {
+        if (empty($data) && !is_bool($data) && !is_numeric($data)) {
             return true;
         }
         $isArray = is_array($data);

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -83,6 +83,8 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::notBlank('π'));
         $this->assertTrue(Validation::notBlank('0'));
         $this->assertTrue(Validation::notBlank(0));
+        $this->assertTrue(Validation::notBlank(0.0));
+        $this->assertTrue(Validation::notBlank('0.0'));
         $this->assertFalse(Validation::notBlank("\t "));
         $this->assertFalse(Validation::notBlank(""));
     }


### PR DESCRIPTION
`Validation::notBlank` currently sees float values of `0.0` as being empty, and as such `notBlank` validation for such values fails incorrectly.  This PR aims to fix that specific problem, and also to simplify the conditions that are used to perform the `notBlank` checks.