### PR TITLE
Clarified the docblocks

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -238,7 +238,8 @@ abstract class Association
     }
 
     /**
-     * Sets the name for this association.
+     * Sets the name for this association, usually the alias
+     * assigned to the target associated table
      *
      * @param string $name Name to be assigned
      * @return $this
@@ -258,7 +259,8 @@ abstract class Association
     }
 
     /**
-     * Gets the name for this association.
+     * Gets the name for this association, usually the alias
+     * assigned to the target associated table
      *
      * @return string
      */


### PR DESCRIPTION
When reading these docblocks I found it confusing, because it's the Association class, I assumed that `getName()` would return the name of the association, such as `oneToMany` or similar. So I've just tried to clarify that the intended return is a Table class alias, as a string.
