### PR TITLE
Fix XML output of Cake\Console\HelpFormatter

### DIFF
--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -186,7 +186,7 @@ class ConsoleInputArgument
         $option = $parent->addChild('argument');
         $option->addAttribute('name', $this->_name);
         $option->addAttribute('help', $this->_help);
-        $option->addAttribute('required', $this->isRequired());
+        $option->addAttribute('required', (int)$this->isRequired());
         $choices = $option->addChild('choices');
         foreach ($this->_choices as $valid) {
             $choices->addChild('choice', $valid);

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -249,9 +249,10 @@ class ConsoleInputOption
         $option->addAttribute('name', '--' . $this->_name);
         $short = '';
         if (strlen($this->_short) > 0) {
-            $short = $this->_short;
+            $short = '-' . $this->_short;
         }
-        $option->addAttribute('short', '-' . $short);
+        $option->addAttribute('short', $short);
+        $option->addAttribute('help', $this->_help);
         $option->addAttribute('boolean', $this->_boolean);
         $option->addChild('default', $this->_default);
         $choices = $option->addChild('choices');

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -253,7 +253,7 @@ class ConsoleInputOption
         }
         $option->addAttribute('short', $short);
         $option->addAttribute('help', $this->_help);
-        $option->addAttribute('boolean', $this->_boolean);
+        $option->addAttribute('boolean', (int)$this->_boolean);
         $option->addChild('default', $this->_default);
         $choices = $option->addChild('choices');
         foreach ($this->_choices as $valid) {

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -196,7 +196,6 @@ class HelpFormatter
         $xml->addChild('command', $parser->getCommand());
         $xml->addChild('description', $parser->getDescription());
 
-        $xml->addChild('epilog', $parser->getEpilog());
         $subcommands = $xml->addChild('subcommands');
         foreach ($parser->subcommands() as $command) {
             $command->xml($subcommands);
@@ -209,6 +208,7 @@ class HelpFormatter
         foreach ($parser->arguments() as $argument) {
             $argument->xml($arguments);
         }
+        $xml->addChild('epilog', $parser->getEpilog());
 
         return $string ? $xml->asXML() : $xml;
     }

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -314,15 +314,15 @@ xml;
         $expected = <<<xml
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
-<description>Description text</description>
+<command>mycommand</command>
+<description />
 <subcommands />
 <options>
 	<option name="--help" short="-h" help="Display this help." boolean="1">
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="">
 		<default></default>
 		<choices>
 			<choice>one</choice>
@@ -337,11 +337,14 @@ xml;
 			<choice>aro</choice>
 		</choices>
 	</argument>
+	<argument name="other_longer" help="Another argument." required="">
+		<choices></choices>
+	</argument>
 </arguments>
-<epilog>epilog text</epilog>
+<epilog />
 </shell>
 xml;
-        $this->assertXmlStringNotEqualsXmlString($expected, $result, 'Help does not match');
+        $this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
     }
 
     /**
@@ -362,7 +365,7 @@ xml;
         $expected = <<<xml
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
+<command>mycommand</command>
 <description>Description text</description>
 <subcommands />
 <options>
@@ -370,7 +373,7 @@ xml;
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -383,7 +386,7 @@ xml;
 <epilog>epilog text</epilog>
 </shell>
 xml;
-        $this->assertXmlStringNotEqualsXmlString($expected, $result, 'Help does not match');
+        $this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
     }
 
     /**
@@ -402,7 +405,7 @@ xml;
         $expected = <<<xml
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
+<command>mycommand</command>
 <description/>
 <subcommands>
 	<command name="method" help="This is another command" />
@@ -412,7 +415,7 @@ xml;
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -421,7 +424,7 @@ xml;
 <epilog/>
 </shell>
 xml;
-        $this->assertXmlStringNotEqualsXmlString($expected, $result, 'Help does not match');
+        $this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
     }
 
     /**
@@ -442,20 +445,20 @@ xml;
         $expected = <<<xml
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
+<command>mycommand</command>
 <description/>
 <subcommands/>
 <options>
+	<option name="--connection" short="-c" help="The connection to use." boolean="">
+		<default>default</default>
+		<choices></choices>
+	</option>
 	<option name="--help" short="-h" help="Display this help." boolean="1">
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="0">
+	<option name="--test" short="" help="A test option." boolean="">
 		<default></default>
-		<choices></choices>
-	</option>
-	<option name="--connection" short="-c" help="The connection to use." boolean="0">
-		<default>default</default>
 		<choices></choices>
 	</option>
 </options>
@@ -463,7 +466,7 @@ xml;
 <epilog/>
 </shell>
 xml;
-        $this->assertXmlStringNotEqualsXmlString($expected, $result, 'Help does not match');
+        $this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
     }
 
     /**
@@ -483,7 +486,7 @@ xml;
         $expected = <<<xml
 <?xml version="1.0"?>
 <shell>
-	<name>mycommand</name>
+	<command>mycommand</command>
 	<description/>
 	<subcommands/>
 	<options>
@@ -491,7 +494,7 @@ xml;
 			<default></default>
 			<choices></choices>
 		</option>
-		<option name="--test" short="" help="A test option." boolean="0">
+		<option name="--test" short="" help="A test option." boolean="">
 			<default></default>
 			<choices></choices>
 		</option>
@@ -500,14 +503,14 @@ xml;
 		<argument name="model" help="The model to make." required="1">
 			<choices></choices>
 		</argument>
-		<argument name="other_longer" help="Another argument." required="0">
+		<argument name="other_longer" help="Another argument." required="">
 			<choices></choices>
 		</argument>
 	</arguments>
 	<epilog/>
 </shell>
 xml;
-        $this->assertXmlStringNotEqualsXmlString($expected, $result, 'Help does not match');
+        $this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
     }
 
     /**

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -322,7 +322,7 @@ xml;
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="">
+	<option name="--test" short="" help="A test option." boolean="0">
 		<default></default>
 		<choices>
 			<choice>one</choice>
@@ -337,7 +337,7 @@ xml;
 			<choice>aro</choice>
 		</choices>
 	</argument>
-	<argument name="other_longer" help="Another argument." required="">
+	<argument name="other_longer" help="Another argument." required="0">
 		<choices></choices>
 	</argument>
 </arguments>
@@ -373,7 +373,7 @@ xml;
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="">
+	<option name="--test" short="" help="A test option." boolean="0">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -415,7 +415,7 @@ xml;
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="">
+	<option name="--test" short="" help="A test option." boolean="0">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -449,7 +449,7 @@ xml;
 <description/>
 <subcommands/>
 <options>
-	<option name="--connection" short="-c" help="The connection to use." boolean="">
+	<option name="--connection" short="-c" help="The connection to use." boolean="0">
 		<default>default</default>
 		<choices></choices>
 	</option>
@@ -457,7 +457,7 @@ xml;
 		<default></default>
 		<choices></choices>
 	</option>
-	<option name="--test" short="" help="A test option." boolean="">
+	<option name="--test" short="" help="A test option." boolean="0">
 		<default></default>
 		<choices></choices>
 	</option>
@@ -494,7 +494,7 @@ xml;
 			<default></default>
 			<choices></choices>
 		</option>
-		<option name="--test" short="" help="A test option." boolean="">
+		<option name="--test" short="" help="A test option." boolean="0">
 			<default></default>
 			<choices></choices>
 		</option>
@@ -503,7 +503,7 @@ xml;
 		<argument name="model" help="The model to make." required="1">
 			<choices></choices>
 		</argument>
-		<argument name="other_longer" help="Another argument." required="">
+		<argument name="other_longer" help="Another argument." required="0">
 			<choices></choices>
 		</argument>
 	</arguments>


### PR DESCRIPTION
- Help text wasn't rendered in `<option>` tag
- Non-existent short name was rendered as '-' unintentionally
- Related test cases had never worked

Note that I didn't change boolean values to be rendered as '0'. Instead, I fixed the test case so that it matches empty strings.

After this commit merged, I would like to port the same changes to the 2.x branch.