### PR TITLE
msSQL - also handle offset as string

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -411,7 +411,7 @@ class Sqlserver extends DboSource {
 				$rt = ' TOP';
 			}
 			$rt .= sprintf(' %u', $limit);
-			if (is_int($offset) && $offset > 0) {
+			if ((is_int($offset) || ctype_digit($offset)) && $offset > 0) {
 				$rt = sprintf(' OFFSET %u ROWS FETCH FIRST %u ROWS ONLY', $offset, $limit);
 			}
 			return $rt;


### PR DESCRIPTION
When doing pagination you could get offset not as a int(eg. 10) but string(eg. "10") and it will not paginate at all.

For example DataTables plugin pass offset from params and all params from http request are strings or numbers wrapped in strings.

Adding ctype_digit($offset) will also check the case.
ctype_digit will only allow string cotaining pure numbers.
