### PR TITLE
Fix parsing bool values out of route shell.

### DIFF
--- a/src/Shell/RoutesShell.php
+++ b/src/Shell/RoutesShell.php
@@ -137,6 +137,9 @@ class RoutesShell extends Shell
         foreach ($args as $arg) {
             if (strpos($arg, ':') !== false) {
                 list($key, $value) = explode(':', $arg);
+                if (in_array($value, ['true', 'false'])) {
+                    $value = $value === 'true' ? true : false;
+                }
                 $out[$key] = $value;
             } else {
                 $out[] = $arg;

--- a/tests/TestCase/Shell/RoutesShellTest.php
+++ b/tests/TestCase/Shell/RoutesShellTest.php
@@ -174,6 +174,23 @@ class RoutesShellTest extends TestCase
     }
 
     /**
+     * Test generating URLs with bool params
+     *
+     * @return void
+     */
+    public function testGenerateBoolParams()
+    {
+        $this->io->expects($this->never())
+            ->method('err');
+        $this->io->expects($this->at(0))
+            ->method('out')
+            ->with($this->stringContains('> https://example.com/articles/index'));
+
+        $this->shell->args = ['_ssl:true', '_host:example.com', 'controller:Articles', 'action:index'];
+        $this->shell->generate();
+    }
+
+    /**
      * Test generating URLs
      *
      * @return void


### PR DESCRIPTION
`cake routes generate` should allow the usage of boolean parameters. This is necessary to test `_ssl` and a few other flag options.

Related to #10333