### PR TITLE
Fix docblock @param (boolean inversion)

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -800,7 +800,7 @@ trait EntityTrait
      * true means that the instance is not yet persisted in the database, false
      * that it already is.
      *
-     * @param bool|null $new true if it is known this instance was persisted
+     * @param bool|null $new true if it is known this instance was not yet persisted
      * @return bool Whether or not the entity has been persisted.
      */
     public function isNew($new = null)


### PR DESCRIPTION
`EntityTrait::isNew()` has its `@param` docblock for its return type state that it would return true if persisted (but then it would return false!)