### PR TITLE
Deprecate orWhere() and orHaving()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -995,6 +995,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @see \Cake\Database\Query::where()
      * @see \Cake\Database\Type
      * @return $this
+     * @deprecated 3.5.0 This method creates hard to predict SQL based on the current query state.
+     *   Use `Query::where()` instead as it has more predicatable and easier to understand behavior.
      */
     public function orWhere($conditions, $types = [])
     {
@@ -1210,6 +1212,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param array $types associative array of type names used to bind values to query.
      * @see \Cake\Database\Query::orWhere()
      * @return $this
+     * @deprecated 3.5.0 This method creates hard to predict SQL based on the current query state.
+     *   Use `Query::having()` instead as it has more predicatable and easier to understand behavior.
      */
     public function orHaving($conditions, $types = [])
     {


### PR DESCRIPTION
These methods behave differently based on the last used query method. This results in code that has fragile temporal coupling, and hard to  predict outcomes.

Refs #10845