### PR TITLE
Revert "Replace parse_url() with a regex.", and add fallback code to parseDsn()

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -259,7 +259,7 @@ trait StaticConfigTrait
         if ($parsed === false) {
             // Failed to parse.
             // Try to encode the userinfo if the DSN string contains '@' marks.
-            for ($p = 0; ($p = strpos($noScheme, '@', $p)) !== false; ++$p) {
+            for ($p = 0; ($p = strpos($noScheme, '@', $p)) !== false; ++$p) { // @codingStandardsIgnoreLine
                 $user = substr($noScheme, 0, $p);
                 $rest = substr($noScheme, $p + 1);
 

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -306,6 +306,31 @@ class ConnectionManagerTest extends TestCase
                     'log' => '1'
                 ]
             ],
+            'no password' => [
+                'mysql://user@localhost:3306/database',
+                [
+                    'className' => 'Cake\Database\Connection',
+                    'driver' => 'Cake\Database\Driver\Mysql',
+                    'host' => 'localhost',
+                    'database' => 'database',
+                    'port' => 3306,
+                    'scheme' => 'mysql',
+                    'username' => 'user',
+                ]
+            ],
+            'empty password' => [
+                'mysql://user:@localhost:3306/database',
+                [
+                    'className' => 'Cake\Database\Connection',
+                    'driver' => 'Cake\Database\Driver\Mysql',
+                    'host' => 'localhost',
+                    'database' => 'database',
+                    'port' => 3306,
+                    'scheme' => 'mysql',
+                    'username' => 'user',
+                    'password' => '',
+                ]
+            ],
             'sqlite memory' => [
                 'sqlite:///:memory:',
                 [
@@ -391,6 +416,19 @@ class ConnectionManagerTest extends TestCase
                 ]
             ],
             'complex password' => [
+                'mysql://user:@#@localhost:3306/database',
+                [
+                    'className' => 'Cake\Database\Connection',
+                    'driver' => 'Cake\Database\Driver\Mysql',
+                    'host' => 'localhost',
+                    'database' => 'database',
+                    'port' => 3306,
+                    'scheme' => 'mysql',
+                    'username' => 'user',
+                    'password' => '@#',
+                ]
+            ],
+            'more complex password' => [
                 'mysql://user:pas#][{}$%20@!@localhost:3306/database?log=1&quoteIdentifiers=1',
                 [
                     'className' => 'Cake\Database\Connection',
@@ -424,12 +462,12 @@ class ConnectionManagerTest extends TestCase
      * Test parseDsn invalid.
      *
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The DSN string 'bagof:nope' could not be parsed.
+     * @expectedExceptionMessage The DSN string 'mysql://@/' could not be parsed.
      * @return void
      */
     public function testParseDsnInvalid()
     {
-        $result = ConnectionManager::parseDsn('bagof:nope');
+        $result = ConnectionManager::parseDsn('mysql://@/');
     }
 
     /**


### PR DESCRIPTION
Reported in the japanese channel on the Slack.

As of 3.4.13 / 3.5.0, parseDsn() no longer accepts empty passwords:
```php
mysql://user:@localhost:3306/database
```

Since it is hard to distinguish 'empty string' from unmatch in the regular expression, I reverted StaticConfigTrait to the previous code before the change in 519b0ce66f3c43206ed9b8e026a928ef2339d3ff. Instead, I added fallback code to parseDsn() and more test cases.