### PR TITLE
3.next - Use CookieCollection in Client responses

### DIFF
--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -78,15 +78,7 @@ class CookieCollection extends BaseCollection
     {
         $out = [];
         foreach ($this->cookies as $cookie) {
-            $out[] = [
-                'name' => $cookie->getName(),
-                'value' => $cookie->getValue(),
-                'path' => $cookie->getPath(),
-                'domain' => $cookie->getDomain(),
-                'secure' => $cookie->isSecure(),
-                'httponly' => $cookie->isHttpOnly(),
-                'expires' => $cookie->getExpiry()
-            ];
+            $out[] = $cookie->toArray();
         }
 
         return $out;

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -396,6 +396,21 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
+     * Get the cookie collection from this response.
+     *
+     * This method exposes the response's CookieCollection
+     * instance allowing you to interact with cookie objects directly.
+     *
+     * @return \Cake\Http\Cookie\CookieCollection
+     */
+    public function getCookieCollection()
+    {
+        $this->buildCookieCollection();
+
+        return $this->cookies;
+    }
+
+    /**
      * Get the value of a single cookie.
      *
      * @param string $name The name of the cookie value.

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -13,7 +13,9 @@
  */
 namespace Cake\Http\Client;
 
-use Cake\Http\Cookie\CookieCollection;
+// This alias is necessary to avoid class name conflicts
+// with the deprecated class in this namespace.
+use Cake\Http\Cookie\CookieCollection as CookiesCollection;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 use Zend\Diactoros\MessageTrait;
@@ -453,7 +455,7 @@ class Response extends Message implements ResponseInterface
         if ($this->cookies) {
             return;
         }
-        $this->cookies = CookieCollection::createFromHeader($this->getHeader('Set-Cookie'));
+        $this->cookies = CookiesCollection::createFromHeader($this->getHeader('Set-Cookie'));
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -49,6 +49,13 @@ class Cookie implements CookieInterface
     use CookieCryptTrait;
 
     /**
+     * Expires attribute format.
+     *
+     * @var string
+     */
+    const EXPIRES_FORMAT = 'D, d-M-Y H:i:s T';
+
+    /**
      * Cookie name
      *
      * @var string
@@ -160,7 +167,7 @@ class Cookie implements CookieInterface
     {
         return sprintf(
             'expires=%s',
-            gmdate('D, d-M-Y H:i:s T', $this->expiresAt)
+            gmdate(static::EXPIRES_FORMAT, $this->expiresAt)
         );
     }
 
@@ -613,6 +620,27 @@ class Cookie implements CookieInterface
             'secure' => $this->isSecure(),
             'httponly' => $this->isHttpOnly(),
             'expires' => $this->getExpiry()
+        ];
+    }
+
+    /**
+     * Convert the cookie into an array of its properties.
+     *
+     * This method is compatible with older client code that
+     * expects date strings instead of timestamps.
+     *
+     * @return array
+     */
+    public function toArrayCompat()
+    {
+        return [
+            'name' => $this->getName(),
+            'value' => $this->getValue(),
+            'path' => $this->getPath(),
+            'domain' => $this->getDomain(),
+            'secure' => $this->isSecure(),
+            'httponly' => $this->isHttpOnly(),
+            'expires' => gmdate(static::EXPIRES_FORMAT, $this->expiresAt)
         ];
     }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -597,6 +597,26 @@ class Cookie implements CookieInterface
     }
 
     /**
+     * Convert the cookie into an array of its properties.
+     *
+     * Primarily useful where backwards compatibility is needed.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'name' => $this->getName(),
+            'value' => $this->getValue(),
+            'path' => $this->getPath(),
+            'domain' => $this->getDomain(),
+            'secure' => $this->isSecure(),
+            'httponly' => $this->isHttpOnly(),
+            'expires' => $this->getExpiry()
+        ];
+    }
+
+    /**
      * Implode method to keep keys are multidimensional arrays
      *
      * @param array $array Map of key and values

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -52,6 +52,19 @@ class CookieCollection implements IteratorAggregate, Countable
     }
 
     /**
+     * Create a Cookie Collection from an array of Set-Cookie Headers
+     *
+     * @param array $header The array of set-cookie header values.
+     * @return static
+     */
+    public static function createFromHeader(array $header)
+    {
+        $cookies = static::parseSetCookieHeader($header);
+
+        return new CookieCollection($cookies);
+    }
+
+    /**
      * Get the number of cookies in the collection.
      *
      * @return int
@@ -251,8 +264,7 @@ class CookieCollection implements IteratorAggregate, Countable
         $host = $uri->getHost();
         $path = $uri->getPath() ?: '/';
 
-        $header = $response->getHeader('Set-Cookie');
-        $cookies = $this->parseSetCookieHeader($header);
+        $cookies = static::parseSetCookieHeader($response->getHeader('Set-Cookie'));
         $cookies = $this->setRequestDefaults($cookies, $host, $path);
         $new = clone $this;
         foreach ($cookies as $cookie) {
@@ -293,7 +305,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param array $values List of Set-Cookie Header values.
      * @return \Cake\Http\Cookie\Cookie[] An array of cookie objects
      */
-    protected function parseSetCookieHeader($values)
+    protected static function parseSetCookieHeader($values)
     {
         $cookies = [];
         foreach ($values as $value) {

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -14,6 +14,7 @@
 namespace Cake\Test\TestCase\Http\Client;
 
 use Cake\Http\Client\Response;
+use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -328,6 +329,29 @@ XML;
         $this->assertArrayHasKey('test', $result);
         $this->assertArrayHasKey('session', $result);
         $this->assertArrayHasKey('expiring', $result);
+    }
+
+    /**
+     * Test accessing cookie collection
+     *
+     * @return void
+     */
+    public function testGetCookieCollection()
+    {
+        $headers = [
+            'HTTP/1.0 200 Ok',
+            'Set-Cookie: test=value',
+            'Set-Cookie: session=123abc',
+            'Set-Cookie: expiring=soon; Expires=Wed, 09-Jun-2021 10:18:14 GMT; Path=/; HttpOnly; Secure;',
+        ];
+        $response = new Response($headers, '');
+
+        $cookies = $response->getCookieCollection();
+        $this->assertInstanceOf(CookieCollection::class, $cookies);
+        $this->assertTrue($cookies->has('test'));
+        $this->assertTrue($cookies->has('session'));
+        $this->assertTrue($cookies->has('expiring'));
+        $this->assertSame('123abc', $cookies->get('session')->getValue());
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -403,4 +403,23 @@ class CookieCollectionTest extends TestCase
         $request = $collection->addToRequest($request);
         $this->assertSame('public=b', $request->getHeaderLine('Cookie'));
     }
+
+    /**
+     * test createFromHeader() building cookies from a header string.
+     *
+     * @return void
+     */
+    public function testCreateFromHeader()
+    {
+        $header = [
+            'http=name; HttpOnly; Secure;',
+            'expires=expiring; Expires=Wed, 15-Jun-2022 10:22:22; Path=/api; HttpOnly; Secure;',
+            'expired=expired; Expires=Wed, 15-Jun-2015 10:22:22;',
+        ];
+        $cookies = CookieCollection::createFromHeader($header);
+        $this->assertCount(3, $cookies);
+        $this->assertTrue($cookies->has('http'));
+        $this->assertTrue($cookies->has('expires'));
+        $this->assertTrue($cookies->has('expired'), 'Expired cookies should be present');
+    }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -547,4 +547,30 @@ class CookieTest extends TestCase
         ];
         $this->assertEquals($expected, $cookie->toArray());
     }
+
+    /**
+     * Test toArrayCompat
+     *
+     * @return void
+     */
+    public function testToArrayCompat()
+    {
+        $date = Chronos::parse('2017-03-31 12:34:56');
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withPath('/api')
+            ->withExpiry($date)
+            ->withHttpOnly(true)
+            ->withSecure(true);
+        $expected = [
+            'name' => 'cakephp',
+            'value' => 'cakephp-rocks',
+            'path' => '/api',
+            'domain' => 'cakephp.org',
+            'expires' => $date->format(DATE_COOKIE),
+            'secure' => true,
+            'httponly' => true
+        ];
+        $this->assertEquals($expected, $cookie->toArrayCompat());
+    }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -567,7 +567,7 @@ class CookieTest extends TestCase
             'value' => 'cakephp-rocks',
             'path' => '/api',
             'domain' => 'cakephp.org',
-            'expires' => $date->format(DATE_COOKIE),
+            'expires' => 'Fri, 31-Mar-2017 12:34:56 GMT',
             'secure' => true,
             'httponly' => true
         ];

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -521,4 +521,30 @@ class CookieTest extends TestCase
         $cookie = new Cookie('test', 'val', null, '/path', 'example.com');
         $this->assertEquals('test;example.com;/path', $cookie->getId());
     }
+
+    /**
+     * Test toArray
+     *
+     * @return void
+     */
+    public function testToArray()
+    {
+        $date = Chronos::parse('2017-03-31 12:34:56');
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withPath('/api')
+            ->withExpiry($date)
+            ->withHttpOnly(true)
+            ->withSecure(true);
+        $expected = [
+            'name' => 'cakephp',
+            'value' => 'cakephp-rocks',
+            'path' => '/api',
+            'domain' => 'cakephp.org',
+            'expires' => (int)$date->format('U'),
+            'secure' => true,
+            'httponly' => true
+        ];
+        $this->assertEquals($expected, $cookie->toArray());
+    }
 }


### PR DESCRIPTION
Use the new CookieCollection objects in Client responses. This allows us to remove one copy of the Cookie parsing code we had.

Refs #10406