### PR TITLE
Make AssociationCollection aware of a table locator.

### DIFF
--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -16,6 +16,7 @@ namespace Cake\ORM;
 
 use ArrayIterator;
 use Cake\Datasource\EntityInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use InvalidArgumentException;
 use IteratorAggregate;
 
@@ -29,6 +30,7 @@ class AssociationCollection implements IteratorAggregate
 {
 
     use AssociationsNormalizerTrait;
+    use LocatorAwareTrait;
 
     /**
      * Stored associations

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -57,6 +57,30 @@ class AssociationCollection implements IteratorAggregate
     }
 
     /**
+     * Creates and adds the Association object to this collection.
+     *
+     * @param string $className The name of association class.
+     * @param string $associated The alias for the target table.
+     * @param array $options List of options to configure the association definition.
+     * @return \Cake\ORM\Association
+     * @throws InvalidArgumentException
+     */
+    public function load($className, $associated, array $options = [])
+    {
+        $options += [
+            'tableLocator' => $this->getTableLocator()
+        ];
+
+        $association = new $className($associated, $options);
+        if (!$association instanceof Association) {
+            $message = sprintf('The association must extend `%s` class, `%s` given.', Association::class, get_class($association));
+            throw new InvalidArgumentException($message);
+        }
+
+        return $this->add($association->getName(), $association);
+    }
+
+    /**
      * Fetch an attached association by name.
      *
      * @param string $alias The association alias to get.

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -17,6 +17,7 @@ namespace Cake\ORM;
 use ArrayIterator;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Locator\LocatorInterface;
 use InvalidArgumentException;
 use IteratorAggregate;
 
@@ -38,6 +39,21 @@ class AssociationCollection implements IteratorAggregate
      * @var \Cake\ORM\Association[]
      */
     protected $_items = [];
+
+    /**
+     * Constructor.
+     *
+     * Sets the default table locator for associations.
+     * If no locator is provided, the global one will be used.
+     *
+     * @param \Cake\ORM\Locator\LocatorInterface|null $tableLocator Table locator instance.
+     */
+    public function __construct(LocatorInterface $tableLocator = null)
+    {
+        if ($tableLocator !== null) {
+            $this->_tableLocator = $tableLocator;
+        }
+    }
 
     /**
      * Add an association to the collection

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -16,6 +16,7 @@ namespace Cake\ORM\Locator;
 
 use Cake\Core\App;
 use Cake\Datasource\ConnectionManager;
+use Cake\ORM\AssociationCollection;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 use RuntimeException;
@@ -210,6 +211,11 @@ class TableLocator implements LocatorInterface
                 $connectionName = $className::defaultConnectionName();
             }
             $options['connection'] = ConnectionManager::get($connectionName);
+        }
+        if (empty($options['associations'])) {
+            $associations = new AssociationCollection();
+            $associations->setTableLocator($this);
+            $options['associations'] = $associations;
         }
 
         $options['registryAlias'] = $alias;

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -213,8 +213,7 @@ class TableLocator implements LocatorInterface
             $options['connection'] = ConnectionManager::get($connectionName);
         }
         if (empty($options['associations'])) {
-            $associations = new AssociationCollection();
-            $associations->setTableLocator($this);
+            $associations = new AssociationCollection($this);
             $options['associations'] = $associations;
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -967,9 +967,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function belongsTo($associated, array $options = [])
     {
         $options += ['sourceTable' => $this];
-        $association = new BelongsTo($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->load(BelongsTo::class, $associated, $options);
     }
 
     /**
@@ -1011,9 +1010,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function hasOne($associated, array $options = [])
     {
         $options += ['sourceTable' => $this];
-        $association = new HasOne($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->load(HasOne::class, $associated, $options);
     }
 
     /**
@@ -1061,9 +1059,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function hasMany($associated, array $options = [])
     {
         $options += ['sourceTable' => $this];
-        $association = new HasMany($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->load(HasMany::class, $associated, $options);
     }
 
     /**
@@ -1113,9 +1110,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function belongsToMany($associated, array $options = [])
     {
         $options += ['sourceTable' => $this];
-        $association = new BelongsToMany($associated, $options);
 
-        return $this->_associations->add($association->getName(), $association);
+        return $this->_associations->load(BelongsToMany::class, $associated, $options);
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -19,6 +19,7 @@ use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorInterface;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -40,6 +41,20 @@ class AssociationCollectionTest extends TestCase
     {
         parent::setUp();
         $this->associations = new AssociationCollection();
+    }
+
+    /**
+     * Test the constructor.
+     *
+     * @return void
+     */
+    public function testConstructor()
+    {
+        $this->assertSame(TableRegistry::getTableLocator(), $this->associations->getTableLocator());
+
+        $tableLocator = $this->createMock(LocatorInterface::class);
+        $associations = new AssociationCollection($tableLocator);
+        $this->assertSame($tableLocator, $associations->getTableLocator());
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -18,6 +18,7 @@ use Cake\ORM\AssociationCollection;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
+use Cake\ORM\Locator\LocatorInterface;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -68,6 +69,47 @@ class AssociationCollectionTest extends TestCase
         $this->assertFalse($this->associations->has('Users'));
         $this->assertNull($this->associations->get('users'));
         $this->assertNull($this->associations->get('Users'));
+    }
+
+    /**
+     * Test the load method.
+     *
+     * @return void
+     */
+    public function testLoad()
+    {
+        $this->associations->load(BelongsTo::class, 'Users');
+        $this->assertTrue($this->associations->has('Users'));
+        $this->assertInstanceOf(BelongsTo::class, $this->associations->get('Users'));
+        $this->assertSame($this->associations->getTableLocator(), $this->associations->get('Users')->getTableLocator());
+    }
+
+    /**
+     * Test the load method with custom locator.
+     *
+     * @return void
+     */
+    public function testLoadCustomLocator()
+    {
+        $locator = $this->createMock(LocatorInterface::class);
+        $this->associations->load(BelongsTo::class, 'Users', [
+            'tableLocator' => $locator
+        ]);
+        $this->assertTrue($this->associations->has('Users'));
+        $this->assertInstanceOf(BelongsTo::class, $this->associations->get('Users'));
+        $this->assertSame($locator, $this->associations->get('Users')->getTableLocator());
+    }
+
+    /**
+     * Test load invalid class.
+     *
+     * @return void
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The association must extend `Cake\ORM\Association` class, `stdClass` given.
+     */
+    public function testLoadInvalid()
+    {
+        $this->associations->load('stdClass', 'Users');
     }
 
     /**

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -164,6 +164,8 @@ class TableLocatorTest extends TestCase
         $result2 = $this->_locator->get('Articles');
         $this->assertSame($result, $result2);
         $this->assertEquals('my_articles', $result->table());
+
+        $this->assertSame($this->_locator, $result->associations()->getTableLocator());
     }
 
     /**


### PR DESCRIPTION
Alternative for #11072

Following https://github.com/cakephp/cakephp/issues/11023#issuecomment-321171559

-----

`TableLocator` instance passes itself to the `AssociationCollection` object. Then the locator is being passed to the created associations. The association creation has been delegated to new `AssociationCollection::load()` method.

This allows to isolate tables created with a particular table locator making independent of a "global" table locator. 

This also makes sure that associations created by tables originating from different locators do not collide making it possible to isolate parts of the system where groups of tables should behave differently in some scenarios, ie share different connections.

For example:

```php
class OrdersTable extends Table
{
    public function initialize()
    {
        $this->hasMany('Articles');
    }
}

class ConnectionAwareLocator extends TableLocator
{
    public function __construct(ConnectionInterface $connection)
    {
        $this->connection = $connection;
    }

    public function get($alias, array $options = [])
    {
        $table = parent::get($alias, $options);
        return $table->setConnection($this->connection);
    }
}

$fooLocator = new ConnectionAwareLocator(ConnectionManager::get('foo'));
$table = $fooLocator->get('Orders');
//this table and it's associations share the "foo" connection


$barLocator = new ConnectionAwareLocator(ConnectionManager::get('bar'));
$table = $barLocator->get('Orders');
//this table and it's associations share the "bar" connection
```