### PR TITLE
Add more clear error messaging for incorrect URL inflection

### DIFF
--- a/src/Template/Error/missing_controller.ctp
+++ b/src/Template/Error/missing_controller.ctp
@@ -18,8 +18,11 @@ use Cake\Utility\Inflector;
 
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 $namespace = Configure::read('App.namespace');
-$prefixNs = '';
-$prefixPath = '';
+$prefixNs = $prefixPath = '';
+
+$incompleteInflection = (strpos($class, '_') !== false || strpos($class, '-'));
+$originalClass = $class;
+
 $class = Inflector::camelize($class);
 
 if (!empty($prefix)) {
@@ -42,33 +45,47 @@ $this->layout = 'dev_error';
 $this->assign('title', 'Missing Controller');
 $this->assign('templateName', 'missing_controller.ctp');
 
-$this->start('subheading');
 ?>
+<?php $this->start('subheading');?>
 <strong>Error: </strong>
-<em><?= h($pluginDot . $class) ?>Controller</em> could not be found.
-<p>
-    In the case you tried to access a plugin controller make sure you added it to your composer file or you use the autoload option for the plugin.
-</p>
+<?php if ($incompleteInflection): ?>
+    Your routing resulted in <em><?= h($originalClass) ?></em> as a controller name.
+<?php else: ?>
+    <em><?= h($pluginDot . $class) ?>Controller</em> could not be found.
+<?php endif; ?>
 <?php $this->end() ?>
 
-<?php $this->start('file') ?>
-<p class="error">
-    <strong>Error: </strong>
-    Create the class <em><?= h($class) ?>Controller</em> below in file: <?= h($path) ?>
-</p>
 
-<?php
-$code = <<<PHP
-<?php
-namespace {$namespace}\Controller{$prefixNs};
+<?php $this->start('file'); ?>
+<?php if ($incompleteInflection): ?>
+    <p>The controller name <em><?= h($originalClass) ?></em> has not been properly inflected, and
+    could not be resolved to a controller that exists in your application.</p>
 
-use {$namespace}\Controller\AppController;
+    <p>Ensure that your URL <strong><?= h($this->request->getUri()->getPath()) ?></strong> is
+    using the same inflection style as your routes do. By default applications use <code>DashedRoute</code>
+    and URLs should use <strong>-</strong> to separate multi-word controller names.</p>
+<?php else: ?>
+    <p>
+        In the case you tried to access a plugin controller make sure you added it to your composer file or you use the autoload option for the plugin.
+    </p>
+    <p class="error">
+        <strong>Error: </strong>
+        Create the class <em><?= h($class) ?>Controller</em> below in file: <?= h($path) ?>
+    </p>
 
-class {$class}Controller extends AppController
-{
+    <?php
+    $code = <<<PHP
+    <?php
+    namespace {$namespace}\Controller{$prefixNs};
 
-}
+    use {$namespace}\Controller\AppController;
+
+    class {$class}Controller extends AppController
+    {
+
+    }
 PHP;
-?>
-<div class="code-dump"><?php highlight_string($code) ?></div>
-<?php $this->end() ?>
+    ?>
+    <div class="code-dump"><?php highlight_string($code); ?></div>
+<?php endif; ?>
+<?php $this->end(); ?>


### PR DESCRIPTION
Update the missing controller error page in an attempt to make it clearer when a developer is using the wrong inflection type in their URLs.

![screen shot 2017-08-02 at 21 54 39](https://user-images.githubusercontent.com/24086/28902525-6c0c57f2-77cd-11e7-865b-dbe6060f4399.png)


Refs #10948
