### PR TITLE
Add casting to make CookieComponent more backwards compatible.

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -316,8 +316,8 @@ class CookieComponent extends Component
             'expire' => $expires->format('U'),
             'path' => $config['path'],
             'domain' => $config['domain'],
-            'secure' => $config['secure'],
-            'httpOnly' => $config['httpOnly']
+            'secure' => (bool)$config['secure'],
+            'httpOnly' => (bool)$config['httpOnly']
         ]);
     }
 

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -106,6 +106,25 @@ class CookieComponentTest extends TestCase
     }
 
     /**
+     * Test backwards compatibility with settings that use type juggling.
+     *
+     * @return void
+     */
+    public function testSettingsCompatibility()
+    {
+        $this->Cookie->config([
+            'expires' => '+10 seconds',
+            'path' => '/',
+            'domain' => '',
+            'secure' => 0,
+            'key' => 'somerandomhaskeysomerandomhaskey',
+            'encryption' => 0,
+        ]);
+        $this->Cookie->write('key', 'value');
+        $this->assertSame('value', $this->Cookie->read('key'));
+    }
+
+    /**
      * sets up some default cookie data.
      *
      * @return void


### PR DESCRIPTION
Add casting that allows CookieComponent to continue working with loose typing that was supported in earlier versions.

Refs #11120
