### PR TITLE
3.next - Make entity context recognize junction tables

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -500,8 +500,18 @@ class EntityContext implements ContextInterface
         }
 
         $table = $this->_tables[$this->_rootName];
+        $assoc = null;
         foreach ($normalized as $part) {
-            $assoc = $table->associations()->getByProperty($part);
+            if ($part === '_joinData') {
+                if ($assoc) {
+                    $table = $assoc->junction();
+                    $assoc = null;
+                    continue;
+                }
+            } else {
+                $assoc = $table->associations()->getByProperty($part);
+            }
+
             if (!$assoc && $rootFallback) {
                 break;
             }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -477,10 +477,11 @@ class EntityContext implements ContextInterface
      * Get the table instance from a property path
      *
      * @param array $parts Each one of the parts in a path for a field name
-     * @param bool $rootFallback Whether or not to fallback to the root entity.
+     * @param bool $fallback Whether or not to fallback to the last found table
+     *  when a non-existent field/property is being encountered.
      * @return \Cake\ORM\Table|bool Table instance or false
      */
-    protected function _getTable($parts, $rootFallback = true)
+    protected function _getTable($parts, $fallback = true)
     {
         if (count($parts) === 1) {
             return $this->_tables[$this->_rootName];
@@ -512,10 +513,10 @@ class EntityContext implements ContextInterface
                 $assoc = $table->associations()->getByProperty($part);
             }
 
-            if (!$assoc && $rootFallback) {
+            if (!$assoc && $fallback) {
                 break;
             }
-            if (!$assoc && !$rootFallback) {
+            if (!$assoc && !$fallback) {
                 return false;
             }
 

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -102,6 +102,8 @@ class EntityContextTest extends TestCase
      */
     public function testIsPrimaryKey()
     {
+        $this->_setupTables();
+
         $row = new Article();
         $context = new EntityContext($this->request, [
             'entity' => $row,
@@ -1249,7 +1251,8 @@ class EntityContextTest extends TestCase
             'id' => ['type' => 'integer', 'length' => 11, 'null' => false],
             'title' => ['type' => 'string', 'length' => 255],
             'user_id' => ['type' => 'integer', 'length' => 11, 'null' => false],
-            'body' => ['type' => 'crazy_text', 'baseType' => 'text']
+            'body' => ['type' => 'crazy_text', 'baseType' => 'text'],
+            '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
         ]);
         $users->schema([
             'id' => ['type' => 'integer', 'length' => 11],

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -1073,7 +1073,7 @@ class EntityContextTest extends TestCase
         $this->assertEquals($expected, $context->attributes('user.rating'));
 
         $expected = [
-            'length' => null, 'precision' => null
+            'length' => 11, 'precision' => null
         ];
         $this->assertEquals($expected, $context->attributes('tags.0._joinData.article_id'));
     }
@@ -1253,6 +1253,11 @@ class EntityContextTest extends TestCase
             'user_id' => ['type' => 'integer', 'length' => 11, 'null' => false],
             'body' => ['type' => 'crazy_text', 'baseType' => 'text'],
             '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+        ]);
+        $articles->Tags->junction()->schema([
+            'article_id' => ['type' => 'integer', 'length' => 11, 'null' => false],
+            'tag_id' => ['type' => 'integer', 'length' => 11, 'null' => false],
+            '_constraints' => ['unique_tag' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]]
         ]);
         $users->schema([
             'id' => ['type' => 'integer', 'length' => 11],

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -942,10 +942,6 @@ class EntityContextTest extends TestCase
         $context = new EntityContext($this->request, [
             'entity' => $row,
             'table' => 'Articles',
-            'validator' => [
-                'Articles' => 'create',
-                'Users' => 'custom',
-            ]
         ]);
 
         $this->assertTrue($context->isRequired('tags.0._joinData.article_id'));
@@ -1026,9 +1022,11 @@ class EntityContextTest extends TestCase
         $this->assertEquals('integer', $context->type('tags.0._joinData.article_id'));
         $this->assertNull($context->type('tags.0._joinData.non_existent'));
 
-        // tests the root fallback behavior
+        // tests the fallback behavior
         $this->assertEquals('integer', $context->type('tags.0._joinData._joinData.article_id'));
+        $this->assertEquals('integer', $context->type('tags.0._joinData.non_existent.article_id'));
         $this->assertNull($context->type('tags.0._joinData._joinData.non_existent'));
+        $this->assertNull($context->type('tags.0._joinData.non_existent'));
     }
 
     /**
@@ -1254,7 +1252,7 @@ class EntityContextTest extends TestCase
             'body' => ['type' => 'crazy_text', 'baseType' => 'text'],
             '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
         ]);
-        $articles->Tags->junction()->schema([
+        $articlesTags->schema([
             'article_id' => ['type' => 'integer', 'length' => 11, 'null' => false],
             'tag_id' => ['type' => 'integer', 'length' => 11, 'null' => false],
             '_constraints' => ['unique_tag' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]]


### PR DESCRIPTION
Adds support to the entity context for recognizing `_joinData` properties and resolving the respective junction table classes. This makes reading errors, introspecting types, etc working with join table columns.

While testing I noticed that the root fallback behavior in [**`EntityContext::_getTable()`**](https://github.com/cakephp/cakephp/blob/9fff233e7d38e0f30dd55377af637775f7f98104/src/View/Form/EntityContext.php#L483) doesn't actually falls back to the root node, but the last found / parent node.

The newly added `testTypeAssociatedJoinData` test seems to be the only one that fails when the fallback behavior is being changed to actually fall back to the root node, ie it seems that there is no other test actually covering that functionality, so I'm not 100% sure whether the current behavior is the actually intended behavior, and the description/name should be changed, or if it's maybe a bug, and it should really fall back to the root node?