### PR TITLE
Fix docblock for PK generation and composite keys

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1923,8 +1923,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * value if possible. You can override this method if you have specific requirements
      * for id generation.
      *
+     * Note: The ORM will not generate primary key values for composite primary keys.
+     * You can overwrite _newId() in your table class.
+     *
      * @param array $primary The primary key columns to get a new ID for.
-     * @return mixed Either null or the new primary key value.
+     * @return null|string|array Either null or the primary key value or a list of primary key values.
      */
     protected function _newId($primary)
     {


### PR DESCRIPTION
Ref: https://github.com/cakephp/cakephp/issues/4936#issuecomment-59808744

Where it is being used actually assumes that it can be handled like an array by casting it.
```
$id = (array)$this->_newId($primary) + $keys;
```

Could this cast be moved into the _newId() method to make clear that you can return array of primary key values?
