### PR TITLE
QueryLogger strips some characters from queries

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -68,7 +68,19 @@ class QueryLogger
                 return $p ? '1' : '0';
             }
 
-            return is_string($p) ? "'$p'" : $p;
+            if (is_string($p)) {
+                $replacements = [
+                    '$' => '\\$',
+                    '\\' => '\\\\\\\\',
+                    "'" => "''",
+                ];
+
+                $p = strtr($p, $replacements);
+
+                return "'$p'";
+            }
+
+            return $p;
         }, $query->params);
 
         $keys = [];

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -128,6 +128,26 @@ class QueryLoggerTest extends TestCase
     }
 
     /**
+     * Tests that placeholders are replaced with correctly escaped strings
+     *
+     * @return void
+     */
+    public function testStringInterpolationSpecialChars()
+    {
+        $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')
+            ->setMethods(['_log'])
+            ->getMock();
+        $query = new LoggedQuery;
+        $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4';
+        $query->params = ['p1' => '$2y$10$dUAIj', 'p2' => '$0.23', 'p3' => 'a\\0b\\1c\\d', 'p4' => "a'b"];
+
+        $logger->expects($this->once())->method('_log')->with($query);
+        $logger->log($query);
+        $expected = "duration=0 rows=0 SELECT a FROM b where a = '\$2y\$10\$dUAIj' AND b = '\$0.23' AND c = 'a\\\\0b\\\\1c\\\\d' AND d = 'a''b'";
+        $this->assertEquals($expected, (string)$query);
+    }
+
+    /**
      * Tests that the logged query object is passed to the built-in logger using
      * the correct scope
      *


### PR DESCRIPTION
When using DebugKit SqlLog, I noticed that when saving hashed user password, log contained
`UPDATE users SET password = 'y$uEFBAE...' WHERE id = 123` which is not in valid Bcrypt format.

But after checking database, password was saved correctly as `'$2a$10$uEFBAE...'`.

I enabled logging to text file - still same result, so not fault of DebugKit.

After inspecting code, problem is that QueryLogger interpolates bind parameters using `preg_replace`: but `preg_replace` replacement string uses `$1` or `\\1` for backreferences.

`$2` and `$10` in hash refers to invalid backrefences, so replaced with empty strings.

Another possible common string could be "$0.12" which would replace to `":p1.12"` because `$0` refers to bind parameter matched by the whole pattern.

---

My commit escapes `$` and `\` to `\$` and `\\` to ignore them by preg_replace.

Also I replace `'` to double single-quote `''` and `\` to `\\`  to be even more valid SQL string. This is why there is `\\` to `\\\\\\\\` replacement (preg_replace and SQL escape).
