### PR TITLE
Consistent unicode logging

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1231,7 +1231,7 @@ trait EntityTrait
      */
     public function __toString()
     {
-        return json_encode($this, JSON_PRETTY_PRINT);
+        return json_encode($this, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -100,7 +100,7 @@ abstract class BaseLog extends AbstractLogger
         }
 
         if ($object && $data instanceof JsonSerializable) {
-            return json_encode($data);
+            return json_encode($data, JSON_UNESCAPED_UNICODE);
         }
 
         return print_r($data, true);

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         t.b.d.
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Log\Engine;
+
+use Cake\Log\Engine\BaseLog;
+use Cake\ORM\Entity;
+use Cake\TestSuite\TestCase;
+use Psr\Log\LogLevel;
+
+class BaseLogTest extends TestCase
+{
+
+    private $testData = ['ä', 'ö', 'ü'];
+
+    private $logger;
+
+    /**
+     * Setting up the test case.
+     * Creates a stub logger implementing the log() function missing from abstract class BaseLog.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->logger = new class() extends BaseLog {
+
+            /**
+             * Logs with an arbitrary level.
+             *
+             * @param mixed $level
+             * @param mixed $message
+             * @param array $context
+             *
+             * @return mixed
+             */
+            public function log($level, $message, array $context = array())
+            {
+                return $this->_format($message, $context);
+            }
+        };
+    }
+
+    private function assertUnescapedUnicode(array $needles, string $haystack)
+    {
+        foreach ($needles as $needle) {
+            $this->assertContains(
+                $needle,
+                $haystack,
+                'Formatted log message does not contain unescaped unicode character.'
+            );
+        }
+    }
+
+    /**
+     * Tests the logging output of a single string containing unicode characters.
+     */
+    public function testLogUnicodeString()
+    {
+        $logged = $this->logger->log(LogLevel::INFO, implode($this->testData));
+
+        $this->assertUnescapedUnicode($this->testData, $logged);
+    }
+
+    /**
+     * Tests the logging output of an array containing unicode characters.
+     */
+    public function testLogUnicodeArray()
+    {
+        $logged = $this->logger->log(LogLevel::INFO, $this->testData);
+
+        $this->assertUnescapedUnicode($this->testData, $logged);
+    }
+
+    /**
+     * Tests the logging output of an object implementing __toString().
+     * Note: __toString() will return a single string containing unicode characters.
+     */
+    public function testLogUnicodeObjectToString()
+    {
+        $stub = $this->createMock(Entity::class);
+        $stub->method('__toString')
+            ->willReturn(implode($this->testData));
+
+        $logged = $this->logger->log(LogLevel::INFO, $stub);
+
+        $this->assertUnescapedUnicode($this->testData, $logged);
+    }
+
+    /**
+     * Tests the logging output of an object implementing jsonSerializable().
+     * Note: jsonSerializable() will return an array containing unicode characters.
+     */
+    public function testLogUnicodeObjectJsonSerializable()
+    {
+        $stub = $this->createMock(\JsonSerializable::class);
+        $stub->method('jsonSerialize')
+            ->willReturn($this->testData);
+
+        $logged = $this->logger->log(LogLevel::INFO, $stub);
+
+        $this->assertUnescapedUnicode($this->testData, $logged);
+    }
+}

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1461,6 +1461,17 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Tests the entity's __toString method with a property containing unicode characters.
+     * Unicode characters should be passed on unescaped.
+     * @return void
+     */
+    public function testToStringWithUnicode()
+    {
+        $entity = new Entity(['foo' => 'äöü']);
+        $this->assertContains($entity->get('foo'), (string)$entity);
+    }
+
+    /**
      * Tests __debugInfo
      *
      * @return void


### PR DESCRIPTION
The current behaviour of CakePHP regarding the logging of unicode characters is inconsistent. Strings and arrays containing unicode characters will be logged as such, keeping the unicode characters readable. Entity properties and objects implementing JsonSerializable with unicode characters will be logged with all unicode characters escaped as \uXXXX, making them very hard to read and to search for.

As CakePHP is unicode aware in general, I'd like to suggest implementing a consistent logging of unicode characters over all types of parameters. Unicode characters should always be logged as such, keeping them readable and searchable.

This can be achieved by using `JSON_UNESCAPED_UNICODE` with `json_encode()`. This applies to `BaseLog::_format()` and `EntityTrait::__toString()` as those are the functions participating in logging message and objects.