### PR TITLE
Make init() chainable and improve docs.

### DIFF
--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -19,6 +19,17 @@ use RuntimeException;
 
 /**
  * Create a progress bar using a supplied callback.
+ *
+ * ## Usage
+ *
+ * The ProgressHelper can be accessed from shells using the helper() method
+ *
+ * ```
+ * $this->helper('Progress')->output(['callback' => function ($progress) {
+ *     // Do work
+ *     $progress->increment();
+ * });
+ * ```
  */
 class ProgressHelper extends Helper
 {
@@ -86,7 +97,7 @@ class ProgressHelper extends Helper
      * - `width` The width of the progress bar. Defaults to 80.
      *
      * @param array $args The initialization data.
-     * @return void
+     * @return $this
      */
     public function init(array $args = [])
     {
@@ -94,6 +105,8 @@ class ProgressHelper extends Helper
         $this->_progress = 0;
         $this->_width = $args['width'];
         $this->_total = $args['total'];
+
+        return $this;
     }
 
     /**

--- a/tests/TestCase/Shell/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Shell/Helper/ProgressHelperTest.php
@@ -40,6 +40,20 @@ class ProgressHelperTest extends TestCase
     }
 
     /**
+     * Test using the helper manually.
+     *
+     * @return void
+     */
+    public function testInit()
+    {
+        $helper = $this->helper->init([
+            'total' => 200,
+            'width' => 50
+        ]);
+        $this->assertSame($helper, $this->helper, 'init should be chainable');
+    }
+
+    /**
      * Test that a callback is required.
      *
      * @expectedException \RuntimeException


### PR DESCRIPTION
I bumped into this during the workshops and found it annoying that `init()` couldn't be chained as I wanted to do `helper('Progress')->init(...)->output(...)` and couldn't.
