### PR TITLE
Fix up return void setConfig()

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -77,7 +77,9 @@ class ConnectionManager
             $config['name'] = $key;
         }
 
-        return static::_setConfig($key, $config);
+        static::_setConfig($key, $config);
+
+        return static::getConfig($key);
     }
 
     /**

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -278,7 +278,9 @@ class Log
      */
     public static function setConfig($key, $config = null)
     {
-        $return = static::_setConfig($key, $config);
+        static::_setConfig($key, $config);
+
+        $return = static::getConfig($key);
         if ($return !== null) {
             return $return;
         }


### PR DESCRIPTION
As pointed out @ https://github.com/cakephp/cakephp/pull/10044#issuecomment-276144775 the changes in Log and ConnectionManager cannot work, as they return void and then expect this to be non-void.
Does the following make more sense?
If not, what should be the intended code here? Using the old combined one again to be safe?