### PR TITLE
[2.next] Add support for having/lock options

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -593,10 +593,11 @@ class Sqlite extends DboSource {
 
 /**
  * Returns a locking hint for the given mode.
+ *
  * Sqlite Datasource doesn't support row-level locking.
  *
  * @param mixed $mode Lock mode
- * @return string|null
+ * @return string|null Null
  */
 	public function getLockingHint($mode) {
 		return null;

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -591,4 +591,14 @@ class Sqlite extends DboSource {
 		return $this->useNestedTransactions && version_compare($this->getVersion(), '3.6.8', '>=');
 	}
 
+/**
+ * Returns a locking hint for the given mode.
+ * Sqlite Datasource doesn't support row-level locking.
+ *
+ * @param mixed $mode Lock mode
+ * @return string|null
+ */
+	public function getLockingHint($mode) {
+		return null;
+	}
 }

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -819,10 +819,11 @@ class Sqlserver extends DboSource {
 
 /**
  * Returns a locking hint for the given mode.
- * Currently, this method only returns WITH (UPDLOCK) when the mode is true.
+ *
+ * Currently, this method only returns WITH (UPDLOCK) when the mode is set to true.
  *
  * @param mixed $mode Lock mode
- * @return string|null
+ * @return string|null WITH (UPDLOCK) clause or null
  */
 	public function getLockingHint($mode) {
 		if ($mode !== true) {

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -526,6 +526,9 @@ class Sqlserver extends DboSource {
 				extract($data);
 				$fields = trim($fields);
 
+				$having = !empty($having) ? " $having" : '';
+				$lock = !empty($lock) ? " $lock" : '';
+
 				if (strpos($limit, 'TOP') !== false && strpos($fields, 'DISTINCT ') === 0) {
 					$limit = 'DISTINCT ' . trim($limit);
 					$fields = substr($fields, 9);
@@ -547,7 +550,7 @@ class Sqlserver extends DboSource {
 					$rowCounter = static::ROW_COUNTER;
 					$sql = "SELECT {$limit} * FROM (
 							SELECT {$fields}, ROW_NUMBER() OVER ({$order}) AS {$rowCounter}
-							FROM {$table} {$alias} {$joins} {$conditions} {$group}
+							FROM {$table} {$alias}{$lock} {$joins} {$conditions} {$group}{$having}
 						) AS _cake_paging_
 						WHERE _cake_paging_.{$rowCounter} > {$offset}
 						ORDER BY _cake_paging_.{$rowCounter}
@@ -555,9 +558,9 @@ class Sqlserver extends DboSource {
 					return trim($sql);
 				}
 				if (strpos($limit, 'FETCH') !== false) {
-					return trim("SELECT {$fields} FROM {$table} {$alias} {$joins} {$conditions} {$group} {$order} {$limit}");
+					return trim("SELECT {$fields} FROM {$table} {$alias}{$lock} {$joins} {$conditions} {$group}{$having} {$order} {$limit}");
 				}
-				return trim("SELECT {$limit} {$fields} FROM {$table} {$alias} {$joins} {$conditions} {$group} {$order}");
+				return trim("SELECT {$limit} {$fields} FROM {$table} {$alias}{$lock} {$joins} {$conditions} {$group}{$having} {$order}");
 			case "schema":
 				extract($data);
 
@@ -814,4 +817,17 @@ class Sqlserver extends DboSource {
 		return $this->config['schema'];
 	}
 
+/**
+ * Returns a locking hint for the given mode.
+ * Currently, this method only returns WITH (UPDLOCK) when the mode is true.
+ *
+ * @param mixed $mode Lock mode
+ * @return string|null
+ */
+	public function getLockingHint($mode) {
+		if ($mode !== true) {
+			return null;
+		}
+		return ' WITH (UPDLOCK)';
+	}
 }

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3141,7 +3141,7 @@ class DboSource extends DataSource {
  * @param mixed $fields Array or string of conditions
  * @param bool $quoteValues If true, values should be quoted
  * @param Model $Model A reference to the Model instance making the query
- * @return string|null
+ * @return string|null HAVING clause or null
  */
 	public function having($fields, $quoteValues = true, Model $Model = null) {
 		if (!$fields) {
@@ -3152,10 +3152,11 @@ class DboSource extends DataSource {
 
 /**
  * Returns a locking hint for the given mode.
- * Currently, this method only returns FOR UPDATE when the mode is true.
+ *
+ * Currently, this method only returns FOR UPDATE when the mode is set to true.
  *
  * @param mixed $mode Lock mode
- * @return string|null
+ * @return string|null FOR UPDATE clause or null
  */
 	public function getLockingHint($mode) {
 		if ($mode !== true) {

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -1277,6 +1277,8 @@ SQL;
 			'limit' => array(),
 			'offset' => array(),
 			'group' => array(),
+			'having' => null,
+			'lock' => null,
 			'callbacks' => null
 		);
 		$queryData['joins'][0]['table'] = $this->Dbo->fullTableName($queryData['joins'][0]['table']);

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -626,4 +626,25 @@ SQL;
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Test Sqlite Datasource doesn't support locking hint
+ *
+ * @return void
+ */
+	public function testBuildStatementWithoutLockingHint() {
+		$model = new TestModel();
+		$sql = $this->Dbo->buildStatement(
+			array(
+				'fields' => array('id'),
+				'table' => 'users',
+				'alias' => 'User',
+				'order' => array('id'),
+				'limit' => 1,
+				'lock' => true,
+			),
+			$model
+		);
+		$expected = 'SELECT id FROM users AS "User"   WHERE 1 = 1   ORDER BY "id" ASC  LIMIT 1';
+		$this->assertEquals($expected, $sql);
+	}
 }

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -708,18 +708,17 @@ SQL;
 	}
 
 /**
- * Test build statement
+ * Test build statement with having option
  *
  * @return void
  */
-	public function testBuildStatement() {
+	public function testBuildStatementWithHaving() {
 		$db = $this->getMock('SqlserverTestDb', array('getVersion'), array($this->Dbo->config));
 
 		$db->expects($this->any())
 			->method('getVersion')
 			->will($this->returnValue('11.00.0000'));
 
-		// HAVING
 		$query = array(
 			'fields' => array('user_id', 'COUNT(*) AS count'),
 			'table' => 'articles',
@@ -737,8 +736,20 @@ SQL;
 		$sql = $db->buildStatement(array('offset' => 15) + $query, $this->model);
 		$expected = 'SELECT user_id, COUNT(*) AS count FROM articles AS [Article]   WHERE 1 = 1  GROUP BY user_id  HAVING COUNT(*) > 10  ORDER BY COUNT(*) DESC  OFFSET 15 ROWS FETCH FIRST 5 ROWS ONLY';
 		$this->assertEquals($expected, $sql);
+	}
 
-		// WITH (UPDLOCK)
+/**
+ * Test build statement with lock option
+ *
+ * @return void
+ */
+	public function testBuildStatementWithLockingHint() {
+		$db = $this->getMock('SqlserverTestDb', array('getVersion'), array($this->Dbo->config));
+
+		$db->expects($this->any())
+			->method('getVersion')
+			->will($this->returnValue('11.00.0000'));
+
 		$query = array(
 			'fields' => array('id'),
 			'table' => 'users',
@@ -758,18 +769,17 @@ SQL;
 	}
 
 /**
- * Test build statement with legacy version
+ * Test build statement with having option for legacy version
  *
  * @return void
  */
-	public function testBuildStatementWithLegacyVersion() {
+	public function testBuildStatementWithHavingForLegacyVersion() {
 		$db = $this->getMock('SqlserverTestDb', array('getVersion'), array($this->Dbo->config));
 
 		$db->expects($this->any())
 			->method('getVersion')
 			->will($this->returnValue('10.00.0000'));
 
-		// HAVING
 		$query = array(
 			'fields' => array('user_id', 'COUNT(*) AS count'),
 			'table' => 'articles',
@@ -794,8 +804,20 @@ WHERE _cake_paging_._cake_page_rownum_ > 15
 ORDER BY _cake_paging_._cake_page_rownum_
 SQL;
 		$this->assertEquals($expected, preg_replace('/^\s+|\s+$/m', '', $sql));
+	}
 
-		// WITH (UPDLOCK)
+/**
+ * Test build statement with lock option for legacy version
+ *
+ * @return void
+ */
+	public function testBuildStatementWithLockingHintForLegacyVersion() {
+		$db = $this->getMock('SqlserverTestDb', array('getVersion'), array($this->Dbo->config));
+
+		$db->expects($this->any())
+			->method('getVersion')
+			->will($this->returnValue('10.00.0000'));
+
 		$query = array(
 			'fields' => array('id'),
 			'table' => 'users',

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1473,8 +1473,21 @@ class DboSourceTest extends CakeTestCase {
 		);
 		$expected = 'SELECT DISTINCT(AssetsTag.asset_id) FROM assets_tags AS AssetsTag   WHERE Tag.name = foo bar  GROUP BY AssetsTag.asset_id';
 		$this->assertEquals($expected, $subQuery);
+	}
 
-		// HAVING
+/**
+ * Test build statement with having option
+ *
+ * @return void
+ */
+	public function testBuildStatementWithHaving() {
+		$conn = $this->getMock('MockPDO', array('quote'));
+		$conn->expects($this->any())
+			->method('quote')
+			->will($this->returnArgument(0));
+		$db = new DboTestSource();
+		$db->setConnection($conn);
+
 		$sql = $db->buildStatement(
 			array(
 				'fields' => array('user_id', 'COUNT(*) AS count'),
@@ -1489,8 +1502,21 @@ class DboSourceTest extends CakeTestCase {
 		);
 		$expected = 'SELECT user_id, COUNT(*) AS count FROM articles AS Article   WHERE 1 = 1  GROUP BY user_id  HAVING COUNT(*) > 10  ORDER BY COUNT(*) DESC  LIMIT 5';
 		$this->assertEquals($expected, $sql);
+	}
 
-		// FOR UPDATE
+/**
+ * Test build statement with lock option
+ *
+ * @return void
+ */
+	public function testBuildStatementWithLockingHint() {
+		$conn = $this->getMock('MockPDO', array('quote'));
+		$conn->expects($this->any())
+			->method('quote')
+			->will($this->returnArgument(0));
+		$db = new DboTestSource();
+		$db->setConnection($conn);
+
 		$sql = $db->buildStatement(
 			array(
 				'fields' => array('id'),

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -353,6 +353,33 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * Test find method with having clause
+ *
+ * @return void
+ */
+	public function testHaving() {
+		$this->loadFixtures('Comment');
+
+		$Comment = ClassRegistry::init('Comment');
+		$comments = $Comment->find('all', array(
+			'fields' => array('user_id', 'COUNT(*) AS count'),
+			'group' => array('user_id'),
+			'having' => array('COUNT(*) >' => 1),
+			'order' => array('COUNT(*)' => 'DESC'),
+			'recursive' => -1,
+		));
+
+		$results = Hash::combine($comments, '{n}.Comment.user_id', '{n}.0.count');
+
+		$expected = array(
+			1 => 3,
+			2 => 2,
+		);
+
+		$this->assertEquals($expected, $results);
+	}
+
+/**
  * testOldQuery method
  *
  * @return void


### PR DESCRIPTION
Fixes #9812 

I didn't add support for `LOCK IN SHARE MODE`/`FOR SHARE`/`WITH (SERIALIZABLE)` and dynamic finder, to make things simple. After this PR has been merged, I'll try to update related 2.next documents.