### PR TITLE
Fix cookies not being sent by classic Dispatcher.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -540,15 +540,15 @@ class Response implements ResponseInterface
      */
     protected function _setCookies()
     {
-        foreach ($this->_cookies as $name => $c) {
+        foreach ($this->_cookies as $cookie) {
             setcookie(
-                $name,
-                $c['value'],
-                $c['expire'],
-                $c['path'],
-                $c['domain'],
-                $c['secure'],
-                $c['httpOnly']
+                $cookie->getName(),
+                $cookie->getValue(),
+                $cookie->getExpiresTimestamp(),
+                $cookie->getPath(),
+                $cookie->getDomain(),
+                $cookie->isSecure(),
+                $cookie->isHttpOnly()
             );
         }
     }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -339,29 +339,34 @@ class ResponseTest extends TestCase
     public function testSend()
     {
         $response = $this->getMockBuilder('Cake\Http\Response')
-            ->setMethods(['_sendHeader', '_sendContent', '_setCookies'])
+            ->setMethods(['_sendHeader', '_sendContent'])
             ->getMock();
         $response->header([
             'Content-Language' => 'es',
             'WWW-Authenticate' => 'Negotiate',
             'Access-Control-Allow-Origin' => ['domain1', 'domain2'],
         ]);
+        $response->cookie(['name' => 'thing', 'value' => 'value']);
         $response->body('the response body');
+
         $response->expects($this->once())->method('_sendContent')->with('the response body');
-        $response->expects($this->at(0))->method('_setCookies');
-        $response->expects($this->at(1))
+        $response->expects($this->at(0))
             ->method('_sendHeader')->with('HTTP/1.1 200 OK');
-        $response->expects($this->at(2))
+        $response->expects($this->at(1))
             ->method('_sendHeader')->with('Content-Type', 'text/html; charset=UTF-8');
-        $response->expects($this->at(3))
+        $response->expects($this->at(2))
             ->method('_sendHeader')->with('Content-Language', 'es');
-        $response->expects($this->at(4))
+        $response->expects($this->at(3))
             ->method('_sendHeader')->with('WWW-Authenticate', 'Negotiate');
-        $response->expects($this->at(5))
+        $response->expects($this->at(4))
             ->method('_sendHeader')->with('Access-Control-Allow-Origin', 'domain1');
-        $response->expects($this->at(6))
+        $response->expects($this->at(5))
             ->method('_sendHeader')->with('Access-Control-Allow-Origin', 'domain2');
         $response->send();
+
+        $this->assertCount(1, $GLOBALS['mockedCookies']);
+        $this->assertSame('value', $GLOBALS['mockedCookies'][0]['value']);
+        $this->assertSame('thing', $GLOBALS['mockedCookies'][0]['name']);
     }
 
     /**


### PR DESCRIPTION
Cookies are not arrays anymore. We lacked test coverage for this in the past.

Refs #11070