### PR TITLE
[3.5] Split BelongsToMany::sort() into getSort()/setSort()

### DIFF
--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -56,23 +56,6 @@ class BelongsTo extends Association
     }
 
     /**
-     * Sets the name of the field representing the foreign key to the target table.
-     * If no parameters are passed current field is returned
-     *
-     * @deprecated 3.4.0 Use setForeignKey()/getForeignKey() instead.
-     * @param string|null $key the key to be used to link both tables together
-     * @return string
-     */
-    public function foreignKey($key = null)
-    {
-        if ($key !== null) {
-            $this->setForeignKey($key);
-        }
-
-        return $this->getForeignKey();
-    }
-
-    /**
      * Handle cascading deletes.
      *
      * BelongsTo associations are never cleared in a cascading delete scenario.

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -244,18 +244,42 @@ class BelongsToMany extends Association
 
     /**
      * Sets the sort order in which target records should be returned.
+     *
+     * @param mixed $sort A find() compatible order clause
+     * @return $this
+     */
+    public function setSort($sort)
+    {
+        $this->_sort = $sort;
+
+        return $this;
+    }
+
+    /**
+     * Gets the sort order in which target records should be returned.
+     *
+     * @return mixed
+     */
+    public function getSort()
+    {
+        return $this->_sort;
+    }
+
+    /**
+     * Sets the sort order in which target records should be returned.
      * If no arguments are passed the currently configured value is returned
      *
+     * @deprecated 3.4.0 Use setSort()/getSort() instead.
      * @param mixed $sort A find() compatible order clause
      * @return mixed
      */
     public function sort($sort = null)
     {
         if ($sort !== null) {
-            $this->_sort = $sort;
+            $this->setSort($sort);
         }
 
-        return $this->_sort;
+        return $this->getSort();
     }
 
     /**
@@ -554,7 +578,7 @@ class BelongsToMany extends Association
             'bindingKey' => $this->getBindingKey(),
             'strategy' => $this->getStrategy(),
             'associationType' => $this->type(),
-            'sort' => $this->sort(),
+            'sort' => $this->getSort(),
             'junctionAssociationName' => $name,
             'junctionProperty' => $this->_junctionProperty,
             'junctionAssoc' => $this->getTarget()->association($name),
@@ -1450,7 +1474,7 @@ class BelongsToMany extends Association
             $this->setSaveStrategy($opts['saveStrategy']);
         }
         if (isset($opts['sort'])) {
-            $this->sort($opts['sort']);
+            $this->setSort($opts['sort']);
         }
     }
 }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -194,7 +194,7 @@ class BelongsToMany extends Association
     public function targetForeignKey($key = null)
     {
         if ($key !== null) {
-            return $this->setTargetForeignKey($key);
+            $this->setTargetForeignKey($key);
         }
 
         return $this->getTargetForeignKey();
@@ -224,22 +224,6 @@ class BelongsToMany extends Association
         }
 
         return $this->_foreignKey;
-    }
-
-    /**
-     * Sets the name of the field representing the foreign key to the source table.
-     * If no parameters are passed current field is returned
-     *
-     * @param string|null $key the key to be used to link both tables together
-     * @return string
-     */
-    public function foreignKey($key = null)
-    {
-        if ($key !== null) {
-            $this->setForeignKey($key);
-        }
-
-        return $this->getForeignKey();
     }
 
     /**
@@ -990,19 +974,6 @@ class BelongsToMany extends Association
         $this->_targetConditions = $this->_junctionConditions = null;
 
         return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     * @deprecated 3.4.0 Use setConditions()/getConditions() instead.
-     */
-    public function conditions($conditions = null)
-    {
-        if ($conditions !== null) {
-            $this->setConditions($conditions);
-        }
-
-        return $this->getConditions();
     }
 
     /**

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -564,23 +564,6 @@ class HasMany extends Association
     }
 
     /**
-     * Sets the name of the field representing the foreign key to the source table.
-     * If no parameters are passed current field is returned
-     *
-     * @deprecated 3.4.0 Use setForeignKey()/getForeignKey() instead.
-     * @param string|null $key the key to be used to link both tables together
-     * @return string
-     */
-    public function foreignKey($key = null)
-    {
-        if ($key !== null) {
-            return $this->setForeignKey($key);
-        }
-
-        return $this->getForeignKey();
-    }
-
-    /**
      * Sets the sort order in which target records should be returned.
      *
      * @param mixed $sort A find() compatible order clause

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -56,23 +56,6 @@ class HasOne extends Association
     }
 
     /**
-     * Sets the name of the field representing the foreign key to the target table.
-     * If no parameters are passed current field is returned
-     *
-     * @deprecated 3.4.0 Use setForeignKey()/getForeignKey() instead.
-     * @param string|null $key the key to be used to link both tables together
-     * @return string
-     */
-    public function foreignKey($key = null)
-    {
-        if ($key !== null) {
-            return $this->setForeignKey($key);
-        }
-
-        return $this->getForeignKey();
-    }
-
-    /**
      * Returns default property name based on association name.
      *
      * @return string

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -78,6 +78,22 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that foreignKey() returns the correct configured value
+     *
+     * @return void
+     */
+    public function testForeignKey()
+    {
+        $assoc = new BelongsToMany('Test', [
+            'sourceTable' => $this->article,
+            'targetTable' => $this->tag
+        ]);
+        $this->assertEquals('article_id', $assoc->foreignKey());
+        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->foreignKey());
+    }
+
+    /**
      * Tests that the association reports it can be joined
      *
      * @return void
@@ -930,7 +946,7 @@ class BelongsToManyTest extends TestCase
             'targetTable' => $this->tag
         ]);
         $this->assertEquals('tag_id', $assoc->targetForeignKey());
-        $assoc->targetForeignKey('another_key');
+        $this->assertEquals('another_key', $assoc->targetForeignKey('another_key'));
         $this->assertEquals('another_key', $assoc->targetForeignKey());
 
         $assoc = new BelongsToMany('Test', [

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -90,6 +90,22 @@ class BelongsToTest extends TestCase
      */
     public function testForeignKey()
     {
+        $assoc = new BelongsTo('Companies', [
+            'sourceTable' => $this->client,
+            'targetTable' => $this->company,
+        ]);
+        $this->assertEquals('company_id', $assoc->foreignKey());
+        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->foreignKey());
+    }
+
+    /**
+     * Test that foreignKey generation ignores database names in target table.
+     *
+     * @return void
+     */
+    public function testForeignKeyIgnoreDatabaseName()
+    {
         $this->company->table('schema.companies');
         $this->client->table('schema.clients');
         $assoc = new BelongsTo('Companies', [

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -95,11 +95,26 @@ class HasManyTest extends TestCase
     }
 
     /**
-     * Test that foreignKey generation ignores database names in target table.
+     * Tests that foreignKey() returns the correct configured value
      *
      * @return void
      */
     public function testForeignKey()
+    {
+        $assoc = new HasMany('Articles', [
+            'sourceTable' => $this->author
+        ]);
+        $this->assertEquals('author_id', $assoc->foreignKey());
+        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->foreignKey());
+    }
+
+    /**
+     * Test that foreignKey generation ignores database names in target table.
+     *
+     * @return void
+     */
+    public function testForeignKeyIgnoreDatabaseName()
     {
         $this->author->table('schema.authors');
         $assoc = new HasMany('Articles', [

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -79,6 +79,21 @@ class HasOneTest extends TestCase
     }
 
     /**
+     * Tests that foreignKey() returns the correct configured value
+     *
+     * @return void
+     */
+    public function testForeignKey()
+    {
+        $assoc = new HasOne('Profiles', [
+            'sourceTable' => $this->user
+        ]);
+        $this->assertEquals('user_id', $assoc->foreignKey());
+        $this->assertEquals('another_key', $assoc->foreignKey('another_key'));
+        $this->assertEquals('another_key', $assoc->foreignKey());
+    }
+
+    /**
      * Tests that the association reports it can be joined
      *
      * @return void


### PR DESCRIPTION
`HasMany::sort()` has been split, but `BelongsToMany::sort()` has not been split yet. People would  be confused.

Additionally, I have removed overridden combined setter/getter methods. Previously, `foreignKey()` returns `$this` incorrectly in some of them.

Also, I fixed `BelongsToMany::targetForeignKey()` returns `$this`.

Related to https://github.com/cakephp/cakephp/pull/9676