### PR TITLE
ObjectRegistry: Trigger an error if trying to unload an unknown object

### DIFF
--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -60,6 +60,7 @@ class HelperRegistry extends ObjectRegistry
      * Throws an exception when a helper is missing.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
+     * and Cake\Core\ObjectRegistry::unload()
      *
      * @param string $class The classname that is missing.
      * @param string $plugin The plugin the helper is missing in.

--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -59,6 +59,7 @@ class TaskRegistry extends ObjectRegistry
      * Throws an exception when a task is missing.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
+     * and Cake\Core\ObjectRegistry::unload()
      *
      * @param string $class The classname that is missing.
      * @param string $plugin The plugin the task is missing in.

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -88,6 +88,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * Throws an exception when a component is missing.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
+     * and Cake\Core\ObjectRegistry::unload()
      *
      * @param string $class The classname that is missing.
      * @param string $plugin The plugin the component is missing in.

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -285,7 +285,7 @@ abstract class ObjectRegistry
     {
         list(, $name) = pluginSplit($objectName);
 
-        // Just call unload if the object was loaded before */
+        // Just call unload if the object was loaded before
         if (array_key_exists($objectName, $this->_loaded)) {
             $this->unload($objectName);
         }
@@ -306,17 +306,8 @@ abstract class ObjectRegistry
     public function unload($objectName)
     {
         if (empty($this->_loaded[$objectName])) {
-            $additionalInfo = '';
-            if (strpos($objectName, '.') !== false) {
-                $additionalInfo = ' Remember to omit plugin prefixes.';
-            }
-            trigger_error(sprintf(
-                'Object "%s" was not loaded before.%s',
-                $objectName,
-                $additionalInfo
-            ), E_USER_WARNING);
-
-            return;
+            list($plugin, $objectName) = pluginSplit($objectName);
+            $this->_throwMissingClassError($objectName, $plugin);
         }
 
         $object = $this->_loaded[$objectName];

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -100,6 +100,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * Throws an exception when a behavior is missing.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
+     * and Cake\Core\ObjectRegistry::unload()
      *
      * @param string $class The classname that is missing.
      * @param string $plugin The plugin the behavior is missing in.

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -115,6 +115,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * Throws an exception when a helper is missing.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
+     * and Cake\Core\ObjectRegistry::unload()
      *
      * @param string $class The classname that is missing.
      * @param string $plugin The plugin the helper is missing in.

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -209,6 +209,36 @@ class ComponentRegistryTest extends TestCase
     }
 
     /**
+     * Test that unloading a none existing component triggers an error.
+     *
+     * This should produce an "Object "Foo" was not loaded before." error
+     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     *
+     * @expectedException \PHPUnit\Framework\Error\Error
+     * @expectedExceptionMessage Object "Foo" was not loaded before.
+     * @return void
+     */
+    public function testUnloadUnknown()
+    {
+        $this->Components->unload('Foo');
+    }
+
+    /**
+     * Test that unloading a none existing plugin component triggers an error.
+     *
+     * This should produce an "Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes." error
+     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     *
+     * @expectedException \PHPUnit\Framework\Error\Error
+     * @expectedExceptionMessage Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes.
+     * @return void
+     */
+    public function testUnloadUnknownPluginComponent()
+    {
+        $this->Components->unload('Plugin.Foo');
+    }
+
+    /**
      * Test set.
      *
      * @return void

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -211,31 +211,13 @@ class ComponentRegistryTest extends TestCase
     /**
      * Test that unloading a none existing component triggers an error.
      *
-     * This should produce an "Object "Foo" was not loaded before." error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Object "Foo" was not loaded before.
+     * @expectedException \Cake\Controller\Exception\MissingComponentException
+     * @expectedExceptionMessage Component class FooComponent could not be found.
      * @return void
      */
     public function testUnloadUnknown()
     {
         $this->Components->unload('Foo');
-    }
-
-    /**
-     * Test that unloading a none existing plugin component triggers an error.
-     *
-     * This should produce an "Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes." error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes.
-     * @return void
-     */
-    public function testUnloadUnknownPluginComponent()
-    {
-        $this->Components->unload('Plugin.Foo');
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -365,31 +365,27 @@ class BehaviorRegistryTest extends TestCase
     /**
      * Test that unloading a none existing behavior triggers an error.
      *
-     * This should produce an "Behavior "Foo" was not loaded before." error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     * @return void
+     */
+    public function testUnload()
+    {
+        $this->Behaviors->load('Sluggable');
+        $this->Behaviors->unload('Sluggable');
+
+        $this->assertEmpty($this->Behaviors->loaded());
+        $this->assertCount(0, $this->EventManager->listeners('Model.beforeFind'));
+    }
+
+    /**
+     * Test that unloading a none existing behavior triggers an error.
      *
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Object "Foo" was not loaded before.
+     * @expectedException \Cake\ORM\Exception\MissingBehaviorException
+     * @expectedExceptionMessage Behavior class FooBehavior could not be found.
      * @return void
      */
     public function testUnloadUnknown()
     {
         $this->Behaviors->unload('Foo');
-    }
-
-    /**
-     * Test that unloading a none existing plugin behavior triggers an error.
-     *
-     * This should produce an "Behavior "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes." error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes.
-     * @return void
-     */
-    public function testUnloadUnknownPluginBehavior()
-    {
-        $this->Behaviors->unload('Plugin.Foo');
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -363,6 +363,36 @@ class BehaviorRegistryTest extends TestCase
     }
 
     /**
+     * Test that unloading a none existing behavior triggers an error.
+     *
+     * This should produce an "Behavior "Foo" was not loaded before." error
+     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     *
+     * @expectedException \PHPUnit\Framework\Error\Error
+     * @expectedExceptionMessage Object "Foo" was not loaded before.
+     * @return void
+     */
+    public function testUnloadUnknown()
+    {
+        $this->Behaviors->unload('Foo');
+    }
+
+    /**
+     * Test that unloading a none existing plugin behavior triggers an error.
+     *
+     * This should produce an "Behavior "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes." error
+     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     *
+     * @expectedException \PHPUnit\Framework\Error\Error
+     * @expectedExceptionMessage Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes.
+     * @return void
+     */
+    public function testUnloadUnknownPluginBehavior()
+    {
+        $this->Behaviors->unload('Plugin.Foo');
+    }
+
+    /**
      * Test setTable() method.
      *
      * @return void

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -274,6 +274,36 @@ class HelperRegistryTest extends TestCase
     }
 
     /**
+     * Test that unloading a none existing helper triggers an error.
+     *
+     * This should produce an "Object "Foo" was not loaded before." error
+     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     *
+     * @expectedException \PHPUnit\Framework\Error\Error
+     * @expectedExceptionMessage Object "Foo" was not loaded before.
+     * @return void
+     */
+    public function testUnloadUnknown()
+    {
+        $this->Helpers->unload('Foo');
+    }
+
+    /**
+     * Test that unloading a none existing plugin helper triggers an error.
+     *
+     * This should produce an "Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes." error
+     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
+     *
+     * @expectedException \PHPUnit\Framework\Error\Error
+     * @expectedExceptionMessage Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes.
+     * @return void
+     */
+    public function testUnloadUnknownPluginHelper()
+    {
+        $this->Helpers->unload('Plugin.Foo');
+    }
+
+    /**
      * Loading a helper with no config should "just work"
      *
      * The addToAssertionCount call is to record that no exception was thrown

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -276,31 +276,13 @@ class HelperRegistryTest extends TestCase
     /**
      * Test that unloading a none existing helper triggers an error.
      *
-     * This should produce an "Object "Foo" was not loaded before." error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Object "Foo" was not loaded before.
+     * @expectedException \Cake\View\Exception\MissingHelperException
+     * @expectedExceptionMessage Helper class FooHelper could not be found.
      * @return void
      */
     public function testUnloadUnknown()
     {
         $this->Helpers->unload('Foo');
-    }
-
-    /**
-     * Test that unloading a none existing plugin helper triggers an error.
-     *
-     * This should produce an "Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes." error
-     * which gets thrown as a \PHPUnit\Framework\Error\Error Exception by PHPUnit.
-     *
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Object "Plugin.Foo" was not loaded before. Remember to omit plugin prefixes.
-     * @return void
-     */
-    public function testUnloadUnknownPluginHelper()
-    {
-        $this->Helpers->unload('Plugin.Foo');
     }
 
     /**


### PR DESCRIPTION
This provides a better indication when trying to unload unloaded behaviors, instead of just returning `void`.
I also added a case, when trying to unload a plugin behavior.

Doing this directly inside the `ObjectRegistry` would have caused many breaking tests, as for example, `ObjectRegistry::set()` calls `ObjectRegistry::unload()`.

We can maybe expand this to other child classes of the `ObjectRegistry`, like `ComponentRegistry` and `HelperRegistry`.
