### PR TITLE
Fix error when default value is reported as CURRENT_TIMESTAMP() by mysql - Fixes #10829

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -352,7 +352,8 @@ class Mysql extends DboSource {
 			if (in_array($fields[$column->Field]['type'], $this->fieldParameters['unsigned']['types'], true)) {
 				$fields[$column->Field]['unsigned'] = $this->_unsigned($column->Type);
 			}
-			if (in_array($fields[$column->Field]['type'], array('timestamp', 'datetime')) && strtoupper($column->Default) === 'CURRENT_TIMESTAMP') {
+			if (in_array($fields[$column->Field]['type'], array('timestamp', 'datetime')) &&
+					in_array(strtoupper($column->Default), array('CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP()'))) {
 				$fields[$column->Field]['default'] = null;
 			}
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {


### PR DESCRIPTION
My database version (mysqld  Ver 10.2.6-MariaDB for osx10.12 on x86_64 (Homebrew)) reports the default value current_timestamp with parenthesis (like so: ``` `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()```) which confuses the CakePHP mysql driver to think it is a string and that leads to the following error when running tests: 
```
2017-06-27 11:51:16 Error: Fixture creation for "ad_campaigns" failed "SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'updated_at'"
PHP Warning:  Fixture creation for "ad_campaigns" failed "SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'updated_at'" in /Users/kurre/mcn/nativeflow/Vendor/cakephp/cakephp/lib/Cake/TestSuite/Fixture/CakeTestFixture.php on line 244
```
This patch will allow for the parenthesis and that fixes my issue (#10829)

I am unsure how to write a test for this as it seems to be database version specific issue.