### PR TITLE
Remove unused HTTP application related import

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -20,7 +20,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\StopException;
 use Cake\Console\Shell;
 use Cake\Core\ConsoleApplicationInterface;
-use Cake\Core\HttpApplicationInterface;
 use Cake\Event\EventManagerTrait;
 use Cake\Shell\HelpShell;
 use Cake\Shell\VersionShell;


### PR DESCRIPTION
Import introtduced in https://github.com/cakephp/cakephp/pull/10851/files#diff-5746a5b6845a932f92018ff514ae2000R23 but I do not see a reason for this import.

The following imports also seem to be unused:

```` php
use Cake\Console\CommandCollection;
use Cake\Console\CommandCollectionAwareInterface;
use Cake\Console\ConsoleIo;
use Cake\Console\Shell;
````