### PR TITLE
Add failing test for Http/Client/Response

### DIFF
--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -151,6 +151,7 @@ class Response extends Message implements ResponseInterface
         }
         $stream = new Stream('php://memory', 'wb+');
         $stream->write($body);
+        $stream->rewind();
         $this->stream = $stream;
     }
 

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -102,10 +102,12 @@ class ResponseTest extends TestCase
         $encoded = json_encode($data);
 
         $response = new Response([], $encoded);
-        $result = $response->body('json_decode');
-        $this->assertEquals($data['property'], $result->property);
+
+        $this->assertEquals($encoded, $response->getBody()->getContents());
         $this->assertEquals($encoded, $response->body());
 
+        $result = $response->body('json_decode');
+        $this->assertEquals($data['property'], $result->property);
         $this->assertEquals($encoded, $response->body);
         $this->assertTrue(isset($response->body));
     }


### PR DESCRIPTION
`$response->getBody()->getContents()` returns empty string instead of same output as `$response->body()`.

I was trying use the response instance created by `HttpClient()` with an external lib which expects a `Psr\Http\Message\ResponseInterface` instance.