### PR TITLE
[2.next] Make test suites compatible with PHPUnit 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ php:
   - 7.1
 
 env:
-  - DB=mysql
+  matrix:
+    - DB=mysql
+  global:
+    - PHPUNIT=3.7.33
 
 services:
   - memcached
@@ -17,6 +20,9 @@ services:
 matrix:
   fast_finish: true
   include:
+    - php: 5.3
+      env: DB=mysql PHPUNIT=4.8.35
+
     - php: 5.4
       env: DB=pgsql
 
@@ -28,8 +34,8 @@ matrix:
 
 
 before_script:
-  - sh -c "composer global require 'phpunit/phpunit=3.7.33'"
-  - sh -c "ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit ./vendors/PHPUnit"
+  - composer global require "phpunit/phpunit=$PHPUNIT"
+  - echo "require_once '$HOME/.composer/vendor/autoload.php';" >> app/Config/bootstrap.php
   - sudo locale-gen de_DE
   - sudo locale-gen es_ES
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"

--- a/lib/Cake/Console/ConsoleInputArgument.php
+++ b/lib/Cake/Console/ConsoleInputArgument.php
@@ -159,7 +159,7 @@ class ConsoleInputArgument {
 		$option = $parent->addChild('argument');
 		$option->addAttribute('name', $this->_name);
 		$option->addAttribute('help', $this->_help);
-		$option->addAttribute('required', $this->isRequired());
+		$option->addAttribute('required', (int)$this->isRequired());
 		$choices = $option->addChild('choices');
 		foreach ($this->_choices as $valid) {
 			$choices->addChild('choice', $valid);

--- a/lib/Cake/Console/ConsoleInputOption.php
+++ b/lib/Cake/Console/ConsoleInputOption.php
@@ -205,10 +205,11 @@ class ConsoleInputOption {
 		$option->addAttribute('name', '--' . $this->_name);
 		$short = '';
 		if (strlen($this->_short)) {
-			$short = $this->_short;
+			$short = '-' . $this->_short;
 		}
-		$option->addAttribute('short', '-' . $short);
-		$option->addAttribute('boolean', $this->_boolean);
+		$option->addAttribute('short', $short);
+		$option->addAttribute('help', $this->_help);
+		$option->addAttribute('boolean', (int)$this->_boolean);
 		$option->addChild('default', $this->_default);
 		$choices = $option->addChild('choices');
 		foreach ($this->_choices as $valid) {

--- a/lib/Cake/Console/HelpFormatter.php
+++ b/lib/Cake/Console/HelpFormatter.php
@@ -182,7 +182,6 @@ class HelpFormatter {
 		$xml->addChild('command', $parser->command());
 		$xml->addChild('description', $parser->description());
 
-		$xml->addChild('epilog', $parser->epilog());
 		$subcommands = $xml->addChild('subcommands');
 		foreach ($parser->subcommands() as $command) {
 			$command->xml($subcommands);
@@ -195,6 +194,7 @@ class HelpFormatter {
 		foreach ($parser->arguments() as $argument) {
 			$argument->xml($arguments);
 		}
+		$xml->addChild('epilog', $parser->epilog());
 		return $string ? $xml->asXml() : $xml;
 	}
 

--- a/lib/Cake/Test/Case/Console/HelpFormatterTest.php
+++ b/lib/Cake/Test/Case/Console/HelpFormatterTest.php
@@ -299,8 +299,8 @@ TEXT;
 		$expected = <<<TEXT
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
-<description>Description text</description>
+<command>mycommand</command>
+<description />
 <subcommands />
 <options>
 	<option name="--help" short="-h" help="Display this help." boolean="1">
@@ -322,11 +322,14 @@ TEXT;
 			<choice>aro</choice>
 		</choices>
 	</argument>
+	<argument help="Another argument." name="other_longer" required="0">
+		<choices/>
+	</argument>
 </arguments>
-<epilog>epilog text</epilog>
+<epilog />
 </shell>
 TEXT;
-		$this->assertEquals(new DomDocument($expected), new DomDocument($result), 'Help does not match');
+		$this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
 	}
 
 /**
@@ -346,7 +349,7 @@ TEXT;
 		$expected = <<<TEXT
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
+<command>mycommand</command>
 <description>Description text</description>
 <subcommands />
 <options>
@@ -367,7 +370,7 @@ TEXT;
 <epilog>epilog text</epilog>
 </shell>
 TEXT;
-		$this->assertEquals(new DomDocument($expected), new DomDocument($result), 'Help does not match');
+		$this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
 	}
 
 /**
@@ -385,7 +388,7 @@ TEXT;
 		$expected = <<<TEXT
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
+<command>mycommand</command>
 <description/>
 <subcommands>
 	<command name="method" help="This is another command" />
@@ -404,7 +407,7 @@ TEXT;
 <epilog/>
 </shell>
 TEXT;
-		$this->assertEquals(new DomDocument($expected), new DomDocument($result), 'Help does not match');
+		$this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
 	}
 
 /**
@@ -424,7 +427,7 @@ TEXT;
 		$expected = <<<TEXT
 <?xml version="1.0"?>
 <shell>
-<name>mycommand</name>
+<command>mycommand</command>
 <description/>
 <subcommands/>
 <options>
@@ -445,7 +448,7 @@ TEXT;
 <epilog/>
 </shell>
 TEXT;
-		$this->assertEquals(new DomDocument($expected), new DomDocument($result), 'Help does not match');
+		$this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
 	}
 
 /**
@@ -464,7 +467,7 @@ TEXT;
 		$expected = <<<TEXT
 <?xml version="1.0"?>
 <shell>
-	<name>mycommand</name>
+	<command>mycommand</command>
 	<description/>
 	<subcommands/>
 	<options>
@@ -488,7 +491,7 @@ TEXT;
 	<epilog/>
 </shell>
 TEXT;
-		$this->assertEquals(new DomDocument($expected), new DomDocument($result), 'Help does not match');
+		$this->assertXmlStringEqualsXmlString($expected, $result, 'Help does not match');
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/ThemeViewTest.php
+++ b/lib/Cake/Test/Case/View/ThemeViewTest.php
@@ -198,7 +198,6 @@ class ThemeViewTest extends CakeTestCase {
 /**
  * testMissingView method
  *
- * @expectedException MissingViewException
  * @return void
  */
 	public function testMissingView() {
@@ -211,17 +210,18 @@ class ThemeViewTest extends CakeTestCase {
 		$this->Controller->params['pass'] = array('home');
 
 		$View = new TestTheme2View($this->Controller);
-		ob_start();
-		$View->getViewFileName('does_not_exist');
-		$expected = ob_get_clean();
-		$this->assertRegExp("/PagesController::/", $expected);
-		$this->assertRegExp("/views(\/|\\\)themed(\/|\\\)my_theme(\/|\\\)pages(\/|\\\)does_not_exist.ctp/", $expected);
+
+		try {
+			$View->getViewFileName('does_not_exist');
+			$this->fail('No exception');
+		} catch (MissingViewException $e) {
+			$this->assertContains('Pages' . DS . 'does_not_exist.ctp', $e->getMessage());
+		}
 	}
 
 /**
  * testMissingLayout method
  *
- * @expectedException MissingLayoutException
  * @return void
  */
 	public function testMissingLayout() {
@@ -232,11 +232,13 @@ class ThemeViewTest extends CakeTestCase {
 		$this->Controller->theme = 'my_theme';
 
 		$View = new TestTheme2View($this->Controller);
-		ob_start();
-		$View->getLayoutFileName();
-		$expected = ob_get_clean();
-		$this->assertRegExp("/Missing Layout/", $expected);
-		$this->assertRegExp("/views(\/|\\\)themed(\/|\\\)my_theme(\/|\\\)layouts(\/|\\\)whatever.ctp/", $expected);
+
+		try {
+			$View->getLayoutFileName();
+			$this->fail('No exception');
+		} catch (MissingLayoutException $e) {
+			$this->assertContains('Layouts' . DS . 'whatever.ctp', $e->getMessage());
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -625,9 +625,16 @@ class ViewTest extends CakeTestCase {
 		$this->Controller->params['pass'] = array('home');
 
 		$View = new TestView($this->Controller);
-		ob_start();
 		$View->getViewFileName('does_not_exist');
+	}
 
+/**
+ * Test for missing theme views
+ *
+ * @expectedException MissingViewException
+ * @return void
+ */
+	public function testMissingThemeView() {
 		$this->ThemeController->plugin = null;
 		$this->ThemeController->name = 'Pages';
 		$this->ThemeController->viewPath = 'Pages';
@@ -653,10 +660,16 @@ class ViewTest extends CakeTestCase {
 		$this->Controller->layout = 'whatever';
 
 		$View = new TestView($this->Controller);
-		ob_start();
 		$View->getLayoutFileName();
-		ob_get_clean();
+	}
 
+/**
+ * Test for missing theme layouts
+ *
+ * @expectedException MissingLayoutException
+ * @return void
+ */
+	public function testMissingThemeLayout() {
 		$this->ThemeController->plugin = null;
 		$this->ThemeController->name = 'Posts';
 		$this->ThemeController->viewPath = 'posts';
@@ -1512,7 +1525,6 @@ class ViewTest extends CakeTestCase {
 	public static function blockValueProvider() {
 		return array(
 			'string' => array('A string value'),
-			'null' => array(null),
 			'decimal' => array(1.23456),
 			'object with __toString' => array(new TestObjectWithToString()),
 		);
@@ -1631,26 +1643,33 @@ class ViewTest extends CakeTestCase {
 /**
  * Test that starting the same block twice throws an exception
  *
- * @expectedException CakeException
  * @return void
  */
 	public function testStartBlocksTwice() {
-		$this->View->start('first');
-		echo 'In first ';
-		$this->View->start('second');
-		echo 'In second';
-		$this->View->start('first');
+		try {
+			$this->View->start('first');
+			$this->View->start('first');
+			$this->fail('No exception');
+		} catch (CakeException $e) {
+			ob_end_clean();
+			$this->assertTrue(true);
+		}
 	}
 
 /**
  * Test that an exception gets thrown when you leave a block open at the end
  * of a view.
  *
- * @expectedException CakeException
  * @return void
  */
 	public function testExceptionOnOpenBlock() {
-		$this->View->render('open_block');
+		try {
+			$this->View->render('open_block');
+			$this->fail('No exception');
+		} catch (CakeException $e) {
+			ob_end_clean();
+			$this->assertContains('The "no_close" block was left open', $e->getMessage());
+		}
 	}
 
 /**
@@ -1673,23 +1692,33 @@ TEXT;
 /**
  * Make sure that extending the current view with itself causes an exception
  *
- * @expectedException LogicException
  * @return void
  */
 	public function testExtendSelf() {
-		$this->View->layout = false;
-		$this->View->render('extend_self');
+		try {
+			$this->View->layout = false;
+			$this->View->render('extend_self');
+			$this->fail('No exception');
+		} catch (LogicException $e) {
+			ob_end_clean();
+			$this->assertContains('cannot have views extend themselves', $e->getMessage());
+		}
 	}
 
 /**
  * Make sure that extending in a loop causes an exception
  *
- * @expectedException LogicException
  * @return void
  */
 	public function testExtendLoop() {
-		$this->View->layout = false;
-		$this->View->render('extend_loop');
+		try {
+			$this->View->layout = false;
+			$this->View->render('extend_loop');
+			$this->fail('No exception');
+		} catch (LogicException $e) {
+			ob_end_clean();
+			$this->assertContains('cannot have views extend in a loop', $e->getMessage());
+		}
 	}
 
 /**
@@ -1713,12 +1742,18 @@ TEXT;
 /**
  * Extending an element which doesn't exist should throw a missing view exception
  *
- * @expectedException LogicException
  * @return void
  */
 	public function testExtendMissingElement() {
-		$this->View->layout = false;
-		$this->View->render('extend_missing_element');
+		try {
+			$this->View->layout = false;
+			$this->View->render('extend_missing_element');
+			$this->fail('No exception');
+		} catch (LogicException $e) {
+			ob_end_clean();
+			ob_end_clean();
+			$this->assertContains('element', $e->getMessage());
+		}
 	}
 
 /**

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -76,6 +76,8 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @throws InvalidArgumentException
  */
 	public function run(PHPUnit_Framework_TestResult $result = null) {
+		$level = ob_get_level();
+
 		if (!empty($this->fixtureManager)) {
 			$this->fixtureManager->load($this);
 		}
@@ -83,6 +85,11 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 		if (!empty($this->fixtureManager)) {
 			$this->fixtureManager->unload($this);
 		}
+
+		for ($i = ob_get_level(); $i < $level; ++$i) {
+			ob_start();
+		}
+
 		return $result;
 	}
 

--- a/lib/Cake/TestSuite/CakeTestRunner.php
+++ b/lib/Cake/TestSuite/CakeTestRunner.php
@@ -15,7 +15,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-if (!defined('__PHPUNIT_PHAR__')) {
+if (!class_exists('PHPUnit_TextUI_TestRunner')) {
 	require_once 'PHPUnit/TextUI/TestRunner.php';
 }
 
@@ -52,7 +52,11 @@ class CakeTestRunner extends PHPUnit_TextUI_TestRunner {
 		}
 
 		$fixture = $this->_getFixtureManager($arguments);
-		foreach ($suite->getIterator() as $test) {
+		$iterator = $suite->getIterator();
+		if ($iterator instanceof RecursiveIterator) {
+			$iterator = new RecursiveIteratorIterator($iterator);
+		}
+		foreach ($iterator as $test) {
 			if ($test instanceof CakeTestCase) {
 				$fixture->fixturize($test);
 				$test->fixtureManager = $fixture;

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -16,7 +16,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-if (!defined('__PHPUNIT_PHAR__')) {
+if (!class_exists('PHPUnit_TextUI_Command')) {
 	require_once 'PHPUnit/TextUI/Command.php';
 }
 

--- a/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
@@ -15,7 +15,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-if (!defined('__PHPUNIT_PHAR__')) {
+if (!class_exists('PHPUnit_TextUI_ResultPrinter')) {
 	require_once 'PHPUnit/TextUI/ResultPrinter.php';
 }
 

--- a/lib/Cake/View/Errors/missing_controller.ctp
+++ b/lib/Cake/View/Errors/missing_controller.ctp
@@ -27,7 +27,7 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 </p>
 <pre>
 &lt;?php
-class <?php echo h($class . ' extends ' . $plugin); ?>AppController {
+class <?php echo h($class . ' extends ' . (empty($plugin) ? '' : $plugin)); ?>AppController {
 
 }
 </pre>


### PR DESCRIPTION
- Made test suites compatible with PHPUnit 4.8
- Fixed XML output of HelpFormatter (Backport from #10339. The related test cases don't pass with PHPUnit 4.8. I noticed this issue when I was working to make CakePHP 2.x compatible with PHPUnit 4.8 for my project. Then I checked 3.x branch and noticed that the related test cases had been fixed in a wrong way. That was why I reported #10339).
- Added PHPUnit 4.8 to test matrix
- ~~Added CakeFinalizer class. PHPUnit 4.8 marks test cases as 'risky', if the output buffering level is different before and after the test. CakeFinalizer allows us to adjust the output buffering level, when we want to test some function which changes the output buffering level and throws an exception.~~
- Fixed several risky tests.
    - Fixed CakeTestCase::run() to restore original output buffering level
    - Fixed an undefined variable warning in missing_controller.ctp
    - Fixed ViewTest (backport of 92bd86274b64c31ef6034caa74bb168be041b5e0)
    - Fixed ThemeViewTest

I have not changed `composer.json` as I think that using PHPUnit 4.8 is optional. So, for now, only a test is running with PHPUnit 4.8. However, It may be arguable. I am fine to change `composer.json` and `.travis.yml` to let all test cases run with PHPUnit 4.8.

Refs: #10398