### PR TITLE
Empty message strings should return the key

### DIFF
--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -119,7 +119,6 @@ class Translator implements TranslatorInterface
     public function translate($key, array $tokensValues = [])
     {
         $message = $this->getMessage($key);
-
         if (!$message) {
             // Fallback to the message key
             $message = $key;
@@ -135,7 +134,9 @@ class Translator implements TranslatorInterface
                 $message = current($message['_context']);
             } elseif (!isset($message['_context'][$context])) {
                 $message = $key;
-            } elseif (!isset($message['_context'][$context])) {
+            } elseif (is_string($message['_context'][$context]) &&
+                strlen($message['_context'][$context]) === 0
+            ) {
                 $message = $key;
             } else {
                 $message = $message['_context'][$context];

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -441,7 +441,8 @@ class I18nTest extends TestCase
             return $package;
         });
 
-        $this->assertEquals('', __x('character', 'letter'));
+        $this->assertEquals('letter', __x('character', 'letter'));
+        $this->assertEquals('letter', __x('unknown', 'letter'));
     }
 
     /**


### PR DESCRIPTION
context based messages should return the key when the translated value is ''. This mirrors the behavior of context-less messages. Returning '' was incorrectly added in #8932

Refs #10440
