### PR TITLE
Adding controller mapping in resources

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -324,6 +324,7 @@ class RouteBuilder
             'actions' => [],
             'map' => [],
             'prefix' => null,
+            'controller' => $name
         ];
 
         foreach ($options['map'] as $k => $mapped) {
@@ -365,7 +366,7 @@ class RouteBuilder
 
             $url = '/' . implode('/', array_filter([$urlName, $params['path']]));
             $params = [
-                'controller' => $name,
+                'controller' => $options['controller'],
                 'action' => $action,
                 '_method' => $params['method'],
             ];

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -409,6 +409,19 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Test connecting resources with a controller
+     *
+     * @return void
+     */
+    public function testResourcesController()
+    {
+        $routes = new RouteBuilder($this->collection, '/api');
+        $routes->resources('Articles', ['controller' => 'Posts']);
+        $all = $this->collection->routes();
+        $this->assertEquals('Posts', $all[0]->defaults['controller']);
+    }
+
+    /**
      * Test connecting resources with a prefix
      *
      * @return void


### PR DESCRIPTION
This feature allows one to be able to define a resource that may not have the same name as the controller. It is the same concept as the connect method

      $routes->connect('/Gallery', ['controller' => 'Albums', 'action' => 'add']);