### PR TITLE
Return specified default value in EntityContext

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -262,7 +262,7 @@ class EntityContext implements ContextInterface
         if (is_array($entity)) {
             $key = array_pop($parts);
 
-            return isset($entity[$key]) ? $entity[$key] : null;
+            return isset($entity[$key]) ? $entity[$key] : $options['default'];
         }
 
         return null;

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -448,6 +448,21 @@ class EntityContextTest extends TestCase
     }
 
     /**
+     * Test default values when entity is an array.
+     * 
+     * @return void
+     */
+    public function testValDefaultArray()
+    {
+        $context = new EntityContext($this->request, [
+            'entity' => ['title' => 'foo'],
+            'table' => 'Articles',
+        ]);
+        $this->assertEquals('foo', $context->val('title', ['default' => 'bar']));
+        $this->assertEquals('bar', $context->val('nottitle', ['default' => 'bar']));
+    }
+
+    /**
      * Test reading array values from an entity.
      *
      * @return void

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -449,7 +449,7 @@ class EntityContextTest extends TestCase
 
     /**
      * Test default values when entity is an array.
-     * 
+     *
      * @return void
      */
     public function testValDefaultArray()
@@ -458,8 +458,8 @@ class EntityContextTest extends TestCase
             'entity' => ['title' => 'foo'],
             'table' => 'Articles',
         ]);
-        $this->assertEquals('foo', $context->val('title', ['default' => 'bar']));
-        $this->assertEquals('bar', $context->val('nottitle', ['default' => 'bar']));
+        $this->assertEquals('Articles.foo', $context->val('title', ['default' => 'bar']));
+        $this->assertEquals('Articles.bar', $context->val('nottitle', ['default' => 'bar']));
     }
 
     /**


### PR DESCRIPTION
With the current implementation the default value is ignored when the EntityContext was created from an array.