### PR TITLE
Fix last line excerpt not retrievable.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -421,10 +421,10 @@ class Debugger
         if (strpos($data, "\n") !== false) {
             $data = explode("\n", $data);
         }
+        $line--;
         if (!isset($data[$line])) {
             return $lines;
         }
-        $line--;
         for ($i = $line - $context; $i < $line + $context + 1; $i++) {
             if (!isset($data[$i])) {
                 continue;

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -129,6 +129,13 @@ class DebuggerTest extends TestCase
         $this->assertContains('Debugger', $result[5]);
         $this->assertContains('excerpt', $result[5]);
         $this->assertContains('__FILE__', $result[5]);
+
+        $result = Debugger::excerpt(__FILE__, 1, 2);
+        $this->assertCount(3, $result);
+
+        $lastLine = count(explode("\n", file_get_contents(__FILE__)));
+        $result = Debugger::excerpt(__FILE__, $lastLine, 2);
+        $this->assertCount(3, $result);
     }
 
     /**


### PR DESCRIPTION
The line number needs to be decremented before testing for existence,
otherwise the last line number would be out of bounds.