### PR TITLE
Address CakeEmail regression when data is defined with no mimetype

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1084,7 +1084,7 @@ class CakeEmail {
 					$name = basename($fileInfo['file']);
 				}
 			}
-			if (!isset($fileInfo['mimetype']) && function_exists('mime_content_type')) {
+			if (!isset($fileInfo['mimetype']) && isset($fileInfo['file']) && function_exists('mime_content_type')) {
 				$fileInfo['mimetype'] = mime_content_type($fileInfo['file']);
 			}
 			if (!isset($fileInfo['mimetype'])) {

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1139,6 +1139,41 @@ class CakeEmailTest extends CakeTestCase {
 		$expected .= chunk_split(base64_encode($data), 76, "\r\n");
 		$this->assertContains($expected, $result['message']);
 	}
+	
+/**
+ * Test send() with no template and data string attachment, no mimetype
+ *
+ * @return void
+ */
+	public function testSendNoTemplateWithDataStringAttachmentNoMime() {
+		$this->CakeEmail->transport('debug');
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->to('cake@cakephp.org');
+		$this->CakeEmail->subject('My title');
+		$this->CakeEmail->emailFormat('text');
+		$data = file_get_contents(CAKE . 'Console/Templates/skel/webroot/img/cake.icon.png');
+		$this->CakeEmail->attachments(array('cake.icon.png' => array(
+			'data' => $data
+		)));
+		$result = $this->CakeEmail->send('Hello');
+		
+		$boundary = $this->CakeEmail->getBoundary();
+		$this->assertContains('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
+		$expected = "--$boundary\r\n" .
+			"Content-Type: text/plain; charset=UTF-8\r\n" .
+			"Content-Transfer-Encoding: 8bit\r\n" .
+			"\r\n" .
+			"Hello" .
+			"\r\n" .
+			"\r\n" .
+			"\r\n" .
+			"--$boundary\r\n" .
+			"Content-Type: application/octet-stream\r\n" .
+			"Content-Transfer-Encoding: base64\r\n" .
+			"Content-Disposition: attachment; filename=\"cake.icon.png\"\r\n\r\n";
+		$expected .= chunk_split(base64_encode($data), 76, "\r\n");
+		$this->assertContains($expected, $result['message']);
+	}
 
 /**
  * Test send() with no template as both

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1139,7 +1139,7 @@ class CakeEmailTest extends CakeTestCase {
 		$expected .= chunk_split(base64_encode($data), 76, "\r\n");
 		$this->assertContains($expected, $result['message']);
 	}
-	
+
 /**
  * Test send() with no template and data string attachment, no mimetype
  *
@@ -1156,7 +1156,7 @@ class CakeEmailTest extends CakeTestCase {
 			'data' => $data
 		)));
 		$result = $this->CakeEmail->send('Hello');
-		
+
 		$boundary = $this->CakeEmail->getBoundary();
 		$this->assertContains('Content-Type: multipart/mixed; boundary="' . $boundary . '"', $result['headers']);
 		$expected = "--$boundary\r\n" .


### PR DESCRIPTION
Prior to 2.10.x, CakeEmail allowed adding an attachment using only "data" with no "mimtype" defined (which defaulted the mimetype to "application/octet-stream").  Starting in 2.10.0, a "Undefined index: file" is triggered when an attachment is added using "data" with no "mimetype".