### PR TITLE
3.next Update deprecated config() calls.

### DIFF
--- a/src/Auth/AbstractPasswordHasher.php
+++ b/src/Auth/AbstractPasswordHasher.php
@@ -40,7 +40,7 @@ abstract class AbstractPasswordHasher
      */
     public function __construct(array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -88,7 +88,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
         $this->_registry = $registry;
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -51,7 +51,7 @@ abstract class BaseAuthorize
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
         $this->_registry = $registry;
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -106,7 +106,7 @@ class BasicAuthenticate extends BaseAuthenticate
      */
     public function loginHeaders(ServerRequest $request)
     {
-        $realm = $this->config('realm') ?: $request->env('SERVER_NAME');
+        $realm = $this->getConfig('realm') ?: $request->env('SERVER_NAME');
 
         return sprintf('WWW-Authenticate: Basic realm="%s"', $realm);
     }

--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -83,7 +83,7 @@ class DigestAuthenticate extends BasicAuthenticate
      */
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
-        $this->config([
+        $this->setConfig([
             'nonceLifetime' => 300,
             'secret' => Configure::read('Security.salt'),
             'realm' => null,
@@ -251,8 +251,8 @@ class DigestAuthenticate extends BasicAuthenticate
      */
     protected function generateNonce()
     {
-        $expiryTime = microtime(true) + $this->config('nonceLifetime');
-        $signatureValue = md5($expiryTime . ':' . $this->config('secret'));
+        $expiryTime = microtime(true) + $this->getConfig('nonceLifetime');
+        $signatureValue = md5($expiryTime . ':' . $this->getConfig('secret'));
         $nonceValue = $expiryTime . ':' . $signatureValue;
 
         return base64_encode($nonceValue);
@@ -279,6 +279,6 @@ class DigestAuthenticate extends BasicAuthenticate
             return false;
         }
 
-        return md5($expires . ':' . $this->config('secret')) === $checksum;
+        return md5($expires . ':' . $this->getConfig('secret')) === $checksum;
     }
 }

--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -68,7 +68,7 @@ class SessionStorage implements StorageInterface
     public function __construct(ServerRequest $request, Response $response, array $config = [])
     {
         $this->_session = $request->session();
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -147,7 +147,7 @@ class Cache
         $registry->load($name, $config);
 
         if ($config['className'] instanceof CacheEngine) {
-            $config = $config['className']->config();
+            $config = $config['className']->getConfig();
         }
 
         if (!empty($config['groups'])) {

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -65,7 +65,7 @@ abstract class CacheEngine
      */
     public function init(array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
 
         if (!empty($this->_config['groups'])) {
             sort($this->_config['groups']);

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -93,7 +93,7 @@ class CacheRegistry extends ObjectRegistry
             );
         }
 
-        $config = $instance->config();
+        $config = $instance->getConfig();
         if ($config['probability'] && time() % $config['probability'] === 0) {
             $instance->gc();
         }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -129,7 +129,7 @@ class MemcachedEngine extends CacheEngine
         }
 
         if (isset($config['servers'])) {
-            $this->config('servers', $config['servers'], false);
+            $this->setConfig('servers', $config['servers'], false);
         }
 
         if (!is_array($this->_config['servers'])) {

--- a/src/Console/Helper.php
+++ b/src/Console/Helper.php
@@ -50,7 +50,7 @@ abstract class Helper
     public function __construct(ConsoleIo $io, array $config = [])
     {
         $this->_io = $io;
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -125,7 +125,7 @@ class Component implements EventListenerInterface
             $this->response =& $controller->response;
         }
 
-        $this->config($config);
+        $this->setConfig($config);
 
         if ($this->components) {
             $this->_componentMap = $registry->normalizeArray($this->components);
@@ -217,7 +217,7 @@ class Component implements EventListenerInterface
         return [
             'components' => $this->components,
             'implementedEvents' => $this->implementedEvents(),
-            '_config' => $this->config(),
+            '_config' => $this->getConfig(),
         ];
     }
 }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -62,7 +62,7 @@ class AuthComponent extends Component
      *   when users are identified.
      *
      *   ```
-     *   $this->Auth->config('authenticate', [
+     *   $this->Auth->setConfig('authenticate', [
      *      'Form' => [
      *         'userModel' => 'Users.Users'
      *      ]
@@ -74,7 +74,7 @@ class AuthComponent extends Component
      *   config that should be set to all authentications objects using the 'all' key:
      *
      *   ```
-     *   $this->Auth->config('authenticate', [
+     *   $this->Auth->setConfig('authenticate', [
      *       AuthComponent::ALL => [
      *          'userModel' => 'Users.Users',
      *          'scope' => ['Users.active' => 1]
@@ -89,7 +89,7 @@ class AuthComponent extends Component
      *   when authorization checks are done.
      *
      *   ```
-     *   $this->Auth->config('authorize', [
+     *   $this->Auth->setConfig('authorize', [
      *      'Crud' => [
      *          'actionPath' => 'controllers/'
      *      ]
@@ -101,7 +101,7 @@ class AuthComponent extends Component
      *   that should be set to all authorization objects using the AuthComponent::ALL key:
      *
      *   ```
-     *   $this->Auth->config('authorize', [
+     *   $this->Auth->setConfig('authorize', [
      *      AuthComponent::ALL => [
      *          'actionPath' => 'controllers/'
      *      ],
@@ -496,13 +496,13 @@ class AuthComponent extends Component
             'authError' => __d('cake', 'You are not authorized to access that location.')
         ];
 
-        $config = $this->config();
+        $config = $this->getConfig();
         foreach ($config as $key => $value) {
             if ($value !== null) {
                 unset($defaults[$key]);
             }
         }
-        $this->config($defaults);
+        $this->setConfig($defaults);
     }
 
     /**
@@ -917,7 +917,7 @@ class AuthComponent extends Component
     public function __get($name)
     {
         if ($name === 'sessionKey') {
-            return $this->storage()->config('key');
+            return $this->storage()->getConfig('key');
         }
 
         return parent::__get($name);
@@ -936,13 +936,13 @@ class AuthComponent extends Component
             $this->_storage = null;
 
             if ($value === false) {
-                $this->config('storage', 'Memory');
+                $this->setConfig('storage', 'Memory');
 
                 return;
             }
 
-            $this->config('storage', 'Session');
-            $this->storage()->config('key', $value);
+            $this->setConfig('storage', 'Session');
+            $this->storage()->setConfig('key', $value);
 
             return;
         }

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -118,7 +118,7 @@ class CookieComponent extends Component
     public function initialize(array $config)
     {
         if (!$this->_config['key']) {
-            $this->config('key', Security::salt());
+            $this->setConfig('key', Security::salt());
         }
 
         $controller = $this->_registry->getController();
@@ -128,7 +128,7 @@ class CookieComponent extends Component
         }
 
         if (empty($this->_config['path'])) {
-            $this->config('path', $this->request->webroot);
+            $this->setConfig('path', $this->request->webroot);
         }
     }
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -86,7 +86,7 @@ class FlashComponent extends Component
      */
     public function set($message, array $options = [])
     {
-        $options += $this->config();
+        $options += $this->getConfig();
 
         if ($message instanceof Exception) {
             if (!isset($options['params']['code'])) {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -300,7 +300,7 @@ class PaginatorComponent extends Component
             $settings = $settings[$alias];
         }
 
-        $defaults = $this->config();
+        $defaults = $this->getConfig();
         $maxLimit = isset($settings['maxLimit']) ? $settings['maxLimit'] : $defaults['maxLimit'];
         $limit = isset($settings['limit']) ? $settings['limit'] : $defaults['limit'];
 

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -166,7 +166,7 @@ class RequestHandlerComponent extends Component
         }
 
         $extensions = array_unique(
-            array_merge(Router::extensions(), array_keys($this->config('viewClassMap')))
+            array_merge(Router::extensions(), array_keys($this->getConfig('viewClassMap')))
         );
         foreach ($accepts as $types) {
             $ext = array_intersect($extensions, $types);
@@ -210,7 +210,7 @@ class RequestHandlerComponent extends Component
             return;
         }
 
-        foreach ($this->config('inputTypeMap') as $type => $handler) {
+        foreach ($this->getConfig('inputTypeMap') as $type => $handler) {
             if (!is_callable($handler[0])) {
                 throw new RuntimeException(sprintf("Invalid callable for '%s' type.", $type));
             }
@@ -254,7 +254,7 @@ class RequestHandlerComponent extends Component
      */
     public function beforeRedirect(Event $event, $url, Response $response)
     {
-        if (!$this->config('enableBeforeRedirect')) {
+        if (!$this->getConfig('enableBeforeRedirect')) {
             return null;
         }
         $request = $this->request;
@@ -562,7 +562,7 @@ class RequestHandlerComponent extends Component
     public function renderAs(Controller $controller, $type, array $options = [])
     {
         $defaults = ['charset' => 'UTF-8'];
-        $viewClassMap = $this->config('viewClassMap');
+        $viewClassMap = $this->getConfig('viewClassMap');
 
         if (Configure::read('App.encoding') !== null) {
             $defaults['charset'] = Configure::read('App.encoding');
@@ -707,18 +707,18 @@ class RequestHandlerComponent extends Component
      *    for the handler.
      * @return void
      * @throws \Cake\Core\Exception\Exception
-     * @deprecated 3.1.0 Use config('addInputType', ...) instead.
+     * @deprecated 3.1.0 Use setConfig('addInputType', ...) instead.
      */
     public function addInputType($type, $handler)
     {
         trigger_error(
-            'RequestHandlerComponent::addInputType() is deprecated. Use config("inputTypeMap", ...) instead.',
+            'RequestHandlerComponent::addInputType() is deprecated. Use setConfig("inputTypeMap", ...) instead.',
             E_USER_DEPRECATED
         );
         if (!is_array($handler) || !isset($handler[0]) || !is_callable($handler[0])) {
             throw new Exception('You must give a handler callback.');
         }
-        $this->config('inputTypeMap.' . $type, $handler);
+        $this->setConfig('inputTypeMap.' . $type, $handler);
     }
 
     /**
@@ -727,23 +727,23 @@ class RequestHandlerComponent extends Component
      * @param array|string|null $type The type string or array with format `['type' => 'viewClass']` to map one or more
      * @param array|null $viewClass The viewClass to be used for the type without `View` appended
      * @return array|string Returns viewClass when only string $type is set, else array with viewClassMap
-     * @deprecated 3.1.0 Use config('viewClassMap', ...) instead.
+     * @deprecated 3.1.0 Use setConfig('viewClassMap', ...) instead.
      */
     public function viewClassMap($type = null, $viewClass = null)
     {
         trigger_error(
-            'RequestHandlerComponent::viewClassMap() is deprecated. Use config("viewClassMap", ...) instead.',
+            'RequestHandlerComponent::viewClassMap() is deprecated. Use setConfig("viewClassMap", ...) instead.',
             E_USER_DEPRECATED
         );
         if (!$viewClass && is_string($type)) {
-            return $this->config('viewClassMap.' . $type);
+            return $this->getConfig('viewClassMap.' . $type);
         }
         if (is_string($type)) {
-            $this->config('viewClassMap.' . $type, $viewClass);
+            $this->setConfig('viewClassMap.' . $type, $viewClass);
         } elseif (is_array($type)) {
-            $this->config('viewClassMap', $type, true);
+            $this->setConfig('viewClassMap', $type, true);
         }
 
-        return $this->config('viewClassMap');
+        return $this->getConfig('viewClassMap');
     }
 }

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -220,7 +220,7 @@ class SecurityComponent extends Component
         if (isset($actions[0]) && is_array($actions[0])) {
             $actions = $actions[0];
         }
-        $this->config('require' . $method, (empty($actions)) ? ['*'] : $actions);
+        $this->setConfig('require' . $method, (empty($actions)) ? ['*'] : $actions);
     }
 
     /**
@@ -424,7 +424,7 @@ class SecurityComponent extends Component
         }
 
         $unlockedFields = array_unique(
-            array_merge((array)$this->config('disabledFields'), (array)$this->_config['unlockedFields'], $unlocked)
+            array_merge((array)$this->getConfig('disabledFields'), (array)$this->_config['unlockedFields'], $unlocked)
         );
 
         foreach ($fieldList as $i => $key) {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -123,7 +123,7 @@ abstract class ObjectRegistry
         if (empty($config)) {
             return;
         }
-        $existingConfig = $existing->config();
+        $existingConfig = $existing->getConfig();
         unset($config['enabled'], $existingConfig['enabled']);
 
         $fail = false;

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -192,10 +192,10 @@ class Debugger
     public static function configInstance($key = null, $value = null, $merge = true)
     {
         if (is_array($key) || func_num_args() >= 2) {
-            return static::getInstance()->config($key, $value, $merge);
+            return static::getInstance()->setConfig($key, $value, $merge);
         }
 
-        return static::getInstance()->config($key);
+        return static::getInstance()->getConfig($key);
     }
 
     /**

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -76,7 +76,7 @@ class ErrorHandlerMiddleware
         }
 
         $config = $config ?: Configure::read('Error');
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**
@@ -134,7 +134,7 @@ class ErrorHandlerMiddleware
     protected function getRenderer($exception)
     {
         if (!$this->exceptionRenderer) {
-            $this->exceptionRenderer = $this->config('exceptionRenderer') ?: ExceptionRenderer::class;
+            $this->exceptionRenderer = $this->getConfig('exceptionRenderer') ?: ExceptionRenderer::class;
         }
 
         if (is_string($this->exceptionRenderer)) {
@@ -162,11 +162,11 @@ class ErrorHandlerMiddleware
      */
     protected function logException($request, $exception)
     {
-        if (!$this->config('log')) {
+        if (!$this->getConfig('log')) {
             return;
         }
 
-        $skipLog = $this->config('skipLog');
+        $skipLog = $this->getConfig('skipLog');
         if ($skipLog) {
             foreach ((array)$skipLog as $class) {
                 if ($exception instanceof $class) {
@@ -205,7 +205,7 @@ class ErrorHandlerMiddleware
         if ($referer) {
             $message .= "\nReferer URL: " . $referer;
         }
-        if ($this->config('trace')) {
+        if ($this->getConfig('trace')) {
             $message .= "\nStack Trace:\n" . $exception->getTraceAsString() . "\n\n";
         }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -155,10 +155,10 @@ class Client
      */
     public function __construct($config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
 
         $adapter = $this->_config['adapter'];
-        $this->config('adapter', null);
+        $this->setConfig('adapter', null);
         if (is_string($adapter)) {
             $adapter = new $adapter();
         }
@@ -166,7 +166,7 @@ class Client
 
         if (!empty($this->_config['cookieJar'])) {
             $this->_cookies = $this->_config['cookieJar'];
-            $this->config('cookieJar', null);
+            $this->setConfig('cookieJar', null);
         } else {
             $this->_cookies = new CookieCollection();
         }

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -43,7 +43,7 @@ abstract class BaseLog extends AbstractLogger
      */
     public function __construct(array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
 
         if (!is_array($this->_config['scopes']) && $this->_config['scopes'] !== false) {
             $this->_config['scopes'] = (array)$this->_config['scopes'];

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -46,7 +46,7 @@ abstract class AbstractTransport
      */
     public function __construct($config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -112,7 +112,7 @@ class Socket
      */
     public function __construct(array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -162,7 +162,7 @@ class Behavior implements EventListenerInterface
             $config
         );
         $this->_table = $table;
-        $this->config($config);
+        $this->setConfig($config);
         $this->initialize($config);
     }
 
@@ -193,7 +193,7 @@ class Behavior implements EventListenerInterface
             return $config;
         }
         if (isset($config[$key]) && $config[$key] === []) {
-            $this->config($key, [], false);
+            $this->setConfig($key, [], false);
             unset($config[$key]);
 
             return $config;
@@ -206,7 +206,7 @@ class Behavior implements EventListenerInterface
                 $indexedCustom[$method] = $alias;
             }
         }
-        $this->config($key, array_flip($indexedCustom), false);
+        $this->setConfig($key, array_flip($indexedCustom), false);
         unset($config[$key]);
 
         return $config;
@@ -263,7 +263,7 @@ class Behavior implements EventListenerInterface
             'Model.beforeRules' => 'beforeRules',
             'Model.afterRules' => 'afterRules',
         ];
-        $config = $this->config();
+        $config = $this->getConfig();
         $priority = isset($config['priority']) ? $config['priority'] : null;
         $events = [];
 
@@ -307,7 +307,7 @@ class Behavior implements EventListenerInterface
      */
     public function implementedFinders()
     {
-        $methods = $this->config('implementedFinders');
+        $methods = $this->getConfig('implementedFinders');
         if (isset($methods)) {
             return $methods;
         }
@@ -338,7 +338,7 @@ class Behavior implements EventListenerInterface
      */
     public function implementedMethods()
     {
-        $methods = $this->config('implementedMethods');
+        $methods = $this->getConfig('implementedMethods');
         if (isset($methods)) {
             return $methods;
         }

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -73,7 +73,7 @@ class TimestampBehavior extends Behavior
     public function initialize(array $config)
     {
         if (isset($config['events'])) {
-            $this->config('events', $config['events'], false);
+            $this->setConfig('events', $config['events'], false);
         }
     }
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -208,7 +208,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     {
         $locale = $this->locale();
 
-        if ($locale === $this->config('defaultLocale')) {
+        if ($locale === $this->getConfig('defaultLocale')) {
             return;
         }
 
@@ -278,7 +278,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
         // No additional translation records need to be saved,
         // as the entity is in the default locale.
-        if ($noBundled && $locale === $this->config('defaultLocale')) {
+        if ($noBundled && $locale === $this->getConfig('defaultLocale')) {
             return;
         }
 

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -97,7 +97,7 @@ class TreeBehavior extends Behavior
     public function beforeSave(Event $event, EntityInterface $entity)
     {
         $isNew = $entity->isNew();
-        $config = $this->config();
+        $config = $this->getConfig();
         $parent = $entity->get($config['parent']);
         $primaryKey = $this->_getPrimaryKey();
         $dirty = $entity->dirty($config['parent']);
@@ -179,7 +179,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setChildrenLevel($entity)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
 
         if ($entity->get($config['left']) + 1 === $entity->get($config['right'])) {
             return;
@@ -217,7 +217,7 @@ class TreeBehavior extends Behavior
      */
     public function beforeDelete(Event $event, EntityInterface $entity)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $this->_ensureFields($entity);
         $left = $entity->get($config['left']);
         $right = $entity->get($config['right']);
@@ -246,7 +246,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setParent($entity, $parent)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $parentNode = $this->_getNode($parent);
         $this->_ensureFields($entity);
         $parentLeft = $parentNode->get($config['left']);
@@ -306,7 +306,7 @@ class TreeBehavior extends Behavior
      */
     protected function _setAsRoot($entity)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $edge = $this->_getMax();
         $this->_ensureFields($entity);
         $right = $entity->get($config['right']);
@@ -339,7 +339,7 @@ class TreeBehavior extends Behavior
      */
     protected function _unmarkInternalTree()
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $this->_table->updateAll(
             function ($exp) use ($config) {
                 $leftInverse = clone $exp;
@@ -372,7 +372,7 @@ class TreeBehavior extends Behavior
             throw new InvalidArgumentException("The 'for' key is required for find('path')");
         }
 
-        $config = $this->config();
+        $config = $this->getConfig();
         list($left, $right) = array_map(
             function ($field) {
                 return $this->_table->aliasField($field);
@@ -400,7 +400,7 @@ class TreeBehavior extends Behavior
      */
     public function childCount(EntityInterface $node, $direct = false)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $parent = $this->_table->aliasField($config['parent']);
 
         if ($direct) {
@@ -432,7 +432,7 @@ class TreeBehavior extends Behavior
      */
     public function findChildren(Query $query, array $options)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $options += ['for' => null, 'direct' => false];
         list($parent, $left, $right) = array_map(
             function ($field) {
@@ -483,11 +483,11 @@ class TreeBehavior extends Behavior
      */
     public function findTreeList(Query $query, array $options)
     {
-        $left = $this->_table->aliasField($this->config('left'));
+        $left = $this->_table->aliasField($this->getConfig('left'));
 
         $results = $this->_scope($query)
             ->find('threaded', [
-                'parentField' => $this->config('parent'),
+                'parentField' => $this->getConfig('parent'),
                 'order' => [$left => 'ASC'],
             ]);
 
@@ -555,7 +555,7 @@ class TreeBehavior extends Behavior
      */
     protected function _removeFromTree($node)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $left = $node->get($config['left']);
         $right = $node->get($config['right']);
         $parent = $node->get($config['parent']);
@@ -621,7 +621,7 @@ class TreeBehavior extends Behavior
      */
     protected function _moveUp($node, $number)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
         list($nodeParent, $nodeLeft, $nodeRight) = array_values($node->extract([$parent, $left, $right]));
 
@@ -709,7 +709,7 @@ class TreeBehavior extends Behavior
      */
     protected function _moveDown($node, $number)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
         list($nodeParent, $nodeLeft, $nodeRight) = array_values($node->extract([$parent, $left, $right]));
 
@@ -774,7 +774,7 @@ class TreeBehavior extends Behavior
      */
     protected function _getNode($id)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
         $primaryKey = $this->_getPrimaryKey();
         $fields = [$parent, $left, $right];
@@ -817,7 +817,7 @@ class TreeBehavior extends Behavior
      */
     protected function _recoverTree($counter = 0, $parentId = null, $level = -1)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
         $primaryKey = $this->_getPrimaryKey();
         $aliasedPrimaryKey = $this->_table->aliasField($primaryKey);
@@ -922,7 +922,7 @@ class TreeBehavior extends Behavior
      */
     protected function _scope($query)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
 
         if (is_array($config['scope'])) {
             return $query->where($config['scope']);
@@ -943,7 +943,7 @@ class TreeBehavior extends Behavior
      */
     protected function _ensureFields($entity)
     {
-        $config = $this->config();
+        $config = $this->getConfig();
         $fields = [$config['left'], $config['right']];
         $values = array_filter($entity->extract($fields));
         if (count($values) === count($fields)) {
@@ -986,7 +986,7 @@ class TreeBehavior extends Behavior
         if ($entity instanceof EntityInterface) {
             $id = $entity->get($primaryKey);
         }
-        $config = $this->config();
+        $config = $this->getConfig();
         $entity = $this->_table->find('all')
             ->select([$config['left'], $config['right']])
             ->where([$primaryKey => $id])

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -96,9 +96,9 @@ class LazyEagerLoader
             ->contain($contain);
 
         foreach ($query->getEagerLoader()->attachableAssociations($source) as $loadable) {
-            $config = $loadable->config();
+            $config = $loadable->getConfig();
             $config['includeFields'] = true;
-            $loadable->config($config);
+            $loadable->setConfig($config);
         }
 
         return $query;

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -101,7 +101,7 @@ class DispatcherFilter implements EventListenerInterface
         if (!isset($config['priority'])) {
             $config['priority'] = $this->_priority;
         }
-        $this->config($config);
+        $this->setConfig($config);
         if (isset($config['when']) && !is_callable($config['when'])) {
             throw new InvalidArgumentException('"when" conditions must be a callable.');
         }

--- a/src/Shell/Helper/TableHelper.php
+++ b/src/Shell/Helper/TableHelper.php
@@ -108,7 +108,7 @@ class TableHelper extends Helper
             return;
         }
 
-        $config = $this->config();
+        $config = $this->getConfig();
         $widths = $this->_calculateWidths($rows);
 
         $this->_rowSeparator($widths);

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -118,7 +118,7 @@ class Helper implements EventListenerInterface
         $this->_View = $View;
         $this->request = $View->request;
 
-        $this->config($config);
+        $this->setConfig($config);
 
         if (!empty($this->helpers)) {
             $this->_helperMap = $View->helpers()->normalizeArray($this->helpers);
@@ -254,7 +254,7 @@ class Helper implements EventListenerInterface
             'fieldset' => $this->fieldset,
             'tags' => $this->tags,
             'implementedEvents' => $this->implementedEvents(),
-            '_config' => $this->config(),
+            '_config' => $this->getConfig(),
         ];
     }
 }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -238,7 +238,7 @@ class FormHelper extends Helper
 
         $this->widgetRegistry($registry, $widgets);
         $this->_addDefaultContextProviders();
-        $this->_idPrefix = $this->config('idPrefix');
+        $this->_idPrefix = $this->getConfig('idPrefix');
     }
 
     /**
@@ -548,7 +548,7 @@ class FormHelper extends Helper
         $this->requestType = null;
         $this->_context = null;
         $this->_valueSources = ['context'];
-        $this->_idPrefix = $this->config('idPrefix');
+        $this->_idPrefix = $this->getConfig('idPrefix');
 
         return $out;
     }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -101,7 +101,7 @@ class PaginatorHelper extends Helper
 
         $query = $this->request->getQueryParams();
         unset($query['page'], $query['limit'], $query['sort'], $query['direction']);
-        $this->config(
+        $this->setConfig(
             'options.url',
             array_merge($this->request->getParam('pass'), ['?' => $query])
         );

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -55,7 +55,7 @@ class TimeHelper extends Helper
             return $timezone;
         }
 
-        return $this->config('outputTimezone');
+        return $this->getConfig('outputTimezone');
     }
 
     /**

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -155,7 +155,7 @@ class StringTemplate
      */
     public function add(array $templates)
     {
-        $this->config($templates);
+        $this->setConfig($templates);
         $this->_compileTemplates(array_keys($templates));
 
         return $this;
@@ -212,7 +212,7 @@ class StringTemplate
      */
     public function remove($name)
     {
-        $this->config($name, null);
+        $this->setConfig($name, null);
         unset($this->_compiled[$name]);
     }
 

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -95,10 +95,10 @@ trait StringTemplateTrait
     public function templater()
     {
         if ($this->_templater === null) {
-            $class = $this->config('templateClass') ?: 'Cake\View\StringTemplate';
+            $class = $this->getConfig('templateClass') ?: 'Cake\View\StringTemplate';
             $this->_templater = new $class();
 
-            $templates = $this->config('templates');
+            $templates = $this->getConfig('templates');
             if ($templates) {
                 if (is_string($templates)) {
                     $this->_templater->add($this->_defaultConfig['templates']);


### PR DESCRIPTION
Update internal uses of deprecated methods with new methods. I've not updated `config()` on the `TableLocator` as `getConfig`/`setConfig()` are not part of that interface.

Refs #10128
