### PR TITLE
Fix CookieCollection::parseSetCookieHeader when the cookie has proper…

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -357,7 +357,7 @@ class CookieCollection implements IteratorAggregate, Countable
                     continue;
                 }
                 $key = strtolower($key);
-                if (!strlen($cookie[$key])) {
+                if (array_key_exists($key, $cookie) && !strlen($cookie[$key])) {
                     $cookie[$key] = $value;
                 }
             }

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -436,7 +436,7 @@ class CookieCollectionTest extends TestCase
         $header = [
             'http=name; HttpOnly; Secure;',
             'expires=expiring; Expires=Wed, 15-Jun-2022 10:22:22; Path=/api; HttpOnly; Secure;',
-            'expired=expired; Expires=Wed, 15-Jun-2015 10:22:22;',
+            'expired=expired; version=1; Expires=Wed, 15-Jun-2015 10:22:22;',
         ];
         $cookies = CookieCollection::createFromHeader($header);
         $this->assertCount(3, $cookies);

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -442,6 +442,7 @@ class CookieCollectionTest extends TestCase
         $this->assertCount(3, $cookies);
         $this->assertTrue($cookies->has('http'));
         $this->assertTrue($cookies->has('expires'));
+        $this->assertFalse($cookies->has('version'));
         $this->assertTrue($cookies->has('expired'), 'Expired cookies should be present');
     }
 


### PR DESCRIPTION
When the Cookie has 「version」 property, `CookieCollecion::parseSetCookieHeader` occured Undefined index: version.

I used `Cake\Http\Client`, so the Cookie of the returned Response has value version property....
(in case of in-App Purchase API)

