### PR TITLE
Improved collections performance in common use cases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ init:
 
 install:
   - cd c:\
-  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.6.0-nts-Win32-VC11-x86.zip -FileName php.zip
+  - appveyor DownloadFile http://windows.php.net/downloads/releases/php-5.6.30-nts-Win32-VC11-x86.zip -FileName php.zip
   - 7z x php.zip -oc:\php > nul
   - appveyor DownloadFile https://dl.dropboxusercontent.com/s/euip490d9183jkr/SQLSRV32.cab -FileName sqlsrv.cab
   - 7z x sqlsrv.cab -oc:\php\ext php*_56_nts.dll > nul

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -752,12 +752,12 @@ trait CollectionTrait
         return new Collection($result);
     }
 
-     /**
-      * Unwraps this iterator and returns the simplest
-      * traversable that can be used for getting the data out
-      *
-      * @return \Traversable|array
-      */
+    /**
+     * Unwraps this iterator and returns the simplest
+     * traversable that can be used for getting the data out
+     *
+     * @return \Traversable|array
+     */
     protected function optimizeUnwrap()
     {
         $iterator = $this->unwrap();

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -75,7 +75,7 @@ class ExtractIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some stricness analysys so that the
+     * We perform here some strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -14,7 +14,9 @@
  */
 namespace Cake\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 
 /**
  * Creates an iterator from another iterator that extract the requested column
@@ -68,5 +70,38 @@ class ExtractIterator extends Collection
         $extractor = $this->_extractor;
 
         return $extractor(parent::current());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * We perform here some stricness analysys so that the
+     * iterator logic is bypassed entirely.
+     *
+     * @return \Iterator
+     */
+    public function unwrap()
+    {
+        $iterator = $this->getInnerIterator();
+
+        if ($iterator instanceof CollectionInterface) {
+            $iterator = $iterator->unwrap();
+        }
+
+        if (!$iterator instanceof ArrayIterator) {
+            return $this;
+        }
+
+        // ArrayIterator can be traversed strictly.
+        // Let's do that for performance gains
+
+        $callback = $this->_extractor;
+        $res = [];
+
+        foreach ($iterator->getArrayCopy() as $k => $v) {
+            $res[$k] = $callback($v);
+        }
+
+        return new ArrayIterator($res);
     }
 }

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -14,7 +14,9 @@
  */
 namespace Cake\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 use CallbackFilterIterator;
 use Iterator;
 
@@ -27,6 +29,13 @@ class FilterIterator extends Collection
 {
 
     /**
+     * The callback used to filter the elements in this collection
+     *
+     * @var callable
+     */
+    protected $_callback;
+
+    /**
      * Creates a filtered iterator using the callback to determine which items are
      * accepted or rejected.
      *
@@ -37,9 +46,50 @@ class FilterIterator extends Collection
      * @param \Iterator $items The items to be filtered.
      * @param callable $callback Callback.
      */
-    public function __construct(Iterator $items, callable $callback)
+    public function __construct($items, callable $callback)
     {
+        if (!$items instanceof Iterator) {
+            $items = new Collection($items);
+        }
+
+        $this->_callback = $callback;
         $wrapper = new CallbackFilterIterator($items, $callback);
         parent::__construct($wrapper);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * We perform here some stricness analysys so that the
+     * iterator logic is bypassed entirely.
+     *
+     * @return \Iterator
+     */
+    public function unwrap()
+    {
+        $filter = $this->getInnerIterator();
+        $iterator = $filter->getInnerIterator();
+
+        if ($iterator instanceof CollectionInterface) {
+            $iterator = $iterator->unwrap();
+        }
+
+        if (!$iterator instanceof ArrayIterator) {
+            return $filter;
+        }
+
+        // ArrayIterator can be traversed strictly.
+        // Let's do that for performance gains
+
+        $callback = $this->_callback;
+        $res = [];
+
+        foreach ($iterator as $k => $v) {
+            if ($callback($v, $k, $iterator)) {
+                $res[$k] = $v;
+            }
+        }
+
+        return new ArrayIterator($res);
     }
 }

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -60,7 +60,7 @@ class FilterIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some stricness analysys so that the
+     * We perform here some  strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -60,7 +60,7 @@ class FilterIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some  strictness analysis so that the
+     * We perform here some strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -70,7 +70,6 @@ class ReplaceIterator extends Collection
         return $callback(parent::current(), $this->key(), $this->_innerIterator);
     }
 
-
     /**
      * {@inheritDoc}
      *

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -14,7 +14,9 @@
  */
 namespace Cake\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 
 /**
  * Creates an iterator from another iterator that will modify each of the values
@@ -24,7 +26,7 @@ class ReplaceIterator extends Collection
 {
 
     /**
-     * The callback function to be used to modify each of the values
+     * The callback function to be used to transform values
      *
      * @var callable
      */
@@ -66,5 +68,39 @@ class ReplaceIterator extends Collection
         $callback = $this->_callback;
 
         return $callback(parent::current(), $this->key(), $this->_innerIterator);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
+     * We perform here some stricness analysys so that the
+     * iterator logic is bypassed entirely.
+     *
+     * @return \Iterator
+     */
+    public function unwrap()
+    {
+        $iterator = $this->_innerIterator;
+
+        if ($iterator instanceof CollectionInterface) {
+            $iterator = $iterator->unwrap();
+        }
+
+        if (!$iterator instanceof ArrayIterator) {
+            return $this;
+        }
+
+        // ArrayIterator can be traversed strictly.
+        // Let's do that for performance gains
+
+        $callback = $this->_callback;
+        $res = [];
+
+        foreach ($iterator as $k => $v) {
+            $res[$k] = $callback($v, $k, $iterator);
+        }
+
+        return new ArrayIterator($res);
     }
 }

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -73,7 +73,7 @@ class ReplaceIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some  strictness analysis so that the
+     * We perform here some strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -73,7 +73,7 @@ class ReplaceIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some stricness analysys so that the
+     * We perform here some  strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -59,11 +59,10 @@ class SortIterator extends Collection
      */
     public function __construct($items, $callback, $dir = SORT_DESC, $type = SORT_NUMERIC)
     {
-        if (is_array($items)) {
-            $items = new Collection($items);
+        if (!is_array($items)) {
+            $items = iterator_to_array((new Collection($items))->unwrap(), false);
         }
 
-        $items = iterator_to_array($items, false);
         $callback = $this->_propertyExtractor($callback);
         $results = [];
         foreach ($items as $key => $value) {
@@ -80,5 +79,15 @@ class SortIterator extends Collection
             $results[$key] = $items[$key];
         }
         parent::__construct($results);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return \Iterator
+     */
+    public function unwrap()
+    {
+        return $this->getInnerIterator();
     }
 }

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -14,7 +14,9 @@
  */
 namespace Cake\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 
 /**
  * Creates an iterator from another iterator that will verify a condition on each
@@ -77,5 +79,42 @@ class StoppableIterator extends Collection
         $condition = $this->_condition;
 
         return !$condition($current, $key, $this->_innerIterator);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * We perform here some stricness analysys so that the
+     * iterator logic is bypassed entirely.
+     *
+     * @return \Iterator
+     */
+    public function unwrap()
+    {
+        $iterator = $this->_innerIterator;
+
+        if ($iterator instanceof CollectionInterface) {
+            $iterator = $iterator->unwrap();
+        }
+
+        if (!$iterator instanceof ArrayIterator) {
+            return $this;
+        }
+
+        // ArrayIterator can be traversed strictly.
+        // Let's do that for performance gains
+
+        $callback = $this->_condition;
+        $res = [];
+        $stop = false;
+
+        foreach ($iterator as $k => $v) {
+            if ($callback($v, $k, $iterator)) {
+                break;
+            }
+            $res[$k] = $v;
+        }
+
+        return new ArrayIterator($res);
     }
 }

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -84,7 +84,7 @@ class StoppableIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some  strictness analysis so that the
+     * We perform here some strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -84,7 +84,7 @@ class StoppableIterator extends Collection
     /**
      * {@inheritDoc}
      *
-     * We perform here some stricness analysys so that the
+     * We perform here some  strictness analysis so that the
      * iterator logic is bypassed entirely.
      *
      * @return \Iterator

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -106,7 +106,6 @@ class StoppableIterator extends Collection
 
         $callback = $this->_condition;
         $res = [];
-        $stop = false;
 
         foreach ($iterator as $k => $v) {
             if ($callback($v, $k, $iterator)) {

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -98,6 +98,7 @@ class CollectionTest extends TestCase
     public function filterProvider()
     {
         $items = [1, 2, 0, 3, false, 4, null, 5, ''];
+
         return [
             'array' => [$items],
             'iterator' => [$this->yieldItems($items)]
@@ -2225,7 +2226,7 @@ class CollectionTest extends TestCase
      * @param array $itmes the elements to be yielded
      * @return void
      */
-    function yieldItems(array $items)
+    protected function yieldItems(array $items)
     {
         foreach ($items as $k => $v) {
             yield $k => $v;

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2221,7 +2221,7 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * Yields all the elmentes as passed
+     * Yields all the elements as passed
      *
      * @param array $itmes the elements to be yielded
      * @return void


### PR DESCRIPTION
This improves the performance of most collection methods sometimes
by making it 100% faster compared to the previous implementation.

The improvement is not for free, with this change we are giving up
the lazyness feature (not iterate unless requested). The giving
up of the feature only happens when the collection has been initialized
with an array, as oposed to being initialized with another iterator or
generator; and this is the reson I consider this change a safe one.

For the curious, the improvement comes from the (sad) fact that calling
functions in php is extremenly expensive, specially when using iterators
since each iteration will call at least 4 functions (valid, next, current, key).

This becomes even worse as `IteratorIterator` does not have any optimizations,
so for each wrapped iterator, the number of functions is multiplied by 2
for each iteration.

The change proposed here will unwrap nested iterators as much as possible
to avoid the function call explosion, and in some (safe) cases, will
iterator the collection immediately as an array before wrapping it again
in an iterator.

I was inspired by Haskell when implementing this, as the language is lazy
by default, but the compiler optimizes the cases where code is safe to be
called strictly. Thats is called strictness analysis.