### PR TITLE
Attempt no. 2 to fix PHPUnit aliases

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -14,12 +14,7 @@
  */
 namespace Cake\TestSuite\Fixture;
 
-if (class_exists('PHPUnit_Runner_Version')) {
-    if (version_compare(\PHPUnit_Runner_Version::id(), '5.7', '<')) {
-        trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
-    }
-    class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
-}
+loadPHPUnitAliases();
 
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\BaseTestListener;

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\TestSuite\Fixture;
 
+loadPHPUnitAliases();
+
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\Database\Schema\TableSchema;

--- a/src/TestSuite/TestSuite.php
+++ b/src/TestSuite/TestSuite.php
@@ -16,13 +16,7 @@
  */
 namespace Cake\TestSuite;
 
-if (class_exists('PHPUnit_Runner_Version')) {
-    if (version_compare(\PHPUnit_Runner_Version::id(), '5.7', '<')) {
-        trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
-    }
-    class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
-    class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
-}
+loadPHPUnitAliases();
 
 use Cake\Filesystem\Folder;
 use PHPUnit\Framework\TestSuite as BaseTestSuite;

--- a/src/basics.php
+++ b/src/basics.php
@@ -140,3 +140,18 @@ if (!function_exists('dd')) {
         die(1);
     }
 }
+
+if (!function_exists('loadPHPUnitAliases')) {
+    /**
+     * Loads PHPUnit aliases
+     *
+     * This is an internal function used for backwards compatibility during
+     * fixture related tests.
+     *
+     * @return void
+     */
+    function loadPHPUnitAliases()
+    {
+        require_once dirname(__DIR__) . DS . 'tests' . DS . 'phpunit_aliases.php';
+    }
+}

--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -1,0 +1,10 @@
+<?php
+if (class_exists('PHPUnit_Runner_Version')) {
+    if (version_compare(\PHPUnit_Runner_Version::id(), '5.7', '<')) {
+        trigger_error(sprintf('Your PHPUnit Version must be at least 5.7.0 to use CakePHP Testsuite, found %s', \PHPUnit_Runner_Version::id()), E_USER_ERROR);
+    }
+
+    class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
+    class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
+    class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
+}


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/10814

For reasons I cannot figure out (probably gremlins), autoloading in the plugin from the original issue happens in a different order than that of the cake core. 

To help alleviate this discrepancy, I created a new helper function `loadPHPUnitAliases()` which is guaranteed to exist on all apps and plugins, which in turn uses `require_once` to load a file that defines aliases. If any future breaks happen in PHPUnit 🤞  we should be able to add aliases to the file and use the global function in all files that require said aliases.

I went with `require_once` instead of checking that classes exist because I was still getting redeclare errors even when wrapping them in `class_exists`.