### PR TITLE
2.x Console: Display error message when unknown option is specified

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -431,6 +431,7 @@ class Shell extends CakeObject {
 		try {
 			list($this->params, $this->args) = $this->OptionParser->parse($argv, $command);
 		} catch (ConsoleException $e) {
+			$this->err(__d('cake_console', '<error>Error:</error> %s', $e->getMessage()));
 			$this->out($this->OptionParser->help($command));
 			return false;
 		}

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -779,6 +779,32 @@ class ShellTest extends CakeTestCase {
 	}
 
 /**
+ * test unknown option causes display of error and help.
+ *
+ * @return void
+ */
+	public function testRunCommandUnknownOption() {
+		$output = $this->getMock('ConsoleOutput', array(), array(), '', false);
+		$error = $this->getMock('ConsoleOutput', array(), array(), '', false);
+		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
+
+		$Parser = $this->getMock('ConsoleOptionParser', array(), array(), '', false);
+		$Parser->expects($this->once())->method('parse')
+			->with(array('--unknown'))
+			->will($this->throwException(new ConsoleException('Unknown option `unknown`')));
+		$Parser->expects($this->once())->method('help');
+
+		$Shell = $this->getMock('ShellTestShell', array('getOptionParser'), array($output, $error, $in));
+
+		$Shell->expects($this->once())->method('getOptionParser')
+			->will($this->returnValue($Parser));
+		$Shell->stderr->expects($this->once())->method('write');
+		$Shell->stdout->expects($this->once())->method('write');
+
+		$Shell->runCommand('do_something', array('do_something', '--unknown'));
+	}
+
+/**
  * test that a --help causes help to show.
  *
  * @return void


### PR DESCRIPTION
Implementation of #10914

Display error as follows:

<img width="542" alt="error-message" src="https://user-images.githubusercontent.com/16202/28276943-50373cf8-6b53-11e7-884c-00c77f7e4f90.png">
