### PR TITLE
Restore 'association' option in beforeMarshal event.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -105,7 +105,7 @@ class Marshaller
             }
             if (isset($options['isMerge'])) {
                 $callback = function ($value, $entity) use ($assoc, $nested) {
-                    $options = $nested + ['associated' => []];
+                    $options = $nested + ['associated' => [], 'association' => $assoc];
 
                     return $this->_mergeAssociation($entity->get($assoc->getProperty()), $assoc, $value, $options);
                 };

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3147,7 +3147,8 @@ class MarshallerTest extends TestCase
                 $data['user']['username'] = 'robert';
 
                 $options['associated'] = ['Users'];
-            });
+            }
+        );
 
         $entity = $marshall->one($data);
 
@@ -3196,31 +3197,36 @@ class MarshallerTest extends TestCase
 
                 $this->assertArrayHasKey('association', $options);
                 $this->assertInstanceOf('Cake\ORM\Association', $options['association']);
-            });
+            }
+        );
 
         $this->articles->users->eventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data, $options) {
                 $data['secret'] = 'h45h3d';
-            });
+            }
+        );
 
         $this->articles->comments->eventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data) {
                 $data['comment'] .= ' (modified)';
-            });
+            }
+        );
 
         $this->articles->tags->eventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data) {
                 $data['tag'] .= ' (modified)';
-            });
+            }
+        );
 
         $this->articles->tags->junction()->eventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data) {
                 $data['modified_by'] = 1;
-            });
+            }
+        );
 
         $entity = $marshall->one($data, [
             'associated' => ['Users', 'Comments', 'Tags']

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3139,12 +3139,15 @@ class MarshallerTest extends TestCase
 
         $marshall = new Marshaller($this->articles);
 
-        $this->articles->eventManager()->attach(function ($e, $data, $options) {
-            $data['title'] = 'Modified title';
-            $data['user']['username'] = 'robert';
+        $this->articles->eventManager()->on(
+            'Model.beforeMarshal',
+            function ($e, $data, $options) {
+                $this->assertArrayHasKey('validate', $options);
+                $data['title'] = 'Modified title';
+                $data['user']['username'] = 'robert';
 
-            $options['associated'] = ['Users'];
-        }, 'Model.beforeMarshal');
+                $options['associated'] = ['Users'];
+            });
 
         $entity = $marshall->one($data);
 
@@ -3181,21 +3184,43 @@ class MarshallerTest extends TestCase
 
         $marshall = new Marshaller($this->articles);
 
-        $this->articles->users->eventManager()->attach(function ($e, $data) {
-            $data['secret'] = 'h45h3d';
-        }, 'Model.beforeMarshal');
+        // Assert event options are correct
+        $this->articles->users->eventManager()->on(
+            'Model.beforeMarshal',
+            function ($e, $data, $options) {
+                $this->assertArrayHasKey('validate', $options);
+                $this->assertTrue($options['validate']);
 
-        $this->articles->comments->eventManager()->attach(function ($e, $data) {
-            $data['comment'] .= ' (modified)';
-        }, 'Model.beforeMarshal');
+                $this->assertArrayHasKey('associated', $options);
+                $this->assertSame([], $options['associated']);
 
-        $this->articles->tags->eventManager()->attach(function ($e, $data) {
-            $data['tag'] .= ' (modified)';
-        }, 'Model.beforeMarshal');
+                $this->assertArrayHasKey('association', $options);
+                $this->assertInstanceOf('Cake\ORM\Association', $options['association']);
+            });
 
-        $this->articles->tags->junction()->eventManager()->attach(function ($e, $data) {
-            $data['modified_by'] = 1;
-        }, 'Model.beforeMarshal');
+        $this->articles->users->eventManager()->on(
+            'Model.beforeMarshal',
+            function ($e, $data, $options) {
+                $data['secret'] = 'h45h3d';
+            });
+
+        $this->articles->comments->eventManager()->on(
+            'Model.beforeMarshal',
+            function ($e, $data) {
+                $data['comment'] .= ' (modified)';
+            });
+
+        $this->articles->tags->eventManager()->on(
+            'Model.beforeMarshal',
+            function ($e, $data) {
+                $data['tag'] .= ' (modified)';
+            });
+
+        $this->articles->tags->junction()->eventManager()->on(
+            'Model.beforeMarshal',
+            function ($e, $data) {
+                $data['modified_by'] = 1;
+            });
 
         $entity = $marshall->one($data, [
             'associated' => ['Users', 'Comments', 'Tags']


### PR DESCRIPTION
This was accidentally dropped in 3.2 because there were no tests around the required keys of the beforeMarshal event.

Refs #10247
