### PR TITLE
Always do count for paginator results in params

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -190,7 +190,7 @@ class PaginatorComponent extends Component
         $cleanQuery = clone $query;
         $results = $query->all();
         $numResults = count($results);
-        $count = $numResults ? $cleanQuery->count() : 0;
+        $count = $cleanQuery->count();
 
         $defaults = $this->getDefaults($alias, $settings);
         unset($defaults[0]);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -673,7 +673,6 @@ class PaginatorComponentTest extends TestCase
             $this->Paginator->paginate($table);
             $this->fail('No exception raised');
         } catch (NotFoundException $e) {
-
             $this->assertEquals(
                 3,
                 $this->request->params['paging']['PaginatorPosts']['pageCount'],

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -658,6 +658,31 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
+     * Test that a out of bounds request still knows about the page size
+     *
+     * @return void
+     */
+    public function testOutOfRangePageNumberStillProvidesPageCount()
+    {
+        $this->loadFixtures('Posts');
+        $this->request->query['limit'] = 1;
+        $this->request->query['page'] = 4;
+
+        $table = TableRegistry::get('PaginatorPosts');
+        try {
+            $this->Paginator->paginate($table);
+            $this->fail('No exception raised');
+        } catch (NotFoundException $e) {
+
+            $this->assertEquals(
+                3,
+                $this->request->params['paging']['PaginatorPosts']['pageCount'],
+                'Page count number should not be 0'
+            );
+        }
+    }
+
+    /**
      * Test that a really REALLY large page number gets clamped to the max page size.
      *
      * @expectedException \Cake\Network\Exception\NotFoundException
@@ -1216,7 +1241,7 @@ class PaginatorComponentTest extends TestCase
      * Helper method for making mocks.
      *
      * @param array $methods
-     * @return \Cake\ORM\Table
+     * @return \Cake\ORM\Table|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function _getMockPosts($methods = [])
     {
@@ -1240,7 +1265,9 @@ class PaginatorComponentTest extends TestCase
     /**
      * Helper method for mocking queries.
      *
-     * @return \Cake\ORM\Query
+     * @param string|null $table
+     *
+     * @return \Cake\ORM\Query|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function _getMockFindQuery($table = null)
     {


### PR DESCRIPTION
Always do a count on the pagination results in order to have that available when catching the NotFoundException to e.g. redirect to last page.
This was a quite a few times already requested feature that would easily be possible.

Is there a way maybe to only run the count() and fake the collection as empty one to avoid the 2nd query?
If so, it would invert the status quo resulting in the same output as this PR.

With the change here you now then could do sth like
```php
    public function paginate($object, array $settings = [])
    {
        try {
            $resultSet = parent::paginate($object, $settings);
        } catch (NotFoundException $exception) {
            $query = null;
            if ($object instanceof QueryInterface) {
                $query = $object;
                $object = $query->repository();
            }
            $alias = $object->alias();
            $lastPage = $this->request->params['paging'][$alias]['pageCount'] > 1 ? $this->request->params['paging'][$alias]['pageCount'] : null;

            $response = $this->getController()->redirect(['?' => ['page' => $lastPage] + $this->request->getQuery()]);

            // To be please PHPCS and tests, cannot be reached in production.
            if (PHP_SAPI === 'cli') {
                throw new NotFoundException('Redirect to ' . $response->getHeaderLine('Location') . ' for non-CLI.');
            } else {
                $response->send();
            }

            exit();
        }

        return $resultSet;
    }
```
for all your paginations at once.

But without the total count it will not be possible to calculate the correct page reusing the query inside the parent.