### PR TITLE
Skip redis tests until PHP7.2 stabilizes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ cache:
 matrix:
   fast_finish: true
 
-  allow_failures:
-    - php: 7.2
-
   include:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -174,8 +174,8 @@ class MapReduce implements IteratorAggregate
     protected function _execute()
     {
         $mapper = $this->_mapper;
-        foreach ($this->_data as $key => $value) {
-            $mapper($value, $key, $this);
+        foreach ($this->_data as $key => $val) {
+            $mapper($val, $key, $this);
         }
         $this->_data = null;
 

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -139,26 +139,26 @@ class MapReduce implements IteratorAggregate
      * Appends a new record to the bucket labelled with $key, usually as a result
      * of mapping a single record from the original data.
      *
-     * @param mixed $value The record itself to store in the bucket
+     * @param mixed $val The record itself to store in the bucket
      * @param string $bucket the name of the bucket where to put the record
      * @return void
      */
-    public function emitIntermediate($value, $bucket)
+    public function emitIntermediate($val, $bucket)
     {
-        $this->_intermediate[$bucket][] = $value;
+        $this->_intermediate[$bucket][] = $val;
     }
 
     /**
      * Appends a new record to the final list of results and optionally assign a key
      * for this record.
      *
-     * @param mixed $value The value to be appended to the final list of results
+     * @param mixed $val The value to be appended to the final list of results
      * @param string|null $key and optional key to assign to the value
      * @return void
      */
-    public function emit($value, $key = null)
+    public function emit($val, $key = null)
     {
-        $this->_result[$key === null ? $this->_counter : $key] = $value;
+        $this->_result[$key === null ? $this->_counter : $key] = $val;
         $this->_counter++;
     }
 

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -65,12 +65,12 @@ class SortIterator extends Collection
 
         $callback = $this->_propertyExtractor($callback);
         $results = [];
-        foreach ($items as $key => $value) {
-            $value = $callback($value);
-            if ($value instanceof DateTimeInterface && $type === SORT_NUMERIC) {
-                $value = $value->format('U');
+        foreach ($items as $key => $val) {
+            $val = $callback($val);
+            if ($val instanceof DateTimeInterface && $type === SORT_NUMERIC) {
+                $val = $val->format('U');
             }
-            $results[$key] = $value;
+            $results[$key] = $val;
         }
 
         $dir === SORT_DESC ? arsort($results, $type) : asort($results, $type);

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -455,7 +455,7 @@ class Session
      */
     public function id($id = null)
     {
-        if ($id !== null && ($this->_isCLI || !headers_sent())) {
+        if ($id !== null && !headers_sent()) {
             session_id($id);
         }
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -33,6 +33,7 @@ class RedisEngineTest extends TestCase
     {
         parent::setUp();
         $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
+        $this->skipIf(version_compare(PHP_VERSION, '7.2.0beta', '>='), 'Redis is misbehaving in PHP7.2');
 
         // @codingStandardsIgnoreStart
         $socket = @fsockopen('127.0.0.1', 6379, $errno, $errstr, 1);

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -33,7 +33,7 @@ class RedisEngineTest extends TestCase
     {
         parent::setUp();
         $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
-        $this->skipIf(version_compare(PHP_VERSION, '7.2.0beta', '>='), 'Redis is misbehaving in PHP7.2');
+        $this->skipIf(version_compare(PHP_VERSION, '7.2.0dev', '>='), 'Redis is misbehaving in PHP7.2');
 
         // @codingStandardsIgnoreStart
         $socket = @fsockopen('127.0.0.1', 6379, $errno, $errstr, 1);


### PR DESCRIPTION
This will let us get passing builds out of PHP7.2 and hopefully make changes in future beta's more visible.