### PR TITLE
Support non-callable HttpApplicationInterface implementations.

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -77,7 +77,9 @@ class Server
             throw new RuntimeException('The application `middleware` method did not return a middleware queue.');
         }
         $this->dispatchEvent('Server.buildMiddleware', ['middleware' => $middleware]);
-        $middleware->add($this->app);
+        if (is_callable($this->app)) {
+            $middleware->add($this->app);
+        }
         $response = $this->runner->run($middleware, $request, $response);
 
         if (!($response instanceof ResponseInterface)) {

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -18,7 +18,9 @@ use Cake\Event\Event;
 use Cake\Http\CallbackStream;
 use Cake\Http\Server;
 use Cake\TestSuite\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use TestApp\Http\BadResponseApplication;
+use TestApp\Http\CustomApplication;
 use TestApp\Http\InvalidMiddlewareApplication;
 use TestApp\Http\MiddlewareApplication;
 use Zend\Diactoros\Response;
@@ -153,6 +155,18 @@ class ServerTest extends TestCase
         $app = new BadResponseApplication($this->config);
         $server = new Server($app);
         $server->run();
+    }
+
+    /**
+     * Test custom implementations of HttpApplicationInterface.
+     */
+    public function testRunCustomApplication()
+    {
+        $app = new CustomApplication();
+        $server = new Server($app);
+        $response = $server->run();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
     }
 
     /**

--- a/tests/test_app/TestApp/Http/CustomApplication.php
+++ b/tests/test_app/TestApp/Http/CustomApplication.php
@@ -1,0 +1,21 @@
+<?php
+namespace TestApp\Http;
+
+use Cake\Core\HttpApplicationInterface;
+
+class CustomApplication implements HttpApplicationInterface
+{
+
+    public function bootstrap()
+    {
+    }
+
+    public function middleware($middleware)
+    {
+        return $middleware;
+    }
+
+    public function routes($routes)
+    {
+    }
+}


### PR DESCRIPTION
Custom Application classes are not required to implement `__invoke()` method
so they shouldn't be treated as a middleware in such case.