### PR TITLE
Don't append an empty Cookie header

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -226,6 +226,9 @@ class CookieCollection implements IteratorAggregate, Countable
         foreach ($cookies as $key => $value) {
             $cookiePairs[] = sprintf("%s=%s", rawurlencode($key), rawurlencode($value));
         }
+        if (empty($cookiePairs)) {
+            return $request;
+        }
 
         return $request->withHeader('Cookie', implode('; ', $cookiePairs));
     }

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -357,6 +357,19 @@ class CookieCollectionTest extends TestCase
     }
 
     /**
+     * Test adding no cookies
+     *
+     * @return void
+     */
+    public function testAddToRequestNoCookies()
+    {
+        $collection = new CookieCollection();
+        $request = new ClientRequest('http://example.com/api');
+        $request = $collection->addToRequest($request);
+        $this->assertFalse($request->hasHeader('Cookie'), 'No header should be set.');
+    }
+
+    /**
      * Test adding cookies from the collection to request.
      *
      * @return void


### PR DESCRIPTION
The HttpClient should not append `Cookie:` to the request if there are no cookies. The empty cookie header blew up a bunch of my integration tests.