### PR TITLE
Change docblock to using getters

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -188,8 +188,8 @@ trait EntityTrait
      *
      * ```
      * $entity->set(['name' => 'andrew', 'id' => 1]);
-     * echo $entity->name // prints andrew
-     * echo $entity->id // prints 1
+     * echo $entity->get('name') // prints andrew
+     * echo $entity->get('id') // prints 1
      * ```
      *
      * Some times it is handy to bypass setter functions in this entity when assigning


### PR DESCRIPTION
This docblock shows the use of setter methods, but doesn't show the getter methods, and instead uses the "old school" direct class property approach. Just changed that to show getters instead for consistency.