### PR TITLE
Fix annotation for main()

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -33,7 +33,7 @@ use ReflectionMethod;
  *
  * Is the equivalent of Cake\Controller\Controller on the command line.
  *
- * @method int main()
+ * @method int|bool main()
  */
 class Shell
 {


### PR DESCRIPTION
PHPStorm trips over this if people use the bool true/false return values.