### PR TITLE
Don't doubly include MessageTrait.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "cakephp/chronos": "~1.0",
         "aura/intl": "^3.0.0",
         "psr/log": "^1.0",
-        "zendframework/zend-diactoros": "~1.0"
+        "zendframework/zend-diactoros": "^1.4"
     },
     "suggest": {
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -27,7 +27,6 @@ use Zend\Diactoros\Stream;
  */
 class Request extends Message implements RequestInterface
 {
-    use MessageTrait;
     use RequestTrait;
 
     /**


### PR DESCRIPTION
RequestTrait already includes MessageTrait. Also pin to newer diactoros as there are problems with older versions.

People using CakePHP 3.3.x will need to require diactoros 1.3.10 in their application, as there aren't maintenance releases for 3.3 anymore.

Refs #10495
