### PR TITLE
Ensure input passwords will be hashed even when a user doesn't exist

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -107,6 +107,9 @@ abstract class BaseAuthenticate implements EventListenerInterface
         $result = $this->_query($username)->first();
 
         if (empty($result)) {
+            $hasher = $this->passwordHasher();
+            $hasher->hash((string)$password);
+
             return false;
         }
 


### PR DESCRIPTION
While the docblock states `Input passwords will be hashed even when a user doesn't exist` in fact it does not. This change ensures passwords are actually hashed even when no user was found to help mitigate timing-based user enumeration attacks.