### PR TITLE
[3.next] reduce usage of error_reporting() in tests 

### DIFF
--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -515,7 +515,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Test the options method.
+     * Test the setOptions/getOptions methods.
      *
      * @return void
      */
@@ -538,15 +538,15 @@ class TableTest extends TestCase
      */
     public function testOptionsDeprecated()
     {
-        $errorLevel = error_reporting(E_ALL & ~E_USER_DEPRECATED);
         $table = new Table('articles');
         $options = [
             'engine' => 'InnoDB'
         ];
-        $return = $table->options($options);
-        $this->assertInstanceOf('Cake\Database\Schema\Table', $return);
-        $this->assertEquals($options, $table->options());
-        error_reporting($errorLevel);
+        $this->deprecated(function () use ($table, $options) {
+            $return = $table->options($options);
+            $this->assertInstanceOf('Cake\Database\Schema\Table', $return);
+            $this->assertEquals($options, $table->options());
+        });
     }
 
     /**


### PR DESCRIPTION
also needs 
https://github.com/cakephp/cakephp/blob/9fa798e39affdc574e6b41f3639cc82b5a34c32d/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php#L326-L328
and
https://github.com/cakephp/cakephp/blob/9fa798e39affdc574e6b41f3639cc82b5a34c32d/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php#L560-L562
and
https://github.com/cakephp/cakephp/blob/9fa798e39affdc574e6b41f3639cc82b5a34c32d/tests/TestCase/Http/Client/FormDataTest.php#L126-L129

should I flag `testAddArrayWithFile` testCase to `@group deprecated` ?