### PR TITLE
Revert Event::$_result to Event::$result.

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -53,7 +53,7 @@ class Event
      *
      * @var mixed
      */
-    protected $_result = null;
+    public $result = null;
 
     /**
      * Flags an event as stopped or not, default is false
@@ -99,7 +99,7 @@ class Event
             return $this->_data;
         }
         if ($attribute === 'result') {
-            return $this->_result;
+            return $this->result;
         }
     }
 
@@ -117,7 +117,7 @@ class Event
             $this->_data = (array)$value;
         }
         if ($attribute === 'result') {
-            $this->_result = $value;
+            $this->result = $value;
         }
     }
 
@@ -191,7 +191,7 @@ class Event
      */
     public function result()
     {
-        return $this->_result;
+        return $this->result;
     }
 
     /**
@@ -201,7 +201,7 @@ class Event
      */
     public function getResult()
     {
-        return $this->_result;
+        return $this->result;
     }
 
     /**
@@ -212,7 +212,7 @@ class Event
      */
     public function setResult($value = null)
     {
-        $this->_result = $value;
+        $this->result = $value;
 
         return $this;
     }

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -422,6 +422,7 @@ class EventManagerTest extends TestCase
             ->with($event);
         $manager->dispatch($event);
         $this->assertEquals('something special', $event->result());
+        $this->assertEquals('something special', $event->result);
     }
 
     /**


### PR DESCRIPTION
Removing the public property is a regression caused by #9376 which breaks existing apps/plugins.

Refs https://github.com/ADmad/CakePHP-HybridAuth/issues/94#issuecomment-281581244