### PR TITLE
Allow run integration tests from any directory

### DIFF
--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -63,7 +63,7 @@ class MiddlewareDispatcher
     {
         $this->_test = $test;
         $this->_class = $class ?: Configure::read('App.namespace') . '\Application';
-        $this->_constructorArgs = $constructorArgs ?: ['./config'];
+        $this->_constructorArgs = $constructorArgs ?: [CONFIG];
     }
 
     /**


### PR DESCRIPTION
If `phpunit` started from non root directory, integration tests fails with `Warning Error: require_once(./config/bootstrap.php): failed to open stream: No such file or directory in [/path/to/myapp/vendor/cakephp/cakephp/src/Http/BaseApplication.php, line 61]`.

`CONFIG` const is absolute path, so not dependent on working directory.