### PR TITLE
Output the command list when no command is given.

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -162,6 +162,10 @@ class CommandRunner
      */
     protected function getShell(ConsoleIo $io, CommandCollection $commands, $name)
     {
+        if (!$name) {
+            $io->err('<error>No command provided. Choose one of the available commands.</error>', 2);
+            $name = 'help';
+        }
         if (isset($this->aliases[$name])) {
             $name = $this->aliases[$name];
         }

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -146,6 +146,29 @@ class CommandRunnerTest extends TestCase
     }
 
     /**
+     * Test that no command outputs the command list
+     *
+     * @return void
+     */
+    public function testRunNoCommand()
+    {
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->setMethods(['middleware', 'bootstrap'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
+
+        $output = new ConsoleOutput();
+        $runner = new CommandRunner($app);
+        $result = $runner->run(['cake'], $this->getMockIo($output));
+
+        $this->assertSame(0, $result, 'help output is success.');
+        $messages = implode("\n", $output->messages());
+        $this->assertContains('No command provided. Choose one of the available commands', $messages);
+        $this->assertContains('- i18n', $messages);
+        $this->assertContains('Available Commands', $messages);
+    }
+
+    /**
      * Test using `cake --verson` invokes the version command
      *
      * @return void


### PR DESCRIPTION
Make `bin/cake` in CommandRunner work similar to how it works with ShellDispatcher. Output the help list when no command is given.

cc @robertpustulka @cleptric 