### PR TITLE
Mute E_DEPRECATED warnings during tests and add depreciation warnings

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,8 @@
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
-        <ini name="error_reporting" value="E_ALL ~ &amp;E_USER_DEPRECATED"/>
+        <!-- E_ALL & ~E_USER_DEPRECATED -->
+        <ini name="error_reporting" value="16383"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
+        <ini name="error_reporting" value="E_ALL ~ &amp;E_USER_DEPRECATED"/>
     </php>
 
     <testsuites>

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -351,6 +351,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function column($name)
     {
+        deprecationWarning('TableSchema::column() is deprecated. Use TableSchema::getColumn() instead.');
+
         return $this->getColumn($name);
     }
 
@@ -379,6 +381,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function columnType($name, $type = null)
     {
+        deprecationWarning('TableSchema::columnType() is deprecated. Use TableSchema::setColumnType() or TableSchema::getColumnType() instead.');
+
         if ($type !== null) {
             $this->setColumnType($name, $type);
         }
@@ -536,6 +540,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function index($name)
     {
+        deprecationWarning('TableSchema::index() is deprecated. Use TableSchema::getIndex() instead.');
+
         return $this->getIndex($name);
     }
 
@@ -689,6 +695,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function constraint($name)
     {
+        deprecationWarning('TableSchema::constraint() is deprecated. Use TableSchema::getConstraint() instead.');
+
         return $this->getConstraint($name);
     }
 
@@ -734,6 +742,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function options($options = null)
     {
+        deprecationWarning('TableSchema::options() is deprecated. Use TableSchema::setOptions() or TableSchema::getOptions() instead.');
+
         if ($options !== null) {
             return $this->setOptions($options);
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -378,7 +378,7 @@ SQL;
         foreach ($expected as $field => $definition) {
             $this->assertEquals(
                 $definition,
-                $result->column($field),
+                $result->getColumn($field),
                 'Field definition does not match for ' . $field
             );
         }
@@ -468,11 +468,11 @@ SQL;
         $table = $schema->describe('odd_primary_key');
         $connection->execute('DROP TABLE odd_primary_key');
 
-        $column = $table->column('id');
+        $column = $table->getColumn('id');
         $this->assertNull($column['autoIncrement'], 'should not autoincrement');
         $this->assertTrue($column['unsigned'], 'should be unsigned');
 
-        $column = $table->column('other_field');
+        $column = $table->getColumn('other_field');
         $this->assertTrue($column['autoIncrement'], 'should not autoincrement');
         $this->assertFalse($column['unsigned'], 'should not be unsigned');
 
@@ -1057,7 +1057,7 @@ SQL;
                 'type' => 'primary',
                 'columns' => ['id']
             ])
-            ->options([
+            ->setOptions([
                 'engine' => 'InnoDB',
                 'charset' => 'utf8',
                 'collate' => 'utf8_general_ci',
@@ -1110,7 +1110,7 @@ SQL;
                 'type' => 'primary',
                 'columns' => ['id']
             ])
-            ->options([
+            ->setOptions([
                 'engine' => 'InnoDB',
                 'charset' => 'utf8',
                 'collate' => 'utf8_general_ci',

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -421,9 +421,9 @@ SQL;
                 'delete' => 'restrict',
             ]
         ];
-        $this->assertEquals($expected['primary'], $result->constraint('primary'));
-        $this->assertEquals($expected['length_idx'], $result->constraint('length_idx'));
-        $this->assertEquals($expected['schema_articles_ibfk_1'], $result->constraint('schema_articles_ibfk_1'));
+        $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
+        $this->assertEquals($expected['length_idx'], $result->getConstraint('length_idx'));
+        $this->assertEquals($expected['schema_articles_ibfk_1'], $result->getConstraint('schema_articles_ibfk_1'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [
@@ -431,7 +431,7 @@ SQL;
             'columns' => ['author_id'],
             'length' => []
         ];
-        $this->assertEquals($expected, $result->index('author_idx'));
+        $this->assertEquals($expected, $result->getIndex('author_idx'));
     }
 
     /**
@@ -446,8 +446,8 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_articles');
-        $this->assertArrayHasKey('engine', $result->options());
-        $this->assertArrayHasKey('collation', $result->options());
+        $this->assertArrayHasKey('engine', $result->getOptions());
+        $this->assertArrayHasKey('collation', $result->getOptions());
     }
 
     public function testDescribeNonPrimaryAutoIncrement()
@@ -1293,7 +1293,7 @@ SQL;
         ];
         $this->assertEquals(
             $expected,
-            $result->column('data'),
+            $result->getColumn('data'),
             'Field definition does not match for data'
         );
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -405,7 +405,7 @@ SQL;
         ];
         $this->assertEquals(['id'], $result->primaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->column($field));
+            $this->assertEquals($definition, $result->getColumn($field));
         }
     }
 
@@ -432,8 +432,8 @@ SQL;
         $connection->execute('DROP TABLE schema_composite');
 
         $this->assertEquals(['id', 'site_id'], $result->primaryKey());
-        $this->assertTrue($result->column('id')['autoIncrement'], 'id should be autoincrement');
-        $this->assertNull($result->column('site_id')['autoIncrement'], 'site_id should not be autoincrement');
+        $this->assertTrue($result->getColumn('id')['autoIncrement'], 'id should be autoincrement');
+        $this->assertNull($result->getColumn('site_id')['autoIncrement'], 'site_id should not be autoincrement');
     }
 
     /**
@@ -498,7 +498,7 @@ SQL;
         ];
         $this->assertEquals(['id'], $result->primaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->column($field), "Mismatch in $field column");
+            $this->assertEquals($definition, $result->getColumn($field), "Mismatch in $field column");
         }
     }
 
@@ -528,8 +528,8 @@ SQL;
             ]
         ];
         $this->assertCount(2, $result->constraints());
-        $this->assertEquals($expected['primary'], $result->constraint('primary'));
-        $this->assertEquals($expected['unique_position'], $result->constraint('unique_position'));
+        $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
+        $this->assertEquals($expected['unique_position'], $result->getConstraint('unique_position'));
     }
 
     /**
@@ -578,9 +578,9 @@ SQL;
                 'delete' => 'restrict',
             ]
         ];
-        $this->assertEquals($expected['primary'], $result->constraint('primary'));
-        $this->assertEquals($expected['content_idx'], $result->constraint('content_idx'));
-        $this->assertEquals($expected['author_idx'], $result->constraint('author_idx'));
+        $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
+        $this->assertEquals($expected['content_idx'], $result->getConstraint('content_idx'));
+        $this->assertEquals($expected['author_idx'], $result->getConstraint('author_idx'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [
@@ -588,7 +588,7 @@ SQL;
             'columns' => ['author_id'],
             'length' => []
         ];
-        $this->assertEquals($expected, $result->index('author_idx'));
+        $this->assertEquals($expected, $result->getIndex('author_idx'));
     }
 
     /**
@@ -631,7 +631,7 @@ SQL;
             'columns' => ['group_id', 'grade'],
             'length' => []
         ];
-        $this->assertEquals($expected, $result->index('schema_index_nulls'));
+        $this->assertEquals($expected, $result->getIndex('schema_index_nulls'));
         $connection->execute('DROP TABLE schema_index');
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -371,7 +371,7 @@ SQL;
         $this->assertInstanceOf('Cake\Database\Schema\Table', $result);
         $this->assertEquals(['id'], $result->primaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->column($field));
+            $this->assertEquals($definition, $result->getColumn($field));
         }
     }
 
@@ -391,8 +391,8 @@ SQL;
         $result = $schema->describe('schema_composite');
 
         $this->assertEquals(['id', 'site_id'], $result->primaryKey());
-        $this->assertNull($result->column('site_id')['autoIncrement'], 'site_id should not be autoincrement');
-        $this->assertNull($result->column('id')['autoIncrement'], 'id should not be autoincrement');
+        $this->assertNull($result->getColumn('site_id')['autoIncrement'], 'site_id should not be autoincrement');
+        $this->assertNull($result->getColumn('id')['autoIncrement'], 'id should not be autoincrement');
     }
 
     /**
@@ -429,14 +429,14 @@ SQL;
             ]
         ];
         $this->assertCount(3, $result->constraints());
-        $this->assertEquals($expected['primary'], $result->constraint('primary'));
+        $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals(
             $expected['sqlite_autoindex_schema_articles_1'],
-            $result->constraint('sqlite_autoindex_schema_articles_1')
+            $result->getConstraint('sqlite_autoindex_schema_articles_1')
         );
         $this->assertEquals(
             $expected['author_id_fk'],
-            $result->constraint('author_id_fk')
+            $result->getConstraint('author_id_fk')
         );
 
         $this->assertCount(1, $result->indexes());
@@ -445,7 +445,7 @@ SQL;
             'columns' => ['created'],
             'length' => []
         ];
-        $this->assertEquals($expected, $result->index('created_idx'));
+        $this->assertEquals($expected, $result->getIndex('created_idx'));
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -408,7 +408,7 @@ SQL;
         ];
         $this->assertEquals(['id'], $result->primaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->column($field), 'Failed to match field ' . $field);
+            $this->assertEquals($definition, $result->getColumn($field), 'Failed to match field ' . $field);
         }
     }
 
@@ -435,8 +435,8 @@ SQL;
         $connection->execute('DROP TABLE schema_composite');
 
         $this->assertEquals(['id', 'site_id'], $result->primaryKey());
-        $this->assertNull($result->column('site_id')['autoIncrement'], 'site_id should not be autoincrement');
-        $this->assertTrue($result->column('id')['autoIncrement'], 'id should be autoincrement');
+        $this->assertNull($result->getColumn('site_id')['autoIncrement'], 'site_id should not be autoincrement');
+        $this->assertTrue($result->getColumn('id')['autoIncrement'], 'id should be autoincrement');
     }
 
     /**
@@ -489,9 +489,9 @@ SQL;
                 'delete' => 'cascade',
             ]
         ];
-        $this->assertEquals($expected['primary'], $result->constraint('primary'));
-        $this->assertEquals($expected['content_idx'], $result->constraint('content_idx'));
-        $this->assertEquals($expected['author_idx'], $result->constraint('author_idx'));
+        $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
+        $this->assertEquals($expected['content_idx'], $result->getConstraint('content_idx'));
+        $this->assertEquals($expected['author_idx'], $result->getConstraint('author_idx'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [
@@ -499,7 +499,7 @@ SQL;
             'columns' => ['author_id'],
             'length' => []
         ];
-        $this->assertEquals($expected, $result->index('author_idx'));
+        $this->assertEquals($expected, $result->getIndex('author_idx'));
     }
 
     /**

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -530,7 +530,6 @@ class TableTest extends TestCase
         $this->assertEquals($options, $table->getOptions());
     }
 
-
     /**
      * Test the options method.
      *
@@ -539,6 +538,7 @@ class TableTest extends TestCase
      */
     public function testOptionsDeprecated()
     {
+        $errorLevel = error_reporting(E_ALL & ~E_USER_DEPRECATED);
         $table = new Table('articles');
         $options = [
             'engine' => 'InnoDB'
@@ -546,6 +546,7 @@ class TableTest extends TestCase
         $return = $table->options($options);
         $this->assertInstanceOf('Cake\Database\Schema\Table', $return);
         $this->assertEquals($options, $table->options());
+        error_reporting($errorLevel);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -136,7 +136,7 @@ class TableTest extends TestCase
 
         $this->assertSame($table, $result);
         $this->assertEquals([], $table->columns());
-        $this->assertNull($table->column('title'));
+        $this->assertNull($table->getColumn('title'));
         $this->assertSame([], $table->typeMap());
     }
 
@@ -175,16 +175,16 @@ class TableTest extends TestCase
             'length' => 25,
             'null' => false
         ]);
-        $this->assertEquals('string', $table->columnType('title'));
-        $this->assertNull($table->columnType('not there'));
+        $this->assertEquals('string', $table->getColumnType('title'));
+        $this->assertNull($table->getColumnType('not there'));
     }
 
     /**
-     * Test columnType setter method
+     * Test setColumnType setter method
      *
      * @return void
      */
-    public function testColumnTypeSet()
+    public function testSetColumnType()
     {
         $table = new Table('articles');
         $table->addColumn('title', [
@@ -192,9 +192,9 @@ class TableTest extends TestCase
             'length' => 25,
             'null' => false
         ]);
-        $this->assertEquals('string', $table->columnType('title'));
-        $table->columnType('title', 'json');
-        $this->assertEquals('json', $table->columnType('title'));
+        $this->assertEquals('string', $table->getColumnType('title'));
+        $table->setColumnType('title', 'json');
+        $this->assertEquals('json', $table->getColumnType('title'));
     }
 
     /**
@@ -211,7 +211,7 @@ class TableTest extends TestCase
             'length' => 25,
             'null' => false
         ]);
-        $this->assertEquals('json', $table->columnType('title'));
+        $this->assertEquals('json', $table->getColumnType('title'));
         $this->assertEquals('text', $table->baseColumnType('title'));
     }
 
@@ -228,7 +228,7 @@ class TableTest extends TestCase
             'type' => 'foo',
             'null' => false
         ]);
-        $this->assertEquals('foo', $table->columnType('thing'));
+        $this->assertEquals('foo', $table->getColumnType('thing'));
         $this->assertEquals('integer', $table->baseColumnType('thing'));
     }
 
@@ -243,7 +243,7 @@ class TableTest extends TestCase
         $table->addColumn('title', [
             'type' => 'string'
         ]);
-        $result = $table->column('title');
+        $result = $table->getColumn('title');
         $expected = [
             'type' => 'string',
             'length' => null,
@@ -259,7 +259,7 @@ class TableTest extends TestCase
         $table->addColumn('author_id', [
             'type' => 'integer'
         ]);
-        $result = $table->column('author_id');
+        $result = $table->getColumn('author_id');
         $expected = [
             'type' => 'integer',
             'length' => null,
@@ -275,7 +275,7 @@ class TableTest extends TestCase
         $table->addColumn('amount', [
             'type' => 'decimal'
         ]);
-        $result = $table->column('amount');
+        $result = $table->getColumn('amount');
         $expected = [
             'type' => 'decimal',
             'length' => null,
@@ -525,6 +525,24 @@ class TableTest extends TestCase
         $options = [
             'engine' => 'InnoDB'
         ];
+        $return = $table->setOptions($options);
+        $this->assertInstanceOf('Cake\Database\Schema\Table', $return);
+        $this->assertEquals($options, $table->getOptions());
+    }
+
+
+    /**
+     * Test the options method.
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testOptionsDeprecated()
+    {
+        $table = new Table('articles');
+        $options = [
+            'engine' => 'InnoDB'
+        ];
         $return = $table->options($options);
         $this->assertInstanceOf('Cake\Database\Schema\Table', $return);
         $this->assertEquals($options, $table->options());
@@ -557,7 +575,7 @@ class TableTest extends TestCase
     public function testConstraintForeignKey()
     {
         $table = TableRegistry::get('ArticlesTags');
-        $compositeConstraint = $table->schema()->constraint('tag_id_fk');
+        $compositeConstraint = $table->schema()->getConstraint('tag_id_fk');
         $expected = [
             'type' => 'foreign',
             'columns' => ['tag_id'],
@@ -581,7 +599,7 @@ class TableTest extends TestCase
     public function testConstraintForeignKeyTwoColumns()
     {
         $table = TableRegistry::get('Orders');
-        $compositeConstraint = $table->schema()->constraint('product_category_fk');
+        $compositeConstraint = $table->schema()->getConstraint('product_category_fk');
         $expected = [
             'type' => 'foreign',
             'columns' => [

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -412,7 +412,7 @@ class TableLocatorTest extends TestCase
         $this->assertEquals('users', $table->alias());
         $this->assertSame($connection, $table->connection());
         $this->assertEquals(array_keys($schema), $table->schema()->columns());
-        $this->assertEquals($schema['id']['type'], $table->schema()->column('id')['type']);
+        $this->assertEquals($schema['id']['type'], $table->schema()->getColumnType('id'));
 
         $this->_locator->clear();
         $this->assertEmpty($this->_locator->config());
@@ -424,7 +424,7 @@ class TableLocatorTest extends TestCase
         $this->assertEquals('users', $table->alias());
         $this->assertSame($connection, $table->connection());
         $this->assertEquals(array_keys($schema), $table->schema()->columns());
-        $this->assertEquals($schema['id']['type'], $table->schema()->column('id')['type']);
+        $this->assertEquals($schema['id']['type'], $table->schema()->getColumnType('id'));
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -346,12 +346,12 @@ class TableTest extends TestCase
             ->method('_initializeSchema')
             ->with($schema)
             ->will($this->returnCallback(function ($schema) {
-                $schema->columnType('username', 'integer');
+                $schema->setColumnType('username', 'integer');
 
                 return $schema;
             }));
         $result = $table->schema();
-        $schema->columnType('username', 'integer');
+        $schema->setColumnType('username', 'integer');
         $this->assertEquals($schema, $result);
         $this->assertEquals($schema, $table->schema(), '_initializeSchema should be called once');
     }

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -158,7 +158,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => []
         ];
-        $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
+        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
         $this->manager->unload($test);
 
         $this->manager->load($test);
@@ -177,7 +177,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => []
         ];
-        $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
+        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
 
         $this->manager->unload($test);
     }
@@ -358,7 +358,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => []
         ];
-        $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
+        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
         $this->assertCount(4, $results);
 
         $this->manager->unload($test);
@@ -383,7 +383,7 @@ class FixtureManagerTest extends TestCase
             'delete' => 'cascade',
             'length' => []
         ];
-        $this->assertEquals($expectedConstraint, $schema->constraint('tag_id_fk'));
+        $this->assertEquals($expectedConstraint, $schema->getConstraint('tag_id_fk'));
         $this->assertCount(4, $results);
         $this->manager->unload($test);
     }

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -689,7 +689,7 @@ class EntityContextTest extends TestCase
     public function testValSchemaDefault()
     {
         $table = TableRegistry::get('Articles');
-        $column = $table->schema()->column('title');
+        $column = $table->schema()->getColumn('title');
         $table->schema()->addColumn('title', ['default' => 'default title'] + $column);
         $row = $table->newEntity();
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4379,7 +4379,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $Articles = TableRegistry::get('Articles');
-        $title = $Articles->schema()->column('title');
+        $title = $Articles->schema()->getColumn('title');
         $Articles->schema()->addColumn(
             'title',
             ['default' => 'default title'] + $title
@@ -4714,7 +4714,7 @@ class FormHelperTest extends TestCase
     public function testRadioDefaultValue()
     {
         $Articles = TableRegistry::get('Articles');
-        $title = $Articles->schema()->column('title');
+        $title = $Articles->schema()->getColumn('title');
         $Articles->schema()->addColumn(
             'title',
             ['default' => '1'] + $title


### PR DESCRIPTION
First batch of added deprecation warnings. How atomic should we do this?
Also, which test should be updated?
For example `EntityContextTest::testValSchemaDefault` calls `$table->schema()->column('title');`.
Should this become `getColumn()`?
We also have a whole test file for `Cake\Database\Schema\Table`