### PR TITLE
2.x - Fix `ControllerTestCase::testAction()` incompatibility with `App.base`.

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -624,4 +624,30 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$this->assertEquals($restored, $_POST);
 	}
 
+/**
+ * Tests that the `App.base` path is properly stripped from the URL generated from the
+ * given URL array, and that consequently the correct controller/action is being matched.
+ *
+ * @return void
+ */
+	public function testAppBaseConfigCompatibilityWithArrayUrls() {
+		Configure::write('App.base', '/cakephp');
+
+		$this->Case->generate('TestsApps');
+		$this->Case->testAction(array('controller' => 'tests_apps', 'action' => 'index'));
+
+		$this->assertEquals('/cakephp', $this->Case->controller->request->base);
+		$this->assertEquals('/cakephp/', $this->Case->controller->request->webroot);
+		$this->assertEquals('/cakephp/tests_apps', $this->Case->controller->request->here);
+		$this->assertEquals('tests_apps', $this->Case->controller->request->url);
+
+		$expected = array(
+			'plugin' => null,
+			'controller' => 'tests_apps',
+			'action' => 'index',
+			'named' => array(),
+			'pass' => array(),
+		);
+		$this->assertEquals($expected, array_intersect_key($expected, $this->Case->controller->request->params));
+	}
 }

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -248,7 +248,8 @@ abstract class ControllerTestCase extends CakeTestCase {
 				$_GET = array();
 			}
 		}
-		$request = $this->getMock('CakeRequest', array('_readInput'), array($url));
+		$_SERVER['REQUEST_URI'] = $url;
+		$request = $this->getMock('CakeRequest', array('_readInput'));
 
 		if (is_string($options['data'])) {
 			$request->expects($this->any())


### PR DESCRIPTION
When using array URLs with `testAction()`, the generated URL possibly
contains the configured `App.base` path, which needs to be stripped when
set on the request object, as otherwise routes cannot be matched
correctly.

When passing the URL as an option to the `CakeRequest` constructor, the
it will be set as-is, unlike when the URL is being generated by
`CakeRequest::_url()`, which grabs the URL from the environment, and
strips the possible base path.