### PR TITLE
Escape fields to avoid issues with reserved words

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1365,6 +1365,11 @@ class Query implements ExpressionInterface, IteratorAggregate
         if (empty($columns)) {
             throw new RuntimeException('At least 1 column is required to perform an insert.');
         }
+
+        foreach ($columns as &$column) {
+            $column = "`$column`";
+        }
+
         $this->_dirty();
         $this->_type = 'insert';
         $this->_parts['insert'][1] = $columns;


### PR DESCRIPTION
Tests fail to import fixtures structure when a table has a field named with a keyword. This happens because Cake doesn't properly escape field's names. This commit fixes this thing.