### PR TITLE
Make TranslatorFactory::newInstance compatible with Aura 3.0

### DIFF
--- a/src/I18n/TranslatorFactory.php
+++ b/src/I18n/TranslatorFactory.php
@@ -15,6 +15,7 @@
 namespace Cake\I18n;
 
 use Aura\Intl\FormatterInterface;
+use Aura\Intl\Package;
 use Aura\Intl\TranslatorFactory as BaseTranslatorFactory;
 use Aura\Intl\TranslatorInterface;
 use RuntimeException;
@@ -37,7 +38,7 @@ class TranslatorFactory extends BaseTranslatorFactory
      * Returns a new Translator.
      *
      * @param string $locale The locale code for the translator.
-     * @param array $messages The localized messages for the translator.
+     * @param \Aura\Intl\Package $package The Package containing keys and translations.
      * @param \Aura\Intl\FormatterInterface $formatter The formatter to use for interpolating token values.
      * @param \Aura\Intl\TranslatorInterface $fallback A fallback translator to use, if any.
      * @throws \Cake\Core\Exception\Exception If fallback class does not match Cake\I18n\Translator
@@ -45,7 +46,7 @@ class TranslatorFactory extends BaseTranslatorFactory
      */
     public function newInstance(
         $locale,
-        array $messages,
+        Package $package,
         FormatterInterface $formatter,
         TranslatorInterface $fallback = null
     ) {
@@ -57,6 +58,6 @@ class TranslatorFactory extends BaseTranslatorFactory
             ));
         }
 
-        return new $class($locale, $messages, $formatter, $fallback);
+        return new $class($locale, $package, $formatter, $fallback);
     }
 }

--- a/tests/TestCase/I18n/TranslatorFactoryTest.php
+++ b/tests/TestCase/I18n/TranslatorFactoryTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\I18n;
 
+use Aura\Intl\Package;
 use Aura\Intl\Translator as AuraTranslator;
 use Cake\I18n\TranslatorFactory;
 use Cake\TestSuite\TestCase;
@@ -32,8 +33,9 @@ class TranslatorFactoryTest extends TestCase
     public function testNewInstanceErrorOnFallback()
     {
         $formatter = $this->getMockBuilder('Aura\Intl\FormatterInterface')->getMock();
-        $fallback = new AuraTranslator('en_CA', [], $formatter, null);
+        $package = $this->getMockBuilder(Package::class)->getMock();
+        $fallback = new AuraTranslator('en_CA', $package, $formatter, null);
         $factory = new TranslatorFactory();
-        $factory->newInstance('en_CA', [], $formatter, $fallback);
+        $factory->newInstance('en_CA', $package, $formatter, $fallback);
     }
 }


### PR DESCRIPTION
The `Cake\I18n\Translator:: construct()` signature changed in Cake 3.4