### PR TITLE
Make internal driver usage consistent.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -294,7 +294,7 @@ class Connection implements ConnectionInterface
      */
     public function compileQuery(Query $query, ValueBinder $generator)
     {
-        return $this->getDriver()->compileQuery($query, $generator)[1];
+        return $this->_driver->compileQuery($query, $generator)[1];
     }
 
     /**
@@ -843,7 +843,7 @@ class Connection implements ConnectionInterface
      */
     protected function _newLogger(StatementInterface $statement)
     {
-        $log = new LoggingStatement($statement, $this->getDriver());
+        $log = new LoggingStatement($statement, $this->_driver);
         $log->logger($this->logger());
 
         return $log;

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -294,7 +294,7 @@ class Connection implements ConnectionInterface
      */
     public function compileQuery(Query $query, ValueBinder $generator)
     {
-        return $this->_driver->compileQuery($query, $generator)[1];
+        return $this->getDriver()->compileQuery($query, $generator)[1];
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -211,10 +211,10 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function execute()
     {
         $statement = $this->_connection->run($this);
-        $driver = $this->_connection->driver();
         $typeMap = $this->getSelectTypeMap();
 
         if ($typeMap->toArray() && $this->_typeCastAttached === false) {
+            $driver = $this->_connection->getDriver();
             $this->decorateResults(new FieldTypeConverter($typeMap, $driver));
             $this->_typeCastAttached = true;
         }


### PR DESCRIPTION
Edit: Adjusting internal use of property.

The Connection typehints are necessary because the used methods are not in the interface (not clean!),
so we need to typehint the concretes are until we can clean this up in 4.x.