### PR TITLE
3.x - Fix error output line highlighting off by one.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -792,7 +792,7 @@ class Debugger
             $file = $files[1];
         }
         if ($file) {
-            $code = static::excerpt($file['file'], $file['line'] - 1, 1);
+            $code = static::excerpt($file['file'], $file['line'], 1);
         }
         $trace = static::trace(['start' => $data['start'], 'depth' => '20']);
         $insertOpts = ['before' => '{:', 'after' => '}'];

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -207,6 +207,31 @@ class DebuggerTest extends TestCase
     }
 
     /**
+     * Tests that the correct line is being highlighted.
+     *
+     * @return void
+     */
+    public function testOutputErrorLineHighlight()
+    {
+        Debugger::outputAs('js');
+
+        ob_start();
+        $debugger = Debugger::getInstance();
+        $data = [
+            'level' => E_NOTICE,
+            'code' => E_NOTICE,
+            'file' => __FILE__,
+            'line' => __LINE__,
+            'description' => 'Error description',
+            'start' => 1
+        ];
+        $debugger->outputError($data);
+        $result = ob_get_clean();
+
+        $this->assertRegExp('#^\<span class\="code\-highlight"\>.*outputError.*\</span\>$#m', $result);
+    }
+
+    /**
      * Tests that changes in output formats using Debugger::output() change the templates used.
      *
      * @return void


### PR DESCRIPTION
The debugger highlights the line before the actual line of error.
