### PR TITLE
Fix up config() to accept any scalar value for getting as per setConfig()

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -163,7 +163,7 @@ trait StaticConfigTrait
      */
     public static function config($key, $config = null)
     {
-        if ($config !== null || !is_string($key)) {
+        if ($config !== null || is_array($key)) {
             static::setConfig($key, $config);
 
             return null;

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -460,7 +460,8 @@ class StaticConfigTraitTest extends TestCase
      *
      * @return void
      */
-    public function testConfigBC() {
+    public function testConfigBC()
+    {
         $result = TestLogStaticConfig::config(404);
         $this->assertNull($result);
     }

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -453,4 +453,15 @@ class StaticConfigTraitTest extends TestCase
         $result = TestLogStaticConfig::dsnClassMap(['my' => 'Special\OtherLog']);
         $this->assertEquals($expected, $result, "Should be possible to add to the map");
     }
+
+    /**
+     * Tests that former handling of integer keys coming in from PHP internal conversions
+     * won't break in 3.4.
+     *
+     * @return void
+     */
+    public function testConfigBC() {
+        $result = TestLogStaticConfig::config(404);
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
I have the following log config on app.php:
```php
	'Log' => [
		'debug' => [
			'scopes' => false,
			'className' => 'DatabaseLog.Database'
		],
		'error' => [
			'scopes' => false,
			'className' => 'DatabaseLog.Database'
		],
		'404' => [
			'className' => 'DatabaseLog.Database',
			'type' => '404',
			'levels' => ['error'],
			'scopes' => ['404'],
		]
```
Those are all strings.
Somewhere inside the core, though, some type joggling makes this a integer 404 then as key, breaking the config() nonsplit method.
Using this fix it works again as expected (as it checks for the actual array vs non array), and this is the same check used inside setConfig(), so it is then consistent, as well.

Note: it used to work in 3.3 and before like this, that's why this is a regression bugfix.