### PR TITLE
Alias fields when finding dependent records to delete.

### DIFF
--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -41,7 +41,7 @@ class DependentDeleteHelper
             return true;
         }
         $table = $association->getTarget();
-        $foreignKey = (array)$association->getForeignKey();
+        $foreignKey = array_map([$association, 'aliasField'], (array)$association->getForeignKey());
         $bindingKey = (array)$association->getBindingKey();
         $conditions = array_combine($foreignKey, $entity->extract($bindingKey));
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -461,7 +461,7 @@ class HasManyTest extends TestCase
             ->method('deleteAll')
             ->with([
                 'Articles.is_active' => true,
-                'author_id' => 1
+                'Articles.author_id' => 1
             ]);
 
         $entity = new Entity(['id' => 1, 'name' => 'PHP']);


### PR DESCRIPTION
Prevent ambiguous column issues by aliasing fields used in conditions.

Refs #11170
