### PR TITLE
Make sure id() also returns a non empty value for CLI faking.

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -310,6 +310,7 @@ class Session
 
         if ($this->_isCLI) {
             $_SESSION = [];
+            $this->id('cli');
 
             return $this->_started = true;
         }

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -287,14 +287,15 @@ class SessionTest extends TestCase
         $session = new Session();
         $result = $session->id();
         $expected = session_id();
-        $this->assertEquals($expected, $result);
+        $this->assertNotEmpty($result);
+        $this->assertSame($expected, $result);
 
         $session->id('MySessionId');
-        $this->assertEquals('MySessionId', $session->id());
-        $this->assertEquals('MySessionId', session_id());
+        $this->assertSame('MySessionId', $session->id());
+        $this->assertSame('MySessionId', session_id());
 
         $session->id('');
-        $this->assertEquals('', session_id());
+        $this->assertSame('', session_id());
     }
 
     /**


### PR DESCRIPTION
In CLI mode the session behaves conceptually problematic IMO.

If a controller internally requires a valid `$this->request->session->id()`, e.g. to hand off to model layer and persist it, it will fail with IntegrationTestCase right now, as it always returns an empty string. In my case the DB threw a constraint error because of the empty string going into a !allowEmpty entity patching.

But a started session should always have a valid non empty string set. 
One can't exist without the other. The ID can also be quite relevant in internal handling of business logic.

The integration test case as well as others relying on the similar behavior here as the web part should not have to deal with this low level implementation detail and sudden change of content IMO. Especially since the Session class provides this switch internally.

The alternative would be a 
`$session->id('testsuite')`  around here https://github.com/cakephp/cakephp/blob/master/src/TestSuite/IntegrationTestCase.php#L513

But this would just workaround the fact that a session in cli is not "faked" the way it probably should be -
In a consistent way.
What do you think?