### PR TITLE
Add selectAllExcept method

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1277,8 +1277,6 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
      * Selects all fields in the schema with the exception of the fields you pass
      * in the $excludedFields parameter.
      *
@@ -1293,6 +1291,6 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $aliasedExcluded = $this->aliasFields($excludedFields, $this->repository()->alias());
 
         $fields = array_diff($aliased, $aliasedExcluded);
-        return parent::select($fields, $overwrite);
+        return $this->select($fields, $overwrite);
     }
 }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1275,4 +1275,24 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
 
         return $result;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Selects all fields in the schema with the exception of the fields you pass
+     * in the $excludedFields parameter.
+     *
+     * @param array $excludedFields fields you don't want to select
+     * @param bool $overwrite whether to reset fields with passed list or not
+     * @return $this
+     */
+    public function selectAllExcept($excludedFields = [], $overwrite = false)
+    {
+        $allFields = $this->repository()->getSchema()->columns();
+        $aliased = $this->aliasFields($allFields, $this->repository()->alias());
+        $aliasedExcluded = $this->aliasFields($excludedFields, $this->repository()->alias());
+
+        $fields = array_diff($aliased, $aliasedExcluded);
+        return parent::select($fields, $overwrite);
+    }
 }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1284,7 +1284,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
-    public function selectAllExcept($excludedFields = [], $overwrite = false)
+    public function selectAllExcept(array $excludedFields = [], $overwrite = false)
     {
         $allFields = $this->repository()->getSchema()->columns();
         $aliased = $this->aliasFields($allFields, $this->repository()->alias());

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -3466,4 +3466,28 @@ class QueryTest extends TestCase
 
         $this->assertEquals(1, $query->__debugInfo()['decorators'], 'Only one typecaster should exist');
     }
+
+    /**
+     * Tests that selectAllExcept() selects all columns, except
+     * the one that are passed.
+     *
+     * @return void
+     */
+    public function testSelectAllExcept()
+    {
+        $table = TableRegistry::get('articles');
+        $result = $table
+            ->find()
+            ->selectAllExcept(['body']);
+
+        $selectedFields = $result->clause('select');
+        $expected = [
+            'articles__id' => 'articles.id',
+            'articles__author_id' => 'articles.author_id',
+            'articles__title' => 'articles.title',
+            'articles__published' =>'articles.published'
+        ];
+
+        $this->assertEquals($expected, $selectedFields);
+    }
 }


### PR DESCRIPTION
Added Query::selectAllExcept(), which makes it possible to select all the fields in a schema, with the exception of the one passed to the method. 

Also see issue #10992 