### PR TITLE
View, table getter

### DIFF
--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -180,6 +180,16 @@ class Behavior implements EventListenerInterface
     }
 
     /**
+     * Get the table instance this behavior is bound to.
+     *
+     * @return \Cake\ORM\Table The bound table instance.
+     */
+    public function getTable()
+    {
+        return $this->_table;
+    }
+
+    /**
      * Removes aliased methods that would otherwise be duplicated by userland configuration.
      *
      * @param string $key The key to filter.

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -156,6 +156,16 @@ class Helper implements EventListenerInterface
     }
 
     /**
+     * Get the view instance this helper is bound to.
+     *
+     * @return \Cake\View\View The bound view instance.
+     */
+    public function getView()
+    {
+        return $this->_View;
+    }
+
+    /**
      * Returns a string to be used as onclick handler for confirm dialogs.
      *
      * @param string $message Message to be displayed

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -196,6 +196,19 @@ class BehaviorTest extends TestCase
         $this->assertEquals($config, $behavior->config());
     }
 
+    /**
+     * Test getting table instance.
+     *
+     * @return void
+     */
+    public function testGetTable()
+    {
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+
+        $behavior = new TestBehavior($table);
+        $this->assertSame($table, $behavior->getTable());
+    }
+
     public function testReflectionCache()
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -151,6 +151,17 @@ class HelperTest extends TestCase
     }
 
     /**
+     * test getting view instance
+     *
+     * @return void
+     */
+    public function testGetView()
+    {
+        $Helper = new TestHelper($this->View);
+        $this->assertSame($this->View, $Helper->getView());
+    }
+
+    /**
      * Tests __debugInfo
      *
      * @return void


### PR DESCRIPTION
- Added `Helper::getView()` to avoid having to use `$this->_View` in helpers. This was specially annoying as one had to remember that casing of `_View` is not consistent with other lower case names.
- Added `Behavior::getTable()`. Is the method name fine or should be use something more generic like `getModel()`?

`Component::getController()` already exits.