### PR TITLE
Add ability to remove columns from schema objects.

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -346,6 +346,21 @@ class TableSchema
     }
 
     /**
+     * Remove a column from the table schema.
+     *
+     * If the column is not defined in the table, no error will be raised.
+     *
+     * @param string $name The name of the column
+     * @return $this
+     */
+    public function removeColumn($name)
+    {
+        unset($this->_columns[$name], $this->_typeMap[$name]);
+
+        return $this;
+    }
+
+    /**
      * Get the column names in the table.
      *
      * @return array

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -105,6 +105,27 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test removing columns.
+     *
+     * @return void
+     */
+    public function testRemoveColumn()
+    {
+        $table = new Table('articles');
+        $result = $table->addColumn('title', [
+            'type' => 'string',
+            'length' => 25,
+            'null' => false
+        ])->removeColumn('title')
+        ->removeColumn('unknown');
+
+        $this->assertSame($table, $result);
+        $this->assertEquals([], $table->columns());
+        $this->assertNull($table->column('title'));
+        $this->assertSame([], $table->typeMap());
+    }
+
+    /**
      * Test isNullable method
      *
      * @return void


### PR DESCRIPTION
This is useful when you want to drop a column with 0 downtime/errors. This method can be used in ORM\Table::_initializeSchema() to un-map fields that are going to be dropped soon.