### PR TITLE
Fix up contain() to be BC with key value contains.

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -389,6 +389,10 @@ class EagerLoader
                 };
             }
 
+            if (!is_array($options)) {
+                $options = [$options => []];
+            }
+
             $pointer[$table] = $options + $pointer[$table];
         }
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -276,6 +276,30 @@ class EagerLoaderTest extends TestCase
         $this->assertEquals($expected, $loader->contain());
     }
 
+
+    /**
+     * Tests setting containments using direct key value pairs works just as with key array.
+     *
+     * @return void
+     */
+    public function testContainKeyValueNotation()
+    {
+        $loader = new EagerLoader;
+        $loader->contain([
+            'clients',
+            'companies' => 'categories',
+        ]);
+        $expected = [
+            'clients' => [
+            ],
+            'companies' => [
+                'categories' => [
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $loader->contain());
+    }
+
     /**
      * Tests that it is possible to pass a function as the array value for contain
      *


### PR DESCRIPTION
I classified this as a small regression when coming from 2.x.
I did some basic upgrading of a 2.x app to 3.x and ran into a lot of those errors:

> Fatal error: Unsupported operand types in /home/vagrant/Apps/.../vendor/cakephp/cakephp/src/ORM/EagerLoader.php on line 392

The error doesn't say much and is rather difficult to understand, especially for beginners or 2.x upgraders.I
t means that the old way of a basic `contain => ['Message' => 'Author']` was dropped.
We should add that back, if it is a simple fix.

I think it eases upgrading on the one side if introduced back, and on the other side doesn't hurt to have.
Semantically, both are the same, and we usually also allow that to be normalized internally for other places and things, too.