### PR TITLE
Fix parseDSN not working for SqlLocalDB

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -249,9 +249,9 @@ trait StaticConfigTrait
             throw new InvalidArgumentException('Only strings can be passed to parseDsn');
         }
 
-        $pattern = '/^(?P<scheme>[\w\\\\]+):\/\/((?P<user>.*?)(:(?P<password>.*?))?@)?' .
-            '((?P<host>[.\w-\\\\]+)(:(?P<port>\d+))?)?' .
-            '(?P<path>\/[^?]*)?(\?(?P<query>.*))?$/';
+        $pattern = '/^(?P<scheme>[\w\\\\]+):\/\/((?P<username>.*?)(:(?P<password>.*?))?@)?' .
+            '((?P<host>[^?#\/:@]+)(:(?P<port>\d+))?)?' .
+            '(?P<path>\/[^?#]*)?(\?(?P<query>[^#]*))?(#(?P<fragment>.*))?$/';
         preg_match($pattern, $dsn, $parsed);
 
         if (!$parsed) {
@@ -285,15 +285,6 @@ trait StaticConfigTrait
             }
         }
 
-        if (isset($parsed['user'])) {
-            $parsed['username'] = $parsed['user'];
-        }
-
-        if (isset($parsed['pass'])) {
-            $parsed['password'] = $parsed['pass'];
-        }
-
-        unset($parsed['pass'], $parsed['user']);
         $parsed = $queryArgs + $parsed;
 
         if (empty($parsed['className'])) {

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -196,7 +196,7 @@ class StaticConfigTraitTest extends TestCase
         ];
         $this->assertEquals($expected, TestEmailStaticConfig::parseDsn($dsn));
 
-        $dsn = 'mail://user:secret@localhost:25?timeout=30&client=null&tls=null';
+        $dsn = 'mail://user:secret@localhost:25?timeout=30&client=null&tls=null#fragment';
         $expected = [
             'className' => 'Cake\Mailer\Transport\MailTransport',
             'client' => null,
@@ -207,6 +207,7 @@ class StaticConfigTraitTest extends TestCase
             'timeout' => '30',
             'tls' => null,
             'username' => 'user',
+            'fragment' => 'fragment',
         ];
         $this->assertEquals($expected, TestEmailStaticConfig::parseDsn($dsn));
 

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -346,6 +346,18 @@ class ConnectionManagerTest extends TestCase
                     'username' => 'sa',
                 ]
             ],
+            'sqllocaldb' => [
+                'sqlserver://username:password@(localdb)\.\DeptSharedLocalDB/database',
+                [
+                    'className' => 'Cake\Database\Connection',
+                    'driver' => 'Cake\Database\Driver\Sqlserver',
+                    'host' => '(localdb)\.\DeptSharedLocalDB',
+                    'password' => 'password',
+                    'database' => 'database',
+                    'scheme' => 'sqlserver',
+                    'username' => 'username',
+                ]
+            ],
             'classname query arg' => [
                 'mysql://localhost/database?className=Custom\Driver',
                 [


### PR DESCRIPTION
When using SqlLocalDB, the host part will be `(localdb)\.\DeptSharedLocalDB` and the current regular expression doesn't match it.

Also I have fixed the regex for url with fragment, and removed unused code.