### PR TITLE
Fix incorrect doc block

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -139,7 +139,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Constructor.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection
+     * @param \Cake\Database\Connection $connection The connection
      * object to be used for transforming and executing this query
      */
     public function __construct($connection)
@@ -150,7 +150,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Sets the connection instance to be used for executing and transforming this query.
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection Connection instance
+     * @param \Cake\Database\Connection $connection Connection instance
      * @return $this
      */
     public function setConnection($connection)
@@ -176,8 +176,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      * When called with a null argument, it will return the current connection instance.
      *
      * @deprecated 3.4.0 Use setConnection()/getConnection() instead.
-     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection instance
-     * @return $this|\Cake\Datasource\ConnectionInterface
+     * @param \Cake\Database\Connection|null $connection Connection instance
+     * @return $this|\Cake\Database\Connection
      */
     public function connection($connection = null)
     {
@@ -342,7 +342,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ```
      *
      * By default no fields are selected, if you have an instance of `Cake\ORM\Query` and try to append
-     * fields you should also call `Cake\ORM\Query::autoFields()` to select the default fields
+     * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
      * from the table.
      *
      * @param array|\Cake\Database\ExpressionInterface|string|callable $fields fields to be added to the list.

--- a/src/Database/TypedResultInterface.php
+++ b/src/Database/TypedResultInterface.php
@@ -16,6 +16,9 @@ namespace Cake\Database;
 
 /**
  * Represents an expression that is known to return a specific type
+ *
+ * @method string getReturnType()
+ * @method $this setReturnType($type)
  */
 interface TypedResultInterface
 {
@@ -24,6 +27,7 @@ interface TypedResultInterface
      * Sets the type of the value this object will generate.
      * If called without arguments, returns the current known type
      *
+     * @deprecated 3.5.0 Use getReturnType()/setReturnType() instead.
      * @param string|null $type The name of the type that is to be returned
      * @return string|$this
      */

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -33,7 +33,7 @@ use JsonSerializable;
  * @method array getError($field)
  * @method array setErrors(array $fields, $overwrite = false)
  * @method array setError($field, $errors, $overwrite = false)
- * @method $this setAccess($properties, $merge)
+ * @method $this setAccess($property, $set)
  * @method bool isAccessible($property)
  * @method $this setSource($source)
  * @method array getSource()

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -17,6 +17,9 @@ namespace Cake\Datasource;
 /**
  * Describes the methods that any class representing a data storage should
  * comply with.
+ *
+ * @method $this setAlias($alias)
+ * @method string getAlias()
  */
 interface RepositoryInterface
 {
@@ -24,6 +27,7 @@ interface RepositoryInterface
     /**
      * Returns the table alias or sets a new one
      *
+     * @deprecated 3.4.0 Use setAlias()/getAlias() instead.
      * @param string|null $alias the new table alias
      * @return string
      */

--- a/src/Event/EventDispatcherInterface.php
+++ b/src/Event/EventDispatcherInterface.php
@@ -22,6 +22,9 @@ namespace Cake\Event;
  *
  * The Cake\Event\EventDispatcherTrait lets you easily implement
  * this interface.
+ *
+ * @method \Cake\Event\EventManager getEventManager()
+ * @method $this setEventManager(\Cake\Event\EventManager $eventManager)
  */
 interface EventDispatcherInterface
 {
@@ -46,6 +49,7 @@ interface EventDispatcherInterface
      * You can use this instance to register any new listeners or callbacks to the
      * object events, or create your own events and trigger them at will.
      *
+     * @deprecated 3.5.0 Use getEventManager()/setEventManager() instead.
      * @param \Cake\Event\EventManager|null $eventManager the eventManager to set
      * @return \Cake\Event\EventManager
      */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -253,7 +253,7 @@ class BelongsToMany extends Association
      * Sets the sort order in which target records should be returned.
      * If no arguments are passed the currently configured value is returned
      *
-     * @deprecated 3.4.0 Use setSort()/getSort() instead.
+     * @deprecated 3.5.0 Use setSort()/getSort() instead.
      * @param mixed $sort A find() compatible order clause
      * @return mixed
      */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -155,7 +155,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     /**
      * Constructor
      *
-     * @param \Cake\Datasource\ConnectionInterface $connection The connection object
+     * @param \Cake\Database\Connection $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
     public function __construct($connection, $table)


### PR DESCRIPTION
- Since \Cake\Database\Query::$_connection is declared as \Cake\Database\Connection, it doesn't accept QueryInterface actually.
- \Cake\ORM\Query::autoFields() has been already deprecated in 3.4.0.
- TypedResultInterface::returnType() was deprecated.
- `@method` annotation for EntityInterface::setAccess() was incorrect.
- RepositoryInterface::alias() has been already deprecated in 3.4.0.
- EventDispatcherInterface::eventManager() was deprecated.
- BelongsToMany::sort() was deprecated in 3.5.0, not in 3.4.0.

I would add related deprecation notes if necessary.