### PR TITLE
Remove root command comparisons.

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -126,11 +126,8 @@ class CommandRunner
         }
         $this->dispatchEvent('Console.buildCommands', ['commands' => $commands]);
 
-        if (empty($argv) || $argv[0] !== $this->root) {
-            $command = empty($argv) ? '' : " `{$argv[0]}`";
-            throw new RuntimeException(
-                "Unknown root command{$command}. Was expecting `{$this->root}`."
-            );
+        if (empty($argv)) {
+            throw new RuntimeException("Cannot run any commands. No arguments received.");
         }
         // Remove the root executable segment
         array_shift($argv);

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -70,7 +70,7 @@ class CommandRunnerTest extends TestCase
      * Test that running with empty argv fails
      *
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unknown root command. Was expecting `cake`
+     * @expectedExceptionMessage Cannot run any commands. No arguments received.
      * @return void
      */
     public function testRunMissingRootCommand()
@@ -82,24 +82,6 @@ class CommandRunnerTest extends TestCase
 
         $runner = new CommandRunner($app);
         $runner->run([]);
-    }
-
-    /**
-     * Test that running an unknown command raises an error.
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unknown root command `bad`. Was expecting `cake`
-     * @return void
-     */
-    public function testRunInvalidRootCommand()
-    {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->setMethods(['middleware', 'bootstrap'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
-        $runner = new CommandRunner($app);
-        $runner->run(['bad', 'i18n']);
     }
 
     /**


### PR DESCRIPTION
This has not worked out well. Because the cake.php file can be anywhere on the file system, and wrapped by bash, or powershell it often has a name that there is no point in validating, as we'd need to compare against argv[0] which removes any value validation could provide.

Refs #10716