### PR TITLE
[RFC] Association name setter

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -244,6 +244,13 @@ abstract class Association
      */
     public function setName($name)
     {
+        if ($this->_targetTable !== null) {
+            $alias = $this->_targetTable->getAlias();
+            if ($alias !== $name) {
+                throw new InvalidArgumentException('Association name does not match target table alias.');
+            }
+        }
+
         $this->_name = $name;
 
         return $this;

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -111,6 +111,42 @@ class AssociationTest extends TestCase
     }
 
     /**
+     * Tests that setName() succeeds before the target table is resolved.
+     *
+     * @return void
+     */
+    public function testSetNameBeforeTarget()
+    {
+        $this->association->setName('Bar');
+        $this->assertEquals('Bar', $this->association->getName());
+    }
+
+    /**
+     * Tests that setName() fails after the target table is resolved.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Association name does not match target table alias.
+     * @return void
+     */
+    public function testSetNameAfterTarger()
+    {
+        $this->association->getTarget();
+        $this->association->setName('Bar');
+    }
+
+    /**
+     * Tests that setName() succeeds if name equals target table alias.
+     *
+     * @return void
+     */
+    public function testSetNameToTargetAlias()
+    {
+        $alias = $this->association->getTarget()->getAlias();
+        $this->association->setName($alias);
+        $this->assertEquals($alias, $this->association->getName());
+    }
+
+    /**
      * Tests that className() returns the correct association className
      *
      * @return void


### PR DESCRIPTION
Following [comments](https://github.com/cakephp/cakephp/pull/10142).

Association names are mutable, but that change isn't reflected in a collection nor the target table. Changing association name without manually reattaching it in a collection makes it unusable. `EagerLoader` [checks if these names match](https://github.com/cakephp/cakephp/blob/3.next/src/ORM/EagerLoader.php#L496) and throws an exception. Is this exception enough or should we disallow changing association name as it would probably break it?

In other words `AssociationCollection` key, `Association` name and target `Table` alias should be identical. Changing one of them would probably break things.

My way to improve this is to check if a new association name matches the target table alias **after** it has been resolved.

There's also an issue with `AssociationCollection` not reflecting association name change, but I'm not sure we can do anything about it without changing the way associations are collected.