### PR TITLE
Make Redis::increment/decrement() set a TTL

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -165,7 +165,7 @@ class RedisEngine extends CacheEngine
     }
 
     /**
-     * Increments the value of an integer cached key
+     * Increments the value of an integer cached key & update the expiry time
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to increment
@@ -177,14 +177,13 @@ class RedisEngine extends CacheEngine
         $key = $this->_key($key);
 
         $value = (int)$this->_Redis->incrBy($key, $offset);
-
         $this->_Redis->setTimeout($key, $duration);
 
         return $value;
     }
 
     /**
-     * Decrements the value of an integer cached key
+     * Decrements the value of an integer cached key & update the expiry time
      *
      * @param string $key Identifier for the data
      * @param int $offset How much to subtract
@@ -196,7 +195,6 @@ class RedisEngine extends CacheEngine
         $key = $this->_key($key);
 
         $value = (int)$this->_Redis->decrBy($key, $offset);
-
         $this->_Redis->setTimeout($key, $duration);
 
         return $value;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -173,9 +173,14 @@ class RedisEngine extends CacheEngine
      */
     public function increment($key, $offset = 1)
     {
+        $duration = $this->_config['duration'];
         $key = $this->_key($key);
 
-        return (int)$this->_Redis->incrBy($key, $offset);
+        $value = (int)$this->_Redis->incrBy($key, $offset);
+
+        $this->_Redis->setTimeout($key, $duration);
+
+        return $value;
     }
 
     /**
@@ -187,9 +192,14 @@ class RedisEngine extends CacheEngine
      */
     public function decrement($key, $offset = 1)
     {
+        $duration = $this->_config['duration'];
         $key = $this->_key($key);
 
-        return (int)$this->_Redis->decrBy($key, $offset);
+        $value = (int)$this->_Redis->decrBy($key, $offset);
+
+        $this->_Redis->setTimeout($key, $duration);
+
+        return $value;
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -723,6 +723,26 @@ class MemcachedEngineTest extends TestCase
     }
 
     /**
+     * Test that increment and decrement set ttls.
+     *
+     * @return void
+     */
+    public function testIncrementDecrementExpiring()
+    {
+        $this->_configCache(['duration' => 1]);
+        Cache::write('test_increment', 1, 'memcached');
+        Cache::write('test_decrement', 1, 'memcached');
+
+        $this->assertSame(2, Cache::increment('test_increment', 1, 'memcached'));
+        $this->assertSame(0, Cache::decrement('test_decrement', 1, 'memcached'));
+
+        sleep(1);
+
+        $this->assertFalse(Cache::read('test_increment', 'memcached'));
+        $this->assertFalse(Cache::read('test_decrement', 'memcached'));
+    }
+
+    /**
      * test incrementing compressed keys
      *
      * @return void

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * RedisEngineTest file
- *
- * CakePHP(tm) Tests <https://book.cakephp.org/view/1196/Testing>
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
  * Licensed under The MIT License
@@ -339,6 +337,26 @@ class RedisEngineTest extends TestCase
 
         $result = Cache::read('test_increment', 'redis');
         $this->assertEquals(3, $result);
+    }
+
+    /**
+     * Test that increment and decrement set ttls.
+     *
+     * @return void
+     */
+    public function testIncrementDecrementExpiring()
+    {
+        $this->_configCache(['duration' => 1]);
+        Cache::delete('test_increment', 'redis');
+        Cache::delete('test_decrement', 'redis');
+
+        $this->assertSame(1, Cache::increment('test_increment', 1, 'redis'));
+        $this->assertSame(-1, Cache::decrement('test_decrement', 1, 'redis'));
+
+        sleep(1);
+
+        $this->assertFalse(Cache::read('test_increment', 'redis'));
+        $this->assertFalse(Cache::read('test_decrement', 'redis'));
     }
 
     /**


### PR DESCRIPTION
Continuing the work done in #10786 and adding tests. I've not modified the Memcached driver as memcached values will have a TTL set when the key is initially created.

I am targeting `master` with these changes as it is reasonable to expect that counters would work consistently across Redis and Memcached implementations (which they didn't) and these changes are normalizing behavior across backends.