### PR TITLE
Fix hiddenField option not working for radio (2.x)

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -4945,6 +4945,30 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * test setting a hiddenField value
+ *
+ * @return void
+ */
+	public function testRadioHiddenFieldValue() {
+		$result = $this->Form->input('Model.1.field', array(
+				'type' => 'radio',
+				'options' => array('option A'),
+				'hiddenField' => 'N'
+			)
+		);
+		$expected = array(
+			'div' => array('class' => 'input radio'),
+			array('input' => array('type' => 'hidden', 'name' => 'data[Model][1][field]', 'value' => 'N', 'id' => 'Model1Field_')),
+			array('input' => array('type' => 'radio', 'name' => 'data[Model][1][field]', 'value' => '0', 'id' => 'Model1Field0')),
+			'label' => array('for' => 'Model1Field0'),
+			'option A',
+			'/label',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * test adding an empty option for radio buttons
  *
  * @return void

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1674,7 +1674,7 @@ class FormHelper extends AppHelper {
 				$hidden = $this->hidden($fieldName, array(
 					'form' => isset($attributes['form']) ? $attributes['form'] : null,
 					'id' => $attributes['id'] . '_',
-					'value' => '',
+					'value' => $hiddenField === true ? '' : $hiddenField,
 					'name' => $attributes['name']
 				));
 			}


### PR DESCRIPTION
The hiddenField option was not working as documented for radio buttons. Instead of using the provided value, the hidden input's value was hardcoded to ''

Refs #11002
