### PR TITLE
Improved parsing of AngularJS URLS.

### DIFF
--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -123,7 +123,7 @@ class TextHelper extends Helper
                     (?<left>[\[<(]) # left paren,brace
                     (?>
                         # Lax match URL
-                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]()#@\+~!;%]+)?)
+                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\()#@\+~!;,%]+[^-_:?=&>\[\()#@\+~!;,.%\s])?)
                         (?<right>[\])>]) # right paren,brace
                     )
                 )

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -123,7 +123,7 @@ class TextHelper extends Helper
                     (?<left>[\[<(]) # left paren,brace
                     (?>
                         # Lax match URL
-                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\()#@\+~!;,%]+[^-_:?=&>\[\()#@\+~!;,.%\s])?)
+                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]\(\#@\+~!;,%]+[^-_:?>\[\]\(\#@\+~!;<,.%\s])?)
                         (?<right>[\])>]) # right paren,brace
                     )
                 )

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -123,7 +123,7 @@ class TextHelper extends Helper
                     (?<left>[\[<(]) # left paren,brace
                     (?>
                         # Lax match URL
-                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]\(\#@\+~!;,%]+[^-_:?>\[\]\(\@\+~!;<,.%\s])?)
+                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]\(\)\#\@\+~!;,%]+[^-_:?>\[\(\@\+~!;<,.%\s])?)
                         (?<right>[\])>]) # right paren,brace
                     )
                 )

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -123,7 +123,7 @@ class TextHelper extends Helper
                     (?<left>[\[<(]) # left paren,brace
                     (?>
                         # Lax match URL
-                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]()#@\+~%]+)?)
+                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]()#@\+~!;%]+)?)
                         (?<right>[\])>]) # right paren,brace
                     )
                 )

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -123,7 +123,7 @@ class TextHelper extends Helper
                     (?<left>[\[<(]) # left paren,brace
                     (?>
                         # Lax match URL
-                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]()#@\+~!;%]+)?)
+                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]()#@\+~!%]+)?)
                         (?<right>[\])>]) # right paren,brace
                     )
                 )

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -123,7 +123,7 @@ class TextHelper extends Helper
                     (?<left>[\[<(]) # left paren,brace
                     (?>
                         # Lax match URL
-                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]\(\#@\+~!;,%]+[^-_:?>\[\]\(\#@\+~!;<,.%\s])?)
+                        (?<url>(?:https?|ftp|nntp):\/\/[\p{L}0-9.\-_:]+(?:[\/?][\p{L}0-9.\-_:\/?=&>\[\]\(\#@\+~!;,%]+[^-_:?>\[\]\(\@\+~!;<,.%\s])?)
                         (?<right>[\])>]) # right paren,brace
                     )
                 )

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -376,6 +376,14 @@ class TextHelperTest extends TestCase
             [
                 'https://fakedomain.ext/path/#!topic/test;other;tag',
                 '<a href="https://fakedomain.ext/path/#!topic/test;other;tag">https://fakedomain.ext/path/#!topic/test;other;tag</a>'
+            ],
+            [
+                'This is text,https://fakedomain.ext/path/#!topic/test,tag, with a comma',
+                'This is text,<a href="https://fakedomain.ext/path/#!topic/test,tag">https://fakedomain.ext/path/#!topic/test,tag</a>, with a comma'
+            ],
+            [
+                'This is text,https://fakedomain.ext/path/#!topic/test,tag, with a comma',
+                'This is text <a href="https://fakedomain.ext/path/#!topic/path">https://fakedomain.ext/path/#!topic/path</a>!'
             ]
         ];
     }

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -368,6 +368,14 @@ class TextHelperTest extends TestCase
             [
                 'https://sevvlor.com/page%20not%20found',
                 '<a href="https://sevvlor.com/page%20not%20found">https://sevvlor.com/page%20not%20found</a>'
+            ],
+            [
+                'https://fakedomain.ext/path/#!topic/test',
+                '<a href="https://fakedomain.ext/path/#!topic/test">https://fakedomain.ext/path/#!topic/test</a>'
+            ],
+            [
+                'https://fakedomain.ext/path/#!topic/test;other;tag',
+                '<a href="https://fakedomain.ext/path/#!topic/test;other;tag">https://fakedomain.ext/path/#!topic/test;other;tag</a>'
             ]
         ];
     }

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -382,7 +382,7 @@ class TextHelperTest extends TestCase
                 'This is text,<a href="https://fakedomain.ext/path/#!topic/test,tag">https://fakedomain.ext/path/#!topic/test,tag</a>, with a comma'
             ],
             [
-                'This is text,https://fakedomain.ext/path/#!topic/test,tag, with a comma',
+                'This is text https://fakedomain.ext/path/#!topic/path!',
                 'This is text <a href="https://fakedomain.ext/path/#!topic/path">https://fakedomain.ext/path/#!topic/path</a>!'
             ]
         ];


### PR DESCRIPTION
The AngularJS URLS may contain `;` and `!`, they broke (parsed partially).

I have added the two characters to the regex and added the unittests. Though I really think that I (or someone else) should look into an more permanent solution to this.

See issue #10329 