### PR TITLE
Add Deprecation warnings to a few packages

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -91,6 +91,13 @@ abstract class BaseAuthenticate implements EventListenerInterface
     {
         $this->_registry = $registry;
         $this->setConfig($config);
+
+        if ($this->getConfig('scope') || $this->getConfig('contain')) {
+            deprecationWarning(
+                'The `scope` and `contain` options for Authentication are deprecated. ' .
+                'Use the `finder` option instead to define additional conditions.'
+            );
+        }
     }
 
     /**

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -975,7 +975,6 @@ interface CollectionInterface extends Iterator, JsonSerializable
      *
      * @param int $chunkSize The maximum size for each chunk
      * @return \Cake\Collection\CollectionInterface
-     * @deprecated 4.0.0 Deprecated in favor of chunks
      */
     public function chunk($chunkSize);
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -725,11 +725,12 @@ trait CollectionTrait
      * Backwards compatible wrapper for unwrap()
      *
      * @return \Traversable
-     * @deprecated
+     * @deprecated 3.0.10 Will be removed in 4.0.0
      */
     // @codingStandardsIgnoreLine
     public function _unwrap()
     {
+        deprecationWarning('CollectionTrait::_unwrap() is deprecated. Use CollectionTrait::unwrap() instead.');
         return $this->unwrap();
     }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -731,6 +731,7 @@ trait CollectionTrait
     public function _unwrap()
     {
         deprecationWarning('CollectionTrait::_unwrap() is deprecated. Use CollectionTrait::unwrap() instead.');
+
         return $this->unwrap();
     }
 

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -372,6 +372,7 @@ class ConsoleIo
      */
     public function outputAs($mode)
     {
+        deprecationWarning('ConsoleIo::outputAs() is deprecated. Use ConsoleIo::setOutputAs() instead.');
         $this->_out->setOutputAs($mode);
     }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -310,6 +310,10 @@ class ConsoleOptionParser
      */
     public function command($text = null)
     {
+        deprecationWarning(
+            'ConsoleOptionParser::command() is deprecated. ' .
+            'Use ConsoleOptionParser::setCommand()/getCommand() instead.'
+        );
         if ($text !== null) {
             return $this->setCommand($text);
         }
@@ -354,6 +358,10 @@ class ConsoleOptionParser
      */
     public function description($text = null)
     {
+        deprecationWarning(
+            'ConsoleOptionParser::description() is deprecated. ' .
+            'Use ConsoleOptionParser::setDescription()/getDescription() instead.'
+        );
         if ($text !== null) {
             return $this->setDescription($text);
         }
@@ -400,6 +408,10 @@ class ConsoleOptionParser
      */
     public function epilog($text = null)
     {
+        deprecationWarning(
+            'ConsoleOptionParser::epliog() is deprecated. ' .
+            'Use ConsoleOptionParser::setEpilog()/getEpilog() instead.'
+        );
         if ($text !== null) {
             return $this->setEpilog($text);
         }
@@ -785,6 +797,10 @@ class ConsoleOptionParser
      */
     public function setHelpAlias($alias)
     {
+        deprecationWarning(
+            'ConsoleOptionParser::setHelpAlias() is deprecated. ' .
+            'Use ConsoleOptionParser::setRootName() instead.'
+        );
         $this->rootName = $alias;
     }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -339,6 +339,10 @@ class ConsoleOutput
      */
     public function outputAs($type = null)
     {
+        deprecationWarning(
+            'ConsoleOutput::outputAs() is deprecated. ' .
+            'Use ConsoleOutput::setOutputAs()/getOutputAs() instead.'
+        );
         if ($type === null) {
             return $this->_outputAs;
         }

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -243,6 +243,10 @@ class Shell
      */
     public function io(ConsoleIo $io = null)
     {
+        deprecationWarning(
+            'Shell::io() is deprecated. ' .
+            'Use Shell::setIo()/getIo() instead.'
+        );
         if ($io !== null) {
             $this->_io = $io;
         }
@@ -783,6 +787,10 @@ class Shell
      */
     protected function wrapMessageWithType($messageType, $message)
     {
+        deprecationWarning(
+            'Shell::wrapMessageWithType() is deprecated. ' .
+            'Use output methods on ConsoleIo instead.'
+        );
         if (is_array($message)) {
             foreach ($message as $k => $v) {
                 $message[$k] = "<$messageType>" . $v . "</$messageType>";
@@ -849,6 +857,7 @@ class Shell
      */
     public function error($title, $message = null, $exitCode = self::CODE_ERROR)
     {
+        deprecationWarning('Shell::error() is deprecated. `Use Shell::abort() instead.');
         $this->_io->err(sprintf('<error>Error:</error> %s', $title));
 
         if (!empty($message)) {

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -688,6 +688,9 @@ class Debugger
      */
     public static function outputAs($format = null)
     {
+        deprecationWarning(
+            'Debugger::outputAs() is deprecated. Use Debugger::getOutputFormat()/setOutputFormat() instead.'
+        );
         $self = Debugger::getInstance();
         if ($format === null) {
             return $self->_outputFormat;

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -34,7 +34,7 @@ class ConsoleOptionParserTest extends TestCase
      */
     public function testDescriptionDeprecated()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $parser = new ConsoleOptionParser('test', false);
             $result = $parser->description('A test');
 
@@ -68,7 +68,7 @@ class ConsoleOptionParserTest extends TestCase
      */
     public function testEplilogDeprecated()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $parser = new ConsoleOptionParser('test', false);
             $result = $parser->epilog('A test');
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -29,18 +29,52 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test setting the console description
      *
+     * @group deprecated
+     * @return void
+     */
+    public function testDescriptionDeprecated()
+    {
+        $this->deprecated(function() {
+            $parser = new ConsoleOptionParser('test', false);
+            $result = $parser->description('A test');
+
+            $this->assertEquals($parser, $result, 'Setting description is not chainable');
+            $this->assertEquals('A test', $parser->description(), 'getting value is wrong.');
+        });
+    }
+
+    /**
+     * test setting the console description
+     *
      * @return void
      */
     public function testDescription()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $result = $parser->description('A test');
+        $result = $parser->setDescription('A test');
 
         $this->assertEquals($parser, $result, 'Setting description is not chainable');
-        $this->assertEquals('A test', $parser->description(), 'getting value is wrong.');
+        $this->assertEquals('A test', $parser->getDescription(), 'getting value is wrong.');
 
-        $result = $parser->description(['A test', 'something']);
-        $this->assertEquals("A test\nsomething", $parser->description(), 'getting value is wrong.');
+        $result = $parser->setDescription(['A test', 'something']);
+        $this->assertEquals("A test\nsomething", $parser->getDescription(), 'getting value is wrong.');
+    }
+
+    /**
+     * test setting the console description
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testEplilogDeprecated()
+    {
+        $this->deprecated(function() {
+            $parser = new ConsoleOptionParser('test', false);
+            $result = $parser->epilog('A test');
+
+            $this->assertEquals($parser, $result, 'Setting epilog is not chainable');
+            $this->assertEquals('A test', $parser->epilog(), 'getting value is wrong.');
+        });
     }
 
     /**
@@ -51,13 +85,13 @@ class ConsoleOptionParserTest extends TestCase
     public function testEpilog()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $result = $parser->epilog('A test');
+        $result = $parser->setEpilog('A test');
 
         $this->assertEquals($parser, $result, 'Setting epilog is not chainable');
-        $this->assertEquals('A test', $parser->epilog(), 'getting value is wrong.');
+        $this->assertEquals('A test', $parser->getEpilog(), 'getting value is wrong.');
 
-        $result = $parser->epilog(['A test', 'something']);
-        $this->assertEquals("A test\nsomething", $parser->epilog(), 'getting value is wrong.');
+        $result = $parser->setEpilog(['A test', 'something']);
+        $this->assertEquals("A test\nsomething", $parser->getEpilog(), 'getting value is wrong.');
     }
 
     /**
@@ -789,7 +823,7 @@ TEXT;
     public function testHelpWithRootName()
     {
         $parser = new ConsoleOptionParser('sample', false);
-        $parser->description('A command!')
+        $parser->setDescription('A command!')
             ->setRootName('tool')
             ->addOption('test', ['help' => 'A test option.']);
 
@@ -874,8 +908,8 @@ TEXT;
         ];
         $parser = ConsoleOptionParser::buildFromArray($spec);
 
-        $this->assertEquals($spec['description'], $parser->description());
-        $this->assertEquals($spec['epilog'], $parser->epilog());
+        $this->assertEquals($spec['description'], $parser->getDescription());
+        $this->assertEquals($spec['epilog'], $parser->getEpilog());
 
         $options = $parser->options();
         $this->assertTrue(isset($options['name']));
@@ -897,7 +931,7 @@ TEXT;
     {
         $parser = ConsoleOptionParser::create('factory', false);
         $this->assertInstanceOf('Cake\Console\ConsoleOptionParser', $parser);
-        $this->assertEquals('factory', $parser->command());
+        $this->assertEquals('factory', $parser->getCommand());
     }
 
     /**
@@ -908,7 +942,7 @@ TEXT;
     public function testCommandInflection()
     {
         $parser = new ConsoleOptionParser('CommandLine');
-        $this->assertEquals('command_line', $parser->command());
+        $this->assertEquals('command_line', $parser->getCommand());
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -36,7 +36,7 @@ class ConsoleOutputTest extends TestCase
         $this->output = $this->getMockBuilder('Cake\Console\ConsoleOutput')
             ->setMethods(['_write'])
             ->getMock();
-        $this->output->outputAs(ConsoleOutput::COLOR);
+        $this->output->setOutputAs(ConsoleOutput::COLOR);
     }
 
     /**
@@ -222,13 +222,31 @@ class ConsoleOutputTest extends TestCase
     }
 
     /**
+     * test deprecated outputAs
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testOutputAsPlain()
+    {
+        $this->deprecated(function() {
+            $this->output->outputAs(ConsoleOutput::PLAIN);
+            $this->assertSame(ConsoleOutput::PLAIN, $this->output->outputAs());
+            $this->output->expects($this->once())->method('_write')
+                ->with('Bad Regular');
+
+            $this->output->write('<error>Bad</error> Regular', false);
+        });
+    }
+
+    /**
      * test raw output not getting tags replaced.
      *
      * @return void
      */
-    public function testOutputAsRaw()
+    public function testSetOutputAsRaw()
     {
-        $this->output->outputAs(ConsoleOutput::RAW);
+        $this->output->setOutputAs(ConsoleOutput::RAW);
         $this->output->expects($this->once())->method('_write')
             ->with('<error>Bad</error> Regular');
 
@@ -240,9 +258,9 @@ class ConsoleOutputTest extends TestCase
      *
      * @return void
      */
-    public function testOutputAsPlain()
+    public function testSetOutputAsPlain()
     {
-        $this->output->outputAs(ConsoleOutput::PLAIN);
+        $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->output->expects($this->once())->method('_write')
             ->with('Bad Regular');
 
@@ -254,7 +272,7 @@ class ConsoleOutputTest extends TestCase
      *
      * @return void
      */
-    public function testSetOutputAsPlain()
+    public function testSetSetOutputAsPlain()
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->output->expects($this->once())->method('_write')
@@ -279,9 +297,9 @@ class ConsoleOutputTest extends TestCase
      *
      * @return void
      */
-    public function testOutputAsPlainSelectiveTagRemoval()
+    public function testSetOutputAsPlainSelectiveTagRemoval()
     {
-        $this->output->outputAs(ConsoleOutput::PLAIN);
+        $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->output->expects($this->once())->method('_write')
             ->with('Bad Regular <b>Left</b> <i>behind</i> <name>');
 

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -229,7 +229,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testOutputAsPlain()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $this->output->outputAs(ConsoleOutput::PLAIN);
             $this->assertSame(ConsoleOutput::PLAIN, $this->output->outputAs());
             $this->output->expects($this->once())->method('_write')

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -34,7 +34,7 @@ class HelpFormatterTest extends TestCase
     public function testWidthFormatting()
     {
         $parser = new ConsoleOptionParser('test', false);
-        $parser->description('This is fifteen This is fifteen This is fifteen')
+        $parser->setDescription('This is fifteen This is fifteen This is fifteen')
             ->addOption('four', ['help' => 'this is help text this is help text'])
             ->addArgument('four', ['help' => 'this is help text this is help text'])
             ->addSubcommand('four', ['help' => 'this is help text this is help text']);
@@ -115,8 +115,8 @@ txt;
     public function testHelpDescriptionAndEpilog()
     {
         $parser = new ConsoleOptionParser('mycommand', false);
-        $parser->description('Description text')
-            ->epilog('epilog text')
+        $parser->setDescription('Description text')
+            ->setEpilog('epilog text')
             ->addOption('test', ['help' => 'A test option.'])
             ->addArgument('model', ['help' => 'The model to make.', 'required' => true]);
 
@@ -384,8 +384,8 @@ xml;
     public function testXmlHelpDescriptionAndEpilog()
     {
         $parser = new ConsoleOptionParser('mycommand', false);
-        $parser->description('Description text')
-            ->epilog('epilog text')
+        $parser->setDescription('Description text')
+            ->setEpilog('epilog text')
             ->addOption('test', ['help' => 'A test option.'])
             ->addArgument('model', ['help' => 'The model to make.', 'required' => true]);
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -157,7 +157,26 @@ class ShellTest extends TestCase
     public function testConstruct()
     {
         $this->assertEquals('ShellTestShell', $this->Shell->name);
-        $this->assertInstanceOf('Cake\Console\ConsoleIo', $this->Shell->io());
+        $this->assertInstanceOf(ConsoleIo::class, $this->Shell->getIo());
+    }
+
+    /**
+     * test io method
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testIo()
+    {
+        $this->deprecated(function() {
+            $this->assertInstanceOf(ConsoleIo::class, $this->Shell->io());
+
+            $io = $this->getMockBuilder(ConsoleIo::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $this->assertSame($io, $this->Shell->io($io));
+            $this->assertSame($io, $this->Shell->io());
+        });
     }
 
     /**
@@ -438,6 +457,7 @@ class ShellTest extends TestCase
     /**
      * testError
      *
+     * @group deprecated
      * @return void
      */
     public function testError()
@@ -450,8 +470,10 @@ class ShellTest extends TestCase
             ->method('err')
             ->with('Searched all...');
 
-        $this->Shell->error('Foo Not Found', 'Searched all...');
-        $this->assertSame($this->Shell->stopped, 1);
+        $this->deprecated(function() {
+            $this->Shell->error('Foo Not Found', 'Searched all...');
+            $this->assertSame($this->Shell->stopped, 1);
+        });
     }
 
     /**
@@ -1065,7 +1087,7 @@ TEXT;
             ->setMethods(['startup', 'getOptionParser', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
-        $shell->io(
+        $shell->setIo(
             $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->setMethods(['err'])
             ->getMock()
@@ -1094,7 +1116,7 @@ TEXT;
             ->setMethods(['startup', 'getOptionParser', 'hr'])
             ->disableOriginalConstructor()
             ->getMock();
-        $shell->io(
+        $shell->setIo(
             $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->setMethods(['err'])
             ->getMock()
@@ -1131,7 +1153,7 @@ TEXT;
             ->setMethods(['getOptionParser', 'out', 'startup', '_welcome'])
             ->disableOriginalConstructor()
             ->getMock();
-        $shell->io($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
+        $shell->setIo($this->getMockBuilder('Cake\Console\ConsoleIo')->getMock());
         $shell->expects($this->once())->method('getOptionParser')
             ->will($this->returnValue($parser));
         $shell->expects($this->once())->method('out');
@@ -1150,7 +1172,7 @@ TEXT;
             ->setMethods(['startup', 'hasTask'])
             ->disableOriginalConstructor()
             ->getMock();
-        $shell->io(
+        $shell->setIo(
             $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->setMethods(['err'])
             ->getMock()
@@ -1189,12 +1211,12 @@ TEXT;
             ->setMethods(['hasTask', 'startup', 'getOptionParser'])
             ->disableOriginalConstructor()
             ->getMock();
-        $shell->io($io);
+        $shell->setIo($io);
         $task = $this->getMockBuilder('Cake\Console\Shell')
             ->setMethods(['main', 'runCommand'])
             ->disableOriginalConstructor()
             ->getMock();
-        $task->io($io);
+        $task->setIo($io);
         $task->expects($this->once())
             ->method('runCommand')
             ->with(['one'], false, ['requested' => true]);
@@ -1373,7 +1395,7 @@ TEXT;
         $this->Shell->plugin = 'plugin';
         $parser = $this->Shell->getOptionParser();
 
-        $this->assertEquals('plugin.test', $parser->command());
+        $this->assertEquals('plugin.test', $parser->getCommand());
     }
 
     /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -168,7 +168,7 @@ class ShellTest extends TestCase
      */
     public function testIo()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $this->assertInstanceOf(ConsoleIo::class, $this->Shell->io());
 
             $io = $this->getMockBuilder(ConsoleIo::class)
@@ -470,7 +470,7 @@ class ShellTest extends TestCase
             ->method('err')
             ->with('Searched all...');
 
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $this->Shell->error('Foo Not Found', 'Searched all...');
             $this->assertSame($this->Shell->stopped, 1);
         });

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -155,7 +155,6 @@ class DebuggerTest extends TestCase
     /**
      * Test that setOutputFormat works.
      *
-     * @group deprecated
      * @return void
      */
     public function testSetOutputFormat()

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -146,7 +146,7 @@ class DebuggerTest extends TestCase
      */
     public function testOutputAs()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             Debugger::outputAs('html');
             $this->assertEquals('html', Debugger::outputAs());
         });
@@ -173,7 +173,7 @@ class DebuggerTest extends TestCase
      */
     public function testOutputAsException()
     {
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             Debugger::outputAs('Invalid junk');
         });
     }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -141,23 +141,41 @@ class DebuggerTest extends TestCase
     /**
      * Test that outputAs works.
      *
+     * @group deprecated
      * @return void
      */
     public function testOutputAs()
     {
-        Debugger::outputAs('html');
-        $this->assertEquals('html', Debugger::outputAs());
+        $this->deprecated(function() {
+            Debugger::outputAs('html');
+            $this->assertEquals('html', Debugger::outputAs());
+        });
+    }
+
+    /**
+     * Test that setOutputFormat works.
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testSetOutputFormat()
+    {
+        Debugger::setOutputFormat('html');
+        $this->assertEquals('html', Debugger::getOutputFormat());
     }
 
     /**
      * Test that choosing a non-existent format causes an exception
      *
+     * @group deprecated
      * @expectedException \InvalidArgumentException
      * @return void
      */
     public function testOutputAsException()
     {
-        Debugger::outputAs('Invalid junk');
+        $this->deprecated(function() {
+            Debugger::outputAs('Invalid junk');
+        });
     }
 
     /**
@@ -189,7 +207,7 @@ class DebuggerTest extends TestCase
      */
     public function testOutputErrorDescriptionEncoding()
     {
-        Debugger::outputAs('html');
+        Debugger::setOutputFormat('html');
 
         ob_start();
         $debugger = Debugger::getInstance();
@@ -213,7 +231,7 @@ class DebuggerTest extends TestCase
      */
     public function testOutputErrorLineHighlight()
     {
-        Debugger::outputAs('js');
+        Debugger::setOutputFormat('js');
 
         ob_start();
         $debugger = Debugger::getInstance();
@@ -242,7 +260,7 @@ class DebuggerTest extends TestCase
             'traceLine' => '{:reference} - <a href="txmt://open?url=file://{:file}' .
                 '&line={:line}">{:path}</a>, line {:line}'
         ]);
-        Debugger::outputAs('js');
+        Debugger::setOutputFormat('js');
 
         $result = Debugger::trace();
         $this->assertRegExp('/' . preg_quote('txmt://open?url=file://', '/') . '(\/|[A-Z]:\\\\)' . '/', $result);
@@ -251,7 +269,7 @@ class DebuggerTest extends TestCase
             'error' => '<error><code>{:code}</code><file>{:file}</file><line>{:line}</line>' .
                 '{:description}</error>',
         ]);
-        Debugger::outputAs('xml');
+        Debugger::setOutputFormat('xml');
 
         ob_start();
         $debugger = Debugger::getInstance();
@@ -283,7 +301,7 @@ class DebuggerTest extends TestCase
     public function testAddFormatCallback()
     {
         Debugger::addFormat('callback', ['callback' => [$this, 'customFormat']]);
-        Debugger::outputAs('callback');
+        Debugger::setOutputFormat('callback');
 
         ob_start();
         $debugger = Debugger::getInstance();

--- a/tests/TestCase/Shell/I18nShellTest.php
+++ b/tests/TestCase/Shell/I18nShellTest.php
@@ -78,10 +78,10 @@ class I18nShellTest extends TestCase
             unlink($deDir . 'cake.po');
         }
 
-        $this->shell->io()->expects($this->at(0))
+        $this->shell->getIo()->expects($this->at(0))
             ->method('ask')
             ->will($this->returnValue('de_DE'));
-        $this->shell->io()->expects($this->at(1))
+        $this->shell->getIo()->expects($this->at(1))
             ->method('ask')
             ->will($this->returnValue($this->localeDir));
 


### PR DESCRIPTION
Add deprecation warnings to a few packages. I've updated the tests as well to leverage the `deprecated()` helper.