### PR TITLE
Allow debug() to provide current fields instead of all content.

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -834,6 +834,33 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
         return $dialect->dropConstraintSql($this);
     }
+
+    /**
+     * Returns an array of the table schema.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'columns' => $this->_columns,
+            'indexes' => $this->_indexes,
+            'constraints' => $this->_constraints,
+            'options' => $this->_options,
+            'typeMap' => $this->_typeMap,
+            'temporary' => $this->_temporary,
+        ];
+    }
+
+    /**
+     * Returns an array of the table schema.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return $this->toArray();
+    }
 }
 
 // @deprecated Add backwards compat alias.

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -840,9 +840,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @return array
      */
-    public function toArray()
+    public function __debugInfo()
     {
         return [
+            'table' => $this->_table,
             'columns' => $this->_columns,
             'indexes' => $this->_indexes,
             'constraints' => $this->_constraints,
@@ -850,16 +851,6 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             'typeMap' => $this->_typeMap,
             'temporary' => $this->_temporary,
         ];
-    }
-
-    /**
-     * Returns an array of the table schema.
-     *
-     * @return array
-     */
-    public function __debugInfo()
-    {
-        return $this->toArray();
     }
 }
 

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -663,6 +663,48 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests the toArray() method.
+     *
+     * @return void
+     */
+    public function testToArray()
+    {
+        $table = new Table('articles');
+        $result = $table->toArray();
+        $expected = [
+            'columns' => [],
+            'indexes' => [],
+            'constraints' => [],
+            'options' => [],
+            'typeMap' => [],
+            'temporary' => false,
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Tests the __debugInfo() method.
+     *
+     * @return void
+     */
+    public function testDebugInfo()
+    {
+        $table = new Table('articles');
+        $table->setTemporary(true);
+
+        $result = $table->__debugInfo();
+        $expected = [
+            'columns' => [],
+            'indexes' => [],
+            'constraints' => [],
+            'options' => [],
+            'typeMap' => [],
+            'temporary' => true,
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * Assertion for comparing a regex pattern against a query having its identifiers
      * quoted. It accepts queries quoted with the characters `<` and `>`. If the third
      * parameter is set to true, it will alter the pattern to both accept quoted and

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -663,48 +663,6 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests the toArray() method.
-     *
-     * @return void
-     */
-    public function testToArray()
-    {
-        $table = new Table('articles');
-        $result = $table->toArray();
-        $expected = [
-            'columns' => [],
-            'indexes' => [],
-            'constraints' => [],
-            'options' => [],
-            'typeMap' => [],
-            'temporary' => false,
-        ];
-        $this->assertSame($expected, $result);
-    }
-
-    /**
-     * Tests the __debugInfo() method.
-     *
-     * @return void
-     */
-    public function testDebugInfo()
-    {
-        $table = new Table('articles');
-        $table->setTemporary(true);
-
-        $result = $table->__debugInfo();
-        $expected = [
-            'columns' => [],
-            'indexes' => [],
-            'constraints' => [],
-            'options' => [],
-            'typeMap' => [],
-            'temporary' => true,
-        ];
-        $this->assertSame($expected, $result);
-    }
-
-    /**
      * Assertion for comparing a regex pattern against a query having its identifiers
      * quoted. It accepts queries quoted with the characters `<` and `>`. If the third
      * parameter is set to true, it will alter the pattern to both accept quoted and


### PR DESCRIPTION
A toArray() and maybe even __debugInfo() could make sense here.

Refs https://github.com/cakephp/cakephp/issues/11372

Should the static stuff also be in there? Or just the non static attributes?