### PR TITLE
3.next Update cascadeDelete to not use a trait

### DIFF
--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
+ * @since         3.5.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\ORM\Association;

--- a/src/ORM/Association/DependentDeleteTrait.php
+++ b/src/ORM/Association/DependentDeleteTrait.php
@@ -39,6 +39,7 @@ trait DependentDeleteTrait
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
         $helper = new DependentDeleteHelper();
+
         return $helper->cascadeDelete($this, $entity, $options);
     }
 }

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -661,6 +661,7 @@ class HasMany extends Association
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
         $helper = new DependentDeleteHelper();
+
         return $helper->cascadeDelete($this, $entity, $options);
     }
 }

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -20,6 +20,7 @@ use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
+use Cake\ORM\Association\DependentDeleteHelper;
 use Cake\ORM\Association\Loader\SelectLoader;
 use Cake\ORM\Table;
 use InvalidArgumentException;
@@ -33,8 +34,6 @@ use Traversable;
  */
 class HasMany extends Association
 {
-
-    use DependentDeleteTrait;
 
     /**
      * Order in which target records should be returned
@@ -654,5 +653,14 @@ class HasMany extends Association
         ]);
 
         return $loader->buildEagerLoader($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function cascadeDelete(EntityInterface $entity, array $options = [])
+    {
+        $helper = new DependentDeleteHelper();
+        return $helper->cascadeDelete($this, $entity, $options);
     }
 }

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -16,6 +16,7 @@ namespace Cake\ORM\Association;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
+use Cake\ORM\Association\DependentDeleteHelper;
 use Cake\ORM\Association\Loader\SelectLoader;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
@@ -28,9 +29,6 @@ use Cake\Utility\Inflector;
  */
 class HasOne extends Association
 {
-
-    use DependentDeleteTrait;
-
     /**
      * Valid strategies for this type of association
      *
@@ -144,5 +142,14 @@ class HasOne extends Association
         ]);
 
         return $loader->buildEagerLoader($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function cascadeDelete(EntityInterface $entity, array $options = [])
+    {
+        $helper = new DependentDeleteHelper();
+        return $helper->cascadeDelete($this, $entity, $options);
     }
 }

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -150,6 +150,7 @@ class HasOne extends Association
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
         $helper = new DependentDeleteHelper();
+
         return $helper->cascadeDelete($this, $entity, $options);
     }
 }

--- a/tests/Fixture/ProfilesFixture.php
+++ b/tests/Fixture/ProfilesFixture.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * ProfileFixture
+ */
+class ProfilesFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'user_id' => ['type' => 'integer', 'null' => false],
+        'first_name' => ['type' => 'string', 'null' => true],
+        'last_name' => ['type' => 'string', 'null' => true],
+        'is_active' => ['type' => 'boolean', 'null' => false, 'default' => true],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'user_idx' => [
+                'type' => 'foreign',
+                'columns' => ['user_id'],
+                'references' => ['users', 'id']
+            ]
+        ]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['user_id' => 1, 'first_name' => 'mariano', 'last_name' => 'iglesias', 'is_active' => false],
+        ['user_id' => 2, 'first_name' => 'nate', 'last_name' => 'abele', 'is_active' => false],
+        ['user_id' => 3, 'first_name' => 'larry', 'last_name' => 'masters', 'is_active' => true],
+        ['user_id' => 4, 'first_name' => 'garrett', 'last_name' => 'woodworth', 'is_active' => false],
+    ];
+}

--- a/tests/Fixture/ProfilesFixture.php
+++ b/tests/Fixture/ProfilesFixture.php
@@ -35,11 +35,6 @@ class ProfilesFixture extends TestFixture
         'is_active' => ['type' => 'boolean', 'null' => false, 'default' => true],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'user_idx' => [
-                'type' => 'foreign',
-                'columns' => ['user_id'],
-                'references' => ['users', 'id']
-            ]
         ]
     ];
 

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -284,7 +284,7 @@ class HasOneTest extends TestCase
         $query = $this->user->query();
 
         $this->listenerCalled = false;
-        $this->profile->eventManager()->on('Model.beforeFind', function($event, $query, $options, $primary) {
+        $this->profile->eventManager()->on('Model.beforeFind', function ($event, $query, $options, $primary) {
             $this->listenerCalled = true;
             $this->assertInstanceOf('\Cake\Event\Event', $event);
             $this->assertInstanceOf('\Cake\ORM\Query', $query);
@@ -313,13 +313,14 @@ class HasOneTest extends TestCase
         $opts = new \ArrayObject(['something' => 'more']);
         $this->profile->eventManager()->on(
             'Model.beforeFind',
-            function ($event, $query, $options, $primary) use ($opts)  {
+            function ($event, $query, $options, $primary) use ($opts) {
                 $this->listenerCalled = true;
                 $this->assertInstanceOf('\Cake\Event\Event', $event);
                 $this->assertInstanceOf('\Cake\ORM\Query', $query);
                 $this->assertEquals($options, $opts);
                 $this->assertFalse($primary);
-            });
+            }
+        );
         $association = new HasOne('Profiles', $config);
         $query = $this->user->find();
         $association->attachTo($query, ['queryBuilder' => function ($q) {


### PR DESCRIPTION
We went a bit overboard with traits in the ORM early on. This deprecates another trait from the Association classes. I've also updated the tests to contain more integration style tests and fewer mock dependent tests. I think the coverage should stay the same but we'll have higher confidence that the code actually works as real queries are used now.