### PR TITLE
Fixed bug causing requests with queries to be invalidated

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -547,11 +547,12 @@ abstract class IntegrationTestCase extends TestCase
         list ($url, $query) = $this->_url($url);
         $tokenUrl = $url;
 
+        parse_str($query, $queryData);
+
         if ($query) {
-            $tokenUrl .= '?' . $query;
+            $tokenUrl .= '?' . http_build_query($queryData);
         }
 
-        parse_str($query, $queryData);
         $props = [
             'url' => $url,
             'post' => $this->_addTokens($tokenUrl, $data),

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -535,6 +535,24 @@ class IntegrationTestCaseTest extends IntegrationTestCase
     }
 
     /**
+     * Test posting to a secured form action with a query that has a part that
+     * will be encoded by the security component
+     *
+     * @return void
+     */
+    public function testPostSecuredFormWithUnencodedQuery()
+    {
+        $this->enableSecurityToken();
+        $data = [
+            'title' => 'Some title',
+            'body' => 'Some text'
+        ];
+        $this->post('/posts/securePost?foo=/', $data);
+        $this->assertResponseOk();
+        $this->assertResponseContains('Request was accepted');
+    }
+
+    /**
      * Test posting to a secured form action action.
      *
      * @return void


### PR DESCRIPTION
The SecurityComponent would fail at _validatePost because the query
arguments were not encoded when the tokens were generated in the
IntegrationTestCase

I found this regression when one of my test cases failed during an upgrade.

edit: as I recall this was an issue brought up in slack that I couldn't reproduce because my app didn't have the latest version. I never did delve into it until it affected me, sorry!