### PR TITLE
Allow whitespace before tags when checking HTML.

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -410,7 +410,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
                     $tags = $matches[1];
                     $type = 'Regex matches';
                 } else {
-                    $tags = preg_quote($tags, '/');
+                    $tags = '\s*' . preg_quote($tags, '/');
                     $type = 'Text equals';
                 }
                 $regex[] = [

--- a/tests/TestCase/TestSuite/AssertHtmlTest.php
+++ b/tests/TestCase/TestSuite/AssertHtmlTest.php
@@ -9,7 +9,12 @@ use PHPUnit_Framework_ExpectationFailedException;
  */
 class AssertHtmlTest extends TestCase
 {
-    public function testAssertHtmlWhitespace()
+    /**
+     * Test whitespace after HTML tags
+     *
+     * @return
+     */
+    public function testAssertHtmlWhitespaceAfter()
     {
         $input = <<<HTML
 <div class="wrapper">
@@ -27,6 +32,31 @@ HTML;
         ];
         $this->assertHtml($pattern, $input);
     }
+
+    /**
+     * Test whitespace inside HTML tags
+     *
+     * @return void
+     */
+    public function testAssertHtmlInnerWhitespace()
+    {
+        $input = <<<HTML
+<div class="widget">
+    <div class="widget-content">
+        A custom widget
+    </div>
+</div>
+HTML;
+        $expected = [
+            ['div' => ['class' => 'widget']],
+            ['div' => ['class' => 'widget-content']],
+            'A custom widget',
+            '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $input);
+    }
+
     /**
      * test assertHtml works with single and double quotes
      *


### PR DESCRIPTION
Whitespace before tags is generally of no consequence, and we should allow it by default.

Refs #10117