### PR TITLE
Add custom message to response code assertions

### DIFF
--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -763,11 +763,11 @@ abstract class IntegrationTestCase extends TestCase
     public function assertResponseCode($code, $message = null)
     {
         $actual = $this->_response->getStatusCode();
-        
+
         if (empty($message)) {
             $message = 'Status code is not ' . $code . ' but ' . $actual;
         }
-        
+
         $this->_assertStatus($code, $code, $message);
     }
 

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -700,6 +700,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the response status code is in the 2xx range.
      *
+     * @param string $message Custom message for failure.
      * @return void
      */
     public function assertResponseOk($message = null)
@@ -713,6 +714,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the response status code is in the 2xx/3xx range.
      *
+     * @param string $message Custom message for failure.
      * @return void
      */
     public function assertResponseSuccess($message = null)
@@ -726,6 +728,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the response status code is in the 4xx range.
      *
+     * @param string $message Custom message for failure.
      * @return void
      */
     public function assertResponseError($message = null)
@@ -739,6 +742,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Asserts that the response status code is in the 5xx range.
      *
+     * @param string $message Custom message for failure.
      * @return void
      */
     public function assertResponseFailure($message = null)
@@ -753,6 +757,7 @@ abstract class IntegrationTestCase extends TestCase
      * Asserts a specific response status code.
      *
      * @param int $code Status code to assert.
+     * @param string $message Custom message for failure.
      * @return void
      */
     public function assertResponseCode($code, $message = null)

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -702,9 +702,12 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseOk()
+    public function assertResponseOk($message)
     {
-        $this->_assertStatus(200, 204, 'Status code is not between 200 and 204');
+        if (empty($message)) {
+            $message = 'Status code is not between 200 and 204';
+        }
+        $this->_assertStatus(200, 204, $message);
     }
 
     /**
@@ -712,9 +715,12 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseSuccess()
+    public function assertResponseSuccess($message)
     {
-        $this->_assertStatus(200, 308, 'Status code is not between 200 and 308');
+        if (empty($message)) {
+            $message = 'Status code is not between 200 and 308';
+        }
+        $this->_assertStatus(200, 308, $message);
     }
 
     /**
@@ -722,9 +728,12 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseError()
+    public function assertResponseError($message)
     {
-        $this->_assertStatus(400, 429, 'Status code is not between 400 and 429');
+        if (empty($message)) {
+            $message = 'Status code is not between 400 and 429';
+        }
+        $this->_assertStatus(400, 429, $message);
     }
 
     /**
@@ -732,9 +741,12 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseFailure()
+    public function assertResponseFailure($message)
     {
-        $this->_assertStatus(500, 505, 'Status code is not between 500 and 505');
+        if (empty($message)) {
+            $message = 'Status code is not between 500 and 505';
+        }
+        $this->_assertStatus(500, 505, $message);
     }
 
     /**
@@ -743,10 +755,15 @@ abstract class IntegrationTestCase extends TestCase
      * @param int $code Status code to assert.
      * @return void
      */
-    public function assertResponseCode($code)
+    public function assertResponseCode($code, $message)
     {
         $actual = $this->_response->getStatusCode();
-        $this->_assertStatus($code, $code, 'Status code is not ' . $code . ' but ' . $actual);
+        
+        if (empty($message)) {
+            $message = 'Status code is not ' . $code . ' but ' . $actual;
+        }
+        
+        $this->_assertStatus($code, $code, $message);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -702,7 +702,7 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseOk($message)
+    public function assertResponseOk($message = null)
     {
         if (empty($message)) {
             $message = 'Status code is not between 200 and 204';
@@ -715,7 +715,7 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseSuccess($message)
+    public function assertResponseSuccess($message = null)
     {
         if (empty($message)) {
             $message = 'Status code is not between 200 and 308';
@@ -728,7 +728,7 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseError($message)
+    public function assertResponseError($message = null)
     {
         if (empty($message)) {
             $message = 'Status code is not between 400 and 429';
@@ -741,7 +741,7 @@ abstract class IntegrationTestCase extends TestCase
      *
      * @return void
      */
-    public function assertResponseFailure($message)
+    public function assertResponseFailure($message = null)
     {
         if (empty($message)) {
             $message = 'Status code is not between 500 and 505';
@@ -755,7 +755,7 @@ abstract class IntegrationTestCase extends TestCase
      * @param int $code Status code to assert.
      * @return void
      */
-    public function assertResponseCode($code, $message)
+    public function assertResponseCode($code, $message = null)
     {
         $actual = $this->_response->getStatusCode();
         


### PR DESCRIPTION
It would be nice to be able to pass in a custom message to the response code convenience methods.  Especially since it is already supported in the protected method _assertStatus.
