### PR TITLE
Added the ability to serialize Table objects.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -175,6 +175,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected $_connection;
 
     /**
+     * Connection configure name stored in serialization.
+     *
+     * @var string
+     */
+    protected $_connectionName;
+
+    /**
      * The schema object containing a description of this table fields
      *
      * @var \Cake\Database\Schema\TableSchema
@@ -2748,9 +2755,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function __wakeup()
     {
-        if (isset($this->_connectionName)) {
+        if ($this->_connectionName !== null) {
             $this->_connection = ConnectionManager::get($this->_connectionName);
-            unset($this->_connectionName);
+            $this->_connectionName = null;
         }
     }
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6512,4 +6512,21 @@ class TableTest extends TestCase
             'SQLServer does not support the requirements of this test.'
         );
     }
+
+    /**
+     * Test __sleep() and __wakeup() methods.
+     *
+     * @return void
+     */
+    public function testSerialize()
+    {
+        $table = TableRegistry::get('Authors');
+
+        $serialized = serialize($table);
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf(Table::class, $unserialized);
+        $this->assertEquals($table->getAlias(), $unserialized->getAlias());
+        $this->assertSame($table->getConnection(), $unserialized->getConnection());
+    }
 }


### PR DESCRIPTION
The connection name is stored for serialization and reinstantated on wakeup.

I'm not sure if this is done right so the suggestions are welcome.

Targetting this for next 3.4.7 because for me this has always been a bug that I couldn't serialize tables.
This also shouldn't break anything Let's see if tests pass on all adapters.