### PR TITLE
False positive URL validation (Test case only)

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -899,7 +899,7 @@ class Validation
      *   with an optional port number
      * - an optional valid path
      * - an optional query string (get parameters)
-     * - an optional fragment (anchor tag)
+     * - an optional fragment (anchor tag) as defined in RFC 3986
      *
      * @param string $check Value to check
      * @param bool $strict Require URL to be prefixed by a valid scheme (one of http(s)/ftp(s)/file/news/gopher)
@@ -908,12 +908,16 @@ class Validation
     public static function url($check, $strict = false)
     {
         static::_populateIp();
-        $validChars = '([' . preg_quote('!"$&\'()*+,-.@_:;=~[]') . '\/0-9\p{L}\p{N}]|(%[0-9a-f]{2}))';
+        $alpha = '0-9\p{L}\p{N}';
+        $hex = '(%[0-9a-f]{2})';
+        $subDelimiters = preg_quote('/!"$&\'()*+,-.@_:;=~[]', '/');
+        $path = '([' . $subDelimiters . $alpha . ']|' . $hex . ')';
+        $fragmentAndQuery = '([\?' . $subDelimiters . $alpha . ']|' . $hex . ')';
         $regex = '/^(?:(?:https?|ftps?|sftp|file|news|gopher):\/\/)' . (!empty($strict) ? '' : '?') .
             '(?:' . static::$_pattern['IPv4'] . '|\[' . static::$_pattern['IPv6'] . '\]|' . static::$_pattern['hostname'] . ')(?::[1-9][0-9]{0,4})?' .
-            '(?:\/?|\/' . $validChars . '*)?' .
-            '(?:\?' . $validChars . '*)?' .
-            '(?:#' . $validChars . '*)?$/iu';
+            '(?:\/' . $path . '*)?' .
+            '(?:\?' . $fragmentAndQuery . '*)?' .
+            '(?:#' . $fragmentAndQuery . '*)?$/iu';
 
         return static::_check($check, $regex);
     }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2138,6 +2138,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::url('https://cakephp.org'));
         $this->assertTrue(Validation::url('https://www.cakephp.org/somewhere#anchor'));
         $this->assertTrue(Validation::url('https://192.168.0.1'));
+        $this->assertTrue(Validation::url('https://example.com/kibana/app/kibana#/dashboard/4422c500-8e1b?_g=()'));
         $this->assertTrue(Validation::url('ftps://www.cakephp.org/pub/cake'));
         $this->assertTrue(Validation::url('ftps://cakephp.org/pub/cake'));
         $this->assertTrue(Validation::url('ftps://192.168.0.1/pub/cake'));


### PR DESCRIPTION
with Kibana urls for instance

Kibana urls such as this one are not valid whereas they seem to be valid regarding the specs (valid in an `input type=url` for instance). The failure seems to be related to the presence of the trailing `?_g=()` part.

The sample url in this failing test can be found from the "Share" tab of a dashboard in the latest Kibana version.

![kibana-report-template-dashboard-link](https://user-images.githubusercontent.com/75968/30576664-a4e79e22-9d09-11e7-8cd9-56bd5ea9cf60.png)

The PR only contains the failing test case for now, I will try to look at the regex and update the PR if nobody beats me to it!
