### PR TITLE
Fix get methods not being proxied correctly.

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -249,7 +249,10 @@ abstract class Mailer implements EventListenerInterface
      */
     public function __call($method, $args)
     {
-        $this->_email->$method(...$args);
+        $result = $this->_email->$method(...$args);
+        if (strpos($method, 'get') === 0) {
+            return $result;
+        }
 
         return $this;
     }

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -53,6 +53,7 @@ class MailerTest extends TestCase
         $result = (new TestMailer())->layout('foo');
         $this->assertInstanceOf('TestApp\Mailer\TestMailer', $result);
         $this->assertEquals('foo', $result->viewBuilder()->layout());
+        $this->assertEquals('foo', $result->getLayout());
     }
 
     public function testProxies()
@@ -81,6 +82,23 @@ class MailerTest extends TestCase
             ['file' => CAKE . 'basics.php', 'mimetype' => 'text/plain']
         ]);
         $this->assertInstanceOf('TestApp\Mailer\TestMailer', $result);
+    }
+
+    /**
+     * Test that get/set methods can be proxied.
+     *
+     * @return void
+     */
+    public function testGetSetProxies()
+    {
+        $mailer = new TestMailer();
+        $result = $mailer->setLayout('custom')
+            ->setTo('test@example.com')
+            ->setCc('cc@example.com');
+        $this->assertSame($result, $mailer);
+
+        $this->assertSame(['test@example.com' => 'test@example.com'], $result->getTo());
+        $this->assertSame(['cc@example.com' => 'cc@example.com'], $result->getCc());
     }
 
     public function testSet()


### PR DESCRIPTION
Add method checking to make __call() better emulate the new un-deprecated method proxies.

Refs #10721