### PR TITLE
TranslateBehavior's method TranslationField now returns standard table alias for default locale

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -436,7 +436,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     public function translationField($field)
     {
         $table = $this->_table;
-        if($this->locale() === $this->getConfig('defaultLocale')) {
+        if ($this->locale() === $this->getConfig('defaultLocale')) {
             return $table->aliasField($field);
         }
         $associationName = $table->getAlias() . '_' . $field . '_translation';

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -436,6 +436,9 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     public function translationField($field)
     {
         $table = $this->_table;
+        if($this->locale() === $this->getConfig('defaultLocale')) {
+            return $table->aliasField($field);
+        }
         $associationName = $table->getAlias() . '_' . $field . '_translation';
 
         if ($table->associations()->has($associationName)) {

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1736,29 +1736,4 @@ class TranslateBehaviorTest extends TestCase
         ];
         $this->assertEquals($expected, $entity->errors('es'));
     }
-
-//    /**
-//     * Test that translationField method returns the standard column name
-//     * while using the default locale, and the i18n table alias when
-//     * using other language
-//     *
-//     * @return void
-//     */
-//    public function testTranslationFieldErrors()
-//    {
-//        $table = TableRegistry::get('Articles');
-//        $table->addBehavior('Translate', [
-//            'fields' => ['title'],
-//            'defaultLocale' => 'en_US'
-//        ]);
-//
-////        I18n::locale('en_US');
-////        $this->assertEquals('Articles.title', $table->translationField('title'));
-//
-////        I18n::locale('de_DE');
-////        $this->assertEquals($table->translationField('title'), 'Articles_title_translation.content');
-//
-////        I18n::locale('en');
-////        $this->assertEquals($table->translationField('title'), 'Articles_title_translation.content');
-//    }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -328,11 +328,47 @@ class TranslateBehaviorTest extends TestCase
     public function testTranslationFieldForTranslatedFields()
     {
         $table = TableRegistry::get('Articles');
-        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $table->addBehavior('Translate', [
+            'fields' => ['title', 'body'],
+            'defaultLocale' => 'en_US'
+        ]);
 
-        $expected = 'Articles_title_translation.content';
+        $expectedSameLocale = 'Articles.title';
+        $expectedOtherLocale = 'Articles_title_translation.content';
+
         $field = $table->translationField('title');
-        $this->assertSame($expected, $field);
+        $this->assertSame($expectedSameLocale, $field);
+
+        I18n::locale('es_ES');
+        $field = $table->translationField('title');
+        $this->assertSame($expectedOtherLocale, $field);
+
+        I18n::locale('en');
+        $field = $table->translationField('title');
+        $this->assertSame($expectedOtherLocale, $field);
+
+        $table->removeBehavior('Translate');
+
+        $table->addBehavior('Translate', [
+            'fields' => ['title', 'body'],
+            'defaultLocale' => 'de_DE'
+        ]);
+
+        I18n::locale('de_DE');
+        $field = $table->translationField('title');
+        $this->assertSame($expectedSameLocale, $field);
+
+        I18n::locale('en_US');
+        $field = $table->translationField('title');
+        $this->assertSame($expectedOtherLocale, $field);
+
+        $table->locale('de_DE');
+        $field = $table->translationField('title');
+        $this->assertSame($expectedSameLocale, $field);
+
+        $table->locale('es');
+        $field = $table->translationField('title');
+        $this->assertSame($expectedOtherLocale, $field);
     }
 
     /**
@@ -1700,4 +1736,29 @@ class TranslateBehaviorTest extends TestCase
         ];
         $this->assertEquals($expected, $entity->errors('es'));
     }
+
+//    /**
+//     * Test that translationField method returns the standard column name
+//     * while using the default locale, and the i18n table alias when
+//     * using other language
+//     *
+//     * @return void
+//     */
+//    public function testTranslationFieldErrors()
+//    {
+//        $table = TableRegistry::get('Articles');
+//        $table->addBehavior('Translate', [
+//            'fields' => ['title'],
+//            'defaultLocale' => 'en_US'
+//        ]);
+//
+////        I18n::locale('en_US');
+////        $this->assertEquals('Articles.title', $table->translationField('title'));
+//
+////        I18n::locale('de_DE');
+////        $this->assertEquals($table->translationField('title'), 'Articles_title_translation.content');
+//
+////        I18n::locale('en');
+////        $this->assertEquals($table->translationField('title'), 'Articles_title_translation.content');
+//    }
 }


### PR DESCRIPTION
TranslateBehavior's method TranslationField always returned the alias for the i18n table for the field argument, be the default locale or not.

This fix compares before anything if the current locale is equals to the default locale for the table. If so, returns the default alias. If not, it behaves as always.