### PR TITLE
Don't emit errors when clauses are undefined.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1698,7 +1698,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function clause($name)
     {
-        return $this->_parts[$name];
+        return isset($this->_parts[$name]) ? $this->_parts[$name] : null;
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1703,6 +1703,7 @@ class Query implements ExpressionInterface, IteratorAggregate
             $clauses = implode(', ', array_keys($this->_parts));
             throw new InvalidArgumentException("The '$name' clause is not defined. Valid clauses are: $clauses");
         }
+
         return $this->_parts[$name];
     }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1695,10 +1695,15 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param string $name name of the clause to be returned
      * @return mixed
+     * @throws InvalidArgumentException When the named clause does not exist.
      */
     public function clause($name)
     {
-        return isset($this->_parts[$name]) ? $this->_parts[$name] : null;
+        if (!array_key_exists($name, $this->_parts)) {
+            $clauses = implode(', ', array_keys($this->_parts));
+            throw new InvalidArgumentException("The '$name' clause is not defined. Valid clauses are: $clauses");
+        }
+        return $this->_parts[$name];
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4330,6 +4330,18 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test that reading an undefined clause does not emit an error.
+     *
+     * @return void
+     */
+    public function testClauseUndefined()
+    {
+        $query = new Query($this->connection);
+        $this->assertEmpty($query->clause('where'));
+        $this->assertNull($query->clause('nope'));
+    }
+
+    /**
      * Assertion for comparing a table's contents with what is in it.
      *
      * @param string $table

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4332,13 +4332,15 @@ class QueryTest extends TestCase
     /**
      * Test that reading an undefined clause does not emit an error.
      *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The 'nope' clause is not defined. Valid clauses are: delete, update
      * @return void
      */
     public function testClauseUndefined()
     {
         $query = new Query($this->connection);
         $this->assertEmpty($query->clause('where'));
-        $this->assertNull($query->clause('nope'));
+        $query->clause('nope');
     }
 
     /**


### PR DESCRIPTION
Refs #10734
