### PR TITLE
Make RouteBuilder::connect() return route instances.

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -592,7 +592,7 @@ class RouteBuilder
      *   element should match. Also contains additional parameters such as which routed parameters should be
      *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
      *   custom routing class.
-     * @return void
+     * @return \Cake\Routing\Route\Route
      * @throws \InvalidArgumentException
      * @throws \BadMethodCallException
      */
@@ -615,6 +615,8 @@ class RouteBuilder
 
         $route = $this->_makeRoute($route, $defaults, $options);
         $this->_collection->add($route, $options);
+
+        return $route;
     }
 
     /**

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -127,7 +127,7 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'api']);
 
         $route = new Route('/:controller');
-        $this->assertNull($routes->connect($route));
+        $this->assertSame($route, $routes->connect($route));
 
         $result = $this->collection->routes()[0];
         $this->assertSame($route, $result);
@@ -142,10 +142,10 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'api']);
 
-        $this->assertNull($routes->connect('/:controller'));
-        $route = $this->collection->routes()[0];
-
+        $route = $routes->connect('/:controller');
         $this->assertInstanceOf(Route::class, $route);
+
+        $this->assertSame($route, $this->collection->routes()[0]);
         $this->assertEquals('/l/:controller', $route->template);
         $expected = ['prefix' => 'api', 'action' => 'index', 'plugin' => null];
         $this->assertEquals($expected, $route->defaults);


### PR DESCRIPTION
The utility of the fluent setters on Route are limited if connect() does not also return the route instances.