### PR TITLE
Fix Correspond to RedisCluster from RedisEngine::clear()

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -218,7 +218,12 @@ class RedisEngine extends CacheEngine
         }
         $keys = $this->_Redis->getKeys($this->_config['prefix'] . '*');
 
-        return !in_array(false, $this->deleteMany($keys));
+        $result = [];
+        foreach ($keys as $key) {
+            $result[] = $this->_Redis->delete($key) > 0;
+        }
+
+        return !in_array(false, $result);
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -217,9 +217,8 @@ class RedisEngine extends CacheEngine
             return true;
         }
         $keys = $this->_Redis->getKeys($this->_config['prefix'] . '*');
-        $this->_Redis->del($keys);
 
-        return true;
+        return !in_array(false, $this->deleteMany($keys));
     }
 
     /**


### PR DESCRIPTION
Redis cluster will fail with Multiple Keys

redis-cli : 
```
> del kye1 kye2
> (error) CROSSSLOT Keys in request don't hash to the same slot
```

Execution of the `RedisEngine::clear()` makes it true, but the key is not deleted