### PR TITLE
Fix tests failing due to environment pollution.

### DIFF
--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1191,7 +1191,7 @@ class AuthComponentTest extends TestCase
 
         $result = $this->Auth->user('username');
         $this->assertEquals('mariano', $result);
-        $this->assertFalse(isset($_SESSION));
+        $this->assertFalse(isset($_SESSION['Auth']), 'No user data in session');
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -45,6 +45,13 @@ class RequestHandlerComponentTest extends TestCase
     public $RequestHandler;
 
     /**
+     * Backup of $_SERVER
+     *
+     * @var array
+     */
+    protected $server = [];
+
+    /**
      * setUp method
      *
      * @return void
@@ -52,6 +59,7 @@ class RequestHandlerComponentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+        $this->server = $_SERVER;
         Configure::write('App.namespace', 'TestApp');
         DispatcherFactory::add('Routing');
         DispatcherFactory::add('ControllerFactory');
@@ -90,6 +98,7 @@ class RequestHandlerComponentTest extends TestCase
         DispatcherFactory::clear();
         Router::reload();
         Router::$initialized = false;
+        $_SERVER = $this->server;
         unset($this->RequestHandler, $this->Controller);
     }
 

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -125,6 +125,12 @@ class SecurityTestController extends Controller
  */
 class SecurityComponentTest extends TestCase
 {
+    /**
+     * SERVER variable backup.
+     *
+     * @var array
+     */
+    protected $server = [];
 
     /**
      * Controller property
@@ -151,6 +157,7 @@ class SecurityComponentTest extends TestCase
     {
         parent::setUp();
 
+        $this->server = $_SERVER;
         $session = new Session();
         $request = $this->getMockBuilder('Cake\Network\Request')
             ->setMethods(['here'])
@@ -180,6 +187,7 @@ class SecurityComponentTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
+        $_SERVER = $this->server;
         $this->Security->session->delete('_Token');
         unset($this->Controller->Security);
         unset($this->Controller->Component);

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -24,10 +24,16 @@ use Zend\Diactoros\UploadedFile;
 use Zend\Diactoros\Uri;
 
 /**
- * TestRequest
+ * ServerRequest Test
  */
 class ServerRequestTest extends TestCase
 {
+    /**
+     * SERVER variable backup.
+     *
+     * @var array
+     */
+    protected $server = [];
 
     /**
      * Setup callback
@@ -37,26 +43,16 @@ class ServerRequestTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_case = null;
-        if (isset($_GET['case'])) {
-            $this->_case = $_GET['case'];
-            unset($_GET['case']);
-        }
+        $this->server = $_SERVER;
 
         Configure::write('App.baseUrl', false);
     }
 
-    /**
-     * TearDown
-     *
-     * @return void
-     */
     public function tearDown()
     {
         parent::tearDown();
-        if (!empty($this->_case)) {
-            $_GET['case'] = $this->_case;
-        }
+
+        $_SERVER = $this->server;
     }
 
     /**

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -28,6 +28,35 @@ use Zend\Diactoros\Stream;
 class ResponseTest extends TestCase
 {
     /**
+     * SERVER variable backup.
+     *
+     * @var array
+     */
+    protected $server = [];
+
+    /**
+     * setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->server = $_SERVER;
+    }
+
+    /**
+     * teardown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $_SERVER = $this->server;
+    }
+
+    /**
      * Tests the request object constructor
      *
      * @return void


### PR DESCRIPTION
In some environments (my laptop) tests are run in a different order which causes them to fail as we muck about with global state and don't restore it.