### PR TITLE
Make one()/many() more consistent with empty associations

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -227,8 +227,7 @@ trait EntityTrait
      */
     public function set($property, $value = null, array $options = [])
     {
-        $isString = is_string($property);
-        if ($isString && $property !== '') {
+        if (is_string($property) && $property !== '') {
             $guard = false;
             $property = [$property => $value];
         } else {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -595,11 +595,12 @@ class Marshaller
         }
 
         foreach ((array)$options['fields'] as $field) {
-            if (array_key_exists($field, $properties)) {
-                $entity->set($field, $properties[$field]);
-                if ($properties[$field] instanceof EntityInterface) {
-                    $entity->setDirty($field, $properties[$field]->isDirty());
-                }
+            if (!array_key_exists($field, $properties)) {
+                continue;
+            }
+            $entity->set($field, $properties[$field]);
+            if ($properties[$field] instanceof EntityInterface) {
+                $entity->setDirty($field, $properties[$field]->isDirty());
             }
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -212,6 +212,14 @@ class Marshaller
             $entity->set($properties);
         }
 
+        // Don't flag clean association entities as
+        // dirty so we don't persist empty records.
+        foreach ($properties as $field => $value) {
+            if ($value instanceof EntityInterface) {
+                $entity->dirty($field, $value->dirty());
+            }
+        }
+
         $entity->setErrors($errors);
 
         return $entity;


### PR DESCRIPTION
When an association is cleaned out by a beforeMarshal hook, the entity property should not be marked as dirty as the related entity has no properties to persist.

Refs #10658