### PR TITLE
Fix wrong variable assignment

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -508,11 +508,12 @@ class RouteBuilder
             $name = $this->_namePrefix . $name;
         }
         $options = [
-            '_method' => $method,
             '_ext' => $this->_extensions,
             'routeClass' => $this->_routeClass,
             '_name' => $name,
         ];
+
+        $target['_method'] = $method;
 
         $route = $this->_makeRoute($template, $target, $options);
         $this->_collection->add($route, $options);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -935,8 +935,8 @@ class RouteBuilderTest extends TestCase
         });
         $this->assertCount(2, $this->collection->routes());
         $this->assertEquals(['faq', 'article:update'], array_keys($this->collection->named()));
-        $this->assertNotEmpty($this->collection->parse('/faq/things_you_know'));
-        $result = $this->collection->parse('/articles/123');
+        $this->assertNotEmpty($this->collection->parse('/faq/things_you_know', 'GET'));
+        $result = $this->collection->parse('/articles/123', 'POST');
         $this->assertEquals(['123'], $result['pass']);
     }
 
@@ -977,6 +977,6 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/');
         $routes->loadPlugin('TestPlugin');
         $this->assertCount(1, $this->collection->routes());
-        $this->assertNotEmpty($this->collection->parse('/test_plugin'));
+        $this->assertNotEmpty($this->collection->parse('/test_plugin', 'GET'));
     }
 }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -907,11 +907,11 @@ class RouteBuilderTest extends TestCase
             'route-name'
         );
         $this->assertInstanceOf(Route::class, $route, 'Should return a route');
-        $this->assertSame($method, $route->options['_method']);
+        $this->assertSame($method, $route->defaults['_method']);
         $this->assertSame('app:route-name', $route->options['_name']);
         $this->assertSame('/bookmarks/:id', $route->template);
         $this->assertEquals(
-            ['plugin' => null, 'controller' => 'Bookmarks', 'action' => 'view'],
+            ['plugin' => null, 'controller' => 'Bookmarks', 'action' => 'view', '_method' => $method],
             $route->defaults
         );
     }


### PR DESCRIPTION
This fixes an issue when using the newly added fluent route methods.
The`_method` was assigned to the wrong variable.

This PR lacks a fix for the case when no method could be gathered out of the request. That's why two test cases are failing. I wasn't sure what to do here.