### PR TITLE
Cast length/precision/scale to integers in SQLServer

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -81,6 +81,10 @@ class SqlserverSchema extends BaseSchema
     protected function _convertColumn($col, $length = null, $precision = null, $scale = null)
     {
         $col = strtolower($col);
+        $length = (int)$length;
+        $precision = (int)$precision;
+        $scale = (int)$scale;
+
         if (in_array($col, ['date', 'time'])) {
             return ['type' => $col, 'length' => null];
         }

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -408,7 +408,11 @@ SQL;
         ];
         $this->assertEquals(['id'], $result->primaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertSame($definition, $result->column($field), 'Failed to match field ' . $field);
+            $column = $result->column($field);
+            $this->assertEquals($definition, $column, 'Failed to match field ' . $field);
+            $this->assertSame($definition['length'], $column['length']);
+            $this->assertSame($definition['scale'], $column['scale']);
+            $this->assertSame($definition['precision'], $column['precision']);
         }
     }
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -408,7 +408,7 @@ SQL;
         ];
         $this->assertEquals(['id'], $result->primaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->column($field), 'Failed to match field ' . $field);
+            $this->assertSame($definition, $result->column($field), 'Failed to match field ' . $field);
         }
     }
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -411,7 +411,6 @@ SQL;
             $column = $result->column($field);
             $this->assertEquals($definition, $column, 'Failed to match field ' . $field);
             $this->assertSame($definition['length'], $column['length']);
-            $this->assertSame($definition['scale'], $column['scale']);
             $this->assertSame($definition['precision'], $column['precision']);
         }
     }


### PR DESCRIPTION
Schema reflection would leave length as a string when it should be an integer. The same was true for precision and scale.

Refs #11296
