### PR TITLE
Fix issue #10346

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -119,6 +119,7 @@ class Text
                             $open = true;
                         } else {
                             $depth--;
+                            $open = false;
                         }
                     }
                 }

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -315,6 +315,10 @@ class TextTest extends TestCase
         $expected = ['tagA', '"single tag"', 'tagB'];
         $this->assertEquals($expected, $result);
 
+        $result = Text::tokenize('tagA "first tag" tagB "second tag" tagC', ' ', '"', '"');
+        $expected = ['tagA', '"first tag"', 'tagB', '"second tag"', 'tagC'];
+        $this->assertEquals($expected, $result);
+
         // Ideographic width space.
         $result = Text::tokenize("tagA\xe3\x80\x80\"single\xe3\x80\x80tag\"\xe3\x80\x80tagB", "\xe3\x80\x80", '"', '"');
         $expected = ['tagA', '"single　tag"', 'tagB'];


### PR DESCRIPTION
This merge resolves issue #10346 . It only impacts the tokenize function when the `leftBound` and `rightBound` parameters are the same and properly terminates the token.