### PR TITLE
Force email domain lookups to work in fallback case.

### DIFF
--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -478,7 +478,7 @@ class Validation {
 			if (function_exists('checkdnsrr') && checkdnsrr($regs[1], 'MX')) {
 				return true;
 			}
-			return is_array(gethostbynamel($regs[1]));
+			return is_array(gethostbynamel($regs[1] . '.'));
 		}
 		return false;
 	}


### PR DESCRIPTION
Exactly the same fix as #11356, but for the Cake 2.x branch. 