### PR TITLE
Add notSameAs validation rule.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -316,7 +316,7 @@ class Validation
     /**
      * Compare one field to another.
      *
-     * Return true if the comparison match the expected result.
+     * Return true if the comparison matches the expected result.
      *
      * @param mixed $check The value to find in $field.
      * @param string $field The field to check $check against. This field must be present in $context.

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -306,14 +306,34 @@ class Validation
      * @param string $field The field to check $check against. This field must be present in $context.
      * @param array $context The validation context.
      * @return bool
+     * @deprecated 3.6.0 Use compareFields() instead.
      */
     public static function compareWith($check, $field, $context)
+    {
+        return self::compareFields($check, $field, true, $context);
+    }
+
+    /**
+     * Compare one field to another.
+     *
+     * Return true if the comparison match the expected result.
+     *
+     * @param mixed $check The value to find in $field.
+     * @param string $field The field to check $check against. This field must be present in $context.
+     * @param bool $result The expected result of field comparison.
+     * @param array $context The validation context.
+     * @return bool
+     * @since 3.6.0
+     */
+    public static function compareFields($check, $field, $result, $context)
     {
         if (!isset($context['data'][$field])) {
             return false;
         }
 
-        return $context['data'][$field] === $check;
+        $comparison = $context['data'][$field] === $check;
+
+        return $comparison === $result;
     }
 
     /**

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -306,7 +306,6 @@ class Validation
      * @param string $field The field to check $check against. This field must be present in $context.
      * @param array $context The validation context.
      * @return bool
-     * @deprecated 3.6.0 Use compareFields() instead.
      */
     public static function compareWith($check, $field, $context)
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -971,7 +971,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|null $message The error message when the rule fails.
      * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
      *   true when the validation rule should be applied.
-     * @see \Cake\Validation\Validation::compareWith()
+     * @see \Cake\Validation\Validation::compareFields()
      * @return $this
      */
     public function sameAs($field, $secondField, $message = null, $when = null)
@@ -979,7 +979,28 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'sameAs', $extra + [
-            'rule' => ['compareWith', $secondField]
+            'rule' => ['compareFields', $secondField, true]
+        ]);
+    }
+
+    /**
+     * Add a rule to compare that two fields have different values.
+     *
+     * @param mixed $field The field you want to apply the rule to.
+     * @param mixed $secondField The field you want to compare against.
+     * @param string|null $message The error message when the rule fails.
+     * @param string|callable|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \Cake\Validation\Validation::compareFields()
+     * @return $this
+     * @since 3.6.0
+     */
+    public function notSameAs($field, $secondField, $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'notSameAs', $extra + [
+            'rule' => ['compareFields', $secondField, false]
         ]);
     }
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2741,28 +2741,53 @@ class ValidationTest extends TestCase
     }
 
     /**
-     * Test the compareWith method.
+     * Test the compareFields method with true result.
      *
      * @return void
      */
-    public function testCompareWith()
+    public function testCompareFieldsTrue()
     {
         $context = [
             'data' => [
                 'other' => 'a value'
             ]
         ];
-        $this->assertTrue(Validation::compareWith('a value', 'other', $context));
+        $this->assertTrue(Validation::compareFields('a value', 'other', true, $context));
 
         $context = [
             'data' => [
                 'other' => 'different'
             ]
         ];
-        $this->assertFalse(Validation::compareWith('a value', 'other', $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', true, $context));
 
         $context = [];
-        $this->assertFalse(Validation::compareWith('a value', 'other', $context));
+        $this->assertFalse(Validation::compareFields('a value', 'other', true, $context));
+    }
+
+    /**
+     * Test the compareFields method with false result.
+     *
+     * @return void
+     */
+    public function testCompareFieldsFalse()
+    {
+        $context = [
+            'data' => [
+                'other' => 'different'
+            ]
+        ];
+        $this->assertTrue(Validation::compareFields('a value', 'other', false, $context));
+
+        $context = [
+            'data' => [
+                'other' => 'a value'
+            ]
+        ];
+        $this->assertFalse(Validation::compareFields('a value', 'other', false, $context));
+
+        $context = [];
+        $this->assertFalse(Validation::compareFields('a value', 'other', false, $context));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1425,8 +1425,20 @@ class ValidatorTest extends TestCase
     public function testSameAs()
     {
         $validator = new Validator();
-        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other'], 'compareWith');
+        $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', true], 'compareFields');
         $this->assertNotEmpty($validator->errors(['username' => 'foo']));
+    }
+
+    /**
+     * Tests the notSameAs proxy method
+     *
+     * @return void
+     */
+    public function testNotSameAs()
+    {
+        $validator = new Validator();
+        $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', false], 'compareFields');
+        $this->assertNotEmpty($validator->errors(['username' => 'foo', 'other' => 'foo']));
     }
 
     /**


### PR DESCRIPTION
This is the opposite to `sameAs` validation rule. The rule will pass only when field values are different.

I added `Validation::compareFields()` method that allows to check if the comparison result matches the expected boolean value. ~~This is a replacement for `compareWith()` method which is now deprecated.~~

Any suggestions for a better implementation are welcome.