### PR TITLE
3.next - Implicit cookie value expansion

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -542,36 +542,6 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Expands a serialized cookie value
-     *
-     * @return $this
-     */
-    public function expand()
-    {
-        if (!$this->isExpanded) {
-            $this->value = $this->_expand($this->value);
-            $this->isExpanded = true;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Serializes the cookie value to a string
-     *
-     * @return $this
-     */
-    public function flatten()
-    {
-        if ($this->isExpanded) {
-            $this->value = $this->_flatten($this->value);
-            $this->isExpanded = false;
-        }
-
-        return $this;
-    }
-
-    /**
      * Checks if the cookie value was expanded
      *
      * @return bool

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -273,12 +273,7 @@ class Cookie implements CookieInterface
      */
     protected function _setValue($value)
     {
-        if (is_array($value)) {
-            $this->isExpanded = true;
-        } else {
-            $this->isExpanded = false;
-        }
-
+        $this->isExpanded = is_array($value);
         $this->value = $value;
     }
 
@@ -441,16 +436,19 @@ class Cookie implements CookieInterface
     /**
      * Checks if a value exists in the cookie data.
      *
+     * This method will expand serialized complex data,
+     * on first use.
+     *
      * @param string $path Path to check
      * @return bool
      */
     public function check($path)
     {
         if ($this->isExpanded === false) {
-            $value = $this->_expand($this->value);
+            $this->value = $this->_expand($this->value);
         }
 
-        return Hash::check($value, $path);
+        return Hash::check($this->value, $path);
     }
 
     /**
@@ -490,6 +488,9 @@ class Cookie implements CookieInterface
 
     /**
      * Read data from the cookie
+     *
+     * This method will expand serialized complex data,
+     * on first use.
      *
      * @param string $path Path to read the data from
      * @return mixed

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -385,6 +385,34 @@ class CookieTest extends TestCase
     }
 
     /**
+     * test read() and set on different types
+     *
+     * @return void
+     */
+    public function testReadExpandsOnDemand()
+    {
+        $data = [
+            'username' => 'florian',
+            'profile' => [
+                'profession' => 'developer'
+            ]
+        ];
+        $cookie = new Cookie('cakephp', json_encode($data));
+        $this->assertFalse($cookie->isExpanded());
+        $this->assertEquals('developer', $cookie->read('profile.profession'));
+        $this->assertTrue($cookie->isExpanded(), 'Cookies expand when read.');
+
+        $cookie = $cookie->withValue(json_encode($data));
+        $this->assertTrue($cookie->check('profile.profession'), 'Cookies expand when read.');
+        $this->assertTrue($cookie->isExpanded());
+
+        $cookie = $cookie->withValue(json_encode($data))
+            ->withAddedValue('face', 'punch');
+        $this->assertTrue($cookie->isExpanded());
+        $this->assertSame('punch', $cookie->read('face'));
+    }
+
+    /**
      * test read() on structured data.
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -473,6 +473,19 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test reading complex data serialized in 1.x and early 2.x
+     *
+     * @return void
+     */
+    public function testReadLegacyComplexData()
+    {
+        $data = 'key|value,key2|value2';
+        $cookie = new Cookie('cakephp', $data);
+        $this->assertEquals('value', $cookie->read('key'));
+        $this->assertNull($cookie->read('nope'));
+    }
+
+    /**
      * Test that toHeaderValue() collapses data.
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -385,6 +385,38 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test check() with serialized source data.
+     *
+     * @return void
+     */
+    public function testCheckStringSourceData()
+    {
+        $cookie = new Cookie('cakephp', '{"type":"mvc", "user": {"name":"mark"}}');
+        $this->assertTrue($cookie->check('type'));
+        $this->assertTrue($cookie->check('user.name'));
+        $this->assertFalse($cookie->check('nope'));
+        $this->assertFalse($cookie->check('user.nope'));
+    }
+
+    /**
+     * Test check() with array source data.
+     *
+     * @return void
+     */
+    public function testCheckArraySourceData()
+    {
+        $data = [
+            'type' => 'mvc',
+            'user' => ['name' => 'mark']
+        ];
+        $cookie = new Cookie('cakephp', $data);
+        $this->assertTrue($cookie->check('type'));
+        $this->assertTrue($cookie->check('user.name'));
+        $this->assertFalse($cookie->check('nope'));
+        $this->assertFalse($cookie->check('user.nope'));
+    }
+
+    /**
      * test read() and set on different types
      *
      * @return void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -359,7 +359,6 @@ class CookieTest extends TestCase
     public function testWithAddedValue()
     {
         $cookie = new Cookie('cakephp', '{"type":"mvc", "icing": true}');
-        $cookie->expand();
         $new = $cookie->withAddedValue('type', 'mvc')
             ->withAddedValue('user.name', 'mark');
         $this->assertNotSame($new, $cookie, 'Should clone');
@@ -376,7 +375,6 @@ class CookieTest extends TestCase
     public function testWithoutAddedValue()
     {
         $cookie = new Cookie('cakephp', '{"type":"mvc", "user": {"name":"mark"}}');
-        $cookie->expand();
         $new = $cookie->withoutAddedValue('type', 'mvc')
             ->withoutAddedValue('user.name');
         $this->assertNotSame($new, $cookie, 'Should clone');
@@ -387,11 +385,11 @@ class CookieTest extends TestCase
     }
 
     /**
-     * testInflateAndExpand
+     * test read() on structured data.
      *
      * @return void
      */
-    public function testInflateAndExpand()
+    public function testReadComplexData()
     {
         $data = [
             'username' => 'florian',
@@ -412,13 +410,25 @@ class CookieTest extends TestCase
 
         $result = $cookie->read('profile.profession');
         $this->assertEquals('developer', $result);
+    }
 
-        $result = $cookie->flatten();
-        $this->assertInstanceOf(Cookie::class, $result);
+    /**
+     * Test that toHeaderValue() collapses data.
+     *
+     * @return void
+     */
+    public function testToHeaderValueCollapsesComplexData()
+    {
+        $data = [
+            'username' => 'florian',
+            'profile' => [
+                'profession' => 'developer'
+            ]
+        ];
+        $cookie = new Cookie('cakephp', $data);
+        $this->assertEquals('developer', $cookie->read('profile.profession'));
 
         $expected = '{"username":"florian","profile":{"profession":"developer"}}';
-        $result = $cookie->getValue();
-
-        $this->assertEquals($expected, $result);
+        $this->assertContains(urlencode($expected), $cookie->toHeaderValue());
     }
 }


### PR DESCRIPTION
We can transparently expand and flatten encoded data. This makes cookies easier to work with as the no longer have expanded state that developers have to manually check. While this implicit type changing is a departure from the immutable patterns, I think it is a reasonable trade off for more ergonomic objects.

Refs #10406 