### PR TITLE
Adding a json exception test case

### DIFF
--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -437,16 +437,13 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(404);
 
         $result = $ExceptionRenderer->render()->body();
+        $expected = [
+            'message' => 'Custom message',
+            'url' => '/posts/view/1000?sort=title&amp;direction=desc',
+            'code' => 404
+        ];
 
-        $expected = <<<JSON
-{
-    "message": "Custom message",
-    "url": "\\/posts\\/view\\/1000?sort=title\\u0026amp;direction=desc",
-    "code": 404
-}
-JSON;
-
-        $this->assertTextEquals($expected, $result);
+        $this->assertEquals($expected, json_decode($result, true));
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -416,6 +416,40 @@ class ExceptionRendererTest extends TestCase
     }
 
     /**
+     * testerror400 method when returning as json
+     *
+     * @return void
+     */
+    public function testError400AsJson()
+    {
+        Router::reload();
+
+        $request = new Request('posts/view/1000?sort=title&direction=desc');
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('Content-Type', 'application/json');
+        Router::setRequestInfo($request);
+
+        $exception = new NotFoundException('Custom message');
+        $ExceptionRenderer = new ExceptionRenderer($exception);
+        $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
+            ->setMethods(['statusCode', '_sendHeader'])
+            ->getMock();
+        $ExceptionRenderer->controller->response->expects($this->once())->method('statusCode')->with(404);
+
+        $result = $ExceptionRenderer->render()->body();
+
+        $expected = <<<JSON
+{
+    "message": "Custom message",
+    "url": "\\/posts\\/view\\/1000?sort=title\\u0026amp;direction=desc",
+    "code": 404
+}
+JSON;
+
+        $this->assertTextEquals($expected, $result);
+    }
+
+    /**
      * test that error400 only modifies the messages on Cake Exceptions.
      *
      * @return void


### PR DESCRIPTION
Added a test case of rendering an exception as json to ensure the returned url is correct.

I encountered a situation in my application where my json errors were including the url inside the query component. Such as the following,

```json
    "error": {
      "message": "Not Found",
      "url": "/api/v4/packages/home?/api/v4/packages/home&site_id=4&page=125"
    }
```

I started by checking the `ServerRequest` to make sure that the request was being created properly, due to the `ExceptionRenderer` calling `ServerRequest::getRequestTarget()` to get it's url. However when I checked for a test case there wasn't one.

I've created this test case, to check for this possible regression. However this test case passes, so my issue must be in my application, but worth contributing the test case anyway.

Hope it's helpful, even if it creates a minor cross over between ExceptionRenderer and ServerRequest in the tests.