### PR TITLE
Adds Table::deleteEach() method

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -17,6 +17,8 @@ namespace Cake\Datasource;
 /**
  * Describes the methods that any class representing a data storage should
  * comply with.
+ *
+ * @method int deleteEach($conditions, $options = []);
  */
 interface RepositoryInterface
 {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -985,12 +985,28 @@ class TableTest extends TestCase
      */
     public function testDeleteEach(array $options)
     {
-        $table = new Table([
-            'table' => 'users',
-            'connection' => $this->connection,
-        ]);
+        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
+
+        $beforeCount = 0;
+        $table->eventManager()->on('Model.beforeDeleteEach', function () use(&$beforeCount) {
+            $beforeCount++;
+        });
+
+        $afterCount = 0;
+        $table->eventManager()->on('Model.afterDeleteEach', function () use(&$afterCount) {
+            $afterCount++;
+        });
+
         $result = $table->deleteEach(['username !=' => 'mariano'], $options);
         $this->assertSame(3, $result);
+
+        if(isset($options['batch']) && $options['batch'] === 100) {
+            $this->assertSame(1, $beforeCount);
+            $this->assertSame(1, $afterCount);
+        } else {
+            $this->assertSame(3, $beforeCount);
+            $this->assertSame(3, $afterCount);
+        }
 
         $result = $table->find('all')->toArray();
         $this->assertCount(1, $result, 'Only one record should remain');
@@ -1016,10 +1032,7 @@ class TableTest extends TestCase
      */
     public function testDeleteEachInvalidArgument(array $invalidParams)
     {
-        $table = new Table([
-            'table' => 'users',
-            'connection' => $this->connection,
-        ]);
+        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
         $table->deleteEach(['username !=' => 'mariano'], $invalidParams);
     }
 
@@ -1028,10 +1041,15 @@ class TableTest extends TestCase
      */
     public function testDeleteEachFinder()
     {
-
-        $table = TableRegistry::get('articles');
-        $result = $table->deleteEach(['username !=' => 'mariano'], ['finder' => 'published']);
-        $this->assertSame(4, $result);
+        /**
+         * @var \TestApp\Model\Table\ArticlesTable $table
+         */
+        $table = TableRegistry::get('Articles');
+        $table->save(new Entity(['published' => 'N']));
+        $result = $table->deleteEach([1 => 1], ['finder' => 'published', 'batch' => 100]);
+        $this->assertSame(3, $result);
+        $this->assertSame(2, $table->finderCount);
+        $this->assertSame(1, $table->find()->count());
     }
 
     /**
@@ -1039,15 +1057,32 @@ class TableTest extends TestCase
      */
     public function testDeleteEachAtomic()
     {
+        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
 
+        $table->eventManager()->on('Model.afterDeleteEachCommit', function () {
+            $this->fail('afterDeleteEachCommit should not fire inside transaction');
+        });
+
+        $this->connection->begin();
+        $result = $table->deleteEach(['username !=' => 'mariano']);
+        $this->assertSame(4, $result);
+        $this->connection->commit();
     }
 
     /**
-     * Tests failure by having a rule block delete.
+     * Tests that event can stop deleting.
      */
-    public function testDeleteEachStopOnFailure()
+    public function testBeforeDeleteEachStopsDeleting()
     {
-
+        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
+        $called = false;
+        $table->eventManager()->on('Model.beforeDeleteEach', function (Event $event) use (&$called) {
+            $event->stopPropagation();
+            $called = true;
+        });
+        $result = $table->deleteEach([1 => 1]);
+        $this->assertSame(0, $result);
+        $this->assertTrue($called);
     }
 
     /**
@@ -1056,15 +1091,8 @@ class TableTest extends TestCase
      */
     public function testDeleteEachZeroBatch()
     {
-
-    }
-
-    /**
-     *
-     */
-    public function testDeleteEachCheckRules()
-    {
-
+        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
+        $table->deleteEach(['username !=' => 'mariano'], ['batch' => 0]);
     }
 
     /**
@@ -1788,6 +1816,10 @@ class TableTest extends TestCase
                 'afterSave',
                 'beforeDelete',
                 'afterDelete',
+                'afterDeleteCommit',
+                'beforeDeleteEach',
+                'afterDeleteEach',
+                'afterDeleteEachCommit',
                 'afterRules'
             ])
             ->getMock();
@@ -1799,6 +1831,10 @@ class TableTest extends TestCase
             'Model.beforeSave' => 'beforeSave',
             'Model.afterSave' => 'afterSave',
             'Model.beforeDelete' => 'beforeDelete',
+            'Model.afterDeleteCommit' => 'afterDeleteCommit',
+            'Model.beforeDeleteEach' => 'beforeDeleteEach',
+            'Model.afterDeleteEach' => 'afterDeleteEach',
+            'Model.afterDeleteEachCommit' => 'afterDeleteEachCommit',
             'Model.afterDelete' => 'afterDelete',
             'Model.afterRules' => 'afterRules',
         ];

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -964,6 +964,102 @@ class TableTest extends TestCase
         $table->deleteAll(['id >' => 4]);
     }
 
+
+    /**
+     * @return array
+     */
+    public function dataDeleteEach()
+    {
+        return [
+            [['batch' => 1]],
+            [['batch' => 100]],
+            [['atomic' => false]],
+            [['stopOnFailure' => false]],
+            [['checkRules' => false]]
+        ];
+    }
+
+    /**
+     * @dataProvider dataDeleteEach
+     * @param array $options
+     */
+    public function testDeleteEach(array $options) {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $result = $table->deleteEach(['username !=' => 'mariano'], $options);
+        $this->assertSame(3, $result);
+
+        $result = $table->find('all')->toArray();
+        $this->assertCount(1, $result, 'Only one record should remain');
+        $this->assertEquals('mariano', $result[0]['username']);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataDeleteEachInvalidArgument()
+    {
+        return [
+            [['limit' => 10]],
+            [['offset' => 10]],
+            [['page' => 10]]
+        ];
+    }
+
+    /**
+     * @param array $invalidParams
+     * @dataProvider dataDeleteEachInvalidArgument
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDeleteEachInvalidArgument(array $invalidParams) {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $table->deleteEach(['username !=' => 'mariano'], $invalidParams);
+    }
+
+    /**
+     *
+     */
+    public function testDeleteEachFinder() {
+
+        $table = TableRegistry::get('articles');
+        $result = $table->deleteEach(['username !=' => 'mariano'], ['finder' => 'published']);
+        $this->assertSame(4, $result);
+    }
+
+    /**
+     *
+     */
+    public function testDeleteEachAtomic() {
+
+    }
+
+    /**
+     * Tests failure by having a rule block delete.
+     */
+    public function testDeleteEachStopOnFailure() {
+
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid batch size: 0
+     */
+    public function testDeleteEachZeroBatch() {
+
+    }
+
+    /**
+     *
+     */
+    public function testDeleteEachCheckRules() {
+
+    }
+
     /**
      * Tests that array options are passed to the query object using applyOptions
      *

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -985,22 +985,22 @@ class TableTest extends TestCase
      */
     public function testDeleteEach(array $options)
     {
-        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
+        $table = new Table(['table' => 'users', 'connection' => $this->connection]);
 
         $beforeCount = 0;
-        $table->eventManager()->on('Model.beforeDeleteEach', function () use(&$beforeCount) {
+        $table->eventManager()->on('Model.beforeDeleteEach', function () use (&$beforeCount) {
             $beforeCount++;
         });
 
         $afterCount = 0;
-        $table->eventManager()->on('Model.afterDeleteEach', function () use(&$afterCount) {
+        $table->eventManager()->on('Model.afterDeleteEach', function () use (&$afterCount) {
             $afterCount++;
         });
 
         $result = $table->deleteEach(['username !=' => 'mariano'], $options);
         $this->assertSame(3, $result);
 
-        if(isset($options['batch']) && $options['batch'] === 100) {
+        if (isset($options['batch']) && $options['batch'] === 100) {
             $this->assertSame(1, $beforeCount);
             $this->assertSame(1, $afterCount);
         } else {
@@ -1032,18 +1032,17 @@ class TableTest extends TestCase
      */
     public function testDeleteEachInvalidArgument(array $invalidParams)
     {
-        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
+        $table = new Table(['table' => 'users', 'connection' => $this->connection]);
         $table->deleteEach(['username !=' => 'mariano'], $invalidParams);
     }
 
     /**
-     *
+     * @test
+     * @return void
      */
     public function testDeleteEachFinder()
     {
-        /**
-         * @var \TestApp\Model\Table\ArticlesTable $table
-         */
+        /* @var \TestApp\Model\Table\ArticlesTable $table */
         $table = TableRegistry::get('Articles');
         $table->save(new Entity(['published' => 'N']));
         $result = $table->deleteEach([1 => 1], ['finder' => 'published', 'batch' => 100]);
@@ -1053,11 +1052,12 @@ class TableTest extends TestCase
     }
 
     /**
-     *
+     * @test
+     * @return void
      */
     public function testDeleteEachAtomic()
     {
-        $table = new Table(['table' => 'users', 'connection' => $this->connection,]);
+        $table = new Table(['table' => 'users', 'connection' => $this->connection]);
 
         $table->eventManager()->on('Model.afterDeleteEachCommit', function () {
             $this->fail('afterDeleteEachCommit should not fire inside transaction');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -27,9 +27,9 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\I18n\Time;
-use Cake\ORM\AssociationCollection;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
+use Cake\ORM\AssociationCollection;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -983,7 +983,8 @@ class TableTest extends TestCase
      * @dataProvider dataDeleteEach
      * @param array $options
      */
-    public function testDeleteEach(array $options) {
+    public function testDeleteEach(array $options)
+    {
         $table = new Table([
             'table' => 'users',
             'connection' => $this->connection,
@@ -1013,7 +1014,8 @@ class TableTest extends TestCase
      * @dataProvider dataDeleteEachInvalidArgument
      * @expectedException \InvalidArgumentException
      */
-    public function testDeleteEachInvalidArgument(array $invalidParams) {
+    public function testDeleteEachInvalidArgument(array $invalidParams)
+    {
         $table = new Table([
             'table' => 'users',
             'connection' => $this->connection,
@@ -1024,7 +1026,8 @@ class TableTest extends TestCase
     /**
      *
      */
-    public function testDeleteEachFinder() {
+    public function testDeleteEachFinder()
+    {
 
         $table = TableRegistry::get('articles');
         $result = $table->deleteEach(['username !=' => 'mariano'], ['finder' => 'published']);
@@ -1034,14 +1037,16 @@ class TableTest extends TestCase
     /**
      *
      */
-    public function testDeleteEachAtomic() {
+    public function testDeleteEachAtomic()
+    {
 
     }
 
     /**
      * Tests failure by having a rule block delete.
      */
-    public function testDeleteEachStopOnFailure() {
+    public function testDeleteEachStopOnFailure()
+    {
 
     }
 
@@ -1049,14 +1054,16 @@ class TableTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid batch size: 0
      */
-    public function testDeleteEachZeroBatch() {
+    public function testDeleteEachZeroBatch()
+    {
 
     }
 
     /**
      *
      */
-    public function testDeleteEachCheckRules() {
+    public function testDeleteEachCheckRules()
+    {
 
     }
 

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -19,6 +19,12 @@ use Cake\ORM\Table;
  */
 class ArticlesTable extends Table
 {
+    /**
+     * Number of times finder method is executed.
+     *
+     * @var int
+     */
+    public $finderCount = 0;
 
     public function initialize(array $config)
     {
@@ -35,6 +41,7 @@ class ArticlesTable extends Table
      */
     public function findPublished($query)
     {
+        $this->finderCount++;
         return $query->where(['published' => 'Y']);
     }
 


### PR DESCRIPTION
closes #9727

- adds a new deleteEach method to the Table interface
- adds beforeDeleteEach  and afterDeleteEach events

moved from: https://github.com/cakephp/cakephp/pull/9774