### PR TITLE
Fix method annotation as per review

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -33,7 +33,7 @@ use ReflectionMethod;
  *
  * Is the equivalent of Cake\Controller\Controller on the command line.
  *
- * @method int|bool main()
+ * @method int|bool|null main(...$args)
  */
 class Shell
 {


### PR DESCRIPTION
You can actually also return null and get 0 (success) exit code.
Also, the var $args is possible for main - if you dont have any other matching subcommand.