### PR TITLE
Add a setAppNamespace() convenience function to replace literal calls

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -676,4 +676,15 @@ abstract class TestCase extends BaseTestCase
 
         return $mock;
     }
+
+    /**
+     * Set the app namespace
+     *
+     * @param string $appNamespace The app namespace, defaults to "TestApp".
+     * @return void
+     */
+    public static function setAppNamespace($appNamespace = 'TestApp')
+    {
+        Configure::write('App.namespace', $appNamespace);
+    }
 }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -132,7 +132,7 @@ class CacheTest extends TestCase
      */
     public function testConfigWithLibAndPluginEngines()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Plugin::load('TestPlugin');
 
         $config = ['engine' => 'TestAppCache', 'path' => TMP, 'prefix' => 'cake_test_'];
@@ -401,7 +401,7 @@ class CacheTest extends TestCase
      */
     public function testDrop()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $result = Cache::drop('some_config_that_does_not_exist');
         $this->assertFalse($result, 'Drop should not succeed when config is missing.');
@@ -515,7 +515,7 @@ class CacheTest extends TestCase
      */
     public function testWriteTriggerError()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Cache::config('test_trigger', [
             'engine' => 'TestAppCache',
             'prefix' => ''

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -17,7 +17,6 @@ namespace Cake\Test\TestCase\Cache;
 use Cake\Cache\Cache;
 use Cake\Cache\CacheRegistry;
 use Cake\Cache\Engine\FileEngine;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -33,7 +33,7 @@ class ConsoleIoTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->out = $this->getMockBuilder('Cake\Console\ConsoleOutput')
             ->disableOriginalConstructor()

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -15,7 +15,6 @@
 namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\ConsoleIo;
-use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -32,7 +32,7 @@ class HelperRegistryTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -14,7 +14,6 @@
 namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\HelperRegistry;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -35,7 +35,7 @@ class ShellDispatcherTest extends TestCase
     {
         parent::setUp();
         Plugin::load('TestPlugin');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->setMethods(['_stop'])
             ->getMock();

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\Shell;
 use Cake\Console\ShellDispatcher;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -168,7 +168,7 @@ class ShellTest extends TestCase
      */
     public function testInitialize()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         Plugin::load('TestPlugin');
         $this->Shell->tasks = ['DbConfig' => ['one', 'two']];
@@ -191,7 +191,7 @@ class ShellTest extends TestCase
      */
     public function testLoadModel()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $Shell = new MergeShell();
         $this->assertInstanceOf(

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -17,7 +17,6 @@ namespace Cake\Test\TestCase\Console;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Folder;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -60,7 +60,7 @@ class AuthComponentTest extends TestCase
         parent::setUp();
 
         Security::salt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         Router::scope('/', function ($routes) {
             $routes->fallbacks(InflectedRoute::class);

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -17,7 +17,6 @@ namespace Cake\Test\TestCase\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\Network\Session;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -37,7 +37,7 @@ class FlashComponentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->Controller = new Controller(new ServerRequest(['session' => new Session()]));
         $this->ComponentRegistry = new ComponentRegistry($this->Controller);
         $this->Flash = new FlashComponent($this->ComponentRegistry);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -17,7 +17,6 @@ namespace Cake\Test\TestCase\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\PaginatorComponent;
 use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\ServerRequest;

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -69,7 +69,7 @@ class PaginatorComponentTest extends TestCase
     {
         parent::setUp();
 
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->request = new ServerRequest('controller_posts/index');
         $this->request->params['pass'] = [];

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\RequestHandlerComponent;
-use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\ServerRequest;
 use Cake\Routing\DispatcherFactory;

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -60,7 +60,7 @@ class RequestHandlerComponentTest extends TestCase
     {
         parent::setUp();
         $this->server = $_SERVER;
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         DispatcherFactory::add('Routing');
         DispatcherFactory::add('ControllerFactory');
         $this->_init();
@@ -584,7 +584,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testBeforeRedirectDisabled()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action');
         $this->Controller->request->env('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
 
@@ -909,7 +909,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testAjaxRedirectAsRequestAction()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
@@ -940,7 +940,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testAjaxRedirectAsRequestActionWithQueryString()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action');
 
         $this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
@@ -981,7 +981,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testAjaxRedirectAsRequestActionWithCookieData()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
@@ -1016,7 +1016,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testAjaxRedirectAsRequestActionStatusCode()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
@@ -1048,7 +1048,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testAjaxRedirectAsRequestActionStillRenderingLayout()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action');
         $event = new Event('Controller.beforeRedirect', $this->Controller);
 
@@ -1080,7 +1080,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testBeforeRedirectCallbackWithArrayUrl()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::connect('/:controller/:action/*');
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
         $event = new Event('Controller.beforeRender', $this->Controller);

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -40,7 +40,7 @@ class ComponentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\Controller;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\CookieComponent;
 use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use TestApp\Controller\ComponentTestController;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -245,7 +245,7 @@ class ControllerTest extends TestCase
     {
         parent::setUp();
 
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Router::reload();
     }
 

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -51,7 +51,7 @@ class AppTest extends TestCase
      */
     public function testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false)
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $i = 0;
         TestApp::$existsInBaseCallback = function ($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
             if ($i++ === 0) {
@@ -80,7 +80,7 @@ class AppTest extends TestCase
      */
     public function testShortName($class, $type, $suffix = '', $expected = false)
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $return = TestApp::shortName($class, $type, $suffix);
         $this->assertSame($expected, $return);
@@ -102,7 +102,7 @@ class AppTest extends TestCase
         );
         $this->assertSame('Pages', $return);
 
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -14,7 +14,6 @@
 namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\App;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use TestApp\Core\TestApp;
@@ -93,7 +92,7 @@ class AppTest extends TestCase
      */
     public function testShortNameWithNestedAppNamespace()
     {
-        Configure::write('App.namespace', 'TestApp/Nested');
+        static::setAppNamespace('TestApp/Nested');
 
         $return = TestApp::shortName(
             'TestApp/Nested/Controller/PagesController',

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -48,7 +48,7 @@ class ConnectionTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     public function tearDown()

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Database;
 
-use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Exception\NestedTransactionRollbackException;

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -298,7 +298,7 @@ class ExceptionRendererTest extends TestCase
      */
     public function testCakeErrorHelpersNotLost()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $exception = new SocketException('socket exception');
         $renderer = $this->_mockResponse(new \TestApp\Error\TestAppsExceptionRenderer($exception));
 

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -40,7 +40,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
         Log::reset();

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Error\Middleware;
 
-use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;

--- a/tests/TestCase/Http/ActionDispatcherTest.php
+++ b/tests/TestCase/Http/ActionDispatcherTest.php
@@ -39,7 +39,7 @@ class ActionDispatcherTest extends TestCase
     {
         parent::setUp();
         Router::reload();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->dispatcher = new ActionDispatcher();
         $this->dispatcher->addFilter(new ControllerFactoryFilter());
     }

--- a/tests/TestCase/Http/ActionDispatcherTest.php
+++ b/tests/TestCase/Http/ActionDispatcherTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Http;
 
-use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\ActionDispatcher;
 use Cake\Http\Response;

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Cake\Test\TestCase;
 
-use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -19,7 +19,7 @@ class BaseApplicationTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -13,7 +13,6 @@
  */
 namespace Cake\Test\TestCase\Http;
 
-use Cake\Core\Configure;
 use Cake\Http\Client;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -402,7 +402,7 @@ class ClientTest extends TestCase
      */
     public function testAuthenticationWithMutation()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $response = new Response();
         $mock = $this->getMockBuilder('Cake\Http\Client\Adapter\Stream')
             ->setMethods(['send'])

--- a/tests/TestCase/Http/ControllerFactoryTest.php
+++ b/tests/TestCase/Http/ControllerFactoryTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Http;
 
-use Cake\Core\Configure;
 use Cake\Http\ControllerFactory;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;

--- a/tests/TestCase/Http/ControllerFactoryTest.php
+++ b/tests/TestCase/Http/ControllerFactoryTest.php
@@ -33,7 +33,7 @@ class ControllerFactoryTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->factory = new ControllerFactory();
         $this->response = $this->getMockBuilder('Cake\Http\Response')->getMock();
     }

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -35,7 +35,7 @@ class MiddlewareQueueTest extends TestCase
         parent::setUp();
 
         $this->appNamespace = Configure::read('App.namespace');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -46,8 +46,7 @@ class MiddlewareQueueTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-
-        Configure::write('App.namespace', $this->appNamespace);
+        static::setAppNamespace($this->appNamespace);
     }
 
     /**

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -13,7 +13,6 @@
  */
 namespace Cake\Test\TestCase\Log;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -44,7 +44,7 @@ class LogTest extends TestCase
      */
     public function testImportingLoggers()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Plugin::load('TestPlugin');
 
         Log::config('libtest', [
@@ -568,7 +568,7 @@ class LogTest extends TestCase
      */
     public function testPassingScopeToEngine()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         Log::reset();
 

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -42,7 +42,7 @@ class MailerAwareTraitTest extends TestCase
     public function testGetMailer()
     {
         $originalAppNamespace = Configure::read('App.namespace');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $stub = new Stub();
         $this->assertInstanceOf('TestApp\Mailer\TestMailer', $stub->getMailer('Test'));
         Configure::write('App.namespace', $originalAppNamespace);

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -45,7 +45,7 @@ class MailerAwareTraitTest extends TestCase
         static::setAppNamespace();
         $stub = new Stub();
         $this->assertInstanceOf('TestApp\Mailer\TestMailer', $stub->getMailer('Test'));
-        Configure::write('App.namespace', $originalAppNamespace);
+        static::setAppNamespace($originalAppNamespace);
     }
 
     /**

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -16,7 +16,6 @@
  */
 namespace Cake\Test\TestCase\Network\Session;
 
-use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Network\Session;
 use Cake\Network\Session\DatabaseSession;

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -45,7 +45,7 @@ class DatabaseSessionTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->storage = new DatabaseSession();
     }
 

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -475,7 +475,7 @@ class SessionTest extends TestCase
      */
     public function testUsingAppLibsHandler()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $config = [
             'defaults' => 'cake',
             'handler' => [
@@ -498,7 +498,7 @@ class SessionTest extends TestCase
      */
     public function testUsingPluginHandler()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         \Cake\Core\Plugin::load('TestPlugin');
 
         $config = [
@@ -520,7 +520,7 @@ class SessionTest extends TestCase
      */
     public function testEngineWithPreMadeInstance()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $engine = new \TestApp\Network\Session\TestAppLibSession;
         $session = new Session(['handler' => ['engine' => $engine]]);
         $this->assertSame($engine, $session->engine());

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Network;
 
-use Cake\Core\Configure;
 use Cake\Network\Session;
 use Cake\Network\Session\CacheSession;
 use Cake\Network\Session\DatabaseSession;

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -37,7 +37,7 @@ class BehaviorRegistryTest extends TestCase
         $this->Table = new Table(['table' => 'articles']);
         $this->EventManager = $this->Table->eventManager();
         $this->Behaviors = new BehaviorRegistry($this->Table);
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Table;

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -57,7 +57,7 @@ class TableLocatorTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->_locator = new TableLocator;
     }

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\ORM\Locator;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Locator\TableLocator;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
 use Cake\Collection\Collection;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Database\Exception;
 use Cake\Database\Expression\QueryExpression;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -80,7 +80,7 @@ class TableTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->usersTypeMap = new TypeMap([
             'Users.id' => 'integer',

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -45,7 +45,7 @@ class TableUuidTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;

--- a/tests/TestCase/Routing/DispatcherFactoryTest.php
+++ b/tests/TestCase/Routing/DispatcherFactoryTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Routing;
 
-use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\Routing\DispatcherFactory;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Routing/DispatcherFactoryTest.php
+++ b/tests/TestCase/Routing/DispatcherFactoryTest.php
@@ -33,7 +33,7 @@ class DispatcherFactoryTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         DispatcherFactory::clear();
     }
 

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -43,7 +43,7 @@ class DispatcherTest extends TestCase
         Configure::write('App.baseUrl', false);
         Configure::write('App.dir', 'app');
         Configure::write('App.webroot', 'webroot');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->dispatcher = new Dispatcher();
         $this->dispatcher->addFilter(new ControllerFactoryFilter());

--- a/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Routing\Filter;
 
-use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;

--- a/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ControllerFactoryFilterTest.php
@@ -34,7 +34,7 @@ class ControllerFactoryFilterTest extends TestCase
      */
     public function testBeforeDispatch()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $filter = new ControllerFactoryFilter();
 

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -40,7 +40,7 @@ class RequestActionTraitTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Security::salt('not-the-default');
         DispatcherFactory::add('Routing');
         DispatcherFactory::add('ControllerFactory');

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3185,7 +3185,7 @@ class RouterTest extends TestCase
         $this->assertEquals('/FooBar', $result);
 
         // This is needed because tests/boostrap.php sets App.namespace to 'App'
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         Router::defaultRouteClass('DashedRoute');
         Router::connect('/cake/:controller', ['action' => 'cake']);

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\Shell;
 
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOutput;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 
@@ -74,7 +73,7 @@ class CompletionShellTest extends TestCase
     {
         parent::tearDown();
         unset($this->Shell);
-        Configure::write('App.namespace', 'App');
+        static::setAppNamespace('App');
         Plugin::unload();
     }
 

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -48,7 +48,7 @@ class CompletionShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Plugin::load(['TestPlugin', 'TestPluginTwo']);
 
         $this->out = new TestCompletionStringOutput();

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -243,7 +243,7 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractExcludePlugins()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
             ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
             ->setConstructorArgs([$this->io])
@@ -268,7 +268,7 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractPlugin()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
             ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
@@ -292,7 +292,7 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractVendoredPlugin()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $this->Task = $this->getMockBuilder('Cake\Shell\Task\ExtractTask')
             ->setMethods(['_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'])
@@ -316,7 +316,7 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractOverwrite()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->Task->interactive = false;
 
         $this->Task->params['paths'] = TEST_APP . 'TestApp/';
@@ -340,7 +340,7 @@ class ExtractTaskTest extends TestCase
      */
     public function testExtractCore()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $this->Task->interactive = false;
 
         $this->Task->params['paths'] = TEST_APP . 'TestApp/';

--- a/tests/TestCase/Shell/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Shell/Task/ExtractTaskTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Shell\Task;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Filesystem\Folder;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
+++ b/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Controller;
 
-use Cake\Core\Configure;
 use Cake\Routing\DispatcherFactory;
 use Cake\Routing\Router;
 use Cake\TestSuite\IntegrationTestCase;

--- a/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
+++ b/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
@@ -33,7 +33,7 @@ class CookieEncryptedUsingControllerTest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         Security::salt('abcdabcdabcdabcdabcdabcdabcdabcdabcd');
         Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\TestSuite;
 
-use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Routing\DispatcherFactory;

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -37,7 +37,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         Router::connect('/get/:controller/:action', ['_method' => 'GET'], ['routeClass' => 'InflectedRoute']);
         Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -306,7 +306,7 @@ class TestCaseTest extends TestCase
      */
     public function testGetMockForModel()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $Posts = $this->getMockForModel('Posts');
         $entity = new Entity([]);
 
@@ -349,7 +349,7 @@ class TestCaseTest extends TestCase
      */
     public function testGetMockForModelWithPlugin()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Plugin::load('TestPlugin');
         $TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments');
 
@@ -413,7 +413,7 @@ class TestCaseTest extends TestCase
      */
     public function testGetMockForModelSetTable()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $I18n = $this->getMockForModel('I18n', ['doSomething']);
         $this->assertEquals('custom_i18n_table', $I18n->table());

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\TestSuite;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -15,7 +15,6 @@
 namespace Cake\Test\TestCase\View;
 
 use Cake\Cache\Cache;
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -43,7 +43,7 @@ class CellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Plugin::load(['TestPlugin', 'TestTheme']);
         $request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
         $response = $this->getMockBuilder('Cake\Http\Response')->getMock();

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -144,7 +144,7 @@ class FormHelperTest extends TestCase
 
         Configure::write('Config.language', 'eng');
         Configure::write('App.base', '');
-        Configure::write('App.namespace', 'Cake\Test\TestCase\View\Helper');
+        static::setAppNamespace('Cake\Test\TestCase\View\Helper');
         $this->View = new View();
 
         $this->Form = new FormHelper($this->View);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -74,7 +74,7 @@ class HtmlHelperTest extends TestCase
         $this->Html->Url->request = $this->Html->request;
 
         Plugin::load(['TestTheme']);
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Configure::write('Asset.timestamp', false);
     }
 

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -63,7 +63,7 @@ class NumberHelperTest extends TestCase
         $this->View = new View();
 
         $this->_appNamespace = Configure::read('App.namespace');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -74,7 +74,7 @@ class NumberHelperTest extends TestCase
     public function tearDown()
     {
         parent::tearDown();
-        Configure::write('App.namespace', $this->_appNamespace);
+        static::setAppNamespace($this->_appNamespace);
         unset($this->View);
     }
 

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -67,7 +67,7 @@ class TextHelperTest extends TestCase
         $this->Text = new TextHelper($this->View);
 
         $this->_appNamespace = Configure::read('App.namespace');
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -78,7 +78,7 @@ class TextHelperTest extends TestCase
     public function tearDown()
     {
         unset($this->Text, $this->View);
-        Configure::write('App.namespace', $this->_appNamespace);
+        static::setAppNamespace($this->_appNamespace);
         parent::tearDown();
     }
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -47,7 +47,7 @@ class UrlHelperTest extends TestCase
         $this->Helper = new UrlHelper($this->View);
         $this->Helper->request = new ServerRequest();
 
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         Plugin::load(['TestTheme']);
     }
 

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -236,7 +236,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testReset()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $instance = $this->Helpers->load('EventListenerTest');
         $this->assertSame(
@@ -259,7 +259,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testUnload()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
 
         $instance = $this->Helpers->load('EventListenerTest');
         $this->assertSame(

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\View;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper;

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\View;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\ViewBuilder;
 
@@ -151,7 +150,7 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildAppViewMissing()
     {
-        Configure::write('App.namespace', 'Nope');
+        static::setAppNamespace('Nope');
         $builder = new ViewBuilder();
         $view = $builder->build();
         $this->assertInstanceOf('Cake\View\View', $view);

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -164,7 +164,7 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildAppViewPresent()
     {
-        Configure::write('App.namespace', 'TestApp');
+        static::setAppNamespace();
         $builder = new ViewBuilder();
         $view = $builder->build();
         $this->assertInstanceOf('TestApp\View\AppView', $view);

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -3,7 +3,6 @@
 namespace TestApp\Error;
 
 use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\Error\ExceptionRenderer;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -17,7 +17,7 @@
 namespace TestApp\Shell;
 
 use Cake\Console\Shell;
-use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
 
 /**
  * for testing dispatchShell functionality
@@ -38,35 +38,35 @@ class TestingDispatchShell extends Shell
     public function testTask()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell('testing_dispatch dispatch_test_task');
     }
 
     public function testTaskDispatchArray()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell('testing_dispatch', 'dispatch_test_task');
     }
 
     public function testTaskDispatchCommandString()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell(['command' => 'testing_dispatch dispatch_test_task']);
     }
 
     public function testTaskDispatchCommandArray()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell(['command' => ['testing_dispatch', 'dispatch_test_task']]);
     }
 
     public function testTaskDispatchWithParam()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell([
             'command' => ['testing_dispatch', 'dispatch_test_task_param'],
             'extra' => [
@@ -78,7 +78,7 @@ class TestingDispatchShell extends Shell
     public function testTaskDispatchWithMultipleParams()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell([
             'command' => 'testing_dispatch dispatch_test_task_params',
             'extra' => [
@@ -91,7 +91,7 @@ class TestingDispatchShell extends Shell
     public function testTaskDispatchWithRequestedOff()
     {
         $this->out('I am a test task, I dispatch another Shell');
-        Configure::write('App.namespace', 'TestApp');
+        TestCase::setAppNamespace();
         $this->dispatchShell([
             'command' => ['testing_dispatch', 'dispatch_test_task'],
             'extra' => [


### PR DESCRIPTION
I noticed we are doing this quite often. Thought we could replace it with a convencience function. No big deal, though.