### PR TITLE
Logging email fails array to string conversion

### DIFF
--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2061,7 +2061,6 @@ class Email implements JsonSerializable, Serializable
         return $contents;
     }
 
-    
     /**
      * Log the email message delivery.
      *

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2101,6 +2101,7 @@ class Email implements JsonSerializable, Serializable
         return is_array($key) ? implode(';', $key) : (string) $key;
     }
 
+    
     /**
      * Static method to fast create an instance of \Cake\Mailer\Email
      *

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2060,7 +2060,8 @@ class Email implements JsonSerializable, Serializable
 
         return $contents;
     }
-
+    
+    
     /**
      * Log the email message delivery.
      *
@@ -2084,9 +2085,19 @@ class Email implements JsonSerializable, Serializable
         }
         Log::write(
             $config['level'],
-            PHP_EOL . $contents['headers'] . PHP_EOL . PHP_EOL . $contents['message'],
+            PHP_EOL . $this->_isKeyArray($contents['headers']) . PHP_EOL . PHP_EOL . $this->_isKeyArray($contents['message']),
             $config['scope']
         );
+    }
+    
+    
+    /**
+     * @param null $key
+     * @return null|string
+     */
+    private function _isKeyArray($key = null)
+    {
+        return is_array($key) ? implode(';', $key) : $key;
     }
 
     /**

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2089,7 +2089,8 @@ class Email implements JsonSerializable, Serializable
             $config['scope']
         );
     }
-
+    
+    
     /**
      * Converts an array to string
      * @param null $key

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2092,13 +2092,13 @@ class Email implements JsonSerializable, Serializable
     
     
     /**
-     * Converts $param to string if array given
+     * Converts $array to string if array given
      * @param null $key
      * @return string
      */
-    protected function flatten($param = null)
+    protected function flatten($array = null)
     {
-        return is_array($param) ? implode(';', $param) : (string) $param;
+        return is_array($array) ? implode(';', $array) : (string)$array;
     }
 
     

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2092,12 +2092,12 @@ class Email implements JsonSerializable, Serializable
     /**
      * Converts given value to string
      *
-     * @param string|array $value
+     * @param string|array $value The value to convert
      * @return string
      */
     protected function flatten($value)
     {
-        return is_array($value) ? implode(';', $value) : $value;
+        return is_array($value) ? implode(';', $value) : (string)$value;
     }
 
     /**

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2092,11 +2092,11 @@ class Email implements JsonSerializable, Serializable
     
     
     /**
-     * Converts $array to string if array given
-     * @param null $key
+     * Converts array to string
+     * @param array $array
      * @return string
      */
-    protected function flatten($array = null)
+    protected function flatten($array = [])
     {
         return is_array($array) ? implode(';', $array) : (string)$array;
     }

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2089,19 +2089,18 @@ class Email implements JsonSerializable, Serializable
             $config['scope']
         );
     }
-    
-    
+
     /**
      * Converts given value to string
-     * @param $value
+     *
+     * @param string|array $value
      * @return string
      */
     protected function flatten($value)
     {
-        return is_array($value) ? implode(';', $value) : (string)$value;
+        return is_array($value) ? implode(';', $value) : $value;
     }
 
-    
     /**
      * Static method to fast create an instance of \Cake\Mailer\Email
      *

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2092,13 +2092,13 @@ class Email implements JsonSerializable, Serializable
     
     
     /**
-     * Converts array to string
-     * @param array $array
+     * Converts given value to string
+     * @param $value
      * @return string
      */
-    protected function flatten($array = [])
+    protected function flatten($value)
     {
-        return is_array($array) ? implode(';', $array) : (string)$array;
+        return is_array($value) ? implode(';', $value) : (string)$value;
     }
 
     

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2092,13 +2092,13 @@ class Email implements JsonSerializable, Serializable
     
     
     /**
-     * Converts an array to string
+     * Converts $param to string if array given
      * @param null $key
      * @return string
      */
-    protected function flatten($key = null)
+    protected function flatten($param = null)
     {
-        return is_array($key) ? implode(';', $key) : (string) $key;
+        return is_array($param) ? implode(';', $param) : (string) $param;
     }
 
     

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -2060,7 +2060,7 @@ class Email implements JsonSerializable, Serializable
 
         return $contents;
     }
-    
+
     
     /**
      * Log the email message delivery.
@@ -2085,19 +2085,19 @@ class Email implements JsonSerializable, Serializable
         }
         Log::write(
             $config['level'],
-            PHP_EOL . $this->_isKeyArray($contents['headers']) . PHP_EOL . PHP_EOL . $this->_isKeyArray($contents['message']),
+            PHP_EOL . $this->flatten($contents['headers']) . PHP_EOL . PHP_EOL . $this->flatten($contents['message']),
             $config['scope']
         );
     }
-    
-    
+
     /**
+     * Converts an array to string
      * @param null $key
-     * @return null|string
+     * @return string
      */
-    private function _isKeyArray($key = null)
+    protected function flatten($key = null)
     {
-        return is_array($key) ? implode(';', $key) : $key;
+        return is_array($key) ? implode(';', $key) : (string) $key;
     }
 
     /**


### PR DESCRIPTION
Array to string conversion fails at class Email.php line 2087.
The _logDelivery function under Email.php is trying to convert an array to a string and it's failing as expected.