### PR TITLE
Fix nested transactions may be rolled back or committed unexpectedly

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -18,6 +18,7 @@ use Cake\Core\App;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\MissingDriverException;
 use Cake\Database\Exception\MissingExtensionException;
+use Cake\Database\Exception\NestedTransactionRollbackException;
 use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
@@ -90,6 +91,14 @@ class Connection implements ConnectionInterface
      * @var \Cake\Database\Schema\Collection|null
      */
     protected $_schemaCollection = null;
+
+    /**
+     * NestedTransactionRollbackException object instance, will be stored if
+     * the rollback method is called in some nested transaction.
+     *
+     * @var \Cake\Database\Exception\NestedTransactionRollbackException|null
+     */
+    protected $_nestedTransactionRollbackException = null;
 
     /**
      * Constructor.
@@ -441,6 +450,7 @@ class Connection implements ConnectionInterface
             $this->_driver->beginTransaction();
             $this->_transactionLevel = 0;
             $this->_transactionStarted = true;
+            $this->_nestedTransactionRollbackException = null;
 
             return;
         }
@@ -463,7 +473,12 @@ class Connection implements ConnectionInterface
         }
 
         if ($this->_transactionLevel === 0) {
+            if ($this->wasNestedTransactionRolledback()) {
+                throw $this->_nestedTransactionRollbackException;
+            }
+
             $this->_transactionStarted = false;
+            $this->_nestedTransactionRollbackException = null;
             if ($this->_logQueries) {
                 $this->log('COMMIT');
             }
@@ -482,18 +497,24 @@ class Connection implements ConnectionInterface
     /**
      * Rollback current transaction.
      *
+     * @param bool|null $toBeginning Whether or not the transaction should be rolled back to the
+     * beginning of it. Defaults to false if using savepoints, or true if not.
      * @return bool
      */
-    public function rollback()
+    public function rollback($toBeginning = null)
     {
         if (!$this->_transactionStarted) {
             return false;
         }
 
         $useSavePoint = $this->isSavePointsEnabled();
-        if ($this->_transactionLevel === 0 || !$useSavePoint) {
+        if ($toBeginning === null) {
+            $toBeginning = !$useSavePoint;
+        }
+        if ($this->_transactionLevel === 0 || $toBeginning) {
             $this->_transactionLevel = 0;
             $this->_transactionStarted = false;
+            $this->_nestedTransactionRollbackException = null;
             if ($this->_logQueries) {
                 $this->log('ROLLBACK');
             }
@@ -502,8 +523,11 @@ class Connection implements ConnectionInterface
             return true;
         }
 
+        $savePoint = $this->_transactionLevel--;
         if ($useSavePoint) {
-            $this->rollbackSavepoint($this->_transactionLevel--);
+            $this->rollbackSavepoint($savePoint);
+        } elseif ($this->_nestedTransactionRollbackException === null) {
+            $this->_nestedTransactionRollbackException = new NestedTransactionRollbackException();
         }
 
         return true;
@@ -653,19 +677,34 @@ class Connection implements ConnectionInterface
         try {
             $result = $callback($this);
         } catch (\Exception $e) {
-            $this->rollback();
+            $this->rollback(false);
             throw $e;
         }
 
         if ($result === false) {
-            $this->rollback();
+            $this->rollback(false);
 
             return false;
         }
 
-        $this->commit();
+        try {
+            $this->commit();
+        } catch (NestedTransactionRollbackException $e) {
+            $this->rollback(false);
+            throw $e;
+        }
 
         return $result;
+    }
+
+    /**
+     * Returns whether some nested transaction has been already rolled back.
+     *
+     * @return bool
+     */
+    public function wasNestedTransactionRolledback()
+    {
+        return $this->_nestedTransactionRollbackException instanceof NestedTransactionRollbackException;
     }
 
     /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -98,7 +98,7 @@ class Connection implements ConnectionInterface
      *
      * @var \Cake\Database\Exception\NestedTransactionRollbackException|null
      */
-    protected $_nestedTransactionRollbackException = null;
+    protected $nestedTransactionRollbackException = null;
 
     /**
      * Constructor.
@@ -450,7 +450,7 @@ class Connection implements ConnectionInterface
             $this->_driver->beginTransaction();
             $this->_transactionLevel = 0;
             $this->_transactionStarted = true;
-            $this->_nestedTransactionRollbackException = null;
+            $this->nestedTransactionRollbackException = null;
 
             return;
         }
@@ -474,11 +474,13 @@ class Connection implements ConnectionInterface
 
         if ($this->_transactionLevel === 0) {
             if ($this->wasNestedTransactionRolledback()) {
-                throw $this->_nestedTransactionRollbackException;
+                $e = $this->nestedTransactionRollbackException;
+                $this->nestedTransactionRollbackException = null;
+                throw $e;
             }
 
             $this->_transactionStarted = false;
-            $this->_nestedTransactionRollbackException = null;
+            $this->nestedTransactionRollbackException = null;
             if ($this->_logQueries) {
                 $this->log('COMMIT');
             }
@@ -514,7 +516,7 @@ class Connection implements ConnectionInterface
         if ($this->_transactionLevel === 0 || $toBeginning) {
             $this->_transactionLevel = 0;
             $this->_transactionStarted = false;
-            $this->_nestedTransactionRollbackException = null;
+            $this->nestedTransactionRollbackException = null;
             if ($this->_logQueries) {
                 $this->log('ROLLBACK');
             }
@@ -526,8 +528,8 @@ class Connection implements ConnectionInterface
         $savePoint = $this->_transactionLevel--;
         if ($useSavePoint) {
             $this->rollbackSavepoint($savePoint);
-        } elseif ($this->_nestedTransactionRollbackException === null) {
-            $this->_nestedTransactionRollbackException = new NestedTransactionRollbackException();
+        } elseif ($this->nestedTransactionRollbackException === null) {
+            $this->nestedTransactionRollbackException = new NestedTransactionRollbackException();
         }
 
         return true;
@@ -702,9 +704,9 @@ class Connection implements ConnectionInterface
      *
      * @return bool
      */
-    public function wasNestedTransactionRolledback()
+    protected function wasNestedTransactionRolledback()
     {
-        return $this->_nestedTransactionRollbackException instanceof NestedTransactionRollbackException;
+        return $this->nestedTransactionRollbackException instanceof NestedTransactionRollbackException;
     }
 
     /**

--- a/src/Database/Exception/NestedTransactionRollbackException.php
+++ b/src/Database/Exception/NestedTransactionRollbackException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.4.3
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class NestedTransactionRollbackException extends Exception
+{
+
+    /**
+     * Constructor
+     *
+     * @param string|null $message If no message is given a default meesage will be used.
+     * @param int $code Status code, defaults to 500.
+     * @param \Exception|null $previous the previous exception.
+     */
+    public function __construct($message = null, $code = 500, $previous = null)
+    {
+        if ($message === null) {
+            $message = 'Cannot commit transaction - rollback() has been already called in the nested transaction';
+        }
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
Refs #10348

I added the `$toBeginning` argument to `Connection::rollback()` in this pull request, as I couldn't break backward compatibility. One `rollback()` rolls back to the begining of transaction seems [intentional](https://github.com/cakephp/cakephp/blob/902c9910279eff909295e413d43fc6a5d2dbd7bf/tests/TestCase/Database/ConnectionTest.php#L475-L497). If it is arguable, I am willing to target 3.next branch.

Also, I added the `NestedTransactionRollbackException` class and the <code>Connection::wasNestedTransactionRoll<b>ed</b>back()</code> method. If this naming is not natural, please teach me.

**Edit:** Added description