### PR TITLE
Add root command propagation and CommandCollectionInterface

### DIFF
--- a/src/Console/CommandCollectionAwareInterface.php
+++ b/src/Console/CommandCollectionAwareInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Console;
+
+/**
+ * An interface for shells that take a CommandCollection
+ * during initialization.
+ *
+ */
+interface CommandCollectionAwareInterface
+{
+    /**
+     * Set the command collection being used.
+     *
+     * @param \Cake\Console\CommandCollection $commands The commands to use.
+     * @return void
+     */
+    public function setCommandCollection(CommandCollection $commands);
+}

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -15,6 +15,7 @@
 namespace Cake\Console;
 
 use Cake\Console\CommandCollection;
+use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Console\Shell;
@@ -165,11 +166,10 @@ class CommandRunner
         if (is_string($instance)) {
             $instance = new $instance($io);
         }
-        // Moving to an interface/method on Shell soon.
-        if (method_exists($instance, 'setCommandCollection')) {
+        $instance->setRootName($this->root);
+        if ($instance instanceof CommandCollectionAwareInterface) {
             $instance->setCommandCollection($commands);
         }
-        $instance->setRootName($this->root);
 
         return $instance;
     }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -169,6 +169,7 @@ class CommandRunner
         if (method_exists($instance, 'setCommandCollection')) {
             $instance->setCommandCollection($commands);
         }
+        $instance->setRootName($this->root);
 
         return $instance;
     }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -741,6 +741,7 @@ class ConsoleOptionParser
                 $subparser->setDescription($command->getRawHelp());
             }
             $subparser->setCommand($this->getCommand() . ' ' . $subcommand);
+            $subparser->setRootName($this->rootName);
 
             return $subparser->help(null, $format, $width);
         }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -135,12 +135,12 @@ class ConsoleOptionParser
     protected $_tokens = [];
 
     /**
-     * Help alias used in the HelpFormatter.
+     * Root alias used in help output
      *
      * @see \Cake\Console\HelpFormatter::setAlias()
      * @var string
      */
-    protected $_helpAlias = 'cake';
+    protected $rootName = 'cake';
 
     /**
      * Construct an OptionParser so you can define its behavior
@@ -719,6 +719,7 @@ class ConsoleOptionParser
 
     /**
      * Gets formatted help for this parser object.
+     *
      * Generates help text based on the description, options, arguments, subcommands and epilog
      * in the parser.
      *
@@ -745,7 +746,7 @@ class ConsoleOptionParser
         }
 
         $formatter = new HelpFormatter($this);
-        $formatter->setAlias($this->_helpAlias);
+        $formatter->setAlias($this->rootName);
 
         if ($format === 'text') {
             return $formatter->text($width);
@@ -760,10 +761,24 @@ class ConsoleOptionParser
      *
      * @param string $alias The alias
      * @return void
+     * @deprecated 3.5.0 Use setRootName() instead.
      */
     public function setHelpAlias($alias)
     {
-        $this->_helpAlias = $alias;
+        $this->rootName = $alias;
+    }
+
+    /**
+     * Set the root name used in the HelpFormatter
+     *
+     * @param string $name The root command name
+     * @return void
+     */
+    public function setRootName($name)
+    {
+        $this->rootName = (string)$name;
+
+        return $this;
     }
 
     /**

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -773,7 +773,7 @@ class ConsoleOptionParser
      * Set the root name used in the HelpFormatter
      *
      * @param string $name The root command name
-     * @return void
+     * @return $this
      */
     public function setRootName($name)
     {

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -163,6 +163,13 @@ class Shell
     protected $_io;
 
     /**
+     * The root command name used when generating help output.
+     *
+     * @var string
+     */
+    protected $rootName = 'cake';
+
+    /**
      * Constructs this Shell instance.
      *
      * @param \Cake\Console\ConsoleIo|null $io An io instance.
@@ -188,6 +195,19 @@ class Shell
         if (isset($this->modelClass)) {
             $this->loadModel();
         }
+    }
+
+    /**
+     * Set the root command name for help output.
+     *
+     * @param string $name The name of the root command.
+     * @return $this
+     */
+    public function setRootName($name)
+    {
+        $this->rootName = (string)$name;
+
+        return $this;
     }
 
     /**
@@ -550,8 +570,10 @@ class Shell
     public function getOptionParser()
     {
         $name = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
+        $parser = new ConsoleOptionParser($name);
+        $parser->setRootName($this->rootName);
 
-        return new ConsoleOptionParser($name);
+        return $parser;
     }
 
     /**

--- a/src/Shell/HelpShell.php
+++ b/src/Shell/HelpShell.php
@@ -16,6 +16,7 @@
 namespace Cake\Shell;
 
 use Cake\Console\CommandCollection;
+use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleOutput;
 use Cake\Console\Shell;
 use SimpleXmlElement;
@@ -23,7 +24,7 @@ use SimpleXmlElement;
 /**
  * Print out command list
  */
-class HelpShell extends Shell
+class HelpShell extends Shell implements CommandCollectionAwareInterface
 {
     /**
      * The command collection to get help on.
@@ -45,10 +46,7 @@ class HelpShell extends Shell
     }
 
     /**
-     * Set the command collection being used.
-     *
-     * @param \Cake\Console\CommandCollection $commands The commands to use.
-     * @return void
+     * {@inheritDoc}
      */
     public function setCommandCollection(CommandCollection $commands)
     {

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -241,6 +241,30 @@ class CommandRunnerTest extends TestCase
         $this->assertSame(99, $result);
     }
 
+    /**
+     * Ensure that the root command name propagates to shell help
+     *
+     * @return void
+     */
+    public function testRunRootNamePropagates()
+    {
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->setMethods(['middleware', 'bootstrap', 'console'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
+
+        $commands = new CommandCollection(['sample' => SampleShell::class]);
+        $app->method('console')->will($this->returnValue($commands));
+
+        $output = new ConsoleOutput();
+
+        $runner = new CommandRunner($app, 'widget');
+        $runner->run(['widget', 'sample', '-h'], $this->getMockIo($output));
+        $result = implode("\n", $output->messages());
+        $this->assertContains('widget sample [-h]', $result);
+        $this->assertNotContains('cake sample [-h]', $result);
+    }
+
     protected function getMockIo($output)
     {
         $io = $this->getMockBuilder(ConsoleIo::class)

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -771,6 +771,34 @@ TEXT;
     }
 
     /**
+     * test that help() with a custom rootName
+     *
+     * @return void
+     */
+    public function testHelpWithRootName()
+    {
+        $parser = new ConsoleOptionParser('sample', false);
+        $parser->description('A command!')
+            ->setRootName('tool')
+            ->addOption('test', ['help' => 'A test option.']);
+
+        $result = $parser->help();
+        $expected = <<<TEXT
+A command!
+
+<info>Usage:</info>
+tool sample [-h] [--test]
+
+<info>Options:</info>
+
+--help, -h  Display this help.
+--test      A test option.
+
+TEXT;
+        $this->assertTextEquals($expected, $result, 'Help is not correct.');
+    }
+
+    /**
      * test building a parser from an array.
      *
      * @return void

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -747,9 +747,10 @@ TEXT;
 
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addSubcommand('method', [
-            'help' => 'This is a subcommand',
-            'parser' => $subParser
-        ])
+                'help' => 'This is a subcommand',
+                'parser' => $subParser
+            ])
+            ->setRootName('tool')
             ->addOption('test', ['help' => 'A test option.']);
 
         $result = $parser->help('method');
@@ -757,7 +758,7 @@ TEXT;
 This is a subcommand
 
 <info>Usage:</info>
-cake mycommand method [-f] [-h] [-q] [-v]
+tool mycommand method [-f] [-h] [-q] [-v]
 
 <info>Options:</info>
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1340,6 +1340,17 @@ TEXT;
     }
 
     /**
+     * Test setRootName filters into the option parser help text.
+     *
+     * @return void
+     */
+    public function testSetRootNamePropagatesToHelpText()
+    {
+        $this->assertSame($this->Shell, $this->Shell->setRootName('tool'), 'is chainable');
+        $this->assertContains('tool shell_test_shell [-h]', $this->Shell->getOptionParser()->help());
+    }
+
+    /**
      * Tests __debugInfo
      *
      * @return void


### PR DESCRIPTION
Add root command propagation and an interface for shells to hint that they need the command collection in the new runner.

Presently the `HelpShell` will not work for applications using `ShellDispatcher`. I'm thinking of putting that requirement into the error messages HelpShell creates.