### PR TITLE
PHPUnit_Util_Diff class not found fix

### DIFF
--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -267,13 +267,9 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
 			
 			$diffs = "";
-			
-			// PHPUnit 3.7.38 support
-			if(class_exists('PHPUnit_Util_Diff')) {
+			if (class_exists('PHPUnit_Util_Diff')) {
 				$diffs = PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
-				
-			// PHPUnit 4.x and 5.x support
-			}else if(class_exists('SebastianBergmann\Diff\Differ')){
+			} elseif (class_exists('SebastianBergmann\Diff\Differ')) {
 				$diffs = (new SebastianBergmann\Diff\Differ())->diff($expectedMsg, $actualMsg);
 			}
 			

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -265,7 +265,7 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
 
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
-			
+
 			$diffs = "";
 			if (class_exists('PHPUnit_Util_Diff')) {
 				$diffs = PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
@@ -273,7 +273,7 @@ class CakeHtmlReporter extends CakeBaseReporter {
 				$differ = new SebastianBergmann\Diff\Differ();
 				$diffs = $differ->diff($expectedMsg, $actualMsg);
 			}
-			
+
 			echo "<br />" . $this->_htmlEntities($diffs);
 		}
 

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -270,7 +270,8 @@ class CakeHtmlReporter extends CakeBaseReporter {
 			if (class_exists('PHPUnit_Util_Diff')) {
 				$diffs = PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
 			} elseif (class_exists('SebastianBergmann\Diff\Differ')) {
-				$diffs = (new SebastianBergmann\Diff\Differ())->diff($expectedMsg, $actualMsg);
+				$differ = new SebastianBergmann\Diff\Differ();
+				$diffs = $differ->diff($expectedMsg, $actualMsg);
 			}
 			
 			echo "<br />" . $this->_htmlEntities($diffs);

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -265,7 +265,19 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
 
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
-			echo "<br />" . $this->_htmlEntities(PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg));
+			
+			$diffs = "";
+			
+			// PHPUnit 3.7.38 support
+			if(class_exists('PHPUnit_Util_Diff')) {
+				$diffs = PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
+				
+			// PHPUnit 4.x and 5.x support
+			}else if(class_exists('SebastianBergmann\Diff\Differ')){
+				$diffs = (new SebastianBergmann\Diff\Differ())->diff($expectedMsg, $actualMsg);
+			}
+			
+			echo "<br />" . $this->_htmlEntities($diffs);
 		}
 
 		echo "</pre></div>\n";


### PR DESCRIPTION
Added `PHPUnit 4.x+` support for the webrunner. The changes are backward compatible with PHPUnit version `3.7.28`

Fixes #11016