### PR TITLE
Show the CakePHP logo on the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# CakePHP Framework
-
+<p align="center"><a href="https://cakephp.org" target="_blank"><img src="https://cakephp.org/img/trademarks/logo-1.jpg"></a></p>
+<p align="center">
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.txt)
 [![Build Status](https://img.shields.io/travis/cakephp/cakephp/master.svg?style=flat-square)](https://travis-ci.org/cakephp/cakephp)
 [![Coverage Status](https://img.shields.io/codecov/c/github/cakephp/cakephp.svg?style=flat-square)](https://codecov.io/github/cakephp/cakephp)
 [![Code Consistency](https://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/grade.svg)](http://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/)
 [![Total Downloads](https://img.shields.io/packagist/dt/cakephp/cakephp.svg?style=flat-square)](https://packagist.org/packages/cakephp/cakephp)
 [![Latest Stable Version](https://img.shields.io/packagist/v/cakephp/cakephp.svg?style=flat-square&label=stable)](https://packagist.org/packages/cakephp/cakephp)
+<p>
 
 [CakePHP](http://www.cakephp.org) is a rapid development framework for PHP which
 uses commonly known design patterns like Associative Data


### PR DESCRIPTION
Showing a logo on the top of a readme gives the else boring looking page a little coloured touch.
As we don't have to hide our awesome logo, I added it to the README :)

Before:

![screen shot 2017-01-31 at 16 01 57](https://cloud.githubusercontent.com/assets/6617432/22470442/a0408ffe-e7cf-11e6-9f76-abb2cb101654.png)

After:

![screen shot 2017-01-31 at 16 02 11](https://cloud.githubusercontent.com/assets/6617432/22470443/a058c7cc-e7cf-11e6-961d-6ab784efa08b.png)

(Github responded with some `504 (Gateway Timeout)`on the badges, so they are not displayed in the screenshots)