### PR TITLE
3.6 - Add a deprecation warning helper.

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -248,3 +248,16 @@ if (!function_exists('env')) {
     }
 
 }
+
+if (!function_exists('deprecationWarning')) {
+    /**
+     * Helper method for outputting deprecation warnings
+     *
+     * @param string $message The message to output as a deprecation warning.
+     * @return void
+     */
+    function deprecationWarning($message)
+    {
+        trigger_error($message, E_USER_DEPRECATED);
+    }
+}

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -263,6 +263,7 @@ if (!function_exists('deprecationWarning')) {
         if (!(error_reporting() & E_USER_DEPRECATED)) {
             return;
         }
+
         $trace = debug_backtrace();
         if (isset($trace[$stackFrame])) {
             $frame = $trace[$stackFrame];

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -260,7 +260,7 @@ if (!function_exists('deprecationWarning')) {
      */
     function deprecationWarning($message, $stackFrame = 2)
     {
-        if (!Configure::read('debug')) {
+        if (!(error_reporting() & E_USER_DEPRECATED)) {
             return;
         }
         $trace = debug_backtrace();

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -254,10 +254,28 @@ if (!function_exists('deprecationWarning')) {
      * Helper method for outputting deprecation warnings
      *
      * @param string $message The message to output as a deprecation warning.
+     * @param int $stackFrame The stack frame to include in the error. Defaults to 2
+     *   as that should point to application/plugin code.
      * @return void
      */
-    function deprecationWarning($message)
+    function deprecationWarning($message, $stackFrame = 2)
     {
+        if (!Configure::read('debug')) {
+            return;
+        }
+        $trace = debug_backtrace();
+        if (isset($trace[$stackFrame])) {
+            $frame = $trace[$stackFrame];
+            $frame += ['file' => '[internal]', 'line' => '??'];
+
+            $message = sprintf(
+                '%s - %s, line: %s',
+                $message,
+                $frame['file'],
+                $frame['line']
+            );
+        }
+
         trigger_error($message, E_USER_DEPRECATED);
     }
 }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -49,6 +49,7 @@ class FunctionsTest extends TestCase
      */
     public function testDeprecationWarning()
     {
+        error_reporting(E_ALL);
         deprecationWarning('This is going away');
     }
 }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -59,7 +59,7 @@ class FunctionsTest extends TestCase
      * Test error messages coming out when debug is on, not setting the stack frame manually
      *
      * @expectedException PHPUnit\Framework\Error\Deprecated
-     * @expectedExceptionMessageRegExp /This is going away - (.*?)\/TestCase.php, line\: \d+/
+     * @expectedExceptionMessageRegExp /This is going away - (.*?)[\/\\]TestCase.php, line\: \d+/
      */
     public function testDeprecationWarningEnabledDefaultFrame()
     {

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -42,4 +42,13 @@ class FunctionsTest extends TestCase
         $this->assertEquals('0', env('ZERO'));
         $this->assertEquals('0', env('ZERO', '1'));
     }
+
+    /**
+     * @expectedException PHPUnit\Framework\Error\Deprecated
+     * @expectedExceptionMessage This is going away
+     */
+    public function testDeprecationWarning()
+    {
+        deprecationWarning('This is going away');
+    }
 }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\TestCase\Core;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -50,9 +49,8 @@ class FunctionsTest extends TestCase
      * @expectedException PHPUnit\Framework\Error\Deprecated
      * @expectedExceptionMessage This is going away - [internal], line: ??
      */
-    public function testDeprecationWarningDebugEnabled()
+    public function testDeprecationWarningEnabled()
     {
-        Configure::write('debug', true);
         error_reporting(E_ALL);
         deprecationWarning('This is going away', 1);
     }
@@ -63,9 +61,8 @@ class FunctionsTest extends TestCase
      * @expectedException PHPUnit\Framework\Error\Deprecated
      * @expectedExceptionMessageRegExp /This is going away - (.*?)\/TestCase.php, line\: \d+/
      */
-    public function testDeprecationWarningDebugEnabledDefaultFrame()
+    public function testDeprecationWarningEnabledDefaultFrame()
     {
-        Configure::write('debug', true);
         error_reporting(E_ALL);
         deprecationWarning('This is going away');
     }
@@ -75,10 +72,9 @@ class FunctionsTest extends TestCase
      *
      * @return void
      */
-    public function testDeprecationWarningDebugDisabled()
+    public function testDeprecationWarningLevelDisabled()
     {
-        Configure::write('debug', false);
-        error_reporting(E_ALL);
+        error_reporting(E_ALL ^ E_USER_DEPRECATED);
         $this->assertNull(deprecationWarning('This is going away'));
     }
 }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -44,7 +44,7 @@ class FunctionsTest extends TestCase
     }
 
     /**
-     * Test error messages coming out when debug is on
+     * Test error messages coming out when debug is on, manually setting the stack frame
      *
      * @expectedException PHPUnit\Framework\Error\Deprecated
      * @expectedExceptionMessage This is going away - [internal], line: ??
@@ -56,7 +56,7 @@ class FunctionsTest extends TestCase
     }
 
     /**
-     * Test error messages coming out when debug is on
+     * Test error messages coming out when debug is on, not setting the stack frame manually
      *
      * @expectedException PHPUnit\Framework\Error\Deprecated
      * @expectedExceptionMessageRegExp /This is going away - (.*?)\/TestCase.php, line\: \d+/

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Core;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -44,12 +45,40 @@ class FunctionsTest extends TestCase
     }
 
     /**
+     * Test error messages coming out when debug is on
+     *
      * @expectedException PHPUnit\Framework\Error\Deprecated
-     * @expectedExceptionMessage This is going away
+     * @expectedExceptionMessage This is going away - [internal], line: ??
      */
-    public function testDeprecationWarning()
+    public function testDeprecationWarningDebugEnabled()
     {
+        Configure::write('debug', true);
+        error_reporting(E_ALL);
+        deprecationWarning('This is going away', 1);
+    }
+
+    /**
+     * Test error messages coming out when debug is on
+     *
+     * @expectedException PHPUnit\Framework\Error\Deprecated
+     * @expectedExceptionMessageRegExp /This is going away - (.*?)\/TestCase.php, line\: \d+/
+     */
+    public function testDeprecationWarningDebugEnabledDefaultFrame()
+    {
+        Configure::write('debug', true);
         error_reporting(E_ALL);
         deprecationWarning('This is going away');
+    }
+
+    /**
+     * Test no error when debug is off.
+     *
+     * @return void
+     */
+    public function testDeprecationWarningDebugDisabled()
+    {
+        Configure::write('debug', false);
+        error_reporting(E_ALL);
+        $this->assertNull(deprecationWarning('This is going away'));
     }
 }

--- a/tests/phpunit_aliases.php
+++ b/tests/phpunit_aliases.php
@@ -7,4 +7,5 @@ if (class_exists('PHPUnit_Runner_Version')) {
     class_alias('PHPUnit_Framework_Test', 'PHPUnit\Framework\Test');
     class_alias('PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
     class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
+    class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
 }


### PR DESCRIPTION
This will make adding framework deprecation warnings we plan to add in 3.6.x simpler as they will be easier to write.