### PR TITLE
Revert "Change default red to use the high intensity code"

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -95,7 +95,7 @@ class ConsoleOutput
      */
     protected static $_foregroundColors = [
         'black' => 30,
-        'red' => 91,
+        'red' => 31,
         'green' => 32,
         'yellow' => 33,
         'blue' => 34,

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -144,7 +144,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingSimple()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[91mError:\033[0m Something bad");
+            ->with("\033[31mError:\033[0m Something bad");
 
         $this->output->write('<error>Error:</error> Something bad', false);
     }
@@ -203,7 +203,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingMultipleStylesName()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[91mBad\033[0m \033[33mWarning\033[0m Regular");
+            ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', false);
     }
@@ -216,7 +216,7 @@ class ConsoleOutputTest extends TestCase
     public function testFormattingMultipleSameTags()
     {
         $this->output->expects($this->once())->method('_write')
-            ->with("\033[91mBad\033[0m \033[91mWarning\033[0m Regular");
+            ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <error>Warning</error> Regular', false);
     }


### PR DESCRIPTION
This reverts commit 38ed099e265f685b0682573e2ee752a0601a5d9f.
Non-standard SGR code should not be used, as it doesn't work depending on environment, such as ANSICON:
```php
// In your shell
$this->info('Info');
$this->warn('Warning');
$this->err('Error');
$this->success('Success');
```

![non-standard-sgr](https://user-images.githubusercontent.com/7399393/31316775-4c28dace-ac6f-11e7-91f8-08fa5f308797.png)
 
While we could use `31;1` instead of `91` to get bright red, I would suggest to change the color code for ANSI red in your terminal preferences if it is unreadable for you. It seems odd to me to use bright color only for red. An alternative approach would be to use bright versions for all colors, not only for red.

Refs #6399, https://en.wikipedia.org/wiki/ANSI_escape_code#Colors