### PR TITLE
Fix encoding of addreses contain comma & unicode

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -830,7 +830,10 @@ class CakeEmail {
 				$return[] = $email;
 			} else {
 				$encoded = $this->_encode($alias);
-				if ($encoded === $alias && preg_match('/[^a-z0-9 ]/i', $encoded)) {
+				if (
+					$encoded === $alias && preg_match('/[^a-z0-9 ]/i', $encoded) ||
+					strpos($encoded, ',') !== false
+				) {
 					$encoded = '"' . str_replace('"', '\"', $encoded) . '"';
 				}
 				$return[] = sprintf('%s <%s>', $encoded, $email);

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -450,10 +450,6 @@ class CakeEmailTest extends CakeTestCase {
 		$expected = array('CakePHP <cake@cakephp.org>', 'Cake <php@cakephp.org>');
 		$this->assertSame($expected, $result);
 
-		$result = $this->CakeEmail->formatAddress(array('me@example.com' => 'Last, First'));
-		$expected = array('"Last, First" <me@example.com>');
-		$this->assertSame($expected, $result);
-
 		$result = $this->CakeEmail->formatAddress(array('me@example.com' => '"Last" First'));
 		$expected = array('"\"Last\" First" <me@example.com>');
 		$this->assertSame($expected, $result);
@@ -468,6 +464,33 @@ class CakeEmailTest extends CakeTestCase {
 
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => '日本語Test'));
 		$expected = array('=?UTF-8?B?5pel5pys6KqeVGVzdA==?= <cake@cakephp.org>');
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * Test that addresses are quoted correctly when they contain unicode and
+ * commas
+ *
+ * @return void
+ */
+	public function testFormatAddressEncodeAndEscape()
+	{
+		$result = $this->CakeEmail->formatAddress(array(
+			'test@example.com' => 'Website, ascii'
+		));
+		$expected = array('"Website, ascii" <test@example.com>');
+		$this->assertSame($expected, $result);
+
+		$result = $this->CakeEmail->formatAddress(array(
+			'test@example.com' => 'Wébsite, unicode'
+		));
+		$expected = array('=?UTF-8?B?V8OpYnNpdGUsIHVuaWNvZGU=?= <test@example.com>');
+		$this->assertSame($expected, $result);
+
+		$result = $this->CakeEmail->formatAddress(array(
+			'test@example.com' => 'Website, électric'
+		));
+		$expected = array('"Website, =?UTF-8?B?w6lsZWN0cmlj?=" <test@example.com>');
 		$this->assertSame($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -473,8 +473,7 @@ class CakeEmailTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testFormatAddressEncodeAndEscape()
-	{
+	public function testFormatAddressEncodeAndEscape() {
 		$result = $this->CakeEmail->formatAddress(array(
 			'test@example.com' => 'Website, ascii'
 		));


### PR DESCRIPTION
Email addresses that contain both unicode and commas will not be correctly encoded by mime_encode_header if the comma precedes the unicode. In this scenario we have to quote the encoded address.

Refs #10763