### PR TITLE
update i18n to include aura/intl 3.0 for standalone usage.

### DIFF
--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -19,7 +19,7 @@
         "lib-ICU": ">=4.8",
         "ext-intl": "*",
         "cakephp/chronos": "*",
-        "aura/intl": "1.1.*"
+        "aura/intl": "^3.0.0"
     },
     "suggest": {
         "cakephp/cache": "Require this if you want automatic caching of translators"


### PR DESCRIPTION
This looks missed  due to root composer.json contains 3.0 https://github.com/cakephp/cakephp/blob/124477d942f5da922c07e355d2a1ab11fa26f054/composer.json#L26