### PR TITLE
Fix bug in returning integer code in CLI.

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -186,6 +186,9 @@ class ShellDispatcher
         if ($result === null || $result === true) {
             return Shell::CODE_SUCCESS;
         }
+        if (is_int($result)) {
+            return $result;
+        }
 
         return Shell::CODE_ERROR;
     }

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -238,7 +238,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['mock_without_main', 'initdb'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(Shell::CODE_SUCCESS, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -248,6 +248,8 @@ class ShellDispatcherTest extends TestCase
      */
     public function testDispatchShellWithCustomIntegerCodes()
     {
+        $customErrorCode = 3;
+
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->setMethods(['findShell'])
             ->getMock();
@@ -256,7 +258,7 @@ class ShellDispatcherTest extends TestCase
         $Shell->expects($this->once())->method('initialize');
         $Shell->expects($this->once())->method('runCommand')
             ->with(['initdb'])
-            ->will($this->returnValue(3));
+            ->will($this->returnValue($customErrorCode));
 
         $dispatcher->expects($this->any())
             ->method('findShell')
@@ -265,7 +267,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['mock_without_main', 'initdb'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(3, $result);
+        $this->assertSame($customErrorCode, $result);
     }
 
     /**
@@ -292,7 +294,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['mock_without_main', 'initdb'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(Shell::CODE_SUCCESS, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -319,7 +321,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['example'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(Shell::CODE_SUCCESS, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -346,7 +348,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['Example'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(Shell::CODE_SUCCESS, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
     }
 
     /**
@@ -373,7 +375,7 @@ class ShellDispatcherTest extends TestCase
 
         $dispatcher->args = ['sample'];
         $result = $dispatcher->dispatch();
-        $this->assertEquals(Shell::CODE_SUCCESS, $result);
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
     }
 
     /**

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -215,6 +215,60 @@ class ShellDispatcherTest extends TestCase
     }
 
     /**
+     * Verifies correct dispatch of Shell subclasses with integer exit codes.
+     *
+     * @return void
+     */
+    public function testDispatchShellWithIntegerSuccessCode()
+    {
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell'])
+            ->getMock();
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
+
+        $Shell->expects($this->once())->method('initialize');
+        $Shell->expects($this->once())->method('runCommand')
+            ->with(['initdb'])
+            ->will($this->returnValue(Shell::CODE_SUCCESS));
+
+        $dispatcher->expects($this->any())
+            ->method('findShell')
+            ->with('mock_without_main')
+            ->will($this->returnValue($Shell));
+
+        $dispatcher->args = ['mock_without_main', 'initdb'];
+        $result = $dispatcher->dispatch();
+        $this->assertEquals(Shell::CODE_SUCCESS, $result);
+    }
+
+    /**
+     * Verifies correct dispatch of Shell subclasses with custom integer exit codes.
+     *
+     * @return void
+     */
+    public function testDispatchShellWithCustomIntegerCodes()
+    {
+        $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
+            ->setMethods(['findShell'])
+            ->getMock();
+        $Shell = $this->getMockBuilder('Cake\Console\Shell')->getMock();
+
+        $Shell->expects($this->once())->method('initialize');
+        $Shell->expects($this->once())->method('runCommand')
+            ->with(['initdb'])
+            ->will($this->returnValue(3));
+
+        $dispatcher->expects($this->any())
+            ->method('findShell')
+            ->with('mock_without_main')
+            ->will($this->returnValue($Shell));
+
+        $dispatcher->args = ['mock_without_main', 'initdb'];
+        $result = $dispatcher->dispatch();
+        $this->assertEquals(3, $result);
+    }
+
+    /**
      * Verify correct dispatch of Shell subclasses without a main method
      *
      * @return void


### PR DESCRIPTION
According to the documentation and doc blocks one is allowed to return either nothing (success) true/false which will become 0/1 or simply the own integer code.
I was wondering why my shell always returned error code "1" on success (using `echo $?`).

My code in my shell command method:

    return count($errors) ? self::CODE_ERROR : self::CODE_SUCCESS;

It turns out that if you returned 0 or 1 those so far got ignored, and always 1 (error) is then outputted.

We must allow all integers, but especially 0 (success), to be passed up when returned from the shell method. Imagine, I wanted to have error code 3 or 4. That would currently also being ignored.
