### PR TITLE
Make test suite compatible with PHPUnit 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     - php: 7.0
       env: PHPCS=1
 
+    - php: 7.1
+      env: DB=mysql PHPUNIT=5.7.19
+
 
 before_script:
   - composer global require "phpunit/phpunit=$PHPUNIT"

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -655,7 +655,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @deprecated 3.0.0 This is a compatibility wrapper for 1.x. It will be removed in 3.0.
  * @return void
  */
-	protected function expectException($name = 'Exception', $message = '') {
+	public function expectException($name = 'Exception', $message = '') {
 		$this->setExpectedException($name, $message);
 	}
 

--- a/lib/Cake/TestSuite/CakeTestRunner.php
+++ b/lib/Cake/TestSuite/CakeTestRunner.php
@@ -44,9 +44,10 @@ class CakeTestRunner extends PHPUnit_TextUI_TestRunner {
  *
  * @param PHPUnit_Framework_Test $suite The test suite to run
  * @param array $arguments The CLI arguments
+ * @param bool $exit Exits by default or returns the results
  * @return void
  */
-	public function doRun(PHPUnit_Framework_Test $suite, array $arguments = array()) {
+	public function doRun(PHPUnit_Framework_Test $suite, array $arguments = array(), $exit = true) {
 		if (isset($arguments['printer'])) {
 			static::$versionStringPrinted = true;
 		}


### PR DESCRIPTION
Sadly there are 1200 deprecation warnings for `getMock`, but at least we can use PHP7 features now!

Closes #9973