### PR TITLE
Fix EntityTrait::__debugInfo doesn't show the actual accessible property

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1232,7 +1232,7 @@ trait EntityTrait
     {
         return $this->_properties + [
             '[new]' => $this->isNew(),
-            '[accessible]' => array_filter($this->_accessible),
+            '[accessible]' => $this->_accessible,
             '[dirty]' => $this->_dirty,
             '[original]' => $this->_original,
             '[virtual]' => $this->_virtual,

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1379,6 +1379,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(['foo' => 'bar'], ['markClean' => true]);
         $entity->somethingElse = 'value';
+        $entity->accessible('id', false);
         $entity->accessible('name', true);
         $entity->virtualProperties(['baz']);
         $entity->dirty('foo', true);
@@ -1390,7 +1391,7 @@ class EntityTest extends TestCase
             'foo' => 'bar',
             'somethingElse' => 'value',
             '[new]' => true,
-            '[accessible]' => ['*' => true, 'name' => true],
+            '[accessible]' => ['*' => true, 'id' => false, 'name' => true],
             '[dirty]' => ['somethingElse' => true, 'foo' => true],
             '[original]' => [],
             '[virtual]' => ['baz'],


### PR DESCRIPTION
If people baked some model, the accessible property of the entity class would be the follwoing:
```php
protected $_accessible = [
    '*' => true,
    'id' => false
];
```
However, since `EntityTrait::__debugInfo()` method filters `false` values in the property, people cannot retrieve the actual value by using `debug()`.
```
'[accessible]' => [
     '*' => true
],
```
I would like to fix this issue as it would confuse people.