### PR TITLE
Change default for parseHuge to false to avoid OOM on xml expansion

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -107,7 +107,7 @@ class Xml
             'return' => 'simplexml',
             'loadEntities' => false,
             'readFile' => true,
-            'parseHuge' => true,
+            'parseHuge' => false,
         ];
         $options += $defaults;
 


### PR DESCRIPTION
The option was added to allow for enabling (https://github.com/cakephp/cakephp/pull/10034) parseHuge as the docblock also decribes, having this enabled though by default is not recommended.