### PR TITLE
Fix EntityTrait and merging of properties that are not assoc arrays.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -433,7 +433,7 @@ trait EntityTrait
             return $this;
         }
 
-        $this->_hidden += $properties;
+        $this->_hidden = array_merge($this->_hidden, $properties);
 
         return $this;
     }
@@ -482,7 +482,7 @@ trait EntityTrait
             return $this;
         }
 
-        $this->_virtual += $properties;
+        $this->_virtual = array_merge($this->_virtual, $properties);
 
         return $this;
     }

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -433,7 +433,8 @@ trait EntityTrait
             return $this;
         }
 
-        $this->_hidden = array_merge($this->_hidden, $properties);
+        $properties = array_merge($this->_hidden, $properties);
+        $this->_hidden = array_unique($properties);
 
         return $this;
     }
@@ -482,7 +483,8 @@ trait EntityTrait
             return $this;
         }
 
-        $this->_virtual = array_merge($this->_virtual, $properties);
+        $properties = array_merge($this->_virtual, $properties);
+        $this->_virtual = array_unique($properties);
 
         return $this;
     }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1070,6 +1070,7 @@ class EntityTest extends TestCase
         $this->assertSame(['secret', 'name'], $result);
 
         $entity->setHidden(['name'], true);
+        $result = $entity->getHidden();
         $this->assertSame(['secret', 'name'], $result);
     }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1039,14 +1039,14 @@ class EntityTest extends TestCase
     {
         $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
-        $entity->setVirtual(['secret']);
+        $entity->setHidden(['secret']);
 
-        $result = $entity->getVirtual();
+        $result = $entity->getHidden();
         $this->assertSame(['secret'], $result);
 
-        $entity->setVirtual(['name']);
+        $entity->setHidden(['name']);
 
-        $result = $entity->getVirtual();
+        $result = $entity->getHidden();
         $this->assertSame(['name'], $result);
     }
 
@@ -1059,17 +1059,17 @@ class EntityTest extends TestCase
     {
         $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
-        $entity->setVirtual(['secret']);
+        $entity->setHidden(['secret'], true);
 
-        $result = $entity->getVirtual();
+        $result = $entity->getHidden();
         $this->assertSame(['secret'], $result);
 
-        $entity->setVirtual(['name'], true);
+        $entity->setHidden(['name'], true);
 
-        $result = $entity->getVirtual();
+        $result = $entity->getHidden();
         $this->assertSame(['secret', 'name'], $result);
 
-        $entity->setVirtual(['name'], true);
+        $entity->setHidden(['name'], true);
         $this->assertSame(['secret', 'name'], $result);
     }
 
@@ -1100,6 +1100,29 @@ class EntityTest extends TestCase
         $expected = ['email' => 'mark@example.com'];
         $this->assertEquals($expected, $entity->toArray());
         $this->assertEquals(['name'], $entity->hiddenProperties());
+    }
+
+    /**
+     * Tests setting virtual properties with merging.
+     *
+     * @return void
+     */
+    public function testSetVirtualWithMerge()
+    {
+        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new Entity($data);
+        $entity->setVirtual(['secret']);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['secret'], $result);
+
+        $entity->setVirtual(['name'], true);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['secret', 'name'], $result);
+
+        $entity->setVirtual(['name'], true);
+        $this->assertSame(['secret', 'name'], $result);
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1110,20 +1110,21 @@ class EntityTest extends TestCase
      */
     public function testSetVirtualWithMerge()
     {
-        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $data = ['virtual' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
-        $entity->setVirtual(['secret']);
+        $entity->setVirtual(['virtual']);
 
         $result = $entity->getVirtual();
-        $this->assertSame(['secret'], $result);
+        $this->assertSame(['virtual'], $result);
 
         $entity->setVirtual(['name'], true);
 
         $result = $entity->getVirtual();
-        $this->assertSame(['secret', 'name'], $result);
+        $this->assertSame(['virtual', 'name'], $result);
 
         $entity->setVirtual(['name'], true);
-        $this->assertSame(['secret', 'name'], $result);
+        $result = $entity->getVirtual();
+        $this->assertSame(['virtual', 'name'], $result);
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1031,6 +1031,49 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Tests setting hidden properties.
+     *
+     * @return void
+     */
+    public function testSetHidden()
+    {
+        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new Entity($data);
+        $entity->setVirtual(['secret']);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['secret'], $result);
+
+        $entity->setVirtual(['name']);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['name'], $result);
+    }
+
+    /**
+     * Tests setting hidden properties with merging.
+     *
+     * @return void
+     */
+    public function testSetHiddenWithMerge()
+    {
+        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new Entity($data);
+        $entity->setVirtual(['secret']);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['secret'], $result);
+
+        $entity->setVirtual(['name'], true);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['secret', 'name'], $result);
+
+        $entity->setVirtual(['name'], true);
+        $this->assertSame(['secret', 'name'], $result);
+    }
+
+    /**
      * Test toArray includes 'virtual' properties.
      *
      * @return void


### PR DESCRIPTION
Interesting that there were no test cases for these methods, neither for the merge part nor without.

Resolves https://github.com/cakephp/cakephp/issues/10361