### PR TITLE
Fixed Xdebug issue in combination with isConnected() #10836

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -386,7 +386,7 @@ abstract class Driver
     public function __debugInfo()
     {
         return [
-            'connected' => $this->isConnected()
+            'connected' => $this->_connection !== null
         ];
     }
 }


### PR DESCRIPTION
Xdebug uses PHP's var_dump() function for displaying variables.
https://xdebug.org/docs/display

Setting a breakpoint at or before a line with a lastInsertId() method call the __debugInfo() method of the Driver object was magically called by Xdebug and PHP.

Within the __debugInfo() a new SELECT 1 statement was called and cleared the lastInsertId of the connection. Instead of a new SELECT we only check the state of the connection object now.

You can find more details here: #10836 (comment)