### PR TITLE
Use more atomic options when creating directories.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -380,9 +380,10 @@ class FileEngine extends CacheEngine
         }
         $dir = $this->_config['path'] . $groups;
 
-        if (!is_dir($dir)) {
-            mkdir($dir, 0775, true);
-        }
+        // @codingStandardsIgnoreStart
+        @mkdir($dir, 0775, true);
+        // @codingStandardsIgnoreEnd
+
         $path = new SplFileInfo($dir . $key);
 
         if (!$createKey && !$path->isFile()) {


### PR DESCRIPTION
Using `is_dir` and then `mkdir` creates an opportunity for a concurrent process to create the directory at the same time resulting in `mkdir()` emitting an error. We can always create the directory and silence the warning to avoid that issue.

Refs #10530
