### PR TITLE
Remove errors when aliases don't match

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1144,7 +1144,7 @@ abstract class Association
         }
 
         if ($fields) {
-            $query->select($query->aliasFields($fields, $target->getAlias()));
+            $query->select($query->aliasFields($fields, $this->_name));
         }
         $query->addDefaultTypes($target);
     }
@@ -1245,7 +1245,7 @@ abstract class Association
     protected function _joinCondition($options)
     {
         $conditions = [];
-        $tAlias = $this->getTarget()->getAlias();
+        $tAlias = $this->_name;
         $sAlias = $this->getSource()->getAlias();
         $foreignKey = (array)$options['foreignKey'];
         $bindingKey = (array)$this->getBindingKey();

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -151,7 +151,7 @@ class BelongsTo extends Association
     protected function _joinCondition($options)
     {
         $conditions = [];
-        $tAlias = $this->getTarget()->getAlias();
+        $tAlias = $this->_name;
         $sAlias = $this->_sourceTable->getAlias();
         $foreignKey = (array)$options['foreignKey'];
         $bindingKey = (array)$this->getBindingKey();

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -497,13 +497,6 @@ class EagerLoader
                 sprintf('%s is not associated with %s', $parent->getAlias(), $alias)
             );
         }
-        if ($instance->getAlias() !== $alias) {
-            throw new InvalidArgumentException(sprintf(
-                "You have contained '%s' but that association was bound as '%s'.",
-                $alias,
-                $instance->getAlias()
-            ));
-        }
 
         $paths += ['aliasPath' => '', 'propertyPath' => '', 'root' => $alias];
         $paths['aliasPath'] .= '.' . $alias;

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -436,21 +436,6 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
-     * Check that normalizing contains checks alias names.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You have contained 'Clients' but that association was bound as 'clients'
-     * @return void
-     */
-    public function testNormalizedChecksAliasNames()
-    {
-        $contains = ['Clients'];
-        $loader = new EagerLoader;
-        $loader->contain($contains);
-        $loader->normalized($this->table);
-    }
-
-    /**
      * Tests that the path for getting to a deep association is materialized in an
      * array key
      *


### PR DESCRIPTION
This hard error makes using the `targetTable` option in associations really hard as it always triggers this condition. By reworking how we generate aliases and eagerloader aliases we can enable the `targetTable` option to behave as intended. The foreignKey will need to be set, when used with `targetTable` and a table that doesn't have a matching alias, but I think that is reasonable given how key generation uses the table's alias for other reasons.

I've had to replace target aliases with the association names, so that the selected fields reflect the association's alias and not the table's original alias. I don't think this will cause problems with application code that relies on the target table's alias being used, as aliases always had to match between the association and table instance. One situation that could be problematic with the new code is if a user is using `$table->aliasField()` in query expressions for association finders. Because the table's alias and association alias no longer have be the same, mismatching aliases could end up in the same query.

Refs #7125
Refs #10410