### PR TITLE
Fix a bug in paginating multiple results

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -451,8 +451,8 @@ class PaginatorHelper extends Helper
         }
         $isSorted = (
             $sortKey === $table . '.' . $field ||
-            $sortKey === $defaultModel . '.' . $key ||
-            $table . '.' . $field === $defaultModel . '.' . $sortKey
+            $sortKey === $model . '.' . $key ||
+            $table . '.' . $field === $model . '.' . $sortKey
         );
 
         $template = 'sort';


### PR DESCRIPTION
Paginating multiple result without specifying a default model didn't work. This pull request fix the bug