### PR TITLE
Check for session.use_trans_sid and session ID in URL when cookies are disabled

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -538,7 +538,8 @@ class Session
     {
         return !ini_get('session.use_cookies')
             || isset($_COOKIE[session_name()])
-            || $this->_isCLI;
+            || $this->_isCLI
+            || (ini_get('session.use_trans_sid') && isset($_GET[session_name()]));
     }
 
     /**

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -371,7 +371,7 @@ class Session
      * Returns given session variable, or all of them, if no parameters given.
      *
      * @param string|null $name The name of the session variable (or a path as sent to Hash.extract)
-     * @return string|null The value of the session variable, null if session not available,
+     * @return string|array|null The value of the session variable, null if session not available,
      *   session not started, or provided name not found in the session.
      */
     public function read($name = null)


### PR DESCRIPTION
If cookies are disabled in the browser and the session ID is passed via URL Cake doesn't recognize that a session exists and calls of Session::read() or check() before the first write() will fail.

An alternative would be to start the session in read() and check() like it's done in write(). But I like it better this way fixing the check, what do you think?

It would be great if this could be backported to Cake2, I can create another PR for this if you like.