### PR TITLE
Update Plugin.php

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -220,6 +220,7 @@ class Plugin
      *
      * @param array $options Options.
      * @return void
+     * @throws \Cake\Core\Exception\MissingPluginException
      */
     public static function loadAll(array $options = [])
     {


### PR DESCRIPTION
Throws a non-annotated/unhandled exception: '\Cake\Core\Exception\MissingPluginException'.