### PR TITLE
Remove internal annotations from Cake\Database\Expression classes

### DIFF
--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -20,8 +20,6 @@ use Cake\Database\ValueBinder;
 
 /**
  * An expression object that represents a SQL BETWEEN snippet
- *
- * @internal
  */
 class BetweenExpression implements ExpressionInterface, FieldInterface
 {

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -20,8 +20,6 @@ use Cake\Database\ValueBinder;
 
 /**
  * This class represents a SQL Case statement
- *
- * @internal
  */
 class CaseExpression implements ExpressionInterface
 {

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -23,8 +23,6 @@ use Cake\Database\ValueBinder;
  * A Comparison is a type of query expression that represents an operation
  * involving a field an operator and a value. In its most common form the
  * string representation of a comparison is `field = value`
- *
- * @internal
  */
 class Comparison implements ExpressionInterface, FieldInterface
 {

--- a/src/Database/Expression/FieldInterface.php
+++ b/src/Database/Expression/FieldInterface.php
@@ -17,8 +17,6 @@ namespace Cake\Database\Expression;
 /**
  * Describes a getter and a setter for the a field property. Useful for expressions
  * that contain an identifier to compare against.
- *
- * @internal
  */
 interface FieldInterface
 {

--- a/src/Database/Expression/FieldTrait.php
+++ b/src/Database/Expression/FieldTrait.php
@@ -16,8 +16,6 @@ namespace Cake\Database\Expression;
 
 /**
  * Contains the field property with a getter and a setter for it
- *
- * @internal
  */
 trait FieldTrait
 {

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -25,8 +25,6 @@ use Cake\Database\ValueBinder;
  * constructed by passing the name of the function and a list of params.
  * For security reasons, all params passed are quoted by default unless
  * explicitly told otherwise.
- *
- * @internal
  */
 class FunctionExpression extends QueryExpression implements TypedResultInterface
 {

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -19,8 +19,6 @@ use Cake\Database\ValueBinder;
 
 /**
  * Represents a single identifier name in the database
- *
- * @internal
  */
 class IdentifierExpression implements ExpressionInterface
 {

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -19,8 +19,6 @@ use Cake\Database\ValueBinder;
 
 /**
  * An expression object for ORDER BY clauses
- *
- * @internal
  */
 class OrderByExpression extends QueryExpression
 {

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -19,8 +19,6 @@ use Cake\Database\ValueBinder;
 
 /**
  * An expression object for complex ORDER BY clauses
- *
- * @internal
  */
 class OrderClauseExpression implements ExpressionInterface, FieldInterface
 {

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -20,8 +20,6 @@ use Cake\Database\ValueBinder;
 /**
  * This expression represents SQL fragments that are used for comparing one tuple
  * to another, one tuple to a set of other tuples or one tuple to an expression
- *
- * @internal
  */
 class TupleComparison extends Comparison
 {

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -19,8 +19,6 @@ use Cake\Database\ValueBinder;
 
 /**
  * An expression object that represents an expression with only a single operand.
- *
- * @internal
  */
 class UnaryExpression implements ExpressionInterface
 {

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -26,8 +26,6 @@ use Cake\Database\ValueBinder;
  *
  * Helps generate SQL with the correct number of placeholders and bind
  * values correctly into the statement.
- *
- * @internal
  */
 class ValuesExpression implements ExpressionInterface
 {


### PR DESCRIPTION
Since being mentioned in the Cookbook, these classes are no longer internal classes.