### PR TITLE
Allow Emoji Characters in the URL

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -908,7 +908,9 @@ class Validation
     public static function url($check, $strict = false)
     {
         static::_populateIp();
-        $alpha = '0-9\p{L}\p{N}';
+
+        $emoji = '\x{1F300}-\x{1F6FF}';
+        $alpha = '0-9(\p{L}\p{N}' . $emoji;
         $hex = '(%[0-9a-f]{2})';
         $subDelimiters = preg_quote('/!"$&\'()*+,-.@_:;=~[]', '/');
         $path = '([' . $subDelimiters . $alpha . ']|' . $hex . ')';

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -909,7 +909,7 @@ class Validation
     {
         static::_populateIp();
 
-        $emoji = '\x{1F300}-\x{1F6FF}';
+        $emoji = '\x{1F190}-\x{1F9EF}';
         $alpha = '0-9(\p{L}\p{N}' . $emoji;
         $hex = '(%[0-9a-f]{2})';
         $subDelimiters = preg_quote('/!"$&\'()*+,-.@_:;=~[]', '/');

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -904,6 +904,7 @@ class Validation
      * @param string $check Value to check
      * @param bool $strict Require URL to be prefixed by a valid scheme (one of http(s)/ftp(s)/file/news/gopher)
      * @return bool Success
+     * @link https://tools.ietf.org/html/rfc3986
      */
     public static function url($check, $strict = false)
     {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2181,7 +2181,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::url('http://www.electrohome.ro/images/239537750-284232-215_300[1].jpg'));
         $this->assertTrue(Validation::url('http://www.eräume.foo'));
         $this->assertTrue(Validation::url('http://äüö.eräume.foo'));
-        $this->assertTrue(Validation::url('http://www.domain.com/👹'), 'utf8Extended path failed');
+        $this->assertTrue(Validation::url('http://www.domain.com/👹/🧀'), 'utf8Extended path failed');
 
         $this->assertTrue(Validation::url('http://cakephp.org:80'));
         $this->assertTrue(Validation::url('http://cakephp.org:443'));

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2181,6 +2181,7 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::url('http://www.electrohome.ro/images/239537750-284232-215_300[1].jpg'));
         $this->assertTrue(Validation::url('http://www.eräume.foo'));
         $this->assertTrue(Validation::url('http://äüö.eräume.foo'));
+        $this->assertTrue(Validation::url('http://www.domain.com/👹'), 'utf8Extended path failed');
 
         $this->assertTrue(Validation::url('http://cakephp.org:80'));
         $this->assertTrue(Validation::url('http://cakephp.org:443'));


### PR DESCRIPTION
Emoji characters are a valid in a URL, so the validator should be updated to allow this edge case to pass.

Fun Emoji/Browser facts
1. Browsers utilize something called `punycoder` to convert something like `🍕` to `xn--vi8h`
2. At the moment, the only ccTLD that supports emojis in the domain name, is `.ws`!

refs #8368
