### PR TITLE
Fix: Duplicate path in $themePaths

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1458,8 +1458,8 @@ class View implements EventDispatcherInterface
             $themePaths = App::path(static::NAME_TEMPLATE, Inflector::camelize($this->theme));
 
             if ($plugin) {
-                for ($i = 0, $count = count($themePaths); $i < $count; $i++) {
-                    array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DIRECTORY_SEPARATOR . $plugin . DIRECTORY_SEPARATOR);
+                foreach (array_reverse($themePaths) as $path) {
+                    array_unshift($themePaths, $path . 'Plugin' . DIRECTORY_SEPARATOR . $plugin . DIRECTORY_SEPARATOR);
                 }
             }
         }


### PR DESCRIPTION
Consider:

```
$themePaths = [
    'Theme1',
    'Theme2',
];

array_unshift($themePaths, $themePaths[$i] . 'Plugin' . DS . $plugin . DS);
```

After first iteration, a new element is inserted as first element
so at 2nd iteration, Theme1 is no longer at key 0, but pushed to key 1,
Hence it will do another one with Theme1

Now we can correctly override plugin layouts and elements from app and themes
template files again.

Fixed with a little help from admad, ceeram and robertpustulka

This is a stripped down version of #11198