### PR TITLE
Add tests covering small/tiny integer in save operations.

### DIFF
--- a/tests/Fixture/DatatypesFixture.php
+++ b/tests/Fixture/DatatypesFixture.php
@@ -29,6 +29,8 @@ class DatatypesFixture extends TestFixture
         'id' => ['type' => 'biginteger'],
         'cost' => ['type' => 'decimal', 'length' => 20, 'precision' => 0, 'null' => true],
         'floaty' => ['type' => 'float', 'null' => true],
+        'small' => ['type' => 'smallinteger', 'null' => true],
+        'tiny' => ['type' => 'tinyinteger', 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3030,6 +3030,9 @@ class QueryTest extends TestCase
         $table = TableRegistry::get('Datatypes');
         $entity = $table->newEntity([]);
         $entity->cost = $big;
+        $entity->tiny = 1;
+        $entity->small = 10;
+
         $table->save($entity);
         $out = $table->find()->where([
             'cost' => $big


### PR DESCRIPTION
Gain integration coverage for small/tiny integer types.