### PR TITLE
Fix empty translations

### DIFF
--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -174,7 +174,7 @@ class Translator implements TranslatorInterface
         // No or missing context, fallback to the key/first message
         if ($context === null) {
             if (isset($message['_context'][''])) {
-                return $message['_context'][''];
+                return $message['_context'][''] === '' ? $key : $message['_context'][''];
             }
 
             return current($message['_context']);

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -844,4 +844,16 @@ class I18nTest extends TestCase
         $this->assertEquals('Le moo', $translator->translate('Cow'));
         $this->assertEquals('Le bark', $translator->translate('Dog'));
     }
+
+    /**
+     * Tests the __() function on empty translations
+     *
+     * @return void
+     */
+    public function testEmptyTranslationString()
+    {
+        I18n::defaultFormatter('sprintf');
+        $result = __('No translation needed');
+        $this->assertEquals('No translation needed', $result);
+    }
 }

--- a/tests/test_app/TestApp/Locale/en/default.po
+++ b/tests/test_app/TestApp/Locale/en/default.po
@@ -32,7 +32,7 @@ msgstr  "This is a multiline translation\n"
 "This is the third line.\n"
 "This is the forth line. (translated)"
 
-msgid "No Translation needed"
+msgid "No translation needed"
 msgstr ""
 
 msgid "test"


### PR DESCRIPTION
With the latest changes in the handling of contexts, empty translations had stopped working and returned an empty string. I've added a test and had a try at fixing it.

I don't think it's an efficient way to handle it. I would rather discard all empty translations when parsing the PO file or parse the MO file instead because the gettext formatter already discards them (and also fuzzy translations).

Still this is an easy fix for the regression.

Issue #10954.