### PR TITLE
Update URL in Docs and composer.json

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Help us keep CakePHP open and inclusive. Please read and follow our [Code of Con
 * Core test cases should continue to pass. You can run tests locally or enable
   [travis-ci](https://travis-ci.org/) for your fork, so all tests and codesniffs
   will be executed.
-* Your work should apply the [CakePHP coding standards](http://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html).
+* Your work should apply the [CakePHP coding standards](https://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html).
 
 ## Which branch to base the work
 
@@ -80,11 +80,11 @@ for the sniff and phpcs.
 
 ## Reporting a Security Issue
 
-If you've found a security related issue in CakePHP, please don't open an issue in github. Instead contact us at security@cakephp.org. For more information on how we handle security issues, [see the CakePHP Security Issue Process](http://book.cakephp.org/3.0/en/contributing/tickets.html#reporting-security-issues).
+If you've found a security related issue in CakePHP, please don't open an issue in github. Instead contact us at security@cakephp.org. For more information on how we handle security issues, [see the CakePHP Security Issue Process](https://book.cakephp.org/3.0/en/contributing/tickets.html#reporting-security-issues).
 
 # Additional Resources
 
-* [CakePHP coding standards](http://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html)
+* [CakePHP coding standards](https://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html)
 * [Existing issues](https://github.com/cakephp/cakephp/issues)
 * [Development Roadmaps](https://github.com/cakephp/cakephp/wiki#roadmaps)
 * [General GitHub documentation](https://help.github.com/)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ EXPLAIN WHAT IS ACTUALLY HAPPENING, HERE.
 ### What you expected to happen
 EXPLAIN WHAT IS TO BE EXPECTED, HERE.
 
-P.S. Remember, an issue is not the place to ask questions. You can use [Stack Overflow](http://stackoverflow.com/questions/tagged/cakephp)
+P.S. Remember, an issue is not the place to ask questions. You can use [Stack Overflow](https://stackoverflow.com/questions/tagged/cakephp)
 for that or join the #cakephp channel on irc.freenode.net, where we will be more
 than happy to help answer your questions.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.txt)
 [![Build Status](https://img.shields.io/travis/cakephp/cakephp/master.svg?style=flat-square)](https://travis-ci.org/cakephp/cakephp)
 [![Coverage Status](https://img.shields.io/codecov/c/github/cakephp/cakephp.svg?style=flat-square)](https://codecov.io/github/cakephp/cakephp)
-[![Code Consistency](https://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/grade.svg)](http://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/)
+[![Code Consistency](https://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/grade.svg)](https://squizlabs.github.io/PHP_CodeSniffer/analysis/cakephp/cakephp/)
 [![Total Downloads](https://img.shields.io/packagist/dt/cakephp/cakephp.svg?style=flat-square)](https://packagist.org/packages/cakephp/cakephp)
 [![Latest Stable Version](https://img.shields.io/packagist/v/cakephp/cakephp.svg?style=flat-square&label=stable)](https://packagist.org/packages/cakephp/cakephp)
 
-[CakePHP](http://www.cakephp.org) is a rapid development framework for PHP which
+[CakePHP](https://cakephp.org) is a rapid development framework for PHP which
 uses commonly known design patterns like Associative Data
 Mapping, Front Controller, and MVC.  Our primary goal is to provide a structured
 framework that enables PHP users at all levels to rapidly develop robust web
@@ -16,7 +16,7 @@ applications, without any loss to flexibility.
 ## Installing CakePHP via Composer
 
 You can install CakePHP into your project using
-[Composer](http://getcomposer.org).  If you're starting a new project, we
+[Composer](https://getcomposer.org).  If you're starting a new project, we
 recommend using the [app skeleton](https://github.com/cakephp/app) as
 a starting point. For existing applications you can run the following:
 
@@ -37,21 +37,21 @@ tests for CakePHP by doing the following:
 
 ## Some Handy Links
 
-* [CakePHP](http://www.cakephp.org) - The rapid development PHP framework.
-* [CookBook](http://book.cakephp.org) - The CakePHP user documentation; start learning here!
-* [API](http://api.cakephp.org) - A reference to CakePHP's classes.
+* [CakePHP](https://cakephp.org) - The rapid development PHP framework.
+* [CookBook](https://book.cakephp.org) - The CakePHP user documentation; start learning here!
+* [API](https://api.cakephp.org) - A reference to CakePHP's classes.
 * [Awesome CakePHP](https://github.com/FriendsOfCake/awesome-cakephp) - A list of featured resources around the framework.
-* [Plugins](http://plugins.cakephp.org) - A repository of extensions to the framework.
-* [The Bakery](http://bakery.cakephp.org) - Tips, tutorials and articles.
-* [Community Center](http://community.cakephp.org) - A source for everything community related.
-* [Training](http://training.cakephp.org) - Join a live session and get skilled with the framework.
-* [CakeFest](http://cakefest.org) - Don't miss our annual CakePHP conference.
-* [Cake Software Foundation](http://cakefoundation.org) - Promoting development related to CakePHP.
+* [Plugins](https://plugins.cakephp.org) - A repository of extensions to the framework.
+* [The Bakery](https://bakery.cakephp.org) - Tips, tutorials and articles.
+* [Community Center](https://community.cakephp.org) - A source for everything community related.
+* [Training](https://training.cakephp.org) - Join a live session and get skilled with the framework.
+* [CakeFest](https://cakefest.org) - Don't miss our annual CakePHP conference.
+* [Cake Software Foundation](https://cakefoundation.org) - Promoting development related to CakePHP.
 
 ## Get Support!
 
-* [Slack](http://cakesf.herokuapp.com/) - Join us on Slack.
-* [#cakephp](http://webchat.freenode.net/?channels=#cakephp) on irc.freenode.net - Come chat with us, we have cake.
+* [Slack](https://cakesf.herokuapp.com/) - Join us on Slack.
+* [#cakephp](https://webchat.freenode.net/?channels=#cakephp) on irc.freenode.net - Come chat with us, we have cake.
 * [Forum](http://discourse.cakephp.org/) - Official CakePHP forum.
 * [GitHub Issues](https://github.com/cakephp/cakephp/issues) - Got issues? Please tell us!
 * [Roadmaps](https://github.com/cakephp/cakephp/wiki#roadmaps) - Want to contribute? Get involved!
@@ -59,7 +59,7 @@ tests for CakePHP by doing the following:
 ## Contributing
 
 * [CONTRIBUTING.md](.github/CONTRIBUTING.md) - Quick pointers for contributing to the CakePHP project.
-* [CookBook "Contributing" Section](http://book.cakephp.org/3.0/en/contributing.html) - Details about contributing to the project.
+* [CookBook "Contributing" Section](https://book.cakephp.org/3.0/en/contributing.html) - Details about contributing to the project.
 
 # Security
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "The CakePHP framework",
     "type": "library",
     "keywords": ["framework"],
-    "homepage": "http://cakephp.org",
+    "homepage": "https://cakephp.org",
     "license": "MIT",
     "authors": [
         {
@@ -13,7 +13,7 @@
     ],
     "support": {
         "issues": "https://github.com/cakephp/cakephp/issues",
-        "forum": "http://stackoverflow.com/tags/cakephp",
+        "forum": "https://stackoverflow.com/tags/cakephp",
         "irc": "irc://irc.freenode.org/cakephp",
         "source": "https://github.com/cakephp/cakephp"
     },

--- a/src/Cache/README.md
+++ b/src/Cache/README.md
@@ -52,6 +52,6 @@ the callback will be executed and the returned data will be cached for future ca
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/core-libraries/caching.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/core-libraries/caching.html)
 
 

--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {

--- a/src/Collection/README.md
+++ b/src/Collection/README.md
@@ -28,4 +28,4 @@ you have in your application as well.
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/core-libraries/collections.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/core-libraries/collections.html)

--- a/src/Collection/composer.json
+++ b/src/Collection/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -34,4 +34,4 @@ Configure::dump('my_config', 'default');
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/development/configuration.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/development/configuration.html)

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "require": {

--- a/src/Database/README.md
+++ b/src/Database/README.md
@@ -345,7 +345,7 @@ SELECT CONCAT(title, :c0) ...;
 
 ### Other SQL Clauses
 
-Read of all other SQL clauses that the builder is capable of generating in the [official API docs](http://api.cakephp.org/3.2/class-Cake.Database.Query.html)
+Read of all other SQL clauses that the builder is capable of generating in the [official API docs](https://api.cakephp.org/3.x/class-Cake.Database.Query.html)
 
 ### Getting Results out of a Query
 
@@ -363,5 +363,5 @@ $results = $query->execute()->fetchAll('assoc');
 
 ## Official API
 
-You can read the official [official API docs](http://api.cakephp.org/3.2/namespace-Cake.Database.html) to learn more of what this library
+You can read the official [official API docs](https://api.cakephp.org/3.x/namespace-Cake.Database.html) to learn more of what this library
 has to offer.

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "CakePHP Community",
-            "homepage": "http://cakephp.org"
+            "homepage": "https://cakephp.org"
         }
     ],
     "require": {

--- a/src/Datasource/README.md
+++ b/src/Datasource/README.md
@@ -79,4 +79,4 @@ $conn = ConnectionManager::config('other', $connectionInstance);
 
 ## Documentation
 
-Please make sure you check the [official API documentation](http://api.cakephp.org/3.2/namespace-Cake.Datasource.html)
+Please make sure you check the [official API documentation](https://api.cakephp.org/3.x/namespace-Cake.Datasource.html)

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "CakePHP Community",
-            "homepage": "http://cakephp.org"
+            "homepage": "https://cakephp.org"
         }
     ],
     "require": {

--- a/src/Event/README.md
+++ b/src/Event/README.md
@@ -48,4 +48,4 @@ in separate objects that focus on those concerns.
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/core-libraries/events.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/core-libraries/events.html)

--- a/src/Event/composer.json
+++ b/src/Event/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {

--- a/src/Filesystem/README.md
+++ b/src/Filesystem/README.md
@@ -32,4 +32,4 @@ foreach ($files as $file) {
 ## Documentation
 
 Please make sure you check the [official
-documentation](http://book.cakephp.org/3.0/en/core-libraries/file-folder.html)
+documentation](https://book.cakephp.org/3.0/en/core-libraries/file-folder.html)

--- a/src/Filesystem/composer.json
+++ b/src/Filesystem/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {

--- a/src/Form/README.md
+++ b/src/Form/README.md
@@ -60,4 +60,4 @@ $errors = $contact->errors();
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/core-libraries/form.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/core-libraries/form.html)

--- a/src/Form/composer.json
+++ b/src/Form/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "CakePHP Community",
-            "homepage": "http://cakephp.org"
+            "homepage": "https://cakephp.org"
         }
     ],
     "autoload": {

--- a/src/I18n/README.md
+++ b/src/I18n/README.md
@@ -30,7 +30,7 @@ use Cake\Core\Configure;
 
 Configure::write('App.paths.locales', ['/path/with/trailing/slash/']);
 
-Please refer to the [CakePHP Manual](http://book.cakephp.org/3.0/en/core-libraries/internationalization-and-localization.html#language-files) for details
+Please refer to the [CakePHP Manual](https://book.cakephp.org/3.0/en/core-libraries/internationalization-and-localization.html#language-files) for details
 about expected folder structure and file naming.
 
 ### Translating a Message
@@ -91,12 +91,12 @@ echo Number::currency(123456.7890, 'EUR');
 ## Documentation
 
 Please make sure you check the [official I18n
-documentation](http://book.cakephp.org/3.0/en/core-libraries/internationalization-and-localization.html).
+documentation](https://book.cakephp.org/3.0/en/core-libraries/internationalization-and-localization.html).
 
 The [documentation for the Time
-class](http://book.cakephp.org/3.0/en/core-libraries/time.html) contains
+class](https://book.cakephp.org/3.0/en/core-libraries/time.html) contains
 instructions on how to configure and output time strings for selected locales.
 
 The [documentation for the Number
-class](http://book.cakephp.org/3.0/en/core-libraries/number.html) shows how to
+class](https://book.cakephp.org/3.0/en/core-libraries/number.html) shows how to
 use the `Number` class for displaying numbers in specific locales.

--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {

--- a/src/Log/README.md
+++ b/src/Log/README.md
@@ -80,4 +80,4 @@ Log::warning('this gets written only to payments.log', ['scope' => ['payments']]
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/core-libraries/logging.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/core-libraries/logging.html)

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {

--- a/src/ORM/README.md
+++ b/src/ORM/README.md
@@ -50,7 +50,7 @@ supports 4 association types out of the box:
 * belongsToMany - E.g. An article belongsToMany tags.
 
 You define associations in your table's `initialize()` method. See the
-[documentation](http://book.cakephp.org/3.0/en/orm/associations.html) for
+[documentation](https://book.cakephp.org/3.0/en/orm/associations.html) for
 complete examples.
 
 ## Reading Data
@@ -66,8 +66,8 @@ foreach ($articles->find() as $article) {
 }
 ```
 
-You can use the [query builder](http://book.cakephp.org/3.0/en/orm/query-builder.html) to create
-complex queries, and a [variety of methods](http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html)
+You can use the [query builder](https://book.cakephp.org/3.0/en/orm/query-builder.html) to create
+complex queries, and a [variety of methods](https://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html)
 to access your data.
 
 ## Saving Data
@@ -101,7 +101,7 @@ $articles->save($article, [
 ```
 
 The above shows how you can easily marshal and save an entity and its
-associations in a simple & powerful way. Consult the [ORM documentation](http://book.cakephp.org/3.0/en/orm/saving-data.html)
+associations in a simple & powerful way. Consult the [ORM documentation](https://book.cakephp.org/3.0/en/orm/saving-data.html)
 for more in-depth examples.
 
 ## Deleting Data
@@ -116,5 +116,5 @@ $articles->delete($article);
 
 ## Additional Documentation
 
-Consult [the CakePHP ORM documentation](http://book.cakephp.org/3.0/en/orm.html)
+Consult [the CakePHP ORM documentation](https://book.cakephp.org/3.0/en/orm.html)
 for more in-depth documentation.

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "CakePHP Community",
-            "homepage": "http://cakephp.org"
+            "homepage": "https://cakephp.org"
         }
     ],
     "autoload": {

--- a/src/Template/Layout/dev_error.ctp
+++ b/src/Template/Layout/dev_error.ctp
@@ -206,8 +206,8 @@ use Cake\Error\Debugger;
             <span class="header-type"><?= get_class($error) ?></span>
         </h1>
         <div class="header-help">
-            <a target="_blank" href="http://book.cakephp.org/3.0/">Documentation</a>
-            <a target="_blank" href="http://api.cakephp.org/">API</a>
+            <a target="_blank" href="https://book.cakephp.org/3.0/">Documentation</a>
+            <a target="_blank" href="https://api.cakephp.org/">API</a>
         </div>
     </header>
 

--- a/src/Utility/README.md
+++ b/src/Utility/README.md
@@ -23,7 +23,7 @@ $bigPeople = Hash::extract($things, '{n}[age>21].name');
 // $bigPeople will contain ['Susan', 'Lucy']
 ```
 
-Check the [official Hash class documentation](http://book.cakephp.org/3.0/en/core-libraries/hash.html)
+Check the [official Hash class documentation](https://book.cakephp.org/3.0/en/core-libraries/hash.html)
 
 ### Inflector
 
@@ -36,7 +36,7 @@ echo Inflector::pluralize('Apple'); // echoes Apples
 echo Inflector::singularize('People'); // echoes Person
 ```
 
-Check the [official Inflector class documentation](http://book.cakephp.org/3.0/en/core-libraries/inflector.html)
+Check the [official Inflector class documentation](https://book.cakephp.org/3.0/en/core-libraries/inflector.html)
 
 ### Text
 
@@ -57,7 +57,7 @@ This is the song
 that never ends.
 ```
 
-Check the [official Text class documentation](http://book.cakephp.org/3.0/en/core-libraries/text.html)
+Check the [official Text class documentation](https://book.cakephp.org/3.0/en/core-libraries/text.html)
 
 ### Security
 
@@ -70,7 +70,7 @@ $result = Security::encrypt($value, $key);
 Security::decrypt($result, $key);
 ```
 
-Check the [official Security class documentation](http://book.cakephp.org/3.0/en/core-libraries/security.html)
+Check the [official Security class documentation](https://book.cakephp.org/3.0/en/core-libraries/security.html)
 
 ### Xml
 
@@ -88,4 +88,4 @@ $data = [
 $xml = Xml::build($data);
 ```
 
-Check the [official Xml class documentation](http://book.cakephp.org/3.0/en/core-libraries/xml.html)
+Check the [official Xml class documentation](https://book.cakephp.org/3.0/en/core-libraries/xml.html)

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "CakePHP Community",
-            "homepage": "http://cakephp.org"
+            "homepage": "https://cakephp.org"
         }
     ],
     "suggest": {

--- a/src/Validation/README.md
+++ b/src/Validation/README.md
@@ -34,4 +34,4 @@ if (!empty($errors)) {
 
 ## Documentation
 
-Please make sure you check the [official documentation](http://book.cakephp.org/3.0/en/core-libraries/validation.html)
+Please make sure you check the [official documentation](https://book.cakephp.org/3.0/en/core-libraries/validation.html)

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
         "name": "CakePHP Community",
-        "homepage": "http://cakephp.org"
+        "homepage": "https://cakephp.org"
     }
     ],
     "autoload": {


### PR DESCRIPTION
This PR is Docs improvement in cakephp repository.

## 1. Use https as much as possible on the following sites.

If the linked site is always on https, save time for redirect processing.

## 2. Always link API document to latest version

Now that you can redirect to the latest version of API page: cakephp/cakephp-api-docs#82