### PR TITLE
Fix CakeSocket not being able to connect to TLS1.2 only servers

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -44,7 +44,8 @@ class CakeSocket {
 		'host' => 'localhost',
 		'protocol' => 'tcp',
 		'port' => 80,
-		'timeout' => 30
+		'timeout' => 30,
+        'cryptoType' => 'tls'
 	);
 
 /**
@@ -93,10 +94,14 @@ class CakeSocket {
 		'sslv3_client' => STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
 		'sslv23_client' => STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
 		'tls_client' => STREAM_CRYPTO_METHOD_TLS_CLIENT,
+        'tlsv1_1_client' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT,
+        'tlsv1_2_client' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
 		'sslv2_server' => STREAM_CRYPTO_METHOD_SSLv2_SERVER,
 		'sslv3_server' => STREAM_CRYPTO_METHOD_SSLv3_SERVER,
 		'sslv23_server' => STREAM_CRYPTO_METHOD_SSLv23_SERVER,
-		'tls_server' => STREAM_CRYPTO_METHOD_TLS_SERVER
+		'tls_server' => STREAM_CRYPTO_METHOD_TLS_SERVER,
+        'tlsv1_1_server' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER,
+        'tlsv1_2_server' => STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
 		// @codingStandardsIgnoreEnd
 	);
 
@@ -205,7 +210,7 @@ class CakeSocket {
 					}
 				}
 
-				$this->enableCrypto('tls', 'client');
+                $this->enableCrypto($this->config['cryptoType'], 'client');
 			}
 		}
 		return $this->connected;
@@ -433,7 +438,7 @@ class CakeSocket {
 /**
  * Encrypts current stream socket, using one of the defined encryption methods.
  *
- * @param string $type Type which can be one of 'sslv2', 'sslv3', 'sslv23' or 'tls'.
+ * @param string $type Type which can be one of 'sslv2', 'sslv3', 'sslv23', 'tls', 'tlsv1_1' or 'tlsv1_2'.
  * @param string $clientOrServer Can be one of 'client', 'server'. Default is 'client'.
  * @param bool $enable Enable or disable encryption. Default is true (enable)
  * @return bool True on success

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -45,7 +45,7 @@ class CakeSocket {
 		'protocol' => 'tcp',
 		'port' => 80,
 		'timeout' => 30,
-        'cryptoType' => 'tls'
+		'cryptoType' => 'tls'
 	);
 
 /**
@@ -94,14 +94,14 @@ class CakeSocket {
 		'sslv3_client' => STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
 		'sslv23_client' => STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
 		'tls_client' => STREAM_CRYPTO_METHOD_TLS_CLIENT,
-        'tlsv1_1_client' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT,
-        'tlsv1_2_client' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+		'tlsv1_1_client' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT,
+		'tlsv1_2_client' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
 		'sslv2_server' => STREAM_CRYPTO_METHOD_SSLv2_SERVER,
 		'sslv3_server' => STREAM_CRYPTO_METHOD_SSLv3_SERVER,
 		'sslv23_server' => STREAM_CRYPTO_METHOD_SSLv23_SERVER,
 		'tls_server' => STREAM_CRYPTO_METHOD_TLS_SERVER,
-        'tlsv1_1_server' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER,
-        'tlsv1_2_server' => STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
+		'tlsv1_1_server' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER,
+		'tlsv1_2_server' => STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
 		// @codingStandardsIgnoreEnd
 	);
 
@@ -210,7 +210,7 @@ class CakeSocket {
 					}
 				}
 
-                $this->enableCrypto($this->config['cryptoType'], 'client');
+				$this->enableCrypto($this->config['cryptoType'], 'client');
 			}
 		}
 		return $this->connected;

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -131,6 +131,18 @@ class CakeSocket {
 				$this->_encryptMethods[$key] = constant($const);
 			}
 		}
+
+		// As of PHP5.6.6, STREAM_CRYPTO_METHOD_TLS_CLIENT does not include
+		// TLS1.1 or 1.2. If we have TLS1.2 support we need to update the method map.
+		//
+		// See https://bugs.php.net/bug.php?id=69195 &
+		// https://github.com/php/php-src/commit/10bc5fd4c4c8e1dd57bd911b086e9872a56300a0
+		if (isset($this->_encryptMethods['tlsv1_2_client'])) {
+			$this->_encryptMethods['tls_client'] = STREAM_CRYPTO_METHOD_TLS_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+		}
+		if (isset($this->_encryptMethods['tlsv1_2_server'])) {
+			$this->_encryptMethods['tls_server'] = STREAM_CRYPTO_METHOD_TLS_SERVER | STREAM_CRYPTO_METHOD_TLSv1_1_SERVER | STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+		}
 	}
 
 /**

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -94,14 +94,10 @@ class CakeSocket {
 		'sslv3_client' => STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
 		'sslv23_client' => STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
 		'tls_client' => STREAM_CRYPTO_METHOD_TLS_CLIENT,
-		'tlsv1_1_client' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT,
-		'tlsv1_2_client' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
 		'sslv2_server' => STREAM_CRYPTO_METHOD_SSLv2_SERVER,
 		'sslv3_server' => STREAM_CRYPTO_METHOD_SSLv3_SERVER,
 		'sslv23_server' => STREAM_CRYPTO_METHOD_SSLv23_SERVER,
 		'tls_server' => STREAM_CRYPTO_METHOD_TLS_SERVER,
-		'tlsv1_1_server' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER,
-		'tlsv1_2_server' => STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
 		// @codingStandardsIgnoreEnd
 	);
 
@@ -121,6 +117,20 @@ class CakeSocket {
  */
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
+
+		// These TLS versions are not supported by older PHP versions,
+		// so we have to conditionally set them if they are supported.
+		$conditionalCrypto = array(
+			'tlsv1_1_client' => 'STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT',
+			'tlsv1_2_client' => 'STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT',
+			'tlsv1_1_server' => 'STREAM_CRYPTO_METHOD_TLSv1_1_SERVER',
+			'tlsv1_2_server' => 'STREAM_CRYPTO_METHOD_TLSv1_2_SERVER'
+		);
+		foreach ($conditionalCrypto as $key => $const) {
+			if (defined($const)) {
+				$this->_encryptMethods[$key] = constant($const);
+			}
+		}
 	}
 
 /**

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -45,7 +45,7 @@ class CakeSocket {
 		'protocol' => 'tcp',
 		'port' => 80,
 		'timeout' => 30,
-		'cryptoType' => 'tls'
+		'cryptoType' => 'tls',
 	);
 
 /**
@@ -118,8 +118,23 @@ class CakeSocket {
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
 
-		// These TLS versions are not supported by older PHP versions,
-		// so we have to conditionally set them if they are supported.
+		$this->_addTlsVersions();
+	}
+
+/**
+ * Add TLS versions that are dependent on specific PHP versions.
+ *
+ * These TLS versions are not supported by older PHP versions,
+ * so we have to conditionally set them if they are supported.
+ *
+ * As of PHP5.6.6, STREAM_CRYPTO_METHOD_TLS_CLIENT does not include
+ * TLS1.1 or 1.2. If we have TLS1.2 support we need to update the method map.
+ *
+ * @see https://bugs.php.net/bug.php?id=69195
+ * @see https://github.com/php/php-src/commit/10bc5fd4c4c8e1dd57bd911b086e9872a56300a0
+ * @return void
+ */
+	protected function _addTlsVersions() {
 		$conditionalCrypto = array(
 			'tlsv1_1_client' => 'STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT',
 			'tlsv1_2_client' => 'STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT',
@@ -132,17 +147,14 @@ class CakeSocket {
 			}
 		}
 
-		// As of PHP5.6.6, STREAM_CRYPTO_METHOD_TLS_CLIENT does not include
-		// TLS1.1 or 1.2. If we have TLS1.2 support we need to update the method map.
-		//
-		// See https://bugs.php.net/bug.php?id=69195 &
-		// https://github.com/php/php-src/commit/10bc5fd4c4c8e1dd57bd911b086e9872a56300a0
+		// @codingStandardsIgnoreStart
 		if (isset($this->_encryptMethods['tlsv1_2_client'])) {
 			$this->_encryptMethods['tls_client'] = STREAM_CRYPTO_METHOD_TLS_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
 		}
 		if (isset($this->_encryptMethods['tlsv1_2_server'])) {
 			$this->_encryptMethods['tls_server'] = STREAM_CRYPTO_METHOD_TLS_SERVER | STREAM_CRYPTO_METHOD_TLSv1_1_SERVER | STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
 		}
+		// @codingStandardsIgnoreEnd
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -54,11 +54,12 @@ class CakeSocketTest extends CakeTestCase {
 		$this->Socket = new CakeSocket();
 		$config = $this->Socket->config;
 		$this->assertSame($config, array(
-			'persistent'	=> false,
-			'host'			=> 'localhost',
-			'protocol'		=> 'tcp',
-			'port'			=> 80,
-			'timeout'		=> 30
+			'persistent' => false,
+			'host' => 'localhost',
+			'protocol' => 'tcp',
+			'port' => 80,
+			'timeout' => 30,
+			'cryptoType' => 'tls',
 		));
 
 		$this->Socket->reset();
@@ -321,6 +322,20 @@ class CakeSocketTest extends CakeTestCase {
 		// testing on tls server
 		$this->_connectSocketToSslTls();
 		$this->assertTrue($this->Socket->enableCrypto('tls', 'client'));
+		$this->Socket->disconnect();
+	}
+
+/**
+ * testEnableCrypto tlsv1_1
+ *
+ * @return void
+ */
+	public function testEnableCryptoTlsV11() {
+		$this->skipIf(!defined('STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT'), 'TLS1.1 is not supported on this system');
+
+		// testing on tls server
+		$this->_connectSocketToSslTls();
+		$this->assertTrue($this->Socket->enableCrypto('tlsv1_1', 'client'));
 		$this->Socket->disconnect();
 	}
 

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -215,11 +215,13 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->expects($this->never())->method('connect');
 		$this->Socket->__construct(array('host' => 'foo-bar'));
 		$baseConfig['host'] = 'foo-bar';
+		$baseConfig['cryptoType'] = 'tls';
 		$this->assertEquals($this->Socket->config, $baseConfig);
 
 		$this->Socket->reset();
 		$baseConfig = $this->Socket->config;
 		$this->Socket->__construct('http://www.cakephp.org:23/');
+		$baseConfig['cryptoType'] = 'tls';
 		$baseConfig['host'] = $baseConfig['request']['uri']['host'] = 'www.cakephp.org';
 		$baseConfig['port'] = $baseConfig['request']['uri']['port'] = 23;
 		$baseConfig['request']['uri']['scheme'] = 'http';


### PR DESCRIPTION
Include the changes from #10232 and also fix the issue described in #10445