### PR TITLE
Remove default email for setCc

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -643,7 +643,7 @@ class Email implements JsonSerializable, Serializable
      * @param string|null $name Name
      * @return $this
      */
-    public function setCc($email = null, $name = null)
+    public function setCc($email, $name = null)
     {
         return $this->_setEmail('_cc', $email, $name);
     }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -98,7 +98,7 @@ use Cake\Mailer\Exception\MissingActionException;
  * @method array getReturnPath()
  * @method \Cake\Mailer\Email returnPath($email = null, $name = null)
  * @method \Cake\Mailer\Email addTo($email, $name = null)
- * @method \Cake\Mailer\Email setCc($email = null, $name = null)
+ * @method \Cake\Mailer\Email setCc($email, $name = null)
  * @method array getCc()
  * @method \Cake\Mailer\Email cc($email = null, $name = null)
  * @method \Cake\Mailer\Email addCc($email, $name = null)


### PR DESCRIPTION
This pull request removes the default `null` for email in the method setCc .

