### PR TITLE
10874 sqlite mask

### DIFF
--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -68,7 +68,9 @@ class Sqlite extends Driver
         $this->_connect($dsn, $config);
 
         if (!$databaseExists && $config['database'] != ':memory:') {
-            chmod($config['database'], $config['mask']);
+            //@codingStandardsIgnoreStart
+            @chmod($config['database'], $config['mask']);
+            //@codingStandardsIgnoreEnd
         }
 
         if (!empty($config['init'])) {

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -67,7 +67,7 @@ class Sqlite extends Driver
         $dsn = "sqlite:{$config['database']}";
         $this->_connect($dsn, $config);
 
-        if (!$databaseExists) {
+        if (!$databaseExists && $config['database'] != ':memory:') {
             chmod($config['database'], $config['mask']);
         }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -60,8 +60,14 @@ class Sqlite extends Driver
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ];
 
+        $databaseExists = file_exists($config['database']);
+
         $dsn = "sqlite:{$config['database']}";
         $this->_connect($dsn, $config);
+
+        if (!$databaseExists) {
+            chmod($config['database'], $config['mask']);
+        }
 
         if (!empty($config['init'])) {
             foreach ((array)$config['init'] as $command) {

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -30,6 +30,8 @@ class Sqlite extends Driver
     /**
      * Base configuration settings for Sqlite driver
      *
+     * - `mask` The mask used for created database
+     *
      * @var array
      */
     protected $_baseConfig = [

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -38,6 +38,7 @@ class Sqlite extends Driver
         'password' => null,
         'database' => ':memory:',
         'encoding' => 'utf8',
+        'mask' => 0644,
         'flags' => [],
         'init' => [],
     ];

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -69,7 +69,8 @@ class SqliteTest extends TestCase
             'database' => 'bar.db',
             'flags' => [1 => true, 2 => false],
             'encoding' => 'a-language',
-            'init' => ['Execute this', 'this too']
+            'init' => ['Execute this', 'this too'],
+            'mask' => 0666
         ];
         $driver = $this->getMockBuilder('Cake\Database\driver\Sqlite')
             ->setMethods(['_connect', 'connection'])

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -43,6 +43,7 @@ class SqliteTest extends TestCase
             'password' => null,
             'flags' => [],
             'init' => [],
+            'mask' => 420,
         ];
 
         $expected['flags'] += [


### PR DESCRIPTION
issue #10874

new "mask" option for sqlite database driver.

Driver\Sqlite chmod the database file with mask on creation only.