### PR TITLE
Fix Hash::extract() to not array cast objects unnecessarily.

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -135,7 +135,12 @@ class Hash
 
         // Simple paths.
         if (!preg_match('/[{\[]/', $path)) {
-            return (array)static::get($data, $path);
+            $data = static::get($data, $path);
+            if ($data !== null && !(is_array($data) || $data instanceof ArrayAccess)) {
+                return [$data];
+            }
+
+            return $data !== null ? (array)$data : [];
         }
 
         if (strpos($path, '[') === false) {

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Utility;
 
 use ArrayObject;
+use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
@@ -1486,6 +1487,32 @@ class HashTest extends TestCase
 
         $data['Level1']['Level2'] = ['test1', 'test2'];
         $this->assertEquals($expected, Hash::extract($data, 'Level1.Level2bis'));
+    }
+
+    /**
+     * Tests that objects as values handled correctly.
+     *
+     * @return void
+     */
+    public function testExtractObjects()
+    {
+        $data = [
+            'root' => [
+                'array' => new ArrayObject([
+                    'foo' => 'bar',
+                ]),
+                'created' => new Time('2010-01-05'),
+            ],
+        ];
+
+        $result = Hash::extract($data, 'root.created');
+        $this->assertSame([$data['root']['created']], $result);
+
+        $result = Hash::extract($data, 'root.array');
+        $this->assertSame(['foo' => 'bar'], $result);
+
+        $result = Hash::extract($data, 'root.array.foo');
+        $this->assertSame(['bar'], $result);
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/8053

Is this acceptable to be announced in migration notes in 3.5?
Should we still add a feature flag of some sort to opt-in the object preserving extract?

The \ArrayAccess objects itself do not change, only the magic ones like Time() now don't get unnecessarily array transformed.