### PR TITLE
Add abort() to Command.

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -15,6 +15,7 @@
 namespace Cake\Console;
 
 use Cake\Console\Exception\ConsoleException;
+use Cake\Console\Exception\StopException;
 use Cake\Datasource\ModelAwareTrait;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -232,5 +233,16 @@ class Command
     public function execute(Arguments $args, ConsoleIo $io)
     {
         return null;
+    }
+
+    /**
+     * Halt the the current process with a StopException.
+     *
+     * @param int $code The exit code to use.
+     * @throws \Cake\Console\Exception\ConsoleException
+     */
+    public function abort($code = self::CODE_ERROR)
+    {
+        throw new StopException('Command aborted', $code);
     }
 }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -240,6 +240,7 @@ class Command
      *
      * @param int $code The exit code to use.
      * @throws \Cake\Console\Exception\ConsoleException
+     * @return void
      */
     public function abort($code = self::CODE_ERROR)
     {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -239,7 +239,7 @@ class Command
      * Halt the the current process with a StopException.
      *
      * @param int $code The exit code to use.
-     * @throws \Cake\Console\Exception\ConsoleException
+     * @throws \Cake\Console\Exception\StopException
      * @return void
      */
     public function abort($code = self::CODE_ERROR)

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -235,6 +235,32 @@ class CommandTest extends TestCase
         $this->assertContains('Error: Missing required arguments. name is required', $messages);
     }
 
+    /**
+     * Test abort()
+     *
+     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionCode 1
+     * @return void
+     */
+    public function testAbort()
+    {
+        $command = new Command();
+        $command->abort();
+    }
+
+    /**
+     * Test abort()
+     *
+     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionCode 99
+     * @return void
+     */
+    public function testAbortCustomCode()
+    {
+        $command = new Command();
+        $command->abort(99);
+    }
+
     protected function getMockIo($output)
     {
         $io = $this->getMockBuilder(ConsoleIo::class)


### PR DESCRIPTION
Messages can be handled in the command via the `$io` object. I thought it was a bit silly to pass in ConsoleIo so that a message could be printed using it.

Part of #11137 
