### PR TITLE
Fix lower bound of total pages

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -197,9 +197,9 @@ class PaginatorComponent extends Component
 
         $page = $options['page'];
         $limit = $options['limit'];
-        $pageCount = (int)ceil($count / $limit);
+        $pageCount = max((int)ceil($count / $limit), 1);
         $requestedPage = $page;
-        $page = max(min($page, $pageCount), 1);
+        $page = min($page, $pageCount);
         $request = $this->_registry->getController()->request;
 
         $order = (array)$options['order'];

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -648,17 +648,17 @@ class PaginatorComponentTest extends TestCase
 
         $this->Paginator->paginate($table);
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $this->request->params['paging']['PaginatorPosts']['count'],
             'Count should be 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             1,
             $this->request->params['paging']['PaginatorPosts']['page'],
             'Page number should not be 0'
         );
-        $this->assertEquals(
+        $this->assertSame(
             1,
             $this->request->params['paging']['PaginatorPosts']['pageCount'],
             'Page count number should not be 0'

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -635,6 +635,37 @@ class PaginatorComponentTest extends TestCase
     }
 
     /**
+     * Test empty pagination result.
+     *
+     * @return void
+     */
+    public function testEmptyPaginationResult()
+    {
+        $this->loadFixtures('Posts');
+
+        $table = TableRegistry::get('PaginatorPosts');
+        $table->deleteAll('1=1');
+
+        $this->Paginator->paginate($table);
+
+        $this->assertEquals(
+            0,
+            $this->request->params['paging']['PaginatorPosts']['count'],
+            'Count should be 0'
+        );
+        $this->assertEquals(
+            1,
+            $this->request->params['paging']['PaginatorPosts']['page'],
+            'Page number should not be 0'
+        );
+        $this->assertEquals(
+            1,
+            $this->request->params['paging']['PaginatorPosts']['pageCount'],
+            'Page count number should not be 0'
+        );
+    }
+
+    /**
      * Test that a really large page number gets clamped to the max page size.
      *
      * @return void


### PR DESCRIPTION
This seems to be the fix for https://github.com/cakephp/cakephp/issues/11052


Before (problematic):
```
		'page' => (int) 1,
		'pageCount' => (int) 0,
		'count' => (int) 0,
		...
```

After:
```
		'page' => (int) 1,
		'pageCount' => (int) 1,
		'count' => (int) 0,
		...
```

If you want to easily read the total number of pages and we currently display page 1, you would probably expect the pageCount to also be 1, and not having to do additional operations here based on another field.
If you need to know the results count in total, you can always check count 0.