### PR TITLE
Added second signature for contain that matches the signature for mat…

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -126,12 +126,21 @@ class EagerLoader
      * @param array|string $associations list of table aliases to be queried.
      * When this method is called multiple times it will merge previous list with
      * the new one.
+     * @param callable|null $queryBuilder The query builder callable
      * @return array Containments.
      */
-    public function contain($associations = [])
+    public function contain($associations = [], callable $queryBuilder = null)
     {
         if (empty($associations)) {
             return $this->_containments;
+        }
+
+        if ($queryBuilder) {
+            $associations = [
+                $associations => [
+                    'queryBuilder' => $queryBuilder
+                ]
+            ];
         }
 
         $associations = (array)$associations;

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -128,6 +128,7 @@ class EagerLoader
      * the new one.
      * @param callable|null $queryBuilder The query builder callable
      * @return array Containments.
+     * @throws \InvalidArgumentException When using $queryBuilder with an array of $associations
      */
     public function contain($associations = [], callable $queryBuilder = null)
     {
@@ -136,6 +137,12 @@ class EagerLoader
         }
 
         if ($queryBuilder) {
+            if (!is_string($associations)) {
+                throw new InvalidArgumentException(
+                    sprintf('Cannot set containments. To use $queryBuilder, $associations must be a string')
+                );
+            }
+
             $associations = [
                 $associations => [
                     'queryBuilder' => $queryBuilder

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\EagerLoader;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * Tests EagerLoader
@@ -343,6 +344,28 @@ class EagerLoaderTest extends TestCase
         };
         $loader = new EagerLoader;
         $loader->contain('clients', $builder);
+
+        $expected = [
+            'clients' => [
+                'queryBuilder' => $builder
+            ]
+        ];
+        $this->assertEquals($expected, $loader->contain());
+    }
+
+    /**
+     * Tests passing an array of associations with a query builder
+     *
+     * @return void
+     */
+    public function testContainSecondSignatureInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder = function ($query) {
+        };
+        $loader = new EagerLoader;
+        $loader->contain(['clients'], $builder);
 
         $expected = [
             'clients' => [

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -333,6 +333,26 @@ class EagerLoaderTest extends TestCase
     }
 
     /**
+     * Tests using the same signature as matching with contain
+     *
+     * @return void
+     */
+    public function testContainSecondSignature()
+    {
+        $builder = function ($query) {
+        };
+        $loader = new EagerLoader;
+        $loader->contain('clients', $builder);
+
+        $expected = [
+            'clients' => [
+                'queryBuilder' => $builder
+            ]
+        ];
+        $this->assertEquals($expected, $loader->contain());
+    }
+
+    /**
      * Tests that query builders are stacked
      *
      * @return void

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2019,6 +2019,32 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Integration test that uses the contain signature that is the same as the
+     * matching signature
+     *
+     * @return void
+     */
+    public function testContainSecondSignature()
+    {
+        $table = TableRegistry::get('authors');
+        $table->hasMany('articles');
+        $query = new Query($this->connection, $table);
+        $query
+            ->select()
+            ->contain('articles', function ($q) {
+                return $q->where(['articles.id' => 1]);
+            });
+
+        $ids = [];
+        foreach ($query as $entity) {
+            foreach ((array)$entity->articles as $article) {
+                $ids[] = $article->id;
+            }
+        }
+        $this->assertEquals([1], array_unique($ids));
+    }
+
+    /**
      * Integration test to ensure that filtering associations with the queryBuilder
      * option works.
      *


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/10651

Adds a new signature for `contain()` that matches the signature of `matching()`:

```php
$query->contain('Articles', function ($q) {
    return $q->where(['Articles.published' => true]);
});
```