### PR TITLE
EntityContext: Introspect 'null' to determine use of 'required' attribute

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -541,7 +541,7 @@ class EntityContext implements ContextInterface
         $parts = explode('.', $field);
         $table = $this->_getTable($parts);
         $column = (array)$table->getSchema()->column(array_pop($parts));
-        $whitelist = ['length' => null, 'precision' => null];
+        $whitelist = ['length' => null, 'precision' => null, 'null' => null];
 
         return array_intersect_key($column, $whitelist);
     }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1396,6 +1396,10 @@ class FormHelper extends Helper
             $options += ['empty' => false];
         }
 
+        if (array_key_exists('null', $fieldDef) && $fieldDef['null'] === false) {
+            $options['required'] = true;
+        }
+
         return $options;
     }
 

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -390,7 +390,7 @@ class EntityContextTest extends TestCase
         $this->assertEquals('string', $context->type('99.title'));
         $this->assertNull($context->type('0.nope'));
 
-        $expected = ['length' => 255, 'precision' => null];
+        $expected = ['length' => 255, 'precision' => null, 'null' => null];
         $this->assertEquals($expected, $context->attributes('0.user.username'));
     }
 
@@ -980,17 +980,17 @@ class EntityContextTest extends TestCase
         ]);
 
         $expected = [
-            'length' => 255, 'precision' => null
+            'length' => 255, 'precision' => null, 'null' => null,
         ];
         $this->assertEquals($expected, $context->attributes('title'));
 
         $expected = [
-            'length' => null, 'precision' => null
+            'length' => null, 'precision' => null, 'null' => null,
         ];
         $this->assertEquals($expected, $context->attributes('body'));
 
         $expected = [
-            'length' => 10, 'precision' => 3
+            'length' => 10, 'precision' => 3, 'null' => null,
         ];
         $this->assertEquals($expected, $context->attributes('user.rating'));
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1005,7 +1005,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->text('title');
         $expected = ['input' => [
-            'name' => 'title', 'type' => 'text', 'required' => 'required'
+            'name' => 'title', 'type' => 'text', 'required'
         ]];
         $this->assertHtml($expected, $result);
 
@@ -1314,12 +1314,13 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('foo');
         $expected = [
-            'div' => ['class' => 'input file'],
+            'div' => ['class' => 'input file required'],
             'label' => ['for' => 'foo'],
             'Foo',
             '/label',
             ['input' => [
                 'type' => 'file', 'name' => 'foo',
+                'required',
                 'id' => 'foo'
             ]],
             '/div'
@@ -2639,7 +2640,7 @@ class FormHelperTest extends TestCase
             'input' => [
                 'type' => 'text', 'name' => 'title',
                 'id' => 'title', 'class' => 'form-error',
-                'required' => 'required',
+                'required',
             ],
             ['div' => ['class' => 'error-message']],
             'Custom error!',
@@ -2661,7 +2662,7 @@ class FormHelperTest extends TestCase
                 'name' => 'title',
                 'id' => 'title',
                 'class' => 'form-error',
-                'required' => 'required'
+                'required'
             ],
             ['div' => ['class' => 'error-message']],
             'Custom error!',
@@ -2782,7 +2783,7 @@ class FormHelperTest extends TestCase
             'label' => ['for'],
             'Balance',
             '/label',
-            'input' => ['name', 'type' => 'number', 'id', 'step'],
+            'input' => ['name', 'type' => 'number', 'id', 'required', 'step'],
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -2793,7 +2794,7 @@ class FormHelperTest extends TestCase
             'label' => ['for'],
             'Cost Decimal',
             '/label',
-            'input' => ['name', 'type' => 'number', 'step' => '0.001', 'id'],
+            'input' => ['name', 'type' => 'number', 'required', 'step' => '0.001', 'id'],
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -2804,7 +2805,7 @@ class FormHelperTest extends TestCase
             'label' => ['for'],
             'Null Decimal',
             '/label',
-            'input' => ['name', 'type' => 'number', 'id'],
+            'input' => ['name', 'type' => 'number', 'required', 'id'],
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -3793,11 +3794,11 @@ class FormHelperTest extends TestCase
         $this->View->viewVars['balances'] = [0 => 'nothing', 1 => 'some', 100 => 'a lot'];
         $result = $this->Form->control('balance');
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input select required'],
             'label' => ['for' => 'balance'],
             'Balance',
             '/label',
-            'select' => ['name' => 'balance', 'id' => 'balance'],
+            'select' => ['name' => 'balance', 'id' => 'balance', 'required'],
             ['option' => ['value' => '0']],
             'nothing',
             '/option',
@@ -4928,7 +4929,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'select' => [
                 'name' => 'user_id',
-                'required' => 'required'
+                'required'
             ],
             ['option' => ['value' => '0']], 'option A', '/option',
             '/select'
@@ -6896,7 +6897,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('title', ['label' => false]);
         $expected = [
             'div' => ['class' => 'input text required'],
-            'input' => ['type' => 'text', 'required' => 'required', 'id' => 'title', 'name' => 'title'],
+            'input' => ['type' => 'text', 'required', 'id' => 'title', 'name' => 'title'],
             '/div'
         ];
         $this->assertHtml($expected, $result);
@@ -8096,7 +8097,7 @@ class FormHelperTest extends TestCase
                 '/label',
                 'textarea' => [
                     'name',
-                    'required' => 'required',
+                    'required',
                     'id' => '0-comments-1-comment',
                     'rows' => 5
                 ],
@@ -8201,7 +8202,7 @@ class FormHelperTest extends TestCase
                 'type' => 'text',
                 'name' => 'title',
                 'id' => 'title',
-                'required' => 'required',
+                'required',
             ],
             '/div'
         ];
@@ -8538,7 +8539,7 @@ class FormHelperTest extends TestCase
         $this->Form->setValueSources(['context']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '3']],
         ];
         $this->assertHtml($expected, $result);
 
@@ -8546,7 +8547,7 @@ class FormHelperTest extends TestCase
         $this->Form->setValueSources(['query']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '5']],
         ];
         $this->assertHtml($expected, $result);
 
@@ -8557,7 +8558,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5b']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '5b']],
         ];
         $this->assertHtml($expected, $result);
 
@@ -8565,14 +8566,14 @@ class FormHelperTest extends TestCase
         $this->Form->create($article);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5b']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '5b']],
         ];
         $this->assertHtml($expected, $result);
 
         $this->Form->setValueSources(['query']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5a']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '5a']],
         ];
         $this->assertHtml($expected, $result);
     }
@@ -8595,21 +8596,21 @@ class FormHelperTest extends TestCase
         $this->Form->setValueSources(['context', 'query']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '3']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '3']],
         ];
         $this->assertHtml($expected, $result);
 
         $this->Form->setValueSources(['query', 'context']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '9']],
         ];
         $this->assertHtml($expected, $result);
 
         $this->Form->setValueSources(['data', 'query', 'context']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '9']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '9']],
         ];
         $this->assertHtml($expected, $result);
 
@@ -8618,7 +8619,7 @@ class FormHelperTest extends TestCase
         $this->Form->setValueSources(['data', 'query', 'context']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '8']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '8']],
         ];
         $this->assertHtml($expected, $result);
     }
@@ -8640,7 +8641,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '5']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
@@ -8650,7 +8651,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article, ['valueSources' => 'query']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '5']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '5']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
@@ -8660,7 +8661,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article, ['valueSources' => 'data']);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '4']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '4']],
         ];
         $this->assertHtml($expected, $result);
 
@@ -8671,7 +8672,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article, ['valueSources' => ['context', 'data']]);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '4']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '4']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
@@ -8697,7 +8698,7 @@ class FormHelperTest extends TestCase
             ->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '11']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '11']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');
@@ -8708,7 +8709,7 @@ class FormHelperTest extends TestCase
             ->create($article, ['valueSources' => ['query', 'data']]);
         $result = $this->Form->control('id');
         $expected = [
-            ['input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id', 'value' => '10']],
+            ['input' => ['type' => 'hidden', 'name' => 'id', 'required', 'id' => 'id', 'value' => '10']],
         ];
         $this->assertHtml($expected, $result);
         $result = $this->Form->getSourceValue('id');


### PR DESCRIPTION
Allow browsers to take advantage of html5 validation