### PR TITLE
Run tests against 7.2 not 7.3.0-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.0
   - 5.6
   - 7.1
-  - nightly
+  - 7.2
 
 dist: trusty
 
@@ -34,7 +34,7 @@ matrix:
   fast_finish: true
 
   allow_failures:
-    - php: nightly
+    - php: 7.2
 
   include:
     - php: 7.0


### PR DESCRIPTION
travis nigthly is using 7.3.0-dev
see https://travis-ci.org/cakephp/cakephp/jobs/261692749#L509 for example
