### PR TITLE
Error supressing is causing problems with asset files inside plugin

### DIFF
--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -210,7 +210,7 @@ class UrlHelper extends Helper
             $webrootPath = WWW_ROOT . str_replace('/', DIRECTORY_SEPARATOR, $filepath);
             if (file_exists($webrootPath)) {
                 //@codingStandardsIgnoreStart
-                return $path . '?' . @filemtime($webrootPath);
+                return $path . '?' . filemtime($webrootPath);
                 //@codingStandardsIgnoreEnd
             }
             $segments = explode('/', ltrim($filepath, '/'));
@@ -220,7 +220,7 @@ class UrlHelper extends Helper
                 $pluginPath = Plugin::path($plugin) . 'webroot' . DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $segments);
                 if (file_exists($pluginPath)) {
                     //@codingStandardsIgnoreStart
-                    return $path . '?' . @filemtime($pluginPath);
+                    return $path . '?' . filemtime($pluginPath);
                     //@codingStandardsIgnoreEnd4
                 }
             }

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -218,9 +218,11 @@ class UrlHelper extends Helper
             if (Plugin::loaded($plugin)) {
                 unset($segments[0]);
                 $pluginPath = Plugin::path($plugin) . 'webroot' . DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $segments);
-                //@codingStandardsIgnoreStart
-                return $path . '?' . @filemtime($pluginPath);
-                //@codingStandardsIgnoreEnd
+                if (file_exists($pluginPath)) {
+                    //@codingStandardsIgnoreStart
+                    return $path . '?' . @filemtime($pluginPath);
+                    //@codingStandardsIgnoreEnd4
+                }
             }
         }
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -275,7 +275,7 @@ class UrlHelperTest extends TestCase
         $this->assertRegExp('#/test_theme/js/theme.js\?[0-9]+$#', $result, 'Missing timestamp theme');
 
         $result = $this->Helper->assetTimestamp('/test_theme/js/non_existant.js');
-        $this->assertRegExp('#/test_theme/js/non_existant.js\?$#', $result, 'No error on missing file');
+        $this->assertRegExp('#/test_theme/js/non_existant.js$#', $result, 'No error on missing file');
     }
 
     /**

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -269,7 +269,7 @@ class UrlHelperTest extends TestCase
         $this->assertRegExp('#/test_plugin/css/test_plugin_asset.css\?[0-9]+$#', $result, 'Missing timestamp plugin');
 
         $result = $this->Helper->assetTimestamp('/test_plugin/css/i_dont_exist.css');
-        $this->assertRegExp('#/test_plugin/css/i_dont_exist.css\?$#', $result, 'No error on missing file');
+        $this->assertRegExp('#/test_plugin/css/i_dont_exist.css$#', $result, 'No error on missing file');
 
         $result = $this->Helper->assetTimestamp('/test_theme/js/theme.js');
         $this->assertRegExp('#/test_theme/js/theme.js\?[0-9]+$#', $result, 'Missing timestamp theme');


### PR DESCRIPTION
Fixed bug with missing file inside plugin

This relates to this issue https://github.com/cakephp/cakephp/issues/11251 Same environment.

First this was faced with dynamic asset files when using HtmlHelper->script(), but I testsed it and seems like it happens always if file does not exists.