### PR TITLE
Change ConnectionInterface typehint to Connection in TableSchema.

### DIFF
--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -15,7 +15,7 @@
 namespace Cake\Database\Schema;
 
 use Cake\Database\Exception;
-use Cake\Datasource\ConnectionInterface;
+use Cake\Database\Connection;
 use PDOException;
 
 /**
@@ -30,7 +30,7 @@ class Collection
     /**
      * Connection object
      *
-     * @var \Cake\Datasource\ConnectionInterface
+     * @var \Cake\Database\Connection
      */
     protected $_connection;
 
@@ -44,9 +44,9 @@ class Collection
     /**
      * Constructor.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection instance.
+     * @param \Cake\Database\Connection $connection The connection instance.
      */
-    public function __construct(ConnectionInterface $connection)
+    public function __construct(Connection $connection)
     {
         $this->_connection = $connection;
         $this->_dialect = $connection->driver()->schemaDialect();

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Database\Schema;
 
-use Cake\Database\Exception;
 use Cake\Database\Connection;
+use Cake\Database\Exception;
 use PDOException;
 
 /**

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Connection;
 use Cake\Database\Exception;
 use Cake\Database\Type;
-use Cake\Datasource\ConnectionInterface;
 
 /**
  * Represents a single table in a database schema.
@@ -824,11 +824,11 @@ class TableSchema
      * Uses the connection to access the schema dialect
      * to generate platform specific SQL.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array List of SQL statements to create the table and the
      *    required indexes.
      */
-    public function createSql(ConnectionInterface $connection)
+    public function createSql(Connection $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
         $columns = $constraints = $indexes = [];
@@ -851,10 +851,10 @@ class TableSchema
      * Uses the connection to access the schema dialect to generate platform
      * specific SQL.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
-    public function dropSql(ConnectionInterface $connection)
+    public function dropSql(Connection $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
 
@@ -864,10 +864,10 @@ class TableSchema
     /**
      * Generate the SQL statements to truncate a table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to truncate a table.
      */
-    public function truncateSql(ConnectionInterface $connection)
+    public function truncateSql(Connection $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
 
@@ -877,10 +877,10 @@ class TableSchema
     /**
      * Generate the SQL statements to add the constraints to the table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
-    public function addConstraintSql(ConnectionInterface $connection)
+    public function addConstraintSql(Connection $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
 
@@ -890,10 +890,10 @@ class TableSchema
     /**
      * Generate the SQL statements to drop the constraints to the table
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection to generate SQL for.
+     * @param \Cake\Database\Connection $connection The connection to generate SQL for.
      * @return array SQL to drop a table.
      */
-    public function dropConstraintSql(ConnectionInterface $connection)
+    public function dropConstraintSql(Connection $connection)
     {
         $dialect = $connection->driver()->schemaDialect();
 


### PR DESCRIPTION
`ConnectionInterface` does not provide a `driver()` method which `*Sql()` methods require.
