### PR TITLE
Enable overriding theme/plugin templates in APP

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1459,8 +1459,8 @@ class View implements EventDispatcherInterface
             array_unshift($themePaths, APP . 'Template' . DIRECTORY_SEPARATOR . 'Plugin' . DIRECTORY_SEPARATOR . $this->theme . DIRECTORY_SEPARATOR);
 
             if ($plugin) {
-                for ($i = 0, $count = count($themePaths); $i < $count; $i++) {
-                    array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DIRECTORY_SEPARATOR . $plugin . DIRECTORY_SEPARATOR);
+                foreach (array_reverse($themePaths) as $path) {
+                    array_unshift($themePaths, $path . 'Plugin' . DIRECTORY_SEPARATOR . $plugin . DIRECTORY_SEPARATOR);
                 }
             }
         }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1456,6 +1456,7 @@ class View implements EventDispatcherInterface
 
         if (!empty($this->theme)) {
             $themePaths = App::path(static::NAME_TEMPLATE, Inflector::camelize($this->theme));
+            array_unshift($themePaths, APP . 'Template' . DIRECTORY_SEPARATOR . 'Plugin' . DIRECTORY_SEPARATOR . $this->theme . DIRECTORY_SEPARATOR);
 
             if ($plugin) {
                 for ($i = 0, $count = count($themePaths); $i < $count; $i++) {

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -512,8 +512,11 @@ class ViewTest extends TestCase
         $paths = $View->paths('TestPlugin');
         $pluginPath = Plugin::path('TestPlugin');
         $themePath = Plugin::path('TestTheme');
+
         $expected = [
+            TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestTheme' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
             $themePath . 'src' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+            TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestTheme' . DS,
             $themePath . 'src' . DS . 'Template' . DS,
             TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
             $pluginPath . 'src' . DS . 'Template' . DS,
@@ -545,8 +548,11 @@ class ViewTest extends TestCase
         $paths = $View->paths('TestPlugin');
         $pluginPath = Plugin::path('TestPlugin');
         $themePath = Plugin::path('TestTheme');
+
         $expected = [
+            TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestTheme' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
             $themePath . 'src' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
+            TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestTheme' . DS,
             $themePath . 'src' . DS . 'Template' . DS,
             TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,
             $pluginPath . 'src' . DS . 'Template' . DS . 'Plugin' . DS . 'TestPlugin' . DS,


### PR DESCRIPTION
Example use case:

  You buy a premium theme called Foo and installed in `APP/plugins/Foo`
  and it has the following templates:
    `APP/plugins/Foo/src/Template/Layout/default.ctp`

  You can now override its layout by copying and modifying it in:
    `APP/src/Template/Plugin/Foo/Layout/default.ctp`
