### PR TITLE
3.next - Add remaining fluent methods for routes.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -184,11 +184,18 @@ class Route
     /**
      * Set regexp patterns for routing parameters
      *
+     * If any of your patterns contain multibyte values, the `multibytePattern`
+     * mode will be enabled.
+     *
      * @param array $patterns The patterns to apply to routing elements
      * @return $this
      */
     public function setPatterns(array $patterns)
     {
+        $patternValues = implode("", $patterns);
+        if (mb_strlen($patternValues) < strlen($patternValues)) {
+            $this->options['multibytePattern'] = true;
+        }
         $this->options = array_merge($this->options, $patterns);
 
         return $this;
@@ -203,6 +210,41 @@ class Route
     public function setHost($host)
     {
         $this->options['_host'] = $host;
+
+        return $this;
+    }
+
+    /**
+     * Set the names of parameters that will be converted into passed parameters
+     *
+     * @param array $names The names of the parameters that should be passed.
+     * @return $this
+     */
+    public function setPass(array $names)
+    {
+        $this->options['pass'] = $names;
+
+        return $this;
+    }
+
+    /**
+     * Set the names of parameters that will persisted automatically
+     *
+     * Persistent parametesr allow you to define which route parameters should be automatically
+     * included when generating new URLs. You can override persistent parameters
+     * by redefining them in a URL or remove them by setting the persistent parameter to `false`.
+     *
+     * ```
+     * // remove a persistent 'date' parameter
+     * Router::url(['date' => false', ...]);
+     * ```
+     *
+     * @param array $names The names of the parameters that should be passed.
+     * @return $this
+     */
+    public function setPersist(array $names)
+    {
+        $this->options['persist'] = $names;
 
         return $this;
     }

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1570,9 +1570,27 @@ class RouteTest extends TestCase
         $this->assertArrayHasKey('id', $route->options);
         $this->assertArrayHasKey('date', $route->options);
         $this->assertSame('[a-z]+', $route->options['id']);
+        $this->assertArrayNotHasKey('multibytePattern', $route->options);
 
         $this->assertFalse($route->parse('/reviews/a-b-c/xyz'));
         $this->assertNotEmpty($route->parse('/reviews/2016-05-12/xyz'));
+    }
+
+    /**
+     * Test setting patterns enables multibyte mode
+     *
+     * @return void
+     */
+    public function testSetPatternsMultibyte()
+    {
+        $route = new Route('/reviews/:accountid/:slug', ['controller' => 'Reviews', 'action' => 'view']);
+        $result = $route->setPatterns([
+            'date' => '[A-zА-я\-\ ]+',
+            'accountid' => '[a-z]+'
+        ]);
+        $this->assertArrayHasKey('multibytePattern', $route->options);
+
+        $this->assertNotEmpty($route->parse('/reviews/abcs/bla-blan-тест'));
     }
 
     /**
@@ -1597,5 +1615,31 @@ class RouteTest extends TestCase
         $uri = $request->getUri();
         $request = $request->withUri($uri->withHost('blog.example.com'));
         $this->assertNotEmpty($route->parseRequest($request));
+    }
+
+    /**
+     * Test setting pass parameters
+     *
+     * @return void
+     */
+    public function testSetPass()
+    {
+        $route = new Route('/reviews/:date/:id', ['controller' => 'Reviews', 'action' => 'view']);
+        $result = $route->setPass(['date', 'id']);
+        $this->assertSame($result, $route, 'Should return this');
+        $this->assertEquals(['date', 'id'], $route->options['pass']);
+    }
+
+    /**
+     * Test setting persisted parameters
+     *
+     * @return void
+     */
+    public function testSetPersist()
+    {
+        $route = new Route('/reviews/:date/:id', ['controller' => 'Reviews', 'action' => 'view']);
+        $result = $route->setPersist(['date']);
+        $this->assertSame($result, $route, 'Should return this');
+        $this->assertEquals(['date'], $route->options['persist']);
     }
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -882,4 +882,28 @@ class RouteBuilderTest extends TestCase
             $route->defaults
         );
     }
+
+    /**
+     * Integration test for http method helpers and route fluent method
+     *
+     * @return void
+     */
+    public function testHttpMethodIntegration()
+    {
+        $routes = new RouteBuilder($this->collection, '/');
+        $routes->scope('/', function ($routes) {
+            $routes->get('/faq/:page', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
+                ->setPatterns(['page' => '[a-z0-9_]+'])
+                ->setHost('docs.example.com');
+
+            $routes->post('/articles/:id', ['controller' => 'Articles', 'action' => 'update'], 'article:update')
+                ->setPatterns(['id' => '[0-9]+'])
+                ->setPass(['id']);
+        });
+        $this->assertCount(2, $this->collection->routes());
+        $this->assertEquals(['faq', 'article:update'], array_keys($this->collection->named()));
+        $this->assertNotEmpty($this->collection->parse('/faq/things_you_know'));
+        $result = $this->collection->parse('/articles/123');
+        $this->assertEquals(['123'], $result['pass']);
+    }
 }


### PR DESCRIPTION
I've made the multibyte option an implicit setting. I feel this makes routing simpler to use as we can infer from the patterns used whether or not multiple patterns should be used. Having an additional method call required makes Route clunkier to use.

Refs #10689