### PR TITLE
Separate email log headers and body with empty line.

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -1370,7 +1370,7 @@ class Email implements JsonSerializable, Serializable
         }
         Log::write(
             $config['level'],
-            PHP_EOL . $contents['headers'] . PHP_EOL . $contents['message'],
+            PHP_EOL . $contents['headers'] . PHP_EOL . PHP_EOL . $contents['message'],
             $config['scope']
         );
     }


### PR DESCRIPTION
This is port from 2.x

See comments in https://github.com/cakephp/cakephp/pull/8384#discussion-diff-54658935