### PR TITLE
WIP Issue/text insert time

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -195,8 +195,6 @@ class Text
             return ($options['clean']) ? static::cleanInsert($str, $options) : $str;
         }
 
-        asort($data);
-
         $dataKeys = array_keys($data);
         $hashKeys = array_map('crc32', $dataKeys);
         $tempData = array_combine($dataKeys, $hashKeys);

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Test\TestCase\Utility;
 
+use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 
@@ -228,6 +229,14 @@ class TextTest extends TestCase
         $string = 'switching :timeout_count by :timeout';
         $expected = 'switching 10 by 5';
         $result = Text::insert($string, ['timeout_count' => 10, 'timeout' => 5]);
+        $this->assertEquals($expected, $result);
+        $string = 'inserting a :user.email';
+        $expected = 'inserting a security@example.com';
+        $result = Text::insert($string, [
+            'user.email' => 'security@example.com',
+            'user.id' => 2,
+            'user.created' => Time::parse('2016-01-01')
+        ]);
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
While playing with Text::insert method with flattened entities I got to this use case where objects (Time) cannot be cast to (int) by asort here https://github.com/cakephp/cakephp/blob/3.4.0-RC1/src/Utility/Text.php#L198.

Removing this line makes all tests pass, so I guess we need additional unit tests to ensure we need to asort the data array. I'm leaving this PR open in case you could point me to either add additional test cases or it's fine to remove the asort?

Thanks,
