### PR TITLE
Add web fonts to be treated as binary in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,11 @@
 *.gif binary
 *.ico binary
 *.mo binary
+*.ttf	binary
+*.woff 	binary
+*.woff2	binary
+*.eot	binary
+*.otf	binary
 
 # Remove files for archives generated using `git archive`
 appveyor.yml export-ignore


### PR DESCRIPTION
After spending hours before noticing that cakephp's .gitattributes file was overcharging mine, I thought useful to add webfont files patterns to the main distribution :-)

This makes webfonts not being broken by git during checkout/pull.

Hope this helps !
