### PR TITLE
Fix usage of contain finder options for hasMany relations

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -163,7 +163,14 @@ class SelectLoader
             $options['fields'] = [];
         }
 
-        $fetchQuery = $finder()
+        if (isset($options['finder'])) {
+            list($finderName, $opts) = $this->_extractFinder($options['finder']);
+            $query = $finder()->find($finderName, $opts);
+        } else {
+            $query = $finder();
+        }
+
+        $fetchQuery = $query
             ->select($options['fields'])
             ->where($options['conditions'])
             ->eagerLoaded(true)
@@ -191,6 +198,33 @@ class SelectLoader
         $this->_assertFieldsPresent($fetchQuery, (array)$key);
 
         return $fetchQuery;
+    }
+
+    /**
+     * Helper method to infer the requested finder and its options.
+     *
+     * Returns the inferred options from the finder $type.
+     *
+     * ### Examples:
+     *
+     * The following will call the finder 'translations' with the value of the finder as its options:
+     * $query->contain(['Comments' => ['finder' => ['translations']]]);
+     * $query->contain(['Comments' => ['finder' => ['translations' => []]]]);
+     * $query->contain(['Comments' => ['finder' => ['translations' => ['locales' => ['en_US']]]]]);
+     *
+     * @param string|array $finderData The finder name or an array having the name as key
+     * and options as value.
+     * @return array
+     */
+    protected function _extractFinder($finderData)
+    {
+        $finderData = (array)$finderData;
+
+        if (is_numeric(key($finderData))) {
+            return [current($finderData), []];
+        }
+
+        return [key($finderData), current($finderData)];
     }
 
     /**

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -163,11 +163,10 @@ class SelectLoader
             $options['fields'] = [];
         }
 
+        $query = $finder();
         if (isset($options['finder'])) {
             list($finderName, $opts) = $this->_extractFinder($options['finder']);
-            $query = $finder()->find($finderName, $opts);
-        } else {
-            $query = $finder();
+            $query = $query->find($finderName, $opts);
         }
 
         $fetchQuery = $query

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2877,13 +2877,16 @@ class QueryTest extends TestCase
                 ]
             ]);
 
-        $this->assertSame(2, count($resultWithArticles->first()->articles));
-        $this->assertSame(2, count($resultWithArticlesArray->first()->articles));
+        $this->assertCount(2, $resultWithArticles->first()->articles);
+        $this->assertCount(2, $resultWithArticlesArray->first()->articles);
 
-        $this->assertSame(1, count($resultWithArticlesArrayOptions->first()->articles));
-        $this->assertSame('First Article', $resultWithArticlesArrayOptions->first()->articles[0]->title);
+        $this->assertCount(1, $resultWithArticlesArrayOptions->first()->articles);
+        $this->assertSame(
+            'First Article',
+            $resultWithArticlesArrayOptions->first()->articles[0]->title
+        );
 
-        $this->assertSame(0, count($resultWithoutArticles->first()->articles));
+        $this->assertCount(0, $resultWithoutArticles->first()->articles);
     }
 
     /**
@@ -2915,7 +2918,7 @@ class QueryTest extends TestCase
                 }
             ]);
 
-        $this->assertSame(2, count($resultWithArticles->first()->articles));
+        $this->assertCount(2, $resultWithArticles->first()->articles);
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -33,9 +33,15 @@ class ArticlesTable extends Table
      * @param \Cake\ORM\Query $query The query
      * @return \Cake\ORM\Query
      */
-    public function findPublished($query)
+    public function findPublished($query, array $options = [])
     {
-        return $query->where(['published' => 'Y']);
+        $query = $query->where(['published' => 'Y']);
+
+        if (isset($options['title'])) {
+            $query->andWhere(['title' => $options['title']]);
+        }
+
+        return $query;
     }
 
     /**


### PR DESCRIPTION
This fixes #10223 as the option didn't work anymore for `hasMany` relations.
I didn't created a new trait for `_extractFinder` and instead copied `Association::_extractFinder()`.

@lorenzo Thank you for your help 😄 