### PR TITLE
Fix error message for named route matching

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -298,7 +298,7 @@ class RouteCollection
                 throw new MissingRouteException([
                     'url' => $name,
                     'context' => $context,
-                    'message' => 'A named route was found for "%s", but matching failed.',
+                    'message' => sprintf('A named route was found for "%s", but matching failed.', $name),
                 ]);
             }
             throw new MissingRouteException(['url' => $name, 'context' => $context]);


### PR DESCRIPTION
When a named route doesn't match, the error message contains "%s" instead of the named route. That's my guess.