### PR TITLE
3.next - Integrate CookieCollection into Response

### DIFF
--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -442,7 +442,7 @@ class Response extends Message implements ResponseInterface
             return null;
         }
 
-        return $this->cookies->get($name)->toArrayCompat();
+        return $this->cookies->get($name)->toArrayClient();
     }
 
     /**
@@ -469,7 +469,7 @@ class Response extends Message implements ResponseInterface
 
         $cookies = [];
         foreach ($this->cookies as $cookie) {
-            $cookies[$cookie->getName()] = $cookie->toArrayCompat();
+            $cookies[$cookie->getName()] = $cookie->toArrayClient();
         }
 
         return $cookies;

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -15,8 +15,8 @@ namespace Cake\Http\Cookie;
 
 use Cake\Chronos\Chronos;
 use Cake\Utility\Hash;
-use DateTimeInterface;
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimezone;
 use InvalidArgumentException;
 use RuntimeException;

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -121,7 +121,7 @@ class Cookie implements CookieInterface
      * @link http://php.net/manual/en/function.setcookie.php
      * @param string $name Cookie name
      * @param string|array $value Value of the cookie
-     * @param \DateTimeInterface|null $expiresAt Expiration time and date
+     * @param \DateTimeInterface|int|null $expiresAt Expiration time and date
      * @param string $path Path
      * @param string $domain Domain
      * @param bool $secure Is secure
@@ -130,7 +130,7 @@ class Cookie implements CookieInterface
     public function __construct(
         $name,
         $value = '',
-        DateTimeInterface $expiresAt = null,
+        $expiresAt = null,
         $path = '',
         $domain = '',
         $secure = false,
@@ -153,7 +153,10 @@ class Cookie implements CookieInterface
         $this->validateBool($secure);
         $this->secure = $secure;
 
-        if ($expiresAt !== null) {
+        if (is_int($expiresAt)) {
+            $this->expiresAt = $expiresAt;
+        }
+        if ($expiresAt instanceof DateTimeInterface) {
             $this->expiresAt = (int)$expiresAt->format('U');
         }
     }
@@ -631,7 +634,7 @@ class Cookie implements CookieInterface
      *
      * @return array
      */
-    public function toArrayCompat()
+    public function toArrayClient()
     {
         return [
             'name' => $this->getName(),
@@ -641,6 +644,27 @@ class Cookie implements CookieInterface
             'secure' => $this->isSecure(),
             'httponly' => $this->isHttpOnly(),
             'expires' => gmdate(static::EXPIRES_FORMAT, $this->expiresAt)
+        ];
+    }
+
+    /**
+     * Convert the cookie into an array of its properties.
+     *
+     * This method is compatible with the historical behavior of Cake\Http\Response,
+     * where `httponly` is `httpOnly` and `expires` is `expire`
+     *
+     * @return array
+     */
+    public function toArrayResponse()
+    {
+        return [
+            'name' => $this->getName(),
+            'value' => $this->getValue(),
+            'path' => $this->getPath(),
+            'domain' => $this->getDomain(),
+            'secure' => $this->isSecure(),
+            'httpOnly' => $this->isHttpOnly(),
+            'expire' => $this->expiresAt
         ];
     }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -177,15 +177,18 @@ class Cookie implements CookieInterface
     /**
      * Get the timestamp from the expiration time
      *
-     * @return int
+     * Timestamps are strings as large timestamps can overflow MAX_INT
+     * in 32bit systems.
+     *
+     * @return string|null The expiry time as a string timestamp.
      */
     public function getExpiresTimestamp()
     {
         if (!$this->expiresAt) {
-            return 0;
+            return null;
         }
 
-        return (int)$this->expiresAt->format('U');
+        return $this->expiresAt->format('U');
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -268,6 +268,7 @@ class Cookie implements CookieInterface
      * @param string $name Name of the cookie
      * @return void
      * @throws \InvalidArgumentException
+     * @link https://tools.ietf.org/html/rfc2616#section-2.2 Rules for naming cookies.
      */
     protected function validateName($name)
     {

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -254,7 +254,7 @@ class Cookie implements CookieInterface
      */
     protected function validateName($name)
     {
-        if (preg_match("/[=,; \t\r\n\013\014]/", $name)) {
+        if (preg_match("/[=,;\t\r\n\013\014]/", $name)) {
             throw new InvalidArgumentException(
                 sprintf('The cookie name `%s` contains invalid characters.', $name)
             );

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -253,7 +253,7 @@ class CookieCollection implements IteratorAggregate, Countable
                 $domain = ltrim($domain, '.');
             }
 
-            $expires = $cookie->getExpiry();
+            $expires = $cookie->getExpiresTimestamp();
             if ($expires && time() > $expires) {
                 continue;
             }
@@ -389,7 +389,7 @@ class CookieCollection implements IteratorAggregate, Countable
         $hostPattern = '/' . preg_quote($host, '/') . '$/';
 
         foreach ($this->cookies as $i => $cookie) {
-            $expires = $cookie->getExpiry();
+            $expires = $cookie->getExpiresTimestamp();
             $expired = ($expires > 0 && $expires < $time);
 
             $pathMatches = strpos($path, $cookie->getPath()) === 0;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1942,7 +1942,7 @@ class Response implements ResponseInterface
             return $this->_cookies->get($options)->toArrayResponse();
         }
 
-        $defaults = [
+        $options += [
             'name' => 'CakeCookie[default]',
             'value' => '',
             'expire' => 0,
@@ -1951,11 +1951,10 @@ class Response implements ResponseInterface
             'secure' => false,
             'httpOnly' => false
         ];
-        $options += $defaults;
         $cookie = new Cookie(
             $options['name'],
             $options['value'],
-            $options['expire'],
+            (int)$options['expire'],
             $options['path'],
             $options['domain'],
             $options['secure'],
@@ -2013,7 +2012,7 @@ class Response implements ResponseInterface
             $cookie = new Cookie(
                 $name,
                 $data['value'],
-                $data['expire'],
+                (int)$data['expire'],
                 $data['path'],
                 $data['domain'],
                 $data['secure'],

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -28,10 +28,7 @@ use Zend\Diactoros\MessageTrait;
 use Zend\Diactoros\Stream;
 
 /**
- * Cake Response is responsible for managing the response text, status and headers of a HTTP response.
- *
- * By default controllers will use this class to render their response. If you are going to use
- * a custom response class it should subclass this object in order to ensure compatibility.
+ * Responses contain the response text, status and headers of a HTTP response.
  */
 class Response implements ResponseInterface
 {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -393,7 +393,7 @@ class Response implements ResponseInterface
     /**
      * Collection of cookies to send to the client
      *
-     * @var Cake\Http\Cookie\CookieCollection
+     * @var \Cake\Http\Cookie\CookieCollection
      */
     protected $_cookies = null;
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1951,10 +1951,11 @@ class Response implements ResponseInterface
             'secure' => false,
             'httpOnly' => false
         ];
+        $expires = $options['expire'] ? new DateTime('@' . $options['expire']) : null;
         $cookie = new Cookie(
             $options['name'],
             $options['value'],
-            (int)$options['expire'],
+            $expires,
             $options['path'],
             $options['domain'],
             $options['secure'],
@@ -2009,10 +2010,11 @@ class Response implements ResponseInterface
                 'secure' => false,
                 'httpOnly' => false
             ];
+            $expires = $data['expire'] ? new DateTime('@' . $data['expire']) : null;
             $cookie = new Cookie(
                 $name,
                 $data['value'],
-                (int)$data['expire'],
+                $expires,
                 $data['path'],
                 $data['domain'],
                 $data['secure'],

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1985,35 +1985,41 @@ class Response implements ResponseInterface
      *
      * // customize cookie attributes
      * $response = $response->withCookie('remember_me', ['path' => '/login']);
+     *
+     * // add a cookie object
+     * $response = $response->withCookie(new Cookie('remember_me', 1));
      * ```
      *
-     * @param string $name The name of the cookie to set.
+     * @param string|\Cake\Http\Cookie\Cookie $name The name of the cookie to set, or a cookie object
      * @param array|string $data Either a string value, or an array of cookie options.
      * @return static
      */
     public function withCookie($name, $data = '')
     {
-        if (!is_array($data)) {
-            $data = ['value' => $data];
+        if ($name instanceof Cookie) {
+            $cookie = $name;
+        } else {
+            if (!is_array($data)) {
+                $data = ['value' => $data];
+            }
+            $data += [
+                'value' => '',
+                'expire' => 0,
+                'path' => '/',
+                'domain' => '',
+                'secure' => false,
+                'httpOnly' => false
+            ];
+            $cookie = new Cookie(
+                $name,
+                $data['value'],
+                $data['expire'],
+                $data['path'],
+                $data['domain'],
+                $data['secure'],
+                $data['httpOnly']
+            );
         }
-        $defaults = [
-            'value' => '',
-            'expire' => 0,
-            'path' => '/',
-            'domain' => '',
-            'secure' => false,
-            'httpOnly' => false
-        ];
-        $data += $defaults;
-        $cookie = new Cookie(
-            $name,
-            $data['value'],
-            $data['expire'],
-            $data['path'],
-            $data['domain'],
-            $data['secure'],
-            $data['httpOnly']
-        );
 
         $new = clone $this;
         $new->_cookies = $new->_cookies->add($cookie);

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -222,14 +222,14 @@ class CookieCollectionTest extends TestCase
         $this->assertSame('/app', $new->get('test')->getPath(), 'cookies should inherit request path');
         $this->assertSame('/', $new->get('expiring')->getPath(), 'path attribute should be used.');
 
-        $this->assertSame(0, $new->get('test')->getExpiry(), 'No expiry');
+        $this->assertNull($new->get('test')->getExpiry(), 'No expiry');
         $this->assertSame(
             '2021-06-09 10:18:14',
-            date('Y-m-d H:i:s', $new->get('expiring')->getExpiry()),
+            $new->get('expiring')->getExpiry()->format('Y-m-d H:i:s'),
             'Has expiry'
         );
         $session = $new->get('session');
-        $this->assertSame(0, $session->getExpiry(), 'No expiry');
+        $this->assertNull($session->getExpiry(), 'No expiry');
         $this->assertSame('www.example.com', $session->getDomain(), 'Has domain');
     }
 

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -549,11 +549,11 @@ class CookieTest extends TestCase
     }
 
     /**
-     * Test toArrayCompat
+     * Test toArrayClient
      *
      * @return void
      */
-    public function testToArrayCompat()
+    public function testToArrayClient()
     {
         $date = Chronos::parse('2017-03-31 12:34:56');
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
@@ -571,6 +571,32 @@ class CookieTest extends TestCase
             'secure' => true,
             'httponly' => true
         ];
-        $this->assertEquals($expected, $cookie->toArrayCompat());
+        $this->assertEquals($expected, $cookie->toArrayClient());
+    }
+
+    /**
+     * Test toArrayResponse
+     *
+     * @return void
+     */
+    public function testToArrayResponse()
+    {
+        $date = Chronos::parse('2017-03-31 12:34:56');
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withPath('/api')
+            ->withExpiry($date)
+            ->withHttpOnly(true)
+            ->withSecure(true);
+        $expected = [
+            'name' => 'cakephp',
+            'value' => 'cakephp-rocks',
+            'path' => '/api',
+            'domain' => 'cakephp.org',
+            'expire' => $date->format('U'),
+            'secure' => true,
+            'httpOnly' => true
+        ];
+        $this->assertEquals($expected, $cookie->toArrayResponse());
     }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -30,14 +30,32 @@ class CookieTest extends TestCase
     protected $encryptionKey = 'someverysecretkeythatisatleast32charslong';
 
     /**
+     * Generate invalid cookie names.
+     *
+     * @return array
+     */
+    public function invalidNameProvider()
+    {
+        return [
+            ['no='],
+            ["no\rnewline"],
+            ["no\nnewline"],
+            ["no\ttab"],
+            ["no,comma"],
+            ["no;semi"],
+        ];
+    }
+
+    /**
      * Test invalid cookie name
      *
+     * @dataProvider invalidNameProvider
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The cookie name `no, this wont, work` contains invalid characters.
+     * @expectedExceptionMessage contains invalid characters.
      */
-    public function testValidateNameInvalidChars()
+    public function testValidateNameInvalidChars($name)
     {
-        new Cookie('no, this wont, work', '');
+        new Cookie($name, 'value');
     }
 
     /**

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -356,6 +356,25 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test the withExpiry method changes timezone
+     *
+     * @return void
+     */
+    public function testWithExpiryChangesTimezone()
+    {
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $date = Chronos::createFromDate(2022, 6, 15);
+        $date = $date->setTimezone('America/New_York');
+
+        $new = $cookie->withExpiry($date);
+        $this->assertNotSame($new, $cookie, 'Should clone');
+        $this->assertNotContains('expires', $cookie->toHeaderValue());
+
+        $this->assertContains('expires=Wed, 15-Jun-2022', $new->toHeaderValue());
+        $this->assertContains('GMT', $new->toHeaderValue());
+    }
+
+    /**
      * Test the withName method
      *
      * @return void
@@ -559,7 +578,7 @@ class CookieTest extends TestCase
             'value' => 'cakephp-rocks',
             'path' => '/api',
             'domain' => 'cakephp.org',
-            'expires' => (int)$date->format('U'),
+            'expires' => $date->format('U'),
             'secure' => true,
             'httponly' => true
         ];

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -372,6 +372,7 @@ class CookieTest extends TestCase
 
         $this->assertContains('expires=Wed, 15-Jun-2022', $new->toHeaderValue());
         $this->assertContains('GMT', $new->toHeaderValue());
+        $this->assertSame($date->format('U'), $new->getExpiresTimestamp());
     }
 
     /**

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -1474,6 +1474,22 @@ class ResponseTest extends TestCase
     }
 
     /**
+     * Test withCookie() and a cookie instance
+     *
+     * @return void
+     */
+    public function testWithCookieObject()
+    {
+        $response = new Response();
+        $cookie = new Cookie('yay', 'a value');
+        $new = $response->withCookie($cookie);
+        $this->assertNull($response->getCookie('yay'), 'withCookie does not mutate');
+
+        $this->assertNotEmpty($new->getCookie('yay'));
+        $this->assertSame($cookie, $new->getCookieCollection()->get('yay'));
+    }
+
+    /**
      * Test getCookies() and array data.
      *
      * @return void

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -16,6 +16,8 @@ namespace Cake\Test\TestCase\Http;
 
 include_once CORE_TEST_CASES . DS . 'Http' . DS . 'server_mocks.php';
 
+use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Network\Exception\NotFoundException;
@@ -1332,7 +1334,8 @@ class ResponseTest extends TestCase
             'path' => '/',
             'domain' => '',
             'secure' => false,
-            'httpOnly' => false];
+            'httpOnly' => false
+        ];
         $result = $response->cookie('CakeTestCookie[Testing]');
         $this->assertEquals($expected, $result);
 
@@ -1478,13 +1481,6 @@ class ResponseTest extends TestCase
     public function testGetCookies()
     {
         $response = new Response();
-        $cookie = [
-            'name' => 'ignored key',
-            'value' => '[a,b,c]',
-            'expire' => 1000,
-            'path' => '/test',
-            'secure' => true
-        ];
         $new = $response->withCookie('testing', 'a')
             ->withCookie('test2', ['value' => 'b', 'path' => '/test', 'secure' => true]);
         $expected = [
@@ -1508,6 +1504,28 @@ class ResponseTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $new->getCookies());
+    }
+
+    /**
+     * Test getCookieCollection() as array data
+     *
+     * @return void
+     */
+    public function testGetCookieCollection()
+    {
+        $response = new Response();
+        $new = $response->withCookie('testing', 'a')
+            ->withCookie('test2', ['value' => 'b', 'path' => '/test', 'secure' => true]);
+        $cookies = $response->getCookieCollection();
+        $this->assertInstanceOf(CookieCollection::class, $cookies);
+        $this->assertCount(0, $cookies, 'Original response not mutated');
+
+        $cookies = $new->getCookieCollection();
+        $this->assertInstanceOf(CookieCollection::class, $cookies);
+        $this->assertCount(2, $cookies);
+
+        $this->assertTrue($cookies->has('testing'));
+        $this->assertTrue($cookies->has('test2'));
     }
 
     /**
@@ -3010,7 +3028,7 @@ class ResponseTest extends TestCase
             ],
             'file' => null,
             'fileRange' => [],
-            'cookies' => [],
+            'cookies' => new CookieCollection(),
             'cacheDirectives' => [],
             'body' => ''
         ];

--- a/tests/TestCase/Http/ResponseTransformerTest.php
+++ b/tests/TestCase/Http/ResponseTransformerTest.php
@@ -156,13 +156,13 @@ class ResponseTransformerTest extends TestCase
     public function testToCakeCookies()
     {
         $cookies = [
-            'remember me=1";"1',
+            'remember_me=1";"1',
             'forever=yes; Expires=Wed, 13 Jan 2021 12:30:40 GMT; Path=/some/path; Domain=example.com; HttpOnly; Secure'
         ];
         $psr = new PsrResponse('php://memory', 200, ['Set-Cookie' => $cookies]);
         $result = ResponseTransformer::toCake($psr);
         $expected = [
-            'name' => 'remember me',
+            'name' => 'remember_me',
             'value' => '1";"1',
             'path' => '/',
             'domain' => '',
@@ -170,7 +170,7 @@ class ResponseTransformerTest extends TestCase
             'secure' => false,
             'httpOnly' => false,
         ];
-        $this->assertEquals($expected, $result->cookie('remember me'));
+        $this->assertEquals($expected, $result->cookie('remember_me'));
 
         $expected = [
             'name' => 'forever',
@@ -242,7 +242,7 @@ class ResponseTransformerTest extends TestCase
     {
         $cake = new CakeResponse(['status' => 200]);
         $cake->cookie([
-            'name' => 'remember me',
+            'name' => 'remember_me',
             'value' => '1 1',
             'path' => '/some/path',
             'domain' => 'example.com',
@@ -252,7 +252,7 @@ class ResponseTransformerTest extends TestCase
         ]);
         $result = ResponseTransformer::toPsr($cake);
         $this->assertEquals(
-            'remember+me=1+1; Expires=Wed, 13 Jan 2021 12:30:40 GMT; Path=/some/path; Domain=example.com; HttpOnly; Secure',
+            'remember_me=1+1; Expires=Wed, 13 Jan 2021 12:30:40 GMT; Path=/some/path; Domain=example.com; HttpOnly; Secure',
             $result->getHeader('Set-Cookie')[0],
             'Cookie attributes should exist, and name/value should be encoded'
         );


### PR DESCRIPTION
Integrate the new Cookies and CookieCollection into the Response. All of the existing cookie related methods are backwards compatible, and `withCookie()` allows new style cookies as a parameter.

I've had to add more compatibility shims into Cookie and relax the expires parameter typing to allow integers. I found this preferable to coercing the existing cookie data into a DateTime just so it can be converted back into an integer.

Refs #10406