### PR TITLE
Loading all fixtures if no args are passed to loadFixtures

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -127,6 +127,7 @@ abstract class TestCase extends BaseTestCase
      * Chooses which fixtures to load for a given test
      *
      * Each parameter is a model name that corresponds to a fixture, i.e. 'Posts', 'Authors', etc.
+     * Passing no parameters will cause all fixtures on the test case to load.
      *
      * @return void
      * @see \Cake\TestSuite\TestCase::$autoFixtures

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -141,6 +141,13 @@ abstract class TestCase extends BaseTestCase
         foreach ($args as $class) {
             $this->fixtureManager->loadSingle($class, null, $this->dropTables);
         }
+
+        if (empty($args)) {
+            $autoFixtures = $this->autoFixtures;
+            $this->autoFixtures = true;
+            $this->fixtureManager->load($this);
+            $this->autoFixtures = $autoFixtures;
+        }
     }
 
     /**

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -2,6 +2,7 @@
 namespace Cake\Test\Fixture;
 
 use Cake\TestSuite\TestCase;
+use Cake\ORM\TableRegistry;
 use Exception;
 
 /**
@@ -14,7 +15,7 @@ class FixturizedTestCase extends TestCase
      * Fixtures to use in this test
      * @var array
      */
-    public $fixtures = ['core.categories'];
+    public $fixtures = ['core.categories', 'core.articles'];
 
     /**
      * test that the shared fixture is correctly set
@@ -34,6 +35,20 @@ class FixturizedTestCase extends TestCase
     public function testFixtureLoadOnDemand()
     {
         $this->loadFixtures('Categories');
+    }
+
+    /**
+     * test that calling loadFixtures without args loads all fixtures
+     *
+     * @return void
+     */
+    public function testLoadAllFixtures()
+    {
+        $this->loadFixtures();
+        $article = TableRegistry::get('Articles')->get(1);
+        $this->assertSame(1, $article->id);
+        $category = TableRegistry::get('Categories')->get(1);
+        $this->assertSame(1, $category->id);
     }
 
     /**

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -1,8 +1,8 @@
 <?php
 namespace Cake\Test\Fixture;
 
-use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
 use Exception;
 
 /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -22,6 +22,7 @@ use Cake\Event\EventManager;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
 use Cake\Test\Fixture\FixturizedTestCase;
 
@@ -136,6 +137,26 @@ class TestCaseTest extends TestCase
         $result = $test->run();
 
         $this->assertEquals(0, $result->errorCount());
+    }
+
+    /**
+     * tests loadFixtures loads all fixtures on the test
+     *
+     * @return void
+     */
+    public function testLoadAllFixtures()
+    {
+        $test = new FixturizedTestCase('testLoadAllFixtures');
+        $test->autoFixtures = false;
+        $manager = new FixtureManager();
+        $manager->fixturize($test);
+        $test->fixtureManager = $manager;
+
+        $result = $test->run();
+
+        $this->assertEquals(0, $result->errorCount());
+        $this->assertCount(1, $result->passed());
+        $this->assertFalse($test->autoFixtures);
     }
 
     /**


### PR DESCRIPTION
Closes #10831 

I based this on `3.next` as it's a behavior change.
