### PR TITLE
Fix plugin fixtures in sub-directories not resolving.

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -186,12 +186,18 @@ class FixtureManager
                     $baseNamespace = Configure::read('App.namespace');
                 } elseif ($type === 'plugin') {
                     list($plugin, $name) = explode('.', $pathName);
+                    // Flip vendored plugin separators
                     $path = implode('\\', explode('/', $plugin));
                     $baseNamespace = Inflector::camelize(str_replace('\\', '\ ', $path));
                     $additionalPath = null;
                 } else {
                     $baseNamespace = '';
                     $name = $fixture;
+                }
+
+                // Tweak subdirectory names, so camelize() can make the correct name
+                if (strpos($name, '/') > 0) {
+                    $name = implode('\\ ', explode('/', $name));
                 }
 
                 $name = Inflector::camelize($name);

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -183,7 +183,7 @@ class FixtureManagerTest extends TestCase
     }
 
     /**
-     * Test loading app fixtures.
+     * Test loading plugin fixtures.
      *
      * @return void
      */
@@ -204,11 +204,32 @@ class FixtureManagerTest extends TestCase
     }
 
     /**
-     * Test loading app fixtures.
+     * Test loading plugin fixtures.
      *
      * @return void
      */
-    public function testFixturizeCustom()
+    public function testFixturizePluginSubdirectory()
+    {
+        Plugin::load('TestPlugin');
+
+        $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
+        $test->fixtures = ['plugin.test_plugin.blog/comments'];
+        $this->manager->fixturize($test);
+        $fixtures = $this->manager->loaded();
+        $this->assertCount(1, $fixtures);
+        $this->assertArrayHasKey('plugin.test_plugin.blog/comments', $fixtures);
+        $this->assertInstanceOf(
+            'TestPlugin\Test\Fixture\Blog\CommentsFixture',
+            $fixtures['plugin.test_plugin.blog/comments']
+        );
+    }
+
+    /**
+     * Test loading plugin fixtures from a vendor namespaced plugin
+     *
+     * @return void
+     */
+    public function testFixturizeVendorPlugin()
     {
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->fixtures = ['plugin.Company/TestPluginThree.articles'];
@@ -223,7 +244,7 @@ class FixtureManagerTest extends TestCase
     }
 
     /**
-     * Test loading app fixtures.
+     * Test loading fixtures with fully-qualified namespaces.
      *
      * @return void
      */

--- a/tests/test_app/Plugin/TestPlugin/tests/Fixture/Blog/CommentsFixture.php
+++ b/tests/test_app/Plugin/TestPlugin/tests/Fixture/Blog/CommentsFixture.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.4.9
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Test\Fixture\Blog;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Plugin comments fixture.
+ */
+class CommentsFixture extends TestFixture
+{
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'article_id' => ['type' => 'integer', 'null' => false],
+        'comment' => 'text',
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [];
+}


### PR DESCRIPTION
We need to flip / into \ to correctly generate the namespace for fixtures in subdirectories.

Refs #10795