### PR TITLE
3.next - Command collection autoDiscover()

### DIFF
--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -73,6 +73,22 @@ class CommandCollection implements IteratorAggregate, Countable
     }
 
     /**
+     * Add multiple commands at once.
+     *
+     * @param array $commands A map of command names => command classes/instances.
+     * @return $this
+     * @see \Cake\Console\CommandCollection::add()
+     */
+    public function addMany(array $commands)
+    {
+        foreach ($commands as $name => $class) {
+            $this->add($name, $class);
+        }
+
+        return $this;
+    }
+
+    /**
      * Remove a command from the collection if it exists.
      *
      * @param string $name The named shell.
@@ -150,16 +166,16 @@ class CommandCollection implements IteratorAggregate, Countable
      * the full `plugin_name.shell` name will be used. Plugin shells are added
      * in the order that plugins were loaded.
      *
-     * @return $this
+     * @return array An array of command names and their classes.
      */
     public function autoDiscover()
     {
         $scanner = new CommandScanner();
         $shells = $scanner->scanAll();
 
-        $adder = function ($shells, $key) {
+        $adder = function ($out, $shells, $key) {
             if (empty($shells[$key])) {
-                return;
+                return $out;
             }
             foreach ($shells[$key] as $info) {
                 $name = $info['name'];
@@ -168,27 +184,25 @@ class CommandCollection implements IteratorAggregate, Countable
                 // If the short name has been used, use the full name.
                 // This allows app shells to have name preference.
                 // and app shells to overwrite core shells.
-                if ($this->has($name) && $addLong) {
+                if (isset($out[$name]) && $addLong) {
                     $name = $info['fullName'];
                 }
 
-                try {
-                    $this->add($name, $info['class']);
-                    if ($addLong) {
-                        $this->add($info['fullName'], $info['class']);
-                    }
-                } catch (InvalidArgumentException $e) {
-                    Log::warning("Could not add {$info['class']} via autodiscovery. " . $e->getMessage());
+                $out[$name] = $info['class'];
+                if ($addLong) {
+                    $out[$info['fullName']] = $info['class'];
                 }
             }
+
+            return $out;
         };
 
-        $adder($shells, 'CORE');
-        $adder($shells, 'app');
+        $out = $adder([], $shells, 'CORE');
+        $out = $adder($out, $shells, 'app');
         foreach (array_keys($shells['plugins']) as $key) {
-            $adder($shells['plugins'], $key);
+            $out = $adder($out, $shells['plugins'], $key);
         }
 
-        return $this;
+        return $out;
     }
 }

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -178,7 +178,7 @@ class CommandCollection implements IteratorAggregate, Countable
                         $this->add($info['fullName'], $info['class']);
                     }
                 } catch (InvalidArgumentException $e) {
-                    Log::warn("Could not add {$info['class']} via autodiscovery. " . $e->getMessage());
+                    Log::warning("Could not add {$info['class']} via autodiscovery. " . $e->getMessage());
                 }
             }
         };

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -17,7 +17,6 @@ namespace Cake\Console;
 use ArrayIterator;
 use Cake\Console\CommandScanner;
 use Cake\Console\Shell;
-use Cake\Log\Log;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -66,6 +66,7 @@ class CommandCollection implements IteratorAggregate, Countable
                 "Cannot use '$class' for command '$name' it is not a subclass of Cake\Console\Shell."
             );
         }
+
         $this->commands[$name] = $command;
 
         return $this;
@@ -176,6 +177,7 @@ class CommandCollection implements IteratorAggregate, Countable
             if (empty($shells[$key])) {
                 return $out;
             }
+
             foreach ($shells[$key] as $info) {
                 $name = $info['name'];
                 $addLong = $name !== $info['fullName'];

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Console;
+
+use Cake\Core\App;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\Filesystem\Folder;
+use Cake\Utility\Inflector;
+
+/**
+ * Used by CommanCollection and CommandTask to scan the filesystem
+ * for command classes.
+ *
+ * @internal
+ */
+class CommandScanner
+{
+    /**
+     * Scan the application, cakephp and plugins for shells
+     *
+     * @return array
+     */
+    public function scanAll()
+    {
+        $shellList = [];
+
+        $appNamespace = Configure::read('App.namespace');
+        $shellList['app'] = $this->scanDir(
+            App::path('Shell')[0],
+            $appNamespace . '\Shell\\',
+            '',
+            ['app']
+        );
+
+        $shellList['CORE'] = $this->scanDir(
+            dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Shell' . DIRECTORY_SEPARATOR,
+            'Cake\Shell\\',
+            '',
+            ['command_list']
+        );
+        $plugins = [];
+        foreach (Plugin::loaded() as $plugin) {
+            $plugins[$plugin] = $this->scanDir(
+                Plugin::classPath($plugin) . 'Shell',
+                str_replace('/', '\\', $plugin) . '\Shell\\',
+                Inflector::underscore($plugin) . '.',
+                []
+            );
+        }
+        $shellList['plugins'] = $plugins;
+
+        return $shellList;
+    }
+
+    /**
+     * Scan a directory for .php files and return the class names that
+     * should be within them.
+     *
+     * @param string $path The directory to read.
+     * @param string $namespace The namespace the shells live in.
+     * @param string $prefix The prefix to apply to commands for their full name.
+     * @param array $hide A list of command names to hide as they are internal commands.
+     * @return array The list of shell info arrays based on scanning the filesystem and inflection.
+     */
+    protected function scanDir($path, $namespace, $prefix, array $hide)
+    {
+        $dir = new Folder($path);
+        $contents = $dir->read(true, true);
+        if (empty($contents[1])) {
+            return [];
+        }
+        $shells = [];
+        foreach ($contents[1] as $file) {
+            if (substr($file, -4) !== '.php') {
+                continue;
+            }
+            $shell = substr($file, 0, -4);
+            $name = Inflector::underscore(str_replace('Shell', '', $shell));
+            if (in_array($name, $hide, true)) {
+                continue;
+            }
+            $shells[] = [
+                'file' => $path . $file,
+                'fullName' => $prefix . $name,
+                'name' => $name,
+                'class' => $namespace . $shell
+            ];
+        }
+
+        return $shells;
+    }
+}

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -29,7 +29,7 @@ use Cake\Utility\Inflector;
 class CommandScanner
 {
     /**
-     * Scan the application, cakephp and plugins for shells
+     * Scan CakePHP core, the applications and plugins for shell classes
      *
      * @return array
      */
@@ -51,6 +51,7 @@ class CommandScanner
             '',
             ['command_list']
         );
+
         $plugins = [];
         foreach (Plugin::loaded() as $plugin) {
             $plugins[$plugin] = $this->scanDir(
@@ -82,16 +83,19 @@ class CommandScanner
         if (empty($contents[1])) {
             return [];
         }
+
         $shells = [];
         foreach ($contents[1] as $file) {
             if (substr($file, -4) !== '.php') {
                 continue;
             }
+
             $shell = substr($file, 0, -4);
             $name = Inflector::underscore(str_replace('Shell', '', $shell));
             if (in_array($name, $hide, true)) {
                 continue;
             }
+
             $shells[] = [
                 'file' => $path . $file,
                 'fullName' => $prefix . $name,

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -234,9 +234,9 @@ class CommandCollectionTest extends TestCase
             $collection->has('example'),
             'Used short name for unique plugin shell'
         );
-        $this->assertFalse(
+        $this->assertTrue(
             $collection->has('test_plugin.example'),
-            'Long names not stored for unique shells'
+            'Long names are stored for unique shells'
         );
         $this->assertTrue(
             $collection->has('sample'),
@@ -246,16 +246,17 @@ class CommandCollectionTest extends TestCase
             $collection->has('test_plugin.sample'),
             'Duplicate shell was given a full alias'
         );
-        $this->assertFalse(
-            $collection->has('company/test_plugin_three.company'),
-            'Long names not stored for unique shells'
-        );
         $this->assertTrue(
             $collection->has('company'),
             'Used short name for unique plugin shell'
         );
+        $this->assertTrue(
+            $collection->has('company/test_plugin_three.company'),
+            'Long names are stored as well'
+        );
 
         $this->assertEquals('TestPlugin\Shell\ExampleShell', $collection->get('example'));
+        $this->assertEquals($collection->get('example'), $collection->get('test_plugin.example'));
         $this->assertEquals(
             'TestApp\Shell\SampleShell',
             $collection->get('sample'),

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -186,7 +186,7 @@ class CommandCollectionTest extends TestCase
     public function testAutoDiscoverApp()
     {
         $collection = new CommandCollection();
-        $this->assertSame($collection, $collection->autoDiscover());
+        $collection->addMany($collection->autoDiscover());
 
         $this->assertTrue($collection->has('i18m'));
         $this->assertTrue($collection->has('sample'));
@@ -204,7 +204,7 @@ class CommandCollectionTest extends TestCase
     public function testAutoDiscoverCore()
     {
         $collection = new CommandCollection();
-        $collection->autoDiscover();
+        $collection->addMany($collection->autoDiscover());
 
         $this->assertTrue($collection->has('routes'));
         $this->assertTrue($collection->has('i18n'));
@@ -228,7 +228,7 @@ class CommandCollectionTest extends TestCase
         Plugin::load('TestPlugin');
         Plugin::load('Company/TestPluginThree');
         $collection = new CommandCollection();
-        $collection->autoDiscover();
+        $collection->addMany($collection->autoDiscover());
 
         $this->assertTrue(
             $collection->has('example'),

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -104,6 +104,7 @@ class ShellDispatcherTest extends TestCase
     public function testAddShortPluginAlias()
     {
         $expected = [
+            'Company' => 'Company/TestPluginThree.company',
             'Example' => 'TestPlugin.example'
         ];
         $result = $this->dispatcher->addShortPluginAliases();
@@ -111,6 +112,7 @@ class ShellDispatcherTest extends TestCase
 
         ShellDispatcher::alias('Example', 'SomeOther.PluginsShell');
         $expected = [
+            'Company' => 'Company/TestPluginThree.company',
             'Example' => 'SomeOther.PluginsShell'
         ];
         $result = $this->dispatcher->addShortPluginAliases();

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Shell/CompanyShell.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Shell/CompanyShell.php
@@ -1,0 +1,8 @@
+<?php
+namespace Company\TestPluginThree\Shell;
+
+use Cake\Console\Shell;
+
+class CompanyShell extends Shell
+{
+}

--- a/tests/test_app/TestApp/Shell/I18mShell.php
+++ b/tests/test_app/TestApp/Shell/I18mShell.php
@@ -22,7 +22,7 @@ namespace TestApp\Shell;
 
 use Cake\Console\Shell;
 
-class I18m extends Shell
+class I18mShell extends Shell
 {
 
     /**


### PR DESCRIPTION
Build out the `autoDiscover()` method for `CommandCollection` this method will scan the core, app and all plugins for shell commands and append them into the collection. I've made the results of the scan include enough data that I can refactor the `CommandListShell` and `CompletionShell` in a subsequent pull request.

Refs #10716