### PR TITLE
Update Response classes to accept custom implementations of CookieInterface.

### DIFF
--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -14,6 +14,7 @@
 namespace Cake\Http\Client;
 
 use Cake\Http\Cookie\CookieCollection as BaseCollection;
+use Cake\Http\Cookie\CookieInterface;
 
 /**
  * Container class for cookies used in Http\Client.
@@ -32,7 +33,7 @@ class CookieCollection extends BaseCollection
      * Store the cookies that haven't expired. If a cookie has been expired
      * and is currently stored, it will be removed.
      *
-     * @param \Cake\Http\Client\Response $response The response to read cookies from
+     * @param Response $response The response to read cookies from
      * @param string $url The request URL used for default host/path values.
      * @return void
      */
@@ -78,10 +79,31 @@ class CookieCollection extends BaseCollection
     {
         $out = [];
         foreach ($this->cookies as $cookie) {
-            $out[] = $cookie->toArray();
+            $out[] = $this->convertCookie($cookie);
         }
 
         return $out;
+    }
+
+    /**
+     * Convert the cookie into an array of its properties.
+     *
+     * Primarily useful where backwards compatibility is needed.
+     *
+     * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
+     * @return array
+     */
+    public function convertCookie(CookieInterface $cookie)
+    {
+        return [
+            'name' => $cookie->getName(),
+            'value' => $cookie->getValue(),
+            'path' => $cookie->getPath(),
+            'domain' => $cookie->getDomain(),
+            'secure' => $cookie->isSecure(),
+            'httponly' => $cookie->isHttpOnly(),
+            'expires' => $cookie->getExpiresTimestamp()
+        ];
     }
 }
 

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -70,7 +70,7 @@ class CookieCollection extends BaseCollection
     }
 
     /**
-     * Get all the stored cookies.
+     * Get all the stored cookies as arrays.
      *
      * @return array
      */

--- a/src/Http/Client/CookieCollection.php
+++ b/src/Http/Client/CookieCollection.php
@@ -79,7 +79,7 @@ class CookieCollection extends BaseCollection
     {
         $out = [];
         foreach ($this->cookies as $cookie) {
-            $out[] = $this->convertCookie($cookie);
+            $out[] = $this->convertCookieToArray($cookie);
         }
 
         return $out;
@@ -93,7 +93,7 @@ class CookieCollection extends BaseCollection
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
      * @return array
      */
-    public function convertCookie(CookieInterface $cookie)
+    protected function convertCookieToArray(CookieInterface $cookie)
     {
         return [
             'name' => $cookie->getName(),

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -462,7 +462,9 @@ class Response extends Message implements ResponseInterface
     {
         if ($cookie instanceof Cookie) {
             return $cookie->toArrayClient();
-        } elseif ($cookie->getExpiry()) {
+        }
+
+        if ($cookie->getExpiry()) {
             $expires = $cookie->getExpiry()->format(Cookie::EXPIRES_FORMAT);
         } else {
             $expires = '';

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -13,9 +13,11 @@
  */
 namespace Cake\Http\Client;
 
+use Cake\Http\Cookie\Cookie;
 // This alias is necessary to avoid class name conflicts
 // with the deprecated class in this namespace.
 use Cake\Http\Cookie\CookieCollection as CookiesCollection;
+use Cake\Http\Cookie\CookieInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 use Zend\Diactoros\MessageTrait;
@@ -442,7 +444,39 @@ class Response extends Message implements ResponseInterface
             return null;
         }
 
-        return $this->cookies->get($name)->toArrayClient();
+        $cookie = $this->cookies->get($name);
+
+        return $this->toArrayClient($cookie);
+    }
+
+    /**
+     * Convert the cookie into an array of its properties.
+     *
+     * This method is compatible with older client code that
+     * expects date strings instead of timestamps.
+     *
+     * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
+     * @return array
+     */
+    protected function toArrayClient(CookieInterface $cookie)
+    {
+        if ($cookie instanceof Cookie) {
+            return $cookie->toArrayClient();
+        } elseif ($cookie->getExpiry()) {
+            $expires = $cookie->getExpiry()->format(Cookie::EXPIRES_FORMAT);
+        } else {
+            $expires = '';
+        }
+
+        return [
+            'name' => $cookie->getName(),
+            'value' => $cookie->getValue(),
+            'path' => $cookie->getPath(),
+            'domain' => $cookie->getDomain(),
+            'secure' => $cookie->isSecure(),
+            'httponly' => $cookie->isHttpOnly(),
+            'expires' => $expires
+        ];
     }
 
     /**
@@ -469,7 +503,7 @@ class Response extends Message implements ResponseInterface
 
         $cookies = [];
         foreach ($this->cookies as $cookie) {
-            $cookies[$cookie->getName()] = $cookie->toArrayClient();
+            $cookies[$cookie->getName()] = $this->toArrayClient($cookie);
         }
 
         return $cookies;

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -446,7 +446,7 @@ class Response extends Message implements ResponseInterface
 
         $cookie = $this->cookies->get($name);
 
-        return $this->convertCookie($cookie);
+        return $this->convertCookieToArray($cookie);
     }
 
     /**
@@ -458,7 +458,7 @@ class Response extends Message implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
      * @return array
      */
-    public function convertCookie(CookieInterface $cookie)
+    protected function convertCookieToArray(CookieInterface $cookie)
     {
         return [
             'name' => $cookie->getName(),
@@ -495,7 +495,7 @@ class Response extends Message implements ResponseInterface
 
         $cookies = [];
         foreach ($this->cookies as $cookie) {
-            $cookies[$cookie->getName()] = $this->convertCookie($cookie);
+            $cookies[$cookie->getName()] = $this->convertCookieToArray($cookie);
         }
 
         return $cookies;

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -446,7 +446,7 @@ class Response extends Message implements ResponseInterface
 
         $cookie = $this->cookies->get($name);
 
-        return $this->toArrayClient($cookie);
+        return $this->convertCookie($cookie);
     }
 
     /**
@@ -458,18 +458,8 @@ class Response extends Message implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
      * @return array
      */
-    protected function toArrayClient(CookieInterface $cookie)
+    public function convertCookie(CookieInterface $cookie)
     {
-        if ($cookie instanceof Cookie) {
-            return $cookie->toArrayClient();
-        }
-
-        if ($cookie->getExpiry()) {
-            $expires = $cookie->getExpiry()->format(Cookie::EXPIRES_FORMAT);
-        } else {
-            $expires = '';
-        }
-
         return [
             'name' => $cookie->getName(),
             'value' => $cookie->getValue(),
@@ -477,7 +467,7 @@ class Response extends Message implements ResponseInterface
             'domain' => $cookie->getDomain(),
             'secure' => $cookie->isSecure(),
             'httponly' => $cookie->isHttpOnly(),
-            'expires' => $expires
+            'expires' => $cookie->getFormattedExpires()
         ];
     }
 
@@ -505,7 +495,7 @@ class Response extends Message implements ResponseInterface
 
         $cookies = [];
         foreach ($this->cookies as $cookie) {
-            $cookies[$cookie->getName()] = $this->toArrayClient($cookie);
+            $cookies[$cookie->getName()] = $this->convertCookie($cookie);
         }
 
         return $cookies;

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -163,7 +163,7 @@ class Cookie implements CookieInterface
      *
      * @return string
      */
-    public function getFormattedExpires()
+    protected function getFormattedExpires()
     {
         if (!$this->expiresAt) {
             return '';

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -49,13 +49,6 @@ class Cookie implements CookieInterface
 {
 
     /**
-     * Expires attribute format.
-     *
-     * @var string
-     */
-    const EXPIRES_FORMAT = 'D, d-M-Y H:i:s T';
-
-    /**
      * Cookie name
      *
      * @var string
@@ -156,20 +149,6 @@ class Cookie implements CookieInterface
             $expiresAt = $expiresAt->setTimezone(new DateTimezone('GMT'));
         }
         $this->expiresAt = $expiresAt;
-    }
-
-    /**
-     * Builds the expiration value part of the header string
-     *
-     * @return string
-     */
-    protected function getFormattedExpires()
-    {
-        if (!$this->expiresAt) {
-            return '';
-        }
-
-        return $this->expiresAt->format(static::EXPIRES_FORMAT);
     }
 
     /**
@@ -473,6 +452,20 @@ class Cookie implements CookieInterface
         }
 
         return $this->expiresAt->format('U');
+    }
+
+    /**
+     * Builds the expiration value part of the header string
+     *
+     * @return string
+     */
+    public function getFormattedExpires()
+    {
+        if (!$this->expiresAt) {
+            return '';
+        }
+
+        return $this->expiresAt->format(static::EXPIRES_FORMAT);
     }
 
     /**

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -163,7 +163,7 @@ class Cookie implements CookieInterface
      *
      * @return string
      */
-    protected function getFormattedExpires()
+    public function getFormattedExpires()
     {
         if (!$this->expiresAt) {
             return '';

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -600,26 +600,6 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Convert the cookie into an array of its properties.
-     *
-     * Primarily useful where backwards compatibility is needed.
-     *
-     * @return array
-     */
-    public function toArray()
-    {
-        return [
-            'name' => $this->getName(),
-            'value' => $this->getValue(),
-            'path' => $this->getPath(),
-            'domain' => $this->getDomain(),
-            'secure' => $this->isSecure(),
-            'httponly' => $this->isHttpOnly(),
-            'expires' => $this->getExpiresTimestamp()
-        ];
-    }
-
-    /**
      * Implode method to keep keys are multidimensional arrays
      *
      * @param array $array Map of key and values

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -622,27 +622,6 @@ class Cookie implements CookieInterface
     /**
      * Convert the cookie into an array of its properties.
      *
-     * This method is compatible with older client code that
-     * expects date strings instead of timestamps.
-     *
-     * @return array
-     */
-    public function toArrayClient()
-    {
-        return [
-            'name' => $this->getName(),
-            'value' => $this->getValue(),
-            'path' => $this->getPath(),
-            'domain' => $this->getDomain(),
-            'secure' => $this->isSecure(),
-            'httponly' => $this->isHttpOnly(),
-            'expires' => $this->getFormattedExpires()
-        ];
-    }
-
-    /**
-     * Convert the cookie into an array of its properties.
-     *
      * This method is compatible with the historical behavior of Cake\Http\Response,
      * where `httponly` is `httpOnly` and `expires` is `expire`
      *

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -620,27 +620,6 @@ class Cookie implements CookieInterface
     }
 
     /**
-     * Convert the cookie into an array of its properties.
-     *
-     * This method is compatible with the historical behavior of Cake\Http\Response,
-     * where `httponly` is `httpOnly` and `expires` is `expire`
-     *
-     * @return array
-     */
-    public function toArrayResponse()
-    {
-        return [
-            'name' => $this->getName(),
-            'value' => $this->getValue(),
-            'path' => $this->getPath(),
-            'domain' => $this->getDomain(),
-            'secure' => $this->isSecure(),
-            'httpOnly' => $this->isHttpOnly(),
-            'expire' => $this->getExpiresTimestamp()
-        ];
-    }
-
-    /**
      * Implode method to keep keys are multidimensional arrays
      *
      * @param array $array Map of key and values

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -166,4 +166,13 @@ interface CookieInterface
      * @return string
      */
     public function toHeaderValue();
+
+    /**
+     * Convert the cookie into an array of its properties.
+     *
+     * Primarily useful where backwards compatibility is needed.
+     *
+     * @return array
+     */
+    public function toArray();
 }

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -20,6 +20,14 @@ use DateTimeInterface;
  */
 interface CookieInterface
 {
+
+    /**
+     * Expires attribute format.
+     *
+     * @var string
+     */
+    const EXPIRES_FORMAT = 'D, d-M-Y H:i:s T';
+
     /**
      * Sets the cookie name
      *
@@ -95,6 +103,23 @@ interface CookieInterface
      * @return DateTimeInterface|null Timestamp of expiry or null
      */
     public function getExpiry();
+
+    /**
+     * Get the timestamp from the expiration time
+     *
+     * Timestamps are strings as large timestamps can overflow MAX_INT
+     * in 32bit systems.
+     *
+     * @return string|null The expiry time as a string timestamp.
+     */
+    public function getExpiresTimestamp();
+
+    /**
+     * Builds the expiration value part of the header string
+     *
+     * @return string
+     */
+    public function getFormattedExpires();
 
     /**
      * Create a cookie with an updated expiration date

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -191,13 +191,4 @@ interface CookieInterface
      * @return string
      */
     public function toHeaderValue();
-
-    /**
-     * Convert the cookie into an array of its properties.
-     *
-     * Primarily useful where backwards compatibility is needed.
-     *
-     * @return array
-     */
-    public function toArray();
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1941,7 +1941,7 @@ class Response implements ResponseInterface
 
             $cookie = $this->_cookies->get($options);
 
-            return $this->toArrayResponse($cookie);
+            return $this->convertCookie($cookie);
         }
 
         $options += [
@@ -2047,7 +2047,7 @@ class Response implements ResponseInterface
 
         $cookie = $this->_cookies->get($name);
 
-        return $this->toArrayResponse($cookie);
+        return $this->convertCookie($cookie);
     }
 
     /**
@@ -2061,7 +2061,7 @@ class Response implements ResponseInterface
     {
         $out = [];
         foreach ($this->_cookies as $cookie) {
-            $out[$cookie->getName()] = $this->toArrayResponse($cookie);
+            $out[$cookie->getName()] = $this->convertCookie($cookie);
         }
 
         return $out;
@@ -2076,18 +2076,8 @@ class Response implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
      * @return array
      */
-    protected function toArrayResponse(CookieInterface $cookie)
+    public function convertCookie(CookieInterface $cookie)
     {
-        if ($cookie instanceof Cookie) {
-            return $cookie->toArrayResponse();
-        }
-
-        if ($cookie->getExpiry()) {
-            $expires = $cookie->getExpiry()->format('U');
-        } else {
-            $expires = '';
-        }
-
         return [
             'name' => $cookie->getName(),
             'value' => $cookie->getValue(),
@@ -2095,7 +2085,7 @@ class Response implements ResponseInterface
             'domain' => $cookie->getDomain(),
             'secure' => $cookie->isSecure(),
             'httpOnly' => $cookie->isHttpOnly(),
-            'expire' => $expires
+            'expire' => $cookie->getExpiresTimestamp()
         ];
     }
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2080,7 +2080,9 @@ class Response implements ResponseInterface
     {
         if ($cookie instanceof Cookie) {
             return $cookie->toArrayResponse();
-        } elseif ($cookie->getExpiry()) {
+        }
+
+        if ($cookie->getExpiry()) {
             $expires = $cookie->getExpiry()->format('U');
         } else {
             $expires = '';

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1941,7 +1941,7 @@ class Response implements ResponseInterface
 
             $cookie = $this->_cookies->get($options);
 
-            return $this->convertCookie($cookie);
+            return $this->convertCookieToArray($cookie);
         }
 
         $options += [
@@ -2047,7 +2047,7 @@ class Response implements ResponseInterface
 
         $cookie = $this->_cookies->get($name);
 
-        return $this->convertCookie($cookie);
+        return $this->convertCookieToArray($cookie);
     }
 
     /**
@@ -2061,7 +2061,7 @@ class Response implements ResponseInterface
     {
         $out = [];
         foreach ($this->_cookies as $cookie) {
-            $out[$cookie->getName()] = $this->convertCookie($cookie);
+            $out[$cookie->getName()] = $this->convertCookieToArray($cookie);
         }
 
         return $out;
@@ -2076,7 +2076,7 @@ class Response implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
      * @return array
      */
-    public function convertCookie(CookieInterface $cookie)
+    protected function convertCookieToArray(CookieInterface $cookie)
     {
         return [
             'name' => $cookie->getName(),

--- a/tests/TestCase/Http/Client/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Client/CookieCollectionTest.php
@@ -13,8 +13,10 @@
  */
 namespace Cake\Test\TestCase\Http\Client;
 
+use Cake\Chronos\Chronos;
 use Cake\Http\Client\CookieCollection;
 use Cake\Http\Client\Response;
+use Cake\Http\Cookie\Cookie;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -300,5 +302,31 @@ class CookieCollectionTest extends TestCase
         $result = $this->cookies->get('http://google.com');
         $expected = [];
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test convertCookie
+     *
+     * @return void
+     */
+    public function testConvertCookie()
+    {
+        $date = Chronos::parse('2017-03-31 12:34:56');
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withPath('/api')
+            ->withExpiry($date)
+            ->withHttpOnly(true)
+            ->withSecure(true);
+        $expected = [
+            'name' => 'cakephp',
+            'value' => 'cakephp-rocks',
+            'path' => '/api',
+            'domain' => 'cakephp.org',
+            'expires' => $date->format('U'),
+            'secure' => true,
+            'httponly' => true
+        ];
+        $this->assertEquals($expected, $this->cookies->convertCookie($cookie));
     }
 }

--- a/tests/TestCase/Http/Client/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Client/CookieCollectionTest.php
@@ -303,30 +303,4 @@ class CookieCollectionTest extends TestCase
         $expected = [];
         $this->assertEquals($expected, $result);
     }
-
-    /**
-     * Test convertCookie
-     *
-     * @return void
-     */
-    public function testConvertCookie()
-    {
-        $date = Chronos::parse('2017-03-31 12:34:56');
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org')
-            ->withPath('/api')
-            ->withExpiry($date)
-            ->withHttpOnly(true)
-            ->withSecure(true);
-        $expected = [
-            'name' => 'cakephp',
-            'value' => 'cakephp-rocks',
-            'path' => '/api',
-            'domain' => 'cakephp.org',
-            'expires' => $date->format('U'),
-            'secure' => true,
-            'httponly' => true
-        ];
-        $this->assertEquals($expected, $this->cookies->convertCookie($cookie));
-    }
 }

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -430,31 +430,4 @@ XML;
         $response = new Response($headers, $body);
         $this->assertEquals('Hello world!', $response->body);
     }
-
-    /**
-     * Test convertCookie
-     *
-     * @return void
-     */
-    public function testConvertCookie()
-    {
-        $date = Chronos::parse('2017-03-31 12:34:56');
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org')
-            ->withPath('/api')
-            ->withExpiry($date)
-            ->withHttpOnly(true)
-            ->withSecure(true);
-        $expected = [
-            'name' => 'cakephp',
-            'value' => 'cakephp-rocks',
-            'path' => '/api',
-            'domain' => 'cakephp.org',
-            'expires' => 'Fri, 31-Mar-2017 12:34:56 GMT',
-            'secure' => true,
-            'httponly' => true
-        ];
-        $response = new Response([], '');
-        $this->assertEquals($expected, $response->convertCookie($cookie));
-    }
 }

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -13,7 +13,9 @@
  */
 namespace Cake\Test\TestCase\Http\Client;
 
+use Cake\Chronos\Chronos;
 use Cake\Http\Client\Response;
+use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
 
@@ -427,5 +429,32 @@ XML;
         $body = base64_decode('H4sIAAAAAAAAA/NIzcnJVyjPL8pJUQQAlRmFGwwAAAA=');
         $response = new Response($headers, $body);
         $this->assertEquals('Hello world!', $response->body);
+    }
+
+    /**
+     * Test convertCookie
+     *
+     * @return void
+     */
+    public function testConvertCookie()
+    {
+        $date = Chronos::parse('2017-03-31 12:34:56');
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withPath('/api')
+            ->withExpiry($date)
+            ->withHttpOnly(true)
+            ->withSecure(true);
+        $expected = [
+            'name' => 'cakephp',
+            'value' => 'cakephp-rocks',
+            'path' => '/api',
+            'domain' => 'cakephp.org',
+            'expires' => 'Fri, 31-Mar-2017 12:34:56 GMT',
+            'secure' => true,
+            'httponly' => true
+        ];
+        $response = new Response([], '');
+        $this->assertEquals($expected, $response->convertCookie($cookie));
     }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -568,30 +568,4 @@ class CookieTest extends TestCase
         ];
         $this->assertEquals($expected, $cookie->toArray());
     }
-
-    /**
-     * Test toArrayResponse
-     *
-     * @return void
-     */
-    public function testToArrayResponse()
-    {
-        $date = Chronos::parse('2017-03-31 12:34:56');
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org')
-            ->withPath('/api')
-            ->withExpiry($date)
-            ->withHttpOnly(true)
-            ->withSecure(true);
-        $expected = [
-            'name' => 'cakephp',
-            'value' => 'cakephp-rocks',
-            'path' => '/api',
-            'domain' => 'cakephp.org',
-            'expire' => $date->format('U'),
-            'secure' => true,
-            'httpOnly' => true
-        ];
-        $this->assertEquals($expected, $cookie->toArrayResponse());
-    }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -542,30 +542,4 @@ class CookieTest extends TestCase
         $cookie = new Cookie('test', 'val', null, '/path', 'example.com');
         $this->assertEquals('test;example.com;/path', $cookie->getId());
     }
-
-    /**
-     * Test toArray
-     *
-     * @return void
-     */
-    public function testToArray()
-    {
-        $date = Chronos::parse('2017-03-31 12:34:56');
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org')
-            ->withPath('/api')
-            ->withExpiry($date)
-            ->withHttpOnly(true)
-            ->withSecure(true);
-        $expected = [
-            'name' => 'cakephp',
-            'value' => 'cakephp-rocks',
-            'path' => '/api',
-            'domain' => 'cakephp.org',
-            'expires' => $date->format('U'),
-            'secure' => true,
-            'httponly' => true
-        ];
-        $this->assertEquals($expected, $cookie->toArray());
-    }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -570,32 +570,6 @@ class CookieTest extends TestCase
     }
 
     /**
-     * Test toArrayClient
-     *
-     * @return void
-     */
-    public function testToArrayClient()
-    {
-        $date = Chronos::parse('2017-03-31 12:34:56');
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org')
-            ->withPath('/api')
-            ->withExpiry($date)
-            ->withHttpOnly(true)
-            ->withSecure(true);
-        $expected = [
-            'name' => 'cakephp',
-            'value' => 'cakephp-rocks',
-            'path' => '/api',
-            'domain' => 'cakephp.org',
-            'expires' => 'Fri, 31-Mar-2017 12:34:56 GMT',
-            'secure' => true,
-            'httponly' => true
-        ];
-        $this->assertEquals($expected, $cookie->toArrayClient());
-    }
-
-    /**
      * Test toArrayResponse
      *
      * @return void

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\Http;
 
 include_once CORE_TEST_CASES . DS . 'Http' . DS . 'server_mocks.php';
 
+use Cake\Chronos\Chronos;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Http\Response;
@@ -3049,5 +3050,32 @@ class ResponseTest extends TestCase
             'body' => ''
         ];
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test convertCookie
+     *
+     * @return void
+     */
+    public function testConvertCookie()
+    {
+        $date = Chronos::parse('2017-03-31 12:34:56');
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $cookie = $cookie->withDomain('cakephp.org')
+            ->withPath('/api')
+            ->withExpiry($date)
+            ->withHttpOnly(true)
+            ->withSecure(true);
+        $expected = [
+            'name' => 'cakephp',
+            'value' => 'cakephp-rocks',
+            'path' => '/api',
+            'domain' => 'cakephp.org',
+            'expire' => $date->format('U'),
+            'secure' => true,
+            'httpOnly' => true
+        ];
+        $response = new Response();
+        $this->assertEquals($expected, $response->convertCookie($cookie));
     }
 }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -3051,31 +3051,4 @@ class ResponseTest extends TestCase
         ];
         $this->assertEquals($expected, $result);
     }
-
-    /**
-     * Test convertCookie
-     *
-     * @return void
-     */
-    public function testConvertCookie()
-    {
-        $date = Chronos::parse('2017-03-31 12:34:56');
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
-        $cookie = $cookie->withDomain('cakephp.org')
-            ->withPath('/api')
-            ->withExpiry($date)
-            ->withHttpOnly(true)
-            ->withSecure(true);
-        $expected = [
-            'name' => 'cakephp',
-            'value' => 'cakephp-rocks',
-            'path' => '/api',
-            'domain' => 'cakephp.org',
-            'expire' => $date->format('U'),
-            'secure' => true,
-            'httpOnly' => true
-        ];
-        $response = new Response();
-        $this->assertEquals($expected, $response->convertCookie($cookie));
-    }
 }


### PR DESCRIPTION
`Cake\Http\Client\Response` and `Cake\Client\Response` would call methods that wasn't a part of `CookieInterface`.

Refs #10406