### PR TITLE
Fix #11132 - trim warning in Cake\View\Helper::addClass

### DIFF
--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -197,9 +197,9 @@ class Helper implements EventListenerInterface
      */
     public function addClass(array $options = [], $class = null, $key = 'class')
     {
-        if (is_array($options[$key])) {
+        if (isset($options[$key]) && is_array($options[$key])) {
             $options[$key][] = $class;
-        } else if (isset($options[$key]) && trim($options[$key])) {
+        } elseif (isset($options[$key]) && trim($options[$key])) {
             $options[$key] .= ' ' . $class;
         } else {
             $options[$key] = $class;

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -197,7 +197,9 @@ class Helper implements EventListenerInterface
      */
     public function addClass(array $options = [], $class = null, $key = 'class')
     {
-        if (isset($options[$key]) && trim($options[$key])) {
+        if (is_array($options[$key])) {
+            $options[$key][] = $class;
+        } else if (isset($options[$key]) && trim($options[$key])) {
             $options[$key] .= ' ' . $class;
         } else {
             $options[$key] = $class;

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -188,4 +188,75 @@ class HelperTest extends TestCase
         $result = $Helper->__debugInfo();
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Test addClass() with 'class'=>array
+     */
+    public function testAddClassArray()
+    {
+        $Helper = new TestHelper($this->View);
+        $input = array('class' => [
+            'element1',
+            'element2',
+        ]);
+        $expected = array('class' => [
+            'element1',
+            'element2',
+            'element3'
+        ]);
+
+        $this->assertEquals(
+            $Helper->addClass($input, 'element3'),
+            $expected
+        );
+    }
+
+    /**
+     * Test addClass() with 'class'=>string
+     */
+    public function testAddClassString()
+    {
+        $Helper = new TestHelper($this->View);
+
+        $input = array('class' => 'element1 element2');
+        $expected = array('class' => 'element1 element2 element3');
+
+        $this->assertEquals(
+            $Helper->addClass($input, 'element3'),
+            $expected
+        );
+    }
+
+    /**
+     * Test addClass() with no class element
+     */
+    public function testAddClassEmpty()
+    {
+        $Helper = new TestHelper($this->View);
+
+        $input = array();
+        $expected = array('class' => 'element3');
+
+        $this->assertEquals(
+            $Helper->addClass($input, 'element3'),
+            $expected
+        );
+
+    }
+
+    /**
+     * Test addClass() with adding null class
+     */
+    public function testAddClassNull()
+    {
+        $Helper = new TestHelper($this->View);
+
+        $input = array();
+        $expected = array('class' => '');
+
+        $this->assertEquals(
+            $Helper->addClass($input, null),
+            $expected
+        );
+    }
 }

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -241,7 +241,6 @@ class HelperTest extends TestCase
             $Helper->addClass($input, 'element3'),
             $expected
         );
-
     }
 
     /**

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -195,15 +195,15 @@ class HelperTest extends TestCase
     public function testAddClassArray()
     {
         $Helper = new TestHelper($this->View);
-        $input = array('class' => [
+        $input = ['class' => [
             'element1',
             'element2',
-        ]);
-        $expected = array('class' => [
+        ]];
+        $expected = ['class' => [
             'element1',
             'element2',
             'element3'
-        ]);
+        ]];
 
         $this->assertEquals(
             $Helper->addClass($input, 'element3'),
@@ -218,8 +218,8 @@ class HelperTest extends TestCase
     {
         $Helper = new TestHelper($this->View);
 
-        $input = array('class' => 'element1 element2');
-        $expected = array('class' => 'element1 element2 element3');
+        $input = ['class' => 'element1 element2'];
+        $expected = ['class' => 'element1 element2 element3'];
 
         $this->assertEquals(
             $Helper->addClass($input, 'element3'),
@@ -234,8 +234,8 @@ class HelperTest extends TestCase
     {
         $Helper = new TestHelper($this->View);
 
-        $input = array();
-        $expected = array('class' => 'element3');
+        $input = [];
+        $expected = ['class' => 'element3'];
 
         $this->assertEquals(
             $Helper->addClass($input, 'element3'),
@@ -251,8 +251,8 @@ class HelperTest extends TestCase
     {
         $Helper = new TestHelper($this->View);
 
-        $input = array();
-        $expected = array('class' => '');
+        $input = [];
+        $expected = ['class' => ''];
 
         $this->assertEquals(
             $Helper->addClass($input, null),


### PR DESCRIPTION
Fixes #11132 .

Adds support for the `class` element of an `$options` array to also be an array.