### PR TITLE
Prefer locale parsing to basic float casting.

### DIFF
--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -129,11 +129,11 @@ class DecimalType extends Type implements TypeInterface
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_numeric($value)) {
-            return (float)$value;
-        }
         if (is_string($value) && $this->_useLocaleParser) {
             return $this->_parseValue($value);
+        }
+        if (is_numeric($value)) {
+            return (float)$value;
         }
         if (is_array($value)) {
             return 1;

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -182,6 +182,21 @@ class DecimalTypeTest extends TestCase
     }
 
     /**
+     * test marshall() number in the danish locale which uses . for thousands separator.
+     *
+     * @return void
+     */
+    public function testMarshallWithLocaleParsingDanish()
+    {
+        I18n::setLocale('da_DK');
+
+        $this->type->useLocaleParser();
+        $expected = 47500.0;
+        $result = $this->type->marshal('47.500');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * Test that exceptions are raised on invalid parsers.
      *
      * @expectedException \RuntimeException


### PR DESCRIPTION
Many european locales use `.` for thousands separator, which will result in the wrong value if handled by a float cast.

Refs #11235