### PR TITLE
Proposal for #10616

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -149,6 +149,21 @@ abstract class IntegrationTestCase extends TestCase
     protected $_csrfToken = false;
 
     /**
+     * Boolean flag for whether or not the request should re-store
+     * flash messages
+     *
+     * @var bool
+     */
+    protected $_rememberFlashMessages = false;
+
+    /**
+     * Stored flash messages before render
+     *
+     * @var null|array
+     */
+    protected $_flashMessages;
+
+    /**
      *
      * @var null|string
      */
@@ -187,6 +202,7 @@ abstract class IntegrationTestCase extends TestCase
         $this->_appArgs = null;
         $this->_securityToken = false;
         $this->_csrfToken = false;
+        $this->_rememberFlashMessages = false;
         $this->_useHttpServer = false;
     }
 
@@ -240,6 +256,17 @@ abstract class IntegrationTestCase extends TestCase
     public function enableCsrfToken()
     {
         $this->_csrfToken = true;
+    }
+
+    /**
+     * Calling this method will re-store flash messages into the test session
+     * after being removed by the FlashHelper
+     *
+     * @return void
+     */
+    public function enableRememberFlashMessages()
+    {
+        $this->_rememberFlashMessages = true;
     }
 
     /**
@@ -425,6 +452,9 @@ abstract class IntegrationTestCase extends TestCase
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
             $this->_requestSession = $request['session'];
+            if ($this->_rememberFlashMessages) {
+                $this->_requestSession->write('Flash', $this->_flashMessages);
+            }
             $this->_response = $response;
         } catch (\PHPUnit\Exception $e) {
             throw $e;
@@ -466,9 +496,12 @@ abstract class IntegrationTestCase extends TestCase
         }
         $this->_controller = $controller;
         $events = $controller->eventManager();
-        $events->on('View.beforeRender', function ($event, $viewFile) {
+        $events->on('View.beforeRender', function ($event, $viewFile) use ($controller) {
             if (!$this->_viewName) {
                 $this->_viewName = $viewFile;
+            }
+            if ($this->_rememberFlashMessages) {
+                $this->_flashMessages = $controller->request->session()->read('Flash');
             }
         });
         $events->on('View.beforeLayout', function ($event, $viewFile) {

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -154,7 +154,7 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @var bool
      */
-    protected $_rememberFlashMessages = false;
+    protected $_retainFlashMessages = false;
 
     /**
      * Stored flash messages before render
@@ -202,7 +202,7 @@ abstract class IntegrationTestCase extends TestCase
         $this->_appArgs = null;
         $this->_securityToken = false;
         $this->_csrfToken = false;
-        $this->_rememberFlashMessages = false;
+        $this->_retainFlashMessages = false;
         $this->_useHttpServer = false;
     }
 
@@ -264,9 +264,9 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function enableRememberFlashMessages()
+    public function enableRetainFlashMessages()
     {
-        $this->_rememberFlashMessages = true;
+        $this->_retainFlashMessages = true;
     }
 
     /**
@@ -452,7 +452,7 @@ abstract class IntegrationTestCase extends TestCase
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
             $this->_requestSession = $request['session'];
-            if ($this->_rememberFlashMessages) {
+            if ($this->_retainFlashMessages) {
                 $this->_requestSession->write('Flash', $this->_flashMessages);
             }
             $this->_response = $response;
@@ -500,7 +500,7 @@ abstract class IntegrationTestCase extends TestCase
             if (!$this->_viewName) {
                 $this->_viewName = $viewFile;
             }
-            if ($this->_rememberFlashMessages) {
+            if ($this->_retainFlashMessages) {
                 $this->_flashMessages = $controller->request->session()->read('Flash');
             }
         });

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -413,7 +413,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
      */
     public function testFlashAssertionsAfterRender()
     {
-        $this->enableRememberFlashMessages();
+        $this->enableRetainFlashMessages();
         $this->get('/posts/index/with_flash');
 
         $this->assertSession('An error message', 'Flash.flash.0.message');

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -406,6 +406,20 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test flash assertions stored with enableRememberFlashMessages() after they
+     * are rendered
+     *
+     * @return void
+     */
+    public function testFlashAssertionsAfterRender()
+    {
+        $this->enableRememberFlashMessages();
+        $this->get('/posts/index/with_flash');
+
+        $this->assertSession('An error message', 'Flash.flash.0.message');
+    }
+
+    /**
      * Tests the failure message for assertCookieNotSet
      *
      * @expectedException \PHPUnit\Framework\AssertionFailedError

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -48,9 +48,10 @@ class PostsController extends AppController
     /**
      * Index method.
      *
+     * @param string $layout
      * @return void
      */
-    public function index()
+    public function index($layout = 'default')
     {
         $this->Flash->error('An error message');
         $this->response->cookie([
@@ -58,6 +59,7 @@ class PostsController extends AppController
             'value' => 1
         ]);
         $this->set('test', 'value');
+        $this->viewBuilder()->setLayout($layout);
     }
 
     /**

--- a/tests/test_app/TestApp/Template/Element/Flash/error.ctp
+++ b/tests/test_app/TestApp/Template/Element/Flash/error.ctp
@@ -1,0 +1,1 @@
+<div class="message"><?= h($message); ?></div>

--- a/tests/test_app/TestApp/Template/Layout/with_flash.ctp
+++ b/tests/test_app/TestApp/Template/Layout/with_flash.ctp
@@ -1,0 +1,43 @@
+<?php
+$this->loadHelper('Html');
+
+$cakeDescription = 'CakePHP: the rapid development php framework';
+?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <?= $this->Html->charset(); ?>
+    <title>
+        <?= $cakeDescription ?>:
+        <?= $this->fetch('title'); ?>
+    </title>
+    <?php
+        echo $this->Html->meta('icon');
+
+        echo $this->Html->css('cake.generic');
+
+        echo $this->fetch('script');
+    ?>
+</head>
+<body>
+    <div id="container">
+        <div id="header">
+            <h1><?= $this->Html->link($cakeDescription, 'http://cakephp.org'); ?></h1>
+        </div>
+        <div id="content">
+
+            <?= $this->Flash->render(); ?>
+            <?= $this->fetch('content'); ?>
+
+        </div>
+        <div id="footer">
+            <?= $this->Html->link(
+                    $this->Html->image('cake.power.gif', ['alt' => $cakeDescription, 'border' => '0']),
+                    'http://www.cakephp.org/',
+                    ['target' => '_blank', 'escape' => false]
+                );
+            ?>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Refs #10616 

This adds a new method on the IntegrationTestCase called `enableRememberFlashMessages()` that stores flash messages before rendering them and restores them to the session. It's opt-in as users may be relying on the messages being discarded during render.

Naming ideas welcome 😄  I wanted to keep it similar to enabling the tokens.