### PR TITLE
Fix the allowEmptyTranslations presistence bug

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -658,12 +658,11 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
                 }
             }
 
-            // Workaround to check the remaining properties
-            $arrayEntity = $entity->toArray();
+            $translation = $translation->extract($this->_config['fields']);
 
             // If now, the current locale property is empty,
             // unset it completely.
-            if (empty($arrayEntity['_translations'][$locale])) {
+            if (empty(array_filter($translation))) {
                 unset($entity->get('_translations')[$locale]);
             }
         }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -642,7 +642,8 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
     /**
      * Unset empty translations to avoid persistence.
-     * Should only be called if $this->_config['allowEmptyTranslations'] is false
+     *
+     * Should only be called if $this->_config['allowEmptyTranslations'] is false.
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity to check for empty translations fields inside.
      * @return void

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -272,41 +272,11 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         $newOptions = [$this->_translationTable->getAlias() => ['validate' => false]];
         $options['associated'] = $newOptions + $options['associated'];
 
-        // Check early if empty transaltions are present in the entity.
+        // Check early if empty translations are present in the entity.
         // If this is the case, unset them to prevent persistence.
         // This only applies if $this->_config['allowEmptyTranslations'] is false
         if ($this->_config['allowEmptyTranslations'] === false) {
-            $translations = (array)$entity->get('_translations');
-            if (!empty($translations)) {
-                foreach ($translations as $locale => &$translation) {
-                    $fields = $translation->extract($this->_config['fields'], false);
-                    foreach ($fields as $field => $value) {
-                        if (empty($value)) {
-                            unset($translation->{$field});
-                        }
-                    }
-
-                    // Workaround to check the remaining properties
-                    $arrayEntity = $entity->toArray();
-
-                     // If now, the current locale property is empty,
-                     // unset it completely.
-                    if (empty($arrayEntity['_translations'][$locale])) {
-                        unset($entity->get('_translations')[$locale]);
-                    }
-                }
-
-                // Workaround to check the remaining properties
-                $arrayEntity = $entity->toArray();
-
-                 // If now, the whole _translations property is empty,
-                 // unset it completely and return
-                if (empty($arrayEntity['_translations'])) {
-                    $entity->unsetProperty("_translations");
-
-                    return;
-                }
-            }
+            $this->_unsetEmptyFields($entity);
         }
 
         $this->_bundleTranslatedFields($entity);
@@ -668,6 +638,41 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         }
 
         $entity->set('_i18n', $contents);
+    }
+
+    /**
+     * Unset empty translations to avoid persistence.
+     * Should only be called if $this->_config['allowEmptyTranslations'] is false
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity to check for empty translations fields inside.
+     * @return void
+     */
+    protected function _unsetEmptyFields(EntityInterface $entity)
+    {
+        $translations = (array)$entity->get('_translations');
+        foreach ($translations as $locale => $translation) {
+            $fields = $translation->extract($this->_config['fields'], false);
+            foreach ($fields as $field => $value) {
+                if (strlen($value) === 0) {
+                    $translation->unsetProperty($field);
+                }
+            }
+
+            // Workaround to check the remaining properties
+            $arrayEntity = $entity->toArray();
+
+            // If now, the current locale property is empty,
+            // unset it completely.
+            if (empty($arrayEntity['_translations'][$locale])) {
+                unset($entity->get('_translations')[$locale]);
+            }
+        }
+
+        // If now, the whole _translations property is empty,
+        // unset it completely and return
+        if (empty($entity->get('_translations'))) {
+            $entity->unsetProperty("_translations");
+        }
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -912,6 +912,17 @@ class TranslateBehaviorTest extends TestCase
             ])
             ->first();
         $this->assertSame('Hallo', $deBody->content);
+
+        // Remove the Behavior to unset the content != '' condition
+        $table->removeBehavior('Translate');
+
+        $noTitle = $table->I18n->find()
+            ->where([
+                'locale' => 'fra',
+                'field' => 'title'
+            ])
+            ->first();
+        $this->assertEmpty($noTitle);
     }
 
     /**


### PR DESCRIPTION
See #10323 and #7531

This tries to fix the following problem:

You add the `TranslationBehavior` like this:
```
$this->addBehavior('Translate', [
  'fields' => ['title'],
  'allowEmptyTranslations' => false
]);
```

Create a form, add some `controls` for different languages and save the request data.
When this is saved, all empty translations will also be saved into the DB.

Now comes the tricky part. If you now get the translations out of the `i18n` table, all the empty translations won't be selected (`allowEmptyTranslations`!).
This is caused by an applied condition in the `setupFieldAssociations()`method of the behavior (`$conditions[$name . '.content !='] = '';`).

When you now try to update and save the former empty translations, you'll get an ` Integrity constraint violation` error. 💥

My approach is to unset all empty fields, so that they are not saved.
I'm not happy with the implementation, but the `EntityTrait` is sometimes a little b*** 😉