### PR TITLE
DefaultPasswordHasher with changed options enables needsRehash

### DIFF
--- a/src/Auth/DefaultPasswordHasher.php
+++ b/src/Auth/DefaultPasswordHasher.php
@@ -74,6 +74,6 @@ class DefaultPasswordHasher extends AbstractPasswordHasher
      */
     public function needsRehash($password)
     {
-        return password_needs_rehash($password, $this->_config['hashType']);
+        return password_needs_rehash($password, $this->_config['hashType'], $this->_config['hashOptions']);
     }
 }

--- a/tests/TestCase/Auth/DefaultPasswordHasherTest.php
+++ b/tests/TestCase/Auth/DefaultPasswordHasherTest.php
@@ -36,4 +36,19 @@ class DefaultPasswordHasherTest extends TestCase
         $password = $hasher->hash('foo');
         $this->assertFalse($hasher->needsRehash($password));
     }
+
+    /**
+     * Tests that when the hash options change, the password needs
+     * to be rehashed
+     *
+     * @return void
+     */
+    public function testNeedsRehashWithDifferentOptions()
+    {
+        $defaultHasher = new DefaultPasswordHasher(['hashType' => PASSWORD_BCRYPT, 'hashOptions' => ['cost' => 10]]);
+        $updatedHasher = new DefaultPasswordHasher(['hashType' => PASSWORD_BCRYPT, 'hashOptions' => ['cost' => 12]]);
+        $password = $defaultHasher->hash('foo');
+
+        $this->assertTrue($updatedHasher->needsRehash($password));
+    }
 }


### PR DESCRIPTION
When changing the cost of bcrypt, the `needRehash` function should return `true`.