### PR TITLE
Add failing test for Text::slug()

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1108,7 +1108,7 @@ class Text
 
         $regex = '^\s\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}';
         if ($options['preserve']) {
-            $regex .= '(' . preg_quote($options['preserve'], '/') . ')';
+            $regex .= '|' . preg_quote($options['preserve'], '/');
         }
         $quotedReplacement = preg_quote($options['replacement'], '/');
         $map = [

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1804,7 +1804,15 @@ HTML;
             [
                 'clean!_me.tar.gz', ['preserve' => '.'],
                 'clean-me.tar.gz'
-            ]
+            ],
+            [
+                'cl#ean(me', [],
+                'cl-ean-me'
+            ],
+            [
+                'cl#ean(me.jpg', ['preserve' => '.'],
+                'cl-ean-me.jpg'
+            ],
         ];
     }
 


### PR DESCRIPTION
Cleaning the string fails when string contains bracket and "preserve" option is set.

### What it tried
`Text::slug('cl#ean(me.jpg')`

### What i expected
`cl-ean-me.jpg`

### What i got
`cl-ean(me.jpg`
