### PR TITLE
Add the $previous argument to all exceptions

### DIFF
--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -29,8 +29,5 @@ class MissingActionException extends Exception
     /**
      * {@inheritDoc}
      */
-    public function __construct($message, $code = 404)
-    {
-        parent::__construct($message, $code);
-    }
+    protected $_defaultCode = 404;
 }

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -43,6 +43,13 @@ class Exception extends RuntimeException
     protected $_responseHeaders;
 
     /**
+     * Default exception code
+     *
+     * @var int
+     */
+    protected $_defaultCode = 500;
+
+    /**
      * Constructor.
      *
      * Allows you to create exceptions that are treated as framework errors and disabled
@@ -50,11 +57,15 @@ class Exception extends RuntimeException
      *
      * @param string|array $message Either the string of the error message, or an array of attributes
      *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
-     * @param int $code The code of the error, is also the HTTP status code for the error.
+     * @param int|null $code The code of the error, is also the HTTP status code for the error.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct($message, $code = 500, $previous = null)
+    public function __construct($message, $code = null, $previous = null)
     {
+        if ($code === null) {
+            $code = $this->_defaultCode;
+        }
+
         if (is_array($message)) {
             $this->_attributes = $message;
             $message = vsprintf($this->_messageTemplate, $message);

--- a/src/Datasource/Exception/InvalidPrimaryKeyException.php
+++ b/src/Datasource/Exception/InvalidPrimaryKeyException.php
@@ -14,13 +14,18 @@
  */
 namespace Cake\Datasource\Exception;
 
-use RuntimeException;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when the provided primary key does not match the table primary key
  */
-class InvalidPrimaryKeyException extends RuntimeException
+class InvalidPrimaryKeyException extends Exception
 {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 404;
 
     /**
      * Constructor.
@@ -29,7 +34,7 @@ class InvalidPrimaryKeyException extends RuntimeException
      * @param int $code The code of the error, is also the HTTP status code for the error.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct($message, $code = 404, $previous = null)
+    public function __construct($message, $code = null, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Datasource/Exception/RecordNotFoundException.php
+++ b/src/Datasource/Exception/RecordNotFoundException.php
@@ -14,13 +14,18 @@
  */
 namespace Cake\Datasource\Exception;
 
-use RuntimeException;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception raised when a particular record was not found
  */
-class RecordNotFoundException extends RuntimeException
+class RecordNotFoundException extends Exception
 {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 404;
 
     /**
      * Constructor.
@@ -29,7 +34,7 @@ class RecordNotFoundException extends RuntimeException
      * @param int $code The code of the error, is also the HTTP status code for the error.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct($message, $code = 404, $previous = null)
+    public function __construct($message, $code = null, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Error/FatalErrorException.php
+++ b/src/Error/FatalErrorException.php
@@ -24,13 +24,14 @@ class FatalErrorException extends Exception
      * Constructor
      *
      * @param string $message Message string.
-     * @param int $code Code.
+     * @param int|null $code Code.
      * @param string|null $file File name.
      * @param int|null $line Line number.
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message, $code = 500, $file = null, $line = null)
+    public function __construct($message, $code = null, $file = null, $line = null, $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
         if ($file) {
             $this->file = $file;
         }

--- a/src/Error/PHP7ErrorException.php
+++ b/src/Error/PHP7ErrorException.php
@@ -48,7 +48,7 @@ class PHP7ErrorException extends Exception
             $this->file ?: 'null',
             $this->line ?: 'null'
         );
-        parent::__construct($msg, $this->code);
+        parent::__construct($msg, $this->code, $error->getPrevious());
     }
 
     /**

--- a/src/Mailer/Exception/MissingActionException.php
+++ b/src/Mailer/Exception/MissingActionException.php
@@ -28,8 +28,5 @@ class MissingActionException extends Exception
     /**
      * {@inheritDoc}
      */
-    public function __construct($message, $code = 404)
-    {
-        parent::__construct($message, $code);
-    }
+    protected $_defaultCode = 404;
 }

--- a/src/Network/Exception/BadRequestException.php
+++ b/src/Network/Exception/BadRequestException.php
@@ -19,16 +19,22 @@ class BadRequestException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 400;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Bad Request' will be the message
      * @param int $code Status code, defaults to 400
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 400)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Bad Request';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/ConflictException.php
+++ b/src/Network/Exception/ConflictException.php
@@ -19,16 +19,22 @@ class ConflictException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 409;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Conflict' will be the message
      * @param int $code Status code, defaults to 409
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 409)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Conflict';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/ForbiddenException.php
+++ b/src/Network/Exception/ForbiddenException.php
@@ -19,16 +19,22 @@ class ForbiddenException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 403;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Forbidden' will be the message
      * @param int $code Status code, defaults to 403
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 403)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Forbidden';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/GoneException.php
+++ b/src/Network/Exception/GoneException.php
@@ -19,16 +19,22 @@ class GoneException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 410;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Gone' will be the message
      * @param int $code Status code, defaults to 410
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 410)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Gone';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/InternalErrorException.php
+++ b/src/Network/Exception/InternalErrorException.php
@@ -23,12 +23,13 @@ class InternalErrorException extends HttpException
      *
      * @param string|null $message If no message is given 'Internal Server Error' will be the message
      * @param int $code Status code, defaults to 500
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 500)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Internal Server Error';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/InvalidCsrfTokenException.php
+++ b/src/Network/Exception/InvalidCsrfTokenException.php
@@ -19,16 +19,22 @@ class InvalidCsrfTokenException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 403;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Invalid CSRF Token' will be the message
      * @param int $code Status code, defaults to 403
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 403)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Invalid CSRF Token';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/MethodNotAllowedException.php
+++ b/src/Network/Exception/MethodNotAllowedException.php
@@ -19,16 +19,22 @@ class MethodNotAllowedException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 405;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Method Not Allowed' will be the message
      * @param int $code Status code, defaults to 405
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 405)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Method Not Allowed';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/NotAcceptableException.php
+++ b/src/Network/Exception/NotAcceptableException.php
@@ -19,16 +19,22 @@ class NotAcceptableException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 406;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Not Acceptable' will be the message
      * @param int $code Status code, defaults to 406
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 406)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Not Acceptable';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/NotFoundException.php
+++ b/src/Network/Exception/NotFoundException.php
@@ -19,16 +19,22 @@ class NotFoundException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 404;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Not Found' will be the message
      * @param int $code Status code, defaults to 404
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 404)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Not Found';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/NotImplementedException.php
+++ b/src/Network/Exception/NotImplementedException.php
@@ -26,8 +26,5 @@ class NotImplementedException extends HttpException
     /**
      * {@inheritDoc}
      */
-    public function __construct($message, $code = 501)
-    {
-        parent::__construct($message, $code);
-    }
+    protected $_defaultCode = 501;
 }

--- a/src/Network/Exception/ServiceUnavailableException.php
+++ b/src/Network/Exception/ServiceUnavailableException.php
@@ -19,16 +19,22 @@ class ServiceUnavailableException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 503;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Service Unavailable' will be the message
      * @param int $code Status code, defaults to 503
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 503)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Service Unavailable';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/SocketException.php
+++ b/src/Network/Exception/SocketException.php
@@ -12,12 +12,17 @@
  */
 namespace Cake\Network\Exception;
 
-use RuntimeException;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception class for Socket. This exception will be thrown from Socket, Email, HttpSocket
  * SmtpTransport, MailTransport and HttpResponse when it encounters an error.
  */
-class SocketException extends RuntimeException
+class SocketException extends Exception
 {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 0;
 }

--- a/src/Network/Exception/UnauthorizedException.php
+++ b/src/Network/Exception/UnauthorizedException.php
@@ -19,16 +19,22 @@ class UnauthorizedException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 401;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Unauthorized' will be the message
      * @param int $code Status code, defaults to 401
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 401)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Unauthorized';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Network/Exception/UnavailableForLegalReasonsException.php
+++ b/src/Network/Exception/UnavailableForLegalReasonsException.php
@@ -19,16 +19,22 @@ class UnavailableForLegalReasonsException extends HttpException
 {
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 451;
+
+    /**
      * Constructor
      *
      * @param string|null $message If no message is given 'Unavailable For Legal Reasons' will be the message
      * @param int $code Status code, defaults to 451
+     * @param \Exception|null $previous The previous exception.
      */
-    public function __construct($message = null, $code = 451)
+    public function __construct($message = null, $code = null, $previous = null)
     {
         if (empty($message)) {
             $message = 'Unavailable For Legal Reasons';
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -42,7 +42,7 @@ class PersistenceFailedException extends Exception
      * @param int $code The code of the error, is also the HTTP status code for the error.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct(EntityInterface $entity, $message, $code = 500, $previous = null)
+    public function __construct(EntityInterface $entity, $message, $code = null, $previous = null)
     {
         $this->_entity = $entity;
         parent::__construct($message, $code, $previous);

--- a/src/Routing/Exception/DuplicateNamedRouteException.php
+++ b/src/Routing/Exception/DuplicateNamedRouteException.php
@@ -28,11 +28,11 @@ class DuplicateNamedRouteException extends Exception
     /**
      * {@inheritDoc}
      */
-    public function __construct($message, $code = 404)
+    public function __construct($message, $code = 404, $previous = null)
     {
         if (is_array($message) && isset($message['message'])) {
             $this->_messageTemplate = $message['message'];
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Routing/Exception/MissingControllerException.php
+++ b/src/Routing/Exception/MissingControllerException.php
@@ -29,8 +29,8 @@ class MissingControllerException extends Exception
     /**
      * {@inheritDoc}
      */
-    public function __construct($message, $code = 404)
+    public function __construct($message, $code = 404, $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -36,7 +36,7 @@ class MissingRouteException extends Exception
     /**
      * {@inheritDoc}
      */
-    public function __construct($message, $code = 404)
+    public function __construct($message, $code = 404, $previous = null)
     {
         if (is_array($message)) {
             if (isset($message['message'])) {
@@ -45,6 +45,6 @@ class MissingRouteException extends Exception
                 $this->_messageTemplate = $this->_messageTemplateWithMethod;
             }
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Routing/Exception/RedirectException.php
+++ b/src/Routing/Exception/RedirectException.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Routing\Exception;
 
-use RuntimeException;
+use Cake\Core\Exception\Exception;
 
 /**
  * An exception subclass used by the routing layer to indicate
@@ -26,6 +26,11 @@ use RuntimeException;
  * throw new RedirectException('http://example.com/some/path', 301);
  * ```
  */
-class RedirectException extends RuntimeException
+class RedirectException extends Exception
 {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 302;
 }

--- a/src/Utility/Exception/XmlException.php
+++ b/src/Utility/Exception/XmlException.php
@@ -12,12 +12,17 @@
  */
 namespace Cake\Utility\Exception;
 
-use RuntimeException;
+use Cake\Core\Exception\Exception;
 
 /**
  * Exception class for Xml. This exception will be thrown from Xml when it
  * encounters an error.
  */
-class XmlException extends RuntimeException
+class XmlException extends Exception
 {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultCode = 0;
 }

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * ExceptionsTest file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase;
+
+use Cake\Error\FatalErrorException;
+use Cake\Error\PHP7ErrorException;
+use Cake\ORM\Entity;
+use Cake\ORM\Exception\PersistenceFailedException;
+use Cake\TestSuite\TestCase;
+use Error;
+use Exception;
+
+class ExceptionsTest extends TestCase
+{
+
+    /**
+     * Tests simple exceptions work.
+     *
+     * @dataProvider exceptionProvider
+     * @param $class The exception class name
+     * @param $defaultCode The default exception code
+     * @return void
+     */
+    public function testSimpleException($class, $defaultCode)
+    {
+        $previous = new Exception();
+
+        $exception = new $class('message', 100, $previous);
+        $this->assertSame('message', $exception->getMessage());
+        $this->assertSame(100, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+
+        $exception = new $class('message', null, $previous);
+        $this->assertSame('message', $exception->getMessage());
+        $this->assertSame($defaultCode, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * Tests FatalErrorException works.
+     *
+     * @return void
+     */
+    public function testFatalErrorException()
+    {
+        $previous = new Exception();
+
+        $exception = new FatalErrorException('message', 100, __FILE__, 1, $previous);
+        $this->assertSame('message', $exception->getMessage());
+        $this->assertSame(100, $exception->getCode());
+        $this->assertSame(__FILE__, $exception->getFile());
+        $this->assertSame(1, $exception->getLine());
+        $this->assertSame($previous, $exception->getPrevious());
+
+        $exception = new FatalErrorException('message', null, __FILE__, 1, $previous);
+        $this->assertSame('message', $exception->getMessage());
+        $this->assertSame(500, $exception->getCode());
+        $this->assertSame(__FILE__, $exception->getFile());
+        $this->assertSame(1, $exception->getLine());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * Tests PHP7ErrorException works.
+     *
+     * @return void
+     */
+    public function testPHP7ErrorException()
+    {
+        $this->skipIf(version_compare(PHP_VERSION, '7.0.0', '<'));
+
+        $previous = new Exception();
+        $error = new Error('message', 100, $previous);
+        $line = __LINE__ - 1;
+
+        $exception = new PHP7ErrorException($error);
+        $this->assertSame(100, $exception->getCode());
+        $this->assertSame(__FILE__, $exception->getFile());
+        $this->assertSame($line, $exception->getLine());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * Tests PersistenceFailedException works.
+     *
+     * @return void
+     */
+    public function testPersistenceFailedException()
+    {
+        $previous = new Exception();
+        $entity = new Entity();
+
+        $exception = new PersistenceFailedException($entity, 'message', 100, $previous);
+        $this->assertSame('message', $exception->getMessage());
+        $this->assertSame(100, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+        $this->assertSame($entity, $exception->getEntity());
+
+        $exception = new PersistenceFailedException(new Entity, 'message', null, $previous);
+        $this->assertSame('message', $exception->getMessage());
+        $this->assertSame(500, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * Provides pairs of exception name and default code.
+     *
+     * @return array
+     */
+    public function exceptionProvider()
+    {
+        return [
+            ['Cake\Console\Exception\ConsoleException', 500],
+            ['Cake\Console\Exception\MissingHelperException', 500],
+            ['Cake\Console\Exception\MissingShellException', 500],
+            ['Cake\Console\Exception\MissingShellMethodException', 500],
+            ['Cake\Console\Exception\MissingTaskException', 500],
+            ['Cake\Console\Exception\StopException', 500],
+            ['Cake\Controller\Exception\AuthSecurityException', 400],
+            ['Cake\Controller\Exception\MissingActionException', 404],
+            ['Cake\Controller\Exception\MissingComponentException', 500],
+            ['Cake\Controller\Exception\SecurityException', 400],
+            ['Cake\Core\Exception\Exception', 500],
+            ['Cake\Core\Exception\MissingPluginException', 500],
+            ['Cake\Database\Exception', 500],
+            ['Cake\Database\Exception\MissingConnectionException', 500],
+            ['Cake\Database\Exception\MissingDriverException', 500],
+            ['Cake\Database\Exception\MissingExtensionException', 500],
+            ['Cake\Database\Exception\NestedTransactionRollbackException', 500],
+            ['Cake\Datasource\Exception\InvalidPrimaryKeyException', 404],
+            ['Cake\Datasource\Exception\MissingDatasourceConfigException', 500],
+            ['Cake\Datasource\Exception\MissingDatasourceException', 500],
+            ['Cake\Datasource\Exception\MissingModelException', 500],
+            ['Cake\Datasource\Exception\RecordNotFoundException', 404],
+            ['Cake\Mailer\Exception\MissingActionException', 404],
+            ['Cake\Mailer\Exception\MissingMailerException', 500],
+            ['Cake\Network\Exception\BadRequestException', 400],
+            ['Cake\Network\Exception\ConflictException', 409],
+            ['Cake\Network\Exception\ForbiddenException', 403],
+            ['Cake\Network\Exception\GoneException', 410],
+            ['Cake\Network\Exception\HttpException', 500],
+            ['Cake\Network\Exception\InternalErrorException', 500],
+            ['Cake\Network\Exception\InvalidCsrfTokenException', 403],
+            ['Cake\Network\Exception\MethodNotAllowedException', 405],
+            ['Cake\Network\Exception\NotAcceptableException', 406],
+            ['Cake\Network\Exception\NotFoundException', 404],
+            ['Cake\Network\Exception\NotImplementedException', 501],
+            ['Cake\Network\Exception\ServiceUnavailableException', 503],
+            ['Cake\Network\Exception\SocketException', 0],
+            ['Cake\Network\Exception\UnauthorizedException', 401],
+            ['Cake\Network\Exception\UnavailableForLegalReasonsException', 451],
+            ['Cake\ORM\Exception\MissingBehaviorException', 500],
+            ['Cake\ORM\Exception\MissingEntityException', 500],
+            ['Cake\ORM\Exception\MissingTableClassException', 500],
+            ['Cake\ORM\Exception\RolledbackTransactionException', 500],
+            ['Cake\Routing\Exception\DuplicateNamedRouteException', 500],
+            ['Cake\Routing\Exception\MissingControllerException', 500],
+            ['Cake\Routing\Exception\MissingDispatcherFilterException', 500],
+            ['Cake\Routing\Exception\MissingRouteException', 500],
+            ['Cake\Routing\Exception\RedirectException', 302],
+            ['Cake\Utility\Exception\XmlException', 0],
+            ['Cake\View\Exception\MissingCellException', 500],
+            ['Cake\View\Exception\MissingCellViewException', 500],
+            ['Cake\View\Exception\MissingElementException', 500],
+            ['Cake\View\Exception\MissingHelperException', 500],
+            ['Cake\View\Exception\MissingLayoutException', 500],
+            ['Cake\View\Exception\MissingTemplateException', 500],
+            ['Cake\View\Exception\MissingViewException', 500],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request is the first step to support exception chaining (#9824).

While adding an additional argument to the constructor is usually quite backward compatible, but I would like to target 3.next branch, as this is a little large change.

This is a work in progress, as I am not sure how I should write related test cases. I was going to write test cases for each effected exception class, like the following:
```php
class MissingActionExceptionTest extends TestCase
{

    /**
     * Test the getPrevious() method works.
     *
     * @return void
     */
    public function testGetPrevious()
    {
        $previous = new Exception();
        $exception = new MissingActionException('message', -1, $previous);
        $this->assertSame('message', $exception->getMessage());
        $this->assertSame(-1, $exception->getCode());
        $this->assertSame($previous, $exception->getPrevious());
    }

    /**
     * Test the getPrevious() method works for PHP7 Error
     */
    public function testGetPreviousError() {
        $this->skipIf(version_compare(PHP_VERSION, '7.0.0', '<'));

        $previous = new Error();
        $exception = new MissingActionException('message', -1, $previous);
        $this->assertSame('message', $exception->getMessage());
        $this->assertSame(-1, $exception->getCode());
        $this->assertSame($previous, $exception->getPrevious());
    }
}
```

But should I create something like a `ExceptionsTest` and test all exceptions there instead?