### PR TITLE
Use method instead of public property.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -216,19 +216,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     }
 
     /**
-     * Get loaded object instance.
-     *
-     * @param string $name Name of object.
-     * @return object|null Object instance if loaded else null.
-     */
-    public function __call($name, $params)
-    {
-        $name = ucfirst($name);
-
-        return $this->get($name);
-    }
-
-    /**
      * Provide public read access to the loaded objects
      *
      * @param string $name Name of property to read

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -216,10 +216,24 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     }
 
     /**
+     * Get loaded object instance.
+     *
+     * @param string $name Name of object.
+     * @return object|null Object instance if loaded else null.
+     */
+    public function __call($name, $params)
+    {
+        $name = ucfirst($name);
+
+        return $this->get($name);
+    }
+
+    /**
      * Provide public read access to the loaded objects
      *
      * @param string $name Name of property to read
      * @return mixed
+     * @deprecated 3.6.0 Use method access instead.
      */
     public function __get($name)
     {

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -67,6 +67,20 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     }
 
     /**
+     * Get loaded behavior instance.
+     *
+     * @param string $name Name of behavior.
+     * @return \Cake\ORM\Behavior|object|null
+     */
+    public function __call($name, $params)
+    {
+        $name = substr($name, 0, -8);
+        $name = ucfirst($name);
+
+        return $this->get($name);
+    }
+
+    /**
      * Attaches a table instance to this registry.
      *
      * @param \Cake\ORM\Table $table The table this registry is attached to.

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -74,8 +74,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      */
     public function __call($name, $params)
     {
-        $name = substr($name, 0, -8);
-        $name = ucfirst($name);
+        $name = substr($name, 3);
 
         return $this->get($name);
     }


### PR DESCRIPTION
Implements https://github.com/cakephp/cakephp/issues/11245 on all object registry levels.

//EDIT: As mentioned we need suffixing to avoid collisions with existing method names, adjusting the examples:

E.g.
```php
$searchManager = $this->behaviors()->Search->searchManager();
// becomes
$searchManager = $this->behaviors()->getSearch()->searchManager();
```

Deprecates property access as minimal changeset so far.
If acceptable, I can finalize the tests here.

Since it is auto-competable via IDE you actually have to type less, especially no magic strings here.

You can also continue to use the internally used
```php
$searchManager = $this->behaviors()->get('Search')->searchManager();
```
if you want to, but for this you always need a manual inline doc block to annotate the last chaining element it for IDEs. It also wont work for any element before in the chain here then.