### PR TITLE
Throw a 504 when upstream request times out

### DIFF
--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -16,6 +16,7 @@ namespace Cake\Http\Client\Adapter;
 use Cake\Core\Exception\Exception;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
+use Cake\Network\Exception\HttpException;
 
 /**
  * Implements sending Cake\Http\Client\Request
@@ -246,7 +247,7 @@ class Stream
      *
      * @param \Cake\Http\Client\Request $request The request object.
      * @return array Array of populated Response objects
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Network\Exception\HttpException
      */
     protected function _send(Request $request)
     {
@@ -277,7 +278,7 @@ class Stream
         fclose($this->_stream);
 
         if ($timedOut) {
-            throw new Exception('Connection timed out ' . $url);
+            throw new HttpException('Connection timed out ' . $url, 504);
         }
 
         $headers = $meta['wrapper_data'];

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -423,7 +423,7 @@ class StreamTest extends TestCase
     /**
      * Test that an exception is raised when timed out.
      *
-     * @expectedException \Cake\Core\Exception\Exception
+     * @expectedException \Cake\Network\Exception\HttpException
      * @expectedExceptionMessage Connection timed out http://dummy/?sleep
      * @return void
      */


### PR DESCRIPTION
Rather than throwing a more general Exception, using HttpException to throw a 504 seems to fit the description well for a 504: "The server was acting as a gateway or proxy and did not receive a timely response from the upstream server."