### PR TITLE
Allow setDependent to accept an entity callback

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -586,9 +586,16 @@ class BelongsToMany extends Association
      */
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
-        if (!$this->getDependent()) {
+        $dependent = $association->getDependent();
+
+        if (is_callable($dependent)) {
+            $dependent = (bool)$dependent($entity);
+        }
+
+        if ($dependent === false) {
             return true;
         }
+
         $foreignKey = (array)$this->getForeignKey();
         $bindingKey = (array)$this->getBindingKey();
         $conditions = [];

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -586,7 +586,7 @@ class BelongsToMany extends Association
      */
     public function cascadeDelete(EntityInterface $entity, array $options = [])
     {
-        $dependent = $association->getDependent();
+        $dependent = $this->getDependent();
 
         if (is_callable($dependent)) {
             $dependent = (bool)$dependent($entity);

--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -37,9 +37,16 @@ class DependentDeleteHelper
      */
     public function cascadeDelete(Association $association, EntityInterface $entity, array $options = [])
     {
-        if (!$association->getDependent()) {
+        $dependent = $association->getDependent();
+
+        if (is_callable($dependent)) {
+            $dependent = (bool)$dependent($entity);
+        }
+
+        if ($dependent === false) {
             return true;
         }
+
         $table = $association->getTarget();
         $foreignKey = array_map([$association, 'aliasField'], (array)$association->getForeignKey());
         $bindingKey = (array)$association->getBindingKey();


### PR DESCRIPTION
This just allows setDependent to accept an optional callback (instead of just true/false) that is expected to return boolean and acts on the entity being deleted.

See issue #11361

I think this needs a test which I didn't write yet. Thoughts?