### PR TITLE
3.x ExceptionRenderer should always report filename & line (if debug=true) (PHP 7)

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -179,15 +179,17 @@ class ExceptionRenderer implements ExceptionRendererInterface
             'url' => h($url),
             'error' => $unwrapped,
             'code' => $code,
-            'file' => $exception->getFile(),
-            'line' => $exception->getLine(),
-            '_serialize' => ['message', 'url', 'code', 'file', 'line']
+            '_serialize' => ['message', 'url', 'code']
         ];
         if ($isDebug) {
             $viewVars['trace'] = Debugger::formatTrace($unwrapped->getTrace(), [
                 'format' => 'array',
                 'args' => false
             ]);
+            $viewVars['file'] = $exception->getFile();
+            $viewVars['line'] = $exception->getLine();
+            $viewVars['_serialize'][] = 'file';
+            $viewVars['_serialize'][] = 'line';
         }
         $this->controller->set($viewVars);
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -179,7 +179,9 @@ class ExceptionRenderer implements ExceptionRendererInterface
             'url' => h($url),
             'error' => $unwrapped,
             'code' => $code,
-            '_serialize' => ['message', 'url', 'code']
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+            '_serialize' => ['message', 'url', 'code', 'file', 'line']
         ];
         if ($isDebug) {
             $viewVars['trace'] = Debugger::formatTrace($unwrapped->getTrace(), [


### PR DESCRIPTION
Ref: https://github.com/cakephp/cakephp/issues/10397

### Example Before

```json
{
  "message": "syntax error, unexpected '$this' (T_VARIABLE)",
  "url": "/admin/flexi-cms/cms-documents/post.json",
  "code": 500,
}
```

### Example After without patching PHP7Exception (still wrong!)

```json
{
  "message": "syntax error, unexpected '$this' (T_VARIABLE)",
  "url": "/admin/flexi-cms/cms-documents/post.json",
  "code": 500,
  "file": "/var/www/cakephp/app/vendor/cakephp/cakephp/src/Error/BaseErrorHandler.php",
  "line": 169
}
```

### Example After with patching PHP7Exception
```json
{
  "message": "syntax error, unexpected '$this' (T_VARIABLE)",
  "url": "/admin/flexi-cms/cms-documents/patch.json",
  "code": 500,
  "file": "/var/www/cakephp/app/plugins/FlexiCms/src/Model/Table/CmsTemplatesTable.php",
  "line": 169
}
```

#### Reason in BaseErrorHandler.php:
```php
    public function wrapAndHandleException($exception)
    {
        if ($exception instanceof Error) {
            $exception = new PHP7ErrorException($exception); // wraps exception in exception
        }
        $this->handleException($exception);
    }
```