### PR TITLE
Fix some issues that came up while using strict_types

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -51,7 +51,7 @@ if (!function_exists('h')) {
             } else {
                 $text = '(object)' . get_class($text);
             }
-        } elseif (is_bool($text)) {
+        } elseif (is_bool($text) || is_null($text) || is_int($text)) {
             return $text;
         }
 
@@ -199,7 +199,7 @@ if (!function_exists('env')) {
                 return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
             }
 
-            return (strpos(env('SCRIPT_URI'), 'https://') === 0);
+            return (strpos((string)env('SCRIPT_URI'), 'https://') === 0);
         }
 
         if ($key === 'SCRIPT_NAME') {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -177,7 +177,7 @@ class SqliteSchema extends BaseSchema
         }
 
         // Remove quotes
-        if (preg_match("/^'(.*)'$/", (string)$default, $matches)) {
+        if (preg_match("/^'(.*)'$/", $default, $matches)) {
             return str_replace("''", "'", $matches[1]);
         }
 

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -177,7 +177,7 @@ class SqliteSchema extends BaseSchema
         }
 
         // Remove quotes
-        if (preg_match("/^'(.*)'$/", $default, $matches)) {
+        if (preg_match("/^'(.*)'$/", (string)$default, $matches)) {
             return str_replace("''", "'", $matches[1]);
         }
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1853,7 +1853,7 @@ class Response implements ResponseInterface
      */
     public function checkNotModified(ServerRequest $request)
     {
-        $etags = preg_split('/\s*,\s*/', $request->header('If-None-Match'), null, PREG_SPLIT_NO_EMPTY);
+        $etags = preg_split('/\s*,\s*/', (string)$request->header('If-None-Match'), 0, PREG_SPLIT_NO_EMPTY);
         $modifiedSince = $request->header('If-Modified-Since');
         if ($responseTag = $this->etag()) {
             $etagMatches = in_array('*', $etags) || in_array($responseTag, $etags);

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -288,7 +288,7 @@ class Session
         }
 
         foreach ($options as $setting => $value) {
-            if (ini_set($setting, $value) === false) {
+            if (ini_set($setting, (string)$value) === false) {
                 throw new RuntimeException(
                     sprintf('Unable to configure the session, setting %s failed.', $setting)
                 );


### PR DESCRIPTION
If fixed some issues while using `strict_types`. Most of them caused by passing `null` to internal php functions.