### PR TITLE
Add annotations for missing methods to interfaces.

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -37,6 +37,8 @@ use JsonSerializable;
  * @method bool isAccessible($property)
  * @method $this setSource($source)
  * @method array getSource()
+ * @method array extractOriginal(array $properties)
+ * @method array extractOriginalChanged(array $properties)
  *
  * @property mixed $id Alias for commonly used primary key.
  */

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -18,7 +18,7 @@ namespace Cake\Datasource;
 /**
  * The basis for every query object
  *
- * @package Cake\Datasource
+ * @method $this andWhere($conditions, $types = [])
  */
 interface QueryInterface
 {

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -18,7 +18,6 @@ namespace Cake\Datasource;
 /**
  * The basis for every query object
  *
- * @method $this andWhere($conditions, $types = [])
  */
 interface QueryInterface
 {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -947,7 +947,7 @@ abstract class Association
      * Conditionally adds a condition to the passed Query that will make it find
      * records where there is no match with this association.
      *
-     * @param \Cake\ORM\Query $query The query to modify
+     * @param \Cake\Datasource\QueryInterface $query The query to modify
      * @param array $options Options array containing the `negateMatch` key.
      * @return void
      */

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -956,7 +956,7 @@ abstract class Association
         $target = $this->_targetTable;
         if (!empty($options['negateMatch'])) {
             $primaryKey = $query->aliasFields((array)$target->getPrimaryKey(), $this->_name);
-            $query->andWhere(function ($exp) use ($primaryKey) {
+            $query->where(function ($exp) use ($primaryKey) {
                 array_map([$exp, 'isNull'], $primaryKey);
 
                 return $exp;

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -18,7 +18,6 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\Association;
 use Cake\ORM\Behavior;
-use Cake\ORM\Entity;
 
 /**
  * CounterCache behavior
@@ -199,12 +198,12 @@ class CounterCacheBehavior extends Behavior
      * Updates counter cache for a single association
      *
      * @param \Cake\Event\Event $event Event instance.
-     * @param \Cake\ORM\Entity $entity Entity
+     * @param \Cake\Datasource\EntityInterface $entity Entity
      * @param \Cake\ORM\Association $assoc The association object
      * @param array $settings The settings for for counter cache for this association
      * @return void
      */
-    protected function _processAssociation(Event $event, Entity $entity, Association $assoc, array $settings)
+    protected function _processAssociation(Event $event, EntityInterface $entity, Association $assoc, array $settings)
     {
         $foreignKeys = (array)$assoc->getForeignKey();
         $primaryKeys = (array)$assoc->getBindingKey();

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -159,7 +159,7 @@ class Marshaller
      *
      * @param array $data The data to hydrate.
      * @param array $options List of options
-     * @return \Cake\ORM\Entity
+     * @return \Cake\Datasource\EntityInterface
      * @see \Cake\ORM\Table::newEntity()
      * @see \Cake\ORM\Entity::$_accessible
      */
@@ -169,7 +169,7 @@ class Marshaller
 
         $primaryKey = (array)$this->_table->getPrimaryKey();
         $entityClass = $this->_table->getEntityClass();
-        /* @var \Cake\ORM\Entity $entity */
+        /* @var \Cake\Datasource\EntityInterface $entity */
         $entity = new $entityClass();
         $entity->setSource($this->_table->getRegistryAlias());
 


### PR DESCRIPTION
This prevents static analyzers like phpstan complaining when an argument is
typehinted as interface and a method used on object is not present in the interface.

Closes #11051