### PR TITLE
Fix PO parsing around context.

### DIFF
--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -142,11 +142,10 @@ class PoFileParser
 
         $translation = stripcslashes($translation);
 
-        if ($context && (!isset($messages[$singular]) || is_array($messages[$singular]))) {
+        if ($context !== null) {
             $messages[$singular]['_context'][$context] = $translation;
-        }
-        if ($context === null) {
-            $messages[$singular] = $translation;
+        } else {
+            $messages[$singular]['_context'][''] = $translation;
         }
 
         if (isset($item['ids']['plural'])) {
@@ -166,10 +165,10 @@ class PoFileParser
             $plurals = array_map('stripcslashes', $plurals);
             $key = stripcslashes($item['ids']['plural']);
 
-            if ($context) {
+            if ($context !== null) {
                 $messages[$key]['_context'][$context] = $plurals;
             } else {
-                $messages[$key] = $plurals;
+                $messages[$key]['_context'][''] = $plurals;
             }
         }
     }

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -131,7 +131,11 @@ class Translator implements TranslatorInterface
 
             // No or missing context, fallback to the key/first message
             if ($context === null) {
-                $message = current($message['_context']);
+                if (isset($message['_context'][''])) {
+                    $message = $message['_context'][''];
+                } else {
+                    $message = current($message['_context']);
+                }
             } elseif (!isset($message['_context'][$context])) {
                 $message = $key;
             } elseif (is_string($message['_context'][$context]) &&

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -56,12 +56,12 @@ class MessagesFileLoaderTest extends TestCase
         $loader = new MessagesFileLoader('default', 'en');
         $package = $loader();
         $messages = $package->getMessages();
-        $this->assertEquals('Po (translated)', $messages['Plural Rule 1']);
+        $this->assertEquals('Po (translated)', $messages['Plural Rule 1']['_context']['']);
 
         Configure::write('App.paths.locales', [TEST_APP . 'custom_locale' . DS]);
         $loader = new MessagesFileLoader('default', 'en');
         $package = $loader();
         $messages = $package->getMessages();
-        $this->assertEquals('Po (translated) from custom folder', $messages['Plural Rule 1']);
+        $this->assertEquals('Po (translated) from custom folder', $messages['Plural Rule 1']['_context']['']);
     }
 }

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -37,7 +37,11 @@ class PoFileParserTest extends TestCase
         $messages = $parser->parse($file);
         $this->assertCount(5, $messages);
         $expected = [
-            'Plural Rule 1' => 'Plural Rule 1 (translated)',
+            'Plural Rule 1' => [
+                '_context' => [
+                    '' => 'Plural Rule 1 (translated)',
+                ],
+            ],
             '%d = 1' => [
                 '_context' => [
                     'This is the context' => 'First Context trasnlation',
@@ -52,14 +56,22 @@ class PoFileParserTest extends TestCase
                     ]
                 ]
             ],
-            '%-5d = 1' => '%-5d = 1 (translated)',
+            '%-5d = 1' => [
+                '_context' => [
+                    '' => '%-5d = 1 (translated)',
+                ],
+            ],
             '%-5d = 0 or > 1' => [
-                0 => '%-5d = 1 (translated)',
-                1 => '',
-                2 => '',
-                3 => '',
-                4 => '%-5d = 0 or > 1 (translated)'
-            ]
+                '_context' => [
+                    '' => [
+                        0 => '%-5d = 1 (translated)',
+                        1 => '',
+                        2 => '',
+                        3 => '',
+                        4 => '%-5d = 0 or > 1 (translated)'
+                    ],
+                ],
+            ],
         ];
         $this->assertEquals($expected, $messages);
     }
@@ -75,7 +87,7 @@ class PoFileParserTest extends TestCase
         $file = APP . 'Locale' . DS . 'en' . DS . 'default.po';
         $messages = $parser->parse($file);
         $this->assertCount(12, $messages);
-        $this->assertTextEquals("v\nsecond line", $messages["valid\nsecond line"]);
+        $this->assertTextEquals("v\nsecond line", $messages["valid\nsecond line"]['_context']['']);
     }
 
     /**
@@ -89,7 +101,7 @@ class PoFileParserTest extends TestCase
         $file = APP . 'Locale' . DS . 'en' . DS . 'default.po';
         $messages = $parser->parse($file);
 
-        $this->assertTextEquals('this is a "quoted string" (translated)', $messages['this is a "quoted string"']);
+        $this->assertTextEquals('this is a "quoted string" (translated)', $messages['this is a "quoted string"']['_context']['']);
     }
 
     /**
@@ -113,7 +125,7 @@ class PoFileParserTest extends TestCase
 
             return $package;
         });
-        $this->assertTextEquals('En cours', $messages['Pending']);
-        $this->assertTextEquals('En resolved', $messages['Resolved']);
+        $this->assertTextEquals('En cours', $messages['Pending']['_context']['']);
+        $this->assertTextEquals('En resolved', $messages['Resolved']['_context']['']);
     }
 }

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -130,6 +130,8 @@ class PoFileParserTest extends TestCase
         $this->assertSame('En resolved', $messages['Resolved']['_context']['']);
         $this->assertSame('En resolved - context', $messages['Resolved']['_context']['Pay status']);
 
+        // Confirm actual behavior
+        I18n::locale('en_US');
         $this->assertSame('En cours', __('Pending'));
         $this->assertSame('En cours - context', __x('Pay status', 'Pending'));
         $this->assertSame('En resolved', __('Resolved'));

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -125,7 +125,14 @@ class PoFileParserTest extends TestCase
 
             return $package;
         });
-        $this->assertTextEquals('En cours', $messages['Pending']['_context']['']);
-        $this->assertTextEquals('En resolved', $messages['Resolved']['_context']['']);
+        $this->assertSame('En cours', $messages['Pending']['_context']['']);
+        $this->assertSame('En cours - context', $messages['Pending']['_context']['Pay status']);
+        $this->assertSame('En resolved', $messages['Resolved']['_context']['']);
+        $this->assertSame('En resolved - context', $messages['Resolved']['_context']['Pay status']);
+
+        $this->assertSame('En cours', __('Pending'));
+        $this->assertSame('En cours - context', __x('Pay status', 'Pending'));
+        $this->assertSame('En resolved', __('Resolved'));
+        $this->assertSame('En resolved - context', __x('Pay status', 'Resolved'));
     }
 }

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -119,7 +119,7 @@ class PoFileParserTest extends TestCase
         $file = APP . 'Locale' . DS . 'en' . DS . 'context.po';
         $messages = $parser->parse($file);
 
-        I18n::translator('default', 'en_US', function () use ($messages) {
+        I18n::translator('default', 'de_DE', function () use ($messages) {
             $package = new Package('default');
             $package->setMessages($messages);
 
@@ -131,7 +131,7 @@ class PoFileParserTest extends TestCase
         $this->assertSame('En resolved - context', $messages['Resolved']['_context']['Pay status']);
 
         // Confirm actual behavior
-        I18n::locale('en_US');
+        I18n::locale('de_DE');
         $this->assertSame('En cours', __('Pending'));
         $this->assertSame('En cours - context', __x('Pay status', 'Pending'));
         $this->assertSame('En resolved', __('Resolved'));


### PR DESCRIPTION
While testing a [MessagesDbParser](https://github.com/dereuromark/cakephp-translate/blob/master/src/I18n/MessagesDbLoader.php) I found out that the core silently skips certain context translations - if they have been defined without context already.
Silently ignoring some of the translations is rather hard to detect.

I found out that the following change always works, so no more silent drops.