### PR TITLE
Use utf8mb4 instead uf utf8mb3 (= utf8)

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -39,7 +39,7 @@ class Mysql extends Driver
         'database' => 'cake',
         'port' => '3306',
         'flags' => [],
-        'encoding' => 'utf8',
+        'encoding' => 'utf8mb4',
         'timezone' => null,
         'init' => [],
     ];


### PR DESCRIPTION
- [x] Enhancement
- [x] Bug (inserting valid utf8 such as 😃 will break your data using mysql/cakephp and default utf8 settings set by the driver and recommended app.php)

Refs:
* issue with more info: https://github.com/cakephp/cakephp/issues/11324#issuecomment-336672560
* related app skeleton PR https://github.com/cakephp/app/pull/554
