### PR TITLE
Shell : improve unknown tokens error messages

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -879,13 +879,13 @@ class ConsoleOptionParser
     {
         $bestGuess = null;
         foreach ($haystack as $item) {
-            if (preg_match('/^' . $needle . '/', $item, $matches)) {
+            if (preg_match('/^' . $needle . '/', $item)) {
                 return $item;
             }
         }
 
         foreach ($haystack as $item) {
-            if (preg_match('/' . $needle . '/', $item, $matches)) {
+            if (preg_match('/' . $needle . '/', $item)) {
                 return $item;
             }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -731,6 +731,18 @@ class ConsoleOptionParser
      */
     public function help($subcommand = null, $format = 'text', $width = 72)
     {
+        if ($subcommand === null) {
+            $formatter = new HelpFormatter($this);
+            $formatter->setAlias($this->rootName);
+
+            if ($format === 'text') {
+                return $formatter->text($width);
+            }
+            if ($format === 'xml') {
+                return $formatter->xml();
+            }
+        }
+
         if (isset($this->_subcommands[$subcommand])) {
             $command = $this->_subcommands[$subcommand];
             $subparser = $command->parser();
@@ -746,15 +758,7 @@ class ConsoleOptionParser
             return $subparser->help(null, $format, $width);
         }
 
-        $formatter = new HelpFormatter($this);
-        $formatter->setAlias($this->rootName);
-
-        if ($format === 'text') {
-            return $formatter->text($width);
-        }
-        if ($format === 'xml') {
-            return $formatter->xml();
-        }
+        return $this->getCommandError($subcommand);
     }
 
     /**
@@ -789,7 +793,7 @@ class ConsoleOptionParser
      * @param string $command Unknown command name trying to be dispatched.
      * @return string The message to be displayed in the console.
      */
-    public function getCommandError($command)
+    protected function getCommandError($command)
     {
         $rootCommand = $this->getCommand();
         $subcommands = array_keys((array)$this->subcommands());
@@ -869,7 +873,8 @@ class ConsoleOptionParser
     }
 
     /**
-     * Tries to guess the item name the user originally wanted using the levenshtein algorithm.
+     * Tries to guess the item name the user originally wanted using the some regex pattern and the levenshtein
+     * algorithm.
      *
      * @param string $needle Unknown item (either a subcommand name or an option for instance) trying to be used.
      * @param array $haystack List of items available for the type $needle belongs to.

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -825,7 +825,7 @@ class ConsoleOptionParser
      * @param string $option Unknown option name trying to be used.
      * @return string The message to be displayed in the console.
      */
-    public function getOptionError($option)
+    protected function getOptionError($option)
     {
         $availableOptions = array_keys($this->_options);
         $bestGuess = $this->findClosestItem($option, $availableOptions);

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -799,16 +799,17 @@ class ConsoleOptionParser
         $subcommands = array_keys((array)$this->subcommands());
         $bestGuess = $this->findClosestItem($command, $subcommands);
 
-        $out = [];
+        $out = [
+            sprintf(
+                'Unable to find the `%s %s` subcommand. See `bin/%s %s --help`.',
+                $rootCommand,
+                $command,
+                $this->rootName,
+                $rootCommand
+            ),
+            ''
+        ];
 
-        $out[] = sprintf(
-            'Unable to find the `%s %s` subcommand. See `bin/%s %s --help`.',
-            $rootCommand,
-            $command,
-            $this->rootName,
-            $rootCommand
-        );
-        $out[] = '';
         if ($bestGuess !== null) {
             $out[] = sprintf('Did you mean : `%s %s` ?', $rootCommand, $bestGuess);
             $out[] = '';
@@ -833,9 +834,10 @@ class ConsoleOptionParser
     {
         $availableOptions = array_keys($this->_options);
         $bestGuess = $this->findClosestItem($option, $availableOptions);
-        $out = [];
-        $out[] = sprintf('Unknown option `%s`.', $option);
-        $out[] = '';
+        $out = [
+            sprintf('Unknown option `%s`.', $option),
+            ''
+        ];
 
         if ($bestGuess !== null) {
             $out[] = sprintf('Did you mean `%s` ?', $bestGuess);
@@ -897,7 +899,7 @@ class ConsoleOptionParser
             $score = levenshtein($needle, $item);
 
             if (!isset($bestScore) || $score < $bestScore) {
-                $bestScore = levenshtein($needle, $item);
+                $bestScore = $score;
                 $bestGuess = $item;
             }
         }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -848,6 +848,27 @@ class ConsoleOptionParser
     }
 
     /**
+     * Get the message output in the console stating that the short option can not be found. Output a list of available 
+     * short options and what option they refer to as well.
+     *
+     * @param string $option Unknown short option name trying to be used.
+     * @return string The message to be displayed in the console.
+     */
+    protected function getShortOptionError($option)
+    {
+        $out = [sprintf('Unknown short option `%s`', $option)];
+        $out[] = '';
+        $out[] = 'Available short options are :';
+        $out[] = '';
+
+        foreach ($this->_shortOptions as $short => $long) {
+            $out[] = sprintf(' - `%s` (short for `--%s`)', $short, $long);
+        }
+
+        return implode("\n", $out);
+    }
+
+    /**
      * Tries to guess the item name the user originally wanted using the levenshtein algorithm.
      *
      * @param string $needle Unknown item (either a subcommand name or an option for instance) trying to be used.
@@ -919,7 +940,7 @@ class ConsoleOptionParser
             }
         }
         if (!isset($this->_shortOptions[$key])) {
-            throw new ConsoleException(sprintf('Unknown short option `%s`', $key));
+            throw new ConsoleException($this->getShortOptionError($key));
         }
         $name = $this->_shortOptions[$key];
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -819,6 +819,35 @@ class ConsoleOptionParser
     }
 
     /**
+     * Get the message output in the console stating that the option can not be found and tries to guess what the user
+     * wanted to say. Output a list of available options as well.
+     *
+     * @param string $option Unknown option name trying to be used.
+     * @return string The message to be displayed in the console.
+     */
+    public function getOptionError($option)
+    {
+        $availableOptions = array_keys($this->_options);
+        $bestGuess = $this->findClosestItem($option, $availableOptions);
+        $out = [];
+        $out[] = sprintf('Unknown option `%s`.', $option);
+        $out[] = '';
+
+        if ($bestGuess !== null) {
+            $out[] = sprintf('Did you mean `%s` ?', $bestGuess);
+            $out[] = '';
+        }
+
+        $out[] = 'Available options are :';
+        $out[] = '';
+        foreach ($availableOptions as $availableOption) {
+            $out[] = ' - ' . $availableOption;
+        }
+
+        return implode("\n", $out);
+    }
+
+    /**
      * Tries to guess the item name the user originally wanted using the levenshtein algorithm.
      *
      * @param string $needle Unknown item (either a subcommand name or an option for instance) trying to be used.
@@ -908,7 +937,7 @@ class ConsoleOptionParser
     protected function _parseOption($name, $params)
     {
         if (!isset($this->_options[$name])) {
-            throw new ConsoleException(sprintf('Unknown option `%s`', $name));
+            throw new ConsoleException($this->getOptionError($name));
         }
         $option = $this->_options[$name];
         $isBoolean = $option->isBoolean();

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -793,7 +793,7 @@ class ConsoleOptionParser
     {
         $rootCommand = $this->getCommand();
         $subcommands = array_keys((array)$this->subcommands());
-        $bestGuess = $this->findClosestCommand($command, $subcommands);
+        $bestGuess = $this->findClosestItem($command, $subcommands);
 
         $out = [];
 
@@ -819,21 +819,31 @@ class ConsoleOptionParser
     }
 
     /**
-     * Tries to guess the command the user originally wanted using the levenshtein algorithm.
+     * Tries to guess the item name the user originally wanted using the levenshtein algorithm.
      *
-     * @param string $command Unknown command name trying to be dispatched.
-     * @param array $subcommands List of subcommands name this shell supports.
-     * @return string|null The closest name to the command submitted by the user.
+     * @param string $needle Unknown item (either a subcommand name or an option for instance) trying to be used.
+     * @param array $haystack List of items available for the type $needle belongs to.
+     * @return string|null The closest name to the item submitted by the user.
      */
-    protected function findClosestCommand($command, $subcommands)
+    protected function findClosestItem($needle, $haystack)
     {
         $bestGuess = null;
-        foreach ($subcommands as $subcommand) {
-            $score = levenshtein($command, $subcommand);
+        foreach ($haystack as $item) {
+            if (preg_match('/^' . $needle . '/', $item, $matches)) {
+                return $item;
+            }
+        }
+
+        foreach ($haystack as $item) {
+            if (preg_match('/' . $needle . '/', $item, $matches)) {
+                return $item;
+            }
+
+            $score = levenshtein($needle, $item);
 
             if (!isset($bestScore) || $score < $bestScore) {
-                $bestScore = $score;
-                $bestGuess = $subcommand;
+                $bestScore = levenshtein($needle, $item);
+                $bestGuess = $item;
             }
         }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -852,7 +852,7 @@ class ConsoleOptionParser
     }
 
     /**
-     * Get the message output in the console stating that the short option can not be found. Output a list of available 
+     * Get the message output in the console stating that the short option can not be found. Output a list of available
      * short options and what option they refer to as well.
      *
      * @param string $option Unknown short option name trying to be used.

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -507,7 +507,7 @@ class Shell
             return $this->main(...$this->args);
         }
 
-        $this->out($this->OptionParser->help($command));
+        $this->err($this->OptionParser->getCommandError($command));
 
         return false;
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -550,6 +550,7 @@ class Shell
 
         $subcommands = $this->OptionParser->subcommands();
         $command = isset($subcommands[$command]) ? $command : null;
+
         return $this->out($this->OptionParser->help($command, $format));
     }
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -506,7 +506,7 @@ class Shell
             return $this->main(...$this->args);
         }
 
-        $this->err($this->OptionParser->getCommandError($command));
+        $this->err($this->OptionParser->help($command));
 
         return false;
     }
@@ -548,6 +548,8 @@ class Shell
             $this->_welcome();
         }
 
+        $subcommands = $this->OptionParser->subcommands();
+        $command = isset($subcommands[$command]) ? $command : null;
         return $this->out($this->OptionParser->help($command, $format));
     }
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -459,7 +459,6 @@ class Shell
             list($this->params, $this->args) = $this->OptionParser->parse($argv);
         } catch (ConsoleException $e) {
             $this->err('Error: ' . $e->getMessage());
-            $this->out($this->OptionParser->help($command));
 
             return false;
         }

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -375,12 +375,16 @@ class ConsoleOptionParserTest extends TestCase
      * test parsing short options that do not exist.
      *
      * @expectedException \Cake\Console\Exception\ConsoleException
+     * @expectedExceptionMessageRegexp /Unknown short option `f`.\n\nAvailable short options are :\n\n
+     * - `n` (short for `--no-commit`)\n - `c` (short for `--clear`)/
      * @return void
      */
     public function testShortOptionThatDoesNotExist()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $parser->addOption('no-commit', ['boolean' => true]);
+        $parser->addOption('no-commit', ['boolean' => true, 'short' => 'n']);
+        $parser->addOption('construct', ['boolean' => true]);
+        $parser->addOption('clear', ['boolean' => true, 'short' => 'c']);
 
         $parser->parse(['-f']);
     }

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -831,7 +831,7 @@ TEXT;
             ->addOption('test', ['help' => 'A test option.'])
             ->addSubcommand('unstash');
 
-        $result = $parser->getCommandError('unknown');
+        $result = $parser->help('unknown');
         $expected = <<<TEXT
 Unable to find the `mycommand unknown` subcommand. See `bin/cake mycommand --help`.
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -359,6 +359,8 @@ class ConsoleOptionParserTest extends TestCase
      * test parsing options that do not exist.
      *
      * @expectedException \Cake\Console\Exception\ConsoleException
+     * @expectedExceptionMessageRegexp /Unknown option `fail`.\n\nDid you mean `help` \?\n\nAvailable options are :\n\n
+     * - help\n - no-commit/
      * @return void
      */
     public function testOptionThatDoesNotExist()

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -800,6 +800,46 @@ TEXT;
     }
 
     /**
+     * test that getCommandError() with an unknown subcommand param shows a helpful message
+     *
+     * @return void
+     */
+    public function testHelpUnknownSubcommand()
+    {
+        $subParser = [
+            'options' => [
+                'foo' => [
+                    'short' => 'f',
+                    'help' => 'Foo.',
+                    'boolean' => true,
+                ]
+            ],
+        ];
+
+        $parser = new ConsoleOptionParser('mycommand', false);
+        $parser
+            ->addSubcommand('method', [
+                'help' => 'This is a subcommand',
+                'parser' => $subParser
+            ])
+            ->addOption('test', ['help' => 'A test option.'])
+            ->addSubcommand('unstash');
+
+        $result = $parser->getCommandError('unknown');
+        $expected = <<<TEXT
+Unable to find the `mycommand unknown` subcommand. See `bin/cake mycommand --help`.
+
+Did you mean : `mycommand unstash` ?
+
+Available subcommands for the `mycommand` command are : 
+
+ - method
+ - unstash
+TEXT;
+        $this->assertTextEquals($expected, $result, 'Help is not correct.');
+    }
+
+    /**
      * test building a parser from an array.
      *
      * @return void

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -954,7 +954,7 @@ TEXT;
     public function testRunCommandWithMethodNotInSubcommands()
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
-            ->setMethods(['getCommandError'])
+            ->setMethods(['help'])
             ->setConstructorArgs(['knife'])
             ->getMock();
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
@@ -970,7 +970,7 @@ TEXT;
             ->will($this->returnValue($parser));
 
         $parser->expects($this->once())
-            ->method('getCommandError');
+            ->method('help');
 
         $shell->expects($this->never())->method('startup');
         $shell->expects($this->never())->method('roll');
@@ -1018,7 +1018,7 @@ TEXT;
     public function testRunCommandWithMissingMethodInSubcommands()
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
-            ->setMethods(['getCommandError'])
+            ->setMethods(['help'])
             ->setConstructorArgs(['knife'])
             ->getMock();
         $parser->addSubCommand('slice');
@@ -1036,7 +1036,7 @@ TEXT;
             ->method('startup');
 
         $parser->expects($this->once())
-            ->method('getCommandError');
+            ->method('help');
 
         $shell->runCommand(['slice', 'cakes', '--verbose']);
     }
@@ -1058,7 +1058,7 @@ TEXT;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $parser->expects($this->once())->method('getCommandError');
+        $parser->expects($this->once())->method('help');
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->never())->method('hr');
@@ -1083,7 +1083,7 @@ TEXT;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $parser->expects($this->once())->method('getCommandError');
+        $parser->expects($this->once())->method('help');
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->once())->method('err');

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -954,7 +954,7 @@ TEXT;
     public function testRunCommandWithMethodNotInSubcommands()
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
-            ->setMethods(['help'])
+            ->setMethods(['getCommandError'])
             ->setConstructorArgs(['knife'])
             ->getMock();
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
@@ -970,7 +970,7 @@ TEXT;
             ->will($this->returnValue($parser));
 
         $parser->expects($this->once())
-            ->method('help');
+            ->method('getCommandError');
 
         $shell->expects($this->never())->method('startup');
         $shell->expects($this->never())->method('roll');
@@ -1018,7 +1018,7 @@ TEXT;
     public function testRunCommandWithMissingMethodInSubcommands()
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
-            ->setMethods(['help'])
+            ->setMethods(['getCommandError'])
             ->setConstructorArgs(['knife'])
             ->getMock();
         $parser->addSubCommand('slice');
@@ -1036,7 +1036,7 @@ TEXT;
             ->method('startup');
 
         $parser->expects($this->once())
-            ->method('help');
+            ->method('getCommandError');
 
         $shell->runCommand(['slice', 'cakes', '--verbose']);
     }
@@ -1049,7 +1049,7 @@ TEXT;
     public function testRunCommandBaseClassMethod()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
-            ->setMethods(['startup', 'getOptionParser', 'out', 'hr'])
+            ->setMethods(['startup', 'getOptionParser', 'err', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1058,11 +1058,11 @@ TEXT;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $parser->expects($this->once())->method('help');
+        $parser->expects($this->once())->method('getCommandError');
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->never())->method('hr');
-        $shell->expects($this->once())->method('out');
+        $shell->expects($this->once())->method('err');
 
         $shell->runCommand(['hr']);
     }
@@ -1075,7 +1075,7 @@ TEXT;
     public function testRunCommandMissingMethod()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
-            ->setMethods(['startup', 'getOptionParser', 'out', 'hr'])
+            ->setMethods(['startup', 'getOptionParser', 'err', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
         $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
@@ -1083,10 +1083,10 @@ TEXT;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $parser->expects($this->once())->method('help');
+        $parser->expects($this->once())->method('getCommandError');
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
-        $shell->expects($this->once())->method('out');
+        $shell->expects($this->once())->method('err');
 
         $result = $shell->runCommand(['idontexist']);
         $this->assertFalse($result);
@@ -1127,7 +1127,7 @@ TEXT;
     public function testRunCommandNotCallUnexposedTask()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
-            ->setMethods(['startup', 'hasTask', 'out'])
+            ->setMethods(['startup', 'hasTask', 'err'])
             ->disableOriginalConstructor()
             ->getMock();
         $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
@@ -1143,7 +1143,7 @@ TEXT;
             ->method('hasTask')
             ->will($this->returnValue(true));
         $shell->expects($this->never())->method('startup');
-        $shell->expects($this->once())->method('out');
+        $shell->expects($this->once())->method('err');
         $shell->RunCommand = $task;
 
         $result = $shell->runCommand(['run_command', 'one']);


### PR DESCRIPTION
Replacement for PR #10941.

The aim remains the same : providing the user a more useful feedback by suggesting him the closest subcommand or option name to what he typed.
This PR also provides help for an unknown option or an unknown short option (with no "guess" for the latter for obvious reasons).

Compared to the previous pass, the error messages are now all targeting `stderr`.
I also improved the method in charge of guessing the user intent with some regex patterns before using the `levenshtein()` function. This provides better suggestions based on what the user typed and what tokens are available :
- It will first try to match tokens beginning with what the user typed (`boots` would match an option `bootstrap` before anything else). First match is returned.
- If nothing is found with the above logic, it will try to match tokens containing what the user typed (`boots` would match an option `clear-bootstrap`). First match is returned.
- the `levenshtein()` function is the last resort to suggest the best guess.

Outputs will be :

## Unknown command

```
$ bin/cake plugin lo
```
```
Unable to find the `plugin lo` subcommand. See `bin/cake plugin --help`.

Did you mean : `plugin load` ?

Available subcommands for the `plugin` command are : 

 - assets
 - load
 - loaded
 - unload
```

## Unknown option

```
$ bin/cake plugin load test --loa
```
``` 
Error: Unknown option `loa`.

Did you mean `autoload` ?

Available options are :

 - autoload
 - bootstrap
 - cli
 - help
 - quiet
 - routes
 - verbose
```

## Unknown short option

```
$ bin/cake plugin load test -a
```
```
Error: Unknown short option `a`

Available short options are :

 - `b` (short for `--bootstrap`)
 - `h` (short for `--help`)
 - `q` (short for `--quiet`)
 - `r` (short for `--routes`)
 - `v` (short for `--verbose`)
```