### PR TITLE
[RFC] 3.next Cache fallback

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -175,10 +175,10 @@ class Cache
             if (!array_key_exists('fallback', $config)) {
                 throw $e;
             }
-            $fallbackEngine = static::engine($config['fallback']);
-            static::getRegistry()->set($name, $fallbackEngine);
-
-            return;
+            $fallbackEngine = clone static::engine($config['fallback']);
+            $copyableConfig = ['groups' => null, 'prefix' => null];
+            $fallbackEngine->init(array_intersect_key($config, $copyableConfig));
+            $registry->set($name, $fallbackEngine);
         }
 
         if ($config['className'] instanceof CacheEngine) {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -178,6 +178,13 @@ class Cache
 
                 return;
             }
+
+            if ($config['fallback'] === $name) {
+                throw new InvalidArgumentException(
+                    sprintf('"%s" cache configuration cannot fallback to itself.', $name)
+                );
+            }
+
             $fallbackEngine = clone static::engine($config['fallback']);
             $copyableConfig = ['groups' => null, 'prefix' => null];
             $fallbackEngine->init(array_intersect_key($config, $copyableConfig));

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -186,8 +186,11 @@ class Cache
             }
 
             $fallbackEngine = clone static::engine($config['fallback']);
-            $copyableConfig = ['groups' => null, 'prefix' => null];
-            $fallbackEngine->init(array_intersect_key($config, $copyableConfig));
+            $newConfig = $config + ['groups' => [], 'prefix' => null];
+            $fallbackEngine->setConfig('groups', $newConfig['groups'], false);
+            if ($newConfig['prefix']) {
+                $fallbackEngine->setConfig('prefix', $newConfig['prefix'], false);
+            }
             $registry->set($name, $fallbackEngine);
         }
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -175,6 +175,7 @@ class Cache
             if (!array_key_exists('fallback', $config)) {
                 $registry->set($name, new NullEngine());
                 trigger_error($e->getMessage(), E_USER_WARNING);
+
                 return;
             }
             $fallbackEngine = clone static::engine($config['fallback']);

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -173,7 +173,9 @@ class Cache
             $registry->load($name, $config);
         } catch (RuntimeException $e) {
             if (!array_key_exists('fallback', $config)) {
-                throw $e;
+                $registry->set($name, new NullEngine());
+                trigger_error($e->getMessage(), E_USER_WARNING);
+                return;
             }
             $fallbackEngine = clone static::engine($config['fallback']);
             $copyableConfig = ['groups' => null, 'prefix' => null];

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -168,7 +168,18 @@ class Cache
         }
 
         $config = static::$_config[$name];
-        $registry->load($name, $config);
+
+        try {
+            $registry->load($name, $config);
+        } catch (RuntimeException $e) {
+            if (!array_key_exists('fallback', $config)) {
+                throw $e;
+            }
+            $fallbackEngine = static::engine($config['fallback']);
+            static::getRegistry()->set($name, $fallbackEngine);
+
+            return;
+        }
 
         if ($config['className'] instanceof CacheEngine) {
             $config = $config['className']->getConfig();

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -427,7 +427,8 @@ class FileEngine extends CacheEngine
             //@codingStandardsIgnoreEnd
         }
 
-        if ($success && $this->_init && !($dir->isDir() && $dir->isWritable())) {
+        $isWritableDir = ($dir->isDir() && $dir->isWritable());
+        if (!$success || ($this->_init && !$isWritableDir)) {
             $this->_init = false;
             trigger_error(sprintf(
                 '%s is not writable',

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -420,21 +420,22 @@ class FileEngine extends CacheEngine
     {
         $dir = new SplFileInfo($this->_config['path']);
         $path = $dir->getPathname();
+        $success = true;
         if (!is_dir($path)) {
-            mkdir($path, 0775, true);
+            //@codingStandardsIgnoreStart
+            $success = @mkdir($path, 0775, true);
+            //@codingStandardsIgnoreEnd
         }
 
-        if ($this->_init && !($dir->isDir() && $dir->isWritable())) {
+        if ($success && $this->_init && !($dir->isDir() && $dir->isWritable())) {
             $this->_init = false;
             trigger_error(sprintf(
                 '%s is not writable',
                 $this->_config['path']
             ), E_USER_WARNING);
-
-            return false;
         }
 
-        return true;
+        return $success;
     }
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -21,6 +21,7 @@ use Cake\Cache\Engine\NullEngine;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PHPUnit\Framework\Error\Error;
 
 /**
@@ -93,6 +94,31 @@ class CacheTest extends TestCase
 
         Cache::drop('tests');
         Cache::drop('tests_fallback');
+        unlink($filename);
+    }
+
+    /**
+     * tests handling misconfiguration of fallback
+     *
+     * @return void
+     */
+    public function testCacheEngineFallbackToSelf()
+    {
+        $filename = tempnam(TMP, 'tmp_');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot fallback to itself');
+
+        Cache::setConfig('tests', [
+            'engine' => 'File',
+            'path' => $filename,
+            'prefix' => 'test_',
+            'fallback' => 'tests'
+        ]);
+
+        Cache::engine('tests');
+
+        Cache::drop('tests');
         unlink($filename);
     }
 

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -168,29 +168,31 @@ class CacheTest extends TestCase
         Cache::setConfig('tests', [
             'engine' => 'File',
             'path' => $filename,
-            'prefix' => 'test_',
             'fallback' => 'tests_fallback',
-            'groups' => ['integration_group']
+            'groups' => ['integration_group', 'integration_group_2']
         ]);
         Cache::setConfig('tests_fallback', [
             'engine' => 'File',
             'path' => $filename,
-            'prefix' => 'test_fallback_',
             'fallback' => 'tests_fallback_final',
+            'groups' => ['integration_group'],
         ]);
         Cache::setConfig('tests_fallback_final', [
             'engine' => 'File',
             'path' => TMP,
-            'prefix' => 'test_fallback_final_',
+            'groups' => ['integration_group_3'],
         ]);
 
-        $this->assertTrue(Cache::write('fallback', 'worked', 'tests'));
-        $this->assertSame('worked', Cache::read('fallback', 'tests'));
-        $this->assertTrue(Cache::delete('fallback', 'tests'));
+        $this->assertTrue(Cache::write('grouped', 'worked', 'tests'));
+        $this->assertTrue(Cache::write('grouped_2', 'worked', 'tests_fallback'));
+        $this->assertTrue(Cache::write('grouped_3', 'worked', 'tests_fallback_final'));
 
-        $this->assertTrue(Cache::write('fallback_grouped', 'worked', 'tests'));
         $this->assertTrue(Cache::clearGroup('integration_group', 'tests'));
-        $this->assertFalse(Cache::read('fallback_grouped', 'tests'));
+
+        $this->assertFalse(Cache::read('grouped', 'tests'));
+        $this->assertFalse(Cache::read('grouped_2', 'tests_fallback'));
+
+        $this->assertSame('worked', Cache::read('grouped_3', 'tests_fallback_final'));
 
         Cache::drop('tests');
         Cache::drop('tests_fallback');

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -17,9 +17,11 @@ namespace Cake\Test\TestCase\Cache;
 use Cake\Cache\Cache;
 use Cake\Cache\CacheRegistry;
 use Cake\Cache\Engine\FileEngine;
+use Cake\Cache\Engine\NullEngine;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Error\Error;
 
 /**
  * CacheTest class
@@ -196,39 +198,43 @@ class CacheTest extends TestCase
         Cache::disable();
 
         $result = Cache::engine('tests');
-        $this->assertInstanceOf('Cake\Cache\Engine\NullEngine', $result);
+        $this->assertInstanceOf(NullEngine::class, $result);
     }
 
     /**
      * Test configuring an invalid class fails
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cache engines must use Cake\Cache\CacheEngine
      * @return void
      */
     public function testConfigInvalidClassType()
     {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Cache engines must use Cake\Cache\CacheEngine');
+
         Cache::setConfig('tests', [
             'className' => '\StdClass'
         ]);
-        Cache::engine('tests');
+        $result = Cache::engine('tests');
+        $this->assertInstanceOf(NullEngine::class, $result);
     }
 
     /**
-     * Test engine init failing causes an error
+     * Test engine init failing triggers an error but falls back to NullEngine
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage not properly configured
      * @return void
      */
     public function testConfigFailedInit()
     {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('is not properly configured');
+
         $mock = $this->getMockForAbstractClass('Cake\Cache\CacheEngine', [], '', true, true, true, ['init']);
         $mock->method('init')->will($this->returnValue(false));
         Cache::setConfig('tests', [
             'engine' => $mock
         ]);
-        Cache::engine('tests');
+        $result = Cache::engine('tests');
+        $this->assertInstanceOf(NullEngine::class, $result);
     }
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -71,9 +71,11 @@ class CacheTest extends TestCase
      */
     public function testCacheEngineFallback()
     {
+        $filename = tempnam(TMP, 'tmp_');
+
         Cache::setConfig('tests', [
             'engine' => 'File',
-            'path' => DS . 'missing_dir',
+            'path' => $filename,
             'prefix' => 'test_',
             'fallback' => 'tests_fallback'
         ]);
@@ -89,6 +91,7 @@ class CacheTest extends TestCase
 
         Cache::drop('tests');
         Cache::drop('tests_fallback');
+        unlink($filename);
     }
 
     /**
@@ -98,15 +101,17 @@ class CacheTest extends TestCase
      */
     public function testCacheFallbackIntegration()
     {
+        $filename = tempnam(TMP, 'tmp_');
+
         Cache::setConfig('tests', [
             'engine' => 'File',
-            'path' => DS . 'unwritable_dir',
+            'path' => $filename,
             'prefix' => 'test_',
             'fallback' => 'tests_fallback',
         ]);
         Cache::setConfig('tests_fallback', [
             'engine' => 'File',
-            'path' => DS . 'still_unwritable_dir',
+            'path' => $filename,
             'prefix' => 'test_',
             'fallback' => 'tests_fallback_final',
         ]);
@@ -123,6 +128,7 @@ class CacheTest extends TestCase
         Cache::drop('tests');
         Cache::drop('tests_fallback');
         Cache::drop('tests_fallback_final');
+        unlink($filename);
     }
 
     /**


### PR DESCRIPTION
Missing or broken cache engines can cause applications to fail, and in my opinion, cache is *optional* and shouldn't break an app. Since engines are lazy loaded, it's difficult to predict that an engine will fail by catching the exception unless you build all engines during bootstrap, defeating the lazy loading.

This PR adds the ability to define fallback engines within cache config. An example might be falling back to the FileEngine if Redis fails to connect:

```php
Cache::setConfig('tests', [
    'engine' => 'Redis',
    'host' => 'badhost',
    'fallback' => 'tests_fallback'
]);
Cache::setConfig('tests_fallback', [
    'engine' => 'File',
    'path' => TMP,
    'prefix' => 'test_',
]);
```

A developer could configure fallbacks all the way to the NullEngine in order to prevent their app from ever throwing an exception due to missing cache.

I'd like to discuss potential pitfalls (especially regarding groups, as I do not have much experience with them) of this change. Also, hiding errors isn't a good thing, so ideas on logging those errors are welcome.