### PR TITLE
issue-10750: Fix ISO8601 i18n formatting

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -209,7 +209,7 @@ trait DateFormatTrait
         $key = "{$locale}.{$dateFormat}.{$timeFormat}.{$timezone}.{$calendar}.{$pattern}";
 
         if (!isset(static::$_formatters[$key])) {
-            if ($timezone === '+00:00') {
+            if ($timezone === '+00:00' || $timezone === 'Z') {
                 $timezone = 'UTC';
             } elseif ($timezone[0] === '+' || $timezone[0] === '-') {
                 $timezone = 'GMT' . $timezone;

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -113,6 +113,11 @@ class DateTest extends TestCase
 
         $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'es-ES');
         $this->assertContains('14 de enero de 2010', $result, 'Default locale should not be used');
+
+        $time = new $class('2014-01-01T00:00:00Z');
+        $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'en-US');
+        $expected = 'Wednesday, January 1, 2014 at 12:00:00 AM GMT';
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -506,6 +506,11 @@ class TimeTest extends TestCase
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
         $this->assertTimeFormat($expected, $result);
+
+        $time = new $class('2014-01-01T00:00Z');
+        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
+        $this->assertTimeFormat($expected, $result);
     }
 
     /**


### PR DESCRIPTION
Addresses issue #10750.

When a Time or a Date is created using an ISO8601 UTC timezone, attempting to execute i18nFormat() on it results in an error and the timestamp not being formatted. This patch fixes that and adds the requisite tests.