### PR TITLE
Add deprecation annotation to RepositoryInterface::alias

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -171,7 +171,7 @@ class PaginatorComponent extends Component
             $object = $query->repository();
         }
 
-        $alias = $object->alias();
+        $alias = $object->getAlias();
         $options = $this->mergeOptions($alias, $settings);
         $options = $this->validateSort($object, $options);
         $options = $this->checkLimit($options);
@@ -379,7 +379,7 @@ class PaginatorComponent extends Component
      */
     protected function _prefix(RepositoryInterface $object, $order, $whitelisted = false)
     {
-        $tableAlias = $object->alias();
+        $tableAlias = $object->getAlias();
         $tableOrder = [];
         foreach ($order as $key => $value) {
             if (is_numeric($key)) {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -230,7 +230,7 @@ trait QueryTrait
         }
 
         if (!$alias) {
-            $alias = $this->repository()->alias();
+            $alias = $this->repository()->getAlias();
         }
 
         $key = sprintf('%s__%s', $alias, $field);

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -24,6 +24,7 @@ interface RepositoryInterface
     /**
      * Returns the table alias or sets a new one
      *
+     * @deprecated 3.4.0 Use setAlias()/getAlias() instead.
      * @param string|null $alias the new table alias
      * @return string
      */

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -24,7 +24,6 @@ interface RepositoryInterface
     /**
      * Returns the table alias or sets a new one
      *
-     * @deprecated 3.4.0 Use setAlias()/getAlias() instead.
      * @param string|null $alias the new table alias
      * @return string
      */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1043,7 +1043,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         }
 
         if (empty($this->_parts['from'])) {
-            $this->from([$this->_repository->alias() => $this->_repository->table()]);
+            $this->from([$this->_repository->getAlias() => $this->_repository->table()]);
         }
         $this->_addDefaultFields();
         $this->getEagerLoader()->attachAssociations($this, $this->_repository, !$this->_hasFields);
@@ -1067,7 +1067,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
             $select = $this->clause('select');
         }
 
-        $aliased = $this->aliasFields($select, $this->repository()->alias());
+        $aliased = $this->aliasFields($select, $this->repository()->getAlias());
         $this->select($aliased, true);
     }
 
@@ -1148,7 +1148,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     public function delete($table = null)
     {
         $repo = $this->repository();
-        $this->from([$repo->alias() => $repo->table()]);
+        $this->from([$repo->getAlias() => $repo->table()]);
 
         return parent::delete();
     }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -183,7 +183,7 @@ class ResultSet implements ResultSetInterface
         $this->_hydrate = $query->isHydrationEnabled();
         $this->_entityClass = $repository->getEntityClass();
         $this->_useBuffering = $query->isBufferedResultsEnabled();
-        $this->_defaultAlias = $this->_defaultTable->alias();
+        $this->_defaultAlias = $this->_defaultTable->getAlias();
         $this->_calculateColumnMap($query);
         $this->_calculateTypeMap();
         $this->_autoFields = $query->isAutoFieldsEnabled();

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -69,7 +69,7 @@ class IsUnique
         }
         $allowMultipleNulls = $this->_options['allowMultipleNulls'];
 
-        $alias = $options['repository']->alias();
+        $alias = $options['repository']->getAlias();
         $conditions = $this->_alias($alias, $entity->extract($this->_fields), $allowMultipleNulls);
         if ($entity->isNew() === false) {
             $keys = (array)$options['repository']->getPrimaryKey();

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -97,7 +97,7 @@ class PaginatorComponentTest extends TestCase
     public function testPageParamCasting()
     {
         $this->Post->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('Posts'));
 
         $query = $this->_getMockFindQuery();
@@ -591,7 +591,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())
             ->method('hasField')
@@ -652,7 +652,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())->method('hasField')->will($this->returnValue(true));
 
@@ -675,7 +675,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->once())
             ->method('hasField')
@@ -705,7 +705,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())->method('hasField')
             ->will($this->returnValue(true));
@@ -733,7 +733,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->once())->method('hasField')
             ->will($this->returnValue(false));
@@ -762,7 +762,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->once())
             ->method('hasField')
@@ -793,7 +793,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())->method('hasField')->will($this->returnValue(true));
 
@@ -821,7 +821,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())->method('hasField')->will($this->returnValue(true));
 
@@ -843,7 +843,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())->method('hasField')
             ->will($this->returnValue(true));
@@ -865,7 +865,7 @@ class PaginatorComponentTest extends TestCase
     {
         $model = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $model->expects($this->any())
-            ->method('alias')
+            ->method('getAlias')
             ->will($this->returnValue('model'));
         $model->expects($this->any())->method('hasField')->will($this->returnValue(true));
 


### PR DESCRIPTION
See #10632. As Table::alias was deprecated in 3.4, I added 3.4 to the interface as well. Is this correct?