### PR TITLE
3.x ExceptionRenderer should always report filename & line (if debug=true) (PHP 7)

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -186,8 +186,8 @@ class ExceptionRenderer implements ExceptionRendererInterface
                 'format' => 'array',
                 'args' => false
             ]);
-            $viewVars['file'] = $exception->getFile() ?: "null";
-            $viewVars['line'] = $exception->getLine() ?: "null";
+            $viewVars['file'] = $exception->getFile() ?: 'null';
+            $viewVars['line'] = $exception->getLine() ?: 'null';
             $viewVars['_serialize'][] = 'file';
             $viewVars['_serialize'][] = 'line';
         }

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -186,6 +186,10 @@ class ExceptionRenderer implements ExceptionRendererInterface
                 'format' => 'array',
                 'args' => false
             ]);
+            $viewVars['file'] = $exception->getFile();
+            $viewVars['line'] = $exception->getLine();
+            $viewVars['_serialize'][] = 'file';
+            $viewVars['_serialize'][] = 'line';
         }
         $this->controller->set($viewVars);
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -186,8 +186,8 @@ class ExceptionRenderer implements ExceptionRendererInterface
                 'format' => 'array',
                 'args' => false
             ]);
-            $viewVars['file'] = $exception->getFile();
-            $viewVars['line'] = $exception->getLine();
+            $viewVars['file'] = $exception->getFile() ?: "null";
+            $viewVars['line'] = $exception->getLine() ?: "null";
             $viewVars['_serialize'][] = 'file';
             $viewVars['_serialize'][] = 'line';
         }

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -37,9 +37,11 @@ class PHP7ErrorException extends Exception
     public function __construct($error)
     {
         $this->_error = $error;
-        $message = $error->getMessage();
-        $code = $error->getCode();
-        parent::__construct(sprintf('(%s) - %s', get_class($error), $message), $code);
+        $this->message = $error->getMessage();
+        $this->code = $error->getCode();
+        $this->file = $error->getLine();
+        $this->file = $error->getFile();
+        parent::__construct(sprintf('(%s) - %s in %s on %s', get_class($error), $this->message, $this->file, $this->line), $code);
     }
 
     /**

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -47,7 +47,7 @@ class PHP7ErrorException extends Exception
             $this->file ?: "null",
             $this->line ?: "null"
         );
-        parent::__construct($msg, $code);
+        parent::__construct($msg, $this->code);
     }
 
     /**

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -45,7 +45,8 @@ class PHP7ErrorException extends Exception
             get_class($error),
             $this->message,
             $this->file ?: "null",
-            $this->line ?: "null");
+            $this->line ?: "null"
+        );
         parent::__construct($msg, $code);
     }
 

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -41,7 +41,8 @@ class PHP7ErrorException extends Exception
         $this->code = $error->getCode();
         $this->file = $error->getFile();
         $this->line = $error->getLine();
-        $msg = sprintf('(%s) - %s in %s on %s',
+        $msg = sprintf(
+            '(%s) - %s in %s on %s',
             get_class($error),
             $this->message,
             $this->file ?: "null",

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -39,9 +39,14 @@ class PHP7ErrorException extends Exception
         $this->_error = $error;
         $this->message = $error->getMessage();
         $this->code = $error->getCode();
-        $this->file = $error->getLine();
         $this->file = $error->getFile();
-        parent::__construct(sprintf('(%s) - %s in %s on %s', get_class($error), $this->message, $this->file, $this->line), $code);
+        $this->line = $error->getLine();
+        $msg = sprintf('(%s) - %s in %s on %s',
+            get_class($error),
+            $this->message,
+            $this->file ?: "null",
+            $this->line ?: "null");
+        parent::__construct($msg, $code);
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -430,7 +430,7 @@ class ExceptionRendererTest extends TestCase
         Router::setRequestInfo($request);
 
         $exception = new NotFoundException('Custom message');
-        $execptionLine = __LINE__ - 1;
+        $exceptionLine = __LINE__ - 1;
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['statusCode', '_sendHeader'])
@@ -443,7 +443,7 @@ class ExceptionRendererTest extends TestCase
             'url' => '/posts/view/1000?sort=title&amp;direction=desc',
             'code' => 404,
             'file' => __FILE__,
-            'line' => $execptionLine
+            'line' => $exceptionLine
         ];
 
         $this->assertEquals($expected, json_decode($result, true));

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -430,6 +430,7 @@ class ExceptionRendererTest extends TestCase
         Router::setRequestInfo($request);
 
         $exception = new NotFoundException('Custom message');
+        $execptionLine = __LINE__ - 1;
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $ExceptionRenderer->controller->response = $this->getMockBuilder('Cake\Network\Response')
             ->setMethods(['statusCode', '_sendHeader'])
@@ -440,7 +441,9 @@ class ExceptionRendererTest extends TestCase
         $expected = [
             'message' => 'Custom message',
             'url' => '/posts/view/1000?sort=title&amp;direction=desc',
-            'code' => 404
+            'code' => 404,
+            'file' => __FILE__,
+            'line' => $execptionLine
         ];
 
         $this->assertEquals($expected, json_decode($result, true));


### PR DESCRIPTION
Pass through file name and line number from `PHP7ErrorException` up to `ExceptionRenderer`

Replacement PR for https://github.com/cakephp/cakephp/pull/10399