### PR TITLE
Allow more IDE detectability. Fix invalid doc blocks.

### DIFF
--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -85,7 +85,7 @@ class PDOStatement extends StatementDecorator
      * ```
      *
      * @param string $type 'num' for positional columns, assoc for named columns
-     * @return mixed Result array containing columns and values or false if no results
+     * @return array|false Result array containing columns and values or false if no results
      * are left
      */
     public function fetch($type = 'num')

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -393,7 +393,7 @@ trait QueryTrait
      * $singleUser = $query->select(['id', 'username'])->first();
      * ```
      *
-     * @return \Cake\Datasource\EntityInterface|null The first result from the ResultSet.
+     * @return \Cake\Datasource\EntityInterface|array|null The first result from the ResultSet.
      */
     public function first()
     {
@@ -408,7 +408,7 @@ trait QueryTrait
      * Get the first result from the executing query or raise an exception.
      *
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
-     * @return \Cake\Datasource\EntityInterface The first result from the ResultSet.
+     * @return \Cake\Datasource\EntityInterface|array The first result from the ResultSet.
      */
     public function firstOrFail()
     {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -393,7 +393,7 @@ trait QueryTrait
      * $singleUser = $query->select(['id', 'username'])->first();
      * ```
      *
-     * @return mixed the first result from the ResultSet
+     * @return \Cake\Datasource\EntityInterface|null The first result from the ResultSet.
      */
     public function first()
     {
@@ -408,18 +408,19 @@ trait QueryTrait
      * Get the first result from the executing query or raise an exception.
      *
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
-     * @return mixed The first result from the ResultSet.
+     * @return \Cake\Datasource\EntityInterface The first result from the ResultSet.
      */
     public function firstOrFail()
     {
         $entity = $this->first();
-        if ($entity) {
-            return $entity;
+        if (!$entity) {
+            throw new RecordNotFoundException(sprintf(
+                'Record not found in table "%s"',
+                $this->repository()->table()
+            ));
         }
-        throw new RecordNotFoundException(sprintf(
-            'Record not found in table "%s"',
-            $this->repository()->table()
-        ));
+
+        return $entity;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -40,6 +40,12 @@ use Traversable;
  *
  * Automatic generation of HTML FORMs from given data.
  *
+ * @method string text($fieldName, array $options = [])
+ * @method string number($fieldName, array $options = [])
+ * @method string email($fieldName, array $options = [])
+ * @method string password($fieldName, array $options = [])
+ * @method string search($fieldName, array $options = [])
+ *
  * @property \Cake\View\Helper\HtmlHelper $Html
  * @property \Cake\View\Helper\UrlHelper $Url
  * @link http://book.cakephp.org/3.0/en/views/helpers/form.html
@@ -2654,7 +2660,7 @@ class FormHelper extends Helper
      * If there is no active form null will be returned.
      *
      * @param \Cake\View\Form\ContextInterface|null $context Either the new context when setting, or null to get.
-     * @return null|\Cake\View\Form\ContextInterface The context for the form.
+     * @return \Cake\View\Form\ContextInterface The context for the form.
      */
     public function context($context = null)
     {
@@ -2671,7 +2677,7 @@ class FormHelper extends Helper
      * If no type can be matched a NullContext will be returned.
      *
      * @param mixed $data The data to get a context provider for.
-     * @return mixed Context provider.
+     * @return \Cake\View\Form\ContextInterface Context provider.
      * @throws \RuntimeException when the context class does not implement the
      *   ContextInterface.
      */

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -109,6 +109,7 @@ class ValidateUsersTable extends Table
  * FormHelperTest class
  *
  * @property \Cake\View\Helper\FormHelper $Form
+ * @property \Cake\View\View $View
  */
 class FormHelperTest extends TestCase
 {
@@ -126,6 +127,11 @@ class FormHelperTest extends TestCase
      * @var bool
      */
     public $autoFixtures = false;
+
+    /**
+     * @var array
+     */
+    protected $article = [];
 
     /**
      * setUp method
@@ -8459,7 +8465,7 @@ class FormHelperTest extends TestCase
         $this->Form->templates(['input' => '<input/>']);
         $this->assertEquals('<input/>', $this->Form->templater()->get('input'));
 
-        $this->assertNull($this->Form->resetTemplates());
+        $this->Form->resetTemplates();
         $this->assertNotEquals('<input/>', $this->Form->templater()->get('input'));
     }
 


### PR DESCRIPTION
So far 
```
$result = $this->Bundles->find()->where(['name' => $bundle['name']])->first();
```
always needed a manual inline doc block, as first() said "mixed".
With this it will be `EntityInterface|null`, as expected by Query(Trait).
It then also more clearly states that this could return null :)

Also fixed up a few other lies.