### PR TITLE
Add user specifc data to token hash to avoid privilige escalation

### DIFF
--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -378,7 +378,8 @@ class SecurityComponent extends Component
         return [
             $controller->request->here(),
             serialize($fieldList),
-            $unlocked
+            $unlocked,
+            session_id(),
         ];
     }
 

--- a/src/View/Helper/SecureFieldTokenTrait.php
+++ b/src/View/Helper/SecureFieldTokenTrait.php
@@ -55,7 +55,8 @@ trait SecureFieldTokenTrait
         $hashParts = [
             $url,
             serialize($fields),
-            $unlocked
+            $unlocked,
+            session_id(),
         ];
         $fields = hash_hmac('sha1', implode('', $hashParts), Security::getSalt());
 


### PR DESCRIPTION
Add user specifc data to token hash to avoid privilige escalation

Targeted against token-hmac branch of #11101 
