### PR TITLE
Move PHPUnit aliases definition file to be loaded by apps by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
             "src/Core/functions.php",
             "src/Collection/functions.php",
             "src/I18n/functions.php",
-            "src/Utility/bootstrap.php"
+            "src/Utility/bootstrap.php",
+            "src/TestSuite/phpunit-forward-compat.php"
         ]
     },
     "autoload-dev": {
@@ -56,10 +57,7 @@
             "Company\\TestPluginThree\\": "tests/test_app/Plugin/Company/TestPluginThree/src",
             "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests",
             "PluginJs\\": "tests/test_app/Plugin/PluginJs/src"
-        },
-        "files": [
-            "src/TestSuite/phpunit-forward-compat.php"
-        ]
+        }
     },
     "replace": {
         "cakephp/cache": "self.version",


### PR DESCRIPTION
Using the `require-dev`section isn't enough for apps and therefore forbid tests to run on PHPUnit 5.7
This solution is probably not ideal but does solve the issue.

The other possibilities I can see are:
 - adding the aliases definition in the TestSuite files directly
 - reverting the support until we find something better 
