### PR TITLE
Fixes warning für "disabled" option in FormHelper.php

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2578,7 +2578,7 @@ class FormHelper extends Helper
             $options = $this->addClass($options, $this->_config['errorClass']);
         }
         $isDisabled = false;
-        if (isset($options['disabled'])) {
+        if (isset($options['disabled']) && !empty($options['disabled'])) {
             $isDisabled = (
                 $options['disabled'] === true ||
                 $options['disabled'] === 'disabled' ||


### PR DESCRIPTION
removes warning when key "disabled" is delivered, but array is empty

having the key disabled and filling it, is in my opinion a common procedure, so it is possible, that the the array is set, but empty. 