### PR TITLE
Update IntegrationTestCase.php

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -532,7 +532,7 @@ abstract class IntegrationTestCase extends TestCase
         if (isset($this->_request['headers'])) {
             foreach ($this->_request['headers'] as $k => $v) {
                 $name = strtoupper(str_replace('-', '_', $k));
-                if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'])) {
+                if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE', 'PHP_AUTH_USER', 'PHP_AUTH_PW'])) {
                     $name = 'HTTP_' . $name;
                 }
                 $env[$name] = $v;


### PR DESCRIPTION
Add the two keys PHP_AUTH_USER', PHP_AUTH_PW to the exclusion list to allow unit tests with basic auth. Otherwiese a HTTP_ will be prepended to the environment keys.

Enclosed an example test case 

We are currently using version 3.3.15

```php
public function testAuthGet()
{
        $config = [ 'headers' => [
            'PHP_AUTH_USER' => $this->apiKey,
            'PHP_AUTH_PW' => $this->apiPassword,
        ]];

        $this->configRequest($config);
        $data = json_encode(['username' => 'mitterh', 'password' => '1234']);
        $this->post('/api/auth', $data);
.....
}
```
