### PR TITLE
Improve warnings around Text::uuid()

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -35,29 +35,34 @@ class Text
      * Warning: This method should not be used as a random seed for any cryptographic operations.
      * Instead you should use the openssl or mcrypt extensions.
      *
+     * It should also not be used to create identifiers that have security implications, such as
+     * 'unguessable' URL identifiers. Instead you should use `Security::randomBytes()` for that.
+     *
      * @see https://www.ietf.org/rfc/rfc4122.txt
      * @return string RFC 4122 UUID
      * @copyright Matt Farina MIT License https://github.com/lootils/uuid/blob/master/LICENSE
      */
     public static function uuid()
     {
+        $random = function_exists('random_int') ? 'random_int' : 'mt_rand';
+
         return sprintf(
             '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
             // 32 bits for "time_low"
-            mt_rand(0, 65535),
-            mt_rand(0, 65535),
+            $random(0, 65535),
+            $random(0, 65535),
             // 16 bits for "time_mid"
-            mt_rand(0, 65535),
+            $random(0, 65535),
             // 12 bits before the 0100 of (version) 4 for "time_hi_and_version"
-            mt_rand(0, 4095) | 0x4000,
+            $random(0, 4095) | 0x4000,
             // 16 bits, 8 bits for "clk_seq_hi_res",
             // 8 bits for "clk_seq_low",
             // two most significant bits holds zero and one for variant DCE1.1
-            mt_rand(0, 0x3fff) | 0x8000,
+            $random(0, 0x3fff) | 0x8000,
             // 48 bits for "node"
-            mt_rand(0, 65535),
-            mt_rand(0, 65535),
-            mt_rand(0, 65535)
+            $random(0, 65535),
+            $random(0, 65535),
+            $random(0, 65535)
         );
     }
 


### PR DESCRIPTION
This function should not be used to generate 'secure' identifiers. While UUID v4 has a low chance of collisions it is not as foolproof as 64 fully random bytes.

I've also opted to use a more secure source of random integers in PHP7 as mersenne twister to reduce the risk of if these uuids are used in a security related context.