### PR TITLE
Stop warnings when using count in QueryCompiler in PHP 7.2

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -125,7 +125,9 @@ class QueryCompiler
     protected function _sqlCompiler(&$sql, $query, $generator)
     {
         return function ($parts, $name) use (&$sql, $query, $generator) {
-            if (!count($parts)) {
+            if (!isset($parts) ||
+                ((is_array($parts) || $parts instanceof \Countable) && !count($parts))
+            ) {
                 return;
             }
             if ($parts instanceof ExpressionInterface) {


### PR DESCRIPTION
- PHP 7.2 has changed the count function to emit warnings when the object
  being "counted" is not an array or does not implement the Countable
  interface.  The QueryCompiler was using count for objects that did not
  fall into those two categories.  This fixes that problem while
  maintaining the same logic (returning early when $parts is not set, is
  null, or has a count of 0).

Fixes https://github.com/cakephp/cakephp/issues/10862
