### PR TITLE
Fix backwards compatibility with CommandRunner.

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -23,6 +23,7 @@ use Cake\Core\ConsoleApplicationInterface;
 use Cake\Event\EventManagerTrait;
 use Cake\Shell\HelpShell;
 use Cake\Shell\VersionShell;
+use Cake\Utility\Inflector;
 use RuntimeException;
 
 /**
@@ -168,6 +169,9 @@ class CommandRunner
         }
         if (isset($this->aliases[$name])) {
             $name = $this->aliases[$name];
+        }
+        if (!$commands->has($name)) {
+            $name = Inflector::underscore($name);
         }
         if (!$commands->has($name)) {
             throw new RuntimeException(

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -209,6 +209,29 @@ class CommandRunnerTest extends TestCase
     }
 
     /**
+     * Test running a valid command and that backwards compatible
+     * inflection is hooked up.
+     *
+     * @return void
+     */
+    public function testRunValidCommandInflection()
+    {
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->setMethods(['middleware', 'bootstrap'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
+
+        $output = new ConsoleOutput();
+
+        $runner = new CommandRunner($app, 'cake');
+        $result = $runner->run(['cake', 'OrmCache', 'build'], $this->getMockIo($output));
+        $this->assertSame(Shell::CODE_SUCCESS, $result);
+
+        $contents = implode("\n", $output->messages());
+        $this->assertContains('Cache', $contents);
+    }
+
+    /**
      * Test running a valid raising an error
      *
      * @return void


### PR DESCRIPTION
In making the new runner stricter, I dropped the inflection on command names.

Refs #11174