### PR TITLE
Fix integration tests when named routes are used

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -48,7 +48,7 @@ class RoutingMiddleware
     }
 
     /**
-     * Trigger the application's routes() hook if the application exists.
+     * Trigger the application's routes() hook if the application exists and Router isn't initialized.
      *
      * If the middleware is created without an Application, routes will be
      * loaded via the automatic route loading that pre-dates the routes() hook.
@@ -57,7 +57,7 @@ class RoutingMiddleware
      */
     protected function loadRoutes()
     {
-        if ($this->app) {
+        if ($this->app && !Router::$initialized) {
             $builder = Router::createRouteBuilder('/');
             $this->app->routes($builder);
             // Prevent routes from being loaded again

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\TestSuite;
 
+use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Routing\DispatcherFactory;
@@ -187,6 +188,24 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         $this->_response = null;
         $this->get('/get/request_action/test_request_action');
         $this->assertEquals('This is a test', $this->_response->getBody());
+    }
+
+    /**
+     * Test sending get request and using default `test_app/config/routes.php`.
+     *
+     * @return void
+     */
+    public function testGetUsingApplicationWithDefaultRoutes()
+    {
+        // first clean routes to have Router::$initailized === false
+        Router::reload();
+
+        $this->useHttpServer(true);
+        $this->configApplication(Configure::read('App.namespace') . '\ApplicationWithDefaultRoutes', null);
+
+        $this->get('/some_alias');
+        $this->assertResponseOk();
+        $this->assertEquals('5', $this->_getBodyAsString());
     }
 
     /**

--- a/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.2
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp;
+
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Simple Application class doing nothing that:
+ *
+ * - do nothing in bootstrap
+ * - add just `RoutingMiddleware` to middleware queue
+ *
+ * Useful to test app using the default `BaseApplication::routes()` method
+ */
+class ApplicationWithDefaultRoutes extends BaseApplication
+{
+    /**
+     * Bootstrap hook.
+     *
+     * Nerfed as this is for IntegrationTestCase testing.
+     *
+     * @return void
+     */
+    public function bootstrap()
+    {
+        // Do nothing.
+    }
+
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -17,6 +17,15 @@ use Cake\Routing\Router;
 Router::extensions('json');
 Router::scope('/', function ($routes) {
     $routes->connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);
-    $routes->connect('/some_alias', ['controller' => 'tests_apps', 'action' => 'some_method']);
+    $routes->connect(
+        '/some_alias',
+        [
+            'controller' => 'tests_apps',
+            'action' => 'some_method'],
+        [
+            '_name' => 'some_alias',
+            'routeClass' => 'InflectedRoute',
+        ]
+    );
     $routes->fallbacks();
 });


### PR DESCRIPTION
This PR fix #11160 

The issue here is that in `Application` class of cakephp/app 3.5 the `RoutingMiddlawere` is initialized using the `Application` class and `RoutingMiddleware::loadRoutes()` try to load the route rules again also if they are already loaded in other place as in `Router::url()` called in `IntegrationTestCase::_url()`.

I tried to reproduce that case in unit test. I hope it's ok.