### PR TITLE
'toggle vendor stack frames' do not work

### DIFF
--- a/src/Template/Element/exception_stack_trace_nav.ctp
+++ b/src/Template/Element/exception_stack_trace_nav.ctp
@@ -18,7 +18,7 @@ use Cake\Error\Debugger;
 
 <ul class="stack-trace">
 <?php foreach ($error->getTrace() as $i => $stack): ?>
-    <?php $class = (isset($stack['file']) && strpos(APP, $stack['file']) === false) ? 'vendor-frame' : 'app-frame'; ?>
+    <?php $class = (isset($stack['file']) && strpos($stack['file'], APP) === false) ? 'vendor-frame' : 'app-frame'; ?>
     <li class="stack-frame <?= $class ?>">
     <?php if (isset($stack['function'])): ?>
         <a href="#" data-target="stack-frame-<?= $i ?>">


### PR DESCRIPTION
Arguments of `strpos($haystack, $needle)` were in wrong order.

After clicking 'toggle vendor stack frames', there was no frames visible, because all frames had class 'vendor-frame'

$haystack = '/my/app/src/Controllers/PostsController.php';
$needle = '/my/app/';