### PR TITLE
Fix #11140 - Added support for `fullBase` option in `::link()`.

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -346,7 +346,8 @@ class HtmlHelper extends Helper
     {
         $escapeTitle = true;
         if ($url !== null) {
-            $url = $this->Url->build($url);
+            $url = $this->Url->build($url, $options);
+            $options = array_diff_key($options, ['fullBase' => null]);
         } else {
             $url = $this->Url->build($title);
             $title = htmlspecialchars_decode($url, ENT_QUOTES);

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -347,7 +347,7 @@ class HtmlHelper extends Helper
         $escapeTitle = true;
         if ($url !== null) {
             $url = $this->Url->build($url, $options);
-            $options = array_diff_key($options, ['fullBase' => null]);
+            unset($options['fullBase']);
         } else {
             $url = $this->Url->build($title);
             $title = htmlspecialchars_decode($url, ENT_QUOTES);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -310,6 +310,14 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->link('say hello to 0123465-798', 'sms:0123465-798?body=hello "cakephp"');
         $expected = ['a' => ['href' => 'sms:0123465-798?body=hello &quot;cakephp&quot;'], 'say hello to 0123465-798', '/a'];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Html->link('Home', '/', ['fullBase' => true]);
+        $expected = ['a' => ['href' => 'http://localhost/'], 'Home', '/a'];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->link('Home', '/', ['fullBase' => false]);
+        $expected = ['a' => ['href' => '/'], 'Home', '/a'];
+        $this->assertHtml($expected, $result);
     }
 
     /**


### PR DESCRIPTION
Fixes #11140 
Includes test case for `fullBase`.