### PR TITLE
Sync method signature with parent class method.

### DIFF
--- a/tests/TestCase/DatabaseSuite.php
+++ b/tests/TestCase/DatabaseSuite.php
@@ -40,9 +40,9 @@ class DatabaseSuite extends TestSuite
         return $suite;
     }
 
-    public function count()
+    public function count($preferCache = false)
     {
-        return parent::count() * 2;
+        return parent::count($preferCache) * 2;
     }
 
     /**


### PR DESCRIPTION
Hopefully this should fix [this](https://travis-ci.org/cakephp/cakephp/jobs/251392632#L613) error on PHP 7.2 (nightly) without causing problems for other versions of phpunit / PHP.