### PR TITLE
phpdoc $names param type for applyMiddleware() function

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -984,7 +984,7 @@ class RouteBuilder
      *
      * Requires middleware to be registered via `registerMiddleware()`
      *
-     * @param string[] ...$names The names of the middleware to apply to the current scope.
+     * @param string ...$names The names of the middleware to apply to the current scope.
      * @return $this
      * @see \Cake\Routing\RouteCollection::addMiddlewareToScope()
      */


### PR DESCRIPTION
Phpdoc `...$names` param tag should be of type **string**, not **array of strings** for `applyMiddleware()` function because of the splat operator.
When type is `string[]`, [phan](/etsy/phan) complains about type mismatch when running static analysis.