### PR TITLE
Force email domain lookups to work in fallback case.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -656,7 +656,7 @@ class Validation
                 return true;
             }
 
-            return is_array(gethostbynamel($regs[1]));
+            return is_array(gethostbynamel($regs[1] . '.'));
         }
 
         return false;


### PR DESCRIPTION
In fallback scenarios, Validation::email() would resolve all domains to
localhost because of a missing `.`.

There are no additional tests as Travis and most PHP installations come with `checkdnsrr` or `getmxrr`.

Refs #11342