### PR TITLE
Add iterator annotation

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -885,7 +885,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Get the associations collection for this table.
      *
-     * @return \Cake\ORM\AssociationCollection The collection of association objects.
+     * @return \Cake\ORM\AssociationCollection|\Cake\ORM\Association[] The collection of association objects.
      */
     public function associations()
     {


### PR DESCRIPTION
When you iterate over table associations you always need an internal typehint.

        foreach ($table->associations() as $association) {
            /* @var $association \Cake\ORM\Association */
            ...
        }

This can easily be avoided for the collection by adding the iterator result.