### PR TITLE
Deprecate RouteCollection::extensions()

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -574,7 +574,7 @@ class RouteBuilder
      *   reverse routing lookups. If undefined a name will be generated for each
      *   connected route.
      * - `_ext` is an array of filename extensions that will be parsed out of the url if present.
-     *   See {@link \Cake\Routing\RouteCollection::extensions()}.
+     *   See {@link \Cake\Routing\RouteCollection::setExtensions()}.
      * - `_method` Only match requests with specific HTTP verbs.
      *
      * Example of using the `_method` condition:

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -122,7 +122,7 @@ class RouteCollection
 
         $extensions = $route->getExtensions();
         if (count($extensions) > 0) {
-            $this->extensions($extensions);
+            $this->setExtensions($extensions);
         }
     }
 
@@ -362,23 +362,48 @@ class RouteCollection
      * @param bool $merge Whether to merge with or override existing extensions.
      *   Defaults to `true`.
      * @return array The valid extensions.
+     * @deprecated 3.5.0 Use getExtensions()/setExtensions() instead.
      */
     public function extensions($extensions = null, $merge = true)
     {
-        if ($extensions === null) {
-            return $this->_extensions;
+        if ($extensions !== null) {
+            $this->setExtensions((array)$extensions, $merge);
         }
 
-        $extensions = (array)$extensions;
+        return $this->getExtensions();
+    }
+
+    /**
+     * Get the extensions that can be handled.
+     *
+     * @return array The valid extensions.
+     */
+    public function getExtensions()
+    {
+        return $this->_extensions;
+    }
+
+    /**
+     * Set the extensions that the route collection can handle.
+     *
+     * @param array $extensions The list of extensions to set.
+     * @param bool $merge Whether to merge with or override existing extensions.
+     *   Defaults to `true`.
+     * @return $this
+     */
+    public function setExtensions(array $extensions, $merge = true)
+    {
         if ($merge) {
             $extensions = array_unique(array_merge(
                 $this->_extensions,
                 $extensions
             ));
         }
+        $this->_extensions = $extensions;
 
-        return $this->_extensions = $extensions;
+        return $this;
     }
+
 
     /**
      * Register a middleware with the RouteCollection.

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -404,7 +404,6 @@ class RouteCollection
         return $this;
     }
 
-
     /**
      * Register a middleware with the RouteCollection.
      *

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -844,7 +844,7 @@ class Router
                 static::_loadRoutes();
             }
 
-            return array_unique(array_merge(static::$_defaultExtensions, $collection->extensions()));
+            return array_unique(array_merge(static::$_defaultExtensions, $collection->getExtensions()));
         }
         $extensions = (array)$extensions;
         if ($merge) {

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -593,9 +593,10 @@ class RouteCollectionTest extends TestCase
     }
 
     /**
-     * Test basic get/set of extensions.
+     * Test get/set combined method.
      *
      * @return void
+     * @deprecated 3.5.0
      */
     public function testExtensions()
     {
@@ -609,6 +610,25 @@ class RouteCollectionTest extends TestCase
 
         $this->collection->extensions(['csv'], false);
         $this->assertEquals(['csv'], $this->collection->extensions());
+    }
+
+    /**
+     * Test basic setExtension and its getter.
+     *
+     * @return void
+     */
+    public function testSetExtensions()
+    {
+        $this->assertEquals([], $this->collection->getExtensions());
+
+        $this->collection->setExtensions(['json']);
+        $this->assertEquals(['json'], $this->collection->getExtensions());
+
+        $this->collection->setExtensions(['rss', 'xml']);
+        $this->assertEquals(['json', 'rss', 'xml'], $this->collection->getExtensions());
+
+        $this->collection->setExtensions(['csv'], false);
+        $this->assertEquals(['csv'], $this->collection->getExtensions());
     }
 
     /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -593,7 +593,7 @@ class RouteCollectionTest extends TestCase
     }
 
     /**
-     * Test get/set combined method.
+     * Test combined get/set method.
      *
      * @return void
      * @deprecated 3.5.0


### PR DESCRIPTION
Another combined get/set method.

Refs #9978