### PR TITLE
[2.x] Backport Hash new features & bug fixes

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -1356,7 +1356,7 @@ class HashTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 
-		$result = Hash::sort($items, '{n}.Item.image', 'asc', array('type' => 'natural', 'ignoreCase' => true));
+		$result = Hash::sort($items, '{n}.Item.image', 'asc', array('type' => 'NATURAL', 'ignoreCase' => true));
 		$expected = array(
 			array('Item' => array('image' => 'img1.jpg')),
 			array('Item' => array('image' => 'img2.jpg')),
@@ -1530,6 +1530,58 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Test sorting on a nested key that is sometimes undefined.
+ *
+ * @return void
+ */
+	public function testSortSparse() {
+		$data = array(
+			array(
+				'id' => 1,
+				'title' => 'element 1',
+				'extra' => 1,
+			),
+			array(
+				'id' => 2,
+				'title' => 'element 2',
+				'extra' => 2,
+			),
+			array(
+				'id' => 3,
+				'title' => 'element 3',
+			),
+			array(
+				'id' => 4,
+				'title' => 'element 4',
+				'extra' => 4,
+			)
+		);
+		$result = Hash::sort($data, '{n}.extra', 'desc', 'natural');
+		$expected = array(
+			array(
+				'id' => 4,
+				'title' => 'element 4',
+				'extra' => 4,
+			),
+			array(
+				'id' => 2,
+				'title' => 'element 2',
+				'extra' => 2,
+			),
+			array(
+				'id' => 1,
+				'title' => 'element 1',
+				'extra' => 1,
+			),
+			array(
+				'id' => 3,
+				'title' => 'element 3',
+			),
+		);
+		$this->assertSame($expected, $result);
+	}
+
+/**
  * Test insert()
  *
  * @return void
@@ -1591,6 +1643,17 @@ class HashTest extends CakeTestCase {
 			1 => array('Item' => array('id' => 2, 'title' => 'second', 'test' => 2)),
 			2 => array('Item' => array('id' => 3, 'title' => 'third')),
 			3 => array('Item' => array('id' => 4, 'title' => 'fourth', 'test' => 2)),
+			4 => array('Item' => array('id' => 5, 'title' => 'fifth')),
+		);
+		$this->assertEquals($expected, $result);
+
+		$data[3]['testable'] = true;
+		$result = Hash::insert($data, '{n}[testable].Item[id=/\b2|\b4/].test', 2);
+		$expected = array(
+			0 => array('Item' => array('id' => 1, 'title' => 'first')),
+			1 => array('Item' => array('id' => 2, 'title' => 'second')),
+			2 => array('Item' => array('id' => 3, 'title' => 'third')),
+			3 => array('Item' => array('id' => 4, 'title' => 'fourth', 'test' => 2), 'testable' => true),
 			4 => array('Item' => array('id' => 5, 'title' => 'fifth')),
 		);
 		$this->assertEquals($expected, $result);
@@ -1686,6 +1749,43 @@ class HashTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 		$result = Hash::remove($array, '{n}.{n}.part');
 		$this->assertEquals($expected, $result);
+
+		$array = array(
+			'foo' => 'string',
+		);
+		$expected = $array;
+		$result = Hash::remove($array, 'foo.bar');
+		$this->assertEquals($expected, $result);
+
+		$array = array(
+			'foo' => 'string',
+			'bar' => array(
+				0 => 'a',
+				1 => 'b',
+			),
+		);
+		$expected = array(
+			'foo' => 'string',
+			'bar' => array(
+				1 => 'b',
+			),
+		);
+		$result = Hash::remove($array, '{s}.0');
+		$this->assertEquals($expected, $result);
+
+		$array = array(
+			'foo' => array(
+				0 => 'a',
+				1 => 'b',
+			),
+		);
+		$expected = array(
+			'foo' => array(
+				1 => 'b',
+			),
+		);
+		$result = Hash::remove($array, 'foo[1=b].0');
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1718,6 +1818,17 @@ class HashTest extends CakeTestCase {
 		$expected = array(
 			0 => array('Item' => array('id' => 1, 'title' => 'first')),
 			2 => array('Item' => array('id' => 3, 'title' => 'third')),
+			4 => array('Item' => array('id' => 5, 'title' => 'fifth')),
+		);
+		$this->assertEquals($expected, $result);
+
+		$data[3]['testable'] = true;
+		$result = Hash::remove($data, '{n}[testable].Item[id=/\b2|\b4/].title');
+		$expected = array(
+			0 => array('Item' => array('id' => 1, 'title' => 'first')),
+			1 => array('Item' => array('id' => 2, 'title' => 'second')),
+			2 => array('Item' => array('id' => 3, 'title' => 'third')),
+			3 => array('Item' => array('id' => 4), 'testable' => true),
 			4 => array('Item' => array('id' => 5, 'title' => 'fifth')),
 		);
 		$this->assertEquals($expected, $result);

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -91,8 +91,8 @@ class Hash {
  *
  * - `1.User.name` Get the name of the user at index 1.
  * - `{n}.User.name` Get the name of every user in the set of users.
- * - `{n}.User[id]` Get the name of every user with an id key.
- * - `{n}.User[id>=2]` Get the name of every user with an id key greater than or equal to 2.
+ * - `{n}.User[id].name` Get the name of every user with an id key.
+ * - `{n}.User[id>=2].name` Get the name of every user with an id key greater than or equal to 2.
  * - `{n}.User[username=/^paul/]` Get User elements with username matching `^paul`.
  *
  * @param array $data The data to extract from.
@@ -149,6 +149,7 @@ class Hash {
 		}
 		return $context[$_key];
 	}
+
 /**
  * Split token conditions
  *
@@ -454,7 +455,7 @@ class Hash {
  * The `$format` string can use any format options that `vsprintf()` and `sprintf()` do.
  *
  * @param array $data Source array from which to extract the data
- * @param string $paths An array containing one or more Hash::extract()-style key paths
+ * @param array $paths An array containing one or more Hash::extract()-style key paths
  * @param string $format Format string into which values will be inserted, see sprintf()
  * @return array An array of strings extracted from `$path` and formatted with `$format`
  * @link https://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::format
@@ -729,7 +730,7 @@ class Hash {
  * Counts the dimensions of an array.
  * Only considers the dimension of the first element in the array.
  *
- * If you have an un-even or heterogenous array, consider using Hash::maxDimensions()
+ * If you have an un-even or heterogeneous array, consider using Hash::maxDimensions()
  * to get the dimensions of the array.
  *
  * @param array $data Array to count dimensions on
@@ -809,11 +810,15 @@ class Hash {
  * You can easily count the results of an extract using apply().
  * For example to count the comments on an Article:
  *
- * `$count = Hash::apply($data, 'Article.Comment.{n}', 'count');`
+ * ```
+ * $count = Hash::apply($data, 'Article.Comment.{n}', 'count');
+ * ```
  *
  * You could also use a function like `array_sum` to sum the results.
  *
- * `$total = Hash::apply($data, '{n}.Item.price', 'array_sum');`
+ * ```
+ * $total = Hash::apply($data, '{n}.Item.price', 'array_sum');
+ * ```
  *
  * @param array $data The data to reduce.
  * @param string $path The path to extract from $data.
@@ -833,7 +838,7 @@ class Hash {
  * - `asc` Sort ascending.
  * - `desc` Sort descending.
  *
- * ## Sort types
+ * ### Sort types
  *
  * - `regular` For regular sorting (don't change types)
  * - `numeric` Compare values numerically


### PR DESCRIPTION
Backport #7080, #8233 and #11060. Especially, the last one is necessary to fix CookieComponent problems (#11280), as CookieComponent::delete() is depending on Hash::remove().  Also, I fixed several docblocks.