### PR TITLE
Reset eager loaders before triggering before find.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -756,6 +756,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     public function cleanCopy()
     {
         $clone = clone $this;
+        $clone->setEagerLoader(clone $this->getEagerLoader());
         $clone->triggerBeforeFind();
         $clone->enableAutoFields(false);
         $clone->limit(null);
@@ -765,7 +766,6 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $clone->formatResults(null, true);
         $clone->setSelectTypeMap(new TypeMap());
         $clone->decorateResults(null, true);
-        $clone->setEagerLoader(clone $this->getEagerLoader());
 
         return $clone;
     }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -742,6 +742,34 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Test count() with inner join containments.
+     *
+     * @return void
+     */
+    public function testCountWithInnerJoinContain()
+    {
+        $this->loadFixtures('Articles', 'Authors');
+        $table = TableRegistry::get('Articles');
+        $table->belongsTo('Authors')->setJoinType('INNER');
+
+        $result = $table->save($table->newEntity([
+            'author_id' => null,
+            'title' => 'title',
+            'body' => 'body',
+            'published' => 'Y'
+        ]));
+        $this->assertNotFalse($result);
+
+        $table->eventManager()
+            ->on('Model.beforeFind', function (Event $event, $query) {
+                $query->contain(['Authors']);
+            });
+
+        $count = $table->find()->count();
+        $this->assertEquals(3, $count);
+    }
+
+    /**
      * Tests that bind in subqueries works.
      *
      * @return void


### PR DESCRIPTION
In #10657 I made a change to reset eager loaders when creating a clone to fix state being shared across query clones. Because of method ordering this resulted in the eager loader being reset *after* the beforeFind was triggered, which dropped any contained associations added during that event. Re-ordering the method calls allows contained associations added during the beforeFind to be retained in the count() query.

Refs #10813