### PR TITLE
Fix invalid SQL on paginated results.

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -829,4 +829,18 @@ class EagerLoader
 
         return $keys;
     }
+
+    /**
+     * Clone hook implementation
+     *
+     * Clone the _matching eager loader as well.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        if ($this->_matching) {
+            $this->_matching = clone $this->_matching;
+        }
+    }
 }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -765,6 +765,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $clone->formatResults(null, true);
         $clone->setSelectTypeMap(new TypeMap());
         $clone->decorateResults(null, true);
+        $clone->setEagerLoader(clone $this->getEagerLoader());
 
         return $clone;
     }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2714,12 +2714,20 @@ class QueryTest extends TestCase
         $query->offset(10)
             ->limit(1)
             ->order(['Articles.id' => 'DESC'])
-            ->contain(['Comments']);
+            ->contain(['Comments'])
+            ->matching('Comments');
         $copy = $query->cleanCopy();
 
         $this->assertNotSame($copy, $query);
-        $this->assertNotSame($copy->eagerLoader(), $query->eagerLoader());
-        $this->assertNotEmpty($copy->eagerLoader()->contain());
+        $copyLoader = $copy->getEagerLoader();
+        $loader = $query->getEagerLoader();
+        $this->assertEquals($copyLoader, $loader, 'should be equal');
+        $this->assertNotSame($copyLoader, $loader, 'should be clones');
+        $this->assertNotSame(
+            $this->readAttribute($copyLoader, '_matching'),
+            $this->readAttribute($loader, '_matching'),
+            'should be clones'
+        );
         $this->assertNull($copy->clause('offset'));
         $this->assertNull($copy->clause('limit'));
         $this->assertNull($copy->clause('order'));


### PR DESCRIPTION
When a query with nested matching calls was reused (via pagination), the bound EagerLoadable instances for the nested relations were re-applied incorrectly. By cloning the eagerloader objects when preparing the count() query we can side-step this issue from happening as state is no
longer shared between the two query executions.

Refs #10633