### PR TITLE
Use the phpcs.xml.dist instead of raw CakePHP ruleset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,14 +85,14 @@ before_install:
 before_script:
   - composer install --prefer-dist --no-interaction
   - if [[ $PHPCS = 3 ]]; then composer remove --dev cakephp/cakephp-codesniffer; fi
-  - if [[ $PHPCS = 3 ]]; then composer require --dev squizlabs/php_codesniffer='3.0.*@dev' cakephp/cakephp-codesniffer='3.0.*@dev'; fi
+  - if [[ $PHPCS = 3 ]]; then composer require --dev squizlabs/php_codesniffer='^3.0@dev' cakephp/cakephp-codesniffer='^3.0@dev'; fi
 
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then export CODECOVERAGE=1; vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
 
   - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
-  - if [[ $PHPCS = 3 ]]; then vendor/bin/phpcs -p -s --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
+  - if [[ $PHPCS = 3 ]]; then vendor/bin/phpcs -p -s --extensions=php ./src ./tests; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev phpstan/phpstan:^0.6 && vendor/bin/phpstan analyse -c phpstan.neon -l 0 src; fi
 
 after_success:


### PR DESCRIPTION
Actually the build against future v3 fails because `PSR1.Files.SideEffects.FoundWithSymbols` is not silenced correctly