### PR TITLE
Removing the destructor to prevent notices on reuse.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -121,16 +121,6 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Destructor
-     *
-     * Disconnects the driver to release the connection.
-     */
-    public function __destruct()
-    {
-        unset($this->_driver);
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function config()


### PR DESCRIPTION
Fix for #11044 after more discussion in https://github.com/cakephp/cakephp/pull/11046
The alternative would be to set it to `null` only, not unsetting.

Lets see what the tests say.