### PR TITLE
Fix tests for PHP7.2 session_id problems.

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -113,10 +113,11 @@ class Command
 
         $parser = $this->buildOptionParser($parser);
         if (!($parser instanceof ConsoleOptionParser)) {
+            $actualType = is_object($parser) ? get_class($parser) : gettype($parser);
             throw new RuntimeException(sprintf(
                 "Invalid option parser returned from buildOptionParser(). Expected %s, got %s",
                 ConsoleOptionParser::class,
-                get_class($parser)
+                $actualType
             ));
         }
 

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -156,7 +156,6 @@ class SecurityComponentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        session_id('cli');
 
         $this->server = $_SERVER;
         $session = new Session();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -139,3 +139,8 @@ if (class_exists('PHPUnit_Runner_Version')) {
     class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
     class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
 }
+
+// Fixate sessionid early on, as php7.2+
+// does not allow the sessionid to be set after stdout
+// has been written to.
+session_id('cli');


### PR DESCRIPTION
session_id() can't be set after stdout has been written to. Fixate the session id to a non-empty value during bootstrap to make tests possible.