### PR TITLE
Make error class of div in FormHelper::input configurable

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -10781,7 +10781,7 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-    $result = $this->Form->input('Contact.field', array(
+		$result = $this->Form->input('Contact.field', array(
 			'type' => 'text',
 			'div' => array('errorClass' => 'has-error'),
 			'error' => array('attributes' => array('class' => 'form-control-feedback'))

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -10740,13 +10740,34 @@ class FormHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testInputErrorClass() {
+		$Contact = ClassRegistry::getObject('Contact');
+		$Contact->validationErrors['field'] = array('Badness!');
+
 		$result = $this->Form->input('Contact.field', array(
 			'type' => 'text',
-			'div' => array('errorClass' => 'has-error'),
-			'error' => true
+			'div' => array('errorClass' => 'has-error')
 		));
 		$expected = array(
 			'div' => array('class' => 'input text has-error'),
+			'label' => array('for' => 'ContactField'),
+			'Field',
+			'/label',
+			'input' => array(
+				'type' => 'text', 'name' => 'data[Contact][field]',
+				'id' => 'ContactField', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'error-message')),
+			'Badness!',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('Contact.field', array(
+			'type' => 'text',
+			'error' => array('attributes' => array('class' => 'error'))
+		));
+		$expected = array(
+			'div' => array('class' => 'input text error'),
 			'label' => array('for' => 'ContactField'),
 			'Field',
 			'/label',
@@ -10760,38 +10781,19 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->input('Contact.second', array(
-			'type' => 'text',
-			'error' => array('attributes' => array('class' => 'error'))
-		));
-		$expected = array(
-			'div' => array('class' => 'input text error'),
-			'label' => array('for' => 'ContactSecond'),
-			'Field',
-			'/label',
-			'input' => array(
-				'type' => 'text', 'name' => 'data[Contact][second]',
-				'id' => 'ContactSecond', 'class' => 'form-error'
-			),
-			array('div' => array('class' => 'error')),
-			'Badness!',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-    $result = $this->Form->input('Contact.third', array(
+    $result = $this->Form->input('Contact.field', array(
 			'type' => 'text',
 			'div' => array('errorClass' => 'has-error'),
 			'error' => array('attributes' => array('class' => 'form-control-feedback'))
 		));
 		$expected = array(
 			'div' => array('class' => 'input text has-error'),
-			'label' => array('for' => 'ContactThird'),
+			'label' => array('for' => 'ContactField'),
 			'Field',
 			'/label',
 			'input' => array(
-				'type' => 'text', 'name' => 'data[Contact][third]',
-				'id' => 'ContactThird', 'class' => 'form-error'
+				'type' => 'text', 'name' => 'data[Contact][field]',
+				'id' => 'ContactField', 'class' => 'form-error'
 			),
 			array('div' => array('class' => 'form-control-feedback')),
 			'Badness!',

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -10734,4 +10734,70 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertAttributeEquals($here, '_lastAction', $this->Form, "_lastAction shouldn't be empty.");
 	}
 
+/**
+ * Tests the 'errorClass' option when error is returned.
+ *
+ * @return void
+ */
+	public function testInputErrorClass() {
+		$result = $this->Form->input('Contact.field', array(
+			'type' => 'text',
+			'div' => array('errorClass' => 'has-error'),
+			'error' => true
+		));
+		$expected = array(
+			'div' => array('class' => 'input text has-error'),
+			'label' => array('for' => 'ContactField'),
+			'Field',
+			'/label',
+			'input' => array(
+				'type' => 'text', 'name' => 'data[Contact][field]',
+				'id' => 'ContactField', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'error')),
+			'Badness!',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('Contact.second', array(
+			'type' => 'text',
+			'error' => array('attributes' => array('class' => 'error'))
+		));
+		$expected = array(
+			'div' => array('class' => 'input text error'),
+			'label' => array('for' => 'ContactSecond'),
+			'Field',
+			'/label',
+			'input' => array(
+				'type' => 'text', 'name' => 'data[Contact][second]',
+				'id' => 'ContactSecond', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'error')),
+			'Badness!',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+
+    $result = $this->Form->input('Contact.third', array(
+			'type' => 'text',
+			'div' => array('errorClass' => 'has-error'),
+			'error' => array('attributes' => array('class' => 'form-control-feedback'))
+		));
+		$expected = array(
+			'div' => array('class' => 'input text has-error'),
+			'label' => array('for' => 'ContactThird'),
+			'Field',
+			'/label',
+			'input' => array(
+				'type' => 'text', 'name' => 'data[Contact][third]',
+				'id' => 'ContactThird', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'form-control-feedback')),
+			'Badness!',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
 }

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1068,7 +1068,7 @@ class FormHelper extends AppHelper {
 		if ($type !== 'hidden' && $error !== false) {
 			$errMsg = $this->error($fieldName, $error);
 			if ($errMsg) {
-				$divOptions = $this->addClass($divOptions, 'error');
+				$divOptions = $this->addClass($divOptions, Hash::get($divOptions, 'errorClass', 'error'));
 				if ($errorMessage) {
 					$out['error'] = $errMsg;
 				}
@@ -1089,6 +1089,7 @@ class FormHelper extends AppHelper {
 		if (!empty($divOptions['tag'])) {
 			$tag = $divOptions['tag'];
 			unset($divOptions['tag']);
+			unset($divOptions['errorClass']);
 			$output = $this->Html->tag($tag, $output, $divOptions);
 		}
 		return $output;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1088,8 +1088,7 @@ class FormHelper extends AppHelper {
 
 		if (!empty($divOptions['tag'])) {
 			$tag = $divOptions['tag'];
-			unset($divOptions['tag']);
-			unset($divOptions['errorClass']);
+			unset($divOptions['tag'], $divOptions['errorClass']);
 			$output = $this->Html->tag($tag, $output, $divOptions);
 		}
 		return $output;


### PR DESCRIPTION
Make error class of div in FormHelper::input configurable, so it is possible to generate html snippets compatible with Bootstrap 4.