### PR TITLE
3.5 - Add fluent setters to Route

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -182,6 +182,19 @@ class Route
     }
 
     /**
+     * Set pattern requirements for routing parameters
+     *
+     * @param array $patterns The patterns to apply to routing elements
+     * @return $this
+     */
+    public function setRequirements(array $patterns)
+    {
+        $this->options = array_merge($this->options, $patterns);
+
+        return $this;
+    }
+
+    /**
      * Check if a Route has been compiled into a regular expression.
      *
      * @return bool

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -182,12 +182,12 @@ class Route
     }
 
     /**
-     * Set pattern requirements for routing parameters
+     * Set routing key patterns for routing parameters
      *
      * @param array $patterns The patterns to apply to routing elements
      * @return $this
      */
-    public function setRequirements(array $patterns)
+    public function setPatterns(array $patterns)
     {
         $this->options = array_merge($this->options, $patterns);
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -195,6 +195,19 @@ class Route
     }
 
     /**
+     * Set host requirement
+     *
+     * @param string $host The host name this route is bound to
+     * @return $this
+     */
+    public function setHost($host)
+    {
+        $this->options['_host'] = $host;
+
+        return $this;
+    }
+
+    /**
      * Check if a Route has been compiled into a regular expression.
      *
      * @return bool

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -182,7 +182,7 @@ class Route
     }
 
     /**
-     * Set routing key patterns for routing parameters
+     * Set regexp patterns for routing parameters
      *
      * @param array $patterns The patterns to apply to routing elements
      * @return $this

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1553,4 +1553,25 @@ class RouteTest extends TestCase
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
         $route->setMethods(['nope']);
     }
+
+    /**
+     * Test setting requirements through the method
+     *
+     * @return void
+     */
+    public function testSetRequirements()
+    {
+        $route = new Route('/reviews/:date/:id', ['controller' => 'Reviews', 'action' => 'view']);
+        $result = $route->setRequirements([
+            'date' => '\d+\-\d+\-\d+',
+            'id' => '[a-z]+'
+        ]);
+        $this->assertSame($result, $route, 'Should return this');
+        $this->assertArrayHasKey('id', $route->options);
+        $this->assertArrayHasKey('date', $route->options);
+        $this->assertSame('[a-z]+', $route->options['id']);
+
+        $this->assertFalse($route->parse('/reviews/a-b-c/xyz'));
+        $this->assertNotEmpty($route->parse('/reviews/2016-05-12/xyz'));
+    }
 }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1523,4 +1523,34 @@ class RouteTest extends TestCase
         ];
         $this->assertEquals($expected, $route->parse('/', 'GET'));
     }
+
+    /**
+     * Test setting the method on a route.
+     *
+     * @return void
+     */
+    public function testSetMethods()
+    {
+        $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
+        $result = $route->setMethods(['put']);
+
+        $this->assertSame($result, $route, 'Should return this');
+        $this->assertSame(['PUT'], $route->defaults['_method'], 'method is wrong');
+
+        $route->setMethods(['post', 'get', 'patch']);
+        $this->assertSame(['POST', 'GET', 'PATCH'], $route->defaults['_method']);
+    }
+
+    /**
+     * Test setting the method on a route to an invalid method
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid HTTP method received. NOPE is invalid
+     * @return void
+     */
+    public function testSetMethodsInvalid()
+    {
+        $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
+        $route->setMethods(['nope']);
+    }
 }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1555,14 +1555,14 @@ class RouteTest extends TestCase
     }
 
     /**
-     * Test setting requirements through the method
+     * Test setting patterns through the method
      *
      * @return void
      */
-    public function testSetRequirements()
+    public function testSetPatterns()
     {
         $route = new Route('/reviews/:date/:id', ['controller' => 'Reviews', 'action' => 'view']);
-        $result = $route->setRequirements([
+        $result = $route->setPatterns([
             'date' => '\d+\-\d+\-\d+',
             'id' => '[a-z]+'
         ]);

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1574,4 +1574,28 @@ class RouteTest extends TestCase
         $this->assertFalse($route->parse('/reviews/a-b-c/xyz'));
         $this->assertNotEmpty($route->parse('/reviews/2016-05-12/xyz'));
     }
+
+    /**
+     * Test setting host requirements
+     *
+     * @return void
+     */
+    public function testSetHost()
+    {
+        $route = new Route('/reviews', ['controller' => 'Reviews', 'action' => 'index']);
+        $result = $route->setHost('blog.example.com');
+        $this->assertSame($result, $route, 'Should return this');
+
+        $request = new ServerRequest([
+            'environment' => [
+                'HTTP_HOST' => 'a.example.com',
+                'PATH_INFO' => '/reviews'
+            ]
+        ]);
+        $this->assertFalse($route->parseRequest($request));
+
+        $uri = $request->getUri();
+        $request = $request->withUri($uri->withHost('blog.example.com'));
+        $this->assertNotEmpty($route->parseRequest($request));
+    }
 }


### PR DESCRIPTION
Implement the fluent setter features for Route described in #10689. I've opted to use `set` prefixes on the methods to better match the conventions we are headed towards with other parts of the framework and because `extensions()` is already deprecated in favour of `setExtensions()` and I did not want two method styles in the same class.