### PR TITLE
Fix conditional using count to not emit warning in PHP 7.2

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -482,7 +482,7 @@ class EntityContext implements ContextInterface
      */
     protected function _getTable($parts, $rootFallback = true)
     {
-        if (count($parts) === 1) {
+        if (!is_array($parts) || count($parts) === 1) {
             return $this->_tables[$this->_rootName];
         }
 


### PR DESCRIPTION
- In this case it appears that only arrays with a size greater than 1 need
  to be dealt with by the main part of the _getTable function.  Every
  other kind of object should return $this->_tables[$this->_rootName].

Fixes https://github.com/cakephp/cakephp/issues/10865