### PR TITLE
Added a test for nested array data as a query in the url

### DIFF
--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -63,6 +63,26 @@ class RequestTest extends TestCase
     }
 
     /**
+     * test nested array data for encoding of brackets, header and constructor
+     *
+     * @return void
+     */
+    public function testConstructorArrayNestedData()
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer valid-token',
+        ];
+        $data = ['a' => 'b', 'c' => ['foo', 'bar']];
+        $request = new Request('http://example.com', 'POST', $headers, $data);
+
+        $this->assertEquals('http://example.com', $request->url());
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals('a=b&c%5B0%5D=foo&c%5B1%5D=bar', $request->body());
+    }
+
+    /**
      * test url method
      *
      * @return void


### PR DESCRIPTION
I encountered an issue today where trying to form a url such as `example.com/api/v4/packages?sort=name&direction=desc&limit=2&verbose=1&filter[Broadbands.bandwidth]=30&site_id=4` was causing a fatal error with Zend Diactoros' Uri class, as malformed.

Just wanted to check that the Cake HTTP client was url encoding query params, turns out it was, but there was no test for query param arrays. So this change adds a simple test to ensure that nested array data is url encoded properly.