### PR TITLE
3.next - Convert help & version to commands

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -50,7 +50,7 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null
+     * @return int
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
@@ -75,9 +75,11 @@ class HelpCommand extends Command implements CommandCollectionAwareInterface
         if ($args->getOption('xml')) {
             $this->asXml($io, $commands);
 
-            return;
+            return static::CODE_SUCCESS;
         }
         $this->asText($io, $commands);
+
+        return static::CODE_SUCCESS;
     }
 
     /**

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -9,27 +9,30 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.5.0
+ * @since         3.6.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+namespace Cake\Command;
 
-namespace Cake\Shell;
-
-use Cake\Console\Shell;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\Command;
 use Cake\Core\Configure;
 
 /**
  * Print out the version of CakePHP in use.
  */
-class VersionShell extends Shell
+class VersionCommand extends Command
 {
     /**
      * Print out the version of CakePHP in use.
      *
-     * @return void
+     * @param \Cake\Console\Arguments $args The command arguments.
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return int|null
      */
-    public function main()
+    public function execute(Arguments $args, ConsoleIo $io)
     {
-        $this->out(Configure::version());
+        $io->out(Configure::version());
     }
 }

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -15,8 +15,8 @@
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\ConsoleIo;
 use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 
 /**
@@ -29,10 +29,12 @@ class VersionCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null
+     * @return int
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->out(Configure::version());
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Console;
 
+use Cake\Command\HelpCommand;
+use Cake\Command\VersionCommand;
 use Cake\Console\CommandCollection;
 use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;
@@ -21,8 +23,6 @@ use Cake\Console\Exception\StopException;
 use Cake\Console\Shell;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Event\EventManagerTrait;
-use Cake\Shell\HelpShell;
-use Cake\Shell\VersionShell;
 use Cake\Utility\Inflector;
 use RuntimeException;
 
@@ -114,8 +114,8 @@ class CommandRunner
         $this->app->bootstrap();
 
         $commands = new CommandCollection([
-            'version' => VersionShell::class,
-            'help' => HelpShell::class,
+            'version' => VersionCommand::class,
+            'help' => HelpCommand::class,
         ]);
         $commands = $this->app->console($commands);
         if (!($commands instanceof CommandCollection)) {

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Shell\Task;
 
+use Cake\Console\Command;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Plugin;
@@ -36,28 +37,45 @@ class CommandTask extends Shell
      */
     public function getShellList()
     {
-        $skipFiles = ['AppShell'];
-        $hiddenCommands = ['CommandListShell', 'CompletionShell'];
-
+        $skipFiles = ['app'];
+        $hiddenCommands = ['command_list', 'completion'];
         $plugins = Plugin::loaded();
         $shellList = array_fill_keys($plugins, null) + ['CORE' => null, 'app' => null];
 
         $appPath = App::path('Shell');
-        $appShells = $this->_scanDir($appPath[0]);
-        $appShells = array_diff($appShells, $skipFiles);
-        $shellList = $this->_appendShells('app', $appShells, $shellList);
+        $shellList = $this->_findShells($shellList, $appPath[0], 'app', $skipFiles);
 
-        $shells = $this->_scanDir(dirname(__DIR__));
-        $shells = array_diff($shells, $appShells, $skipFiles, $hiddenCommands);
-        $shellList = $this->_appendShells('CORE', $shells, $shellList);
+        $appPath = App::path('Command');
+        $shellList = $this->_findShells($shellList, $appPath[0], 'app', $skipFiles);
+
+        $skipCore = array_merge($skipFiles, $hiddenCommands, $shellList['app']);
+        $corePath = dirname(__DIR__);
+        $shellList = $this->_findShells($shellList, $corePath, 'CORE', $skipCore);
+
+        $corePath = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'Command';
+        $shellList = $this->_findShells($shellList, $corePath, 'CORE', $skipCore);
 
         foreach ($plugins as $plugin) {
             $pluginPath = Plugin::classPath($plugin) . 'Shell';
-            $pluginShells = $this->_scanDir($pluginPath);
-            $shellList = $this->_appendShells($plugin, $pluginShells, $shellList);
+            $shellList = $this->_findShells($shellList, $pluginPath, $plugin, []);
         }
 
         return array_filter($shellList);
+    }
+
+    /**
+     * Find shells in $path and add them to $shellList
+     *
+     * @param array $shellList The shell listing array.
+     * @param string $path The path to look in.
+     * @param string $key The key to add shells to
+     * @param array $skip A list of commands to exclude.
+     * @return array The updated list of shells.
+     */
+    protected function _findShells($shellList, $path, $key, $skip)
+    {
+        $shells = $this->_scanDir($path);
+        return $this->_appendShells($key, $shells, $shellList, $skip);
     }
 
     /**
@@ -66,13 +84,18 @@ class CommandTask extends Shell
      * @param string $type The type of object.
      * @param array $shells The shell name.
      * @param array $shellList List of shells.
+     * @param array $skip List of command names to skip.
      * @return array The updated $shellList
      */
-    protected function _appendShells($type, $shells, $shellList)
+    protected function _appendShells($type, $shells, $shellList, $skip)
     {
         foreach ($shells as $shell) {
-            $shellList[$type][] = Inflector::underscore(str_replace('Shell', '', $shell));
+            $name = Inflector::underscore(preg_replace('/(Shell|Command)$/', '', $shell));
+            if (!in_array($name, $skip, true)) {
+                $shellList[$type][] = $name;
+            }
         }
+        sort($shellList[$type]);
 
         return $shellList;
     }

--- a/src/Shell/Task/CommandTask.php
+++ b/src/Shell/Task/CommandTask.php
@@ -75,6 +75,7 @@ class CommandTask extends Shell
     protected function _findShells($shellList, $path, $key, $skip)
     {
         $shells = $this->_scanDir($path);
+
         return $this->_appendShells($key, $shells, $shellList, $skip);
     }
 

--- a/src/TestSuite/ConsoleIntegrationTestCase.php
+++ b/src/TestSuite/ConsoleIntegrationTestCase.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\Stub\ConsoleOutput;
  * A test case class intended to make integration tests of cake console commands
  * easier.
  */
-class ConsoleIntegrationTestCase extends TestCase
+abstract class ConsoleIntegrationTestCase extends TestCase
 {
     /**
      * Whether or not to use the CommandRunner

--- a/tests/TestCase/Command/HelpCommandTest.php
+++ b/tests/TestCase/Command/HelpCommandTest.php
@@ -12,7 +12,7 @@
  * @since         3.5.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Shell;
+namespace Cake\Test\TestCase\Command;
 
 use Cake\Console\Shell;
 use Cake\Core\Plugin;

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -22,7 +22,7 @@ use Cake\Shell\I18nShell;
 use Cake\Shell\RoutesShell;
 use Cake\TestSuite\TestCase;
 use stdClass;
-use TestApp\Command\ExampleCommand;
+use TestApp\Command\DemoCommand;
 
 /**
  * Test case for the CommandCollection
@@ -87,9 +87,9 @@ class CommandCollectionTest extends TestCase
     public function testAddCommand()
     {
         $collection = new CommandCollection();
-        $this->assertSame($collection, $collection->add('ex', ExampleCommand::class));
+        $this->assertSame($collection, $collection->add('ex', DemoCommand::class));
         $this->assertTrue($collection->has('ex'));
-        $this->assertSame(ExampleCommand::class, $collection->get('ex'));
+        $this->assertSame(DemoCommand::class, $collection->get('ex'));
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -22,7 +22,7 @@ use Cake\Core\Configure;
 use Cake\Http\BaseApplication;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
-use TestApp\Command\ExampleCommand;
+use TestApp\Command\DemoCommand;
 use TestApp\Shell\SampleShell;
 
 /**
@@ -286,7 +286,7 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunValidCommandClass()
     {
-        $app = $this->makeAppWithCommands(['ex' => ExampleCommand::class]);
+        $app = $this->makeAppWithCommands(['ex' => DemoCommand::class]);
         $output = new ConsoleOutput();
 
         $runner = new CommandRunner($app, 'cake');
@@ -294,7 +294,7 @@ class CommandRunnerTest extends TestCase
         $this->assertSame(Shell::CODE_SUCCESS, $result);
 
         $messages = implode("\n", $output->messages());
-        $this->assertContains('Example Command!', $messages);
+        $this->assertContains('Demo Command!', $messages);
     }
 
     /**
@@ -304,7 +304,7 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunValidCommandClassHelp()
     {
-        $app = $this->makeAppWithCommands(['ex' => ExampleCommand::class]);
+        $app = $this->makeAppWithCommands(['ex' => DemoCommand::class]);
         $output = new ConsoleOutput();
 
         $runner = new CommandRunner($app, 'cake');
@@ -313,7 +313,7 @@ class CommandRunnerTest extends TestCase
 
         $messages = implode("\n", $output->messages());
         $this->assertContains("\ncake ex [-h]", $messages);
-        $this->assertNotContains('Example Command!', $messages);
+        $this->assertNotContains('Demo Command!', $messages);
     }
 
     /**

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -21,7 +21,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
-use TestApp\Command\ExampleCommand;
+use TestApp\Command\DemoCommand;
 
 /**
  * Test case for Console\Command
@@ -143,7 +143,7 @@ class CommandTest extends TestCase
     public function testRunOutputHelp()
     {
         $command = new Command();
-        $command->setName('cake example');
+        $command->setName('cake demo');
         $output = new ConsoleOutput();
 
         $this->assertSame(
@@ -151,8 +151,8 @@ class CommandTest extends TestCase
             $command->run(['-h'], $this->getMockIo($output))
         );
         $messages = implode("\n", $output->messages());
-        $this->assertNotContains('Example', $messages);
-        $this->assertContains('cake example [-h]', $messages);
+        $this->assertNotContains('Demo', $messages);
+        $this->assertContains('cake demo [-h]', $messages);
     }
 
     /**
@@ -163,7 +163,7 @@ class CommandTest extends TestCase
     public function testRunOutputHelpLongOption()
     {
         $command = new Command();
-        $command->setName('cake example');
+        $command->setName('cake demo');
         $output = new ConsoleOutput();
 
         $this->assertSame(
@@ -171,8 +171,8 @@ class CommandTest extends TestCase
             $command->run(['--help'], $this->getMockIo($output))
         );
         $messages = implode("\n", $output->messages());
-        $this->assertNotContains('Example', $messages);
-        $this->assertContains('cake example [-h]', $messages);
+        $this->assertNotContains('Demo', $messages);
+        $this->assertContains('cake demo [-h]', $messages);
     }
 
     /**
@@ -182,16 +182,16 @@ class CommandTest extends TestCase
      */
     public function testRunVerboseOption()
     {
-        $command = new ExampleCommand();
-        $command->setName('cake example');
+        $command = new DemoCommand();
+        $command->setName('cake demo');
         $output = new ConsoleOutput();
 
         $this->assertNull($command->run(['--verbose'], $this->getMockIo($output)));
         $messages = implode("\n", $output->messages());
         $this->assertContains('Verbose!', $messages);
-        $this->assertContains('Example Command!', $messages);
+        $this->assertContains('Demo Command!', $messages);
         $this->assertContains('Quiet!', $messages);
-        $this->assertNotContains('cake example [-h]', $messages);
+        $this->assertNotContains('cake demo [-h]', $messages);
     }
 
     /**
@@ -201,15 +201,15 @@ class CommandTest extends TestCase
      */
     public function testRunQuietOption()
     {
-        $command = new ExampleCommand();
-        $command->setName('cake example');
+        $command = new DemoCommand();
+        $command->setName('cake demo');
         $output = new ConsoleOutput();
 
         $this->assertNull($command->run(['--quiet'], $this->getMockIo($output)));
         $messages = implode("\n", $output->messages());
         $this->assertContains('Quiet!', $messages);
         $this->assertNotContains('Verbose!', $messages);
-        $this->assertNotContains('Example Command!', $messages);
+        $this->assertNotContains('Demo Command!', $messages);
     }
 
     /**

--- a/tests/TestCase/Shell/CommandListShellTest.php
+++ b/tests/TestCase/Shell/CommandListShellTest.php
@@ -65,7 +65,7 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
         $expected = "/\[.*CORE.*\] cache, help, i18n, orm_cache, plugin, routes, schema_cache, server/";
         $this->assertOutputRegExp($expected);
 
-        $expected = "/\[.*app.*\] i18m, integration, sample/";
+        $expected = "/\[.*app.*\] demo, i18m, integration, sample/";
         $this->assertOutputRegExp($expected);
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();
@@ -83,10 +83,10 @@ class CommandListShellTest extends ConsoleIntegrationTestCase
         $this->exec('command_list');
         rename(APP . 'Shell' . DS . 'I18nShell.php', APP . 'Shell' . DS . 'I18mShell.php');
 
-        $expected = "/\[.*CORE.*\] cache, help, orm_cache, plugin, routes, schema_cache, server/";
+        $expected = "/\[.*CORE.*\] cache, help, orm_cache, plugin, routes, schema_cache, server, version/";
         $this->assertOutputRegExp($expected);
 
-        $expected = "/\[.*app.*\] i18n, integration, sample/";
+        $expected = "/\[.*app.*\] demo, i18n, integration, sample/";
         $this->assertOutputRegExp($expected);
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();

--- a/tests/TestCase/Shell/CompletionShellTest.php
+++ b/tests/TestCase/Shell/CompletionShellTest.php
@@ -116,7 +116,8 @@ class CompletionShellTest extends TestCase
         $output = $this->out->output;
 
         $expected = 'TestPlugin.example TestPlugin.sample TestPluginTwo.example unique welcome ' .
-            "cache help i18n orm_cache plugin routes schema_cache server version i18m integration sample testing_dispatch\n";
+            'cache help i18n orm_cache plugin routes schema_cache server version ' .
+            "demo i18m integration sample testing_dispatch\n";
         $this->assertTextEquals($expected, $output);
     }
 

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -5,12 +5,12 @@ use Cake\Console\Arguments;
 use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 
-class ExampleCommand extends Command
+class DemoCommand extends Command
 {
     public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->quiet('Quiet!');
-        $io->out('Example Command!');
+        $io->out('Demo Command!');
         $io->verbose('Verbose!');
     }
 }


### PR DESCRIPTION
Convert the Help/VersionShells into Commands. I've removed the old classes, which might be a backwards incompatible change depending on what you consider the 'API' of the console libraries is. I'm OK with reverting the deletions if folks don't feel comfortable with that part of the change.