### PR TITLE
3.x BaseErrorHandler: Report File Name and Line Number for Exceptions

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -354,9 +354,11 @@ abstract class BaseErrorHandler
             $exception;
         $config = $this->_options;
         $message = sprintf(
-            "[%s] %s",
+            "[%s] %s in %s on line %s",
             get_class($exception),
-            $exception->getMessage()
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
         );
         $debug = Configure::read('debug');
 


### PR DESCRIPTION
### Native PHP Error Handler Example (Browser's Output Buffer)
```
Parse error: syntax error, unexpected ';', expecting ',' or ')' in /var/www/cakephp/app/plugins/TableTranslate/src/Model/Behavior/TranslationsBehavior.php on line 56
```

### Patched BaseErrorHandler Parse Error Exception (PHP 7.1.2) including this PR

```
2017-03-06 15:28:47 Error: [ParseError] syntax error, unexpected ';', expecting ',' or ')' in /var/www/cakephp/app/plugins/TableTranslate/src/Model/Behavior/TranslationsBehavior.php on line 56
```

`_getMessage()` is called by anything handling Exceptions and on my platform (7.1.2) syntax errors where handled by the Exception handler.