### PR TITLE
Don't duplicate command names in help listing.

### DIFF
--- a/src/TestSuite/ConsoleIntegrationTestCase.php
+++ b/src/TestSuite/ConsoleIntegrationTestCase.php
@@ -162,6 +162,18 @@ abstract class ConsoleIntegrationTestCase extends TestCase
         $output = implode(PHP_EOL, $this->_out->messages());
         $this->assertContains($expected, $output, $message);
     }
+    /**
+     * Asserts `stdout` does not contain expected output
+     *
+     * @param string $expected Expected output
+     * @param string $message Failure message
+     * @return void
+     */
+    public function assertOutputNotContains($expected, $message = '')
+    {
+        $output = implode(PHP_EOL, $this->_out->messages());
+        $this->assertNotContains($expected, $output, $message);
+    }
 
     /**
      * Asserts `stdout` contains expected regexp

--- a/tests/TestCase/Command/HelpCommandTest.php
+++ b/tests/TestCase/Command/HelpCommandTest.php
@@ -68,10 +68,15 @@ class HelpShellTest extends ConsoleIntegrationTestCase
      */
     protected function assertCommandList()
     {
+        $this->assertOutputContains('- widget', 'plugin command');
+        $this->assertOutputNotContains(
+            '- test_plugin.widget',
+            'only short alias for plugin command.'
+        );
         $this->assertOutputContains('- sample', 'app shell');
         $this->assertOutputContains('- test_plugin.sample', 'Long plugin name');
         $this->assertOutputContains('- routes', 'core shell');
-        $this->assertOutputContains('- test_plugin.example', 'Long plugin name');
+        $this->assertOutputContains('- example', 'short plugin name');
         $this->assertOutputContains('To run a command', 'more info present');
         $this->assertOutputContains('To get help', 'more info present');
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Command/WidgetCommand.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Command/WidgetCommand.php
@@ -1,0 +1,14 @@
+<?php
+namespace TestPlugin\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
+
+class WidgetCommand extends Command
+{
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $io->out('Widgets!');
+    }
+}


### PR DESCRIPTION
Only show the shortest name that resolves to an individual classname. This simplifies the help output and makes it similar to what we had in the ShellDispatcher implementation.

Refs #11362