### PR TITLE
Display shell help message with `out` instead of `err` when missing method

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -508,7 +508,7 @@ class Shell
             return $this->main(...$this->args);
         }
 
-        $this->err($this->OptionParser->help($command));
+        $this->out($this->OptionParser->help($command));
 
         return false;
     }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -508,6 +508,7 @@ class Shell
             return $this->main(...$this->args);
         }
 
+        $this->err('No subcommand provided. Choose one of the available subcommands.', 2);
         $this->out($this->OptionParser->help($command));
 
         return false;

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -1049,7 +1049,7 @@ TEXT;
     public function testRunCommandBaseClassMethod()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
-            ->setMethods(['startup', 'getOptionParser', 'err', 'hr'])
+            ->setMethods(['startup', 'getOptionParser', 'out', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1062,7 +1062,7 @@ TEXT;
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->never())->method('hr');
-        $shell->expects($this->once())->method('err');
+        $shell->expects($this->once())->method('out');
 
         $shell->runCommand(['hr']);
     }
@@ -1075,7 +1075,7 @@ TEXT;
     public function testRunCommandMissingMethod()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
-            ->setMethods(['startup', 'getOptionParser', 'err', 'hr'])
+            ->setMethods(['startup', 'getOptionParser', 'out', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
         $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
@@ -1086,7 +1086,7 @@ TEXT;
         $parser->expects($this->once())->method('help');
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
-        $shell->expects($this->once())->method('err');
+        $shell->expects($this->once())->method('out');
 
         $result = $shell->runCommand(['idontexist']);
         $this->assertFalse($result);
@@ -1127,7 +1127,7 @@ TEXT;
     public function testRunCommandNotCallUnexposedTask()
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
-            ->setMethods(['startup', 'hasTask', 'err'])
+            ->setMethods(['startup', 'hasTask', 'out'])
             ->disableOriginalConstructor()
             ->getMock();
         $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
@@ -1143,7 +1143,7 @@ TEXT;
             ->method('hasTask')
             ->will($this->returnValue(true));
         $shell->expects($this->never())->method('startup');
-        $shell->expects($this->once())->method('err');
+        $shell->expects($this->once())->method('out');
         $shell->RunCommand = $task;
 
         $result = $shell->runCommand(['run_command', 'one']);


### PR DESCRIPTION
When i run `bin/cake orm_cache` (without any methods), it shows error message (red font color):

```
<info>Usage:</info>
cake orm_cache [subcommand] [-c default] [-h] [-q] [-v] [<name>]

<info>Subcommands:</info>

build  Build all metadata caches for the connection. If a table name is
       provided, only that table will be cached.
clear  Clear all metadata caches for the connection. If a table name is
       provided, only that table will be removed.

To see help on a subcommand use <info>`cake orm_cache [subcommand] --help`</info>

<info>Options:</info>

--connection, -c  The connection to build/clear metadata cache data for.
                  <comment>(default: default)</comment>
--help, -h        Display this help.
--quiet, -q       Enable quiet output.
--verbose, -v     Enable verbose output.

<info>Arguments:</info>

name  A specific table you want to clear/refresh cached data for.
      <comment>(optional)</comment>
```