### PR TITLE
3.next - Expose CookieCollection in ServerRequest

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -68,7 +68,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Create a new collection from the cookies in a ServerRequest
      *
-     * @param \Psr\Http\Message\ServerRequestInterface $request The array of set-cookie header values.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request to extract cookie data from
      * @return static
      */
     public static function createFromServerRequest(ServerRequestInterface $request)

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -68,7 +68,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Create a new collection from the cookies in a ServerRequest
      *
-     * @param array $header The array of set-cookie header values.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The array of set-cookie header values.
      * @return static
      */
     public static function createFromServerRequest(ServerRequestInterface $request)

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Cookie Collection
@@ -61,7 +62,24 @@ class CookieCollection implements IteratorAggregate, Countable
     {
         $cookies = static::parseSetCookieHeader($header);
 
-        return new CookieCollection($cookies);
+        return new static($cookies);
+    }
+
+    /**
+     * Create a new collection from the cookies in a ServerRequest
+     *
+     * @param array $header The array of set-cookie header values.
+     * @return static
+     */
+    public static function createFromServerRequest(ServerRequestInterface $request)
+    {
+        $data = $request->getCookieParams();
+        $cookies = [];
+        foreach ($data as $name => $value) {
+            $cookies[] = new Cookie($name, $value);
+        }
+
+        return new static($cookies);
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -17,6 +17,7 @@ namespace Cake\Http;
 use ArrayAccess;
 use BadMethodCallException;
 use Cake\Core\Configure;
+use Cake\Http\Cookie\CookieCollection;
 use Cake\Network\Exception\MethodNotAllowedException;
 use Cake\Network\Session;
 use Cake\Utility\Hash;
@@ -1603,6 +1604,45 @@ class ServerRequest implements ArrayAccess, ServerRequestInterface
     public function getCookie($key, $default = null)
     {
         return Hash::get($this->cookies, $key, $default);
+    }
+
+    /**
+     * Get a cookie collection based on the request's cookies
+     *
+     * The CookieCollection lets you interact with request cookies using
+     * `\Cake\Http\Cookie\Cookie` objects and can make converting request cookies
+     * into response cookies easier.
+     *
+     * This method will create a new cookie collection each time it is called.
+     * This is an optimization that allows fewer objects to be allocated until
+     * the more complex CookieCollection is needed. In general you should prefer
+     * `getCookie()` and `getCookieParams()` over this method. Using a CookieCollection
+     * is ideal if your cookies contain complex JSON encoded data.
+     *
+     * @return \Cake\Http\Cookie\CookieCollection
+     */
+    public function getCookieCollection()
+    {
+        return CookieCollection::createFromServerRequest($this);
+    }
+
+    /**
+     * Replace the cookies in the request with those contained in
+     * the provided CookieCollection.
+     *
+     * @param \Cake\Http\Cookie\CookieCollection $cookies The cookie collection
+     * @return static
+     */
+    public function withCookieCollection(CookieCollection $cookies)
+    {
+        $new = clone $this;
+        $values = [];
+        foreach ($cookies as $cookie) {
+            $values[$cookie->getName()] = $cookie->getValue();
+        }
+        $new->cookies = $values;
+
+        return $new;
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -422,4 +422,23 @@ class CookieCollectionTest extends TestCase
         $this->assertTrue($cookies->has('expires'));
         $this->assertTrue($cookies->has('expired'), 'Expired cookies should be present');
     }
+
+    /**
+     * test createFromServerRequest() building cookies from a header string.
+     *
+     * @return void
+     */
+    public function testCreateFromServerRequest()
+    {
+        $request = new ServerRequest(['cookies' => ['name' => 'val', 'cakephp' => 'rocks']]);
+        $cookies = CookieCollection::createFromServerRequest($request);
+        $this->assertCount(2, $cookies);
+        $this->assertTrue($cookies->has('name'));
+        $this->assertTrue($cookies->has('cakephp'));
+
+        $cookie = $cookies->get('name');
+        $this->assertSame('val', $cookie->getValue());
+        $this->assertSame('', $cookie->getPath(), 'No path on request cookies');
+        $this->assertSame('', $cookie->getDomain(), 'No domain on request cookies');
+    }
 }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -15,6 +15,8 @@
 namespace Cake\Test\TestCase\Http;
 
 use Cake\Core\Configure;
+use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Network\Exception\MethodNotAllowedException;
@@ -3078,6 +3080,45 @@ XML;
         $this->assertNotSame($new, $request);
         $this->assertSame($cookies, $request->getCookieParams());
         $this->assertSame(['remember_me' => 1], $new->getCookieParams());
+    }
+
+    /**
+     * Test getting a cookie collection from a request.
+     *
+     * @return void
+     */
+    public function testGetCookieCollection()
+    {
+        $cookies = [
+            'remember_me' => '1',
+            'color' => 'blue'
+        ];
+        $request = new ServerRequest(['cookies' => $cookies]);
+
+        $cookies = $request->getCookieCollection();
+        $this->assertInstanceOf(CookieCollection::class, $cookies);
+        $this->assertCount(2, $cookies);
+        $this->assertSame('1', $cookies->get('remember_me')->getValue());
+        $this->assertSame('blue', $cookies->get('color')->getValue());
+    }
+
+    /**
+     * Test replacing cookies from a collection
+     *
+     * @return void
+     */
+    public function testWithCookieCollection()
+    {
+        $cookies = new CookieCollection([new Cookie('remember_me', 1), new Cookie('color', 'red')]);
+        $request = new ServerRequest(['cookies' => ['bad' => 'goaway']]);
+        $new = $request->withCookieCollection($cookies);
+        $this->assertNotSame($new, $request, 'Should clone');
+
+        $this->assertSame(['bad' => 'goaway'], $request->getCookieParams());
+        $this->assertSame(['remember_me' => 1, 'color' => 'red'], $new->getCookieParams());
+        $cookies = $new->getCookieCollection();
+        $this->assertCount(2, $cookies);
+        $this->assertSame('red', $cookies->get('color')->getValue());
     }
 
     /**


### PR DESCRIPTION
I've chosen to not use CookieCollection as the internal storage as  keeping the public property in-sync would be hard/impossible. This  approach also avoid eagerly allocating memory for the cookie collection and the cookie objects.

Refs #10406