### PR TITLE
Revert atomic directory creation.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -380,9 +380,9 @@ class FileEngine extends CacheEngine
         }
         $dir = $this->_config['path'] . $groups;
 
-        // @codingStandardsIgnoreStart
-        @mkdir($dir, 0775, true);
-        // @codingStandardsIgnoreEnd
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
 
         $path = new SplFileInfo($dir . $key);
 


### PR DESCRIPTION
The error suppression has caused issues for a few users, so preventing a potential race condition is less important.

Refs #11251
