### PR TITLE
Updated PHPDoc for Configure::consume

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -195,7 +195,7 @@ class Configure
      * out of configure into the various other classes in CakePHP.
      *
      * @param string $var The key to read and remove.
-     * @return array|null
+     * @return array|string|null
      */
     public static function consume($var)
     {


### PR DESCRIPTION
Configure::consume can return string as well.