### PR TITLE
Replace md5 with hmac hashes 

### DIFF
--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -16,6 +16,7 @@ namespace Cake\View\Helper;
 
 use Cake\Core\App;
 use Cake\Core\Exception\Exception;
+use Cake\Utility\Security;
 use Cake\View\Helper;
 use Cake\View\View;
 
@@ -48,7 +49,7 @@ class TextHelper extends Helper
     ];
 
     /**
-     * An array of md5sums and their contents.
+     * An array of hashes and their contents.
      * Used when inserting links into text.
      *
      * @var array
@@ -167,7 +168,7 @@ class TextHelper extends Helper
         if (isset($matches['url_bare'])) {
             $match = $matches['url_bare'];
         }
-        $key = md5($match);
+        $key = hash_hmac('sha1', $match, Security::getSalt());
         $this->_placeholders[$key] = [
             'content' => $match,
             'envelope' => $envelope


### PR DESCRIPTION
Replace md5 with hmac hashes in autolinking to provide unpredictability and resistance to collisions