### PR TITLE
3.next - Connect Middleware pipelines in RoutingMiddleware

### DIFF
--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -40,6 +40,16 @@ class MiddlewareQueue implements Countable
     protected $callables = [];
 
     /**
+     * Constructor
+     *
+     * @param array $middleware The list of middleware to append.
+     */
+    public function __construct(array $middleware = [])
+    {
+        $this->queue = $middleware;
+    }
+
+    /**
      * Get the middleware at the provided index.
      *
      * @param int $index The index to fetch.

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -62,8 +62,7 @@ class RoutingMiddleware
             $runner = new Runner();
 
             return $runner->run($middleware, $request, $response);
-        } else {
-            return $next($request, $response);
         }
+        return $next($request, $response);
     }
 }

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -29,6 +29,11 @@ class RoutingMiddleware
 {
 
     /**
+     * Apply routing and update the request.
+     *
+     * Any route/path specific middleware will be wrapped around $next and then the new middleware stack
+     * will be invoked.
+     *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Message\ResponseInterface $response The response.
      * @param callable $next The next middleware to call.
@@ -57,12 +62,13 @@ class RoutingMiddleware
             );
         }
         $middleware = Router::getMatchingMiddleware($request->getUri()->getPath());
-        if ($middleware) {
-            $middleware->add($next);
-            $runner = new Runner();
-
-            return $runner->run($middleware, $request, $response);
+        if (!$middleware) {
+            return $next($request, $response);
         }
-        return $next($request, $response);
+        $middleware->add($next);
+        $runner = new Runner();
+
+        return $runner->run($middleware, $request, $response);
+
     }
 }

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -69,6 +69,5 @@ class RoutingMiddleware
         $runner = new Runner();
 
         return $runner->run($middleware, $request, $response);
-
     }
 }

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Routing\Middleware;
 
+use Cake\Http\Runner;
 use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\Router;
 use Psr\Http\Message\ResponseInterface;
@@ -55,7 +56,14 @@ class RoutingMiddleware
                 $response->getHeaders()
             );
         }
+        $middleware = Router::getMatchingMiddleware($request->getUri()->getPath());
+        if ($middleware) {
+            $middleware->add($next);
+            $runner = new Runner();
 
-        return $next($request, $response);
+            return $runner->run($middleware, $request, $response);
+        } else {
+            return $next($request, $response);
+        }
     }
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -16,6 +16,7 @@ namespace Cake\Routing;
 
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
+use Cake\Http\MiddlewareQueue;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -1071,6 +1072,19 @@ class Router
         }
 
         return static::$_collection->routes();
+    }
+
+    public static function getMatchingMiddleware($path)
+    {
+        if (!static::$initialized) {
+            static::_loadRoutes();
+        }
+
+        $middleware = static::$_collection->getMatchingMiddleware($path);
+        if ($middleware) {
+            return new MiddlewareQueue($middleware);
+        }
+        return null;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -15,8 +15,8 @@
 namespace Cake\Routing;
 
 use Cake\Core\Configure;
-use Cake\Http\ServerRequest;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\ServerRequest;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -1090,6 +1090,7 @@ class Router
         if ($middleware) {
             return new MiddlewareQueue($middleware);
         }
+
         return null;
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1074,6 +1074,12 @@ class Router
         return static::$_collection->routes();
     }
 
+    /**
+     * Get a MiddlewareQueue of middleware that matches the provided path.
+     *
+     * @param string $path The URL path to match for.
+     * @return \Cake\Http\MiddlewareQueue|null Either a queue or null if there are no matching middleware.
+     */
     public static function getMatchingMiddleware($path)
     {
         if (!static::$initialized) {

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -50,6 +50,15 @@ class MiddlewareQueueTest extends TestCase
         Configure::write('App.namespace', $this->appNamespace);
     }
 
+    public function testConstructorAddingMiddleware()
+    {
+        $cb = function () {
+        };
+        $queue = new MiddlewareQueue([$cb]);
+        $this->assertCount(1, $queue);
+        $this->assertSame($cb, $queue->get(0));
+    }
+
     /**
      * Test get()
      *

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -184,10 +184,12 @@ class RoutingMiddlewareTest extends TestCase
         Router::scope('/api', function ($routes) {
             $routes->registerMiddleware('first', function ($req, $res, $next) {
                 $this->log[] = 'first';
+
                 return $next($req, $res);
             });
             $routes->registerMiddleware('second', function ($req, $res, $next) {
                 $this->log[] = 'second';
+
                 return $next($req, $res);
             });
             $routes->connect('/ping', ['controller' => 'Pings']);
@@ -202,6 +204,7 @@ class RoutingMiddlewareTest extends TestCase
         $response = new Response();
         $next = function ($req, $res) {
             $this->log[] = 'last';
+
             return $res;
         };
         $middleware = new RoutingMiddleware();
@@ -221,17 +224,19 @@ class RoutingMiddlewareTest extends TestCase
         Router::scope('/api', function ($routes) {
             $routes->registerMiddleware('first', function ($req, $res, $next) {
                 $this->log[] = 'first';
+
                 return $res;
             });
             $routes->registerMiddleware('second', function ($req, $res, $next) {
                 $this->log[] = 'second';
+
                 return $next($req, $res);
             });
 
             $routes->applyMiddleware('second');
             $routes->connect('/ping', ['controller' => 'Pings']);
 
-            $routes->scope('/v1', function ($routes ) {
+            $routes->scope('/v1', function ($routes) {
                 $routes->applyMiddleware('first');
                 $routes->connect('/articles', ['controller' => 'Articles']);
             });

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -25,6 +25,8 @@ use Zend\Diactoros\ServerRequestFactory;
  */
 class RoutingMiddlewareTest extends TestCase
 {
+    protected $log = [];
+
     /**
      * Setup method
      *
@@ -35,6 +37,7 @@ class RoutingMiddlewareTest extends TestCase
         parent::setUp();
         Router::reload();
         Router::connect('/articles', ['controller' => 'Articles', 'action' => 'index']);
+        $this->log = [];
     }
 
     /**
@@ -168,5 +171,84 @@ class RoutingMiddlewareTest extends TestCase
         };
         $middleware = new RoutingMiddleware();
         $middleware($request, $response, $next);
+    }
+
+    /**
+     * Test invoking simple scoped middleware
+     *
+     * @return void
+     */
+    public function testInvokeScopedMiddleware()
+    {
+        $this->counter = 0;
+        Router::scope('/api', function ($routes) {
+            $routes->registerMiddleware('first', function ($req, $res, $next) {
+                $this->log[] = 'first';
+                return $next($req, $res);
+            });
+            $routes->registerMiddleware('second', function ($req, $res, $next) {
+                $this->log[] = 'second';
+                return $next($req, $res);
+            });
+            $routes->connect('/ping', ['controller' => 'Pings']);
+            // Connect middleware in reverse to test ordering.
+            $routes->applyMiddleware('second', 'first');
+        });
+
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/ping'
+        ]);
+        $response = new Response();
+        $next = function ($req, $res) {
+            $this->log[] = 'last';
+            return $res;
+        };
+        $middleware = new RoutingMiddleware();
+        $result = $middleware($request, $response, $next);
+        $this->assertSame($response, $result, 'Should return result');
+        $this->assertSame(['second', 'first', 'last'], $this->log);
+    }
+
+    /**
+     * Test control flow in scoped middleware.
+     *
+     * @return void
+     */
+    public function testInvokeScopedMiddlewareReturnResponse()
+    {
+        $this->counter = 0;
+        Router::scope('/api', function ($routes) {
+            $routes->registerMiddleware('first', function ($req, $res, $next) {
+                $this->log[] = 'first';
+                return $res;
+            });
+            $routes->registerMiddleware('second', function ($req, $res, $next) {
+                $this->log[] = 'second';
+                return $next($req, $res);
+            });
+
+            $routes->applyMiddleware('second');
+            $routes->connect('/ping', ['controller' => 'Pings']);
+
+            $routes->scope('/v1', function ($routes ) {
+                $routes->applyMiddleware('first');
+                $routes->connect('/articles', ['controller' => 'Articles']);
+            });
+        });
+
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/articles'
+        ]);
+        $response = new Response();
+        $next = function ($req, $res) {
+            $this->fail('Should not be invoked as second returns a response');
+        };
+        $middleware = new RoutingMiddleware();
+        $result = $middleware($request, $response, $next);
+
+        $this->assertSame($response, $result, 'Should return result');
+        $this->assertSame(['second', 'first'], $this->log);
     }
 }


### PR DESCRIPTION
Find and apply any scoped middleware from the RoutingMiddleware. With these changes, scoped middleware is now functional, but the proposed changes to `Application` are incomplete, and I'll be doing those next.

I've intentionally not modified the `RoutingFilter` behavior as I feel that scoped middleware is a good reason to migrate to the new `Application` class and PSR7 stack which will become standard in future versions

Refs #10308 