### PR TITLE
Test against PHP nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.0
   - 5.6
   - 7.1
+  - nightly
 
 dist: trusty
 
@@ -31,6 +32,8 @@ cache:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - php: nightly
 
   include:
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ cache:
 
 matrix:
   fast_finish: true
+  
   allow_failures:
     - php: nightly
 
@@ -46,7 +47,7 @@ matrix:
       env: PHPSTAN=1 DEFAULT=0
 
 before_install:
-  - if [ $TRAVIS_PHP_VERSION != 7.0 ]; then phpenv config-rm xdebug.ini; fi
+  - if [ $TRAVIS_PHP_VERSION != 7.0 && $TRAVIS_PHP_VERSION != 'nightly' ]; then phpenv config-rm xdebug.ini; fi
 
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
   - if [ $DB = 'mysql' ]; then mysql -u root -e 'CREATE DATABASE cakephp_test2;'; fi


### PR DESCRIPTION
As discussed on Slack with savant and jeremyharris this adds nightly testing (which is PHP 7.2 at the moment) which is allowed to fail to keep an eye on any possible breaks in future versions.