### PR TITLE
Enable DigestAuth to work when digest key is hidden

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -110,15 +110,22 @@ abstract class BaseAuthenticate implements EventListenerInterface
             return false;
         }
 
+        $passwordField = $this->_config['fields']['password'];
         if ($password !== null) {
             $hasher = $this->passwordHasher();
-            $hashedPassword = $result->get($this->_config['fields']['password']);
+            $hashedPassword = $result->get($passwordField);
             if (!$hasher->check($password, $hashedPassword)) {
                 return false;
             }
 
             $this->_needsPasswordRehash = $hasher->needsRehash($hashedPassword);
-            $result->unsetProperty($this->_config['fields']['password']);
+            $result->unsetProperty($passwordField);
+        }
+        if ($password === null && in_array($passwordField, $result->getHidden())) {
+            $hidden = $result->getHidden();
+            $key = array_search($passwordField, $hidden);
+            unset($hidden[$key]);
+            $result->setHidden($hidden);
         }
 
         return $result->toArray();

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -121,8 +121,8 @@ abstract class BaseAuthenticate implements EventListenerInterface
             $this->_needsPasswordRehash = $hasher->needsRehash($hashedPassword);
             $result->unsetProperty($passwordField);
         }
-        if ($password === null && in_array($passwordField, $result->getHidden())) {
-            $hidden = $result->getHidden();
+        $hidden = $result->getHidden();
+        if ($password === null && in_array($passwordField, $hidden)) {
             $key = array_search($passwordField, $hidden);
             unset($hidden[$key]);
             $result->setHidden($hidden);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -420,7 +420,7 @@ trait EntityTrait
     /**
      * Sets hidden properties.
      *
-     * @param array $properties An array of properties to treat as virtual.
+     * @param array $properties An array of properties to hide from array exports.
      * @param bool $merge Merge the new properties with the existing. By default false.
      * @return $this
      */

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -23,8 +23,17 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\Time;
 use Cake\Network\Exception\UnauthorizedException;
+use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+
+/**
+ * Entity for testing with hidden fields.
+ */
+class ProtectedUser extends Entity
+{
+    protected $_hidden = ['password'];
+}
 
 /**
  * Test case for DigestAuthentication
@@ -242,6 +251,42 @@ class DigestAuthenticateTest extends TestCase
      */
     public function testAuthenticateSuccess()
     {
+        $request = new ServerRequest([
+            'url' => 'posts/index',
+            'environment' => ['REQUEST_METHOD' => 'GET']
+        ]);
+        $request->addParams(['pass' => []]);
+
+        $data = [
+            'uri' => '/dir/index.html',
+            'nonce' => $this->generateNonce(),
+            'nc' => 1,
+            'cnonce' => '123',
+            'qop' => 'auth',
+        ];
+        $data['response'] = $this->auth->generateResponseHash($data, '09faa9931501bf30f0d4253fa7763022', 'GET');
+        $request->env('PHP_AUTH_DIGEST', $this->digestHeader($data));
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $expected = [
+            'id' => 1,
+            'username' => 'mariano',
+            'created' => new Time('2007-03-17 01:16:23'),
+            'updated' => new Time('2007-03-17 01:18:31')
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * test authenticate success even when digest 'password' is a hidden field.
+     *
+     * @return void
+     */
+    public function testAuthenticateSuccessHiddenPasswordField()
+    {
+        $User = TableRegistry::get('Users');
+        $User->setEntityClass(ProtectedUser::class);
+
         $request = new ServerRequest([
             'url' => 'posts/index',
             'environment' => ['REQUEST_METHOD' => 'GET']


### PR DESCRIPTION
When the digest key is a hidden field it will not be included in the results of _findUser() which makes it impossible for users to authenticate. In the case where there was no password comparison done, and the passwordfield is a hidden field, removing the passwordField from the hidden list allows digest auth to work. Digest auth subsequently removes the password field after checking the key.

Refs #10855