### PR TITLE
fix duplicate primary keys for tables without models

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -617,6 +617,7 @@ class CakeSchema extends CakeObject {
 		foreach ($fields as $value) {
 			if (isset($value['key']) && $value['key'] === 'primary') {
 				$hasPrimaryAlready = true;
+				break;
 			}
 		}
 

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -613,9 +613,16 @@ class CakeSchema extends CakeObject {
 		$db = $Obj->getDataSource();
 		$fields = $Obj->schema(true);
 
+		$hasPrimaryAlready = false;
+		foreach ($fields as $value) {
+			if (isset($value['key']) && $value['key'] === 'primary') {
+				$hasPrimaryAlready = true;
+			}
+		}
+
 		$columns = array();
 		foreach ($fields as $name => $value) {
-			if ($Obj->primaryKey === $name) {
+			if ($Obj->primaryKey === $name && !$hasPrimaryAlready && !isset($value['key'])) {
 				$value['key'] = 'primary';
 			}
 			if (!isset($db->columns[$value['type']])) {

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -688,7 +688,6 @@ class CakeSchemaTest extends CakeTestCase {
  * @return void
  */
 	public function testSchemaReadWithNonConventionalPrimaryKey() {
-		$this->skipIf($this->db instanceof Postgres, 'Cannot test on Postgres');
 		$db = ConnectionManager::getDataSource('test');
 		$fixture = new NonConventionalPrimaryKeyFixture();
 		$fixture->create($db);
@@ -700,14 +699,14 @@ class CakeSchemaTest extends CakeTestCase {
 		));
 		$fixture->drop($db);
 
-		$hasTable = isset($read['tables']['non_conventional']);
-		$this->assertTrue($hasTable, 'non_conventional table should appear');
+		$this->assertArrayHasKey('non_conventional', $read['tables']);
 		$versionIdHasKey = isset($read['tables']['non_conventional']['version_id']['key']);
 		$this->assertTrue($versionIdHasKey, 'version_id key should be set');
 		$versionIdKeyIsPrimary = $read['tables']['non_conventional']['version_id']['key'] === 'primary';
 		$this->assertTrue($versionIdKeyIsPrimary, 'version_id key should be primary');
-		$idHasNoKey = !isset($read['tables']['non_conventional']['id']['key']);
-		$this->assertTrue($idHasNoKey, 'id key should not be set');
+
+		$idHasKey = isset($read['tables']['non_conventional']['id']['key']);
+		$this->assertFalse($idHasKey, 'id key should not be set');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -364,6 +364,39 @@ class SchemaCrossDatabaseFixture extends CakeTestFixture {
 }
 
 /**
+ * NonConventionalPrimaryKeyFixture class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class NonConventionalPrimaryKeyFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string
+ */
+	public $name = 'NonConventional';
+
+/**
+ * table property
+ *
+ * @var string
+ */
+	public $table = 'non_conventional';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'version_id' => array('type' => 'integer', 'key' => 'primary'),
+		'id' => array('type' => 'integer'),
+		'name' => 'string'
+	);
+}
+
+/**
  * SchemaPrefixAuthUser class
  *
  * @package       Cake.Test.Case.Model
@@ -647,6 +680,36 @@ class CakeSchemaTest extends CakeTestCase {
 		$this->assertTrue(isset($read['tables']['cross_database']));
 
 		$fixture->drop($db);
+	}
+
+/**
+ * testSchemaRead method when a primary key is on a non-conventional column
+ *
+ * @return void
+ */
+	public function testSchemaReadWithNonConventionalPrimaryKey() {
+		$db = ConnectionManager::getDataSource('test');
+		$fixture = new NonConventionalPrimaryKeyFixture();
+		$fixture->create($db);
+
+		$read = $this->Schema->read(array(
+			'connection' => 'test',
+			'name' => 'TestApp',
+			'models' => false
+		));
+		$fixture->drop($db);
+
+		$has_table = isset($read['tables']['non_conventional']);
+		$this->assertTrue($has_table, 'non_conventional table should appear');
+		if ($has_table) {
+			$version_id_has_key = isset($read['tables']['non_conventional']['version_id']['key']);
+			$this->assertTrue($version_id_has_key, 'version_id key should be set');
+			if ($version_id_has_key) {
+				$version_id_key_is_primary = $read['tables']['non_conventional']['version_id']['key'] === 'primary';
+				$this->assertTrue($version_id_key_is_primary, 'version_id key should be primary');
+			}
+			$this->assertFalse(isset($read['tables']['non_conventional']['id']['key']), 'id key should not be set');
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -702,11 +702,11 @@ class CakeSchemaTest extends CakeTestCase {
 
 		$hasTable = isset($read['tables']['non_conventional']);
 		$this->assertTrue($hasTable, 'non_conventional table should appear');
-		$versionIdHasKey = $hasTable && isset($read['tables']['non_conventional']['version_id']['key']);
+		$versionIdHasKey = isset($read['tables']['non_conventional']['version_id']['key']);
 		$this->assertTrue($versionIdHasKey, 'version_id key should be set');
-		$versionIdKeyIsPrimary = $versionIdHasKey && $read['tables']['non_conventional']['version_id']['key'] === 'primary';
+		$versionIdKeyIsPrimary = $read['tables']['non_conventional']['version_id']['key'] === 'primary';
 		$this->assertTrue($versionIdKeyIsPrimary, 'version_id key should be primary');
-		$idHasNoKey = $hasTable && !isset($read['tables']['non_conventional']['id']['key']);
+		$idHasNoKey = !isset($read['tables']['non_conventional']['id']['key']);
 		$this->assertTrue($idHasNoKey, 'id key should not be set');
 	}
 

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -688,6 +688,7 @@ class CakeSchemaTest extends CakeTestCase {
  * @return void
  */
 	public function testSchemaReadWithNonConventionalPrimaryKey() {
+		$this->skipIf($this->db instanceof Postgres, 'Cannot test on Postgres');
 		$db = ConnectionManager::getDataSource('test');
 		$fixture = new NonConventionalPrimaryKeyFixture();
 		$fixture->create($db);
@@ -699,17 +700,14 @@ class CakeSchemaTest extends CakeTestCase {
 		));
 		$fixture->drop($db);
 
-		$has_table = isset($read['tables']['non_conventional']);
-		$this->assertTrue($has_table, 'non_conventional table should appear');
-		if ($has_table) {
-			$version_id_has_key = isset($read['tables']['non_conventional']['version_id']['key']);
-			$this->assertTrue($version_id_has_key, 'version_id key should be set');
-			if ($version_id_has_key) {
-				$version_id_key_is_primary = $read['tables']['non_conventional']['version_id']['key'] === 'primary';
-				$this->assertTrue($version_id_key_is_primary, 'version_id key should be primary');
-			}
-			$this->assertFalse(isset($read['tables']['non_conventional']['id']['key']), 'id key should not be set');
-		}
+		$hasTable = isset($read['tables']['non_conventional']);
+		$this->assertTrue($hasTable, 'non_conventional table should appear');
+		$versionIdHasKey = $hasTable && isset($read['tables']['non_conventional']['version_id']['key']);
+		$this->assertTrue($versionIdHasKey, 'version_id key should be set');
+		$versionIdKeyIsPrimary = $versionIdHasKey && $read['tables']['non_conventional']['version_id']['key'] === 'primary';
+		$this->assertTrue($versionIdKeyIsPrimary, 'version_id key should be primary');
+		$idHasNoKey = $hasTable && !isset($read['tables']['non_conventional']['id']['key']);
+		$this->assertTrue($idHasNoKey, 'id key should not be set');
 	}
 
 /**


### PR DESCRIPTION
This fixes #10354 for CakePHP 2.9

CakeSchema would create duplicate primary keys for tables that already a primary key set on a non-conventional column (e.g. not `id`).

