### PR TITLE
3.next - Add application routes hook

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -62,6 +62,19 @@ abstract class BaseApplication
     }
 
     /**
+     * Define the routes for an application.
+     *
+     * By default this will load `config/routes.php` for ease of use and backwards compatibility.
+     *
+     * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
+     * @return void
+     */
+    public function routes($routes)
+    {
+        require $this->configDir . '/routes.php';
+    }
+
+    /**
      * Invoke the application.
      *
      * - Convert the PSR response into CakePHP equivalents.

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -100,6 +100,10 @@ abstract class ServerRequestFactory extends BaseFactory
             $uri = static::updatePath($base, $uri);
         }
 
+        if (!$uri->getHost()) {
+            $uri = $uri->withHost('localhost');
+        }
+
         // Splat on some extra attributes to save
         // some method calls.
         $uri->base = $base;

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Routing\Middleware;
 
+use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
 use Cake\Routing\Exception\RedirectException;
 use Cake\Routing\Router;
@@ -27,7 +28,6 @@ use Zend\Diactoros\Response\RedirectResponse;
  */
 class RoutingMiddleware
 {
-
     /**
      * Apply routing and update the request.
      *
@@ -61,11 +61,12 @@ class RoutingMiddleware
                 $response->getHeaders()
             );
         }
-        $middleware = Router::getMatchingMiddleware($request->getUri()->getPath());
-        if (!$middleware) {
+        $matching = Router::getRouteCollection()->getMatchingMiddleware($request->getUri()->getPath());
+        if (!$matching) {
             return $next($request, $response);
         }
-        $middleware->add($next);
+        $matching[] = $next;
+        $middleware = new MiddlewareQueue($matching);
         $runner = new Runner();
 
         return $runner->run($middleware, $request, $response);

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -58,7 +58,7 @@ class RoutingMiddleware
     protected function loadRoutes()
     {
         if ($this->app) {
-            $builder = Router::getRouteBuilder('/');
+            $builder = Router::createRouteBuilder('/');
             $this->app->routes($builder);
             // Prevent routes from being loaded again
             Router::$initialized = true;

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -31,6 +31,13 @@ use Zend\Diactoros\Response\RedirectResponse;
 class RoutingMiddleware
 {
     /**
+     * The application that will have its routing hook invoked.
+     *
+     * @var \Cake\Http\BaseApplication
+     */
+    protected $app;
+
+    /**
      * Constructor
      *
      * @param \Cake\Http\BaseApplication $app The application instance that routes are defined on.

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1060,6 +1060,16 @@ class Router
     }
 
     /**
+     * Get the RouteCollection inside the Router
+     *
+     * @return \Cake\Routing\RouteCollection
+     */
+    public static function getRouteCollection()
+    {
+        return static::$_collection;
+    }
+
+    /**
      * Get a MiddlewareQueue of middleware that matches the provided path.
      *
      * @param string $path The URL path to match for.

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -419,34 +419,19 @@ class Router
     /**
      * Store the request context for a given request.
      *
-     * @param \Cake\Http\ServerRequest|\Psr\Http\Message\ServerRequestInterface $request The request instance.
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request instance.
      * @return void
      * @throws InvalidArgumentException When parameter is an incorrect type.
      */
-    public static function setRequestContext($request)
+    public static function setRequestContext(ServerRequestInterface $request)
     {
-        if ($request instanceof ServerRequest) {
-            static::$_requestContext = [
-                '_base' => $request->base,
-                '_port' => $request->port(),
-                '_scheme' => $request->scheme(),
-                '_host' => $request->host()
-            ];
-
-            return;
-        }
-        if ($request instanceof ServerRequestInterface) {
-            $uri = $request->getUri();
-            static::$_requestContext = [
-                '_base' => $request->getAttribute('base'),
-                '_port' => $uri->getPort(),
-                '_scheme' => $uri->getScheme(),
-                '_host' => $uri->getHost(),
-            ];
-
-            return;
-        }
-        throw new InvalidArgumentException('Unknown request type received.');
+        $uri = $request->getUri();
+        static::$_requestContext = [
+            '_base' => $request->getAttribute('base'),
+            '_port' => $uri->getPort(),
+            '_scheme' => $uri->getScheme(),
+            '_host' => $uri->getHost(),
+        ];
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -911,6 +911,26 @@ class Router
     }
 
     /**
+     * Create a RouteBuilder for the provided path.
+     *
+     * @param string $path The path to set the builder to.
+     * @param array $options The options for the builder
+     * @return \Cake\Routing\RouteBuilder
+     */
+    public static function getRouteBuilder($path, array $options = [])
+    {
+        $defaults = [
+            'routeClass' => static::defaultRouteClass(),
+            'extensions' => static::$_defaultExtensions,
+        ];
+        $options += $defaults;
+        return new RouteBuilder(static::$_collection, $path, [], [
+            'routeClass' => $options['routeClass'],
+            'extensions' => $options['extensions'],
+        ]);
+    }
+
+    /**
      * Create a routing scope.
      *
      * Routing scopes allow you to keep your routes DRY and avoid repeating
@@ -954,18 +974,12 @@ class Router
      */
     public static function scope($path, $params = [], $callback = null)
     {
-        $options = [
-            'routeClass' => static::defaultRouteClass(),
-            'extensions' => static::$_defaultExtensions,
-        ];
+        $options = [];
         if (is_array($params)) {
-            $options = $params + $options;
+            $options = $params;
             unset($params['routeClass'], $params['extensions']);
         }
-        $builder = new RouteBuilder(static::$_collection, '/', [], [
-            'routeClass' => $options['routeClass'],
-            'extensions' => $options['extensions'],
-        ]);
+        $builder = static::getRouteBuilder('/', $options);
         $builder->scope($path, $params, $callback);
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -924,6 +924,7 @@ class Router
             'extensions' => static::$_defaultExtensions,
         ];
         $options += $defaults;
+
         return new RouteBuilder(static::$_collection, $path, [], [
             'routeClass' => $options['routeClass'],
             'extensions' => $options['extensions'],

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1086,6 +1086,7 @@ class Router
     /**
      * Loads route configuration
      *
+     * @deprecated 3.5.0 Routes will be loaded via the Application::routes() hook in 4.0.0
      * @return void
      */
     protected static function _loadRoutes()

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1070,26 +1070,6 @@ class Router
     }
 
     /**
-     * Get a MiddlewareQueue of middleware that matches the provided path.
-     *
-     * @param string $path The URL path to match for.
-     * @return \Cake\Http\MiddlewareQueue|null Either a queue or null if there are no matching middleware.
-     */
-    public static function getMatchingMiddleware($path)
-    {
-        if (!static::$initialized) {
-            static::_loadRoutes();
-        }
-
-        $middleware = static::$_collection->getMatchingMiddleware($path);
-        if ($middleware) {
-            return new MiddlewareQueue($middleware);
-        }
-
-        return null;
-    }
-
-    /**
      * Loads route configuration
      *
      * @return void

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -917,7 +917,7 @@ class Router
      * @param array $options The options for the builder
      * @return \Cake\Routing\RouteBuilder
      */
-    public static function getRouteBuilder($path, array $options = [])
+    public static function createRouteBuilder($path, array $options = [])
     {
         $defaults = [
             'routeClass' => static::defaultRouteClass(),
@@ -980,7 +980,7 @@ class Router
             $options = $params;
             unset($params['routeClass'], $params['extensions']);
         }
-        $builder = static::getRouteBuilder('/', $options);
+        $builder = static::createRouteBuilder('/', $options);
         $builder->scope($path, $params, $callback);
     }
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3358,13 +3358,13 @@ class RouterTest extends TestCase
      *
      * @return void
      */
-    public function testGetRouteBuilder()
+    public function testCreateRouteBuilder()
     {
-        $builder = Router::getRouteBuilder('/api');
+        $builder = Router::createRouteBuilder('/api');
         $this->assertInstanceOf(RouteBuilder::class, $builder);
         $this->assertSame('/api', $builder->path());
 
-        $builder = Router::getRouteBuilder('/', [
+        $builder = Router::createRouteBuilder('/', [
             'routeClass' => 'InflectedRoute',
             'extensions' => ['json']
         ]);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2035,7 +2035,6 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $request = new ServerRequest();
-        $request->env('HTTP_HOST', 'localhost');
         Router::pushRequest(
             $request->addParams([
                 'plugin' => null, 'controller' => 'images', 'action' => 'index'
@@ -2067,7 +2066,6 @@ class RouterTest extends TestCase
         Router::connect('/:controller/:action/*');
 
         $request = new ServerRequest();
-        $request->env('HTTP_HOST', 'localhost');
         $request->env('HTTPS', 'on');
         Router::pushRequest(
             $request->addParams([
@@ -3339,17 +3337,6 @@ class RouterTest extends TestCase
 
         $result = Router::url('/pages/home');
         $this->assertEquals('/subdir/pages/home', $result);
-    }
-
-    /**
-     * Test setting the request context.
-     *
-     * @expectedException \InvalidArgumentException
-     * @return void
-     */
-    public function testSetRequestContextInvalid()
-    {
-        Router::setRequestContext(new \stdClass);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -19,6 +19,7 @@ use Cake\Core\Plugin;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
+use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\Routing\Route\Route;
@@ -3350,6 +3351,25 @@ class RouterTest extends TestCase
         $collection = Router::getRouteCollection();
         $this->assertInstanceOf(RouteCollection::class, $collection);
         $this->assertCount(0, $collection->routes());
+    }
+
+    /**
+     * Test getting a route builder instance.
+     *
+     * @return void
+     */
+    public function testGetRouteBuilder()
+    {
+        $builder = Router::getRouteBuilder('/api');
+        $this->assertInstanceOf(RouteBuilder::class, $builder);
+        $this->assertSame('/api', $builder->path());
+
+        $builder = Router::getRouteBuilder('/', [
+            'routeClass' => 'InflectedRoute',
+            'extensions' => ['json']
+        ]);
+        $this->assertInstanceOf(RouteBuilder::class, $builder);
+        $this->assertSame(['json'], $builder->extensions());
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -19,6 +19,7 @@ use Cake\Core\Plugin;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
+use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
@@ -3361,6 +3362,18 @@ class RouterTest extends TestCase
         $result = Router::getMatchingMiddleware('/api/v1/articles');
         $this->assertInstanceOf(MiddlewareQueue::class, $result);
         $this->assertCount(1, $result);
+    }
+
+    /**
+     * Test getting the route collection
+     *
+     * @return void
+     */
+    public function testGetRouteCollection()
+    {
+        $collection = Router::getRouteCollection();
+        $this->assertInstanceOf(RouteCollection::class, $collection);
+        $this->assertCount(0, $collection->routes());
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3341,30 +3341,6 @@ class RouterTest extends TestCase
     }
 
     /**
-     * Test getting path specific middleware.
-     *
-     * @return void
-     */
-    public function testGetMatchingMiddleware()
-    {
-        Router::scope('/', function ($routes) {
-            $routes->connect('/articles', ['controller' => 'Articles']);
-            $routes->registerMiddleware('noop', function () {
-            });
-        });
-        Router::scope('/api/v1', function ($routes) {
-            $routes->applyMiddleware('noop');
-            $routes->connect('/articles', ['controller' => 'Articles', 'prefix' => 'Api']);
-        });
-        $result = Router::getMatchingMiddleware('/articles');
-        $this->assertNull($result);
-
-        $result = Router::getMatchingMiddleware('/api/v1/articles');
-        $this->assertInstanceOf(MiddlewareQueue::class, $result);
-        $this->assertCount(1, $result);
-    }
-
-    /**
      * Test getting the route collection
      *
      * @return void

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -42,4 +42,17 @@ class Application extends BaseApplication
 
         return $middleware;
     }
+
+    /**
+     * Routes hook, used for testing with RoutingMiddleware.
+     *
+     * @param \Cake\Routing\RouteBuilder $routes
+     * @return void
+     */
+    public function routes($routes)
+    {
+        $routes->scope('/app', function ($routes) {
+            $routes->connect('/articles', ['controller' => 'Articles']);
+        });
+    }
 }


### PR DESCRIPTION
This finishes off the bulk of the work for #10308. I'm expanding the scope of the `Application` class to be a vessel for configuration/setup logic. This change also enables us to deprecate most of the static methods on `Router` (in a subsequent pull request) which will let us significantly reduce the static API surface area in CakePHP.

## TODO

* [x] Test these changes against an 3.2 style app to ensure backwards compatibility for route reloading.
* [ ] Should `RouteBuilder` have an interface added?