### PR TITLE
[2.next] Revert "Fix cookie component being inconsistent about writes."

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -229,27 +229,17 @@ class CookieComponent extends Component {
 		}
 
 		foreach ($key as $name => $value) {
-			$names = array($name);
-			if (strpos($name, '.') !== false) {
-				$names = explode('.', $name, 2);
-			}
-			$firstName = $names[0];
-			$isMultiValue = (is_array($value) || count($names) > 1);
-
-			if (!isset($this->_values[$this->name][$firstName]) && $isMultiValue) {
-				$this->_values[$this->name][$firstName] = array();
-			}
-
-			if (count($names) > 1) {
-				$this->_values[$this->name][$firstName] = Hash::insert(
-					$this->_values[$this->name][$firstName],
-					$names[1],
-					$value
-				);
+			if (strpos($name, '.') === false) {
+				$this->_values[$this->name][$name] = $value;
+				$this->_write("[$name]", $value);
 			} else {
-				$this->_values[$this->name][$firstName] = $value;
+				$names = explode('.', $name, 2);
+				if (!isset($this->_values[$this->name][$names[0]])) {
+					$this->_values[$this->name][$names[0]] = array();
+				}
+				$this->_values[$this->name][$names[0]] = Hash::insert($this->_values[$this->name][$names[0]], $names[1], $value);
+				$this->_write('[' . implode('][', $names) . ']', $value);
 			}
-			$this->_write('[' . $firstName . ']', $this->_values[$this->name][$firstName]);
 		}
 		$this->_encrypted = true;
 	}

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -392,44 +392,6 @@ class CookieComponentTest extends CakeTestCase {
 	}
 
 /**
- * Test that writing mixed arrays results in the correct data.
- *
- * @return void
- */
-	public function testWriteMixedArray() {
-		$this->Cookie->encrypt = false;
-		$this->Cookie->write('User', array('name' => 'mark'), false);
-		$this->Cookie->write('User.email', 'mark@example.com', false);
-		$expected = array(
-			'name' => $this->Cookie->name . '[User]',
-			'value' => '{"name":"mark","email":"mark@example.com"}',
-			'path' => '/',
-			'domain' => '',
-			'secure' => false,
-			'httpOnly' => false
-		);
-		$result = $this->Controller->response->cookie($this->Cookie->name . '[User]');
-		unset($result['expire']);
-
-		$this->assertEquals($expected, $result);
-
-		$this->Cookie->write('User.email', 'mark@example.com', false);
-		$this->Cookie->write('User', array('name' => 'mark'), false);
-		$expected = array(
-			'name' => $this->Cookie->name . '[User]',
-			'value' => '{"name":"mark"}',
-			'path' => '/',
-			'domain' => '',
-			'secure' => false,
-			'httpOnly' => false
-		);
-		$result = $this->Controller->response->cookie($this->Cookie->name . '[User]');
-		unset($result['expire']);
-
-		$this->assertEquals($expected, $result);
-	}
-
-/**
  * testReadingCookieValue
  *
  * @return void


### PR DESCRIPTION
This reverts commit 07f4779efef507c31291ca0f29222c1b06d626b8.

As of 2.4.3, [Cookie::delete('foo.bar')](https://book.cakephp.org/2.0/en/core-libraries/components/cookie.html#CookieComponent::delete) no longer works. Also, it's made impossible to set different expiration times for each individual entry in the same top level.
```php
$this->Cookie->write('Tracking.1', 'something', true, '+1 week');
// After few days later.
$this->Cookie->write('Tracking.2', 'something else', true, '+1 week');
```
The second writing will update expiration time of the first tracking cookie. It is not an expected behavior, and it worked in earlier versions than 2.4.3.

Although this is a bug, I would like to target to the 2.next branch, as some existing applications may be relying on the current behavior.