### PR TITLE
Clone queries during pagination.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -187,9 +187,10 @@ class PaginatorComponent extends Component
             $query->applyOptions($options);
         }
 
+        $cleanQuery = clone $query;
         $results = $query->all();
         $numResults = count($results);
-        $count = $numResults ? $query->count() : 0;
+        $count = $numResults ? $cleanQuery->count() : 0;
 
         $defaults = $this->getDefaults($alias, $settings);
         unset($defaults[0]);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -19,6 +19,7 @@ use Cake\Controller\Component\PaginatorComponent;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\EntityInterface;
 use Cake\Http\ServerRequest;
 use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\Entity;
@@ -47,7 +48,10 @@ class PaginatorComponentTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.posts'];
+    public $fixtures = [
+        'core.posts', 'core.articles', 'core.articles_tags',
+        'core.authors', 'core.authors_tags', 'core.tags'
+    ];
 
     /**
      * Don't load data for fixtures for all tests
@@ -200,6 +204,34 @@ class PaginatorComponentTest extends TestCase
 
         $this->Paginator->paginate($table, $settings);
         $this->assertEquals('popular', $this->request->params['paging']['PaginatorPosts']['finder']);
+    }
+
+    /**
+     * Test that nested eager loaders don't trigger invalid SQL errors.
+     *
+     * @return void
+     */
+    public function testPaginateNestedEagerLoader()
+    {
+        $this->loadFixtures('Articles', 'Tags', 'Authors', 'ArticlesTags', 'AuthorsTags');
+        $articles = TableRegistry::get('Articles');
+        $articles->belongsToMany('Tags');
+        $tags = TableRegistry::get('Tags');
+        $tags->belongsToMany('Authors');
+
+        $articles->eventManager()->on('Model.beforeFind', function($event, $query) {
+            $query ->matching('Tags', function ($q) {
+                return $q->matching('Authors', function ($q) {
+                    return $q->where(['Authors.name' => 'larry']);
+                });
+            });
+        });
+        $results = $this->Paginator->paginate($articles, []);
+
+        $result = $results->first();
+        $this->assertInstanceOf(EntityInterface::class, $result);
+        $this->assertInstanceOf(EntityInterface::class, $result->_matchingData['Tags']);
+        $this->assertInstanceOf(EntityInterface::class, $result->_matchingData['Authors']);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -219,7 +219,7 @@ class PaginatorComponentTest extends TestCase
         $tags = TableRegistry::get('Tags');
         $tags->belongsToMany('Authors');
 
-        $articles->eventManager()->on('Model.beforeFind', function($event, $query) {
+        $articles->eventManager()->on('Model.beforeFind', function ($event, $query) {
             $query ->matching('Tags', function ($q) {
                 return $q->matching('Authors', function ($q) {
                     return $q->where(['Authors.name' => 'larry']);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1429,7 +1429,7 @@ class TableTest extends TestCase
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
         ]);
-        $result = $table->find('all')->contain(['authors'])->first();
+        $result = $table->find('all')->contain(['Authors'])->first();
         $this->assertInstanceOf('TestApp\Model\Entity\Author', $result->author);
     }
 
@@ -1444,7 +1444,7 @@ class TableTest extends TestCase
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
         ]);
-        $result = $table->find('all')->contain(['authors' => ['articles']])->first();
+        $result = $table->find('all')->contain(['Authors' => ['Articles']])->first();
         $this->assertCount(2, $result->author->articles);
         foreach ($result->author->articles as $article) {
             $this->assertInstanceOf('TestApp\Model\Entity\Article', $article);
@@ -1462,7 +1462,7 @@ class TableTest extends TestCase
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
         ]);
-        $result = $table->find('all')->contain(['tags'])->first();
+        $result = $table->find('all')->contain(['Tags'])->first();
         $this->assertInstanceOf('TestApp\Model\Entity\Tag', $result->tags[0]);
         $this->assertInstanceOf(
             'TestApp\Model\Entity\ArticlesTag',
@@ -1480,7 +1480,7 @@ class TableTest extends TestCase
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
         ]);
-        $results = $table->find('all')->contain(['tags', 'authors'])->toArray();
+        $results = $table->find('all')->contain(['Tags', 'Authors'])->toArray();
         $this->assertCount(3, $results);
         foreach ($results as $article) {
             $this->assertFalse($article->dirty('id'));

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -22,8 +22,8 @@ class ArticlesTable extends Table
 
     public function initialize(array $config)
     {
-        $this->belongsTo('authors');
-        $this->belongsToMany('tags');
+        $this->belongsTo('Authors');
+        $this->belongsToMany('Tags');
         $this->hasMany('ArticlesTags');
     }
 

--- a/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTagsTable.php
@@ -22,7 +22,7 @@ class ArticlesTagsTable extends Table
 
     public function initialize(array $config)
     {
-        $this->belongsTo('articles');
-        $this->belongsTo('tags');
+        $this->belongsTo('Articles');
+        $this->belongsTo('Tags');
     }
 }

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -22,8 +22,8 @@ class TagsTable extends Table
 
     public function initialize(array $config)
     {
-        $this->belongsTo('authors');
-        $this->belongsToMany('articles');
+        $this->belongsTo('Authors');
+        $this->belongsToMany('Articles');
         $this->hasMany('ArticlesTags', ['propertyName' => 'extraInfo']);
     }
 }


### PR DESCRIPTION
While I don't think the SQL errors coming from EagerLoader re-use can be fixed without invasive changes to `EagerLoader`, we can treat the symptom of PaginatorComponent triggering this scenario by pre-emptively cloning the query.

Refs #10697