### PR TITLE
Added support for cookie Max-Age.

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -338,7 +338,8 @@ class CookieCollection implements IteratorAggregate, Countable
                 'domain' => '',
                 'secure' => false,
                 'httponly' => false,
-                'expires' => null
+                'expires' => null,
+                'max-age' => null
             ];
             foreach ($parts as $i => $part) {
                 if (strpos($part, '=') !== false) {
@@ -358,7 +359,9 @@ class CookieCollection implements IteratorAggregate, Countable
                 }
             }
             $expires = null;
-            if ($cookie['expires']) {
+            if ($cookie['max-age'] !== null) {
+                $expires = new DateTimeImmutable('@' . (time() + $cookie['max-age']));
+            } elseif ($cookie['expires']) {
                 $expires = new DateTimeImmutable('@' . strtotime($cookie['expires']));
             }
 


### PR DESCRIPTION
Most modern browsers support `Max-Age` directive. 

`Max-Age` should have a precedence over `Expires` if both of these are present (ie. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).