### PR TITLE
Pin phpunit to version 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation."
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6",
+        "phpunit/phpunit": "^5.0",
         "cakephp/cakephp-codesniffer": "~2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation."
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "~5.7.0",
         "cakephp/cakephp-codesniffer": "~2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation."
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.0",
+        "phpunit/phpunit": "^5.6",
         "cakephp/cakephp-codesniffer": "~2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation."
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "<6.0",
         "cakephp/cakephp-codesniffer": "~2.1"
     },
     "autoload": {


### PR DESCRIPTION
With the release of phpunit version 6.0 it is not possible for us to test
the framework with versions older than PHP 7.

There are clever ways of solving this problem, but I think there are no interesting
features in verion 6 that we require for the time being.