### PR TITLE
Split ConsoleOutput::outputAs() into getter/setter

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -266,7 +266,7 @@ class ConsoleIo
      */
     public function outputAs($mode)
     {
-        $this->_out->outputAs($mode);
+        $this->_out->setOutputAs($mode);
     }
 
     /**

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -264,6 +264,19 @@ class ConsoleIo
      * @return void
      * @see \Cake\Console\ConsoleOutput::outputAs()
      */
+    public function setOutputAs($mode)
+    {
+        $this->_out->setOutputAs($mode);
+    }
+
+    /**
+     * Change the output mode of the stdout stream
+     *
+     * @deprecated 3.5.0 Use setOutputAs() instead.
+     * @param int $mode The output mode.
+     * @return void
+     * @see \Cake\Console\ConsoleOutput::outputAs()
+     */
     public function outputAs($mode)
     {
         $this->_out->setOutputAs($mode);

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -262,7 +262,7 @@ class ConsoleIo
      *
      * @param int $mode The output mode.
      * @return void
-     * @see \Cake\Console\ConsoleOutput::outputAs()
+     * @see \Cake\Console\ConsoleOutput::setOutputAs()
      */
     public function setOutputAs($mode)
     {

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -319,11 +319,11 @@ class ConsoleOutput
      *
      * @param int $type The output type to use. Should be one of the class constants.
      * @return void
-     * @throws InvalidArgumentException in case of a not supported output type.
+     * @throws \InvalidArgumentException in case of a not supported output type.
      */
     public function setOutputAs($type)
     {
-        if (in_array($type, [self::RAW, self::PLAIN, self::COLOR], true) === false) {
+        if (!in_array($type, [self::RAW, self::PLAIN, self::COLOR], true)) {
             throw new InvalidArgumentException(sprintf('Invalid output type "%s".', $type));
         }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Console;
 
+use InvalidArgumentException;
+
 /**
  * Object wrapper for outputting information from a shell application.
  * Can be connected to any stream resource that can be used with fopen()
@@ -317,9 +319,14 @@ class ConsoleOutput
      *
      * @param int $type The output type to use. Should be one of the class constants.
      * @return void
+     * @throws InvalidArgumentException in case of a not supported output type.
      */
     public function setOutputAs($type)
     {
+        if (in_array($type, [self::RAW, self::PLAIN, self::COLOR], true) === false) {
+            throw new InvalidArgumentException(sprintf('Invalid output type "%s".', $type));
+        }
+
         $this->_outputAs = $type;
     }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -303,8 +303,30 @@ class ConsoleOutput
     }
 
     /**
+     * Get the output type on how formatting tags are treated.
+     *
+     * @return int
+     */
+    public function getOutputAs()
+    {
+        return $this->_outputAs;
+    }
+
+    /**
+     * Set the output type on how formatting tags are treated.
+     *
+     * @param int $type The output type to use. Should be one of the class constants.
+     * @return void
+     */
+    public function setOutputAs($type)
+    {
+        $this->_outputAs = $type;
+    }
+
+    /**
      * Get/Set the output type to use. The output type how formatting tags are treated.
      *
+     * @deprecated 3.5.0 Use getOutputAs()/setOutputAs() instead.
      * @param int|null $type The output type to use. Should be one of the class constants.
      * @return int|null Either null or the value if getting.
      */

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -509,7 +509,7 @@ class Shell
         $format = 'text';
         if (!empty($this->args[0]) && $this->args[0] === 'xml') {
             $format = 'xml';
-            $this->_io->outputAs(ConsoleOutput::RAW);
+            $this->_io->setOutputAs(ConsoleOutput::RAW);
         } else {
             $this->_welcome();
         }

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -75,7 +75,7 @@ class ConsoleLog extends BaseLog
         } else {
             throw new InvalidArgumentException('`stream` not a ConsoleOutput nor string');
         }
-        $this->_output->outputAs($config['outputAs']);
+        $this->_output->setOutputAs($config['outputAs']);
     }
 
     /**

--- a/src/Shell/CommandListShell.php
+++ b/src/Shell/CommandListShell.php
@@ -126,7 +126,7 @@ class CommandListShell extends Shell
                 $shell->addAttribute('help', $callable . ' -h');
             }
         }
-        $this->_io->outputAs(ConsoleOutput::RAW);
+        $this->_io->setOutputAs(ConsoleOutput::RAW);
         $this->out($shells->saveXML());
     }
 

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -250,6 +250,20 @@ class ConsoleOutputTest extends TestCase
     }
 
     /**
+     * test set plain output.
+     *
+     * @return void
+     */
+    public function testSetOutputAsPlain()
+    {
+        $this->output->setOutputAs(ConsoleOutput::PLAIN);
+        $this->output->expects($this->once())->method('_write')
+            ->with('Bad Regular');
+
+        $this->output->write('<error>Bad</error> Regular', false);
+    }
+
+    /**
      * test plain output only strips tags used for formatting.
      *
      * @return void

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -264,6 +264,17 @@ class ConsoleOutputTest extends TestCase
     }
 
     /**
+     * test set wrong type.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid output type "Foo".
+     */
+    public function testSetOutputWrongType()
+    {
+        $this->output->setOutputAs('Foo');
+    }
+
+    /**
      * test plain output only strips tags used for formatting.
      *
      * @return void

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -76,7 +76,7 @@ class ConsoleLogTest extends TestCase
         $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
         $output->expects($this->at(0))
-            ->method('outputAs')
+            ->method('setOutputAs')
             ->with($expected);
 
         $log = new ConsoleLog([


### PR DESCRIPTION
Continues with #9978 