### PR TITLE
Improve doc blocks for IDE understanding.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -22,6 +22,8 @@ use Cake\ORM\TableRegistry;
 
 /**
  * Base Authentication class with common methods and properties.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class BaseAuthenticate implements EventListenerInterface
 {

--- a/src/Auth/BaseAuthorize.php
+++ b/src/Auth/BaseAuthorize.php
@@ -22,6 +22,7 @@ use Cake\Http\ServerRequest;
  * Abstract base authorization adapter for AuthComponent.
  *
  * @see \Cake\Controller\Component\AuthComponent::$authenticate
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class BaseAuthorize
 {

--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -20,6 +20,8 @@ use Cake\Http\ServerRequest;
 
 /**
  * Session based persistent storage for authenticated user record.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class SessionStorage implements StorageInterface
 {

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -19,6 +19,8 @@ use InvalidArgumentException;
 
 /**
  * Storage engine for CakePHP caching
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class CacheEngine
 {

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -55,6 +55,7 @@ use Cake\Log\LogTrait;
  *
  * @link https://book.cakephp.org/3.0/en/controllers/components.html
  * @see \Cake\Controller\Controller::$components
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Component implements EventListenerInterface
 {

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -33,7 +33,7 @@ interface QueryInterface
      *
      * @param string $field The field to alias
      * @param string|null $alias the alias used to prefix the field
-     * @return array
+     * @return string
      */
     public function aliasField($field, $alias = null);
 
@@ -43,7 +43,7 @@ interface QueryInterface
      *
      * @param array $fields The fields to alias
      * @param string|null $defaultAlias The default alias
-     * @return array
+     * @return string[]
      */
     public function aliasFields($fields, $defaultAlias = null);
 

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -19,6 +19,7 @@ namespace Cake\Datasource;
  * The basis for every query object
  *
  * @method $this andWhere($conditions, $types = [])
+ * @method $this select($fields = [], $overwrite = false)
  */
 interface QueryInterface
 {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -28,7 +28,7 @@ trait QueryTrait
     /**
      * Instance of a table object this query is bound to
      *
-     * @var \Cake\Datasource\RepositoryInterface
+     * @var \Cake\ORM\Table|\Cake\Datasource\RepositoryInterface
      */
     protected $_repository;
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -27,6 +27,8 @@ use Exception;
  *
  * Traps exceptions and converts them into HTML or content-type appropriate
  * error pages using the CakePHP ExceptionRenderer.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class ErrorHandlerMiddleware
 {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -91,6 +91,7 @@ use Zend\Diactoros\Uri;
  * specify which authentication strategy you want to use.
  * CakePHP comes with built-in support for basic authentication.
  *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Client
 {

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -21,6 +21,8 @@ use Psr\Log\AbstractLogger;
 
 /**
  * Base log engine class.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class BaseLog extends AbstractLogger
 {

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -18,6 +18,8 @@ use Cake\Core\InstanceConfigTrait;
 
 /**
  * Abstract transport for sending email
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 abstract class AbstractTransport
 {

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -24,6 +24,8 @@ use InvalidArgumentException;
  * CakePHP network socket connection class.
  *
  * Core base class for network communication.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Socket
 {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1191,6 +1191,7 @@ abstract class Association
                 $extracted = new ResultSetDecorator($callable($extracted));
             }
 
+            /* @var \Cake\Collection\CollectionInterface $results */
             return $results->insert($property, $extracted);
         }, Query::PREPEND);
     }

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -109,6 +109,7 @@ use ReflectionMethod;
  *
  * @see \Cake\ORM\Table::addBehavior()
  * @see \Cake\Event\EventManager
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class Behavior implements EventListenerInterface
 {

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -227,7 +227,7 @@ class CounterCacheBehavior extends Behavior
                 continue;
             }
 
-            if (!is_string($config) && is_callable($config)) {
+            if (is_callable($config)) {
                 $count = $config($event, $entity, $this->_table, false);
             } else {
                 $count = $this->_getCount($config, $countConditions);
@@ -236,7 +236,7 @@ class CounterCacheBehavior extends Behavior
             $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
 
             if (isset($updateOriginalConditions)) {
-                if (!is_string($config) && is_callable($config)) {
+                if (is_callable($config)) {
                     $count = $config($event, $entity, $this->_table, true);
                 } else {
                     $count = $this->_getCount($config, $countOriginalConditions);

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -18,6 +18,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\Association;
 use Cake\ORM\Behavior;
+use RuntimeException;
 
 /**
  * CounterCache behavior
@@ -202,6 +203,7 @@ class CounterCacheBehavior extends Behavior
      * @param \Cake\ORM\Association $assoc The association object
      * @param array $settings The settings for for counter cache for this association
      * @return void
+     * @throws \RuntimeException If invalid callable is passed.
      */
     protected function _processAssociation(Event $event, EntityInterface $entity, Association $assoc, array $settings)
     {
@@ -228,6 +230,9 @@ class CounterCacheBehavior extends Behavior
             }
 
             if (is_callable($config)) {
+                if (is_string($config)) {
+                    throw new RuntimeException('You must not use a string as callable.');
+                }
                 $count = $config($event, $entity, $this->_table, false);
             } else {
                 $count = $this->_getCount($config, $countConditions);
@@ -237,6 +242,9 @@ class CounterCacheBehavior extends Behavior
 
             if (isset($updateOriginalConditions)) {
                 if (is_callable($config)) {
+                    if (is_string($config)) {
+                        throw new RuntimeException('You must not use a string as callable.');
+                    }
                     $count = $config($event, $entity, $this->_table, true);
                 } else {
                     $count = $this->_getCount($config, $countOriginalConditions);

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -213,17 +213,19 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         }
 
         $conditions = function ($field, $locale, $query, $select) {
-            return function ($q) use ($field, $locale, $query, $select) {
-                $q->where([$q->repository()->aliasField('locale') => $locale]);
+            return function ($query) use ($field, $locale, $query, $select) {
+                /* @var \Cake\Datasource\QueryInterface $query */
+                $query->where([$query->repository()->aliasField('locale') => $locale]);
 
+                /* @var \Cake\ORM\Query $query */
                 if ($query->isAutoFieldsEnabled() ||
                     in_array($field, $select, true) ||
                     in_array($this->_table->aliasField($field), $select, true)
                 ) {
-                    $q->select(['id', 'content']);
+                    $query->select(['id', 'content']);
                 }
 
-                return $q;
+                return $query;
             };
         };
 
@@ -381,12 +383,13 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
         return [
             '_translations' => function ($value, $entity) use ($marshaller, $options) {
+                /* @var \Cake\Datasource\EntityInterface $entity */
                 $translations = $entity->get('_translations');
                 foreach ($this->_config['fields'] as $field) {
                     $options['validate'] = $this->_config['validator'];
                     $errors = [];
                     if (!is_array($value)) {
-                        return;
+                        return null;
                     }
                     foreach ($value as $language => $fields) {
                         if (!isset($translations[$language])) {
@@ -477,12 +480,13 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         $targetAlias = $this->_translationTable->getAlias();
 
         return $query
-            ->contain([$targetAlias => function ($q) use ($locales, $targetAlias) {
+            ->contain([$targetAlias => function ($query) use ($locales, $targetAlias) {
                 if ($locales) {
-                    $q->where(["$targetAlias.locale IN" => $locales]);
+                    /* @var \Cake\Datasource\QueryInterface $query */
+                    $query->where(["$targetAlias.locale IN" => $locales]);
                 }
 
-                return $q;
+                return $query;
             }])
             ->formatResults([$this, 'groupTranslations'], $query::PREPEND);
     }
@@ -545,6 +549,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
             $row['_locale'] = $locale;
             if ($hydrated) {
+                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->clean();
             }
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -549,7 +549,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 
             $row['_locale'] = $locale;
             if ($hydrated) {
-                /** @var \Cake\Datasource\EntityInterface $row */
+                /* @var \Cake\Datasource\EntityInterface $row */
                 $row->clean();
             }
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -213,19 +213,19 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         }
 
         $conditions = function ($field, $locale, $query, $select) {
-            return function ($query) use ($field, $locale, $query, $select) {
-                /* @var \Cake\Datasource\QueryInterface $query */
-                $query->where([$query->repository()->aliasField('locale') => $locale]);
+            return function ($q) use ($field, $locale, $query, $select) {
+                /* @var \Cake\Datasource\QueryInterface $q */
+                $q->where([$q->repository()->aliasField('locale') => $locale]);
 
                 /* @var \Cake\ORM\Query $query */
                 if ($query->isAutoFieldsEnabled() ||
                     in_array($field, $select, true) ||
                     in_array($this->_table->aliasField($field), $select, true)
                 ) {
-                    $query->select(['id', 'content']);
+                    $q->select(['id', 'content']);
                 }
 
-                return $query;
+                return $q;
             };
         };
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -65,6 +65,7 @@ use RuntimeException;
  *   with the first rows of the query and each of the items, then the second rows and so on.
  * @method \Cake\Collection\CollectionInterface chunk($size) Groups the results in arrays of $size rows each.
  * @method bool isEmpty() Returns true if this query found no results.
+ * @mixin \Cake\Datasource\QueryTrait
  */
 class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
 {
@@ -423,7 +424,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Used to recursively add contained association column types to
      * the query.
      *
-     * @param \Cake\ORM\Table $table The table instance to pluck associations from.
+     * @param \Cake\Datasource\RepositoryInterface $table The table instance to pluck associations from.
      * @param \Cake\Database\TypeMap $typeMap The typemap to check for columns in.
      *   This typemap is indirectly mutated via Cake\ORM\Query::addDefaultTypes()
      * @param array $associations The nested tree of associations to walk.
@@ -432,6 +433,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     protected function _addAssociationsToTypeMap($table, $typeMap, $associations)
     {
         foreach ($associations as $name => $nested) {
+            /* @var \Cake\ORM\Table $table */
             $association = $table->association($name);
             if (!$association) {
                 continue;
@@ -998,6 +1000,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         if (!$this->_beforeFindFired && $this->_type === 'select') {
             $table = $this->repository();
             $this->_beforeFindFired = true;
+            /* @var \Cake\Event\EventDispatcherInterface $table */
             $table->dispatchEvent('Model.beforeFind', [
                 $this,
                 new ArrayObject($this->_options),

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -424,7 +424,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Used to recursively add contained association column types to
      * the query.
      *
-     * @param \Cake\Datasource\RepositoryInterface $table The table instance to pluck associations from.
+     * @param \Cake\ORM\Table|\Cake\Datasource\RepositoryInterface $table The table instance to pluck associations from.
      * @param \Cake\Database\TypeMap $typeMap The typemap to check for columns in.
      *   This typemap is indirectly mutated via Cake\ORM\Query::addDefaultTypes()
      * @param array $associations The nested tree of associations to walk.
@@ -433,7 +433,6 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     protected function _addAssociationsToTypeMap($table, $typeMap, $associations)
     {
         foreach ($associations as $name => $nested) {
-            /* @var \Cake\ORM\Table $table */
             $association = $table->association($name);
             if (!$association) {
                 continue;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1289,6 +1289,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         );
 
         return $query->formatResults(function ($results) use ($options) {
+            /* @var \Cake\Collection\CollectionInterface $results */
             return $results->combine(
                 $options['keyField'],
                 $options['valueField'],
@@ -1338,6 +1339,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $options = $this->_setFieldMatchers($options, ['keyField', 'parentField']);
 
         return $query->formatResults(function ($results) use ($options) {
+            /* @var \Cake\Collection\CollectionInterface $results */
             return $results->nest($options['keyField'], $options['parentField'], $options['nestingKey']);
         });
     }

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -62,6 +62,8 @@ use InvalidArgumentException;
  *
  * When using the `for` or `when` matchers, conditions will be re-checked on the before and after
  * callback as the conditions could change during the dispatch cycle.
+ *
+ * @mixin \Cake\Core\InstanceConfigTrait
  */
 class DispatcherFilter implements EventListenerInterface
 {


### PR DESCRIPTION
Turns out we need mixin annotations when accessing the properties _config directly etc.
The methods work without it, but we still have a lot of direct property access.
This makes it less "red" in IDEs.

Also fixed a few other missing interface annotations. The alternative would be to typehint the closure signatures, but I wasn't sure if that was a performance issue in loops. This way it doesnt cost anything but a single line more.

And by properly annotating everything the IDE then found out that aliasField() has the wrong type annotated :) So that is now also fixed for good.

Note:
When we add methods to classes, but due to BC not to the interface, we must at least add the `@method` annotation in the interface doc block.