### PR TITLE
implement response::withMimeType()

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1136,6 +1136,33 @@ class Response implements ResponseInterface
     }
 
     /**
+     * Get a new instance with an updated mime types.
+     *
+     * ### Storing content type definitions
+     *
+     * ```
+     * type(['keynote' => 'application/keynote', 'bat' => 'application/bat']);
+     * ```
+     *
+     * ### Replacing a content type definition
+     *
+     * ```
+     * type(['jpg' => 'text/plain']);
+     *
+     * @param array $mimeTypes list of $mimeTypes to insert into  current mime type list
+     * @return static
+     */
+    public function withMimeType(array $mimeTypes)
+    {
+        $new = clone $this;
+        foreach ($mimeTypes as $type => $definition) {
+            $new->_mimeTypes[$type] = $definition;
+        }
+
+        return $new;
+    }
+
+    /**
      * Maps a content-type back to an alias
      *
      * e.g `mapType('application/pdf'); // returns 'pdf'`


### PR DESCRIPTION
feel free to close the PR if you think  (like me) we no need to this method

because we have `withType()` and `withHeader()`
```php
$response->withType('custom/stuff');
or
$response->withType('json');

//test case
        $this->assertEquals(
            'custom/stuff',
            $response->withType('custom/stuff')->getType()
        );
        $this->assertEquals(
            'application/json',
            $response->withType('json')->getType()
        );
```
and probably
```php
->withHeader('Content-Type', 'application/json')
```

Refs: https://github.com/cakephp/cakephp/pull/11335