### PR TITLE
Don't add auto increment to columns that turn it off.

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -382,7 +382,8 @@ class MysqlSchema extends BaseSchema
         }
         $addAutoIncrement = (
             [$name] == (array)$schema->primaryKey() &&
-            !$schema->hasAutoincrement()
+            !$schema->hasAutoincrement() &&
+            !isset($data['autoIncrement'])
         );
         if (in_array($data['type'], ['integer', 'biginteger']) &&
             ($data['autoIncrement'] === true || $addAutoIncrement)

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -594,6 +594,11 @@ SQL;
             ],
             [
                 'post_id',
+                ['type' => 'integer', 'length' => 20, 'null' => false, 'autoIncrement' => false],
+                '`post_id` INTEGER(20) NOT NULL'
+            ],
+            [
+                'post_id',
                 ['type' => 'biginteger', 'length' => 20, 'autoIncrement' => true],
                 '`post_id` BIGINT AUTO_INCREMENT'
             ],


### PR DESCRIPTION
When autoIncrement has been set to a specific value we shouldn't overwrite the user's request. This allows integer keys to exist without autoincrement being set.

Refs #10765
Refs #10045