### PR TITLE
Fix CLI session ID to be set, resolves regression.

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -455,7 +455,7 @@ class Session
      */
     public function id($id = null)
     {
-        if ($id !== null) {
+        if ($id !== null && ($this->_isCLI || !headers_sent())) {
             session_id($id);
         }
 

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -455,7 +455,7 @@ class Session
      */
     public function id($id = null)
     {
-        if ($id !== null && !headers_sent()) {
+        if ($id !== null) {
             session_id($id);
         }
 


### PR DESCRIPTION
There was a regression in how tests can access the session id to set a non empty value.
The headers_sent() here does not seem to be allowed to check.
The id('cli') is non functional right now on CLI, failing all tests that require this to work as it used to.

This resolves tests for now broken travis runs @ e.g. https://github.com/dereuromark/cakephp-captcha
And also removes tmp workarounds like [this](https://github.com/dereuromark/cakephp-captcha/commit/c0e2c316ce43b355ab1f3ba01e1a40b6e53d79a4).

The alternative if we only want to allow this for CLI could be:
```php
    if ($id !== null && ($this->_isCLI || !headers_sent())) {}
```