### PR TITLE
3.x - Don't filter out 0.0 in Hash::filter()

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -646,7 +646,7 @@ class Hash
      */
     protected static function _filter($var)
     {
-        return $var === 0 || $var === '0' || !empty($var);
+        return $var === 0 || $var === 0.0 || $var === '0' || !empty($var);
     }
 
     /**

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -857,8 +857,21 @@ class HashTest extends TestCase
      */
     public function testFilter()
     {
-        $result = Hash::filter(['0', false, true, 0, ['one thing', 'I can tell you', 'is you got to be', false]]);
-        $expected = ['0', 2 => true, 3 => 0, 4 => ['one thing', 'I can tell you', 'is you got to be']];
+        $result = Hash::filter([
+            '0',
+            false,
+            true,
+            0,
+            0.0,
+            ['one thing', 'I can tell you', 'is you got to be', false]
+        ]);
+        $expected = [
+            0 => '0',
+            2 => true,
+            3 => 0,
+            4 => 0.0,
+            5 => ['one thing', 'I can tell you', 'is you got to be']
+        ];
         $this->assertSame($expected, $result);
 
         $result = Hash::filter([1, [false]]);


### PR DESCRIPTION
Refs #10385