### PR TITLE
Add version shell and --version

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -64,11 +64,17 @@ class CommandRunner
     }
 
     /**
-     * Replace the alias map for a runner.
+     * Replace the entire alias map for a runner.
      *
      * Aliases allow you to define alternate names for commands
      * in the collection. This can be useful to add top level switches
      * like `--version` or `-h`
+     *
+     * ### Usage
+     *
+     * ```
+     * $runner->setAliases(['--version' => 'version']);
+     * ```
      *
      * @param array $aliases The map of aliases to replace.
      * @return $this

--- a/src/Shell/VersionShell.php
+++ b/src/Shell/VersionShell.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Shell;
+
+use Cake\Console\Shell;
+use Cake\Core\Configure;
+
+/**
+ * Print out the version of CakePHP in use.
+ */
+class VersionShell extends Shell
+{
+    /**
+     * Print out the version of CakePHP in use.
+     *
+     * @return void
+     */
+    public function main()
+    {
+        $this->out(Configure::version());
+    }
+}

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -138,19 +138,17 @@ class CommandRunnerTest extends TestCase
      *
      * @return void
      */
-    public function testRunVersionLongOption()
+    public function testRunVersionAlias()
     {
-        $this->markTestIncomplete();
-    }
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->setMethods(['middleware', 'bootstrap'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
 
-    /**
-     * Test using `cake -v` invokes the version command
-     *
-     * @return void
-     */
-    public function testRunVersionShortOption()
-    {
-        $this->markTestIncomplete();
+        $output = new ConsoleOutput();
+        $runner = new CommandRunner($app, 'cake');
+        $result = $runner->run(['cake', '--version'], $this->getMockIo($output));
+        $this->assertContains(Configure::version(), $output->messages()[0]);
     }
 
     /**

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -116,7 +116,7 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = 'TestPlugin.example TestPlugin.sample TestPluginTwo.example unique welcome ' .
-            "cache i18n orm_cache plugin routes server i18m sample testing_dispatch\n";
+            "cache i18n orm_cache plugin routes server version i18m sample testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
 


### PR DESCRIPTION
By having aliases and standalone shells we avoid having 'command' logic in the command runner. It also means that application developers can replace the default --version behavior if they want to.

Part of #10716 