### PR TITLE
Add support for default value to InstanceConfigTrait::getConfig().

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -313,11 +313,12 @@ class PaginatorComponent extends Component
      * Proxy getting config options to Paginator.
      *
      * @param string|null $key The key to get or null for the whole config.
+     * @param mixed $default The return value when the key does not exist.
      * @return mixed Config value being read.
      */
-    public function getConfig($key = null)
+    public function getConfig($key = null, $default = null)
     {
-        return $this->_paginator->getConfig($key);
+        return $this->_paginator->getConfig($key, $default);
     }
 
     /**

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -103,17 +103,26 @@ trait InstanceConfigTrait
      * $this->getConfig('some.nested.key');
      * ```
      *
+     * Reading with default value:
+     *
+     * ```
+     * $this->getConfig('some-key', 'default-value');
+     * ```
+     *
      * @param string|null $key The key to get or null for the whole config.
+     * @param mixed $default The return value when the key does not exist.
      * @return mixed Config value being read.
      */
-    public function getConfig($key = null)
+    public function getConfig($key = null, $default = null)
     {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;
             $this->_configInitialized = true;
         }
 
-        return $this->_configRead($key);
+        $return = $this->_configRead($key);
+
+        return $return === null ? $default : $return;
     }
 
     /**

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -151,6 +151,24 @@ class InstanceConfigTraitTest extends TestCase
     }
 
     /**
+     * testGetDefault
+     *
+     * @return void
+     */
+    public function testGetDefault()
+    {
+        $this->assertSame(
+            'default',
+            $this->object->getConfig('nonexistent', 'default')
+        );
+
+        $this->assertSame(
+            'my-default',
+            $this->object->getConfig('nested.nonexistent', 'my-default')
+        );
+    }
+
+    /**
      * testSetSimple
      *
      * @return void


### PR DESCRIPTION
`InstanceConfigTrait::getConfig()` was missing the default value convenience which has been added to various other getters like `Hash::get()`, `Configure::read()` etc.