### PR TITLE
3.next - ConsoleIo helper methods

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -175,6 +175,92 @@ class ConsoleIo
     }
 
     /**
+     * Convenience method for out() that wraps message between <info /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @param int $level The message's output level, see above.
+     * @return int|bool The number of bytes returned from writing to stdout.
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
+     */
+    public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
+    {
+        $messageType = 'info';
+        $message = $this->wrapMessageWithType($messageType, $message);
+
+        return $this->out($message, $newlines, $level);
+    }
+
+    /**
+     * Convenience method for err() that wraps message between <warning /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @return int|bool The number of bytes returned from writing to stderr.
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
+     */
+    public function warning($message = null, $newlines = 1)
+    {
+        $messageType = 'warning';
+        $message = $this->wrapMessageWithType($messageType, $message);
+
+        return $this->err($message, $newlines);
+    }
+
+    /**
+     * Convenience method for err() that wraps message between <error /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @return int|bool The number of bytes returned from writing to stderr.
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::err
+     */
+    public function error($message = null, $newlines = 1)
+    {
+        $messageType = 'error';
+        $message = $this->wrapMessageWithType($messageType, $message);
+
+        return $this->err($message, $newlines);
+    }
+
+    /**
+     * Convenience method for out() that wraps message between <success /> tag
+     *
+     * @param string|array|null $message A string or an array of strings to output
+     * @param int $newlines Number of newlines to append
+     * @param int $level The message's output level, see above.
+     * @return int|bool The number of bytes returned from writing to stdout.
+     * @see https://book.cakephp.org/3.0/en/console-and-shells.html#Shell::out
+     */
+    public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
+    {
+        $messageType = 'success';
+        $message = $this->wrapMessageWithType($messageType, $message);
+
+        return $this->out($message, $newlines, $level);
+    }
+
+    /**
+     * Wraps a message with a given message type, e.g. <warning>
+     *
+     * @param string $messageType The message type, e.g. "warning".
+     * @param string|array $message The message to wrap.
+     * @return array|string The message wrapped with the given message type.
+     */
+    protected function wrapMessageWithType($messageType, $message)
+    {
+        if (is_array($message)) {
+            foreach ($message as $k => $v) {
+                $message[$k] = "<{$messageType}>{$v}</{$messageType}>";
+            }
+        } else {
+            $message = "<{$messageType}>{$message}</{$messageType}>";
+        }
+
+        return $message;
+    }
+
+    /**
      * Overwrite some already output text.
      *
      * Useful for building progress bars, or when you want to replace

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -729,10 +729,7 @@ class Shell
      */
     public function err($message = null, $newlines = 1)
     {
-        $messageType = 'error';
-        $message = $this->wrapMessageWithType($messageType, $message);
-
-        return $this->_io->err($message, $newlines);
+        return $this->_io->error($message, $newlines);
     }
 
     /**
@@ -746,10 +743,7 @@ class Shell
      */
     public function info($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
-        $messageType = 'info';
-        $message = $this->wrapMessageWithType($messageType, $message);
-
-        return $this->out($message, $newlines, $level);
+        return $this->_io->info($message, $newlines, $level);
     }
 
     /**
@@ -762,10 +756,7 @@ class Shell
      */
     public function warn($message = null, $newlines = 1)
     {
-        $messageType = 'warning';
-        $message = $this->wrapMessageWithType($messageType, $message);
-
-        return $this->_io->err($message, $newlines);
+        return $this->_io->warning($message, $newlines);
     }
 
     /**
@@ -779,10 +770,7 @@ class Shell
      */
     public function success($message = null, $newlines = 1, $level = Shell::NORMAL)
     {
-        $messageType = 'success';
-        $message = $this->wrapMessageWithType($messageType, $message);
-
-        return $this->out($message, $newlines, $level);
+        return $this->_io->success($message, $newlines, $level);
     }
 
     /**
@@ -791,6 +779,7 @@ class Shell
      * @param string $messageType The message type, e.g. "warning".
      * @param string|array $message The message to wrap.
      * @return array|string The message wrapped with the given message type.
+     * @deprecated 3.6.0 Will be removed in 4.0.0 as it is no longer in use.
      */
     protected function wrapMessageWithType($messageType, $message)
     {

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -497,4 +497,64 @@ class ConsoleIoTest extends TestCase
         $this->assertInstanceOf('Cake\Console\Helper', $helper);
         $helper->output(['well', 'ish']);
     }
+
+    /**
+     * Provider for output helpers
+     *
+     * @return array
+     */
+    public function outHelperProvider()
+    {
+        return [['info'], ['success']];
+    }
+
+    /**
+     * Provider for err helpers
+     *
+     * @return array
+     */
+    public function errHelperProvider()
+    {
+        return [['warning'], ['error']];
+    }
+
+    /**
+     * test out helper methods
+     *
+     * @dataProvider outHelperProvider
+     * @return void
+     */
+    public function testOutHelpers($method)
+    {
+        $this->out->expects($this->at(0))
+            ->method('write')
+            ->with("<{$method}>Just a test</{$method}>", 1);
+
+        $this->out->expects($this->at(1))
+            ->method('write')
+            ->with(["<{$method}>Just</{$method}>", "<{$method}>a test</{$method}>"], 1);
+
+        $this->io->{$method}('Just a test');
+        $this->io->{$method}(['Just', 'a test']);
+    }
+
+    /**
+     * test err helper methods
+     *
+     * @dataProvider errHelperProvider
+     * @return void
+     */
+    public function testErrHelpers($method)
+    {
+        $this->err->expects($this->at(0))
+            ->method('write')
+            ->with("<{$method}>Just a test</{$method}>", 1);
+
+        $this->err->expects($this->at(1))
+            ->method('write')
+            ->with(["<{$method}>Just</{$method}>", "<{$method}>a test</{$method}>"], 1);
+
+        $this->io->{$method}('Just a test');
+        $this->io->{$method}(['Just', 'a test']);
+    }
 }

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -303,8 +303,8 @@ class ShellTest extends TestCase
     public function testErr()
     {
         $this->io->expects($this->once())
-            ->method('err')
-            ->with('<error>Just a test</error>', 1);
+            ->method('error')
+            ->with('Just a test', 1);
 
         $this->Shell->err('Just a test');
     }
@@ -317,8 +317,8 @@ class ShellTest extends TestCase
     public function testErrArray()
     {
         $this->io->expects($this->once())
-            ->method('err')
-            ->with(['<error>Just</error>', '<error>a</error>', '<error>test</error>'], 1);
+            ->method('error')
+            ->with(['Just', 'a', 'test'], 1);
 
         $this->Shell->err(['Just', 'a', 'test']);
     }
@@ -331,8 +331,8 @@ class ShellTest extends TestCase
     public function testInfo()
     {
         $this->io->expects($this->once())
-            ->method('out')
-            ->with('<info>Just a test</info>', 1);
+            ->method('info')
+            ->with('Just a test', 1);
 
         $this->Shell->info('Just a test');
     }
@@ -345,8 +345,8 @@ class ShellTest extends TestCase
     public function testInfoArray()
     {
         $this->io->expects($this->once())
-            ->method('out')
-            ->with(['<info>Just</info>', '<info>a</info>', '<info>test</info>'], 1);
+            ->method('info')
+            ->with(['Just', 'a', 'test'], 1);
 
         $this->Shell->info(['Just', 'a', 'test']);
     }
@@ -359,8 +359,8 @@ class ShellTest extends TestCase
     public function testWarn()
     {
         $this->io->expects($this->once())
-            ->method('err')
-            ->with('<warning>Just a test</warning>', 1);
+            ->method('warning')
+            ->with('Just a test', 1);
 
         $this->Shell->warn('Just a test');
     }
@@ -373,8 +373,8 @@ class ShellTest extends TestCase
     public function testWarnArray()
     {
         $this->io->expects($this->once())
-            ->method('err')
-            ->with(['<warning>Just</warning>', '<warning>a</warning>', '<warning>test</warning>'], 1);
+            ->method('warning')
+            ->with(['Just', 'a', 'test'], 1);
 
         $this->Shell->warn(['Just', 'a', 'test']);
     }
@@ -387,8 +387,8 @@ class ShellTest extends TestCase
     public function testSuccess()
     {
         $this->io->expects($this->once())
-            ->method('out')
-            ->with('<success>Just a test</success>', 1);
+            ->method('success')
+            ->with('Just a test', 1);
 
         $this->Shell->success('Just a test');
     }
@@ -401,8 +401,8 @@ class ShellTest extends TestCase
     public function testSuccessArray()
     {
         $this->io->expects($this->once())
-            ->method('out')
-            ->with(['<success>Just</success>', '<success>a</success>', '<success>test</success>'], 1);
+            ->method('success')
+            ->with(['Just', 'a', 'test'], 1);
 
         $this->Shell->success(['Just', 'a', 'test']);
     }
@@ -1271,8 +1271,8 @@ TEXT;
         $shell->expects($this->never())->method('main');
 
         $io->expects($this->once())
-            ->method('err')
-            ->with('<error>Error: Missing required arguments. filename is required.</error>');
+            ->method('error')
+            ->with('Error: Missing required arguments. filename is required.');
         $result = $shell->runCommand([]);
         $this->assertFalse($result, 'Shell should fail');
     }


### PR DESCRIPTION
These methods will allow Commands to have the same output interfaces as shells have today. One change is that `warn` has been renamed to `warning`. This removes a short form that to remember, and makes output consistent with logging which also uses `warning`.

Refs #11137