### PR TITLE
Enable EntityContext to read from ArrayAccess properties

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -19,6 +19,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use ArrayAccess;
 use RuntimeException;
 use Traversable;
 
@@ -259,7 +260,7 @@ class EntityContext implements ContextInterface
 
             return $this->_schemaDefault($part, $entity);
         }
-        if (is_array($entity)) {
+        if (is_array($entity) || $entity instanceof ArrayAccess) {
             $key = array_pop($parts);
 
             return isset($entity[$key]) ? $entity[$key] : null;

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -14,12 +14,12 @@
  */
 namespace Cake\View\Form;
 
+use ArrayAccess;
 use Cake\Collection\Collection;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
-use ArrayAccess;
 use RuntimeException;
 use Traversable;
 

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -461,7 +461,8 @@ class EntityContextTest extends TestCase
                 'name' => 'Test tag',
             ],
             'author' => new Entity([
-                'roles' => ['admin', 'publisher']
+                'roles' => ['admin', 'publisher'],
+                'aliases' => new ArrayObject(['dave', 'david']),
             ])
         ]);
         $context = new EntityContext($this->request, [
@@ -477,11 +478,12 @@ class EntityContextTest extends TestCase
         $result = $context->val('tag.name');
         $this->assertEquals($row->tag['name'], $result);
 
-        $result = $context->val('tag.nope');
-        $this->assertNull($result);
+        $result = $context->val('author.aliases.0');
+        $this->assertEquals($row->author->aliases[0], $result, 'ArrayAccess can be read');
 
-        $result = $context->val('author.roles.3');
-        $this->assertNull($result);
+        $this->assertNull($context->val('author.aliases.3'));
+        $this->assertNull($context->val('tag.nope'));
+        $this->assertNull($context->val('author.roles.3'));
     }
 
     /**


### PR DESCRIPTION
Traverse into ArrayAccess properties as custom type mappings should be readable if they quack like arrays.

Refs #10853
