### PR TITLE
Deprecate public Controller properties

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -213,9 +213,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Automatically set to the name of a plugin.
      *
      * @var string
-     * @deprecated 3.6.0 Use `$this->request->getParam('plugin')` instead.
      */
-    public $plugin;
+    protected $plugin;
 
     /**
      * Holds all passed params.
@@ -348,7 +347,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
-            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
+//            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s instead.', $name, $deprecated[$name]['method']));
 
             return $this->{$method}();
         }
@@ -391,13 +390,14 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
-            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
+//            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
             $this->{$method}($value);
 
             return;
         }
         if ($name === 'autoRender') {
             $value ? $this->enableAutoRender() : $this->disableAutoRender();
+//            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->enableAutoRender/disableAutoRender() instead.', $name));
 
             return;
         }
@@ -442,6 +442,31 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Returns the plugin name.
+     *
+     * @return string
+     * @since 3.6.0
+     */
+    public function getPlugin()
+    {
+        return $this->plugin;
+    }
+
+    /**
+     * Sets the plugin name.
+     *
+     * @param string $name Plugin name.
+     * @return $this
+     * @since 3.6.0
+     */
+    public function setPlugin($name)
+    {
+        $this->plugin = $name;
 
         return $this;
     }
@@ -500,9 +525,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * which must also be updated here. The properties that get set are:
      *
      * - $this->request - To the $request parameter
-     * - $this->plugin - To the $request->params['plugin']
      * - $this->passedArgs - Same as $request->params['pass]
-     * - View::$plugin - $this->plugin
      *
      * @param \Cake\Http\ServerRequest $request Request instance.
      * @return $this

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -163,7 +163,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * after action logic.
      *
      * @var bool
-     * @deprecated 3.6.0 Use enableAutoRender()/disableAutoRender() and isAutoRenderEnabled() instead.
      */
     protected $autoRender = true;
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -125,6 +125,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var \Cake\Http\ServerRequest
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#request
+     * @deprecated 3.5.0 Use getRequest()/setRequest instead.
      */
     public $request;
 
@@ -133,6 +134,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var \Cake\Http\Response
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#response
+     * @deprecated 3.5.0 Use getResponse()/setResponse instead.
      */
     public $response;
 
@@ -451,6 +453,16 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     }
 
     /**
+     * Gets the request instance.
+     *
+     * @return \Cake\Http\ServerRequest
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
      * Sets the request objects and configures a number of controller properties
      * based on the contents of the request. Controller acts as a proxy for certain View variables
      * which must also be updated here. The properties that get set are:
@@ -461,7 +473,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * - View::$plugin - $this->plugin
      *
      * @param \Cake\Http\ServerRequest $request Request instance.
-     * @return void
+     * @return $this
      */
     public function setRequest(ServerRequest $request)
     {
@@ -471,6 +483,31 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($request->getParam('pass')) {
             $this->passedArgs = $request->getParam('pass');
         }
+
+        return $this;
+    }
+
+    /**
+     * Gets the response instance.
+     *
+     * @return \Cake\Http\Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Sets the response instance.
+     *
+     * @param \Cake\Http\Response $response Response instance.
+     * @return $this
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+
+        return $this;
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -347,7 +347,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
-//            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s instead.', $name, $deprecated[$name]['method']));
+            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s instead.', $name, $method));
 
             return $this->{$method}();
         }
@@ -390,14 +390,14 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
-//            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
+            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
             $this->{$method}($value);
 
             return;
         }
         if ($name === 'autoRender') {
             $value ? $this->enableAutoRender() : $this->disableAutoRender();
-//            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->enableAutoRender/disableAutoRender() instead.', $name));
+            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->enableAutoRender/disableAutoRender() instead.', $name));
 
             return;
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -212,8 +212,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Automatically set to the name of a plugin.
      *
      * @var string
+     * @deprecated 3.5.0 Use `$this->request->getParam('plugin')` instead.
      */
-    protected $plugin;
+    public $plugin;
 
     /**
      * Holds all passed params.
@@ -252,14 +253,15 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         $this->setRequest($request !== null ? $request : new ServerRequest());
-        $this->response = $response !== null ? $response : new Response();
+        $this->setResponse($response !== null ? $response : new Response());
 
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);
         }
 
         $this->modelFactory('Table', [$this->getTableLocator(), 'get']);
-        $modelClass = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
+        $plugin = $this->request->getParam('plugin');
+        $modelClass = ($plugin ? $plugin . '.' : '') . $this->name;
         $this->_setModelClass($modelClass);
 
         if ($components !== null) {
@@ -435,29 +437,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function setName($name)
     {
         $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * Returns the controller plugin name.
-     *
-     * @return string
-     */
-    public function getPlugin()
-    {
-        return $this->plugin;
-    }
-
-    /**
-     * Sets the controller plugin name.
-     *
-     * @param string $plugin Controller plugin name.
-     * @return $this
-     */
-    public function setPlugin($plugin)
-    {
-        $this->plugin = $plugin;
 
         return $this;
     }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -348,6 +348,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
+            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
 
             return $this->{$method}();
         }
@@ -390,6 +391,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
+            deprecationWarning(sprintf('Controller::$%s is deprecated. Use $this->%s() instead.', $name, $method));
             $this->{$method}($value);
 
             return;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -253,8 +253,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $this->name = substr($name, 0, -10);
         }
 
-        $this->setRequest($request !== null ? $request : new ServerRequest());
-        $this->setResponse($response !== null ? $response : new Response());
+        $this->setRequest($request ?: new ServerRequest());
+        $this->setResponse($response ?: new Response());
 
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -449,7 +449,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Returns the plugin name.
      *
-     * @return string
+     * @return string|null
      * @since 3.6.0
      */
     public function getPlugin()

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -115,6 +115,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var array
      * @link https://book.cakephp.org/3.0/en/controllers.html#configuring-helpers-to-load
+     *
+     * @deprecated 3.0.0 You should configure helpers in your AppView::initialize() method.
      */
     public $helpers = [];
 
@@ -182,6 +184,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var array
      * @link https://book.cakephp.org/3.0/en/controllers/components.html
+     *
+     * @deprecated 3.0.0 You should configure components in your Controller::initialize() method.
      */
     public $components = [];
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -127,7 +127,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var \Cake\Http\ServerRequest
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#request
-     * @deprecated 3.5.0 Use getRequest()/setRequest instead.
+     * @deprecated 3.6.0 The property will become protected in 4.0.0. Use getRequest()/setRequest instead.
      */
     public $request;
 
@@ -136,7 +136,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var \Cake\Http\Response
      * @link https://book.cakephp.org/3.0/en/controllers/request-response.html#response
-     * @deprecated 3.5.0 Use getResponse()/setResponse instead.
+     * @deprecated 3.6.0 The property will become protected in 4.0.0. Use getResponse()/setResponse instead.
      */
     public $response;
 
@@ -163,7 +163,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * after action logic.
      *
      * @var bool
-     * @deprecated 3.5.0 Use enableAutoRender()/disableAutoRender() and isAutoRenderEnabled() instead.
+     * @deprecated 3.6.0 Use enableAutoRender()/disableAutoRender() and isAutoRenderEnabled() instead.
      */
     protected $autoRender = true;
 
@@ -213,7 +213,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Automatically set to the name of a plugin.
      *
      * @var string
-     * @deprecated 3.5.0 Use `$this->request->getParam('plugin')` instead.
+     * @deprecated 3.6.0 Use `$this->request->getParam('plugin')` instead.
      */
     public $plugin;
 
@@ -423,6 +423,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Returns the controller name.
      *
      * @return string
+     * @since 3.6.0
      */
     public function getName()
     {
@@ -434,6 +435,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @param string $name Controller name.
      * @return $this
+     * @since 3.6.0
      */
     public function setName($name)
     {
@@ -446,6 +448,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Returns true if an action should be rendered automatically.
      *
      * @return bool
+     * @since 3.6.0
      */
     public function isAutoRenderEnabled()
     {
@@ -456,6 +459,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Enable automatic action rendering.
      *
      * @return $this
+     * @since 3.6.0
      */
     public function enableAutoRender()
     {
@@ -468,6 +472,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Disbale automatic action rendering.
      *
      * @return $this
+     * @since 3.6.0
      */
     public function disableAutoRender()
     {
@@ -480,6 +485,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Gets the request instance.
      *
      * @return \Cake\Http\ServerRequest
+     * @since 3.6.0
      */
     public function getRequest()
     {
@@ -515,6 +521,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Gets the response instance.
      *
      * @return \Cake\Http\Response
+     * @since 3.6.0
      */
     public function getResponse()
     {
@@ -526,6 +533,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @param \Cake\Http\Response $response Response instance.
      * @return $this
+     * @since 3.6.0
      */
     public function setResponse(Response $response)
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -383,12 +383,16 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         $deprecated = [
             'name' => 'setName',
-            'plugin' => 'setPlugin',
-            'autoRender' => 'enableAutoRender',
+            'plugin' => 'setPlugin'
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
             $this->{$method}($value);
+
+            return;
+        }
+        if ($name === 'autoRender') {
+            $value ? $this->enableAutoRender() : $this->disableAutoRender();
 
             return;
         }
@@ -469,14 +473,25 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     }
 
     /**
-     * Enable or disbale automatic action rendering.
+     * Enable automatic action rendering.
      *
-     * @param bool $autoRender Flag.
      * @return $this
      */
-    public function enableAutoRender($autoRender = true)
+    public function enableAutoRender()
     {
-        $this->autoRender = $autoRender;
+        $this->autoRender = true;
+
+        return $this;
+    }
+
+    /**
+     * Disbale automatic action rendering.
+     *
+     * @return $this
+     */
+    public function disableAutoRender()
+    {
+        $this->autoRender = false;
 
         return $this;
     }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -162,7 +162,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var bool
      */
-    public $autoRender = true;
+    protected $autoRender = true;
 
     /**
      * Instance of ComponentRegistry used to create Components
@@ -337,6 +337,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         $deprecated = [
             'name' => 'getName',
             'plugin' => 'getPlugin',
+            'autoRender' => 'isAutoRenderEnabled',
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
@@ -379,6 +380,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         $deprecated = [
             'name' => 'setName',
             'plugin' => 'setPlugin',
+            'autoRender' => 'enableAutoRender',
         ];
         if (isset($deprecated[$name])) {
             $method = $deprecated[$name];
@@ -448,6 +450,29 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function setPlugin($plugin)
     {
         $this->plugin = $plugin;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if an action should be rendered automatically.
+     *
+     * @return bool
+     */
+    public function isAutoRenderEnabled()
+    {
+        return $this->autoRender;
+    }
+
+    /**
+     * Enable or disbale automatic action rendering.
+     *
+     * @param bool $autoRender Flag.
+     * @return $this
+     */
+    public function enableAutoRender($autoRender = true)
+    {
+        $this->autoRender = $autoRender;
 
         return $this;
     }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -163,6 +163,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * after action logic.
      *
      * @var bool
+     * @deprecated 3.5.0 Use enableAutoRender()/disableAutoRender() and isAutoRenderEnabled() instead.
      */
     protected $autoRender = true;
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -102,7 +102,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var string
      */
-    public $name;
+    protected $name;
 
     /**
      * An array containing the names of helpers this controller uses. The array elements should
@@ -207,7 +207,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @var string
      */
-    public $plugin;
+    protected $plugin;
 
     /**
      * Holds all passed params.
@@ -333,6 +333,16 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function __get($name)
     {
         $deprecated = [
+            'name' => 'getName',
+            'plugin' => 'getPlugin',
+        ];
+        if (isset($deprecated[$name])) {
+            $method = $deprecated[$name];
+
+            return $this->{$method}();
+        }
+
+        $deprecated = [
             'layout' => 'getLayout',
             'view' => 'getTemplate',
             'theme' => 'getTheme',
@@ -365,6 +375,16 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function __set($name, $value)
     {
         $deprecated = [
+            'name' => 'setName',
+            'plugin' => 'setPlugin',
+        ];
+        if (isset($deprecated[$name])) {
+            $method = $deprecated[$name];
+            $this->{$method}($value);
+
+            return;
+        }
+        $deprecated = [
             'layout' => 'setLayout',
             'view' => 'setTemplate',
             'theme' => 'setTheme',
@@ -382,6 +402,52 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         $this->{$name} = $value;
+    }
+
+    /**
+     * Returns the controller name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the controller name.
+     *
+     * @param string $name Controller name.
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Returns the controller plugin name.
+     *
+     * @return string
+     */
+    public function getPlugin()
+    {
+        return $this->plugin;
+    }
+
+    /**
+     * Sets the controller plugin name.
+     *
+     * @param string $plugin Controller plugin name.
+     * @return $this
+     */
+    public function setPlugin($plugin)
+    {
+        $this->plugin = $plugin;
+
+        return $this;
     }
 
     /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -338,8 +338,8 @@ class ExceptionRenderer implements ExceptionRendererInterface
             return $this->_outputMessage('error500');
         } catch (MissingPluginException $e) {
             $attributes = $e->getAttributes();
-            if (isset($attributes['plugin']) && $attributes['plugin'] === $this->controller->plugin) {
-                $this->controller->plugin = null;
+            if (isset($attributes['plugin']) && $attributes['plugin'] === $this->controller->getPlugin()) {
+                $this->controller->setPlugin(null);
             }
 
             return $this->_outputMessageSafe('error500');

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -121,7 +121,7 @@ class ActionDispatcher
             throw new LogicException('Controller actions can only return Cake\Http\Response or null.');
         }
 
-        if (!$response && $controller->autoRender) {
+        if (!$response && $controller->isAutoRenderEnabled()) {
             $controller->render();
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1178,7 +1178,7 @@ class ControllerTest extends TestCase
 
         try {
             $controller->$property = $value;
-//
+
             $this->assertSame($value, $controller->$property);
             $this->assertSame($value, $controller->{$getter}());
         } finally {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1155,6 +1155,23 @@ class ControllerTest extends TestCase
     }
 
     /**
+     * Test autoRender getter and setter.
+     *
+     * @return void
+     */
+    public function testAutoRender()
+    {
+        $controller = new PostsController();
+        $this->assertTrue($controller->isAutoRenderEnabled());
+
+        $this->assertSame($controller, $controller->enableAutoRender(false));
+        $this->assertFalse($controller->isAutoRenderEnabled());
+
+        $this->assertSame($controller, $controller->enableAutoRender());
+        $this->assertTrue($controller->isAutoRenderEnabled());
+    }
+
+    /**
      * Tests deprecated view propertiyes work
      *
      * @group deprecated

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -497,7 +497,7 @@ class ControllerTest extends TestCase
         $this->assertSame($response, $Controller->response);
         $this->assertEquals($code, $response->getStatusCode());
         $this->assertEquals('http://cakephp.org', $response->getHeaderLine('Location'));
-        $this->assertFalse($Controller->autoRender);
+        $this->assertFalse($Controller->isAutoRenderEnabled());
     }
 
     /**
@@ -1185,9 +1185,10 @@ class ControllerTest extends TestCase
     public function testDeprecatedControllerProperty($property, $getter, $setter, $value)
     {
         $controller = new AnotherTestController();
-        error_reporting(E_ALL ^ E_USER_DEPRECATED);
-        $controller->$property = $value;
-        $this->assertSame($value, $controller->$property);
+        $this->deprecated(function () use ($controller, $property, $value) {
+            $controller->$property = $value;
+            $this->assertSame($value, $controller->$property);
+        });
         $this->assertSame($value, $controller->{$getter}());
     }
 
@@ -1206,9 +1207,10 @@ class ControllerTest extends TestCase
      */
     public function testDeprecatedControllerPropertySetterMessage($property, $getter, $setter, $value)
     {
-        error_reporting(E_ALL);
         $controller = new AnotherTestController();
-        $controller->$property = $value;
+        $this->withErrorReporting(E_ALL, function () use ($controller, $property, $value) {
+            $controller->$property = $value;
+        });
     }
 
     /**
@@ -1225,10 +1227,11 @@ class ControllerTest extends TestCase
      */
     public function testDeprecatedControllerPropertyGetterMessage($property, $getter, $setter, $value)
     {
-            error_reporting(E_ALL);
-            $controller = new AnotherTestController();
-            $controller->{$setter}($value);
-            $result = $controller->$property;
+        $controller = new AnotherTestController();
+        $controller->{$setter}($value);
+        $this->withErrorReporting(E_ALL, function () use ($controller, $property) {
+            $controller->$property;
+        });
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1164,7 +1164,7 @@ class ControllerTest extends TestCase
         $controller = new PostsController();
         $this->assertTrue($controller->isAutoRenderEnabled());
 
-        $this->assertSame($controller, $controller->enableAutoRender(false));
+        $this->assertSame($controller, $controller->disableAutoRender());
         $this->assertFalse($controller->isAutoRenderEnabled());
 
         $this->assertSame($controller, $controller->enableAutoRender());
@@ -1172,7 +1172,50 @@ class ControllerTest extends TestCase
     }
 
     /**
-     * Tests deprecated view propertiyes work
+     * Tests deprecated controller properties work
+     *
+     * @param $property Deprecated property name
+     * @param $getter Getter name
+     * @param $setter Setter name
+     * @param mixed $value Value to be set
+     * @return void
+     * @dataProvider deprecatedControllerPropertyProvider
+     */
+    public function testDeprecatedControllerProperty($property, $getter, $setter, $value)
+    {
+        $controller = new AnotherTestController();
+        $message = false;
+
+        set_error_handler(function ($errno, $errstr) use (&$message) {
+            $message = ($errno === E_USER_DEPRECATED ? $errstr : false);
+        });
+
+        try {
+            $controller->$property = $value;
+//
+            $this->assertSame($value, $controller->$property);
+            $this->assertSame($value, $controller->{$getter}());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * Data provider for testing deprecated view properties
+     *
+     * @return array
+     */
+    public function deprecatedControllerPropertyProvider()
+    {
+        return [
+            ['name', 'getName', 'setName', 'Foo'],
+            ['plugin', 'getPlugin', 'setPlugin', 'Foo'],
+            ['autoRender', 'isAutoRenderEnabled', 'enableAutoRender/disableAutoRender', false],
+        ];
+    }
+
+    /**
+     * Tests deprecated view properties work
      *
      * @group deprecated
      * @param $property Deprecated property name

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1100,6 +1100,20 @@ class ControllerTest extends TestCase
     }
 
     /**
+     * Test plugin getter and setter.
+     *
+     * @return void
+     */
+    public function testPlugin()
+    {
+        $controller = new PostsController();
+        $this->assertEquals('', $controller->getPlugin());
+
+        $this->assertSame($controller, $controller->setPlugin('Articles'));
+        $this->assertEquals('Articles', $controller->getPlugin());
+    }
+
+    /**
      * Test request getter and setter.
      *
      * @return void
@@ -1156,48 +1170,48 @@ class ControllerTest extends TestCase
         $this->assertSame($controller, $controller->enableAutoRender());
         $this->assertTrue($controller->isAutoRenderEnabled());
     }
-
-    /**
-     * Tests deprecated controller properties work
-     *
-     * @param $property Deprecated property name
-     * @param $getter Getter name
-     * @param $setter Setter name
-     * @param mixed $value Value to be set
-     * @return void
-     * @dataProvider deprecatedControllerPropertyProvider
-     */
-    public function testDeprecatedControllerProperty($property, $getter, $setter, $value)
-    {
-        $controller = new AnotherTestController();
-        $message = false;
-
-        set_error_handler(function ($errno, $errstr) use (&$message) {
-            $message = ($errno === E_USER_DEPRECATED ? $errstr : false);
-        });
-
-        try {
-            $controller->$property = $value;
-
-            $this->assertSame($value, $controller->$property);
-            $this->assertSame($value, $controller->{$getter}());
-        } finally {
-            restore_error_handler();
-        }
-    }
-
-    /**
-     * Data provider for testing deprecated view properties
-     *
-     * @return array
-     */
-    public function deprecatedControllerPropertyProvider()
-    {
-        return [
-            ['name', 'getName', 'setName', 'Foo'],
-            ['autoRender', 'isAutoRenderEnabled', 'enableAutoRender/disableAutoRender', false],
-        ];
-    }
+//
+//    /**
+//     * Tests deprecated controller properties work
+//     *
+//     * @param $property Deprecated property name
+//     * @param $getter Getter name
+//     * @param $setter Setter name
+//     * @param mixed $value Value to be set
+//     * @return void
+//     * @dataProvider deprecatedControllerPropertyProvider
+//     */
+//    public function testDeprecatedControllerProperty($property, $getter, $setter, $value)
+//    {
+//        $controller = new AnotherTestController();
+//        $message = false;
+//
+//        set_error_handler(function ($errno, $errstr) use (&$message) {
+//            $message = ($errno === E_USER_DEPRECATED ? $errstr : false);
+//        });
+//
+//        try {
+//            $controller->$property = $value;
+//
+//            $this->assertSame($value, $controller->$property);
+//            $this->assertSame($value, $controller->{$getter}());
+//        } finally {
+//            restore_error_handler();
+//        }
+//    }
+//
+//    /**
+//     * Data provider for testing deprecated view properties
+//     *
+//     * @return array
+//     */
+//    public function deprecatedControllerPropertyProvider()
+//    {
+//        return [
+//            ['name', 'getName', 'setName', 'Foo'],
+//            ['autoRender', 'isAutoRenderEnabled', 'enableAutoRender/disableAutoRender', false],
+//        ];
+//    }
 
     /**
      * Tests deprecated view properties work

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1170,48 +1170,80 @@ class ControllerTest extends TestCase
         $this->assertSame($controller, $controller->enableAutoRender());
         $this->assertTrue($controller->isAutoRenderEnabled());
     }
-//
-//    /**
-//     * Tests deprecated controller properties work
-//     *
-//     * @param $property Deprecated property name
-//     * @param $getter Getter name
-//     * @param $setter Setter name
-//     * @param mixed $value Value to be set
-//     * @return void
-//     * @dataProvider deprecatedControllerPropertyProvider
-//     */
-//    public function testDeprecatedControllerProperty($property, $getter, $setter, $value)
-//    {
-//        $controller = new AnotherTestController();
-//        $message = false;
-//
-//        set_error_handler(function ($errno, $errstr) use (&$message) {
-//            $message = ($errno === E_USER_DEPRECATED ? $errstr : false);
-//        });
-//
-//        try {
-//            $controller->$property = $value;
-//
-//            $this->assertSame($value, $controller->$property);
-//            $this->assertSame($value, $controller->{$getter}());
-//        } finally {
-//            restore_error_handler();
-//        }
-//    }
-//
-//    /**
-//     * Data provider for testing deprecated view properties
-//     *
-//     * @return array
-//     */
-//    public function deprecatedControllerPropertyProvider()
-//    {
-//        return [
-//            ['name', 'getName', 'setName', 'Foo'],
-//            ['autoRender', 'isAutoRenderEnabled', 'enableAutoRender/disableAutoRender', false],
-//        ];
-//    }
+
+    /**
+     * Tests deprecated controller properties work
+     *
+     * @group deprecated
+     * @param $property Deprecated property name
+     * @param $getter Getter name
+     * @param $setter Setter name
+     * @param mixed $value Value to be set
+     * @return void
+     * @dataProvider deprecatedControllerPropertyProvider
+     */
+    public function testDeprecatedControllerProperty($property, $getter, $setter, $value)
+    {
+        $controller = new AnotherTestController();
+        error_reporting(E_ALL ^ E_USER_DEPRECATED);
+        $controller->$property = $value;
+        $this->assertSame($value, $controller->$property);
+        $this->assertSame($value, $controller->{$getter}());
+    }
+
+    /**
+     * Tests deprecated controller properties message
+     *
+     * @group deprecated
+     * @param $property Deprecated property name
+     * @param $getter Getter name
+     * @param $setter Setter name
+     * @param mixed $value Value to be set
+     * @return void
+     * @expectedException PHPUnit\Framework\Error\Deprecated
+     * @expectedExceptionMessageRegExp /^Controller::\$\w+ is deprecated(.*)/
+     * @dataProvider deprecatedControllerPropertyProvider
+     */
+    public function testDeprecatedControllerPropertySetterMessage($property, $getter, $setter, $value)
+    {
+        error_reporting(E_ALL);
+        $controller = new AnotherTestController();
+        $controller->$property = $value;
+    }
+
+    /**
+     * Tests deprecated controller properties message
+     *
+     * @param $property Deprecated property name
+     * @param $getter Getter name
+     * @param $setter Setter name
+     * @param mixed $value Value to be set
+     * @return void
+     * @expectedException PHPUnit\Framework\Error\Deprecated
+     * @expectedExceptionMessageRegExp /^Controller::\$\w+ is deprecated(.*)/
+     * @dataProvider deprecatedControllerPropertyProvider
+     */
+    public function testDeprecatedControllerPropertyGetterMessage($property, $getter, $setter, $value)
+    {
+            error_reporting(E_ALL);
+            $controller = new AnotherTestController();
+            $controller->{$setter}($value);
+            $result = $controller->$property;
+    }
+
+    /**
+     * Data provider for testing deprecated view properties
+     *
+     * @return array
+     */
+    public function deprecatedControllerPropertyProvider()
+    {
+        return [
+            ['name', 'getName', 'setName', 'Foo'],
+            ['plugin', 'getPlugin', 'setPlugin', 'Foo'],
+            ['autoRender', 'isAutoRenderEnabled', 'disableAutoRender', false],
+        ];
+    }
 
     /**
      * Tests deprecated view properties work

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -322,7 +322,7 @@ class ControllerTest extends TestCase
         Plugin::load('TestPlugin');
 
         $Controller = new TestPluginController();
-        $Controller->plugin = 'TestPlugin';
+        $Controller->setPlugin('TestPlugin');
 
         $this->assertFalse(isset($Controller->TestPluginComments));
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1100,20 +1100,6 @@ class ControllerTest extends TestCase
     }
 
     /**
-     * Test plugin getter and setter.
-     *
-     * @return void
-     */
-    public function testPlugin()
-    {
-        $controller = new PostsController();
-        $this->assertNull($controller->getPlugin());
-
-        $this->assertSame($controller, $controller->setPlugin('Posts'));
-        $this->assertEquals('Posts', $controller->getPlugin());
-    }
-
-    /**
      * Test request getter and setter.
      *
      * @return void
@@ -1135,7 +1121,7 @@ class ControllerTest extends TestCase
         $this->assertSame($controller, $controller->setRequest($request));
         $this->assertSame($request, $controller->getRequest());
 
-        $this->assertEquals('Posts', $controller->getPlugin());
+        $this->assertEquals('Posts', $controller->getRequest()->getParam('plugin'));
         $this->assertEquals(['foo', 'bar'], $controller->passedArgs);
     }
 
@@ -1209,7 +1195,6 @@ class ControllerTest extends TestCase
     {
         return [
             ['name', 'getName', 'setName', 'Foo'],
-            ['plugin', 'getPlugin', 'setPlugin', 'Foo'],
             ['autoRender', 'isAutoRenderEnabled', 'enableAutoRender/disableAutoRender', false],
         ];
     }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1114,6 +1114,47 @@ class ControllerTest extends TestCase
     }
 
     /**
+     * Test request getter and setter.
+     *
+     * @return void
+     */
+    public function testRequest()
+    {
+        $controller = new PostsController();
+        $this->assertInstanceOf(ServerRequest::class, $controller->getRequest());
+
+        $request = new ServerRequest([
+            'params' => [
+                'plugin' => 'Posts',
+                'pass' => [
+                    'foo',
+                    'bar'
+                ]
+            ]
+        ]);
+        $this->assertSame($controller, $controller->setRequest($request));
+        $this->assertSame($request, $controller->getRequest());
+
+        $this->assertEquals('Posts', $controller->getPlugin());
+        $this->assertEquals(['foo', 'bar'], $controller->passedArgs);
+    }
+
+    /**
+     * Test response getter and setter.
+     *
+     * @return void
+     */
+    public function testResponse()
+    {
+        $controller = new PostsController();
+        $this->assertInstanceOf(Response::class, $controller->getResponse());
+
+        $response = new Response;
+        $this->assertSame($controller, $controller->setResponse($response));
+        $this->assertSame($response, $controller->getResponse());
+    }
+
+    /**
      * Tests deprecated view propertiyes work
      *
      * @group deprecated

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1086,7 +1086,35 @@ class ControllerTest extends TestCase
     }
 
     /**
-     * Tests deprecated view properties work
+     * Test name getter and setter.
+     *
+     * @return void
+     */
+    public function testName()
+    {
+        $controller = new PostsController();
+        $this->assertEquals('Posts', $controller->getName());
+
+        $this->assertSame($controller, $controller->setName('Articles'));
+        $this->assertEquals('Articles', $controller->getName());
+    }
+
+    /**
+     * Test plugin getter and setter.
+     *
+     * @return void
+     */
+    public function testPlugin()
+    {
+        $controller = new PostsController();
+        $this->assertNull($controller->getPlugin());
+
+        $this->assertSame($controller, $controller->setPlugin('Posts'));
+        $this->assertEquals('Posts', $controller->getPlugin());
+    }
+
+    /**
+     * Tests deprecated view propertiyes work
      *
      * @group deprecated
      * @param $property Deprecated property name

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -781,7 +781,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->setMethods(['render'])
             ->getMock();
-        $ExceptionRenderer->controller->plugin = 'TestPlugin';
+        $ExceptionRenderer->controller->setPlugin('TestPlugin');
         $ExceptionRenderer->controller->request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
 
         $exception = new MissingPluginException(['plugin' => 'TestPlugin']);
@@ -810,7 +810,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer->controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->setMethods(['render'])
             ->getMock();
-        $ExceptionRenderer->controller->plugin = 'TestPlugin';
+        $ExceptionRenderer->controller->setPlugin('TestPlugin');
         $ExceptionRenderer->controller->request = $this->getMockBuilder('Cake\Http\ServerRequest')->getMock();
 
         $exception = new MissingPluginException(['plugin' => 'TestPluginTwo']);

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -318,7 +318,7 @@ class JsonViewTest extends TestCase
         $Request = new ServerRequest();
         $Response = new Response();
         $Controller = new Controller($Request, $Response);
-        $Controller->name = 'Posts';
+        $Controller->setName('Posts');
 
         $data = [
             'User' => [
@@ -332,7 +332,7 @@ class JsonViewTest extends TestCase
         $Controller->set('user', $data);
         $Controller->viewBuilder()->setClassName('Json');
         $View = $Controller->createView();
-        $View->setTemplatePath($Controller->name);
+        $View->setTemplatePath($Controller->getName());
         $output = $View->render('index');
 
         $expected = json_encode(['user' => 'fake', 'list' => ['item1', 'item2'], 'paging' => null]);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1406,7 +1406,7 @@ class ViewTest extends TestCase
      */
     public function testGetViewFileNameSubdirWithPluginAndViewPath()
     {
-        $this->PostsController->plugin = 'TestPlugin';
+        $this->PostsController->setPlugin('TestPlugin');
         $this->PostsController->setName('Posts');
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
         $View->setTemplatePath('Element');
@@ -1972,7 +1972,7 @@ TEXT;
     public function testMemoryLeakInPaths()
     {
         $this->skipIf(env('CODECOVERAGE') == 1, 'Running coverage this causes this tests to fail sometimes.');
-        $this->ThemeController->plugin = null;
+        $this->ThemeController->setPlugin(null);
         $this->ThemeController->setName('Posts');
 
         $View = $this->ThemeController->createView();

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1069,7 +1069,7 @@ class ViewTest extends TestCase
     public function testViewEvent()
     {
         $View = $this->PostsController->createView();
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
         $View->enableAutoLayout(false);
         $listener = new TestViewEventListenerInterface();
 
@@ -1178,7 +1178,7 @@ class ViewTest extends TestCase
     public function testHelperCallbackTriggering()
     {
         $View = $this->PostsController->createView();
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
 
         $manager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $View->setEventManager($manager);
@@ -1270,7 +1270,7 @@ class ViewTest extends TestCase
             'Html'
         ];
         $View = $this->PostsController->createView();
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
         $View->render('index');
         $this->assertEquals('Valuation', $View->helpers()->TestBeforeAfter->property);
     }
@@ -1289,7 +1289,7 @@ class ViewTest extends TestCase
         $this->PostsController->set('variable', 'values');
 
         $View = $this->PostsController->createView();
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
 
         $content = 'This is my view output';
         $result = $View->renderLayout($content, 'default');
@@ -1306,7 +1306,7 @@ class ViewTest extends TestCase
     {
         $this->PostsController->helpers = ['Form', 'Number'];
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
 
         $result = $View->render('index', false);
         $this->assertEquals('posts index', $result);
@@ -1317,7 +1317,7 @@ class ViewTest extends TestCase
 
         $this->PostsController->helpers = ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper'];
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
 
         $result = $View->render('index', false);
         $this->assertEquals('posts index', $result);
@@ -1335,7 +1335,7 @@ class ViewTest extends TestCase
     public function testRender()
     {
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
         $result = $View->render('index');
 
         $this->assertRegExp("/<meta charset=\"utf-8\"\/>\s*<title>/", $result);
@@ -1354,7 +1354,7 @@ class ViewTest extends TestCase
         Configure::write('Cache.check', true);
 
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
         $result = $View->render('index');
 
         $this->assertRegExp("/<meta charset=\"utf-8\"\/>\s*<title>/", $result);
@@ -1369,7 +1369,7 @@ class ViewTest extends TestCase
     public function testRenderUsingViewProperty()
     {
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
-        $View->setTemplatePath($this->PostsController->name);
+        $View->setTemplatePath($this->PostsController->getName());
         $View->setTemplate('cache_form');
 
         $this->assertEquals('cache_form', $View->getTemplate());
@@ -1407,7 +1407,7 @@ class ViewTest extends TestCase
     public function testGetViewFileNameSubdirWithPluginAndViewPath()
     {
         $this->PostsController->plugin = 'TestPlugin';
-        $this->PostsController->name = 'Posts';
+        $this->PostsController->setName('Posts');
         $View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
         $View->setTemplatePath('Element');
 
@@ -1429,7 +1429,7 @@ class ViewTest extends TestCase
         $Controller->helpers = ['Html'];
         $Controller->set('html', 'I am some test html');
         $View = $Controller->createView();
-        $View->setTemplatePath($Controller->name);
+        $View->setTemplatePath($Controller->getName());
         $result = $View->render('helper_overwrite', false);
 
         $this->assertRegExp('/I am some test html/', $result);
@@ -1973,7 +1973,7 @@ TEXT;
     {
         $this->skipIf(env('CODECOVERAGE') == 1, 'Running coverage this causes this tests to fail sometimes.');
         $this->ThemeController->plugin = null;
-        $this->ThemeController->name = 'Posts';
+        $this->ThemeController->setName('Posts');
 
         $View = $this->ThemeController->createView();
         $View->setTemplatePath('Posts');

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -281,7 +281,7 @@ class XmlViewTest extends TestCase
         $Request = new ServerRequest();
         $Response = new Response();
         $Controller = new Controller($Request, $Response);
-        $Controller->name = 'Posts';
+        $Controller->setName('Posts');
 
         $data = [
             [


### PR DESCRIPTION
Refs #10946

I'm afraid it's hard to change the visibility of `$request` and `$response` properties now, so I kept them public but added deprecation annotations to them.

`$name`, `$plugin`, `$autoRender` properties are now protected and accessed via magic methods for BC.

It was also hard to refactor the code to use request controller name and plugin params as those not always share the same state, at least in tests. So these are still controller properties. We can get back to this in 4.0 though.

I added deprecation annotations to `$components` and `$helpers` as well because those are deprecated since the 3.0 I believe.

After this is reviewed and merged, I'll update the core to use new methods.