### PR TITLE
Improve MissingController error page. 

### DIFF
--- a/src/Template/Error/missing_action.ctp
+++ b/src/Template/Error/missing_action.ctp
@@ -32,13 +32,13 @@ if (isset($controller)) {
     $baseClass = $namespace . '\Controller\AppController';
     $extends = 'AppController';
     $type = 'Controller';
-    $class = $controller;
+    $class = Inflector::camelize($controller);
 }
 // Mailer MissingActionException support
 if (isset($mailer)) {
     $baseClass = 'Cake\Mailer\Mailer';
     $type = $extends = 'Mailer';
-    $class = $mailer;
+    $class = Inflector::camelize($mailer);
 }
 
 if (empty($plugin)) {

--- a/src/Template/Error/missing_controller.ctp
+++ b/src/Template/Error/missing_controller.ctp
@@ -14,11 +14,13 @@
  */
 use Cake\Core\Plugin;
 use Cake\Core\Configure;
+use Cake\Utility\Inflector;
 
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 $namespace = Configure::read('App.namespace');
 $prefixNs = '';
 $prefixPath = '';
+$class = Inflector::camelize($class);
 
 if (!empty($prefix)) {
     $prefix = array_map('\Cake\Utility\Inflector::camelize', explode('/', $prefix));

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -580,6 +580,19 @@ class ExceptionRendererTest extends TestCase
         return [
             [
                 new MissingActionException([
+                    'controller' => 'postsController',
+                    'action' => 'index',
+                    'prefix' => '',
+                    'plugin' => '',
+                ]),
+                [
+                    '/Missing Method in PostsController/',
+                    '/<em>PostsController::index\(\)<\/em>/'
+                ],
+                404
+            ],
+            [
+                new MissingActionException([
                     'controller' => 'PostsController',
                     'action' => 'index',
                     'prefix' => '',

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -550,6 +550,27 @@ class ExceptionRendererTest extends TestCase
     }
 
     /**
+     * test missingController method
+     *
+     * @return void
+     */
+    public function testMissingControllerLowerCase()
+    {
+        $exception = new MissingControllerException([
+            'class' => 'posts',
+            'prefix' => '',
+            'plugin' => '',
+        ]);
+        $ExceptionRenderer = $this->_mockResponse(new MyCustomExceptionRenderer($exception));
+
+        $result = $ExceptionRenderer->render()->body();
+
+        $this->assertEquals('missingController', $ExceptionRenderer->template);
+        $this->assertContains('Missing Controller', $result);
+        $this->assertContains('<em>PostsController</em>', $result);
+    }
+
+    /**
      * Returns an array of tests to run for the various Cake Exception classes.
      *
      * @return array


### PR DESCRIPTION
Don't give people false directions when controllers are missing. Suggest the proper class and filename instead of the lowercased version.

I was inspired to fix this after @lorenzo's talk yesterday.