### PR TITLE
Fix regression with arrays being passed for IO output.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -672,6 +672,7 @@ class Shell
         } else {
             $message = '<error>' . $message . '</error>';
         }
+
         return $this->_io->err($message, $newlines);
     }
 
@@ -693,6 +694,7 @@ class Shell
         } else {
             $message = '<info>' . $message . '</info>';
         }
+
         return $this->out($message, $newlines, $level);
     }
 
@@ -713,6 +715,7 @@ class Shell
         } else {
             $message = '<warning>' . $message . '</warning>';
         }
+
         return $this->_io->err($message, $newlines);
     }
 
@@ -734,6 +737,7 @@ class Shell
         } else {
             $message = '<success>' . $message . '</success>';
         }
+
         return $this->out($message, $newlines, $level);
     }
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -665,7 +665,14 @@ class Shell
      */
     public function err($message = null, $newlines = 1)
     {
-        return $this->_io->err('<error>' . $message . '</error>', $newlines);
+        if (is_array($message)) {
+            foreach ($message as $k => $v) {
+                $message[$k] = '<error>' . $v . '</error>';
+            }
+        } else {
+            $message = '<error>' . $message . '</error>';
+        }
+        return $this->_io->err($message, $newlines);
     }
 
     /**
@@ -679,7 +686,14 @@ class Shell
      */
     public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
-        return $this->out('<info>' . $message . '</info>', $newlines, $level);
+        if (is_array($message)) {
+            foreach ($message as $k => $v) {
+                $message[$k] = '<info>' . $v . '</info>';
+            }
+        } else {
+            $message = '<info>' . $message . '</info>';
+        }
+        return $this->out($message, $newlines, $level);
     }
 
     /**
@@ -692,7 +706,14 @@ class Shell
      */
     public function warn($message = null, $newlines = 1)
     {
-        return $this->_io->err('<warning>' . $message . '</warning>', $newlines);
+        if (is_array($message)) {
+            foreach ($message as $k => $v) {
+                $message[$k] = '<warning>' . $v . '</warning>';
+            }
+        } else {
+            $message = '<warning>' . $message . '</warning>';
+        }
+        return $this->_io->err($message, $newlines);
     }
 
     /**
@@ -706,7 +727,14 @@ class Shell
      */
     public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
-        return $this->out('<success>' . $message . '</success>', $newlines, $level);
+        if (is_array($message)) {
+            foreach ($message as $k => $v) {
+                $message[$k] = '<success>' . $v . '</success>';
+            }
+        } else {
+            $message = '<success>' . $message . '</success>';
+        }
+        return $this->out($message, $newlines, $level);
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -310,6 +310,20 @@ class ShellTest extends TestCase
     }
 
     /**
+     * testErr method with array
+     *
+     * @return void
+     */
+    public function testErrArray()
+    {
+        $this->io->expects($this->once())
+            ->method('err')
+            ->with(['<error>Just</error>', '<error>a</error>', '<error>test</error>'], 1);
+
+        $this->Shell->err(['Just', 'a', 'test']);
+    }
+
+    /**
      * testInfo method
      *
      * @return void

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -338,6 +338,20 @@ class ShellTest extends TestCase
     }
 
     /**
+     * testInfo method with array
+     *
+     * @return void
+     */
+    public function testInfoArray()
+    {
+        $this->io->expects($this->once())
+            ->method('out')
+            ->with(['<info>Just</info>', '<info>a</info>', '<info>test</info>'], 1);
+
+        $this->Shell->info(['Just', 'a', 'test']);
+    }
+
+    /**
      * testWarn method
      *
      * @return void
@@ -352,6 +366,20 @@ class ShellTest extends TestCase
     }
 
     /**
+     * testWarn method with array
+     *
+     * @return void
+     */
+    public function testWarnArray()
+    {
+        $this->io->expects($this->once())
+            ->method('err')
+            ->with(['<warning>Just</warning>', '<warning>a</warning>', '<warning>test</warning>'], 1);
+
+        $this->Shell->warn(['Just', 'a', 'test']);
+    }
+
+    /**
      * testSuccess method
      *
      * @return void
@@ -363,6 +391,20 @@ class ShellTest extends TestCase
             ->with('<success>Just a test</success>', 1);
 
         $this->Shell->success('Just a test');
+    }
+
+    /**
+     * testSuccess method with array
+     *
+     * @return void
+     */
+    public function testSuccessArray()
+    {
+        $this->io->expects($this->once())
+            ->method('out')
+            ->with(['<success>Just</success>', '<success>a</success>', '<success>test</success>'], 1);
+
+        $this->Shell->success(['Just', 'a', 'test']);
     }
 
     /**


### PR DESCRIPTION
I had an app that still had the syntax

```php
$this->Shell->err(['Just', 'a', 'test']);
```

which now breaks due to the markup added.
This fix resolves this regression and restores the untested but documented feature of being able to pass arrays instead of a string as convenience wrapper input.
