### PR TITLE
3.next - Add Client specific methods to CookieCollection

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -293,6 +293,16 @@ class Cookie implements CookieInterface
     }
 
     /**
+     * Get the path attribute.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
      * Create a cookie with an updated domain
      *
      * @param string $domain Domain to set
@@ -305,6 +315,16 @@ class Cookie implements CookieInterface
         $new->domain = $domain;
 
         return $new;
+    }
+
+    /**
+     * Get the domain attribute.
+     *
+     * @return string
+     */
+    public function getDomain()
+    {
+        return $this->domain;
     }
 
     /**
@@ -403,6 +423,16 @@ class Cookie implements CookieInterface
         $new->expiresAt = (int)$dateTime->format('U');
 
         return $new;
+    }
+
+    /**
+     * Get the current expiry time
+     *
+     * @return int|null Timestamp of expiry or null
+     */
+    public function getExpiry()
+    {
+        return $this->expiresAt;
     }
 
     /**

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -65,20 +65,22 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Add a cookie and get an updated collection.
      *
+     * Cookie names do not have to be unique in a collection, but
+     * having duplicate cookie names will change how get() behaves.
+     *
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie instance to add.
      * @return static
      */
     public function add(CookieInterface $cookie)
     {
-        $key = mb_strtolower($cookie->getName());
         $new = clone $this;
-        $new->cookies[$key] = $cookie;
+        $new->cookies[] = $cookie;
 
         return $new;
     }
 
     /**
-     * Get a cookie by name
+     * Get the first cookie by name.
      *
      * If the provided name matches a URL (matches `#^https?://#`) this method
      * will assume you want a list of cookies that match that URL. This is
@@ -91,8 +93,10 @@ class CookieCollection implements IteratorAggregate, Countable
     public function get($name)
     {
         $key = mb_strtolower($name);
-        if (isset($this->cookies[$key])) {
-            return $this->cookies[$key];
+        foreach ($this->cookies as $cookie) {
+            if (mb_strtolower($cookie->getName()) === $key) {
+                return $cookie;
+            }
         }
 
         return null;
@@ -106,11 +110,18 @@ class CookieCollection implements IteratorAggregate, Countable
      */
     public function has($name)
     {
-        return isset($this->cookies[mb_strtolower($name)]);
+        $key = mb_strtolower($name);
+        foreach ($this->cookies as $cookie) {
+            if (mb_strtolower($cookie->getName()) === $key) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
-     * Remove a cookie from the collection and get a new collection
+     * Create a new collection with all cookies matching $name removed.
      *
      * If the cookie is not in the collection, this method will do nothing.
      *
@@ -120,7 +131,12 @@ class CookieCollection implements IteratorAggregate, Countable
     public function remove($name)
     {
         $new = clone $this;
-        unset($new->cookies[mb_strtolower($name)]);
+        $key = mb_strtolower($name);
+        foreach ($new->cookies as $i => $cookie) {
+            if (mb_strtolower($cookie->getName()) === $key) {
+                unset($new->cookies[$i]);
+            }
+        }
 
         return $new;
     }
@@ -189,8 +205,7 @@ class CookieCollection implements IteratorAggregate, Countable
             if ($expires && $expires <= time()) {
                 continue;
             }
-            $key = mb_strtolower($cookie->getName());
-            $new->cookies[$key] = $cookie;
+            $new->cookies[] = $cookie;
         }
 
         return $new;

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -222,14 +222,7 @@ class CookieCollection implements IteratorAggregate, Countable
         $cookies = [];
         foreach ($values as $value) {
             $value = rtrim($value, ';');
-            $nestedSemi = '";"';
-            if (strpos($value, $nestedSemi) !== false) {
-                $value = str_replace($nestedSemi, "{__cookie_replace__}", $value);
-                $parts = explode(';', $value);
-                $parts = str_replace("{__cookie_replace__}", $nestedSemi, $parts);
-            } else {
-                $parts = preg_split('/\;[ \t]*/', $value);
-            }
+            $parts = preg_split('/\;[ \t]*/', $value);
 
             $name = false;
             $cookie = [
@@ -249,7 +242,7 @@ class CookieCollection implements IteratorAggregate, Countable
                 }
                 if ($i === 0) {
                     $name = $key;
-                    $cookie['value'] = $value;
+                    $cookie['value'] = urldecode($value);
                     continue;
                 }
                 $key = strtolower($key);

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -177,7 +177,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Add cookies that match the path/domain/expiration to the request.
      *
-     * This allows CookieCollections to be used a 'cookie jar' in an HTTP client
+     * This allows CookieCollections to be used as a 'cookie jar' in an HTTP client
      * situation. Cookies that match the request's domain + path that are not expired
      * when this method is called will be applied to the request.
      *

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -227,6 +227,27 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
+     * Test adding cookies that contain URL encoded data
+     *
+     * @return void
+     */
+    public function testAddFromResponseValueUrldecodeData()
+    {
+        $collection = new CookieCollection();
+        $request = new ServerRequest([
+            'url' => '/app'
+        ]);
+        $response = (new Response())
+            ->withAddedHeader('Set-Cookie', 'test=val%3Bue; Path=/example; Secure;');
+        $new = $collection->addFromResponse($response, $request);
+        $this->assertTrue($new->has('test'));
+
+        $test = $new->get('test');
+        $this->assertSame('val;ue', $test->getValue());
+        $this->assertSame('/example', $test->getPath());
+    }
+
+    /**
      * Test adding cookies from a response ignores expired cookies
      *
      * @return void
@@ -239,7 +260,7 @@ class CookieCollectionTest extends TestCase
         ]);
         $response = (new Response())
             ->withAddedHeader('Set-Cookie', 'test=value')
-            ->withAddedHeader('Set-Cookie', 'expired=soon; Expires=Wed, 09-Jun-2012 10:18:14 GMT; Path=/; HttpOnly; Secure;');
+            ->withAddedHeader('Set-Cookie', 'expired=soon; Expires=Wed, 09-Jun-2012 10:18:14 GMT; Path=/;');
         $new = $collection->addFromResponse($response, $request);
         $this->assertFalse($new->has('expired'),'Should drop expired cookies');
     }

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -320,6 +320,26 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
+     * Test adding cookies ignores leading dot
+     *
+     * @return void
+     */
+    public function testAddToRequestLeadingDot()
+    {
+        $collection = new CookieCollection();
+        $collection = $collection
+            ->add(new Cookie('public', 'b', null, '/', '.example.com'));
+        $request = new ServerRequest([
+            'environment' => [
+                'HTTP_HOST' => 'example.com',
+                'REQUEST_URI' => '/blog'
+            ]
+        ]);
+        $request = $collection->addToRequest($request);
+        $this->assertSame(['public' => 'b'], $request->getCookieParams());
+    }
+
+    /**
      * Test adding cookies checks the secure crumb
      *
      * @return void
@@ -329,7 +349,7 @@ class CookieCollectionTest extends TestCase
         $collection = new CookieCollection();
         $collection = $collection
             ->add(new Cookie('secret', 'A', null, '/', 'example.com', true))
-            ->add(new Cookie('public', 'b', null, '/', 'example.com', false));
+            ->add(new Cookie('public', 'b', null, '/', '.example.com', false));
         $request = new ServerRequest([
             'environment' => [
                 'HTTPS' => 'on',

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -14,8 +14,8 @@ namespace Cake\Test\TestCase\Http\Cookie;
 
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
-use Cake\Http\ServerRequest;
 use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use DateTime;
 
@@ -265,7 +265,7 @@ class CookieCollectionTest extends TestCase
             ->withAddedHeader('Set-Cookie', 'test=value')
             ->withAddedHeader('Set-Cookie', 'expired=soon; Expires=Wed, 09-Jun-2012 10:18:14 GMT; Path=/;');
         $new = $collection->addFromResponse($response, $request);
-        $this->assertFalse($new->has('expired'),'Should drop expired cookies');
+        $this->assertFalse($new->has('expired'), 'Should drop expired cookies');
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -225,4 +225,22 @@ class CookieCollectionTest extends TestCase
             'Has expiry'
         );
     }
+
+    /**
+     * Test adding cookies from a response ignores expired cookies
+     *
+     * @return void
+     */
+    public function testAddFromResponseIgnoreExpired()
+    {
+        $collection = new CookieCollection();
+        $request = new ServerRequest([
+            'url' => '/app'
+        ]);
+        $response = (new Response())
+            ->withAddedHeader('Set-Cookie', 'test=value')
+            ->withAddedHeader('Set-Cookie', 'expired=soon; Expires=Wed, 09-Jun-2012 10:18:14 GMT; Path=/; HttpOnly; Secure;');
+        $new = $collection->addFromResponse($response, $request);
+        $this->assertFalse($new->has('expired'),'Should drop expired cookies');
+    }
 }

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -92,12 +92,24 @@ class CookieCollectionTest extends TestCase
         $this->assertFalse($collection->has('remember_me'), 'Original instance not modified');
         $this->assertTrue($new->has('remember_me'));
         $this->assertSame($remember, $new->get('remember_me'));
+    }
 
+    /**
+     * Cookie collections need to support duplicate cookie names because
+     * of use cases in Http\Client
+     *
+     * @return void
+     */
+    public function testAddDuplicates()
+    {
+        $remember = new Cookie('remember_me', 'yes');
         $rememberNo = new Cookie('remember_me', 'no');
-        $second = $new->add($remember)->add($rememberNo);
-        $this->assertCount(1, $second);
-        $this->assertNotSame($second, $new);
-        $this->assertSame($rememberNo, $second->get('remember_me'));
+        $collection = new CookieCollection([]);
+        $new = $collection->add($remember)->add($rememberNo);
+
+        $this->assertCount(2, $new);
+        $this->assertNotSame($new, $collection);
+        $this->assertSame($remember, $new->get('remember_me'), 'get() fetches first cookie');
     }
 
     /**
@@ -205,6 +217,7 @@ class CookieCollectionTest extends TestCase
         $this->assertSame('/app', $new->get('test')->getPath(), 'cookies should inherit request path');
         $this->assertSame('/', $new->get('expiring')->getPath(), 'path attribute should be used.');
 
+        $this->assertSame(0, $new->get('test')->getExpiry(), 'No expiry');
         $this->assertSame(0, $new->get('session')->getExpiry(), 'No expiry');
         $this->assertSame(
             '2021-06-09 10:18:14',


### PR DESCRIPTION
Add the methods that will allow the new CookieCollection to be used in Http\Client. This does not cover adding the backwards compatible aliases, those will be done separately.

There is a bunch of duplication with Http\Client\CookieCollection. But it is looking like that class can be entirely removed at the end of this refactoring.

Refs #10406