### PR TITLE
3.next - Make most cookie operations immutable

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -396,6 +396,34 @@ class Cookie implements CookieInterface
     }
 
     /**
+     * Create a new cookie that will virtually never expire.
+     *
+     * @return static
+     */
+    public function withNeverExpire()
+    {
+        $new = clone $this;
+        $new->expiresAt = Chronos::createFromDate(2038, 1, 1)->format('U');
+
+        return $new;
+    }
+
+    /**
+     * Create a new cookie that wil deletes the cookie from the browser
+     *
+     * This is done by setting the expiration time to 1 year ago
+     *
+     * @return static
+     */
+    public function withExpired()
+    {
+        $new = clone $this;
+        $new->expiresAt = Chronos::parse('-1 year')->format('U');
+
+        return $new;
+    }
+
+    /**
      * Checks if a value exists in the cookie data
      *
      * @param string $path Path to check
@@ -452,32 +480,6 @@ class Cookie implements CookieInterface
         if (!$this->isExpanded) {
             throw new RuntimeException('The Cookie data has not been expanded');
         }
-    }
-
-    /**
-     * Sets the cookies date to a far future so it will virtually never expire
-     *
-     * @return $this
-     */
-    public function willNeverExpire()
-    {
-        $this->expiresAt = Chronos::now()->setDate(2038, 1, 1)->format('U');
-
-        return $this;
-    }
-
-    /**
-     * Deletes the cookie from the browser
-     *
-     * This is done by setting the expiration time to "now"
-     *
-     * @return $this
-     */
-    public function willBeDeleted()
-    {
-        $this->expiresAt = Chronos::now()->format('U');
-
-        return $this;
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -418,7 +418,7 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Create a new cookie that wil deletes the cookie from the browser
+     * Create a new cookie that will expire/delete the cookie from the browser.
      *
      * This is done by setting the expiration time to 1 year ago
      *
@@ -433,7 +433,7 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Checks if a value exists in the cookie data
+     * Checks if a value exists in the cookie data.
      *
      * @param string $path Path to check
      * @return bool

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -125,10 +125,12 @@ class Cookie implements CookieInterface
         $this->validateName($name);
         $this->name = $name;
         $this->_setValue($value);
-        $this->validateDomain($domain);
+        $this->validateString($domain);
         $this->domain = $domain;
-        $this->setHttpOnly($httpOnly);
-        $this->setPath($path);
+        $this->validateBool($httpOnly);
+        $this->httpOnly = $httpOnly;
+        $this->validateString($path);
+        $this->path = $path;
 
         if ($expiresAt !== null) {
             $this->expiresAt($expiresAt);
@@ -260,23 +262,18 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Sets the path
+     * Create a new cookie with an updated path
      *
      * @param string $path Sets the path
-     * @return $this
+     * @return static
      */
-    public function setPath($path)
+    public function withPath($path)
     {
-        if (!is_string($path)) {
-            throw new InvalidArgumentException(sprintf(
-                'The provided arg must be of type `string` but `%s` given',
-                gettype($path)
-            ));
-        }
+        $this->validateString($path);
+        $new = clone $this;
+        $new->path = $path;
 
-        $this->path = $path;
-
-        return $this;
+        return $new;
     }
 
     /**
@@ -287,7 +284,7 @@ class Cookie implements CookieInterface
      */
     public function withDomain($domain)
     {
-        $this->validateDomain($domain);
+        $this->validateString($domain);
         $new = clone $this;
         $new->domain = $domain;
 
@@ -295,18 +292,18 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Validate that domains are strings.
+     * Validate that an argument is a string
      *
-     * @param string $domain The domain to validate.
+     * @param string $value The value to validate.
      * @return void
      * @throws \InvalidArgumentException
      */
-    protected function validateDomain($domain)
+    protected function validateString($value)
     {
-        if (!is_string($domain)) {
+        if (!is_string($value)) {
             throw new InvalidArgumentException(sprintf(
                 'The provided arg must be of type `string` but `%s` given',
-                gettype($domain)
+                gettype($value)
             ));
         }
     }
@@ -322,23 +319,35 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Set HTTP Only
+     * Create a cookie with HTTP Only updated
      *
      * @param bool $httpOnly HTTP Only
-     * @return $this
+     * @return static
      */
-    public function setHttpOnly($httpOnly)
+    public function withHttpOnly($httpOnly)
     {
-        if (!is_bool($httpOnly)) {
+        $this->validateBool($httpOnly);
+        $new = clone $this;
+        $new->httpOnly = $httpOnly;
+
+        return $new;
+    }
+
+    /**
+     * Validate that an argument is a boolean
+     *
+     * @param bool $value The value to validate.
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    protected function validateBool($value)
+    {
+        if (!is_bool($value)) {
             throw new InvalidArgumentException(sprintf(
                 'The provided arg must be of type `bool` but `%s` given',
-                gettype($httpOnly)
+                gettype($value)
             ));
         }
-
-        $this->httpOnly = $httpOnly;
-
-        return $this;
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -31,8 +31,7 @@ use RuntimeException;
  * store) or to record the user's browsing activity (including clicking
  * particular buttons, logging in, or recording which pages were visited in
  * the past). They can also be used to remember arbitrary pieces of information
- * that the user previously entered into form fields such as names, addresses,
- * passwords, and credit card numbers.
+ * that the user previously entered into form fields such as names, and preferences.
  *
  * @link https://tools.ietf.org/html/rfc6265
  * @link https://en.wikipedia.org/wiki/HTTP_cookie

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -120,8 +120,15 @@ class Cookie implements CookieInterface
      * @param bool $secure Is secure
      * @param bool $httpOnly HTTP Only
      */
-    public function __construct($name, $value = '', $expiresAt = null, $path = '', $domain = '', $secure = false, $httpOnly = false)
-    {
+    public function __construct(
+        $name,
+        $value = '',
+        DateTimeInterface $expiresAt = null,
+        $path = '',
+        $domain = '',
+        $secure = false,
+        $httpOnly = false
+    ) {
         $this->validateName($name);
         $this->name = $name;
 
@@ -140,7 +147,7 @@ class Cookie implements CookieInterface
         $this->secure = $secure;
 
         if ($expiresAt !== null) {
-            $this->expiresAt($expiresAt);
+            $this->expiresAt = (int)$expiresAt->format('U');
         }
     }
 
@@ -186,17 +193,18 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Sets the cookie name
+     * Create a cookie with an updated name
      *
      * @param string $name Name of the cookie
-     * @return $this
+     * @return static
      */
-    public function setName($name)
+    public function withName($name)
     {
         $this->validateName($name);
-        $this->name = $name;
+        $new = clone $this;
+        $new->name = $name;
 
-        return $this;
+        return $new;
     }
 
     /**
@@ -383,16 +391,17 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Sets the expiration date
+     * Create a cookie with an updated expiration date
      *
      * @param \DateTimeInterface $dateTime Date time object
-     * @return $this
+     * @return static
      */
-    public function expiresAt(DateTimeInterface $dateTime)
+    public function withExpiry(DateTimeInterface $dateTime)
     {
-        $this->expiresAt = (int)$dateTime->format('U');
+        $new = clone $this;
+        $new->expiresAt = (int)$dateTime->format('U');
 
-        return $this;
+        return $new;
     }
 
     /**
@@ -437,19 +446,34 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Writes data to the cookie
+     * Create a new cookie with updated data.
      *
      * @param string $path Path to write to
      * @param mixed $value Value to write
-     * @return $this
+     * @return static
      */
-    public function write($path, $value)
+    public function withAddedValue($path, $value)
     {
         $this->_isExpanded();
+        $new = clone $this;
+        $new->value = Hash::insert($new->value, $path, $value);
 
-        Hash::insert($this->value, $path, $value);
+        return $new;
+    }
 
-        return $this;
+    /**
+     * Create a new cookie without a specific path
+     *
+     * @param string $path Path to remove
+     * @return static
+     */
+    public function withoutAddedValue($path)
+    {
+        $this->_isExpanded();
+        $new = clone $this;
+        $new->value = Hash::remove($new->value, $path);
+
+        return $new;
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -125,7 +125,8 @@ class Cookie implements CookieInterface
         $this->validateName($name);
         $this->name = $name;
         $this->_setValue($value);
-        $this->setDomain($domain);
+        $this->validateDomain($domain);
+        $this->domain = $domain;
         $this->setHttpOnly($httpOnly);
         $this->setPath($path);
 
@@ -279,12 +280,28 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Sets the domain
+     * Create a cookie with an updated domain
      *
      * @param string $domain Domain to set
-     * @return $this
+     * @return static
      */
-    public function setDomain($domain)
+    public function withDomain($domain)
+    {
+        $this->validateDomain($domain);
+        $new = clone $this;
+        $new->domain = $domain;
+
+        return $new;
+    }
+
+    /**
+     * Validate that domains are strings.
+     *
+     * @param string $domain The domain to validate.
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    protected function validateDomain($domain)
     {
         if (!is_string($domain)) {
             throw new InvalidArgumentException(sprintf(
@@ -292,10 +309,6 @@ class Cookie implements CookieInterface
                 gettype($domain)
             ));
         }
-
-        $this->domain = $domain;
-
-        return $this;
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -336,7 +336,7 @@ class Cookie implements CookieInterface
     /**
      * Create a cookie with Secure updated
      *
-     * @param bool $httpOnly HTTP Only
+     * @param bool $secure Secure attribute value
      * @return static
      */
     public function withSecure($secure)

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -33,6 +33,13 @@ use RuntimeException;
  * the past). They can also be used to remember arbitrary pieces of information
  * that the user previously entered into form fields such as names, and preferences.
  *
+ * Cookie objects are immutable, and you must re-assign variables when modifying
+ * cookie objects:
+ *
+ * ```
+ * $cookie = $cookie->withValue('0');
+ * ```
+ *
  * @link https://tools.ietf.org/html/rfc6265
  * @link https://en.wikipedia.org/wiki/HTTP_cookie
  */
@@ -116,8 +123,8 @@ class Cookie implements CookieInterface
     public function __construct($name, $value = '', $expiresAt = null, $path = '', $domain = '', $secure = false, $httpOnly = false)
     {
         $this->validateName($name);
-        $this->setName($name);
-        $this->setValue($value);
+        $this->name = $name;
+        $this->_setValue($value);
         $this->setDomain($domain);
         $this->setHttpOnly($httpOnly);
         $this->setPath($path);
@@ -223,20 +230,32 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Sets the raw cookie data
+     * Create a cookie with an updated value.
      *
      * @param string|array $value Value of the cookie to set
-     * @return $this
+     * @return static
      */
-    public function setValue($value)
+    public function withValue($value)
+    {
+        $new = clone $this;
+        $new->_setValue($value);
+
+        return $new;
+    }
+
+    /**
+     * Setter for the value attribute.
+     *
+     * @param mixed $value The value to store.
+     * @return void
+     */
+    protected function _setValue($value)
     {
         if (is_array($value)) {
             $this->isExpanded = true;
         }
 
         $this->value = $value;
-
-        return $this;
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -124,13 +124,20 @@ class Cookie implements CookieInterface
     {
         $this->validateName($name);
         $this->name = $name;
+
         $this->_setValue($value);
+
         $this->validateString($domain);
         $this->domain = $domain;
+
         $this->validateBool($httpOnly);
         $this->httpOnly = $httpOnly;
+
         $this->validateString($path);
         $this->path = $path;
+
+        $this->validateBool($secure);
+        $this->secure = $secure;
 
         if ($expiresAt !== null) {
             $this->expiresAt($expiresAt);
@@ -316,6 +323,21 @@ class Cookie implements CookieInterface
     public function isSecure()
     {
         return $this->secure;
+    }
+
+    /**
+     * Create a cookie with Secure updated
+     *
+     * @param bool $httpOnly HTTP Only
+     * @return static
+     */
+    public function withSecure($secure)
+    {
+        $this->validateBool($secure);
+        $new = clone $this;
+        $new->secure = $secure;
+
+        return $new;
     }
 
     /**

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -41,12 +41,12 @@ interface CookieInterface
     public function getValue();
 
     /**
-     * Sets the raw cookie data
+     * Create a cookie with an updated value.
      *
      * @param string|array $value Value of the cookie to set
-     * @return $this
+     * @return static
      */
-    public function setValue($value);
+    public function withValue($value);
 
     /**
      * Returns the cookie as header value

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -22,9 +22,9 @@ interface CookieInterface
      * Sets the cookie name
      *
      * @param string $name Name of the cookie
-     * @return $this
+     * @return static
      */
-    public function setName($name);
+    public function withName($name);
 
     /**
      * Gets the cookie name

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -247,6 +247,43 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test setting secure in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithSecureInvalidConstructor()
+    {
+        new Cookie('cakephp', 'cakephp-rocks', null, '', '', 'invalid');
+    }
+
+    /**
+     * Test setting secure in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithSecureInvalid()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie->withSecure('no');
+    }
+
+    /**
+     * Test setting httponly in cookies
+     *
+     * @return void
+     */
+    public function testWithSecure()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withSecure(true);
+        $this->assertNotSame($new, $cookie, 'Should clone');
+        $this->assertFalse($cookie->isSecure());
+        $this->assertTrue($new->isSecure());
+    }
+
+    /**
      * testInflateAndExpand
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -141,6 +141,17 @@ class CookieTest extends TestCase
      * @return void
      * @expectedException \InvalidArgumentException
      */
+    public function testWithDomainInvalidConstructor()
+    {
+        new Cookie('cakephp', 'rocks', null, '', 1234);
+    }
+
+    /**
+     * Test setting domain in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
     public function testWithDomainInvalid()
     {
         $cookie = new Cookie('cakephp', 'rocks');
@@ -158,7 +169,81 @@ class CookieTest extends TestCase
         $new = $cookie->withDomain('example.com');
         $this->assertNotSame($new, $cookie, 'Should make a clone');
         $this->assertNotContains('example.com', $cookie->toHeaderValue(), 'old instance not modified');
-        $this->assertContains('example.com', $new->toHeaderValue());
+        $this->assertContains('domain=example.com', $new->toHeaderValue());
+    }
+
+    /**
+     * Test setting path in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithPathInvalid()
+    {
+        $cookie = new Cookie('cakephp', 'rocks');
+        $cookie->withPath(['oops']);
+    }
+
+    /**
+     * Test setting path in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithPathInvalidConstructor()
+    {
+        new Cookie('cakephp', 'rocks', null, 123);
+    }
+
+    /**
+     * Test setting path in cookies
+     *
+     * @return void
+     */
+    public function testWithPath()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withPath('/api');
+        $this->assertNotSame($new, $cookie, 'Should make a clone');
+        $this->assertNotContains('path=/api', $cookie->toHeaderValue(), 'old instance not modified');
+        $this->assertContains('path=/api', $new->toHeaderValue());
+    }
+
+    /**
+     * Test setting httponly in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithHttpOnlyInvalidConstructor()
+    {
+        new Cookie('cakephp', 'cakephp-rocks', null, '', '', false, 'invalid');
+    }
+
+    /**
+     * Test setting httponly in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithHttpOnlyInvalid()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie->withHttpOnly('no');
+    }
+
+    /**
+     * Test setting httponly in cookies
+     *
+     * @return void
+     */
+    public function testWithHttpOnly()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withHttpOnly(true);
+        $this->assertNotSame($new, $cookie, 'Should clone');
+        $this->assertFalse($cookie->isHttpOnly());
+        $this->assertTrue($new->isHttpOnly());
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -97,12 +97,11 @@ class CookieTest extends TestCase
         $date = Chronos::createFromFormat('m/d/Y h:m:s', '12/1/2027 12:00:00');
 
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie->setDomain('cakephp.org');
+        $cookie = $cookie->withDomain('cakephp.org');
         $cookie->expiresAt($date);
         $result = $cookie->toHeaderValue();
 
         $expected = 'cakephp=cakephp-rocks; expires=Tue, 01-Dec-2026 12:00:00 GMT; domain=cakephp.org';
-
         $this->assertEquals($expected, $result);
     }
 
@@ -134,6 +133,32 @@ class CookieTest extends TestCase
         $this->assertNotSame($new, $cookie, 'Should make a clone');
         $this->assertSame('cakephp-rocks', $cookie->getValue(), 'old instance not modified');
         $this->assertSame('new', $new->getValue());
+    }
+
+    /**
+     * Test setting domain in cookies
+     *
+     * @return void
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithDomainInvalid()
+    {
+        $cookie = new Cookie('cakephp', 'rocks');
+        $cookie->withDomain(['oops']);
+    }
+
+    /**
+     * Test setting domain in cookies
+     *
+     * @return void
+     */
+    public function testWithDomain()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withDomain('example.com');
+        $this->assertNotSame($new, $cookie, 'Should make a clone');
+        $this->assertNotContains('example.com', $cookie->toHeaderValue(), 'old instance not modified');
+        $this->assertContains('example.com', $new->toHeaderValue());
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -142,6 +142,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `string` but `integer` given
      */
     public function testWithDomainInvalidConstructor()
     {
@@ -153,6 +154,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `string` but `array` given
      */
     public function testWithDomainInvalid()
     {
@@ -179,6 +181,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `string` but `array` given
      */
     public function testWithPathInvalid()
     {
@@ -191,6 +194,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `string` but `integer` given
      */
     public function testWithPathInvalidConstructor()
     {
@@ -216,6 +220,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `bool` but `string` given
      */
     public function testWithHttpOnlyInvalidConstructor()
     {
@@ -227,6 +232,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `bool` but `string` given
      */
     public function testWithHttpOnlyInvalid()
     {
@@ -253,6 +259,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `bool` but `string` given
      */
     public function testWithSecureInvalidConstructor()
     {
@@ -264,6 +271,7 @@ class CookieTest extends TestCase
      *
      * @return void
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The provided arg must be of type `bool` but `string` given
      */
     public function testWithSecureInvalid()
     {
@@ -272,7 +280,7 @@ class CookieTest extends TestCase
     }
 
     /**
-     * Test setting httponly in cookies
+     * Test setting secure in cookies
      *
      * @return void
      */

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -286,6 +286,34 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test the never expiry method
+     *
+     * @return void
+     */
+    public function testWithNeverExpire()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withNeverExpire();
+        $this->assertNotSame($new, $cookie, 'Should clone');
+        $this->assertContains('01-Jan-2038', $new->toHeaderValue());
+    }
+
+    /**
+     * Test the expired method
+     *
+     * @return void
+     */
+    public function testWithExpired()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withExpired();
+        $this->assertNotSame($new, $cookie, 'Should clone');
+
+        $now = Chronos::parse('-1 year');
+        $this->assertContains($now->format('Y'), $new->toHeaderValue());
+    }
+
+    /**
      * testInflateAndExpand
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -123,6 +123,20 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test setting values in cookies
+     *
+     * @return void
+     */
+    public function testWithValue()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withValue('new');
+        $this->assertNotSame($new, $cookie, 'Should make a clone');
+        $this->assertSame('cakephp-rocks', $cookie->getValue(), 'old instance not modified');
+        $this->assertSame('new', $new->getValue());
+    }
+
+    /**
      * testInflateAndExpand
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -97,11 +97,13 @@ class CookieTest extends TestCase
         $date = Chronos::createFromFormat('m/d/Y h:m:s', '12/1/2027 12:00:00');
 
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withHttpOnly(true)
+            ->withSecure(true);
         $cookie->expiresAt($date);
         $result = $cookie->toHeaderValue();
 
-        $expected = 'cakephp=cakephp-rocks; expires=Tue, 01-Dec-2026 12:00:00 GMT; domain=cakephp.org';
+        $expected = 'cakephp=cakephp-rocks; expires=Tue, 01-Dec-2026 12:00:00 GMT; domain=cakephp.org; secure; httponly';
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
Make most of the cookie operations use immutable patterns. This makes cookies work in a similar way to the request & response. This is also important so that we can ensure that the request/response stay actually immutable.

I've not attempted to solve the `expand()`, `flatten()`, and encryption related features as I want to do those separately. I feel that the expand/flatten methods should happen implicitly when complex values are manipulated, and that encryption should be moved into a standalone middleware with a whitelist of cookies it handles.