### PR TITLE
Fix PhpDoc for RouteBuilder::redirect()

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -566,7 +566,7 @@ class RouteBuilder
      *   routes that end in `*` are greedy. As you can remap URLs and not loose any passed args.
      *
      * @param string $route A string describing the template of the route
-     * @param array $url An URL to redirect to. Can be a string or a Cake array-based URL
+     * @param array|string $url An URL to redirect to. Can be a string or a Cake array-based URL
      * @param array $options An array matching the named elements in the route to regular expressions which that
      *   element should match. Also contains additional parameters such as which routed parameters should be
      *   shifted into the passed arguments. As well as supplying patterns for routing parameters.


### PR DESCRIPTION
The second argument `$url` of `RouteBuilder::redirect()` accepts a string.