### PR TITLE
3.next - Update Http\Client to use undeprecated cookie methods.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -440,6 +440,7 @@ class Client
         }
 
         $request = new Request($url, $method, $headers, $data);
+        $request = $this->_cookies->addToRequest($request);
         $request->cookie($this->_cookies->get($url));
         if (isset($options['cookies'])) {
             $request->cookie($options['cookies']);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -440,7 +440,7 @@ class Client
         }
 
         $request = new Request($url, $method, $headers, $data);
-        $cookies = isset($options['cookies']) ? $option['cookies'] : [];
+        $cookies = isset($options['cookies']) ? $options['cookies'] : [];
         $request = $this->_cookies->addToRequest($request, $cookies);
         if (isset($options['auth'])) {
             $request = $this->_addAuthentication($request, $options);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -374,7 +374,7 @@ class Client
         $responses = $this->_adapter->send($request, $options);
         $url = $request->getUri();
         foreach ($responses as $response) {
-            $this->_cookies->store($response, $url);
+            $this->_cookies = $this->_cookies->addFromResponse($response, $request);
         }
 
         return array_pop($responses);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -45,8 +45,8 @@ use Cake\Utility\Hash;
  * Client will maintain cookies from the responses done with
  * a client instance. These cookies will be automatically added
  * to future requests to matching hosts. Cookies will respect the
- * `Expires`, `Path` and `Domain` attributes. You can get the list of
- * currently stored cookies using the cookies() method.
+ * `Expires`, `Path` and `Domain` attributes. You can get the client's
+ * CookieCollection using cookies()
  *
  * You can use the 'cookieJar' constructor option to provide a custom
  * cookie jar instance you've restored from cache/disk. By default
@@ -440,11 +440,8 @@ class Client
         }
 
         $request = new Request($url, $method, $headers, $data);
-        $request = $this->_cookies->addToRequest($request);
-        $request->cookie($this->_cookies->get($url));
-        if (isset($options['cookies'])) {
-            $request->cookie($options['cookies']);
-        }
+        $cookies = isset($options['cookies']) ? $option['cookies'] : [];
+        $request = $this->_cookies->addToRequest($request, $cookies);
         if (isset($options['auth'])) {
             $request = $this->_addAuthentication($request, $options);
         }

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -147,19 +147,7 @@ class Stream
     {
         $headers = [];
         foreach ($request->getHeaders() as $name => $values) {
-            if ($name !== 'Cookie') {
-                $headers[] = sprintf('%s: %s', $name, implode(", ", $values));
-            }
-        }
-
-        $cookieHeader = $request->getHeaderLine('Cookie');
-        $cookies = [];
-        foreach ($request->cookies() as $name => $value) {
-            $cookies[] = "$name=$value";
-        }
-        $cookieData = implode('; ', $cookies);
-        if ($cookieData || $cookieHeader) {
-            $headers[] = 'Cookie: ' . implode('; ', [$cookieHeader, $cookieData]);
+            $headers[] = sprintf('%s: %s', $name, implode(", ", $values));
         }
         $this->_contextOptions['header'] = implode("\r\n", $headers);
     }

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -147,15 +147,19 @@ class Stream
     {
         $headers = [];
         foreach ($request->getHeaders() as $name => $values) {
-            $headers[] = sprintf('%s: %s', $name, implode(", ", $values));
+            if ($name !== 'Cookie') {
+                $headers[] = sprintf('%s: %s', $name, implode(", ", $values));
+            }
         }
 
+        $cookieHeader = $request->getHeaderLine('Cookie');
         $cookies = [];
         foreach ($request->cookies() as $name => $value) {
             $cookies[] = "$name=$value";
         }
-        if ($cookies) {
-            $headers[] = 'Cookie: ' . implode('; ', $cookies);
+        $cookieData = implode('; ', $cookies);
+        if ($cookieData || $cookieHeader) {
+            $headers[] = 'Cookie: ' . implode('; ', [$cookieHeader, $cookieData]);
         }
         $this->_contextOptions['header'] = implode("\r\n", $headers);
     }

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -188,6 +188,9 @@ class Request extends Message implements RequestInterface
      * @param string $name The name of the cookie to get/set
      * @param string|null $value Either the value or null when getting values.
      * @return mixed Either $this or the cookie value.
+     * @deprected 3.5.0 No longer used. CookieCollections now add `Cookie` header to the request
+     *   before sending. Use Cake\Http\Cookie\CookieCollection::addToRequest() to make adding cookies
+     *   to a request easier.
      */
     public function cookie($name, $value = null)
     {

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -182,13 +182,16 @@ class CookieCollection implements IteratorAggregate, Countable
     public function addToRequest(RequestInterface $request)
     {
         $uri = $request->getUri();
-        $path = $uri->getPath();
-        $host = $uri->getHost();
-        $scheme = $uri->getScheme();
-        $cookies = $this->findMatchingCookies($scheme, $host, $path);
-        $cookies = array_merge($request->getCookieParams(), $cookies);
-
-        return $request->withCookieParams($cookies);
+        $cookies = $this->findMatchingCookies(
+            $uri->getScheme(),
+            $uri->getHost(),
+            $uri->getPath()
+        );
+        $cookiePairs = [];
+        foreach ($cookies as $key => $value) {
+            $cookiePairs[] = sprintf("%s=%s", urlencode($key), urlencode($value));
+        }
+        return $request->withAddedHeader('Cookie', implode('; ', $cookiePairs));
     }
 
     /**

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -177,9 +177,11 @@ class CookieCollection implements IteratorAggregate, Countable
      * when this method is called will be applied to the request.
      *
      * @param \Psr\Http\Message\RequestInterface $request The request to update.
+     * @param array $extraCookies Associative array of additional cookies to add into the request. This
+     *   is useful when you have cookie data from outside the collection you want to send.
      * @return \Psr\Http\Message\RequestInterface An updated request.
      */
-    public function addToRequest(RequestInterface $request)
+    public function addToRequest(RequestInterface $request, array $extraCookies = [])
     {
         $uri = $request->getUri();
         $cookies = $this->findMatchingCookies(
@@ -187,12 +189,13 @@ class CookieCollection implements IteratorAggregate, Countable
             $uri->getHost(),
             $uri->getPath()
         );
+        $cookies = array_merge($cookies, $extraCookies);
         $cookiePairs = [];
         foreach ($cookies as $key => $value) {
-            $cookiePairs[] = sprintf("%s=%s", urlencode($key), urlencode($value));
+            $cookiePairs[] = sprintf("%s=%s", rawurlencode($key), rawurlencode($value));
         }
 
-        return $request->withAddedHeader('Cookie', implode('; ', $cookiePairs));
+        return $request->withHeader('Cookie', implode('; ', $cookiePairs));
     }
 
     /**

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -191,6 +191,7 @@ class CookieCollection implements IteratorAggregate, Countable
         foreach ($cookies as $key => $value) {
             $cookiePairs[] = sprintf("%s=%s", urlencode($key), urlencode($value));
         }
+
         return $request->withAddedHeader('Cookie', implode('; ', $cookiePairs));
     }
 

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -163,7 +163,8 @@ class StreamTest extends TestCase
         $request->url('http://localhost')
             ->header([
                 'User-Agent' => 'CakePHP TestSuite',
-                'Content-Type' => 'application/json'
+                'Content-Type' => 'application/json',
+                'Cookie' => 'a=b; c=d',
             ])
             ->cookie([
                 'testing' => 'value',
@@ -179,7 +180,7 @@ class StreamTest extends TestCase
             'Connection: close',
             'User-Agent: CakePHP TestSuite',
             'Content-Type: application/json',
-            'Cookie: testing=value; utm_src=awesome',
+            'Cookie: a=b; c=d; testing=value; utm_src=awesome',
         ];
         $this->assertEquals(implode("\r\n", $expected), $result['header']);
         $this->assertEquals($options['redirect'], $result['max_redirects']);

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -164,11 +164,7 @@ class StreamTest extends TestCase
             ->header([
                 'User-Agent' => 'CakePHP TestSuite',
                 'Content-Type' => 'application/json',
-                'Cookie' => 'a=b; c=d',
-            ])
-            ->cookie([
-                'testing' => 'value',
-                'utm_src' => 'awesome',
+                'Cookie' => 'a=b; c=do%20it'
             ]);
 
         $options = [
@@ -180,7 +176,7 @@ class StreamTest extends TestCase
             'Connection: close',
             'User-Agent: CakePHP TestSuite',
             'Content-Type: application/json',
-            'Cookie: a=b; c=d; testing=value; utm_src=awesome',
+            'Cookie: a=b; c=do%20it',
         ];
         $this->assertEquals(implode("\r\n", $expected), $result['header']);
         $this->assertEquals($options['redirect'], $result['max_redirects']);

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -597,7 +597,6 @@ class ClientTest extends TestCase
         $adapter = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])
             ->getMock();
-        $cookieJar = $this->getMockBuilder('Cake\Http\Client\CookieCollection')->getMock();
 
         $headers = [
             'HTTP/1.0 200 Ok',
@@ -605,16 +604,6 @@ class ClientTest extends TestCase
             'Set-Cookie: expiring=now; Expires=Wed, 09-Jun-1999 10:18:14 GMT'
         ];
         $response = new Response($headers, '');
-
-        $cookieJar->expects($this->at(0))
-            ->method('get')
-            ->with('http://cakephp.org/projects')
-            ->will($this->returnValue([]));
-
-        $cookieJar->expects($this->at(1))
-            ->method('store')
-            ->with($response);
-
         $adapter->expects($this->at(0))
             ->method('send')
             ->will($this->returnValue([$response]));
@@ -626,6 +615,10 @@ class ClientTest extends TestCase
         ]);
 
         $http->get('/projects');
+        $cookies = $http->cookies();
+        $this->assertCount(1, $cookies);
+        $this->assertTrue($cookies->has('first'));
+        $this->assertFalse($cookies->has('expiring'));
     }
 
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -611,7 +611,6 @@ class ClientTest extends TestCase
         $http = new Client([
             'host' => 'cakephp.org',
             'adapter' => $adapter,
-            'cookieJar' => $cookieJar
         ]);
 
         $http->get('/projects');

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -177,7 +177,7 @@ class ClientTest extends TestCase
                 $this->assertInstanceOf('Cake\Http\Client\Request', $request);
                 $this->assertEquals(Request::METHOD_GET, $request->getMethod());
                 $this->assertEquals('http://cakephp.org/test.html', $request->getUri() . '');
-                $this->assertEquals($cookies, $request->cookies());
+                $this->assertEquals('split=value', $request->getHeaderLine('Cookie'));
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('content-type'));
                 $this->assertEquals($headers['Connection'], $request->getHeaderLine('connection'));
 

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -348,6 +348,27 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
+     * Test adding cookies from the collection to request.
+     *
+     * @return void
+     */
+    public function testAddToRequestExtraCookies()
+    {
+        $collection = new CookieCollection();
+        $collection = $collection
+            ->add(new Cookie('api', 'A', null, '/api', 'example.com'))
+            ->add(new Cookie('blog', 'b', null, '/blog', 'blog.example.com'))
+            ->add(new Cookie('expired', 'ex', new DateTime('-2 seconds'), '/', 'example.com'));
+        $request = new ClientRequest('http://example.com/api');
+        $request = $collection->addToRequest($request, ['b' => 'B']);
+        $this->assertSame('api=A; b=B', $request->getHeaderLine('Cookie'));
+
+        $request = new ClientRequest('http://example.com/api');
+        $request = $collection->addToRequest($request, ['api' => 'custom']);
+        $this->assertSame('api=custom', $request->getHeaderLine('Cookie'), 'Extra cookies overwrite values in jar');
+    }
+
+    /**
      * Test adding cookies ignores leading dot
      *
      * @return void


### PR DESCRIPTION
Update the Http\Client and Stream adapter to not use deprecated methods on CookieCollection. I've also fixed a small issue where cookie headers that were set in the request would be dropped.

Refs #10406 