### PR TITLE
Remove ini flag for memcached.sasl

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -153,7 +153,7 @@ class MemcachedEngine extends CacheEngine
 
         $servers = [];
         foreach ($this->_config['servers'] as $server) {
-            $servers[] = $this->_parseServerString($server);
+            $servers[] = $this->parseServerString($server);
         }
 
         if (!$this->_Memcached->addServers($servers)) {
@@ -176,7 +176,7 @@ class MemcachedEngine extends CacheEngine
             $sasl = method_exists($this->_Memcached, 'setSaslAuthData');
             if (!$sasl) {
                 throw new InvalidArgumentException(
-                    'Memcached extension is not build with SASL support'
+                    'Memcached extension is not built with SASL support'
                 );
             }
             $this->_Memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
@@ -243,7 +243,7 @@ class MemcachedEngine extends CacheEngine
      * @param string $server The server address string.
      * @return array Array containing host, port
      */
-    protected function _parseServerString($server)
+    public function parseServerString($server)
     {
         $socketTransport = 'unix://';
         if (strpos($server, $socketTransport) === 0) {
@@ -265,6 +265,29 @@ class MemcachedEngine extends CacheEngine
         }
 
         return [$host, (int)$port];
+    }
+
+    /**
+     * Backwards compatible alias of parseServerString
+     *
+     * @param string $server The server address string.
+     * @return array Array containing host, port
+     * @deprecated 3.4.13 Will be removed in 4.0.0
+     */
+    protected function _parseServerString($server)
+    {
+        return $this->parseServerString($server);
+    }
+
+    /**
+     * Read an option value from the memcached connection.
+     *
+     * @param string $name The option name to read.
+     * @return string|integer|null|bool
+     */
+    public function getOption($name)
+    {
+        return $this->_Memcached->getOption($name);
     }
 
     /**

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -283,7 +283,7 @@ class MemcachedEngine extends CacheEngine
      * Read an option value from the memcached connection.
      *
      * @param string $name The option name to read.
-     * @return string|integer|null|bool
+     * @return string|int|null|bool
      */
     public function getOption($name)
     {

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -173,7 +173,7 @@ class MemcachedEngine extends CacheEngine
         }
 
         if ($this->_config['username'] !== null && $this->_config['password'] !== null) {
-            $sasl = method_exists($this->_Memcached, 'setSaslAuthData') && ini_get('memcached.use_sasl');
+            $sasl = method_exists($this->_Memcached, 'setSaslAuthData');
             if (!$sasl) {
                 throw new InvalidArgumentException(
                     'Memcached extension is not build with SASL support'

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -174,7 +174,7 @@ class MemcachedEngine extends CacheEngine
 
         if ($this->_config['username'] !== null && $this->_config['password'] !== null) {
             $sasl = method_exists($this->_Memcached, 'setSaslAuthData');
-            if (!$sasl) {
+            if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
                 throw new InvalidArgumentException(
                     'Memcached extension is not built with SASL support'
                 );

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -20,34 +20,6 @@ use Cake\TestSuite\TestCase;
 use Memcached;
 
 /**
- * TestMemcachedEngine
- */
-class TestMemcachedEngine extends MemcachedEngine
-{
-
-    /**
-     * public accessor to _parseServerString
-     *
-     * @param string $server
-     * @return array
-     */
-    public function parseServerString($server)
-    {
-        return $this->_parseServerString($server);
-    }
-
-    public function setMemcached($memcached)
-    {
-        $this->_Memcached = $memcached;
-    }
-
-    public function getMemcached()
-    {
-        return $this->_Memcached;
-    }
-}
-
-/**
  * MemcachedEngineTest class
  */
 class MemcachedEngineTest extends TestCase
@@ -140,23 +112,23 @@ class MemcachedEngineTest extends TestCase
      */
     public function testCompressionSetting()
     {
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $Memcached->init([
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
             'compress' => false
         ]);
 
-        $this->assertFalse($Memcached->getMemcached()->getOption(\Memcached::OPT_COMPRESSION));
+        $this->assertFalse($Memcached->getOption(\Memcached::OPT_COMPRESSION));
 
-        $MemcachedCompressed = new TestMemcachedEngine();
+        $MemcachedCompressed = new MemcachedEngine();
         $MemcachedCompressed->init([
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
             'compress' => true
         ]);
 
-        $this->assertTrue($MemcachedCompressed->getMemcached()->getOption(\Memcached::OPT_COMPRESSION));
+        $this->assertTrue($MemcachedCompressed->getOption(\Memcached::OPT_COMPRESSION));
     }
 
     /**
@@ -166,7 +138,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testOptionsSetting()
     {
-        $memcached = new TestMemcachedEngine();
+        $memcached = new MemcachedEngine();
         $memcached->init([
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -174,26 +146,25 @@ class MemcachedEngineTest extends TestCase
                 Memcached::OPT_BINARY_PROTOCOL => true
             ]
         ]);
-        $this->assertEquals(1, $memcached->getMemcached()->getOption(Memcached::OPT_BINARY_PROTOCOL));
+        $this->assertEquals(1, $memcached->getOption(Memcached::OPT_BINARY_PROTOCOL));
     }
 
     /**
      * test accepts only valid serializer engine
      *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage invalid_serializer is not a valid serializer engine for Memcached
      * @return  void
      */
     public function testInvalidSerializerSetting()
     {
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'className' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
             'persistent' => false,
             'serialize' => 'invalid_serializer'
         ];
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('invalid_serializer is not a valid serializer engine for Memcached');
         $Memcached->init($config);
     }
 
@@ -204,7 +175,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testPhpSerializerSetting()
     {
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'className' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -213,7 +184,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_PHP, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertEquals(Memcached::SERIALIZER_PHP, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -228,7 +199,7 @@ class MemcachedEngineTest extends TestCase
             'Memcached extension is not compiled with json support'
         );
 
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -237,7 +208,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_JSON, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertEquals(Memcached::SERIALIZER_JSON, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -252,7 +223,7 @@ class MemcachedEngineTest extends TestCase
             'Memcached extension is not compiled with igbinary support'
         );
 
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -261,7 +232,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_IGBINARY, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertEquals(Memcached::SERIALIZER_IGBINARY, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -276,7 +247,7 @@ class MemcachedEngineTest extends TestCase
             'Memcached extension is not compiled with msgpack support'
         );
 
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -285,7 +256,7 @@ class MemcachedEngineTest extends TestCase
         ];
 
         $Memcached->init($config);
-        $this->assertEquals(Memcached::SERIALIZER_MSGPACK, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
+        $this->assertEquals(Memcached::SERIALIZER_MSGPACK, $Memcached->getOption(Memcached::OPT_SERIALIZER));
     }
 
     /**
@@ -300,7 +271,7 @@ class MemcachedEngineTest extends TestCase
             'Memcached extension is compiled with json support'
         );
 
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'className' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -325,7 +296,7 @@ class MemcachedEngineTest extends TestCase
             'Memcached extension is compiled with msgpack support'
         );
 
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -350,7 +321,7 @@ class MemcachedEngineTest extends TestCase
             'Memcached extension is compiled with igbinary support'
         );
 
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $config = [
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -373,7 +344,11 @@ class MemcachedEngineTest extends TestCase
      */
     public function testSaslAuthException()
     {
-        $MemcachedEngine = new TestMemcachedEngine();
+        $this->skipIf(
+            method_exists('setSaslAuthData', Memcached::class),
+            'Cannot test exception when sasl has been compiled in.'
+        );
+        $MemcachedEngine = new MemcachedEngine();
         $config = [
             'engine' => 'Memcached',
             'servers' => ['127.0.0.1:11211'],
@@ -381,7 +356,8 @@ class MemcachedEngineTest extends TestCase
             'username' => 'test',
             'password' => 'password'
         ];
-
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Memcached extension is not built with SASL support');
         $MemcachedEngine->init($config);
     }
 
@@ -441,7 +417,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testParseServerStringWithU()
     {
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $result = $Memcached->parseServerString('udomain.net:13211');
         $this->assertEquals(['udomain.net', '13211'], $result);
     }
@@ -453,7 +429,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testParseServerStringNonLatin()
     {
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $result = $Memcached->parseServerString('schülervz.net:13211');
         $this->assertEquals(['schülervz.net', '13211'], $result);
 
@@ -468,7 +444,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testParseServerStringUnix()
     {
-        $Memcached = new TestMemcachedEngine();
+        $Memcached = new MemcachedEngine();
         $result = $Memcached->parseServerString('unix:///path/to/memcachedd.sock');
         $this->assertEquals(['/path/to/memcachedd.sock', 0], $result);
     }

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -345,7 +345,7 @@ class MemcachedEngineTest extends TestCase
     public function testSaslAuthException()
     {
         $this->skipIf(
-            method_exists('setSaslAuthData', Memcached::class),
+            method_exists(Memcached::class, 'setSaslAuthData'),
             'Cannot test exception when sasl has been compiled in.'
         );
         $MemcachedEngine = new MemcachedEngine();


### PR DESCRIPTION
This ini flag doesn't exist in newer versions of memcached. Instead we should use the existence of the method to see if memcached was compiled with sasl support.

Refs #11027