### PR TITLE
Allow camelBacked method names for subcommands.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -576,6 +576,7 @@ class ConsoleOptionParser
             $command = $name;
             $name = $command->name();
         } else {
+            $name = Inflector::underscore($name);
             $defaults = [
                 'name' => $name,
                 'help' => '',

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -665,7 +665,7 @@ class ConsoleOptionParser
      */
     public function parse($argv)
     {
-        $command = isset($argv[0]) ? $argv[0] : null;
+        $command = isset($argv[0]) ? Inflector::underscore($argv[0]) : null;
         if (isset($this->_subcommands[$command])) {
             array_shift($argv);
         }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -440,7 +440,7 @@ class Shell
      */
     public function runCommand($argv, $autoMethod = false, $extra = [])
     {
-        $command = isset($argv[0]) ? $argv[0] : null;
+        $command = isset($argv[0]) ? Inflector::underscore($argv[0]) : null;
         $this->OptionParser = $this->getOptionParser();
         try {
             list($this->params, $this->args) = $this->OptionParser->parse($argv);

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -592,6 +592,22 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * Tests setting a subcommand up for a Shell method `initMyDb`.
+     *
+     * @return void
+     */
+    public function testSubcommandCamelBacked()
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $result = $parser->addSubcommand('initMyDb', [
+            'help' => 'Initialize the database'
+        ]);
+
+        $subcommands = array_keys($result->subcommands());
+        $this->assertEquals(['init_my_db'], $subcommands, 'Adding a subcommand does not work with camel backed method names.');
+    }
+
+    /**
      * Test addSubcommand inherits options as no
      * parser is created.
      *


### PR DESCRIPTION
This is more a feature than a bug, but the expectation sure is that the internal shell "actions" named "commands" work similar to the controller actions regarding their internal mapping.

In controllers it is `'action' => 'myCoolAction'` and does only inflect for the outside (via routing and dashed inflection).
The same expectation should be met on the CLI level when adding subcommands
```php
$parser->addSubcommand('initMyDb', [...]);
```

Those subcommands are basically the methods of this class just as the methods of a controller are its actions.
Whereas from the outside (CLI) you can then either access it via underscored or CamelCase as usual.

In 4.0 we could probably make this a bit stricter then, allowing one internal format (methodName) only.

PS: Is this safe to go into master or is 3.5 better, as people could (wrongly?) use the uninflected/raw camelCase format already in their apps.