### PR TITLE
Fix up return void setConfig()

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -67,7 +67,7 @@ class ConnectionManager
      *
      * @param string|array $key The name of the connection config, or an array of multiple configs.
      * @param array|null $config An array of name => config data for adapter.
-     * @return array|null Null when adding configuration and an array of configuration data when reading.
+     * @return void
      * @throws \Cake\Core\Exception\Exception When trying to modify an existing config.
      * @see \Cake\Core\StaticConfigTrait::config()
      */
@@ -77,7 +77,7 @@ class ConnectionManager
             $config['name'] = $key;
         }
 
-        return static::_setConfig($key, $config);
+        static::_setConfig($key, $config);
     }
 
     /**

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -29,7 +29,7 @@ use InvalidArgumentException;
  * A sample configuration would look like:
  *
  * ```
- * Log::config('my_log', ['className' => 'FileLog']);
+ * Log::setConfig('my_log', ['className' => 'FileLog']);
  * ```
  *
  * You can define the className as any fully namespaced classname or use a short hand
@@ -48,7 +48,7 @@ use InvalidArgumentException;
  * This allows you to disable debug messages in production for example:
  *
  * ```
- * Log::config('default', [
+ * Log::setConfig('default', [
  *     'className' => 'File',
  *     'path' => LOGS,
  *     'levels' => ['error', 'critical', 'alert', 'emergency']
@@ -66,7 +66,7 @@ use InvalidArgumentException;
  * all scopes that match the handled levels.
  *
  * ```
- * Log::config('payments', [
+ * Log::setConfig('payments', [
  *     'className' => 'File',
  *     'scopes' => ['payment', 'order']
  * ]);
@@ -241,47 +241,38 @@ class Log
      *
      * ### Usage
      *
-     * Reading config data back:
-     *
-     * ```
-     * Log::config('default');
-     * ```
-     *
      * Setting a cache engine up.
      *
      * ```
-     * Log::config('default', $settings);
+     * Log::setConfig('default', $settings);
      * ```
      *
      * Injecting a constructed adapter in:
      *
      * ```
-     * Log::config('default', $instance);
+     * Log::setConfig('default', $instance);
      * ```
      *
      * Using a factory function to get an adapter:
      *
      * ```
-     * Log::config('default', function () { return new FileLog(); });
+     * Log::setConfig('default', function () { return new FileLog(); });
      * ```
      *
      * Configure multiple adapters at once:
      *
      * ```
-     * Log::config($arrayOfConfig);
+     * Log::setConfig($arrayOfConfig);
      * ```
      *
      * @param string|array $key The name of the logger config, or an array of multiple configs.
      * @param array|null $config An array of name => config data for adapter.
-     * @return array|null Null when adding configuration and an array of configuration data when reading.
+     * @return void
      * @throws \BadMethodCallException When trying to modify an existing config.
      */
     public static function setConfig($key, $config = null)
     {
-        $return = static::_setConfig($key, $config);
-        if ($return !== null) {
-            return $return;
-        }
+        static::_setConfig($key, $config);
         static::$_dirtyConfig = true;
     }
 
@@ -351,7 +342,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      * @throws \InvalidArgumentException If invalid level is passed.
      */
@@ -406,7 +397,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function emergency($message, $context = [])
@@ -422,7 +413,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function alert($message, $context = [])
@@ -438,7 +429,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function critical($message, $context = [])
@@ -454,7 +445,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function error($message, $context = [])
@@ -470,7 +461,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function warning($message, $context = [])
@@ -486,7 +477,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function notice($message, $context = [])
@@ -502,7 +493,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function debug($message, $context = [])
@@ -518,7 +509,7 @@ class Log
      *  The special `scope` key can be passed to be used for further filtering of the
      *  log engines to be used. If a string or a numerically index array is passed, it
      *  will be treated as the `scope` key.
-     *  See Cake\Log\Log::config() for more information on logging scopes.
+     *  See Cake\Log\Log::setConfig() for more information on logging scopes.
      * @return bool Success
      */
     public static function info($message, $context = [])


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/10134
I wonder about the now gone getConfig() reading part though. Is that implicitly available now via trait?