### PR TITLE
Fix string handling of Hash::remove() and Hash::_simpleOp('remove')

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -365,7 +365,9 @@ class Hash
                 }
             } elseif ($op === 'remove') {
                 if ($i === $last) {
-                    unset($_list[$key]);
+                    if (!is_string($_list)) {
+                        unset($_list[$key]);
+                    }
 
                     return $data;
                 }
@@ -414,7 +416,7 @@ class Hash
             if ($match && is_array($v)) {
                 if ($conditions) {
                     if (static::_matches($v, $conditions)) {
-                        if ($nextPath) {
+                        if ($nextPath !== '') {
                             $data[$k] = static::remove($v, $nextPath);
                         } else {
                             unset($data[$k]);
@@ -426,7 +428,7 @@ class Hash
                 if (empty($data[$k])) {
                     unset($data[$k]);
                 }
-            } elseif ($match && empty($nextPath)) {
+            } elseif ($match && $nextPath === '') {
                 unset($data[$k]);
             }
         }

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -350,11 +350,6 @@ class Hash
         $count = count($path);
         $last = $count - 1;
         foreach ($path as $i => $key) {
-            if ((is_numeric($key) && (int)$key > 0 || $key === '0') &&
-                strpos($key, '0') !== 0
-            ) {
-                $key = (int)$key;
-            }
             if ($op === 'insert') {
                 if ($i === $last) {
                     $_list[$key] = $values;

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -365,7 +365,7 @@ class Hash
                 }
             } elseif ($op === 'remove') {
                 if ($i === $last) {
-                    if (!is_string($_list)) {
+                    if (is_array($_list)) {
                         unset($_list[$key]);
                     }
 

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -2127,6 +2127,43 @@ class HashTest extends TestCase
         $this->assertEquals($expected, $result);
         $result = Hash::remove($array, '{n}.{n}.part');
         $this->assertEquals($expected, $result);
+
+        $array = [
+            'foo' => 'string',
+        ];
+        $expected = $array;
+        $result = Hash::remove($array, 'foo.bar');
+        $this->assertEquals($expected, $result);
+
+        $array = [
+            'foo' => 'string',
+            'bar' => [
+                0 => 'a',
+                1 => 'b',
+            ],
+        ];
+        $expected = [
+            'foo' => 'string',
+            'bar' => [
+                1 => 'b',
+            ],
+        ];
+        $result = Hash::remove($array, '{s}.0');
+        $this->assertEquals($expected, $result);
+
+        $array = [
+            'foo' => [
+                0 => 'a',
+                1 => 'b',
+            ],
+        ];
+        $expected = [
+            'foo' => [
+                1 => 'b',
+            ],
+        ];
+        $result = Hash::remove($array, 'foo[1=b].0');
+        $this->assertEquals($expected, $result);
     }
 
     /**


### PR DESCRIPTION
At the momemnt,
```php
$array = [
    'foo' => 'string',
];
Hash::remove($array, 'foo.bar');
```
Will cause a fatal error.

```php
$array = [
    'foo' => [
        0 => 'a',
        1 => 'b',
    ],
];
Hash::remove($array, 'foo[1=b].0');
```
Will return an empty array unexpectedly.

Also, I removed a meaningless code. 
https://github.com/cakephp/cakephp/blob/16903f9d60c6e00443637a6f2dd9a77af649269c/src/Utility/Hash.php#L353-L357
Decimal keys need not to be converted to integers explicitly when using operator `[]`.