### PR TITLE
Remove cakephp/i18n as a dependency for cakephp/validation.

### DIFF
--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -24,8 +24,10 @@
     "require": {
         "php": ">=5.6.0",
         "cakephp/utility": "^3.0.0",
-        "cakephp/i18n": "^3.0.0",
         "psr/http-message": "^1.0.0"
+    },
+    "suggest": {
+        "cakephp/i18n": "If you want to use Validation::localizedTime()"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Closes #10883.