### PR TITLE
3.next add new paramater to testing helper

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -913,14 +913,15 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @param string $content The content to check for.
      * @param string $message The failure message that will be appended to the generated message.
+     * @param bool   $ignoreCase A flag to check whether we should ignore case or not.
      * @return void
      */
-    public function assertResponseContains($content, $message = '')
+    public function assertResponseContains($content, $ignoreCase = false, $message = '')
     {
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);
         }
-        $this->assertContains($content, $this->_getBodyAsString(), $message);
+        $this->assertContains($content, $this->_getBodyAsString(), $message, $ignoreCase);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -916,7 +916,7 @@ abstract class IntegrationTestCase extends TestCase
      * @param bool   $ignoreCase A flag to check whether we should ignore case or not.
      * @return void
      */
-    public function assertResponseContains($content, $ignoreCase = false, $message = '')
+    public function assertResponseContains($content, $message = '', $ignoreCase = false)
     {
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content. ' . $message);

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -837,7 +837,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
 
-        $this->assertResponseContains('some', true);
+        $this->assertResponseContains('some', 'Failed asserting that the body contains given content', true);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -828,6 +828,19 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test the content assertion with no case sensitivity.
+     *
+     * @return void
+     */
+    public function testAssertResponseContainsWithIgnoreCaseFlag()
+    {
+        $this->_response = new Response();
+        $this->_response = $this->_response->withStringBody('Some content');
+
+        $this->assertResponseContains('some', true);
+    }
+
+    /**
      * Test the negated content assertion.
      *
      * @return void


### PR DESCRIPTION
Currently, the `assertResponseContains` method accepts only two parameters for assertion against the content and message.

There have been some use-cases while testing where I needed to ignore the case for asserting the content on pages where the content has been capitalized by CSS. `PHPUnit` gives support for ignoring the content case with a `ignoreCase` parameter. I have added support for the same in this test method.