### PR TITLE
MoFileParser support Plural-Forms: nplurals=1; plural=0;

### DIFF
--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -119,7 +119,7 @@ class MoFileParser
             fseek($stream, $offset);
             $translated = fread($stream, $length);
 
-            if (strpos($translated, "\000") !== false) {
+            if ($pluralId !== null || strpos($translated, "\000") !== false) {
                 $translated = explode("\000", $translated);
                 $plurals = $pluralId !== null ? array_map('stripcslashes', $translated) : null;
                 $translated = $translated[0];

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -46,6 +46,27 @@ class MoFileParserTest extends TestCase
     }
 
     /**
+     * Tests parsing a file with single form plurals
+     *
+     * @return void
+     */
+    public function testParse0()
+    {
+        $parser = new MoFileParser;
+        $file = APP . 'Locale' . DS . 'rule_0_mo' . DS . 'core.mo';
+        $messages = $parser->parse($file);
+        $this->assertCount(3, $messages);
+        $expected = [
+            'Plural Rule 1 (from core)' => 'Plural Rule 0 (from core translated)',
+            '%d = 1 (from core)' => '%d ends with any # (from core translated)',
+            '%d = 0 or > 1 (from core)' => [
+                '%d ends with any # (from core translated)',
+            ],
+        ];
+        $this->assertEquals($expected, $messages);
+    }
+
+    /**
      * Tests parsing a file with larger plural forms
      *
      * @return void


### PR DESCRIPTION
This is a (multiple allowed):

* [x] bug
* [x] enhancement

* CakePHP Version: 3.4.9

### What you did
For translation to Japanese, I try to read the `.mo` file created with `nplurals = 1; plural = 0;`.

original `.po` file is:

```
"Plural-Forms: nplurals=1; plural=0;\n"

msgid "{0} day"
msgid_plural "{0} days"
msgstr[0] "{0}日"
```

### What happened
When reading the generated `.mo` file, it reads as follows.

```
'{0} day' => '{0}日',
'{0} days' => null,
```


### What you expected to happen

What I expect is here. (If reading `.po` file, it becomes this.

```
'{0} day' => '{0}日',
'{0} days' => [
	(int) 0 => '{0}日'
],
```