### PR TITLE
Add small/tiny integer type mappings.

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -32,6 +32,9 @@ class Type implements TypeInterface
      * @var array
      */
     protected static $_types = [
+        'tinyinteger' => 'Cake\Database\Type\IntegerType',
+        'smallinteger' => 'Cake\Database\Type\IntegerType',
+        'integer' => 'Cake\Database\Type\IntegerType',
         'biginteger' => 'Cake\Database\Type\IntegerType',
         'binary' => 'Cake\Database\Type\BinaryType',
         'boolean' => 'Cake\Database\Type\BoolType',
@@ -39,7 +42,6 @@ class Type implements TypeInterface
         'datetime' => 'Cake\Database\Type\DateTimeType',
         'decimal' => 'Cake\Database\Type\DecimalType',
         'float' => 'Cake\Database\Type\FloatType',
-        'integer' => 'Cake\Database\Type\IntegerType',
         'json' => 'Cake\Database\Type\JsonType',
         'string' => 'Cake\Database\Type\StringType',
         'text' => 'Cake\Database\Type\StringType',

--- a/tests/TestCase/Database/TypeTest.php
+++ b/tests/TestCase/Database/TypeTest.php
@@ -90,6 +90,10 @@ class TypeTest extends TestCase
         return [
             ['string'],
             ['text'],
+            ['smallinteger'],
+            ['tinyinteger'],
+            ['integer'],
+            ['biginteger'],
         ];
     }
 


### PR DESCRIPTION
The small and tiny integer types were not mapped in `Type`. This fixes errors that would be created when small/tiny integer fields were used as conditions in queries.