### PR TITLE
Cake 2.x - Some fix into Paginator component for order / sort classic sintax

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -382,13 +382,13 @@ class PaginatorComponent extends Component {
 			}
 			return $options;
 		}
-
 		if (!empty($options['order']) && is_array($options['order'])) {
 			$order = array();
 			foreach ($options['order'] as $key => $value) {
 				if (is_int($key)) {
-					$key = $value;
-					$value = 'asc';
+					$field = explode(' ', $value);
+					$key = $field[0];
+					$value = count($field) === 2 ? trim($field[1]) : 'asc';
 				}
 				$field = $key;
 				$alias = $object->alias;

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -320,11 +320,19 @@ class PaginatorComponentTest extends CakeTestCase {
 
 		$Controller->PaginatorControllerPost->order = null;
 
+		/* ORDER ARRAY FIELD => SORT MODE */
 		$Controller->Paginator->settings = array(
 			'order' => array('PaginatorControllerComment.id' => 'ASC')
 		);
 		$results = Hash::extract($Controller->Paginator->paginate('PaginatorControllerComment'), '{n}.PaginatorControllerComment.id');
 		$this->assertEquals(array(1, 2, 3, 4, 5, 6), $results);
+
+		/* ORDER ARRAY "FIELD SORT" MODE */
+		$Controller->Paginator->settings = array(
+			'order' => array('PaginatorControllerComment.id DESC')
+		);
+		$results = Hash::extract($Controller->Paginator->paginate('PaginatorControllerComment'), '{n}.PaginatorControllerComment.id');
+		$this->assertEquals(array(6, 5, 4, 3, 2, 1), $results);
 
 		$Controller->Paginator->settings = array(
 			'order' => array('PaginatorControllerPost.id' => 'ASC')
@@ -619,6 +627,7 @@ class PaginatorComponentTest extends CakeTestCase {
 		$result = $Controller->Paginator->validateSort($Controller->PaginatorControllerPost, array());
 		$this->assertArrayNotHasKey('order', $result);
 
+		/* DEFAULT */
 		$Controller->PaginatorControllerPost->order = array(
 			'PaginatorControllerPost.id',
 			'PaginatorControllerPost.created' => 'asc'
@@ -627,6 +636,18 @@ class PaginatorComponentTest extends CakeTestCase {
 		$expected = array(
 			'PaginatorControllerPost.id' => 'asc',
 			'PaginatorControllerPost.created' => 'asc'
+		);
+		$this->assertEquals($expected, $result['order']);
+
+		/* CLASSIC */
+		$Controller->PaginatorControllerPost->order = array(
+			'PaginatorControllerPost.id ASC',
+			'PaginatorControllerPost.created DESC'
+		);
+		$result = $Controller->Paginator->validateSort($Controller->PaginatorControllerPost, array());
+		$expected = array(
+			'PaginatorControllerPost.id' => 'ASC',
+			'PaginatorControllerPost.created' => 'DESC'
 		);
 		$this->assertEquals($expected, $result['order']);
 	}

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -320,14 +320,12 @@ class PaginatorComponentTest extends CakeTestCase {
 
 		$Controller->PaginatorControllerPost->order = null;
 
-		/* ORDER ARRAY FIELD => SORT MODE */
 		$Controller->Paginator->settings = array(
 			'order' => array('PaginatorControllerComment.id' => 'ASC')
 		);
 		$results = Hash::extract($Controller->Paginator->paginate('PaginatorControllerComment'), '{n}.PaginatorControllerComment.id');
 		$this->assertEquals(array(1, 2, 3, 4, 5, 6), $results);
 
-		/* ORDER ARRAY "FIELD SORT" MODE */
 		$Controller->Paginator->settings = array(
 			'order' => array('PaginatorControllerComment.id DESC')
 		);
@@ -627,7 +625,6 @@ class PaginatorComponentTest extends CakeTestCase {
 		$result = $Controller->Paginator->validateSort($Controller->PaginatorControllerPost, array());
 		$this->assertArrayNotHasKey('order', $result);
 
-		/* DEFAULT */
 		$Controller->PaginatorControllerPost->order = array(
 			'PaginatorControllerPost.id',
 			'PaginatorControllerPost.created' => 'asc'
@@ -639,7 +636,6 @@ class PaginatorComponentTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result['order']);
 
-		/* CLASSIC */
 		$Controller->PaginatorControllerPost->order = array(
 			'PaginatorControllerPost.id ASC',
 			'PaginatorControllerPost.created DESC'


### PR DESCRIPTION
Hi folks,

I've noted that classic array "order" aren't work in pagination (CakePHP 2.x):

```php
$this->Paginator->settings['Post'] = array(
  'order' => array('Post.created DESC', 'Post.id ASC') // <--- this doesn't works
);

$items = $this->Paginator->paginate('Post');
```

In my test only this kind of syntax are working:

```php
'order' => array('Post.created' => 'DESC', 'Post.id' => 'ASC') // this works
'order' => 'Post.created DESC, Post.id ASC' // with string also works

'order' => array('Post.created DESC', 'Post.id ASC') // <--- this doesn't works but with this PR will ;)
```

So this pull request has a fix to support all kind of order by syntax, link find() model method does.

Thanks ;)