### PR TITLE
3.x - Unify conjugation order

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1986,7 +1986,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         } else {
             $expression = $this->newExpr()
                 ->setConjunction($conjunction)
-                ->add([$append, $expression], $types);
+                ->add([$expression, $append], $types);
         }
 
         $this->_parts[$part] = $expression;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -918,8 +918,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      *   ->where(['title' => 'Foo'])
      *   ->andWhere(function ($exp, $query) {
      *     return $exp
-     *       ->add(['author_id' => 1])
-     *       ->or_(['author_id' => 2]);
+     *       ->or_(['author_id' => 1])
+     *       ->add(['author_id' => 2]);
      *   });
      * ```
      *
@@ -981,8 +981,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      *   ->where(['title' => 'Foo'])
      *   ->orWhere(function ($exp, $query) {
      *     return $exp
-     *       ->add(['author_id' => 1])
-     *       ->or_(['author_id' => 2]);
+     *       ->or_(['author_id' => 1])
+     *       ->add(['author_id' => 2]);
      *   });
      * ```
      *


### PR DESCRIPTION
Currently `and*()` methods append conditions, while `or*()` methods
prepend them. While this doesn't affect the logic of the statement,
it might be confusing, and it contradicts the description.

Does this need tests?