### PR TITLE
Fixed SessionHelper not handling stacked messages

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -47,24 +47,32 @@ class SessionHelperTest extends CakeTestCase {
 			'test' => 'info',
 			'Message' => array(
 				'flash' => array(
-					'element' => 'default',
-					'params' => array(),
-					'message' => 'This is a calling'
+					array(
+						'element' => 'default',
+						'params' => array(),
+						'message' => 'This is a calling'
+					),
 				),
 				'notification' => array(
-					'element' => 'session_helper',
-					'params' => array('title' => 'Notice!', 'name' => 'Alert!'),
-					'message' => 'This is a test of the emergency broadcasting system',
+					array(
+						'element' => 'session_helper',
+						'params' => array('title' => 'Notice!', 'name' => 'Alert!'),
+						'message' => 'This is a test of the emergency broadcasting system',
+					),
 				),
 				'classy' => array(
-					'element' => 'default',
-					'params' => array('class' => 'positive'),
-					'message' => 'Recorded'
+					array(
+						'element' => 'default',
+						'params' => array('class' => 'positive'),
+						'message' => 'Recorded'
+					),
 				),
 				'bare' => array(
-					'element' => null,
-					'message' => 'Bare message',
-					'params' => array(),
+					array(
+						'element' => null,
+						'message' => 'Bare message',
+						'params' => array(),
+					),
 				),
 			),
 			'Deeply' => array('nested' => array('key' => 'value')),
@@ -104,7 +112,7 @@ class SessionHelperTest extends CakeTestCase {
 	public function testCheck() {
 		$this->assertTrue($this->Session->check('test'));
 
-		$this->assertTrue($this->Session->check('Message.flash.element'));
+		$this->assertTrue($this->Session->check('Message.flash.0.element'));
 
 		$this->assertFalse($this->Session->check('Does.not.exist'));
 

--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -134,30 +134,14 @@ class SessionHelper extends AppHelper {
 		if (CakeSession::check('Message.' . $key)) {
 			$flash = CakeSession::read('Message.' . $key);
 			CakeSession::delete('Message.' . $key);
-			$message = $flash['message'];
-			unset($flash['message']);
 
-			if (!empty($attrs)) {
-				$flash = array_merge($flash, $attrs);
-			}
-
-			if ($flash['element'] === 'default') {
-				$class = 'message';
-				if (!empty($flash['params']['class'])) {
-					$class = $flash['params']['class'];
+			$out = '';
+			foreach ($flash as $flashArray) {
+				if (!empty($attrs)) {
+					$flashArray = array_merge($flashArray, $attrs);
 				}
-				$out = '<div id="' . $key . 'Message" class="' . $class . '">' . $message . '</div>';
-			} elseif (!$flash['element']) {
-				$out = $message;
-			} else {
-				$options = array();
-				if (isset($flash['params']['plugin'])) {
-					$options['plugin'] = $flash['params']['plugin'];
-				}
-				$tmpVars = $flash['params'];
-				$tmpVars['message'] = $message;
-				$tmpVars['key'] = $key;
-				$out = $this->_View->element($flash['element'], $tmpVars, $options);
+				$flashArray['key'] = $key;
+				$out .= $this->_render($flashArray);
 			}
 		}
 		return $out;
@@ -173,4 +157,34 @@ class SessionHelper extends AppHelper {
 		return CakeSession::valid();
 	}
 
+/**
+ * Renders a flash message
+ *
+ * @param array $flash Flash message array
+ * @return string
+ */
+	protected function _render($flash) {
+		$message = $flash['message'];
+		unset($flash['message']);
+
+		if ($flash['element'] === 'default') {
+			$class = 'message';
+			if (!empty($flash['params']['class'])) {
+				$class = $flash['params']['class'];
+			}
+			$out = '<div id="' . $flash['key'] . 'Message" class="' . $class . '">' . $message . '</div>';
+		} elseif (!$flash['element']) {
+			$out = $message;
+		} else {
+			$options = array();
+			if (isset($flash['params']['plugin'])) {
+				$options['plugin'] = $flash['params']['plugin'];
+			}
+			$tmpVars = $flash['params'];
+			$tmpVars['message'] = $message;
+			$tmpVars['key'] = $flash['key'];
+			$out = $this->_View->element($flash['element'], $tmpVars, $options);
+		}
+		return $out;
+	}
 }


### PR DESCRIPTION
FlashHelper was updated to handle stacked messages, but the tests for SessionHelper weren't updated and caused a regression in the SessionHelper.