### PR TITLE
Fix InflectedRoute calling parent() incorrectly.

### DIFF
--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -43,7 +43,7 @@ class InflectedRoute extends Route
      */
     public function parse($url, $method = '')
     {
-        $params = parent::parse($url);
+        $params = parent::parse($url, $method);
         if (!$params) {
             return false;
         }

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -327,7 +327,7 @@ class Route
             if (empty($method)) {
                 // Deprecated reading the global state is deprecated and will be removed in 4.x
                 $request = Router::getRequest(true) ?: ServerRequest::createFromGlobals();
-                $method = $request->env('REQUEST_METHOD');
+                $method = $request->getMethod();
             }
             if (!in_array($method, (array)$this->defaults['_method'], true)) {
                 return false;

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -193,6 +193,21 @@ class InflectedRouteTest extends TestCase
     }
 
     /**
+     * Test that parse() checks methods.
+     *
+     * @return void
+     */
+    public function testParseMethodMatch()
+    {
+        $route = new InflectedRoute('/:controller/:action', ['_method' => 'POST']);
+        $this->assertFalse($route->parse('/blog_posts/add_new', 'GET'));
+
+        $result = $route->parse('/blog_posts/add_new', 'POST');
+        $this->assertEquals('BlogPosts', $result['controller']);
+        $this->assertEquals('add_new', $result['action']);
+    }
+
+    /**
      * @return void
      */
     public function testMatchThenParse()

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -39,6 +39,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
 
+        Router::connect('/get/:controller/:action', ['_method' => 'GET'], ['routeClass' => 'InflectedRoute']);
         Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
         DispatcherFactory::clear();
         DispatcherFactory::add('Routing');
@@ -182,6 +183,23 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->get('/request_action/test_request_action');
         $this->assertNotEmpty($this->_response);
         $this->assertInstanceOf('Cake\Network\Response', $this->_response);
+        $this->assertEquals('This is a test', $this->_response->body());
+
+        $this->_response = null;
+        $this->get('/get/request_action/test_request_action');
+        $this->assertEquals('This is a test', $this->_response->body());
+    }
+
+    /**
+     * Test sending get requests sets the request method
+     *
+     * @return void
+     */
+    public function testGetSpecificRouteHttpServer()
+    {
+        $this->useHttpServer(true);
+        $this->get('/get/request_action/test_request_action');
+        $this->assertResponseOk();
         $this->assertEquals('This is a test', $this->_response->body());
     }
 


### PR DESCRIPTION
The parent call in InflectedRoute was missing the `$method` parameter. This caused routes to not match correctly when routes have method conditions.

Refs #10220