### PR TITLE
Make meta() accept 'block' option in single argument case.

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -222,17 +222,16 @@ class HtmlHelper extends Helper
      * - `block` - Set to true to append output to view block "meta" or provide
      *   custom block name.
      *
-     * @param string|array $type The title of the external resource
+     * @param string|array $type The title of the external resource, Or an array of attributes for a
+     *   custom meta tag.
      * @param string|array|null $content The address of the external resource or string for content attribute
      * @param array $options Other attributes for the generated tag. If the type attribute is html,
      *    rss, atom, or icon, the mime-type is returned.
-     * @return string A completed `<link />` element.
+     * @return string|null A completed `<link />` element, or null if the element was sent to a block.
      * @link http://book.cakephp.org/3.0/en/views/helpers/html.html#creating-meta-tags
      */
     public function meta($type, $content = null, array $options = [])
     {
-        $options += ['block' => null];
-
         if (!is_array($type)) {
             $types = [
                 'rss' => ['type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $content],
@@ -269,7 +268,7 @@ class HtmlHelper extends Helper
             }
         }
 
-        $options += $type;
+        $options += $type + ['block' => null];
         $out = null;
 
         if (isset($options['link'])) {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1768,6 +1768,25 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
+     * Test meta() with custom tag and block argument
+     */
+    public function testMetaCustomWithBlock()
+    {
+        $this->View->expects($this->at(0))
+            ->method('append')
+            ->with('meta', $this->stringContains('og:site_name'));
+        $this->View->expects($this->at(1))
+            ->method('append')
+            ->with('meta', $this->stringContains('og:description'));
+
+        $result = $this->Html->meta(['property' => 'og:site_name', 'content' => 'CakePHP', 'block' => true]);
+        $this->assertNull($result, 'compact style should work');
+
+        $result = $this->Html->meta(['property' => 'og:description', 'content' => 'CakePHP'], null, ['block' => true]);
+        $this->assertNull($result, 'backwards compat style should work.');
+    }
+
+    /**
      * testTableHeaders method
      *
      * @return void


### PR DESCRIPTION
Allow the block option to be defined in the custom meta tag attributes array. This allows this usage to be more compact and not require a 2nd and 3rd argument.

I attempted this use in one of my apps and it didn't work when I thought it should. If people think this is a bad idea I'm ok with that too :smile: