### PR TITLE
Stacking messages in SessionComponent::setFlash

### DIFF
--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -137,11 +137,11 @@ class SessionComponent extends Component {
  */
 	public function setFlash($message, $element = 'default', $params = array(), $key = 'flash') {
 		$messages = (array)CakeSession::read('Message.' . $key);
-		$messages[] = [
+		$messages[] = array(
 			'message' => $message,
 			'element' => $element,
 			'params' => $params,
-		];
+		);
 		CakeSession::write('Message.' . $key, $messages);
 	}
 

--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -136,7 +136,13 @@ class SessionComponent extends Component {
  * @deprecated 3.0.0 Since 2.7, use the FlashComponent instead.
  */
 	public function setFlash($message, $element = 'default', $params = array(), $key = 'flash') {
-		CakeSession::write('Message.' . $key, compact('message', 'element', 'params'));
+		$messages = (array)CakeSession::read('Message.' . $key);
+		$messages[] = [
+			'message' => $message,
+			'element' => $element,
+			'params' => $params,
+		];
+		CakeSession::write('Message.' . $key, $messages);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
@@ -247,16 +247,13 @@ class SessionComponentTest extends CakeTestCase {
 		$this->assertNull($Session->read('Message.flash'));
 
 		$Session->setFlash('This is a test message');
-		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.flash'));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.flash.0'));
 
 		$Session->setFlash('This is a test message', 'test', array('name' => 'Joel Moss'));
-		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'test', 'params' => array('name' => 'Joel Moss')), $Session->read('Message.flash'));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'test', 'params' => array('name' => 'Joel Moss')), $Session->read('Message.flash.1'));
 
 		$Session->setFlash('This is a test message', 'default', array(), 'myFlash');
-		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.myFlash'));
-
-		$Session->setFlash('This is a test message', 'non_existing_layout');
-		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.myFlash'));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.myFlash.0'));
 
 		$Session->delete('Message');
 	}


### PR DESCRIPTION
In my last attempt to fix flash stacking being BC with the SessionHelper, I accidentally broke compatibility between `SessionComponent` and the `SessionHelper` :(

This PR fixes compatibility between those two deprecated components - all the different components and helpers should be using the same format now.