### PR TITLE
Unset the active user data on logout.

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -645,6 +645,7 @@ class AuthComponent extends Component {
 		foreach ($this->_authenticateObjects as $auth) {
 			$auth->logout($user);
 		}
+		static::$_user = array();
 		$this->Session->delete(static::$sessionKey);
 		$this->Session->delete('Auth.redirect');
 		$this->Session->renew();

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -1429,6 +1429,23 @@ class AuthComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test that logout removes the active user data as well for stateless auth
+ *
+ * @return void
+ */
+	public function testLogoutRemoveUser() {
+		$oldKey = AuthComponent::$sessionKey;
+		AuthComponent::$sessionKey = false;
+		$this->Auth->login(array('id' => 1, 'username' => 'mariano'));
+		$this->assertSame('mariano', $this->Auth->user('username'));
+
+		$this->Auth->logout();
+		AuthComponent::$sessionKey = $oldKey;
+
+		$this->assertNull($this->Auth->user('username'));
+	}
+
+/**
  * Logout should trigger a logout method on authentication objects.
  *
  * @return void


### PR DESCRIPTION
When using stateless authentication the current user should be cleared after logout to maintain consistency with session based authentication.

Refs #10422
