### PR TITLE
Deprecate the RssHelper.

### DIFF
--- a/src/View/Helper/RssHelper.php
+++ b/src/View/Helper/RssHelper.php
@@ -23,6 +23,7 @@ use Cake\View\Helper;
  * @property \Cake\View\Helper\UrlHelper $Url
  * @property \Cake\View\Helper\TimeHelper $Time
  * @link http://book.cakephp.org/3.0/en/views/helpers/rss.html
+ * @deprecated 3.5.0 RssHelper is deprecated and will be removed in 4.0.0
  */
 class RssHelper extends Helper
 {


### PR DESCRIPTION
This helper is infrequently used, and is better suited to being a view. We don't have a replacement view class yet, but we can ensure that RssHelper doesn't come along in 4.x by deprecating it now.

Refs #2108