### PR TITLE
Dropdown select limit (view limit) option for Paginator

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1189,7 +1189,7 @@ class PaginatorHelper extends Helper
         }
 
         if (empty($limits)) {
-            $limits += array('0'=>__('All'), '20' => '20', '50' => '50', '100' => '100');
+            $limits += array('0' => __('All'), '20' => '20', '50' => '50', '100' => '100');
         }
 
         if (!in_array($default, $limits)) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1189,7 +1189,7 @@ class PaginatorHelper extends Helper
         }
 
         if (empty($limits)) {
-            $limits += array('0'=>__('All'), '20' => '20', '50' => '50', '100' => '100');
+            $limits += array('0' =>__('All'), '20' => '20', '50' => '50', '100' => '100');
         }
 
         if (!in_array($default, $limits)) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1189,7 +1189,7 @@ class PaginatorHelper extends Helper
         }
 
         if (empty($limits)) {
-            $limits += array('0' => __('All'), '20' => '20', '50' => '50', '100' => '100');
+            $limits += ['0' => __('All'), '20' => '20', '50' => '50', '100' => '100'];
         }
 
         if (!in_array($default, $limits)) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1172,7 +1172,8 @@ class PaginatorHelper extends Helper
     }
 
     /**
-     * Dropdown select for pagination limit
+     * Dropdown select for pagination limit.
+     * This will generate a wrapping form.
      *
      * @param array $limits The options array.
      * @param int|null $default Default option for pagination limit. Defaults to `$this->param('perPage')`.

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1189,7 +1189,7 @@ class PaginatorHelper extends Helper
         }
 
         if (empty($limits)) {
-            $limits += [20 => '20', 25 => '25', 50 => '50', 100 => '100'];
+            $limits += array(''=>__('All'), '20' => '20', '50' => '50', '100' => '100');
         }
 
         if (!in_array($default, $limits)) {
@@ -1198,7 +1198,7 @@ class PaginatorHelper extends Helper
 
         ksort($limits);
 
-        $out .= $this->Form->control('limit', ($options + ['type' => 'select', 'label' => __("View"), 'value' => $default, 'options' => $limits, 'onChange' => 'this.form.submit()']));
+        $out .= $this->Form->control('limit', ($options + ['type' => 'select', 'label' => __('View'), 'value' => $default, 'options' => $limits, 'onChange' => 'this.form.submit()']));
         $out .= $this->Form->end();
 
         return $out;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1172,12 +1172,11 @@ class PaginatorHelper extends Helper
     }
 
     /**
-     * dropdown array for Select limit
+     * Dropdown select for pagination limit
      *
-     * @param array $limits This is array of options.
-     * @param int|null $default Default limit for option selecting. Default value is $this->param('perPage').
+     * @param array $limits The options array.
+     * @param int|null $default Default option for pagination limit. Defaults to `$this->param('perPage')`.
      * @param array $options Options for Select tag attributes like class, id or event
-     *
      * @return string html output.
      */
     public function limitControl(array $limits = [], $default = null, array $options = [])
@@ -1196,13 +1195,13 @@ class PaginatorHelper extends Helper
             ];
         }
 
-        if (!in_array($default, $limits)) {
-            $limits += [$default => $default];
-        }
-
-        ksort($limits);
-
-        $out .= $this->Form->control('limit', ($options + ['type' => 'select', 'label' => __('View'), 'value' => $default, 'options' => $limits, 'onChange' => 'this.form.submit()']));
+        $out .= $this->Form->control('limit', $options + [
+                'type' => 'select',
+                'label' => __('View'),
+                'value' => $default,
+                'options' => $limits,
+                'onChange' => 'this.form.submit()'
+            ]);
         $out .= $this->Form->end();
 
         return $out;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1189,7 +1189,11 @@ class PaginatorHelper extends Helper
         }
 
         if (empty($limits)) {
-            $limits += ['0' => __('All'), '20' => '20', '50' => '50', '100' => '100'];
+            $limits = [
+                '20' => '20',
+                '50' => '50',
+                '100' => '100'
+            ];
         }
 
         if (!in_array($default, $limits)) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1189,7 +1189,7 @@ class PaginatorHelper extends Helper
         }
 
         if (empty($limits)) {
-            $limits += array(''=>__('All'), '20' => '20', '50' => '50', '100' => '100');
+            $limits += array('0'=>__('All'), '20' => '20', '50' => '50', '100' => '100');
         }
 
         if (!in_array($default, $limits)) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -28,6 +28,7 @@ use Cake\View\View;
  * @property \Cake\View\Helper\UrlHelper $Url
  * @property \Cake\View\Helper\NumberHelper $Number
  * @property \Cake\View\Helper\HtmlHelper $Html
+ * @property \Cake\View\Helper\FormHelper $Form
  * @link http://book.cakephp.org/3.0/en/views/helpers/paginator.html
  */
 class PaginatorHelper extends Helper
@@ -40,7 +41,7 @@ class PaginatorHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Url', 'Number', 'Html'];
+    public $helpers = ['Url', 'Number', 'Html', 'Form'];
 
     /**
      * Default config for this class
@@ -1168,5 +1169,38 @@ class PaginatorHelper extends Helper
     public function implementedEvents()
     {
         return [];
+    }
+
+    /**
+     * dropdown array for Select limit
+     *
+     * @param array $limits This is array of options.
+     * @param int|null $default Default limit for option selecting. Default value is $this->param('perPage').
+     * @param array $options Options for Select tag attributes like class, id or event
+     *
+     * @return string html output.
+     */
+    public function limitControl(array $limits = [], $default = null, array $options = [])
+    {
+        $out = $this->Form->create(null, ['type' => 'get']);
+
+        if (empty($default) || !is_numeric($default)) {
+            $default = $this->param('perPage');
+        }
+
+        if (empty($limits)) {
+            $limits += [20 => '20', 25 => '25', 50 => '50', 100 => '100'];
+        }
+
+        if (!in_array($default, $limits)) {
+            $limits += [$default => $default];
+        }
+
+        ksort($limits);
+
+        $out .= $this->Form->control('limit', ($options + ['type' => 'select', 'label' => __("View"), 'value' => $default, 'options' => $limits, 'onChange' => 'this.form.submit()']));
+        $out .= $this->Form->end();
+
+        return $out;
     }
 }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2562,8 +2562,6 @@ class PaginatorHelperTest extends TestCase
             'View',
             '/label',
             ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()']],
-            ['option' => ['value' => '']],
-            '/option',
             ['option' => ['value' => '1']],
             '1',
             '/option',
@@ -2581,8 +2579,6 @@ class PaginatorHelperTest extends TestCase
             'View',
             '/label',
             ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()', 'class' => 'form-control']],
-            ['option' => ['value' => '']],
-            '/option',
             ['option' => ['value' => '1']],
             '1',
             '/option',
@@ -2603,8 +2599,29 @@ class PaginatorHelperTest extends TestCase
             'View',
             '/label',
             ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()', 'class' => 'form-control']],
-            ['option' => ['value' => '']],
+            ['option' => ['value' => '20']],
+            '20',
             '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            ['option' => ['value' => '100']],
+            '100',
+            '/option',
+            '/select',
+            '/div',
+            '/form'
+        ];
+        $this->assertHtml($expected, $out);
+
+        $out = $this->Paginator->limitControl();
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()']],
             ['option' => ['value' => '20']],
             '20',
             '/option',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2594,5 +2594,30 @@ class PaginatorHelperTest extends TestCase
             '/form'
         ];
         $this->assertHtml($expected, $out);
+
+        $out = $this->Paginator->limitControl([], null, ['class' => 'form-control']);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()', 'class' => 'form-control']],
+            ['option' => ['value' => '']],
+            '/option',
+            ['option' => ['value' => '20']],
+            '20',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            ['option' => ['value' => '100']],
+            '100',
+            '/option',
+            '/select',
+            '/div',
+            '/form'
+        ];
+        $this->assertHtml($expected, $out);
     }
 }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2546,4 +2546,53 @@ class PaginatorHelperTest extends TestCase
 
         $this->assertSame($expected, $this->View->fetch('meta'));
     }
+
+    /**
+     * test the limitControl() method
+     *
+     * @return void
+     */
+    public function testLimitControl()
+    {
+        $out = $this->Paginator->limitControl([1 => 1]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()']],
+            ['option' => ['value' => '']],
+            '/option',
+            ['option' => ['value' => '1']],
+            '1',
+            '/option',
+            '/select',
+            '/div',
+            '/form'
+        ];
+        $this->assertHtml($expected, $out);
+
+        $out = $this->Paginator->limitControl([1 => 1, 5 => 5], null, ['class' => 'form-control']);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()', 'class' => 'form-control']],
+            ['option' => ['value' => '']],
+            '/option',
+            ['option' => ['value' => '1']],
+            '1',
+            '/option',
+            ['option' => ['value' => '5']],
+            '5',
+            '/option',
+            '/select',
+            '/div',
+            '/form'
+        ];
+        $this->assertHtml($expected, $out);
+    }
 }


### PR DESCRIPTION
Dropdown array for Select limit

@param array $limits This is array of options.
@param int|null $default Default limit for option selecting. Default value is $this->param('perPage').
@param array $options Options for Select tag attributes like class, id or event
@return string html output.

This will help to show by data limit for per page without writing extra code, just add following code will give you below image output.

`$this->Paginator->limitControl()`

<img width="109" alt="limit_control" src="https://cloud.githubusercontent.com/assets/4234756/23317055/1d6b9200-faf7-11e6-9b78-78c90c8f8971.png">

Also override select tag attribute can be possible by passing $options.

Thank you