### PR TITLE
"General error: 2006 MySQL server has gone away" bug

### DIFF
--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -89,8 +89,8 @@ trait PDODriverTrait
             $connected = false;
         } else {
             try {
-                $connected = $this->_connection->query('SELECT 1');
-            } catch (\PDOException $e) {
+                $connected = $this->_connection->query('SELECT 1')->fetchAll();
+            } catch (\Exception $e) {
                 $connected = false;
             }
         }


### PR DESCRIPTION
"$this->_connection->query('SELECT 1')" returns PDOStatement object with empty result set.