### PR TITLE
Fix broken cookie issue

### DIFF
--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -220,7 +220,7 @@ class Security {
 			return '';
 		}
 
-		srand((int)Configure::read('Security.cipherSeed'));
+		srand((int)(float)Configure::read('Security.cipherSeed'));
 		$out = '';
 		$keyLength = strlen($key);
 		for ($i = 0, $textLength = strlen($text); $i < $textLength; $i++) {


### PR DESCRIPTION
#10724

This change makes Security::cipher() encoding and decoding same as 2.7 and below.