### PR TITLE
Support protocol relative URL in HTTP Client.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -448,15 +448,20 @@ class Client
             $url .= $q;
             $url .= is_string($query) ? $query : http_build_query($query);
         }
-        if (preg_match('#^https?://#', $url)) {
-            return $url;
-        }
         $defaults = [
             'host' => null,
             'port' => null,
             'scheme' => 'http',
         ];
         $options += $defaults;
+
+        if (preg_match('#^//#', $url)) {
+            $url = $options['scheme'] . ':' . $url;
+        }
+        if (preg_match('#^https?://#', $url)) {
+            return $url;
+        }
+
         $defaultPorts = [
             'http' => 80,
             'https' => 443

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -402,7 +402,8 @@ class Client
                 $locationUrl = $this->buildUrl($location, [], [
                     'host' => $url->getHost(),
                     'port' => $url->getPort(),
-                    'scheme' => $url->getScheme()
+                    'scheme' => $url->getScheme(),
+                    'protocolRelative' => true
                 ]);
 
                 $request = $request->withUri(new Uri($locationUrl));
@@ -452,10 +453,11 @@ class Client
             'host' => null,
             'port' => null,
             'scheme' => 'http',
+            'protocolRelative' => false
         ];
         $options += $defaults;
 
-        if (preg_match('#^//#', $url)) {
+        if ($options['protocolRelative'] && preg_match('#^//#', $url)) {
             $url = $options['scheme'] . ':' . $url;
         }
         if (preg_match('#^https?://#', $url)) {

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -139,12 +139,24 @@ class ClientTest extends TestCase
             ],
             [
                 'http://example.com/test.html',
+                '//test.html',
+                [],
+                [
+                    'scheme' => 'http',
+                    'host' => 'example.com',
+                    'protocolRelative' => false
+                ],
+                'url with a double slash',
+            ],
+            [
+                'http://example.com/test.html',
                 '//example.com/test.html',
                 [],
                 [
-                    'scheme' => 'http'
+                    'scheme' => 'http',
+                    'protocolRelative' => true
                 ],
-                'url without a scheme',
+                'protocol relative url',
             ],
         ];
     }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -137,6 +137,15 @@ class ClientTest extends TestCase
                 [],
                 'query string data with some already on the url.'
             ],
+            [
+                'http://example.com/test.html',
+                '//example.com/test.html',
+                [],
+                [
+                    'scheme' => 'http'
+                ],
+                'url without a scheme',
+            ],
         ];
     }
 


### PR DESCRIPTION
Some servers set `//example.com` as a `Location` header. `buildUrl()` needs to support that in order to build absolute urls.