### PR TITLE
Fix Http\Client\CookieCollection according to RFC6265.

### DIFF
--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -92,15 +92,15 @@ class CookieCollection
                 continue;
             }
             $leadingDot = $cookie['domain'][0] === '.';
-            if (!$leadingDot && $host !== $cookie['domain']) {
+            if ($leadingDot) {
+                $cookie['domain'] = ltrim($cookie['domain'], '.');
+            }
+
+            $pattern = '/' . preg_quote(substr($cookie['domain'], 1), '/') . '$/';
+            if (!preg_match($pattern, $host)) {
                 continue;
             }
-            if ($leadingDot) {
-                $pattern = '/' . preg_quote(substr($cookie['domain'], 1), '/') . '$/';
-                if (!preg_match($pattern, $host)) {
-                    continue;
-                }
-            }
+
             $out[$cookie['name']] = $cookie['value'];
         }
 

--- a/tests/TestCase/Http/Client/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Client/CookieCollectionTest.php
@@ -226,6 +226,42 @@ class CookieCollectionTest extends TestCase
     {
         $headers = [
             'HTTP/1.0 200 Ok',
+            'Set-Cookie: first=1; Domain=example.com',
+            'Set-Cookie: second=2;',
+        ];
+        $response = new Response($headers, '');
+        $this->cookies->store($response, 'http://foo.example.com/');
+
+        $result = $this->cookies->get('http://example.com');
+        $expected = ['first' => 1];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->cookies->get('http://foo.example.com');
+        $expected = ['first' => 1, 'second' => '2'];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->cookies->get('http://bar.foo.example.com');
+        $expected = ['first' => 1, 'second' => '2'];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->cookies->get('http://api.example.com');
+        $expected = ['first' => 1];
+        $this->assertEquals($expected, $result);
+
+        $result = $this->cookies->get('http://google.com');
+        $expected = [];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test getting cookies matching on paths exactly
+     *
+     * @return void
+     */
+    public function testGetMatchingDomainWithDot()
+    {
+        $headers = [
+            'HTTP/1.0 200 Ok',
             'Set-Cookie: first=1; Domain=.example.com',
             'Set-Cookie: second=2;',
         ];
@@ -241,7 +277,7 @@ class CookieCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->cookies->get('http://bar.foo.example.com');
-        $expected = ['first' => 1];
+        $expected = ['first' => 1, 'second' => '2'];
         $this->assertEquals($expected, $result);
 
         $result = $this->cookies->get('http://api.example.com');


### PR DESCRIPTION
Currently `CookieCollection` will not return cookies without leading dot in a domain for subdomain requests.

I had a real life example where cookies with domain `example.com` (no leading dot) would not be sent with requests to `subdomain.example.com`.

I have found out that modern clients should ignore leading dot. Here is a fix for that.

More reading:
- http://bayou.io/draft/cookie.domain.html
- https://tools.ietf.org/html/rfc6265