### PR TITLE
Fix ini_set calls to use strings as second parameter

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -142,9 +142,9 @@ class ShellDispatcher
         }
 
         if (function_exists('ini_set')) {
-            ini_set('html_errors', false);
-            ini_set('implicit_flush', true);
-            ini_set('max_execution_time', 0);
+            ini_set('html_errors', '0');
+            ini_set('implicit_flush', '1');
+            ini_set('max_execution_time', '0');
         }
 
         $this->shiftArgs();

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -96,7 +96,7 @@ class Configure
                 static::$_hasIniSet = function_exists('ini_set');
             }
             if (static::$_hasIniSet) {
-                ini_set('display_errors', $config['debug'] ? 1 : 0);
+                ini_set('display_errors', $config['debug'] ? '1' : '0');
             }
         }
 

--- a/tests/TestCase/Network/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Network/Session/DatabaseSessionTest.php
@@ -154,7 +154,7 @@ class DatabaseSessionTest extends TestCase
     {
         TableRegistry::clear();
 
-        ini_set('session.gc_maxlifetime', 0);
+        ini_set('session.gc_maxlifetime', '0');
         $storage = new DatabaseSession();
         $storage->write('foo', 'Some value');
 


### PR DESCRIPTION
I stumbled upon this while upgrading one of my apps to php 7.1 and strict types enabled.
`ini_set()` expects second parameter to be a string.