### PR TITLE
Make Table aware of a table locator.

### DIFF
--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -211,6 +211,9 @@ class TableLocator implements LocatorInterface
             }
             $options['connection'] = ConnectionManager::get($connectionName);
         }
+        if (empty($options['tableLocator'])) {
+            $options['tableLocator'] = $this;
+        }
 
         $options['registryAlias'] = $alias;
         $this->_instances[$alias] = $this->_create($options);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -35,6 +35,7 @@ use Cake\ORM\Association\HasOne;
 use Cake\ORM\Exception\MissingEntityException;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Exception\RolledbackTransactionException;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Rule\IsUnique;
 use Cake\Utility\Inflector;
 use Cake\Validation\ValidatorAwareInterface;
@@ -128,6 +129,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 {
 
     use EventDispatcherTrait;
+    use LocatorAwareTrait;
     use RulesAwareTrait;
     use ValidatorAwareTrait;
 
@@ -282,6 +284,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     $this->setValidator($name, $validator);
                 }
             }
+        }
+        if (!empty($config['tableLocator'])) {
+            $this->setTableLocator($config['tableLocator']);
         }
         $this->_eventManager = $eventManager ?: new EventManager();
         $this->_behaviors = $behaviors ?: new BehaviorRegistry();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -971,7 +971,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function belongsTo($associated, array $options = [])
     {
-        $options += ['sourceTable' => $this];
+        $options += [
+            'sourceTable' => $this,
+            'tableLocator' => $this->getTableLocator()
+        ];
         $association = new BelongsTo($associated, $options);
 
         return $this->_associations->add($association->getName(), $association);
@@ -1015,7 +1018,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function hasOne($associated, array $options = [])
     {
-        $options += ['sourceTable' => $this];
+        $options += [
+            'sourceTable' => $this,
+            'tableLocator' => $this->getTableLocator()
+        ];
         $association = new HasOne($associated, $options);
 
         return $this->_associations->add($association->getName(), $association);
@@ -1065,7 +1071,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function hasMany($associated, array $options = [])
     {
-        $options += ['sourceTable' => $this];
+        $options += [
+            'sourceTable' => $this,
+            'tableLocator' => $this->getTableLocator()
+        ];
         $association = new HasMany($associated, $options);
 
         return $this->_associations->add($association->getName(), $association);
@@ -1117,7 +1126,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function belongsToMany($associated, array $options = [])
     {
-        $options += ['sourceTable' => $this];
+        $options += [
+            'sourceTable' => $this,
+            'tableLocator' => $this->getTableLocator()
+        ];
         $association = new BelongsToMany($associated, $options);
 
         return $this->_associations->add($association->getName(), $association);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -164,6 +164,8 @@ class TableLocatorTest extends TestCase
         $result2 = $this->_locator->get('Articles');
         $this->assertSame($result, $result2);
         $this->assertEquals('my_articles', $result->table());
+
+        $this->assertSame($this->_locator, $result->getTableLocator());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -31,6 +31,7 @@ use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorInterface;
+use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\SaveOptionsBuilder;
@@ -530,8 +531,9 @@ class TableTest extends TestCase
      */
     public function testBelongsTo()
     {
+        $locator = $this->createMock(LocatorInterface::class);
         $options = ['foreignKey' => 'fake_id', 'conditions' => ['a' => 'b']];
-        $table = new Table(['table' => 'dates']);
+        $table = new Table(['table' => 'dates', 'tableLocator' => $locator]);
         $belongsTo = $table->belongsTo('user', $options);
         $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $belongsTo);
         $this->assertSame($belongsTo, $table->association('user'));
@@ -539,6 +541,7 @@ class TableTest extends TestCase
         $this->assertEquals('fake_id', $belongsTo->foreignKey());
         $this->assertEquals(['a' => 'b'], $belongsTo->conditions());
         $this->assertSame($table, $belongsTo->source());
+        $this->assertSame($locator, $belongsTo->getTableLocator());
     }
 
     /**
@@ -548,8 +551,9 @@ class TableTest extends TestCase
      */
     public function testHasOne()
     {
+        $locator = $this->createMock(LocatorInterface::class);
         $options = ['foreignKey' => 'user_id', 'conditions' => ['b' => 'c']];
-        $table = new Table(['table' => 'users']);
+        $table = new Table(['table' => 'users', 'tableLocator' => $locator]);
         $hasOne = $table->hasOne('profile', $options);
         $this->assertInstanceOf('Cake\ORM\Association\HasOne', $hasOne);
         $this->assertSame($hasOne, $table->association('profile'));
@@ -557,6 +561,7 @@ class TableTest extends TestCase
         $this->assertEquals('user_id', $hasOne->foreignKey());
         $this->assertEquals(['b' => 'c'], $hasOne->conditions());
         $this->assertSame($table, $hasOne->source());
+        $this->assertSame($locator, $hasOne->getTableLocator());
     }
 
     /**
@@ -675,12 +680,13 @@ class TableTest extends TestCase
      */
     public function testHasMany()
     {
+        $locator = $this->createMock(LocatorInterface::class);
         $options = [
             'foreignKey' => 'author_id',
             'conditions' => ['b' => 'c'],
             'sort' => ['foo' => 'asc']
         ];
-        $table = new Table(['table' => 'authors']);
+        $table = new Table(['table' => 'authors', 'tableLocator' => $locator]);
         $hasMany = $table->hasMany('article', $options);
         $this->assertInstanceOf('Cake\ORM\Association\HasMany', $hasMany);
         $this->assertSame($hasMany, $table->association('article'));
@@ -689,6 +695,7 @@ class TableTest extends TestCase
         $this->assertEquals(['b' => 'c'], $hasMany->conditions());
         $this->assertEquals(['foo' => 'asc'], $hasMany->sort());
         $this->assertSame($table, $hasMany->source());
+        $this->assertSame($locator, $hasMany->getTableLocator());
     }
 
     /**
@@ -792,13 +799,18 @@ class TableTest extends TestCase
      */
     public function testBelongsToMany()
     {
+        $locator = new TableLocator();
         $options = [
             'foreignKey' => 'thing_id',
             'joinTable' => 'things_tags',
             'conditions' => ['b' => 'c'],
             'sort' => ['foo' => 'asc']
         ];
-        $table = new Table(['table' => 'authors', 'connection' => $this->connection]);
+        $table = new Table([
+            'table' => 'authors',
+            'connection' => $this->connection,
+            'tableLocator' => $locator
+        ]);
         $belongsToMany = $table->belongsToMany('tag', $options);
         $this->assertInstanceOf('Cake\ORM\Association\BelongsToMany', $belongsToMany);
         $this->assertSame($belongsToMany, $table->association('tag'));
@@ -808,6 +820,7 @@ class TableTest extends TestCase
         $this->assertEquals(['foo' => 'asc'], $belongsToMany->sort());
         $this->assertSame($table, $belongsToMany->source());
         $this->assertSame('things_tags', $belongsToMany->junction()->table());
+        $this->assertSame($locator, $belongsToMany->getTableLocator());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -30,6 +30,7 @@ use Cake\ORM\AssociationCollection;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
+use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\SaveOptionsBuilder;
@@ -207,6 +208,18 @@ class TableTest extends TestCase
         $this->assertNull($table->connection());
         $table->connection($this->connection);
         $this->assertSame($this->connection, $table->connection());
+    }
+
+    /**
+     * Tests tableLocator option
+     *
+     * @return void
+     */
+    public function testTableLocator()
+    {
+        $locator = $this->createMock(LocatorInterface::class);
+        $table = new Table(['tableLocator' => $locator]);
+        $this->assertSame($locator, $table->getTableLocator());
     }
 
     /**


### PR DESCRIPTION
Following https://github.com/cakephp/cakephp/issues/11023#issuecomment-321171559

`TableLocator` instance passes itself to the table objects it creates. Then the locator is being passed to the associations created by this table object.

This allows to isolate tables created with a particular table locator making independent of a "global" table locator. 

This also makes sure that associations created by tables originating from different locators do not collide making it possible to isolate parts of the system where groups of tables should behave differently in some scenarios, ie share different connections.

For example:

```php
class OrdersTable extends Table
{
    public function initialize()
    {
        $this->hasMany('Articles');
    }
}

class ConnectionAwareLocator extends TableLocator
{
    public function __construct(ConnectionInterface $connection)
    {
        $this->connection = $connection;
    }

    public function get($alias, array $options = [])
    {
        $table = parent::get($alias, $options);
        return $table->setConnection($this->connection);
    }
}

$fooLocator = new ConnectionAwareLocator(ConnectionManager::get('foo'));
$table = $fooLocator->get('Orders');
//this table and it's associations share the "foo" connection


$barLocator = new ConnectionAwareLocator(ConnectionManager::get('bar'));
$table = $barLocator->get('Orders');
//this table and it's associations share the "bar" connection
```