### PR TITLE
3.next - Enable scoped middleware to be setup

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -714,4 +714,32 @@ class RouteBuilder
         $this->connect('/:controller', ['action' => 'index'], compact('routeClass'));
         $this->connect('/:controller/:action/*', [], compact('routeClass'));
     }
+
+    /**
+     * Register a middleware with the RouteCollection.
+     *
+     * Once middleware has been registered, it can be applied to the current routing
+     * scope or any child scopes that share the same RoutingCollection.
+     *
+     * @param string $name The name of the middleware. Used when applying middleware to a scope.
+     * @param callable $middleware The middleware object to register.
+     * @return $this
+     * @see \Cake\Routing\RouteCollection
+     */
+    public function registerMiddleware($name, $middleware)
+    {
+    }
+
+    /**
+     * Apply a middleware to the current route scope.
+     *
+     * Requires middleware to be registered via `registerMiddleware()`
+     *
+     * @param string[] ...$names The names of the middleware to apply to the current scope.
+     * @return $this
+     * @see \Cake\Routing\RouteCollection::addMiddlewareToScope()
+     */
+    public function middleware(...$names)
+    {
+    }
 }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -728,6 +728,9 @@ class RouteBuilder
      */
     public function registerMiddleware($name, $middleware)
     {
+        $this->_collection->registerMiddleware($name, $middleware);
+
+        return $this;
     }
 
     /**
@@ -741,5 +744,8 @@ class RouteBuilder
      */
     public function middleware(...$names)
     {
+        $this->_collection->enableMiddleware($this->_path, $names);
+
+        return $this;
     }
 }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -742,9 +742,9 @@ class RouteBuilder
      * @return $this
      * @see \Cake\Routing\RouteCollection::addMiddlewareToScope()
      */
-    public function middleware(...$names)
+    public function applyMiddleware(...$names)
     {
-        $this->_collection->enableMiddleware($this->_path, $names);
+        $this->_collection->applyMiddleware($this->_path, $names);
 
         return $this;
     }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -403,7 +403,7 @@ class RouteCollection
      * Check if the named middleware has been registered.
      *
      * @param string $name The name of the middleware to check.
-     * @return void
+     * @return bool
      */
     public function hasMiddleware($name)
     {
@@ -414,7 +414,7 @@ class RouteCollection
      * Enable a registered middleware(s) for the provided path
      *
      * @param string $path The URL path to register middleware for.
-     * @param string[] $names The middleware names to add for the path.
+     * @param string[] $middleware The middleware names to add for the path.
      * @return $this
      */
     public function enableMiddleware($path, array $middleware)

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -425,6 +425,10 @@ class RouteCollection
                 throw new RuntimeException($message);
             }
         }
+        // Matches route element pattern in Cake\Routing\Route
+        $path = '#^' . preg_quote($path, '#') . '#';
+        $path = preg_replace('/\\\\:([a-z0-9-_]+(?<![-_]))/i', '[^/]+', $path);
+
         if (!isset($this->_middlewarePaths[$path])) {
             $this->_middlewarePaths[$path] = [];
         }
@@ -447,8 +451,8 @@ class RouteCollection
     public function getMatchingMiddleware($needle)
     {
         $matching = [];
-        foreach ($this->_middlewarePaths as $path => $middleware) {
-            if (strpos($needle, $path) === 0) {
+        foreach ($this->_middlewarePaths as $pattern => $middleware) {
+            if (preg_match($pattern, $needle)) {
                 $matching = array_merge($matching, $middleware);
             }
         }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -411,13 +411,13 @@ class RouteCollection
     }
 
     /**
-     * Enable a registered middleware(s) for the provided path
+     * Apply a registered middleware(s) for the provided path
      *
      * @param string $path The URL path to register middleware for.
      * @param string[] $middleware The middleware names to add for the path.
      * @return $this
      */
-    public function enableMiddleware($path, array $middleware)
+    public function applyMiddleware($path, array $middleware)
     {
         foreach ($middleware as $name) {
             if (!$this->hasMiddleware($name)) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -18,6 +18,7 @@ use Cake\Routing\Exception\DuplicateNamedRouteException;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 
 /**
  * Contains a collection of routes.
@@ -57,6 +58,20 @@ class RouteCollection
      * @var array
      */
     protected $_paths = [];
+
+    /**
+     * A map of middleware names and the related objects.
+     *
+     * @var array
+     */
+    protected $_middleware = [];
+
+    /**
+     * A map of paths and the list of applicable middleware.
+     *
+     * @var array
+     */
+    protected $_middlewarePaths = [];
 
     /**
      * Route extensions
@@ -362,5 +377,89 @@ class RouteCollection
         }
 
         return $this->_extensions = $extensions;
+    }
+
+    /**
+     * Register a middleware with the RouteCollection.
+     *
+     * Once middleware has been registered, it can be applied to the current routing
+     * scope or any child scopes that share the same RoutingCollection.
+     *
+     * @param string $name The name of the middleware. Used when applying middleware to a scope.
+     * @param callable $middleware The middleware object to register.
+     * @return $this
+     */
+    public function registerMiddleware($name, callable $middleware)
+    {
+        if (is_string($middleware)) {
+            throw new RuntimeException("The '$name' middleware is not a callable object.");
+        }
+        $this->_middleware[$name] = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Check if the named middleware has been registered.
+     *
+     * @param string $name The name of the middleware to check.
+     * @return void
+     */
+    public function hasMiddleware($name)
+    {
+        return isset($this->_middleware[$name]);
+    }
+
+    /**
+     * Enable a registered middleware(s) for the provided path
+     *
+     * @param string $path The URL path to register middleware for.
+     * @param string[] $names The middleware names to add for the path.
+     * @return $this
+     */
+    public function enableMiddleware($path, array $middleware)
+    {
+        foreach ($middleware as $name) {
+            if (!$this->hasMiddleware($name)) {
+                $message = "Cannot apply '$name' middleware to path '$path'. It has not been registered.";
+                throw new RuntimeException($message);
+            }
+        }
+        if (!isset($this->_middlewarePaths[$path])) {
+            $this->_middlewarePaths[$path] = [];
+        }
+        $this->_middlewarePaths[$path] = array_merge($this->_middlewarePaths[$path], $middleware);
+
+        return $this;
+    }
+
+    /**
+     * Get an array of middleware that matches the provided URL.
+     *
+     * All middleware lists that match the URL will be merged together from shortest
+     * path to longest path. If a middleware would be added to the set more than
+     * once because it is connected to multiple path substrings match, it will only
+     * be added once at its first occurrence.
+     *
+     * @param string $needle The URL path to find middleware for.
+     * @return array
+     */
+    public function getMatchingMiddleware($needle)
+    {
+        $matching = [];
+        foreach ($this->_middlewarePaths as $path => $middleware) {
+            if (strpos($needle, $path) === 0) {
+                $matching = array_merge($matching, $middleware);
+            }
+        }
+
+        $resolved = [];
+        foreach ($matching as $name) {
+            if (!isset($resolved[$name])) {
+                $resolved[$name] = $this->_middleware[$name];
+            }
+        }
+
+        return array_values($resolved);
     }
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -21,6 +21,7 @@ use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\Route\RedirectRoute;
 use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
+use stdClass;
 
 /**
  * RouteBuilder test case
@@ -786,43 +787,39 @@ class RouteBuilderTest extends TestCase
      */
     public function testRegisterMiddleware()
     {
-        $this->markTestIncomplete();
+        $func = function () {
+        };
+        $routes = new RouteBuilder($this->collection, '/api');
+        $result = $routes->registerMiddleware('test', $func);
+
+        $this->assertSame($result, $routes);
+        $this->assertTrue($this->collection->hasMiddleware('test'));
     }
 
     /**
      * Test registering invalid middleware
      *
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage The 'bad' middleware is not callable.
-     * @return void
-     */
-    public function testRegisterMiddlewareObject()
-    {
-        $this->markTestIncomplete();
-    }
-
-    /**
-     * Test registering invalid middleware
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The 'bad' middleware is not callable.
+     * @expectedExceptionMessage The 'bad' middleware is not a callable object.
      * @return void
      */
     public function testRegisterMiddlewareString()
     {
-        $this->markTestIncomplete();
+        $routes = new RouteBuilder($this->collection, '/api');
+        $routes->registerMiddleware('bad', 'strlen');
     }
 
     /**
      * Test applying middleware to a scope when it doesn't exist
      *
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cannot apply 'bad' middleware to /api path. It has not been registered.
+     * @expectedExceptionMessage Cannot apply 'bad' middleware to path '/api'. It has not been registered.
      * @return void
      */
     public function testMiddlewareInvalidName()
     {
-        $this->markTestIncomplete();
+        $routes = new RouteBuilder($this->collection, '/api');
+        $routes->middleware('bad');
     }
 
     /**
@@ -832,6 +829,17 @@ class RouteBuilderTest extends TestCase
      */
     public function testMiddleware()
     {
-        $this->markTestIncomplete();
+        $func = function () {
+        };
+        $routes = new RouteBuilder($this->collection, '/api');
+        $routes->registerMiddleware('test', $func)
+            ->registerMiddleware('test2', $func);
+        $result = $routes->middleware('test', 'test2');
+
+        $this->assertSame($result, $routes);
+        $this->assertEquals(
+            [$func, $func],
+            $this->collection->getMatchingMiddleware('/api/v1/ping')
+        );
     }
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -816,10 +816,10 @@ class RouteBuilderTest extends TestCase
      * @expectedExceptionMessage Cannot apply 'bad' middleware to path '/api'. It has not been registered.
      * @return void
      */
-    public function testMiddlewareInvalidName()
+    public function testApplyMiddlewareInvalidName()
     {
         $routes = new RouteBuilder($this->collection, '/api');
-        $routes->middleware('bad');
+        $routes->applyMiddleware('bad');
     }
 
     /**
@@ -827,14 +827,14 @@ class RouteBuilderTest extends TestCase
      *
      * @return void
      */
-    public function testMiddleware()
+    public function testApplyMiddleware()
     {
         $func = function () {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
             ->registerMiddleware('test2', $func);
-        $result = $routes->middleware('test', 'test2');
+        $result = $routes->applyMiddleware('test', 'test2');
 
         $this->assertSame($result, $routes);
         $this->assertEquals(

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -778,4 +778,60 @@ class RouteBuilderTest extends TestCase
         $this->assertArrayHasKey('api:v1:ping', $all);
         $this->assertArrayHasKey('web:pong', $all);
     }
+
+    /**
+     * Test adding middleware to the collection.
+     *
+     * @return void
+     */
+    public function testRegisterMiddleware()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Test registering invalid middleware
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The 'bad' middleware is not callable.
+     * @return void
+     */
+    public function testRegisterMiddlewareObject()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Test registering invalid middleware
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The 'bad' middleware is not callable.
+     * @return void
+     */
+    public function testRegisterMiddlewareString()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Test applying middleware to a scope when it doesn't exist
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cannot apply 'bad' middleware to /api path. It has not been registered.
+     * @return void
+     */
+    public function testMiddlewareInvalidName()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Test applying middleware to a scope
+     *
+     * @return void
+     */
+    public function testMiddleware()
+    {
+        $this->markTestIncomplete();
+    }
 }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -747,13 +747,18 @@ class RouteCollectionTest extends TestCase
             ->getMock();
         $this->collection->registerMiddleware('callable', $mock);
 
-        $this->collection->enableMiddleware('/articles/:article_id/comments', ['callable']);
-        $this->markTestIncomplete();
+        $this->collection->enableMiddleware('/api-:version/articles/:article_id/comments', ['callable']);
 
-        $middleware = $this->collection->getMatchingMiddleware('/articles/123/comments');
+        $middleware = $this->collection->getMatchingMiddleware('/api-1/articles/comments');
+        $this->assertEmpty($middleware);
+
+        $middleware = $this->collection->getMatchingMiddleware('/api-1/articles/yay/comments');
         $this->assertEquals([$mock], $middleware);
 
-        $middleware = $this->collection->getMatchingMiddleware('/articles/abc-123/comments/99');
+        $middleware = $this->collection->getMatchingMiddleware('/api-1/articles/123/comments');
+        $this->assertEquals([$mock], $middleware);
+
+        $middleware = $this->collection->getMatchingMiddleware('/api-abc123/articles/abc-123/comments/99');
         $this->assertEquals([$mock], $middleware);
     }
 

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -649,7 +649,7 @@ class RouteCollectionTest extends TestCase
      *
      * @return void
      */
-    public function testEnableMiddlewareBasic()
+    public function testApplyMiddlewareBasic()
     {
         $mock = $this->getMockBuilder('\stdClass')
             ->setMethods(['__invoke'])
@@ -657,7 +657,7 @@ class RouteCollectionTest extends TestCase
         $this->collection->registerMiddleware('callable', $mock);
         $this->collection->registerMiddleware('callback_two', $mock);
 
-        $result = $this->collection->enableMiddleware('/api', ['callable', 'callback_two']);
+        $result = $this->collection->applyMiddleware('/api', ['callable', 'callback_two']);
         $this->assertSame($result, $this->collection);
     }
 
@@ -674,7 +674,7 @@ class RouteCollectionTest extends TestCase
         $this->collection->registerMiddleware('callable', $mock);
         $this->collection->registerMiddleware('callback_two', $mock);
 
-        $result = $this->collection->enableMiddleware('/api', ['callable']);
+        $result = $this->collection->applyMiddleware('/api', ['callable']);
         $middleware = $this->collection->getMatchingMiddleware('/api/v1/articles');
         $this->assertCount(1, $middleware);
         $this->assertSame($middleware[0], $mock);
@@ -696,8 +696,8 @@ class RouteCollectionTest extends TestCase
         $this->collection->registerMiddleware('callable', $mock);
         $this->collection->registerMiddleware('callback_two', $mockTwo);
 
-        $this->collection->enableMiddleware('/api', ['callable']);
-        $this->collection->enableMiddleware('/api/v1/articles', ['callback_two']);
+        $this->collection->applyMiddleware('/api', ['callable']);
+        $this->collection->applyMiddleware('/api/v1/articles', ['callback_two']);
 
         $middleware = $this->collection->getMatchingMiddleware('/articles');
         $this->assertCount(0, $middleware);
@@ -727,8 +727,8 @@ class RouteCollectionTest extends TestCase
         $this->collection->registerMiddleware('callable', $mock);
         $this->collection->registerMiddleware('callback_two', $mockTwo);
 
-        $this->collection->enableMiddleware('/api', ['callable']);
-        $this->collection->enableMiddleware('/api/v1/articles', ['callback_two', 'callable']);
+        $this->collection->applyMiddleware('/api', ['callable']);
+        $this->collection->applyMiddleware('/api/v1/articles', ['callback_two', 'callable']);
 
         $middleware = $this->collection->getMatchingMiddleware('/api/v1/articles/1');
         $this->assertCount(2, $middleware);
@@ -740,14 +740,14 @@ class RouteCollectionTest extends TestCase
      *
      * @return void
      */
-    public function testEnableMiddlewareWithPlaceholder()
+    public function testApplyMiddlewareWithPlaceholder()
     {
         $mock = $this->getMockBuilder('\stdClass')
             ->setMethods(['__invoke'])
             ->getMock();
         $this->collection->registerMiddleware('callable', $mock);
 
-        $this->collection->enableMiddleware('/api-:version/articles/:article_id/comments', ['callable']);
+        $this->collection->applyMiddleware('/api-:version/articles/:article_id/comments', ['callable']);
 
         $middleware = $this->collection->getMatchingMiddleware('/api-1/articles/comments');
         $this->assertEmpty($middleware);
@@ -769,12 +769,12 @@ class RouteCollectionTest extends TestCase
      * @expectedExceptionMessage Cannot apply 'bad' middleware to path '/api'. It has not been registered.
      * @return void
      */
-    public function testEnableMiddlewareUnregistered()
+    public function testApplyMiddlewareUnregistered()
     {
         $mock = $this->getMockBuilder('\stdClass')
             ->setMethods(['__invoke'])
             ->getMock();
         $this->collection->registerMiddleware('callable', $mock);
-        $this->collection->enableMiddleware('/api', ['callable', 'bad']);
+        $this->collection->applyMiddleware('/api', ['callable', 'bad']);
     }
 }


### PR DESCRIPTION
Add the methods that help developers register and configure scoped middleware for their applications. The next task will be to use these new features when dispatching requests.

Refs #10308 