### PR TITLE
Move Router::$initialized from RoutingMiddleware to BaseApplication

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -17,6 +17,7 @@ namespace Cake\Http;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -69,7 +70,11 @@ abstract class BaseApplication implements ConsoleApplicationInterface, HttpAppli
      */
     public function routes($routes)
     {
-        require $this->configDir . '/routes.php';
+        if (!Router::$initialized) {
+            require $this->configDir . '/routes.php';
+            // Prevent routes from being loaded again
+            Router::$initialized = true;
+        }
     }
 
     /**

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -56,11 +56,9 @@ class RoutingMiddleware
      */
     protected function loadRoutes()
     {
-        if ($this->app && !Router::$initialized) {
+        if ($this->app) {
             $builder = Router::createRouteBuilder('/');
             $this->app->routes($builder);
-            // Prevent routes from being loaded again
-            Router::$initialized = true;
         }
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -38,6 +38,7 @@ class Router
      * Have routes been loaded
      *
      * @var bool
+     * @deprecated 3.5.0 Routes will be loaded via the Application::routes() hook in 4.0.0
      */
     public static $initialized = false;
 

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -152,7 +152,8 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
             $this->assertTrue(Router::$initialized, 'Router state should indicate routes loaded');
-            $this->assertCount(1, Router::routes());
+            $this->assertNotEmpty(Router::routes());
+            $this->assertEquals('/app/articles', Router::routes()[0]->template);
         };
         $app = new Application(CONFIG);
         $middleware = new RoutingMiddleware($app);


### PR DESCRIPTION
An attempt to fix #11357

This fix will not prevent routes from `routes.php` to load even if the application routes have been loaded. At least in tests it seems. 

I'm not sure if this is a BC breaking change, but since nobody reported the issue before, it seems not many people moved to the app routes yet anyway.

