### PR TITLE
The $showHtml argument of the dd function was not used

### DIFF
--- a/src/basics.php
+++ b/src/basics.php
@@ -121,24 +121,20 @@ if (!function_exists('dd')) {
      *
      * @param mixed $var Variable to show debug information for.
      * @param bool|null $showHtml If set to true, the method prints the debug data in a browser-friendly way.
-     * @param bool $showFrom If set to true, the method prints from where the function was called.
      * @return void
      * @link http://book.cakephp.org/3.0/en/development/debugging.html#basic-debugging
      */
-    function dd($var, $showHtml = null, $showFrom = true)
+    function dd($var, $showHtml = null)
     {
         if (!Configure::read('debug')) {
             return;
         }
 
-        $location = [];
-        if ($showFrom) {
-            $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
-            $location = [
-                'line' => $trace[0]['line'],
-                'file' => $trace[0]['file']
-            ];
-        }
+        $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
+        $location = [
+            'line' => $trace[0]['line'],
+            'file' => $trace[0]['file']
+        ];
 
         Debugger::printVar($var, $location, $showHtml);
         die(1);

--- a/src/basics.php
+++ b/src/basics.php
@@ -121,22 +121,26 @@ if (!function_exists('dd')) {
      *
      * @param mixed $var Variable to show debug information for.
      * @param bool|null $showHtml If set to true, the method prints the debug data in a browser-friendly way.
+     * @param bool $showFrom If set to true, the method prints from where the function was called.
      * @return void
      * @link http://book.cakephp.org/3.0/en/development/debugging.html#basic-debugging
      */
-    function dd($var, $showHtml = null)
+    function dd($var, $showHtml = null, $showFrom = true)
     {
         if (!Configure::read('debug')) {
             return;
         }
 
-        $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
-        $location = [
-            'line' => $trace[0]['line'],
-            'file' => $trace[0]['file']
-        ];
+        $location = [];
+        if ($showFrom) {
+            $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
+            $location = [
+                'line' => $trace[0]['line'],
+                'file' => $trace[0]['file']
+            ];
+        }
 
-        Debugger::printVar($var, $location);
+        Debugger::printVar($var, $location, $showHtml);
         die(1);
     }
 }


### PR DESCRIPTION
This is a bug fix ~~and feature enhancement~~ for dd()

* CakePHP Version: 3.4.2

* The `$showHtml` argument of the dd function was not used.
* ~~I added the `$showFrom` argument because I expect the same behavior as the debug function except that the program terminates when I use the dd function.~~ 
* I couldn't invalidate `die()`, so I can not write a unit test. (But, `BasicsTest.php` is passed.)