### PR TITLE
Added most commonly used cookie methods to the CookieInterface.

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -36,7 +36,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Cookie objects
      *
-     * @var Cookie[]
+     * @var \Cake\Http\Cookie\CookieInterface[]
      */
     protected $cookies = [];
 

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -13,6 +13,8 @@
  */
 namespace Cake\Http\Cookie;
 
+use DateTimeInterface;
+
 /**
  * Cookie Interface
  */
@@ -47,6 +49,116 @@ interface CookieInterface
      * @return static
      */
     public function withValue($value);
+
+    /**
+     * Get the id for a cookie
+     *
+     * Cookies are unique across name, domain, path tuples.
+     *
+     * @return string
+     */
+    public function getId();
+
+    /**
+     * Get the path attribute.
+     *
+     * @return string
+     */
+    public function getPath();
+
+    /**
+     * Create a new cookie with an updated path
+     *
+     * @param string $path Sets the path
+     * @return static
+     */
+    public function withPath($path);
+
+    /**
+     * Get the domain attribute.
+     *
+     * @return string
+     */
+    public function getDomain();
+
+    /**
+     * Create a cookie with an updated domain
+     *
+     * @param string $domain Domain to set
+     * @return static
+     */
+    public function withDomain($domain);
+
+    /**
+     * Get the current expiry time
+     *
+     * @return DateTimeInterface|null Timestamp of expiry or null
+     */
+    public function getExpiry();
+
+    /**
+     * Create a cookie with an updated expiration date
+     *
+     * @param DateTimeInterface $dateTime Date time object
+     * @return static
+     */
+    public function withExpiry(DateTimeInterface $dateTime);
+
+    /**
+     * Create a new cookie that will virtually never expire.
+     *
+     * @return static
+     */
+    public function withNeverExpire();
+
+    /**
+     * Create a new cookie that will expire/delete the cookie from the browser.
+     *
+     * This is done by setting the expiration time to 1 year ago
+     *
+     * @return static
+     */
+    public function withExpired();
+
+    /**
+     * Check if a cookie is expired when compared to $time
+     *
+     * Cookies without an expiration date always return false.
+     *
+     * @param \DatetimeInterface $time The time to test against. Defaults to 'now' in UTC.
+     * @return bool
+     */
+    public function isExpired(DatetimeInterface $time = null);
+
+    /**
+     * Check if the cookie is HTTP only
+     *
+     * @return bool
+     */
+    public function isHttpOnly();
+
+    /**
+     * Create a cookie with HTTP Only updated
+     *
+     * @param bool $httpOnly HTTP Only
+     * @return static
+     */
+    public function withHttpOnly($httpOnly);
+
+    /**
+     * Check if the cookie is secure
+     *
+     * @return bool
+     */
+    public function isSecure();
+
+    /**
+     * Create a cookie with Secure updated
+     *
+     * @param bool $secure Secure attribute value
+     * @return static
+     */
+    public function withSecure($secure);
 
     /**
      * Returns the cookie as header value


### PR DESCRIPTION
Since we allow `CookieInterface` in collections we must ensure methods used on cookies there are implemented.

I've added general cookie related methods to the interface, apart from the ones related to encryption and expanded data.

I'm not sure what to do with `toArray*()` methods. These are here for "historical" reasons. Still used in request/response but I'm not sure we should force users to implement them. Maybe do a `$cookie instanceof Cookie` check where these are used? Or as this is some legacy code - convert cookies to arrays internally in client code and remove these methods from cookie? I think the old code here should adapt to the new one, not otherwise.


Follow-up to the #10505