### PR TITLE
remove lib-ICU requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "lib-ICU": ">=4.8",
         "ext-intl": "*",
         "ext-mbstring": "*",
         "cakephp/chronos": "~1.0",
@@ -28,7 +27,8 @@
         "zendframework/zend-diactoros": "~1.0"
     },
     "suggest": {
-        "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation."
+        "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",
+        "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",

--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "cakephp/core": "~3.0",
-        "lib-ICU": ">=4.8",
         "ext-intl": "*",
         "cakephp/chronos": "*",
         "aura/intl": "^3.0.0"

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "suggest": {
-      "ext-intl": "To use Text::transliterate() or Text::slug()"
+      "ext-intl": "To use Text::transliterate() or Text::slug()",
+      "lib-ICU": "To use Text::transliterate() or Text::slug()"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As it causes pain for users to install CakePHP and is only used in very few part of the framework where a warning will be thrown .
Ref https://github.com/cakephp/cakephp/issues/9697
