### PR TITLE
Add missing version number for @deprecated

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -760,7 +760,7 @@ class Shell
      * @throws \Cake\Console\Exception\StopException
      * @return int Error code
      * @link http://book.cakephp.org/3.0/en/console-and-shells.html#styling-output
-     * @deprecated Since 3.2.0. Use Shell::abort() instead.
+     * @deprecated 3.2.0 Use Shell::abort() instead.
      */
     public function error($title, $message = null, $exitCode = self::CODE_ERROR)
     {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -46,7 +46,7 @@ class DateTimeType extends Type implements TypeInterface
      * class is constructed. After that use `useMutable()` or `useImmutable()` instead.
      *
      * @var string
-     * @deprecated Use DateTimeType::useMutable() or DateTimeType::useImmutable() instead.
+     * @deprecated 3.2.0 Use DateTimeType::useMutable() or DateTimeType::useImmutable() instead.
      */
     public static $dateTimeClass = 'Cake\I18n\Time';
 

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -27,7 +27,7 @@ class DateType extends DateTimeType
      * class is constructed. After that use `useMutable()` or `useImmutable()` instead.
      *
      * @var string
-     * @deprecated Use DateType::useMutable() or DateType::useImmutable() instead.
+     * @deprecated 3.2.0 Use DateType::useMutable() or DateType::useImmutable() instead.
      */
     public static $dateTimeClass = 'Cake\I18n\Date';
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -88,7 +88,7 @@ class Event
      *
      * @param string $attribute Attribute name.
      * @return mixed
-     * @deprecated Public properties will be removed.
+     * @deprecated 3.4.0 Public properties will be removed.
      */
     public function __get($attribute)
     {
@@ -109,7 +109,7 @@ class Event
      * @param string $attribute Attribute name.
      * @param mixed $value The value to set.
      * @return void
-     * @deprecated Public properties will be removed.
+     * @deprecated 3.4.0 Public properties will be removed.
      */
     public function __set($attribute, $value)
     {


### PR DESCRIPTION
This pull request add the missing version number for the function that are deprecated. 
