### PR TITLE
Allow false/true to be read as keys in Hash::get().

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -236,10 +236,13 @@ class HashTest extends CakeTestCase {
  */
 	public function testGetEmptyKey() {
 		$data = array(
-			'' => 'some value'
+			true => 'true value',
+			false => 'false value',
+			'' => 'some value',
 		);
-		$result = Hash::get($data, '');
-		$this->assertSame($data[''], $result);
+		$this->assertSame($data[''], Hash::get($data, ''));
+		$this->assertSame($data[false], Hash::get($data, false));
+		$this->assertSame($data[true], Hash::get($data, true));
 	}
 
 /**
@@ -249,7 +252,7 @@ class HashTest extends CakeTestCase {
  * @return void
  */
 	public function testGetInvalidPath() {
-		Hash::get(array('one' => 'two'), true);
+		Hash::get(array('one' => 'two'), new StdClass());
 	}
 
 /**

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -49,7 +49,7 @@ class Hash {
 		if (is_string($path) || is_numeric($path)) {
 			$parts = explode('.', $path);
 		} elseif (is_bool($path) || $path === null) {
-			$parts = [$path];
+			$parts = array($path);
 		} else {
 			if (!is_array($path)) {
 				throw new InvalidArgumentException(__d('cake_dev',

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -48,11 +48,13 @@ class Hash {
 		}
 		if (is_string($path) || is_numeric($path)) {
 			$parts = explode('.', $path);
+		} elseif (is_bool($path) || $path === null) {
+			$parts = [$path];
 		} else {
 			if (!is_array($path)) {
 				throw new InvalidArgumentException(__d('cake_dev',
-					'Invalid Parameter %s, should be dot separated path or array.',
-					$path
+					'Invalid path parameter: %s, should be dot separated path or array.',
+					var_export($path, true)
 				));
 			}
 			$parts = $path;


### PR DESCRIPTION
While these are not values within the documented types, there exist use cases in CakeSession that necessitate these to be supported types.

Refs #10196