### PR TITLE
Fixed FixtureInjector method compatibility

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -24,24 +24,18 @@ if (class_exists('PHPUnit_Runner_Version')) {
     if (!class_exists('PHPUnit\Framework\TestSuite')) {
         class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
     }
-    if (!class_exists('PHPUnit\Framework\AssertionFailedError')) {
-        class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
-    }
 }
 
 use Cake\TestSuite\TestCase;
-use Exception;
-use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;
-use PHPUnit\Framework\Warning;
 
 /**
  * Test listener used to inject a fixture manager in all tests that
  * are composed inside a Test Suite
  */
-class FixtureInjector implements TestListener
+class FixtureInjector extends BaseTestListener
 {
 
     /**
@@ -101,66 +95,6 @@ class FixtureInjector implements TestListener
     }
 
     /**
-     * Not Implemented
-     *
-     * @param \PHPUnit\Framework\Test $test The test to add errors from.
-     * @param \Exception $e The exception
-     * @param float $time current time
-     * @return void
-     */
-    public function addError(Test $test, Exception $e, $time)
-    {
-    }
-
-    /**
-     * Not Implemented
-     *
-     * @param \PHPUnit\Framework\Test $test The test to add warnings from.
-     * @param \PHPUnit\Framework\Warning $e The warning
-     * @param float $time current time
-     * @return void
-     */
-    public function addWarning(Test $test, Warning $e, $time)
-    {
-    }
-
-    /**
-     * Not Implemented
-     *
-     * @param \PHPUnit\Framework\Test $test The test case
-     * @param \PHPUnit\Framework\AssertionFailedError $e The failed assertion
-     * @param float $time current time
-     * @return void
-     */
-    public function addFailure(Test $test, AssertionFailedError $e, $time)
-    {
-    }
-
-    /**
-     * Not Implemented
-     *
-     * @param \PHPUnit\Framework\Test $test The test case
-     * @param \Exception $e The incomplete test error.
-     * @param float $time current time
-     * @return void
-     */
-    public function addIncompleteTest(Test $test, Exception $e, $time)
-    {
-    }
-
-    /**
-     * Not Implemented
-     *
-     * @param \PHPUnit\Framework\Test $test The test case
-     * @param \Exception $e Skipped test exception
-     * @param float $time current time
-     * @return void
-     */
-    public function addSkippedTest(Test $test, Exception $e, $time)
-    {
-    }
-
-    /**
      * Adds fixtures to a test case when it starts.
      *
      * @param \PHPUnit\Framework\Test $test The test case
@@ -187,17 +121,5 @@ class FixtureInjector implements TestListener
         if ($test instanceof TestCase) {
             $this->_fixtureManager->unload($test);
         }
-    }
-
-    /**
-     * Not Implemented
-     *
-     * @param \PHPUnit\Framework\Test $test The test case
-     * @param \Exception $e The exception to track
-     * @param float $time current time
-     * @return void
-     */
-    public function addRiskyTest(Test $test, Exception $e, $time)
-    {
     }
 }

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -19,11 +19,6 @@ if (class_exists('PHPUnit_Runner_Version')) {
         trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
     }
     class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
-    class_alias('PHPUnit_Framework_Warning', 'PHPUnit\Framework\Warning');
-
-    if (!class_exists('PHPUnit\Framework\TestSuite')) {
-        class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
-    }
 }
 
 use Cake\TestSuite\TestCase;

--- a/src/TestSuite/TestSuite.php
+++ b/src/TestSuite/TestSuite.php
@@ -16,11 +16,12 @@
  */
 namespace Cake\TestSuite;
 
-if (class_exists('PHPUnit_Runner_Version') && !class_exists('PHPUnit\Framework\TestSuite')) {
+if (class_exists('PHPUnit_Runner_Version')) {
     if (version_compare(\PHPUnit_Runner_Version::id(), '5.7', '<')) {
         trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
     }
     class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
+    class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
 }
 
 use Cake\Filesystem\Folder;


### PR DESCRIPTION
Attempt to fix #10814.

Apparently this break has happened before, and according to Sebastian Bergmann we should not be implementing the interface but extending the base class. Hopefully this fixes the builds and prevents future problems.

See: https://github.com/sebastianbergmann/phpunit/pull/1840#issuecomment-162537650