### PR TITLE
3.next - Start command class

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -28,6 +28,13 @@ class Command
     use ModelAwareTrait;
 
     /**
+     * The name of this command. Inflected from the class name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
      * Constructor
      *
      * By default CakePHP will construct command objects when
@@ -37,6 +44,21 @@ class Command
     {
         $locator = $this->getTableLocator() ? : 'Cake\ORM\TableRegistry';
         $this->modelFactory('Table', [$locator, 'get']);
+
+        if (!$this->name) {
+            list(, $class) = namespaceSplit(get_class($this));
+            $this->name = str_replace('Command', '', $class);
+        }
+    }
+
+    /**
+     * Get the command name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 
     /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Console;
+
+use Cake\Datasource\ModelAwareTrait;
+use Cake\Log\LogTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * Base class for console commands.
+ */
+class Command
+{
+    use LocatorAwareTrait;
+    use LogTrait;
+    use ModelAwareTrait;
+
+    /**
+     * Constructor
+     *
+     * By default CakePHP will construct command objects when
+     * building the CommandCollection for your application.
+     */
+    public function __construct()
+    {
+        $locator = $this->getTableLocator() ? : 'Cake\ORM\TableRegistry';
+        $this->modelFactory('Table', [$locator, 'get']);
+    }
+
+    /**
+     * Hook method invoked by CakePHP when a command is about to be executed.
+     *
+     * Override this method and implement expensive/important setup steps that
+     * should not run on every command run. This method will be called *before*
+     * the options and arguments are validated and processed.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+    }
+}

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -17,6 +17,7 @@ namespace Cake\Console;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use RuntimeException;
 
 /**
  * Base class for console commands.
@@ -44,11 +45,21 @@ class Command
     {
         $locator = $this->getTableLocator() ? : 'Cake\ORM\TableRegistry';
         $this->modelFactory('Table', [$locator, 'get']);
+    }
 
-        if (!$this->name) {
-            list(, $class) = namespaceSplit(get_class($this));
-            $this->name = str_replace('Command', '', $class);
-        }
+    /**
+     * Set the name this command uses in the collection.
+     *
+     * Generally invoked by the CommandCollection when the command is added.
+     *
+     * @param string $name The name the command uses in the collection.
+     * @return $this;
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -59,6 +70,40 @@ class Command
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Get the option parser.
+     *
+     * You can override buildOptionParser() to define your options & arguments.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     * @throws \RuntimeException When the parser is invalid
+     */
+    public function getOptionParser()
+    {
+        $parser = new ConsoleOptionParser($this->name);
+        $parser = $this->buildOptionParser($parser);
+        if (!($parser instanceof ConsoleOptionParser)) {
+            throw new RuntimeException(sprintf(
+                "Invalid option parser returned from buildOptionParser(). Expected %s, got %s",
+                ConsoleOptionParser::class,
+                get_class($parser)
+            ));
+        }
+
+        return $parser;
+    }
+
+    /**
+     * Hook method for defining this command's option parser.
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
+     * @return \Cake\Console\ConsoleOptionParser The built parser.
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser)
+    {
+        return $parser;
     }
 
     /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -43,8 +43,7 @@ class Command
      */
     public function __construct()
     {
-        $locator = $this->getTableLocator();
-        $this->modelFactory('Table', function($alias){
+        $this->modelFactory('Table', function ($alias) {
             return $this->getTableLocator()->get($alias);
         });
     }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -43,8 +43,10 @@ class Command
      */
     public function __construct()
     {
-        $locator = $this->getTableLocator() ? : 'Cake\ORM\TableRegistry';
-        $this->modelFactory('Table', [$locator, 'get']);
+        $locator = $this->getTableLocator();
+        $this->modelFactory('Table', function($alias){
+            return $this->getTableLocator()->get($alias);
+        });
     }
 
     /**

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -18,7 +18,7 @@ use Cake\Console\Command;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-
+use TestApp\Command\ExampleCommand;
 
 /**
  * Test case for Console\Command
@@ -47,5 +47,16 @@ class CommandTest extends TestCase
         $command = new Command();
         $command->loadModel('Comments');
         $this->assertInstanceOf(Table::class, $command->Comments);
+    }
+
+    /**
+     * Test name inflection
+     *
+     * @return void
+     */
+    public function testNameInflection()
+    {
+        $command = new ExampleCommand();
+        $this->assertSame('Example', $command->getName());
     }
 }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -15,10 +15,10 @@
 namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\Command;
+use Cake\Console\ConsoleOptionParser;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-use TestApp\Command\ExampleCommand;
 
 /**
  * Test case for Console\Command
@@ -50,13 +50,45 @@ class CommandTest extends TestCase
     }
 
     /**
-     * Test name inflection
+     * Test name
      *
      * @return void
      */
-    public function testNameInflection()
+    public function testSetName()
     {
-        $command = new ExampleCommand();
-        $this->assertSame('Example', $command->getName());
+        $command = new Command();
+        $this->assertSame($command, $command->setName('routes show'));
+        $this->assertSame('routes show', $command->getName());
+    }
+
+    /**
+     * Test option parser fetching
+     *
+     * @return void
+     */
+    public function testGetOptionParser()
+    {
+        $command = new Command();
+        $command->setName('cake routes show');
+        $parser = $command->getOptionParser();
+        $this->assertInstanceOf(ConsoleOptionParser::class, $parser);
+        $this->assertSame('cake routes show', $parser->getCommand());
+    }
+
+    /**
+     * Test option parser fetching
+     *
+     * @expectedException RuntimeException
+     * @return void
+     */
+    public function testGetOptionParserInvalid()
+    {
+        $command = $this->getMockBuilder(Command::class)
+            ->setMethods(['buildOptionParser'])
+            ->getMock();
+        $command->expects($this->once())
+            ->method('buildOptionParser')
+            ->will($this->returnValue(null));
+        $command->getOptionParser();
     }
 }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         3.6.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Console;
+
+use Cake\Console\Command;
+use Cake\ORM\Locator\TableLocator;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+
+/**
+ * Test case for Console\Command
+ */
+class CommandTest extends TestCase
+{
+    /**
+     * test orm locator is setup
+     *
+     * @return void
+     */
+    public function testConstructorSetsLocator()
+    {
+        $command = new Command();
+        $result = $command->getTableLocator();
+        $this->assertInstanceOf(TableLocator::class, $result);
+    }
+
+    /**
+     * test loadModel is configured properly
+     *
+     * @return void
+     */
+    public function testConstructorLoadModel()
+    {
+        $command = new Command();
+        $command->loadModel('Comments');
+        $this->assertInstanceOf(Table::class, $command->Comments);
+    }
+}


### PR DESCRIPTION
This is a modest start to the new Command class proposed in #11137. This gets the option parser integration defined as well as creating a hook point for the `CommandCollection` to set the command name so it can be used to create an option parser.

I'm proposing that we use the validator model to build the option parser. Instead of having to call `parent` as we do with `Shell`, developers will implement the `buildOptionParser` method and define their option parser.