### PR TITLE
Deprecate 2.x-finder option-style via Table::find() deprecationWarning

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1176,16 +1176,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function find($type = 'all', $options = [])
     {
         $deprecatedKeys = [
-            'fields',
-            'conditions',
-            'join',
-            'order',
-            'limit',
-            'offset',
-            'group',
-            'having',
-            'contain',
-            'page',
+            // 'fields', // 24 error warnings
+            // 'conditions', // 77 errors warnings, core seems to rely on thi...
+            'join', // 0 error warnings
+            // 'order', // 19 error warnings
+            // 'limit', // 21 error warnings
+            'offset', // 0 error warnings
+            // 'group', // 1 error warning in cakephp/src/Controller/Component/PaginatorComponent.php, line: 201
+            'having', // 0 error warnings
+            // 'contain', // 83 error warnings, core seems to rely on this...
+            // 'page', // 17 error warnings
         ];
 
         $deprecatedKeyWarns = [];

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1197,7 +1197,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($deprecatedKeyWarns !== []) {
             deprecationWarning(
                 '2.x-style finder options will be removed in 4.0, but you supplied following 2.x-style finder options: '
-                    . join(',', $deprecatedKeyWarns), 3);
+                . join(',', $deprecatedKeyWarns)
+            , 3);
         }
 
         $query = $this->query();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1175,6 +1175,31 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function find($type = 'all', $options = [])
     {
+        $deprecated2xKeys = [
+            'fields',
+            'conditions',
+            'join',
+            'order',
+            'limit',
+            'offset',
+            'group',
+            'having',
+            'contain',
+            'page',
+        ];
+
+        $possiblyDeprecated2xKeys = [];
+        foreach ($deprecated2xKeys as $key) {
+            if (array_key_exists($key, $options)) {
+                $possiblyDeprecated2xKeys[] = $option;
+            }
+        }
+        if ($possiblyDeprecated2xKeys !== []) {
+            deprecationWarning(
+                '2.x-style finder options will be removed in 4.0, but you supplied following 2.x-style finder options: '
+                    . join(',', $possiblyDeprecated2xKeys), 3);
+        }
+
         $query = $this->query();
         $query->select();
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1175,7 +1175,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function find($type = 'all', $options = [])
     {
-        $deprecated2xKeys = [
+        $deprecatedKeys = [
             'fields',
             'conditions',
             'join',
@@ -1188,16 +1188,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             'page',
         ];
 
-        $possiblyDeprecated2xKeys = [];
-        foreach ($deprecated2xKeys as $key) {
+        $deprecatedKeyWarns = [];
+        foreach ($deprecatedKeys as $key) {
             if (array_key_exists($key, $options)) {
-                $possiblyDeprecated2xKeys[] = $option;
+                $deprecatedKeyWarns[] = $key;
             }
         }
-        if ($possiblyDeprecated2xKeys !== []) {
+        if ($deprecatedKeyWarns !== []) {
             deprecationWarning(
                 '2.x-style finder options will be removed in 4.0, but you supplied following 2.x-style finder options: '
-                    . join(',', $possiblyDeprecated2xKeys), 3);
+                    . join(',', $deprecatedKeyWarns), 3);
         }
 
         $query = $this->query();


### PR DESCRIPTION
Ref: https://github.com/cakephp/cakephp/issues/11148#issuecomment-327344580