### PR TITLE
Make timestamp checks less permissive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION = 5.6 ]] ; then echo yes | pecl install apcu-4.0.10; fi
   - if [[ $TRAVIS_PHP_VERSION = 7.0 ]] ; then echo yes | pecl install channel://pecl.php.net/apcu-5.1.5; fi
   - if [[ $TRAVIS_PHP_VERSION = 5.6 && $DB = 'mysql' ]] ; then wget http://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.gz; tar xf xcache-3.2.0.tar.gz; pushd xcache-3.2.0; phpize; ./configure; make; NO_INTERACTION=1 make test; make install; popd;printf "extension=xcache.so\nxcache.size=64M\nxcache.var_size=16M\nxcache.test=On" > ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - sudo locale-gen da_DK
 
 before_script:
   - composer install --prefer-dist --no-interaction

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -157,11 +157,12 @@ class DateTimeType extends Type implements TypeInterface
             if ($value === '' || $value === null || $value === false || $value === true) {
                 return null;
             }
+            $isString = is_string($value);
             if (ctype_digit($value)) {
                 $date = new $class('@' . $value);
-            } elseif (is_string($value) && $this->_useLocaleParser) {
+            } elseif ($isString && $this->_useLocaleParser) {
                 return $this->_parseValue($value);
-            } elseif (is_string($value)) {
+            } elseif ($isString) {
                 $date = new $class($value);
                 $compare = true;
             }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -157,7 +157,7 @@ class DateTimeType extends Type implements TypeInterface
             if ($value === '' || $value === null || $value === false || $value === true) {
                 return null;
             }
-            if (is_numeric($value)) {
+            if (ctype_digit($value)) {
                 $date = new $class('@' . $value);
             } elseif (is_string($value) && $this->_useLocaleParser) {
                 return $this->_parseValue($value);

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\Database\Type;
 
 use Cake\Database\Type\TimeType;
+use Cake\I18n\I18n;
 use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
 
@@ -26,12 +27,17 @@ class TimeTypeTest extends TestCase
     /**
      * @var \Cake\Database\Type\TimeType
      */
-    public $type;
+    protected $type;
 
     /**
      * @var \Cake\Database\Driver
      */
-    public $driver;
+    protected $driver;
+
+    /**
+     * @var string
+     */
+    protected $locale;
 
     /**
      * Setup
@@ -43,6 +49,18 @@ class TimeTypeTest extends TestCase
         parent::setUp();
         $this->type = new TimeType();
         $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
+        $this->locale = I18n::locale();
+    }
+
+    /**
+     * Teardown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        I18n::locale($this->locale);
     }
 
     /**
@@ -181,7 +199,7 @@ class TimeTypeTest extends TestCase
     }
 
     /**
-     * Tests marshalling dates using the locale aware parser
+     * Tests marshalling times using the locale aware parser
      *
      * @return void
      */
@@ -193,6 +211,20 @@ class TimeTypeTest extends TestCase
         $this->assertEquals($expected->format('H:i'), $result->format('H:i'));
 
         $this->assertNull($this->type->marshal('derp:23'));
+    }
+
+    /**
+     * Tests marshalling times in denmark.
+     *
+     * @return void
+     */
+    public function testMarshalWithLocaleParsingDanishLocale()
+    {
+        I18n::locale('da_DK');
+        $this->type->useLocaleParser();
+        $expected = new Time('03:20:00');
+        $result = $this->type->marshal('03.20');
+        $this->assertEquals($expected->format('H:i'), $result->format('H:i'));
     }
 
     /**

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -220,6 +220,9 @@ class TimeTypeTest extends TestCase
      */
     public function testMarshalWithLocaleParsingDanishLocale()
     {
+        $updated = setlocale(LC_COLLATE, 'da_DK.utf8');
+        $this->skipIf($updated === false, 'Could not set locale to da_DK.utf8, skipping test.');
+
         I18n::locale('da_DK');
         $this->type->useLocaleParser();
         $expected = new Time('03:20:00');


### PR DESCRIPTION
Some locale based formats look like numeric values. If locale parsing is enabled we need to enter that case instead of the numeric one. By restricting the valid format of timestamps we can do that.

Refs #10873
