### PR TITLE
Fix doc block for HtmlHelper::link()

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -335,6 +335,7 @@ class HtmlHelper extends Helper
      * - `confirm` JavaScript confirmation message.
      *
      * @param string|array $title The content to be wrapped by `<a>` tags.
+     *   Can also be array if $url is null and will use the URL as title then.
      * @param string|array|null $url Cake-relative URL or array of URL parameters, or
      *   external URL (starts with http://)
      * @param array $options Array of options and HTML attributes.

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -334,7 +334,7 @@ class HtmlHelper extends Helper
      *   over value of `escape`)
      * - `confirm` JavaScript confirmation message.
      *
-     * @param string $title The content to be wrapped by `<a>` tags.
+     * @param string|array $title The content to be wrapped by `<a>` tags.
      * @param string|array|null $url Cake-relative URL or array of URL parameters, or
      *   external URL (starts with http://)
      * @param array $options Array of options and HTML attributes.


### PR DESCRIPTION
Fix doc block when

     ->link([URL]);