### PR TITLE
Fixed overwriting existing flash messages if none were retained

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -452,7 +452,7 @@ abstract class IntegrationTestCase extends TestCase
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
             $this->_requestSession = $request['session'];
-            if ($this->_retainFlashMessages) {
+            if ($this->_retainFlashMessages && $this->_flashMessages) {
                 $this->_requestSession->write('Flash', $this->_flashMessages);
             }
             $this->_response = $response;

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -420,6 +420,21 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test flash assertions stored with enableRememberFlashMessages() even if
+     * no view is rendered
+     *
+     * @return void
+     */
+    public function testFlashAssertionsWithNoRender()
+    {
+        $this->enableRetainFlashMessages();
+        $this->get('/posts/flashNoRender');
+        $this->assertRedirect();
+
+        $this->assertSession('An error message', 'Flash.flash.0.message');
+    }
+
+    /**
      * Tests the failure message for assertCookieNotSet
      *
      * @expectedException \PHPUnit\Framework\AssertionFailedError

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -70,6 +70,7 @@ class PostsController extends AppController
     public function flashNoRender()
     {
         $this->Flash->error('An error message');
+
         return $this->redirect(['action' => 'index']);
     }
 

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -63,6 +63,17 @@ class PostsController extends AppController
     }
 
     /**
+     * Sets a flash message and redirects (no rendering)
+     *
+     * @return \Cake\Network\Response
+     */
+    public function flashNoRender()
+    {
+        $this->Flash->error('An error message');
+        return $this->redirect(['action' => 'index']);
+    }
+
+    /**
      * Stub get method
      *
      * @return void


### PR DESCRIPTION
This fixes `enableRetainFlashMessages()` from overwriting the flash messages if no messages were retained in the first place, which fixes an issue (https://github.com/cakephp/cakephp/pull/10626#issuecomment-303332243) where early response returns had their messages overwritten.

ping @mirko-pagliai 