### PR TITLE
Ignore debug.log and error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /phpcs.xml
 /vendor
 *.mo
+debug.log
+error.log
 
 # IDE and editor specific files #
 #################################


### PR DESCRIPTION
It's always tempting to commit `debug.log` and `error.log` when doing a PR.
@dereuromark Can you add the `plugin` thing?