### PR TITLE
Ensure RoutingMiddleware does not wipe off existing params keys.

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -88,7 +88,7 @@ class RoutingMiddleware
                 if (is_array($parsedBody) && isset($parsedBody['_method'])) {
                     $request = $request->withMethod($parsedBody['_method']);
                 }
-                $params = Router::parseRequest($request);
+                $params = Router::parseRequest($request) + $params;
                 if (isset($params['_middleware'])) {
                     $middleware = $params['_middleware'];
                     unset($params['_middleware']);

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -106,6 +106,31 @@ class RoutingMiddlewareTest extends TestCase
     }
 
     /**
+     * Test routing middleware does wipe off existing params keys.
+     *
+     * @return void
+     */
+    public function testPreservingExistingParams()
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
+        $request = $request->withAttribute('params', ['_csrfToken' => 'i-am-groot']);
+        $response = new Response();
+        $next = function ($req, $res) {
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'index',
+                'plugin' => null,
+                'pass' => [],
+                '_matchedRoute' => '/articles',
+                '_csrfToken' => 'i-am-groot'
+            ];
+            $this->assertEquals($expected, $req->getAttribute('params'));
+        };
+        $middleware = new RoutingMiddleware();
+        $middleware($request, $response, $next);
+    }
+
+    /**
      * Test middleware invoking hook method
      *
      * @return void


### PR DESCRIPTION
Closes #10989