### PR TITLE
Do not ignore PHPStan files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,5 +42,4 @@ phpunit.xml.dist export-ignore
 .stickler.yml export-ignore
 tests/test_app export-ignore
 tests/TestCase export-ignore
-tests/PHPStan export-ignore
 .github export-ignore


### PR DESCRIPTION
Plugins need those classes (similar to Fixture) if they want to include PHPStan.
Otherwise they need to duplicate everything. Many plugins work with the ORM level.