### PR TITLE
Fix for loading plugin in Shell.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -433,7 +433,7 @@ class Shell
             $this->params = array_merge($this->params, $extra);
         }
         $this->_setOutputLevel();
-        if (!empty($this->params['plugin'])) {
+        if (!empty($this->params['plugin']) && !Plugin::loaded($this->params['plugin'])) {
             Plugin::load($this->params['plugin']);
         }
         $this->command = $command;


### PR DESCRIPTION
Currently shell ignores if a plugin has already been loaded and tries to load it again if a `plugin` option is present. That would result in "Plugin not found" exception when a plugin had been loaded with a different path in bootstrap. This is a fix for that.