### PR TITLE
Add options and head methods to IntegrationTestCase

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -450,7 +450,7 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
-     * Performs an OPTION request using the current request data.
+     * Performs an OPTIONS request using the current request data.
      *
      * The response of the dispatched request will be stored as
      * a property. You can use various assert methods to check the

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -435,6 +435,21 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Performs a HEAD request using the current request data.
+     *
+     * The response of the dispatched request will be stored as
+     * a property. You can use various assert methods to check the
+     * response.
+     *
+     * @param string|array $url The URL to request.
+     * @return void
+     */
+    public function head($url)
+    {
+        $this->_sendRequest($url, 'HEAD');
+    }
+
+    /**
      * Performs an OPTION request using the current request data.
      *
      * The response of the dispatched request will be stored as

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -435,6 +435,21 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Performs an OPTION request using the current request data.
+     *
+     * The response of the dispatched request will be stored as
+     * a property. You can use various assert methods to check the
+     * response.
+     *
+     * @param string|array $url The URL to request.
+     * @return void
+     */
+    public function options($url)
+    {
+        $this->_sendRequest($url, 'OPTIONS');
+    }
+
+    /**
      * Creates and send the request into a Dispatcher instance.
      *
      * Receives and stores the response for future inspection.

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -40,6 +40,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         Configure::write('App.namespace', 'TestApp');
 
         Router::connect('/get/:controller/:action', ['_method' => 'GET'], ['routeClass' => 'InflectedRoute']);
+        Router::connect('/head/:controller/:action', ['_method' => 'HEAD'], ['routeClass' => 'InflectedRoute']);
+        Router::connect('/options/:controller/:action', ['_method' => 'OPTIONS'], ['routeClass' => 'InflectedRoute']);
         Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
         DispatcherFactory::clear();
         DispatcherFactory::add('Routing');
@@ -185,6 +187,44 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->_response = null;
         $this->get('/get/request_action/test_request_action');
         $this->assertEquals('This is a test', $this->_response->body());
+    }
+
+    /**
+     * Test sending head requests.
+     *
+     * @return void
+     */
+    public function testHead()
+    {
+        $this->assertNull($this->_response);
+
+        $this->head('/request_action/test_request_action');
+        $this->assertNotEmpty($this->_response);
+        $this->assertInstanceOf('Cake\Http\Response', $this->_response);
+        $this->assertResponseSuccess();
+
+        $this->_response = null;
+        $this->head('/head/request_action/test_request_action');
+        $this->assertResponseSuccess();
+    }
+
+    /**
+     * Test sending options requests.
+     *
+     * @return void
+     */
+    public function testOptions()
+    {
+        $this->assertNull($this->_response);
+
+        $this->options('/request_action/test_request_action');
+        $this->assertNotEmpty($this->_response);
+        $this->assertInstanceOf('Cake\Http\Response', $this->_response);
+        $this->assertResponseSuccess();
+
+        $this->_response = null;
+        $this->options('/options/request_action/test_request_action');
+        $this->assertResponseSuccess();
     }
 
     /**


### PR DESCRIPTION
As of #10700 there is method to simply add an OPTIONS route. I thought is was handy to make an options method in IntegrationTestCase.