### PR TITLE
Fix redis increment/decrement with infinite timeout.

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -177,7 +177,9 @@ class RedisEngine extends CacheEngine
         $key = $this->_key($key);
 
         $value = (int)$this->_Redis->incrBy($key, $offset);
-        $this->_Redis->setTimeout($key, $duration);
+        if ($duration > 0) {
+            $this->_Redis->setTimeout($key, $duration);
+        }
 
         return $value;
     }
@@ -195,7 +197,9 @@ class RedisEngine extends CacheEngine
         $key = $this->_key($key);
 
         $value = (int)$this->_Redis->decrBy($key, $offset);
-        $this->_Redis->setTimeout($key, $duration);
+        if ($duration > 0) {
+            $this->_Redis->setTimeout($key, $duration);
+        }
 
         return $value;
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -340,6 +340,27 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * Test that increment() and decrement() can live forever.
+     *
+     * @return void
+     */
+    public function testIncrementDecrementForvever()
+    {
+        $this->_configCache(['duration' => 0]);
+        Cache::delete('test_increment', 'redis');
+        Cache::delete('test_decrement', 'redis');
+
+        $result = Cache::increment('test_increment', 1, 'redis');
+        $this->assertEquals(1, $result);
+
+        $result = Cache::decrement('test_decrement', 1, 'redis');
+        $this->assertEquals(-1, $result);
+
+        $this->assertEquals(1, Cache::read('test_increment', 'redis'));
+        $this->assertEquals(-1, Cache::read('test_decrement', 'redis'));
+    }
+
+    /**
      * Test that increment and decrement set ttls.
      *
      * @return void


### PR DESCRIPTION
When timeout is 0 (live forever) no TTL should be set on incremented/decremented keys.

Refs #11135