### PR TITLE
Fix E_USER_DEPRECATED error when mocking a model

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -667,8 +667,8 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
-        if (stripos($mock->table(), 'mock') === 0) {
-            $mock->table(Inflector::tableize($baseClass));
+        if (stripos($mock->getTable(), 'mock') === 0) {
+            $mock->setTable(Inflector::tableize($baseClass));
         }
 
         TableRegistry::set($baseClass, $mock);


### PR DESCRIPTION
phpunit triggers an `E_USER_DEPRECATED` error because table is called inside the function `getMockForModel`. This PR fixes the function such that it uses `getTable` and `setTable` instead
