### PR TITLE
HTTP Client cookies add/remove methods.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -18,6 +18,7 @@ use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Http\Client\CookieCollection;
 use Cake\Http\Client\Request;
+use Cake\Http\Cookie\CookieInterface;
 use Cake\Utility\Hash;
 
 /**
@@ -180,6 +181,32 @@ class Client
     public function cookies()
     {
         return $this->_cookies;
+    }
+
+    /**
+     * Adds a cookie to the Client collection.
+     *
+     * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie object.
+     * @return $this
+     */
+    public function addCookie(CookieInterface $cookie)
+    {
+        $this->_cookies = $this->_cookies->add($cookie);
+
+        return $this;
+    }
+
+    /**
+     * Removes a cookie from the Client collection.
+     *
+     * @param string $name Cookie name.
+     * @return $this
+     */
+    public function removeCookie($name)
+    {
+        $this->_cookies = $this->_cookies->remove($name);
+
+        return $this;
     }
 
     /**

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -16,8 +16,8 @@ namespace Cake\Http;
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Http\Client\CookieCollection;
 use Cake\Http\Client\Request;
+use Cake\Http\Cookie\CookieCollection;
 use Cake\Utility\Hash;
 
 /**
@@ -175,9 +175,7 @@ class Client
     /**
      * Get the cookies stored in the Client.
      *
-     * Returns an array of cookie data arrays.
-     *
-     * @return \Cake\Http\Client\CookieCollection
+     * @return \Cake\Http\Cookie\CookieCollection
      */
     public function cookies()
     {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -16,6 +16,7 @@ namespace Cake\Http;
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Http\Client\CookieCollection as ClientCookieCollection;
 use Cake\Http\Client\Request;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\Utility\Hash;
@@ -168,7 +169,7 @@ class Client
             $this->_cookies = $this->_config['cookieJar'];
             $this->setConfig('cookieJar', null);
         } else {
-            $this->_cookies = new CookieCollection();
+            $this->_cookies = new ClientCookieCollection();
         }
     }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -197,19 +197,6 @@ class Client
     }
 
     /**
-     * Removes a cookie from the Client collection.
-     *
-     * @param string $name Cookie name.
-     * @return $this
-     */
-    public function removeCookie($name)
-    {
-        $this->_cookies = $this->_cookies->remove($name);
-
-        return $this;
-    }
-
-    /**
      * Do a GET request.
      *
      * The $data argument supports a special `_content` key

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -176,10 +176,34 @@ class Client
      * Get the cookies stored in the Client.
      *
      * @return \Cake\Http\Cookie\CookieCollection
+     * @deprecated 3.5.0 Use getCookies() instead.
      */
     public function cookies()
     {
         return $this->_cookies;
+    }
+
+    /**
+     * Get the cookies stored in the Client.
+     *
+     * @return \Cake\Http\Cookie\CookieCollection
+     */
+    public function getCookies()
+    {
+        return $this->_cookies;
+    }
+
+    /**
+     * Sets the cookie collection.
+     *
+     * @param \Cake\Http\Cookie\CookieCollection $cookies Cookie collection to be set.
+     * @return $this
+     */
+    public function setCookies(CookieCollection $cookies)
+    {
+        $this->_cookies = $cookies;
+
+        return $this;
     }
 
     /**

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -16,9 +16,8 @@ namespace Cake\Http;
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Http\Client\CookieCollection as ClientCookieCollection;
+use Cake\Http\Client\CookieCollection;
 use Cake\Http\Client\Request;
-use Cake\Http\Cookie\CookieCollection;
 use Cake\Utility\Hash;
 
 /**
@@ -169,42 +168,18 @@ class Client
             $this->_cookies = $this->_config['cookieJar'];
             $this->setConfig('cookieJar', null);
         } else {
-            $this->_cookies = new ClientCookieCollection();
+            $this->_cookies = new CookieCollection();
         }
     }
 
     /**
      * Get the cookies stored in the Client.
      *
-     * @return \Cake\Http\Cookie\CookieCollection
-     * @deprecated 3.5.0 Use getCookies() instead.
+     * @return \Cake\Http\Client\CookieCollection
      */
     public function cookies()
     {
         return $this->_cookies;
-    }
-
-    /**
-     * Get the cookies stored in the Client.
-     *
-     * @return \Cake\Http\Cookie\CookieCollection
-     */
-    public function getCookies()
-    {
-        return $this->_cookies;
-    }
-
-    /**
-     * Sets the cookie collection.
-     *
-     * @param \Cake\Http\Cookie\CookieCollection $cookies Cookie collection to be set.
-     * @return $this
-     */
-    public function setCookies(CookieCollection $cookies)
-    {
-        $this->_cookies = $cookies;
-
-        return $this;
     }
 
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -622,22 +622,18 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Test cookie collection getter and setter,
+     * Test cookieJar config option.
      *
      * @return void
      */
-    public function testCookies()
+    public function testCookieJar()
     {
         $jar = new CookieCollection();
         $http = new Client([
             'cookieJar' => $jar
         ]);
 
-        $this->assertSame($jar, $http->getCookies());
-
-        $cookies = new CookieCollection();
-        $http->setCookies($cookies);
-        $this->assertSame($cookies, $http->getCookies());
+        $this->assertSame($jar, $http->cookies());
     }
 
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -17,6 +17,7 @@ use Cake\Core\Configure;
 use Cake\Http\Client;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
+use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -618,6 +619,25 @@ class ClientTest extends TestCase
         $this->assertCount(1, $cookies);
         $this->assertTrue($cookies->has('first'));
         $this->assertFalse($cookies->has('expiring'));
+    }
+
+    /**
+     * Test cookie collection getter and setter,
+     *
+     * @return void
+     */
+    public function testCookies()
+    {
+        $jar = new CookieCollection();
+        $http = new Client([
+            'cookieJar' => $jar
+        ]);
+
+        $this->assertSame($jar, $http->getCookies());
+
+        $cookies = new CookieCollection();
+        $http->setCookies($cookies);
+        $this->assertSame($cookies, $http->getCookies());
     }
 
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -654,25 +654,6 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Test removeCookie() method.
-     *
-     * @return void
-     */
-    public function testRemoveCookie()
-    {
-        $cookie = new Cookie('foo');
-        $jar = new CookieCollection([$cookie]);
-        $client = new Client([
-            'cookieJar' => $jar
-        ]);
-
-        $this->assertTrue($client->cookies()->has('foo'));
-
-        $client->removeCookie('foo');
-        $this->assertFalse($client->cookies()->has('foo'));
-    }
-
-    /**
      * test head request with querystring data
      *
      * @return void

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -17,6 +17,7 @@ use Cake\Core\Configure;
 use Cake\Http\Client;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
+use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
 
@@ -634,6 +635,41 @@ class ClientTest extends TestCase
         ]);
 
         $this->assertSame($jar, $http->cookies());
+    }
+
+    /**
+     * Test addCookie() method.
+     *
+     * @return void
+     */
+    public function testAddCookie()
+    {
+        $client = new Client();
+        $cookie = new Cookie('foo');
+
+        $this->assertFalse($client->cookies()->has('foo'));
+
+        $client->addCookie($cookie);
+        $this->assertTrue($client->cookies()->has('foo'));
+    }
+
+    /**
+     * Test removeCookie() method.
+     *
+     * @return void
+     */
+    public function testRemoveCookie()
+    {
+        $cookie = new Cookie('foo');
+        $jar = new CookieCollection([$cookie]);
+        $client = new Client([
+            'cookieJar' => $jar
+        ]);
+
+        $this->assertTrue($client->cookies()->has('foo'));
+
+        $client->removeCookie('foo');
+        $this->assertFalse($client->cookies()->has('foo'));
     }
 
     /**


### PR DESCRIPTION
Cookie collections are immutable in 3.5 and the setter allows for modifying client cookies on runtime.