### PR TITLE
Change function signature to be less confusing

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -167,8 +167,19 @@ class Event
      * Stops the event from being used anymore
      *
      * @return void
+     * @deprecated 3.4.10 use stop() instead.
      */
     public function stopPropagation()
+    {
+        $this->_stopped = true;
+    }
+
+    /**
+     * Stops the event from being used anymore
+     *
+     * @return void
+     */
+    public function stop()
     {
         $this->_stopped = true;
     }

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -73,6 +73,20 @@ class EventTest extends TestCase
     }
 
     /**
+     * Tests the event stopping property
+     *
+     * @return void
+     * @triggers fake.event
+     */
+    public function testStop()
+    {
+        $event = new Event('fake.event');
+        $this->assertFalse($event->isStopped());
+        $event->stop();
+        $this->assertTrue($event->isStopped());
+    }
+
+    /**
      * Tests that it is possible to get/set custom data in a event
      *
      * @return void


### PR DESCRIPTION
In the documentation https://book.cakephp.org/3.0/en/orm/table-objects.html#beforesave it says:
```
The Model.beforeSave event is fired before each entity is saved. Stopping this event will abort the save operation. When the event is stopped the result of the event will be returned.
```
So it was confusing that the name of the function to stop the event is called `stopPropagation` as this sounds like the event is still valid but just further events are executed and **not** stopped.

I propose this simple change as it would make it more clear that the function actually stops the event.