### PR TITLE
2.x - Fix query string data in URL arrays not being passed anymore (#10517 follow-up)

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -650,4 +650,81 @@ class ControllerTestCaseTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, array_intersect_key($this->Case->controller->request->params, $expected));
 	}
+
+/**
+ * Tests that query string data from URL arrays properly makes it into the request object
+ * on GET requests.
+ *
+ * @return void
+ */
+	public function testTestActionWithArrayUrlQueryStringDataViaGetRequest() {
+		$query = array('foo' => 'bar');
+
+		$this->Case->generate('TestsApps');
+		$this->Case->testAction(
+			array(
+				'controller' => 'tests_apps',
+				'action' => 'index',
+				'?' => $query
+			),
+			array(
+				'method' => 'get'
+			)
+		);
+
+		$this->assertEquals('tests_apps', $this->Case->controller->request->url);
+		$this->assertEquals($query, $this->Case->controller->request->query);
+	}
+
+/**
+ * Tests that query string data from URL arrays properly makes it into the request object
+ * on POST requests.
+ *
+ * @return void
+ */
+	public function testTestActionWithArrayUrlQueryStringDataViaPostRequest() {
+		$query = array('foo' => 'bar');
+
+		$this->Case->generate('TestsApps');
+		$this->Case->testAction(
+			array(
+				'controller' => 'tests_apps',
+				'action' => 'index',
+				'?' => $query
+			),
+			array(
+				'method' => 'post'
+			)
+		);
+
+		$this->assertEquals('tests_apps', $this->Case->controller->request->url);
+		$this->assertEquals($query, $this->Case->controller->request->query);
+	}
+
+/**
+ * Tests that query string data from both, URL arrays as well as the `data` option,
+ * properly makes it into the request object.
+ *
+ * @return void
+ */
+	public function testTestActionWithArrayUrlQueryStringDataAndDataOptionViaGetRequest() {
+		$query = array('foo' => 'bar');
+		$data = array('bar' => 'foo');
+
+		$this->Case->generate('TestsApps');
+		$this->Case->testAction(
+			array(
+				'controller' => 'tests_apps',
+				'action' => 'index',
+				'?' => $query
+			),
+			array(
+				'method' => 'get',
+				'data' => $data
+			)
+		);
+
+		$this->assertEquals('tests_apps', $this->Case->controller->request->url);
+		$this->assertEquals($data + $query, $this->Case->controller->request->query);
+	}
 }

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -248,6 +248,13 @@ abstract class ControllerTestCase extends CakeTestCase {
 				$_GET = array();
 			}
 		}
+
+		if (strpos($url, '?') !== false) {
+			list($url, $query) = explode('?', $url, 2);
+			parse_str($query, $queryArgs);
+			$_GET += $queryArgs;
+		}
+
 		$_SERVER['REQUEST_URI'] = $url;
 		$request = $this->getMock('CakeRequest', array('_readInput'));
 


### PR DESCRIPTION
Fix query string data in URL arrays not being passed anymore.

refs #10555, #10517, #5473