### PR TITLE
3.next - Add client compatibilty methods to CookieCollection

### DIFF
--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -13,21 +13,18 @@
  */
 namespace Cake\Http\Client;
 
+use Cake\Http\Cookie\CookieCollection as BaseCollection;
+
 /**
  * Container class for cookies used in Http\Client.
  *
  * Provides cookie jar like features for storing cookies between
  * requests, as well as appending cookies to new requests.
+ *
+ * @deprecated 3.5.0 Use Cake\Http\Cookie\CookieCollection instead.
  */
-class CookieCollection
+class CookieCollection extends BaseCollection
 {
-
-    /**
-     * The cookies stored in this jar.
-     *
-     * @var array
-     */
-    protected $_cookies = [];
 
     /**
      * Store the cookies from a response.
@@ -45,27 +42,13 @@ class CookieCollection
         $path = parse_url($url, PHP_URL_PATH);
         $path = $path ?: '/';
 
-        $cookies = $response->cookies();
-        foreach ($cookies as $name => $cookie) {
-            if (empty($cookie['domain'])) {
-                $cookie['domain'] = $host;
-            }
-            if (empty($cookie['path'])) {
-                $cookie['path'] = $path;
-            }
-            $key = implode(';', [$cookie['name'], $cookie['domain'], $cookie['path']]);
-
-            $expires = isset($cookie['expires']) ? $cookie['expires'] : false;
-            $expiresTime = false;
-            if ($expires) {
-                $expiresTime = strtotime($expires);
-            }
-            if ($expiresTime && $expiresTime <= time()) {
-                unset($this->_cookies[$key]);
-                continue;
-            }
-            $this->_cookies[$key] = $cookie;
+        $header = $response->getHeader('Set-Cookie');
+        $cookies = $this->parseSetCookieHeader($header);
+        $cookies = $this->setRequestDefaults($cookies, $host, $path);
+        foreach ($cookies as $cookie) {
+            $this->cookies[$cookie->getId()] = $cookie;
         }
+        $this->removeExpiredCookies($host, $path);
     }
 
     /**
@@ -83,28 +66,7 @@ class CookieCollection
         $host = parse_url($url, PHP_URL_HOST);
         $scheme = parse_url($url, PHP_URL_SCHEME);
 
-        $out = [];
-        foreach ($this->_cookies as $cookie) {
-            if ($scheme === 'http' && !empty($cookie['secure'])) {
-                continue;
-            }
-            if (strpos($path, $cookie['path']) !== 0) {
-                continue;
-            }
-            $leadingDot = $cookie['domain'][0] === '.';
-            if ($leadingDot) {
-                $cookie['domain'] = ltrim($cookie['domain'], '.');
-            }
-
-            $pattern = '/' . preg_quote(substr($cookie['domain'], 1), '/') . '$/';
-            if (!preg_match($pattern, $host)) {
-                continue;
-            }
-
-            $out[$cookie['name']] = $cookie['value'];
-        }
-
-        return $out;
+        return $this->findMatchingCookies($scheme, $host, $path);
     }
 
     /**
@@ -114,7 +76,20 @@ class CookieCollection
      */
     public function getAll()
     {
-        return array_values($this->_cookies);
+        $out = [];
+        foreach ($this->cookies as $cookie) {
+            $out[] = [
+                'name' => $cookie->getName(),
+                'value' => $cookie->getValue(),
+                'path' => $cookie->getPath(),
+                'domain' => $cookie->getDomain(),
+                'secure' => $cookie->isSecure(),
+                'httponly' => $cookie->isHttpOnly(),
+                'expires' => $cookie->getExpiry()
+            ];
+        }
+
+        return $out;
     }
 }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -220,7 +220,8 @@ class Cookie implements CookieInterface
      */
     public function getId()
     {
-        return "{$this->name};{$this->domain};{$this->path}";
+        $name = mb_strtolower($this->name);
+        return "{$name};{$this->domain};{$this->path}";
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -212,6 +212,18 @@ class Cookie implements CookieInterface
     }
 
     /**
+     * Get the id for a cookie
+     *
+     * Cookies are unique across name, domain, path tuples.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return "{$this->name};{$this->domain};{$this->path}";
+    }
+
+    /**
      * Gets the cookie name
      *
      * @return string

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -221,6 +221,7 @@ class Cookie implements CookieInterface
     public function getId()
     {
         $name = mb_strtolower($this->name);
+
         return "{$name};{$this->domain};{$this->path}";
     }
 

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -110,7 +110,6 @@ class CookieCollection implements IteratorAggregate, Countable
      *
      * @param string $url The url to get cookies for.
      * @return array An array of matching cookies.
-     * @deprecated 3.5.0 Will be removed in 4.0.0. Use addToRequest() instead.
      */
     protected function getByUrl($url)
     {

--- a/src/Http/Cookie/RequestCookies.php
+++ b/src/Http/Cookie/RequestCookies.php
@@ -37,33 +37,4 @@ class RequestCookies extends CookieCollection
 
         return new static($cookies);
     }
-
-    /**
-     * Checks if the collection has a cookie with the given name
-     *
-     * @param string $name Name of the cookie
-     * @return bool
-     */
-    public function has($name)
-    {
-        $key = mb_strtolower($name);
-
-        return isset($this->cookies[$key]);
-    }
-
-    /**
-     * Get a cookie from the collection by name.
-     *
-     * @param string $name Name of the cookie to get
-     * @throws \InvalidArgumentException
-     * @return Cookie
-     */
-    public function get($name)
-    {
-        if (!$this->has($name)) {
-            throw new InvalidArgumentException(sprintf('Cookie `%s` does not exist', $name));
-        }
-
-        return $this->cookies[mb_strtolower($name)];
-    }
 }

--- a/tests/TestCase/Http/Client/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Client/CookieCollectionTest.php
@@ -58,13 +58,19 @@ class CookieCollectionTest extends TestCase
                 'name' => 'first',
                 'value' => '1',
                 'path' => '/some/path',
-                'domain' => 'example.com'
+                'domain' => 'example.com',
+                'secure' => false,
+                'httponly' => false,
+                'expires' => 0,
             ],
             [
                 'name' => 'second',
                 'value' => '2',
                 'path' => '/',
-                'domain' => '.foo.example.com'
+                'domain' => '.foo.example.com',
+                'secure' => false,
+                'httponly' => false,
+                'expires' => 0,
             ],
         ];
         $this->assertEquals($expected, $result);
@@ -93,7 +99,10 @@ class CookieCollectionTest extends TestCase
                 'name' => 'first',
                 'value' => '1',
                 'path' => '/some/path',
-                'domain' => 'example.com'
+                'domain' => 'example.com',
+                'secure' => false,
+                'httponly' => false,
+                'expires' => 0,
             ],
             [
                 'name' => 'second',
@@ -102,6 +111,7 @@ class CookieCollectionTest extends TestCase
                 'domain' => 'example.com',
                 'secure' => true,
                 'httponly' => true,
+                'expires' => 0,
             ],
         ];
         $this->assertEquals($expected, $result);
@@ -159,7 +169,10 @@ class CookieCollectionTest extends TestCase
                 'name' => 'second',
                 'value' => '2',
                 'path' => '/',
-                'domain' => 'example.com'
+                'domain' => 'example.com',
+                'expires' => 0,
+                'secure' => false,
+                'httponly' => false,
             ],
         ];
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -176,34 +176,6 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
-     * Test that get() provides backwards compat behavior.
-     *
-     * When the parameter is a string that looks like a URL
-     *
-     * @return void
-     */
-    public function testGetBackwardsCompatibility()
-    {
-        $cookies = [
-            new Cookie('test', 'value', null, '/api', 'example.com', true),
-            new Cookie('test_two', 'value2', null, '/blog', 'blog.example.com', true),
-            new Cookie('test3', 'value3', null, '/blog', 'blog.example.com', false),
-        ];
-        $collection = new CookieCollection($cookies);
-        $result = $collection->get('http://example.com/api');
-        $this->assertSame([], $result);
-
-        $result = $collection->get('https://example.com/api');
-        $this->assertSame(['test' => 'value'], $result);
-
-        $result = $collection->get('http://foo.blog.example.com/blog/path');
-        $this->assertSame(['test3' => 'value3'], $result);
-
-        $result = $collection->get('https://foo.blog.example.com/blog/path');
-        $this->assertSame(['test_two' => 'value2', 'test3' => 'value3'], $result);
-    }
-
-    /**
      * Test that the constructor takes only an array of objects implementing
      * the CookieInterface
      *
@@ -446,60 +418,5 @@ class CookieCollectionTest extends TestCase
         ]);
         $request = $collection->addToRequest($request);
         $this->assertSame(['public' => 'b'], $request->getCookieParams());
-    }
-
-    /**
-     * Test that store() provides backwards compat behavior.
-     *
-     * @return void
-     */
-    public function testStoreCompatibility()
-    {
-        $collection = new CookieCollection();
-        $response = (new ClientResponse())
-            ->withAddedHeader('Set-Cookie', 'test=value')
-            ->withAddedHeader('Set-Cookie', 'expired=soon; Expires=Wed, 09-Jun-2012 10:18:14 GMT; Path=/;');
-        $result = $collection->store($response, 'http://example.com/blog');
-
-        $this->assertNull($result);
-        $this->assertCount(1, $collection, 'Should store 1 cookie');
-        $this->assertTrue($collection->has('test'));
-        $this->assertFalse($collection->has('expired'));
-    }
-
-    /**
-     * Test that getAll() provides backwards compat behavior.
-     *
-     * @return void
-     */
-    public function testGetAllBackwardsCompatibility()
-    {
-        $expires = new DateTime('-2 seconds');
-        $cookies = [
-            new Cookie('test', 'value', $expires, '/api', 'example.com', true, true),
-            new Cookie('test_two', 'value_two', null, '/blog', 'blog.example.com', true, true),
-        ];
-        $collection = new CookieCollection($cookies);
-        $expected = [
-            [
-                'name' => 'test',
-                'value' => 'value',
-                'path' => '/api',
-                'domain' => 'example.com',
-                'secure' => true,
-                'httponly' => true,
-                'expires' => $expires->format('U'),
-            ],
-            [
-                'name' => 'test_two',
-                'value' => 'value_two',
-                'path' => '/blog',
-                'domain' => 'blog.example.com',
-                'secure' => true,
-                'httponly' => true,
-                'expires' => 0
-            ],
-        ];
-        $this->assertEquals($expected, $collection->getAll());
     }
 }

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -176,6 +176,34 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
+     * Test that get() provides backwards compat behavior.
+     *
+     * When the parameter is a string that looks like a URL
+     *
+     * @return void
+     */
+    public function testGetBackwardsCompatibility()
+    {
+        $cookies = [
+            new Cookie('test', 'value', null, '/api', 'example.com', true),
+            new Cookie('test_two', 'value2', null, '/blog', 'blog.example.com', true),
+            new Cookie('test3', 'value3', null, '/blog', 'blog.example.com', false),
+        ];
+        $collection = new CookieCollection($cookies);
+        $result = $collection->get('http://example.com/api');
+        $this->assertSame([], $result);
+
+        $result = $collection->get('https://example.com/api');
+        $this->assertSame(['test' => 'value'], $result);
+
+        $result = $collection->get('http://foo.blog.example.com/blog/path');
+        $this->assertSame(['test3' => 'value3'], $result);
+
+        $result = $collection->get('https://foo.blog.example.com/blog/path');
+        $this->assertSame(['test_two' => 'value2', 'test3' => 'value3'], $result);
+    }
+
+    /**
      * Test that the constructor takes only an array of objects implementing
      * the CookieInterface
      *
@@ -437,18 +465,6 @@ class CookieCollectionTest extends TestCase
         $this->assertCount(1, $collection, 'Should store 1 cookie');
         $this->assertTrue($collection->has('test'));
         $this->assertFalse($collection->has('expired'));
-    }
-
-    /**
-     * Test that get() provides backwards compat behavior.
-     *
-     * When the parameter is a string that looks like a URL
-     *
-     * @return void
-     */
-    public function testGetBackwardsCompatibility()
-    {
-        $this->markTestIncomplete();
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -504,4 +504,18 @@ class CookieTest extends TestCase
         $expected = '{"username":"florian","profile":{"profession":"developer"}}';
         $this->assertContains(urlencode($expected), $cookie->toHeaderValue());
     }
+
+    /**
+     * Tests getting the id
+     *
+     * @return void
+     */
+    public function testGetId()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $this->assertEquals('cakephp;;', $cookie->getId());
+
+        $cookie = new Cookie('test', 'val', null, '/path', 'example.com');
+        $this->assertEquals('test;example.com;/path', $cookie->getId());
+    }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -515,6 +515,9 @@ class CookieTest extends TestCase
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertEquals('cakephp;;', $cookie->getId());
 
+        $cookie = new Cookie('CAKEPHP', 'cakephp-rocks');
+        $this->assertEquals('cakephp;;', $cookie->getId());
+
         $cookie = new Cookie('test', 'val', null, '/path', 'example.com');
         $this->assertEquals('test;example.com;/path', $cookie->getId());
     }


### PR DESCRIPTION
Add the methods that make Http\Cooke\CookieCollection compatible with Http\Client. Next, I'll use the new class in the client.

I've also fixed a few issues around how cookies were being stored. Cookies need to be unique per name;domain;path tuple. Without this constraint expiring cookies becomes very challenging. Also it becomes impossible to update a cookie in the collection.

Refs #10406 