### PR TITLE
Fix response headers set in templates not be sent.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -622,9 +622,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $this->View = $this->createView();
         $contents = $this->View->render($view, $layout);
-        $this->response = $this->View->response;
+        $this->response = $this->View->response->withStringBody($contents);
 
-        return $this->response->withStringBody($contents);
+        return $this->response;
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -621,9 +621,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         $this->View = $this->createView();
-        $this->response->body($this->View->render($view, $layout));
+        $contents = $this->View->render($view, $layout);
+        $this->response = $this->View->response;
 
-        return $this->response;
+        return $this->response->withStringBody($contents);
     }
 
     /**

--- a/src/Http/ActionDispatcher.php
+++ b/src/Http/ActionDispatcher.php
@@ -122,14 +122,15 @@ class ActionDispatcher
         }
 
         if (!$response && $controller->autoRender) {
-            $response = $controller->render();
-        } elseif (!$response) {
-            $response = $controller->response;
+            $controller->render();
         }
 
         $result = $controller->shutdownProcess();
         if ($result instanceof Response) {
             return $result;
+        }
+        if (!$response) {
+            $response = $controller->response;
         }
 
         return $response;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -403,6 +403,26 @@ class ControllerTest extends TestCase
         $this->assertRegExp('/this is the test element/', (string)$result);
     }
 
+
+    /**
+     * test view rendering changing response
+     *
+     * @return void
+     */
+    public function testRenderViewChangesResponse()
+    {
+        $request = new ServerRequest('controller_posts/index');
+        $request->params['action'] = 'header';
+
+        $controller = new Controller($request, new Response());
+        $controller->viewBuilder()->templatePath('Posts');
+
+        $result = $controller->render('header');
+        $this->assertContains('header template', (string)$result);
+        $this->assertTrue($controller->response->hasHeader('X-view-template'));
+        $this->assertSame('yes', $controller->response->getHeaderLine('X-view-template'));
+    }
+
     /**
      * test that a component beforeRender can change the controller view class.
      *

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -403,7 +403,6 @@ class ControllerTest extends TestCase
         $this->assertRegExp('/this is the test element/', (string)$result);
     }
 
-
     /**
      * test view rendering changing response
      *

--- a/tests/TestCase/Routing/DispatcherFactoryTest.php
+++ b/tests/TestCase/Routing/DispatcherFactoryTest.php
@@ -121,12 +121,16 @@ class DispatcherFactoryTest extends TestCase
         $response = $this->getMockBuilder('Cake\Http\Response')
             ->setMethods(['send'])
             ->getMock();
+
+        $response->expects($this->once())
+            ->method('send')
+            ->will($this->returnSelf());
+
         DispatcherFactory::add('ControllerFactory');
         DispatcherFactory::add('Append');
 
         $dispatcher = DispatcherFactory::create();
         $result = $dispatcher->dispatch($url, $response);
-        $this->assertNull($result);
-        $this->assertEquals('posts index appended content', $response->body());
+        $this->assertEquals('posts index appended content', $result->body());
     }
 }

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -160,7 +160,9 @@ class DispatcherTest extends TestCase
                 'pass' => ['extract'],
             ]
         ]);
-        $response = $this->getMockBuilder('Cake\Http\Response')->getMock();
+        $response = $this->getMockBuilder('Cake\Http\Response')
+            ->setMethods(['send'])
+            ->getMock();
         $response->expects($this->once())
             ->method('send');
 

--- a/tests/test_app/TestApp/Template/Posts/header.ctp
+++ b/tests/test_app/TestApp/Template/Posts/header.ctp
@@ -1,0 +1,4 @@
+<?php
+$this->response = $this->response->withHeader('X-view-template', 'yes');
+?>
+header template


### PR DESCRIPTION
When response properties are set in the view templates, they should show up in the controller's response as well.

Fixes #11084
