### PR TITLE
Added a test case for errors when validation is only for create

### DIFF
--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -298,6 +298,28 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Test that validation on a certain condition generate errors
+     * 
+     * @return void
+     */
+    public function testErrorsWithPresenceRequiredOnCreate()
+    {
+        $validator = new Validator;
+        $validator->requirePresence('id', 'update');
+        $validator->allowEmpty('id', 'create');
+        $validator->requirePresence('title');
+
+        $data = [
+            'title' => 'Example title'
+        ];
+
+        $expected = [];
+        $result = $validator->errors($data);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test that errors() can work with nested data.
      *
      * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -299,7 +299,7 @@ class ValidatorTest extends TestCase
 
     /**
      * Test that validation on a certain condition generate errors
-     * 
+     *
      * @return void
      */
     public function testErrorsWithPresenceRequiredOnCreate()


### PR DESCRIPTION
So I've been encountering a strange issue today when trying to add a new user record. It continually fails with `id field is required` or similar validation errors. Even with no validation rules set, it still fails.

At first I thought the culprit might have been inverted logic in the `_checkPresence` method. Thought I'd try and write a test to abstract the problem from my project codebase.

Needless to say the testcase and other Validator tests pass just fine.

Just thought I'd submit a test case in case it was any use.