### PR TITLE
 3.next - Add deprecation warnings to the Database package

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -206,6 +206,7 @@ class Connection implements ConnectionInterface
      */
     public function driver($driver = null, $config = [])
     {
+        deprecationWarning('Connection::driver() is deprecated. Use Connection::setDriver()/getDriver() instead.');
         if ($driver !== null) {
             $this->setDriver($driver, $config);
         }
@@ -380,6 +381,10 @@ class Connection implements ConnectionInterface
      */
     public function schemaCollection(SchemaCollection $collection = null)
     {
+        deprecationWarning(
+            'Connection::schemaCollection() is deprecated. ' .
+            'Use Connection::setSchemaCollection()/getSchemaCollection() instead.'
+        );
         if ($collection !== null) {
             $this->setSchemaCollection($collection);
         }
@@ -591,6 +596,10 @@ class Connection implements ConnectionInterface
      */
     public function useSavePoints($enable = null)
     {
+        deprecationWarning(
+            'Connection::useSavePoints() is deprecated. ' .
+            'Use Connection::enableSavePoints()/isSavePointsEnabled() instead.'
+        );
         if ($enable !== null) {
             $this->enableSavePoints($enable);
         }
@@ -816,6 +825,10 @@ class Connection implements ConnectionInterface
      */
     public function logger($instance = null)
     {
+        deprecationWarning(
+            'Connection::logger() is deprecated. ' .
+            'Use Connection::setLogger()/getLogger() instead.'
+        );
         if ($instance === null) {
             return $this->getLogger();
         }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -336,6 +336,10 @@ abstract class Driver
      */
     public function autoQuoting($enable = null)
     {
+        deprecationWarning(
+            'Driver::autoQuoting() is deprecated. ' .
+            'Use Driver::enableAutoQuoting()/isAutoQuotingEnabled() instead.'
+        );
         if ($enable !== null) {
             $this->enableAutoQuoting($enable);
         }

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -104,6 +104,10 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      */
     public function name($name = null)
     {
+        deprecationWarning(
+            'FunctionExpression::name() is deprecated. ' .
+            'Use FunctionExpression::setName()/getName() instead.'
+        );
         if ($name !== null) {
             return $this->setName($name);
         }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -130,6 +130,7 @@ class QueryExpression implements ExpressionInterface, Countable
             'QueryExpression::type() is deprecated. ' .
             'Use QueryExpression::setConjunction()/getConjunction() instead.'
         );
+
         return $this->tieWith($conjunction);
     }
 

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -105,6 +105,10 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function tieWith($conjunction = null)
     {
+        deprecationWarning(
+            'QueryExpression::tieWith() is deprecated. ' .
+            'Use QueryExpression::setConjunction()/getConjunction() instead.'
+        );
         if ($conjunction !== null) {
             return $this->setConjunction($conjunction);
         }
@@ -118,10 +122,14 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string|null $conjunction value to be used for joining conditions. If null it
      * will not set any value, but return the currently stored one
      * @return string|$this
-     * @deprecated 3.2.0 Use tieWith() instead
+     * @deprecated 3.2.0 Use setConjunction()/getConjunction() instead
      */
     public function type($conjunction = null)
     {
+        deprecationWarning(
+            'QueryExpression::type() is deprecated. ' .
+            'Use QueryExpression::setConjunction()/getConjunction() instead.'
+        );
         return $this->tieWith($conjunction);
     }
 

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -134,6 +134,10 @@ class ValuesExpression implements ExpressionInterface
      */
     public function columns($cols = null)
     {
+        deprecationWarning(
+            'ValuesExpression::columns() is deprecated. ' .
+            'Use ValuesExpression::setColumns()/getColumns() instead.'
+        );
         if ($cols !== null) {
             return $this->setColumns($cols);
         }
@@ -200,6 +204,10 @@ class ValuesExpression implements ExpressionInterface
      */
     public function values($values = null)
     {
+        deprecationWarning(
+            'ValuesExpression::values() is deprecated. ' .
+            'Use ValuesExpression::setValues()/getValues() instead.'
+        );
         if ($values !== null) {
             return $this->setValues($values);
         }
@@ -243,6 +251,10 @@ class ValuesExpression implements ExpressionInterface
      */
     public function query(Query $query = null)
     {
+        deprecationWarning(
+            'ValuesExpression::query() is deprecated. ' .
+            'Use ValuesExpression::setQuery()/getQuery() instead.'
+        );
         if ($query !== null) {
             return $this->setQuery($query);
         }

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -53,7 +53,7 @@ class IdentifierQuoter
     public function quote(Query $query)
     {
         $binder = $query->getValueBinder();
-        $query->valueBinder(false);
+        $query->setValueBinder(false);
 
         if ($query->type() === 'insert') {
             $this->_quoteInsert($query);
@@ -64,7 +64,7 @@ class IdentifierQuoter
         }
 
         $query->traverseExpressions([$this, 'quoteExpression']);
-        $query->valueBinder($binder);
+        $query->setValueBinder($binder);
 
         return $query;
     }

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -115,6 +115,10 @@ class LoggingStatement extends StatementDecorator
      */
     public function logger($instance = null)
     {
+        deprecationWarning(
+            'LoggingStatement::logger() is deprecated. ' .
+            'Use LoggingStatement::setLogger()/getLogger() instead.'
+        );
         if ($instance === null) {
             return $this->getLogger();
         }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1007,7 +1007,6 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function orWhere($conditions, $types = [])
     {
-        deprecationWarning('Query::orWhere() is deprecated. Use Query::where() instead.');
         $this->_conjugate('where', $conditions, 'OR', $types);
 
         return $this;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -182,6 +182,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function connection($connection = null)
     {
+        deprecationWarning(
+            'Query::connection() is deprecated. ' .
+            'Use Query::setConnection()/getConnection() instead.'
+        );
         if ($connection !== null) {
             return $this->setConnection($connection);
         }
@@ -1003,6 +1007,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function orWhere($conditions, $types = [])
     {
+        deprecationWarning('Query::orWhere() is deprecated. Use Query::where() instead.');
         $this->_conjugate('where', $conditions, 'OR', $types);
 
         return $this;
@@ -1242,6 +1247,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function orHaving($conditions, $types = [])
     {
+        deprecationWarning('Query::orHaving() is deprecated. Use Query::having() instead.');
         $this->_conjugate('having', $conditions, 'OR', $types);
 
         return $this;
@@ -1866,6 +1872,23 @@ class Query implements ExpressionInterface, IteratorAggregate
     }
 
     /**
+     * Overwrite the current value binder
+     *
+     * A ValueBinder is responsible for generating query placeholders and temporarily
+     * associate values to those placeholders so that they can be passed correctly
+     * to the statement object.
+     *
+     * @param \Cake\Database\ValueBinder|bool $binder The binder or false to disable binding.
+     * @return $this
+     */
+    public function setValueBinder($binder)
+    {
+        $this->_valueBinder = $binder;
+
+        return $this;
+    }
+
+    /**
      * Returns the currently used ValueBinder instance. If a value is passed,
      * it will be set as the new instance to be used.
      *
@@ -1873,13 +1896,14 @@ class Query implements ExpressionInterface, IteratorAggregate
      * associate values to those placeholders so that they can be passed correctly
      * to the statement object.
      *
-     * @deprecated 3.5.0 Use getValueBinder() for the getter part instead.
+     * @deprecated 3.5.0 Use setValueBinder()/getValueBinder() instead.
      * @param \Cake\Database\ValueBinder|null $binder new instance to be set. If no value is passed the
      *   default one will be returned
      * @return $this|\Cake\Database\ValueBinder
      */
     public function valueBinder($binder = null)
     {
+        deprecationWarning('Query::valueBinder() is deprecated. Use Query::getValueBinder()/setValueBinder() instead.');
         if ($binder === null) {
             if ($this->_valueBinder === null) {
                 $this->_valueBinder = new ValueBinder();
@@ -1949,6 +1973,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function bufferResults($enable = null)
     {
+        deprecationWarning(
+            'Query::bufferResults() is deprecated. ' .
+            'Use Query::enableBufferedResults()/isBufferedResultsEnabled() instead.'
+        );
         if ($enable !== null) {
             return $this->enableBufferedResults($enable);
         }
@@ -1996,6 +2024,10 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function selectTypeMap(TypeMap $typeMap = null)
     {
+        deprecationWarning(
+            'Query::selectTypeMap() is deprecated. ' .
+            'Use Query::setSelectTypeMap()/getSelectTypeMap() instead.'
+        );
         if ($typeMap !== null) {
             return $this->setSelectTypeMap($typeMap);
         }

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -119,6 +119,10 @@ class CachedCollection extends Collection
      */
     public function cacheMetadata($enable = null)
     {
+        deprecationWarning(
+            'CachedCollection::cacheMetadata() is deprecated. ' .
+            'Use CachedCollection::setCacheMetadata()/getCacheMetadata() instead.'
+        );
         if ($enable !== null) {
             $this->setCacheMetadata($enable);
         }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -778,6 +778,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function temporary($temporary = null)
     {
+        deprecationWarning(
+            'TableSchema::temporary() is deprecated. ' .
+            'Use TableSchema::setTemporary()/getTemporary() instead.'
+        );
         if ($temporary !== null) {
             return $this->setTemporary($temporary);
         }

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -223,6 +223,7 @@ class Type implements TypeInterface
      */
     protected function _basicTypeCast($value)
     {
+        deprecationWarning('Type::_basicTypeCast() is deprecated.');
         if ($value === null) {
             return null;
         }
@@ -259,6 +260,7 @@ class Type implements TypeInterface
      */
     public static function boolval($value)
     {
+        deprecationWarning('Type::boolval() is deprecated.');
         if (is_string($value) && !is_numeric($value)) {
             return strtolower($value) === 'true';
         }
@@ -277,6 +279,7 @@ class Type implements TypeInterface
      */
     public static function strval($value)
     {
+        deprecationWarning('Type::strval() is deprecated.');
         if (is_array($value)) {
             $value = '';
         }

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -108,6 +108,10 @@ class TypeMap
      */
     public function defaults(array $defaults = null)
     {
+        deprecationWarning(
+            'TypeMap::defaults() is deprecated. ' .
+            'Use TypeMap::setDefaults()/getDefaults() instead.'
+        );
         if ($defaults !== null) {
             return $this->setDefaults($defaults);
         }
@@ -180,6 +184,10 @@ class TypeMap
      */
     public function types(array $types = null)
     {
+        deprecationWarning(
+            'TypeMap::types() is deprecated. ' .
+            'Use TypeMap::setTypes()/getTypes() instead.'
+        );
         if ($types !== null) {
             return $this->setTypes($types);
         }

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -62,6 +62,10 @@ trait TypeMapTrait
      */
     public function typeMap($typeMap = null)
     {
+        deprecationWarning(
+            'TypeMapTrait::typeMap() is deprecated. ' .
+            'Use TypeMapTrait::setTypeMap()/getTypeMap() instead.'
+        );
         if ($typeMap !== null) {
             return $this->setTypeMap($typeMap);
         }
@@ -101,6 +105,10 @@ trait TypeMapTrait
      */
     public function defaultTypes(array $types = null)
     {
+        deprecationWarning(
+            'TypeMapTrait::defaultTypes() is deprecated. ' .
+            'Use TypeMapTrait::setDefaultTypes()/getDefaultTypes() instead.'
+        );
         if ($types !== null) {
             return $this->setDefaultTypes($types);
         }

--- a/src/Database/TypedResultTrait.php
+++ b/src/Database/TypedResultTrait.php
@@ -60,6 +60,10 @@ trait TypedResultTrait
      */
     public function returnType($type = null)
     {
+        deprecationWarning(
+            'TypedResultTrait::returnType() is deprecated. ' .
+            'Use TypedResultTrait::setReturnType()/getReturnType() instead.'
+        );
         if ($type !== null) {
             $this->_returnType = $type;
 

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -21,7 +21,7 @@ namespace Cake\Datasource;
  * @method object getLogger() Get the current logger instance
  * @method $this setLogger($logger) Set the current logger.
  * @method bool supportsDynamicConstraints()
- * @method \Cake\Database\Schema\Collection schemaCollection()
+ * @method \Cake\Database\Schema\Collection getSchemaCollection()
  * @method \Cake\Database\Query newQuery()
  * @method \Cake\Database\StatementInterface prepare($sql)
  * @method \Cake\Database\StatementInterface execute($query, $params = [], array $types = [])

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -398,7 +398,7 @@ class SelectLoader
         $filterQuery->mapReduce(null, null, true);
         $filterQuery->formatResults(null, true);
         $filterQuery->contain([], true);
-        $filterQuery->valueBinder(new ValueBinder());
+        $filterQuery->setValueBinder(new ValueBinder());
 
         if (!$filterQuery->clause('limit')) {
             $filterQuery->limit(null);

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -353,7 +353,7 @@ class TreeBehavior extends Behavior
             function ($exp) use ($config) {
                 /* @var \Cake\Database\Expression\QueryExpression $exp */
                 $leftInverse = clone $exp;
-                $leftInverse->type('*')->add('-1');
+                $leftInverse->setConjunction('*')->add('-1');
                 $rightInverse = clone $leftInverse;
 
                 return $exp

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -88,7 +88,7 @@ class LazyEagerLoader
                     return $exp->in($source->aliasField($primaryKey), $keys->toList());
                 }
 
-                $types = array_intersect_key($q->defaultTypes(), array_flip($primaryKey));
+                $types = array_intersect_key($q->getDefaultTypes(), array_flip($primaryKey));
                 $primaryKey = array_map([$source, 'aliasField'], $primaryKey);
 
                 return new TupleComparison($primaryKey, $keys->toList(), $types, 'IN');

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -286,7 +286,7 @@ class FixtureManager
 
         try {
             $createTables = function ($db, $fixtures) use ($test) {
-                $tables = $db->schemaCollection()->listTables();
+                $tables = $db->getSchemaCollection()->listTables();
                 $configName = $db->configName();
                 if (!isset($this->_insertionMap[$configName])) {
                     $this->_insertionMap[$configName] = [];
@@ -455,7 +455,7 @@ class FixtureManager
         }
 
         if (!$this->isFixtureSetup($db->configName(), $fixture)) {
-            $sources = $db->schemaCollection()->listTables();
+            $sources = $db->getSchemaCollection()->listTables();
             $this->_setupTable($fixture, $db, $sources, $dropTables);
         }
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -231,7 +231,7 @@ class TestFixture implements FixtureInterface, TableSchemaInterface, TableSchema
         $this->table = $import['table'];
 
         $db = ConnectionManager::get($import['connection'], false);
-        $schemaCollection = $db->schemaCollection();
+        $schemaCollection = $db->getSchemaCollection();
         $table = $schemaCollection->describe($import['table']);
         $this->_schema = $table;
     }
@@ -245,7 +245,7 @@ class TestFixture implements FixtureInterface, TableSchemaInterface, TableSchema
     protected function _schemaFromReflection()
     {
         $db = ConnectionManager::get($this->connection());
-        $schemaCollection = $db->schemaCollection();
+        $schemaCollection = $db->getSchemaCollection();
         $tables = $schemaCollection->listTables();
 
         if (!in_array($this->table, $tables)) {

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -150,7 +150,7 @@ class MysqlTest extends TestCase
         $connection = ConnectionManager::get('test');
         $connection->disconnect();
 
-        $driver = $connection->driver();
+        $driver = $connection->getDriver();
         $this->assertFalse($driver->rollbackTransaction());
         $this->assertTrue($driver->isConnected());
     }
@@ -158,7 +158,7 @@ class MysqlTest extends TestCase
     public function testCommitTransactionAutoConnect()
     {
         $connection = ConnectionManager::get('test');
-        $driver = $connection->driver();
+        $driver = $connection->getDriver();
 
         $this->assertFalse($driver->commitTransaction());
         $this->assertTrue($driver->isConnected());

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -61,12 +61,12 @@ class DriverTest extends TestCase
         $arg = ['quoteIdentifiers' => true];
         $driver = $this->getMockForAbstractClass(Driver::class, [$arg]);
 
-        $this->assertTrue($driver->autoQuoting());
+        $this->assertTrue($driver->isAutoQuotingEnabled());
 
         $arg = ['username' => 'GummyBear'];
         $driver = $this->getMockForAbstractClass(Driver::class, [$arg]);
 
-        $this->assertFalse($driver->autoQuoting());
+        $this->assertFalse($driver->isAutoQuotingEnabled());
     }
 
     /**
@@ -169,19 +169,25 @@ class DriverTest extends TestCase
      */
     public function testAutoQuoting()
     {
-        $this->assertFalse($this->driver->autoQuoting());
+        $this->assertFalse($this->driver->isAutoQuotingEnabled());
 
-        $this->driver->autoQuoting(true);
-        $this->assertTrue($this->driver->autoQuoting());
+        $this->assertSame($this->driver, $this->driver->enableAutoQuoting(true));
+        $this->assertTrue($this->driver->isAutoQuotingEnabled());
 
-        $this->assertTrue($this->driver->autoQuoting(true));
-        $this->assertFalse($this->driver->autoQuoting(false));
+        $this->driver->enableAutoQuoting(false);
+        $this->assertFalse($this->driver->isAutoQuotingEnabled());
 
-        $this->assertTrue($this->driver->autoQuoting('string'));
-        $this->assertFalse($this->driver->autoQuoting('0'));
+        $this->driver->enableAutoQuoting('string');
+        $this->assertTrue($this->driver->isAutoQuotingEnabled());
 
-        $this->assertTrue($this->driver->autoQuoting(1));
-        $this->assertFalse($this->driver->autoQuoting(0));
+        $this->driver->enableAutoQuoting('0');
+        $this->assertFalse($this->driver->isAutoQuotingEnabled());
+
+        $this->driver->enableAutoQuoting(1);
+        $this->assertTrue($this->driver->isAutoQuotingEnabled());
+
+        $this->driver->enableAutoQuoting(0);
+        $this->assertFalse($this->driver->isAutoQuotingEnabled());
     }
 
     /**

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -43,35 +43,41 @@ class QueryExpressionTest extends TestCase
     /**
      * Test tieWith() works.
      *
+     * @group deprecated
      * @return
      */
     public function testTieWith()
     {
-        $expr = new QueryExpression(['1', '2']);
-        $binder = new ValueBinder();
+        $this->deprecated(function () {
+            $expr = new QueryExpression(['1', '2']);
+            $binder = new ValueBinder();
 
-        $this->assertSame($expr, $expr->tieWith('+'));
-        $this->assertSame('+', $expr->tieWith());
+            $this->assertSame($expr, $expr->tieWith('+'));
+            $this->assertSame('+', $expr->tieWith());
 
-        $result = $expr->sql($binder);
-        $this->assertEquals('(1 + 2)', $result);
+            $result = $expr->sql($binder);
+            $this->assertEquals('(1 + 2)', $result);
+        });
     }
 
     /**
      * Test type() works.
      *
+     * @group deprecated
      * @return
      */
     public function testType()
     {
-        $expr = new QueryExpression(['1', '2']);
-        $binder = new ValueBinder();
+        $this->deprecated(function () {
+            $expr = new QueryExpression(['1', '2']);
+            $binder = new ValueBinder();
 
-        $this->assertSame($expr, $expr->type('+'));
-        $this->assertSame('+', $expr->type());
+            $this->assertSame($expr, $expr->type('+'));
+            $this->assertSame('+', $expr->type());
 
-        $result = $expr->sql($binder);
-        $this->assertEquals('(1 + 2)', $result);
+            $result = $expr->sql($binder);
+            $this->assertEquals('(1 + 2)', $result);
+        });
     }
 
     /**

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -79,7 +79,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        $this->skipIf($this->connection->driver() instanceof Sqlserver, 'This tests uses functions specific to other drivers');
+        $this->skipIf($this->connection->getDriver() instanceof Sqlserver, 'This tests uses functions specific to other drivers');
         Type::map('ordered_uuid', OrderedUuidType::class);
     }
 
@@ -109,9 +109,9 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
             ->select('id')
             ->from('ordered_uuid_items')
             ->order('id')
-            ->defaultTypes(['id' => 'ordered_uuid']);
+            ->setDefaultTypes(['id' => 'ordered_uuid']);
 
-        $query->selectTypeMap($query->typeMap());
+        $query->setSelectTypeMap($query->getTypeMap());
         $results = $query->execute()->fetchAll('assoc');
 
         $this->assertEquals(new UuidValue('419a8da0482b7756b21f27da40cf8569'), $results[0]['id']);

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -43,11 +43,11 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->MyFunc(['b' => 'literal']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
-        $this->assertEquals('MyFunc', $function->name());
+        $this->assertEquals('MyFunc', $function->getName());
         $this->assertEquals('MyFunc(b)', $function->sql(new ValueBinder));
 
         $function = $this->functions->MyFunc(['b'], ['string'], 'integer');
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
     }
 
     /**
@@ -60,12 +60,12 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->sum('total');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('SUM(total)', $function->sql(new ValueBinder));
-        $this->assertEquals('float', $function->returnType());
+        $this->assertEquals('float', $function->getReturnType());
 
         $function = $this->functions->sum('total', ['integer']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('SUM(total)', $function->sql(new ValueBinder));
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
     }
 
     /**
@@ -78,7 +78,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->avg('salary');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('AVG(salary)', $function->sql(new ValueBinder));
-        $this->assertEquals('float', $function->returnType());
+        $this->assertEquals('float', $function->getReturnType());
     }
 
     /**
@@ -91,7 +91,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->max('created', ['datetime']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('MAX(created)', $function->sql(new ValueBinder));
-        $this->assertEquals('datetime', $function->returnType());
+        $this->assertEquals('datetime', $function->getReturnType());
     }
 
     /**
@@ -104,7 +104,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->min('created', ['date']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('MIN(created)', $function->sql(new ValueBinder));
-        $this->assertEquals('date', $function->returnType());
+        $this->assertEquals('date', $function->getReturnType());
     }
 
     /**
@@ -117,7 +117,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->count('*');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('COUNT(*)', $function->sql(new ValueBinder));
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
     }
 
     /**
@@ -130,7 +130,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->concat(['title' => 'literal', ' is a string']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('CONCAT(title, :param0)', $function->sql(new ValueBinder));
-        $this->assertEquals('string', $function->returnType());
+        $this->assertEquals('string', $function->getReturnType());
     }
 
     /**
@@ -143,7 +143,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->coalesce(['NULL' => 'literal', '1', 'a'], ['a' => 'date']);
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('COALESCE(NULL, :param0, :param1)', $function->sql(new ValueBinder));
-        $this->assertEquals('date', $function->returnType());
+        $this->assertEquals('date', $function->getReturnType());
     }
 
     /**
@@ -156,17 +156,17 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->now();
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('NOW()', $function->sql(new ValueBinder));
-        $this->assertEquals('datetime', $function->returnType());
+        $this->assertEquals('datetime', $function->getReturnType());
 
         $function = $this->functions->now('date');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('CURRENT_DATE()', $function->sql(new ValueBinder));
-        $this->assertEquals('date', $function->returnType());
+        $this->assertEquals('date', $function->getReturnType());
 
         $function = $this->functions->now('time');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('CURRENT_TIME()', $function->sql(new ValueBinder));
-        $this->assertEquals('time', $function->returnType());
+        $this->assertEquals('time', $function->getReturnType());
     }
 
     /**
@@ -179,12 +179,12 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->extract('day', 'created');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('EXTRACT(day FROM created)', $function->sql(new ValueBinder));
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
 
         $function = $this->functions->datePart('year', 'modified');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('EXTRACT(year FROM modified)', $function->sql(new ValueBinder));
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
     }
 
     /**
@@ -197,7 +197,7 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->dateAdd('created', -3, 'day');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('DATE_ADD(created, INTERVAL -3 day)', $function->sql(new ValueBinder));
-        $this->assertEquals('datetime', $function->returnType());
+        $this->assertEquals('datetime', $function->getReturnType());
     }
 
     /**
@@ -210,11 +210,11 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->dayOfWeek('created');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('DAYOFWEEK(created)', $function->sql(new ValueBinder));
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
 
         $function = $this->functions->weekday('created');
         $this->assertInstanceOf('Cake\Database\Expression\FunctionExpression', $function);
         $this->assertEquals('DAYOFWEEK(created)', $function->sql(new ValueBinder));
-        $this->assertEquals('integer', $function->returnType());
+        $this->assertEquals('integer', $function->getReturnType());
     }
 }

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -44,7 +44,7 @@ class LoggingStatementTest extends TestCase
             ));
         $st = new LoggingStatement($inner);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->logger($logger);
+        $st->setLogger($logger);
         $st->execute();
     }
 
@@ -69,7 +69,7 @@ class LoggingStatementTest extends TestCase
             ));
         $st = new LoggingStatement($inner);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->logger($logger);
+        $st->setLogger($logger);
         $st->execute(['a' => 1, 'b' => 2]);
     }
 
@@ -107,7 +107,7 @@ class LoggingStatementTest extends TestCase
         $driver = $this->getMockBuilder('\Cake\Database\Driver')->getMock();
         $st = new LoggingStatement($inner, $driver);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->logger($logger);
+        $st->setLogger($logger);
         $st->bindValue('a', 1);
         $st->bindValue('b', $date, 'date');
         $st->execute();
@@ -140,8 +140,27 @@ class LoggingStatementTest extends TestCase
             ));
         $st = new LoggingStatement($inner);
         $st->queryString = 'SELECT bar FROM foo';
-        $st->logger($logger);
+        $st->setLogger($logger);
         $st->execute();
+    }
+
+    /**
+     * Tests setting and getting the logger
+     *
+     * @group deprecated
+     * @return void
+     */
+    public function testLoggerCompat()
+    {
+        $this->deprecated(function () {
+            $logger = $this->getMockBuilder('\Cake\Database\Log\QueryLogger')->getMock();
+            $st = new LoggingStatement();
+
+            $this->assertNull($st->logger());
+
+            $st->logger($logger);
+            $this->assertSame($logger, $st->logger());
+        });
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -39,13 +39,13 @@ class QueryTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        $this->autoQuote = $this->connection->driver()->autoQuoting();
+        $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
     }
 
     public function tearDown()
     {
         parent::tearDown();
-        $this->connection->driver()->autoQuoting($this->autoQuote);
+        $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);
         unset($this->connection);
     }
 
@@ -69,7 +69,7 @@ class QueryTest extends TestCase
      */
     public function testSelectFieldsOnly()
     {
-        $this->connection->driver()->autoQuoting(false);
+        $this->connection->getDriver()->enableAutoQuoting(false);
         $query = new Query($this->connection);
         $result = $query->select('1 + 1')->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
@@ -95,7 +95,7 @@ class QueryTest extends TestCase
      */
     public function testSelectClosure()
     {
-        $this->connection->driver()->autoQuoting(false);
+        $this->connection->getDriver()->enableAutoQuoting(false);
         $query = new Query($this->connection);
         $result = $query->select(function ($q) use ($query) {
             $this->assertSame($query, $q);
@@ -384,7 +384,7 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
-            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlite,
+            $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite,
             'SQLite does not support RIGHT joins'
         );
         $query = new Query($this->connection);
@@ -793,22 +793,25 @@ class QueryTest extends TestCase
     /**
      * Tests that Query::orWhere() can be used to concatenate conditions with OR
      *
+     * @group deprecated
      * @return void
      */
     public function testSelectOrWhere()
     {
-        $this->loadFixtures('Comments');
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['id'])
-            ->from('comments')
-            ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
-            ->orWhere(['created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
-            ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $result->closeCursor();
+        $this->deprecated(function () {
+            $this->loadFixtures('Comments');
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['id'])
+                ->from('comments')
+                ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+                ->orWhere(['created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
+                ->execute();
+            $this->assertCount(2, $result);
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+            $result->closeCursor();
+        });
     }
 
     /**
@@ -845,59 +848,65 @@ class QueryTest extends TestCase
      * Tests that combining Query::andWhere() and Query::orWhere() produces
      * correct conditions nesting
      *
+     * @group deprecated
      * @return void
      */
     public function testSelectExpressionNesting()
     {
-        $this->loadFixtures('Comments');
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['id'])
-            ->from('comments')
-            ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
-            ->orWhere(['id' => 2])
-            ->andWhere(['created >=' => new \DateTime('2007-03-18 10:40:00')], ['created' => 'datetime'])
-            ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $result->closeCursor();
+        $this->deprecated(function () {
+            $this->loadFixtures('Comments');
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['id'])
+                ->from('comments')
+                ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+                ->orWhere(['id' => 2])
+                ->andWhere(['created >=' => new \DateTime('2007-03-18 10:40:00')], ['created' => 'datetime'])
+                ->execute();
+            $this->assertCount(2, $result);
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+            $result->closeCursor();
 
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['id'])
-            ->from('comments')
-            ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
-            ->orWhere(['id' => 2])
-            ->andWhere(['created >=' => new \DateTime('2007-03-18 10:40:00')], ['created' => 'datetime'])
-            ->orWhere(['created' => new \DateTime('2007-03-18 10:49:23')], ['created' => 'datetime'])
-            ->execute();
-        $this->assertCount(3, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
-        $result->closeCursor();
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['id'])
+                ->from('comments')
+                ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+                ->orWhere(['id' => 2])
+                ->andWhere(['created >=' => new \DateTime('2007-03-18 10:40:00')], ['created' => 'datetime'])
+                ->orWhere(['created' => new \DateTime('2007-03-18 10:49:23')], ['created' => 'datetime'])
+                ->execute();
+            $this->assertCount(3, $result);
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+            $result->closeCursor();
+        });
     }
 
     /**
      * Tests that Query::orWhere() can be used without calling where() before
      *
+     * @group deprecated
      * @return void
      */
     public function testSelectOrWhereNoPreviousCondition()
     {
-        $this->loadFixtures('Comments');
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['id'])
-            ->from('comments')
-            ->orWhere(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
-            ->orWhere(['created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
-            ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $result->closeCursor();
+        $this->deprecated(function () {
+            $this->loadFixtures('Comments');
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['id'])
+                ->from('comments')
+                ->orWhere(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+                ->orWhere(['created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
+                ->execute();
+            $this->assertCount(2, $result);
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+            $result->closeCursor();
+        });
     }
 
     /**
@@ -1036,39 +1045,42 @@ class QueryTest extends TestCase
      * Tests that it is possible to pass a closure to orWhere() to build a set of
      * conditions and return the expression to be used
      *
+     * @group deprecated
      * @return void
      */
     public function testSelectOrWhereUsingClosure()
     {
-        $this->loadFixtures('Comments');
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['id'])
-            ->from('comments')
-            ->where(['id' => '1'])
-            ->orWhere(function ($exp) {
-                return $exp->eq('created', new \DateTime('2007-03-18 10:47:23'), 'datetime');
-            })
-            ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $result->closeCursor();
+        $this->deprecated(function () {
+            $this->loadFixtures('Comments');
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['id'])
+                ->from('comments')
+                ->where(['id' => '1'])
+                ->orWhere(function ($exp) {
+                    return $exp->eq('created', new \DateTime('2007-03-18 10:47:23'), 'datetime');
+                })
+                ->execute();
+            $this->assertCount(2, $result);
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+            $result->closeCursor();
 
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['id'])
-            ->from('comments')
-            ->where(['id' => '1'])
-            ->orWhere(function ($exp) {
-                return $exp
-                    ->eq('created', new \DateTime('2012-12-22 12:00'), 'datetime')
-                    ->eq('id', 3);
-            })
-            ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $result->closeCursor();
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['id'])
+                ->from('comments')
+                ->where(['id' => '1'])
+                ->orWhere(function ($exp) {
+                    return $exp
+                        ->eq('created', new \DateTime('2012-12-22 12:00'), 'datetime')
+                        ->eq('id', 3);
+                })
+                ->execute();
+            $this->assertCount(1, $result);
+            $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+            $result->closeCursor();
+        });
     }
 
     /**
@@ -1380,7 +1392,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['id IN' => [1, 2]])
             ->sql();
-        $bindings = $query->valueBinder()->bindings();
+        $bindings = $query->getValueBinder()->bindings();
         $this->assertArrayHasKey(':c0', $bindings);
         $this->assertEquals('c0', $bindings[':c0']['placeholder']);
         $this->assertArrayHasKey(':c1', $bindings);
@@ -2040,48 +2052,51 @@ class QueryTest extends TestCase
      * Tests that Query::orHaving() can be used to concatenate conditions with OR
      * in the having clause
      *
+     * @group deprecated
      * @return void
      */
     public function testSelectOrHaving()
     {
-        $this->loadFixtures('Authors', 'Articles');
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['total' => 'count(author_id)', 'author_id'])
-            ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
-            ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
-            ->orHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
-            ->execute();
-        $expected = [['total' => 1, 'author_id' => 3]];
-        $this->assertEquals($expected, $result->fetchAll('assoc'));
+        $this->deprecated(function () {
+            $this->loadFixtures('Authors', 'Articles');
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['total' => 'count(author_id)', 'author_id'])
+                ->from('articles')
+                ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+                ->group('author_id')
+                ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
+                ->orHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
+                ->execute();
+            $expected = [['total' => 1, 'author_id' => 3]];
+            $this->assertEquals($expected, $result->fetchAll('assoc'));
 
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['total' => 'count(author_id)', 'author_id'])
-            ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
-            ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
-            ->orHaving(['count(author_id) <=' => 2], ['count(author_id)' => 'integer'])
-            ->execute();
-        $expected = [['total' => 2, 'author_id' => 1], ['total' => 1, 'author_id' => 3]];
-        $this->assertEquals($expected, $result->fetchAll('assoc'));
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['total' => 'count(author_id)', 'author_id'])
+                ->from('articles')
+                ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+                ->group('author_id')
+                ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
+                ->orHaving(['count(author_id) <=' => 2], ['count(author_id)' => 'integer'])
+                ->execute();
+            $expected = [['total' => 2, 'author_id' => 1], ['total' => 1, 'author_id' => 3]];
+            $this->assertEquals($expected, $result->fetchAll('assoc'));
 
-        $query = new Query($this->connection);
-        $result = $query
-            ->select(['total' => 'count(author_id)', 'author_id'])
-            ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
-            ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
-            ->orHaving(function ($e) {
-                return $e->add('count(author_id) = 1 + 1');
-            })
-            ->execute();
-        $expected = [['total' => 2, 'author_id' => 1]];
-        $this->assertEquals($expected, $result->fetchAll('assoc'));
+            $query = new Query($this->connection);
+            $result = $query
+                ->select(['total' => 'count(author_id)', 'author_id'])
+                ->from('articles')
+                ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+                ->group('author_id')
+                ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
+                ->orHaving(function ($e) {
+                    return $e->add('count(author_id) = 1 + 1');
+                })
+                ->execute();
+            $expected = [['total' => 2, 'author_id' => 1]];
+            $this->assertEquals($expected, $result->fetchAll('assoc'));
+        });
     }
 
     /**
@@ -2537,8 +2552,8 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
-            ($this->connection->driver() instanceof \Cake\Database\Driver\Sqlite ||
-            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver),
+            ($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite ||
+            $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver),
             'Driver does not support ORDER BY in UNIONed queries.'
         );
         $union = (new Query($this->connection))
@@ -3077,7 +3092,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertCount(1, $result, '1 row should be inserted');
         }
 
@@ -3143,7 +3158,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertCount(1, $result, '1 row should be inserted');
         }
 
@@ -3181,7 +3196,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertCount(2, $result, '2 rows should be inserted');
         }
 
@@ -3239,7 +3254,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertCount(1, $result);
         }
 
@@ -3305,7 +3320,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertCount(1, $result);
         }
 
@@ -3335,7 +3350,7 @@ class QueryTest extends TestCase
         $result = $query->execute();
         $result->closeCursor();
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertCount(1, $result);
         }
 
@@ -3467,10 +3482,10 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
-        $this->assertEquals([], $query->defaultTypes());
+        $this->assertEquals([], $query->getDefaultTypes());
         $types = ['id' => 'integer', 'created' => 'datetime'];
-        $this->assertSame($query, $query->defaultTypes($types));
-        $this->assertSame($types, $query->defaultTypes());
+        $this->assertSame($query, $query->setDefaultTypes($types));
+        $this->assertSame($types, $query->getDefaultTypes());
 
         $results = $query->select(['id', 'comment'])
             ->from('comments')
@@ -3601,7 +3616,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingSelectFieldsAndAlias()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->select(['something'])->sql();
         $this->assertQuotedQuery('SELECT <something>$', $sql);
@@ -3634,7 +3649,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingFromAndAlias()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->select('*')->from(['something'])->sql();
         $this->assertQuotedQuery('FROM <something>', $sql);
@@ -3655,7 +3670,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingDistinctOn()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->select('*')->distinct(['something'])->sql();
         $this->assertQuotedQuery('<something>', $sql);
@@ -3668,7 +3683,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingJoinsAndAlias()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->select('*')->join(['something'])->sql();
         $this->assertQuotedQuery('JOIN <something>', $sql);
@@ -3689,7 +3704,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingGroupBy()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->select('*')->group(['something'])->sql();
         $this->assertQuotedQuery('GROUP BY <something>', $sql);
@@ -3710,7 +3725,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingExpressions()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->select('*')
             ->where(['something' => 'value'])
@@ -3735,7 +3750,7 @@ class QueryTest extends TestCase
      */
     public function testQuotingInsert()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $sql = $query->insert(['bar', 'baz'])
             ->into('foo')
@@ -3775,7 +3790,7 @@ class QueryTest extends TestCase
     {
         $query = (new Query($this->connection))->select('*')
             ->from('articles')
-            ->defaultTypes(['id' => 'integer'])
+            ->setDefaultTypes(['id' => 'integer'])
             ->where(['id' => '1']);
 
         $expected = [
@@ -3861,7 +3876,7 @@ class QueryTest extends TestCase
      */
     public function testIsNullAutoQuoting()
     {
-        $this->connection->driver()->autoQuoting(true);
+        $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
         $query->select('*')->from('things')->where(function ($exp) {
             return $exp->isNull('field');
@@ -3992,7 +4007,7 @@ class QueryTest extends TestCase
             );
 
         //Postgres requires the case statement to be cast to a integer
-        if ($this->connection->driver() instanceof \Cake\Database\Driver\Postgres) {
+        if ($this->connection->getDriver() instanceof \Cake\Database\Driver\Postgres) {
             $publishedCase = $query->func()->cast([$publishedCase, 'integer' => 'literal'])->type(' AS ');
             $notPublishedCase = $query->func()->cast([$notPublishedCase, 'integer' => 'literal'])->type(' AS ');
         }
@@ -4062,7 +4077,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $result = $query->select(['body', 'author_id'])
             ->from('articles')
-            ->bufferResults(false)
+            ->enableBufferedResults(false)
             ->execute();
 
         if (!method_exists($result, 'bufferResults')) {
@@ -4120,8 +4135,8 @@ class QueryTest extends TestCase
         $this->assertNotEquals($query->clause('order'), $dupe->clause('order'));
 
         $this->assertNotSame(
-            $query->selectTypeMap(),
-            $dupe->selectTypeMap()
+            $query->getSelectTypeMap(),
+            $dupe->getSelectTypeMap()
         );
     }
 
@@ -4133,11 +4148,11 @@ class QueryTest extends TestCase
     public function testSelectTypeMap()
     {
         $query = new Query($this->connection);
-        $typeMap = $query->selectTypeMap();
+        $typeMap = $query->getSelectTypeMap();
         $this->assertInstanceOf(TypeMap::class, $typeMap);
         $another = clone $typeMap;
-        $query->selectTypeMap($another);
-        $this->assertSame($another, $query->selectTypeMap());
+        $query->setSelectTypeMap($another);
+        $this->assertSame($another, $query->getSelectTypeMap());
     }
 
     /**
@@ -4153,7 +4168,7 @@ class QueryTest extends TestCase
             ->select(['id', 'comment', 'the_date' => 'created'])
             ->from('comments')
             ->limit(1)
-            ->selectTypeMap()->types(['id' => 'integer', 'the_date' => 'datetime']);
+            ->getSelectTypeMap()->setTypes(['id' => 'integer', 'the_date' => 'datetime']);
         $result = $query->execute()->fetchAll('assoc');
         $this->assertInternalType('integer', $result[0]['id']);
         $this->assertInstanceOf('DateTime', $result[0]['the_date']);
@@ -4185,7 +4200,7 @@ class QueryTest extends TestCase
             ->select(['comment'])
             ->from('comments')
             ->where(['id' => $id])
-            ->selectTypeMap()->types(['comment' => 'json']);
+            ->getSelectTypeMap()->setTypes(['comment' => 'json']);
 
         $result = $query->execute();
         $comment = $result->fetchAll('assoc')[0]['comment'];
@@ -4226,7 +4241,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select('id')
             ->from('comments')
-            ->defaultTypes(['created' => 'datetime'])
+            ->setDefaultTypes(['created' => 'datetime'])
             ->where(function ($expr) {
                 $from = new \DateTime('2007-03-18 10:45:00');
                 $to = new \DateTime('2007-03-18 10:48:00');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4008,8 +4008,12 @@ class QueryTest extends TestCase
 
         //Postgres requires the case statement to be cast to a integer
         if ($this->connection->getDriver() instanceof \Cake\Database\Driver\Postgres) {
-            $publishedCase = $query->func()->cast([$publishedCase, 'integer' => 'literal'])->type(' AS ');
-            $notPublishedCase = $query->func()->cast([$notPublishedCase, 'integer' => 'literal'])->type(' AS ');
+            $publishedCase = $query->func()
+                ->cast([$publishedCase, 'integer' => 'literal'])
+                ->setConjunction(' AS ');
+            $notPublishedCase = $query->func()
+                ->cast([$notPublishedCase, 'integer' => 'literal'])
+                ->setConjunction(' AS ');
         }
 
         $results = $query

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -82,12 +82,12 @@ class CollectionTest extends TestCase
      */
     public function testDescribeCache()
     {
-        $schema = $this->connection->schemaCollection();
+        $schema = $this->connection->getSchemaCollection();
         $table = $schema->describe('users');
 
         Cache::delete('test_users', '_cake_model_');
         $this->connection->cacheMetadata(true);
-        $schema = $this->connection->schemaCollection();
+        $schema = $this->connection->getSchemaCollection();
 
         $result = $schema->describe('users');
         $this->assertEquals($table, $result);

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1154,7 +1154,7 @@ SQL;
             'type' => 'integer',
             'null' => false
         ]);
-        $table->temporary(true);
+        $table->setTemporary(true);
         $sql = $table->createSql($connection);
         $this->assertContains('CREATE TEMPORARY TABLE', $sql[0]);
     }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -271,7 +271,7 @@ SQL;
 SQL;
         $connection->execute($table);
 
-        if ($connection->driver()->supportsNativeJson()) {
+        if ($connection->getDriver()->supportsNativeJson()) {
             $table = <<<SQL
                 CREATE TABLE schema_json (
                     id INT(11) PRIMARY KEY AUTO_INCREMENT,
@@ -1287,7 +1287,7 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-        $this->skipIf(!$connection->driver()->supportsNativeJson(), 'Does not support native json');
+        $this->skipIf(!$connection->getDriver()->supportsNativeJson(), 'Does not support native json');
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_json');

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -1131,7 +1131,7 @@ SQL;
             'type' => 'integer',
             'null' => false
         ]);
-        $table->temporary(true);
+        $table->setTemporary(true);
         $sql = $table->createSql($connection);
         $this->assertContains('CREATE TEMPORARY TABLE', $sql[0]);
     }

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -916,7 +916,7 @@ SQL;
             'type' => 'integer',
             'null' => false
         ]);
-        $table->temporary(true);
+        $table->setTemporary(true);
         $sql = $table->createSql($connection);
         $this->assertContains('CREATE TEMPORARY TABLE', $sql[0]);
     }

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -673,12 +673,30 @@ class TableTest extends TestCase
      */
     public function testTemporary()
     {
+        $this->deprecated(function () {
+            $table = new Table('articles');
+            $this->assertFalse($table->temporary());
+            $this->assertSame($table, $table->temporary(true));
+            $this->assertTrue($table->temporary());
+            $table->temporary(false);
+            $this->assertFalse($table->temporary());
+        });
+    }
+
+    /**
+     * Tests the setTemporary() & isTemporary() method
+     *
+     * @return void
+     */
+    public function testSetTemporary()
+    {
         $table = new Table('articles');
-        $this->assertFalse($table->temporary());
-        $this->assertSame($table, $table->temporary(true));
-        $this->assertTrue($table->temporary());
-        $table->temporary(false);
-        $this->assertFalse($table->temporary());
+        $this->assertFalse($table->isTemporary());
+        $this->assertSame($table, $table->setTemporary(true));
+        $this->assertTrue($table->isTemporary());
+
+        $table->setTemporary(false);
+        $this->assertFalse($table->isTemporary());
     }
 
     /**

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -88,7 +88,7 @@ class SchemaCacheTest extends TestCase
         $ormCache = new SchemaCache($ds);
         $ormCache->clear();
 
-        $this->assertInstanceOf('Cake\Database\Schema\CachedCollection', $ds->schemaCollection());
+        $this->assertInstanceOf(CachedCollection::class, $ds->getSchemaCollection());
     }
 
     /**
@@ -104,7 +104,7 @@ class SchemaCacheTest extends TestCase
         $ormCache = new SchemaCache($ds);
         $ormCache->build();
 
-        $this->assertInstanceOf('Cake\Database\Schema\CachedCollection', $ds->schemaCollection());
+        $this->assertInstanceOf(CachedCollection::class, $ds->getSchemaCollection());
     }
 
     /**

--- a/tests/TestCase/DatabaseSuite.php
+++ b/tests/TestCase/DatabaseSuite.php
@@ -55,10 +55,10 @@ class DatabaseSuite extends TestSuite
     {
         $permutations = [
             'Identifier Quoting' => function () {
-                ConnectionManager::get('test')->driver()->autoQuoting(true);
+                ConnectionManager::get('test')->getDriver()->enableAutoQuoting(true);
             },
             'No identifier quoting' => function () {
-                ConnectionManager::get('test')->driver()->autoQuoting(false);
+                ConnectionManager::get('test')->getDriver()->enableAutoQuoting(false);
             }
         ];
 

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -186,7 +186,7 @@ class BelongsToTest extends TestCase
 
         $this->assertEquals(
             'integer',
-            $query->typeMap()->type('Companies__id'),
+            $query->getTypeMap()->type('Companies__id'),
             'Associations should map types.'
         );
     }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -595,7 +595,7 @@ class HasManyTest extends TestCase
     protected function assertJoin($expected, $query)
     {
         if ($this->autoQuote) {
-            $driver = $query->connection()->driver();
+            $driver = $query->getConnection()->getDriver();
             $quoter = new IdentifierQuoter($driver);
             foreach ($expected as &$join) {
                 $join['table'] = $driver->quoteIdentifier($join['table']);
@@ -649,7 +649,7 @@ class HasManyTest extends TestCase
     protected function assertSelectClause($expected, $query)
     {
         if ($this->autoQuote) {
-            $connection = $query->connection();
+            $connection = $query->getConnection();
             foreach ($expected as $key => $value) {
                 $expected[$connection->quoteIdentifier($key)] = $connection->quoteIdentifier($value);
                 unset($expected[$key]);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -80,7 +80,7 @@ class HasManyTest extends TestCase
             'Articles__title' => 'string',
             'Articles__author_id' => 'integer',
         ]);
-        $this->autoQuote = $connection->driver()->autoQuoting();
+        $this->autoQuote = $connection->getDriver()->isAutoQuotingEnabled();
     }
 
     /**
@@ -297,7 +297,7 @@ class HasManyTest extends TestCase
                 'Articles.id !=' => 3,
                 'Articles.author_id IN' => $keys
             ],
-            $query->typeMap()
+            $query->getTypeMap()
         );
         $this->assertWhereClause($expected, $query);
 
@@ -369,7 +369,7 @@ class HasManyTest extends TestCase
                 'type' => 'INNER',
                 'alias' => null,
                 'table' => 'comments',
-                'conditions' => new QueryExpression([], $query->typeMap()),
+                'conditions' => new QueryExpression([], $query->getTypeMap()),
             ]
         ];
         $this->assertJoin($expected, $query);
@@ -379,7 +379,7 @@ class HasManyTest extends TestCase
                 'Articles.author_id IN' => $keys,
                 'comments.id' => 1,
             ],
-            $query->typeMap()
+            $query->getTypeMap()
         );
         $this->assertWhereClause($expected, $query);
     }
@@ -617,7 +617,7 @@ class HasManyTest extends TestCase
     protected function assertWhereClause($expected, $query)
     {
         if ($this->autoQuote) {
-            $quoter = new IdentifierQuoter($query->connection()->driver());
+            $quoter = new IdentifierQuoter($query->getConnection()->getDriver());
             $expected->traverse([$quoter, 'quoteExpression']);
         }
         $this->assertEquals($expected, $query->clause('where'));
@@ -633,7 +633,7 @@ class HasManyTest extends TestCase
     protected function assertOrderClause($expected, $query)
     {
         if ($this->autoQuote) {
-            $quoter = new IdentifierQuoter($query->connection()->driver());
+            $quoter = new IdentifierQuoter($query->getConnection()->getDriver());
             $quoter->quoteExpression($expected);
         }
         $this->assertEquals($expected, $query->clause('order'));

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -750,7 +750,7 @@ class CompositeKeyTest extends TestCase
      */
     public function testNotMatchingBelongsToMany()
     {
-        $driver = $this->connection->driver();
+        $driver = $this->connection->getDriver();
 
         if ($driver instanceof Sqlserver) {
             $this->markTestSkipped('Sqlserver does not support the requirements of this test.');
@@ -794,7 +794,7 @@ class CompositeKeyTest extends TestCase
     public function skipIfSqlite()
     {
         $this->skipIf(
-            $this->connection->driver() instanceof Sqlite,
+            $this->connection->getDriver() instanceof Sqlite,
             'SQLite does not support the requirements of this test.'
         );
     }

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -164,7 +164,7 @@ class EagerLoaderTest extends TestCase
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
 
-        $query->typeMap($this->clientsTypeMap);
+        $query->setTypeMap($this->clientsTypeMap);
 
         $query->expects($this->at(0))->method('join')
             ->with(['clients' => [
@@ -172,7 +172,7 @@ class EagerLoaderTest extends TestCase
                 'type' => 'LEFT',
                 'conditions' => new QueryExpression([
                     ['clients.id' => new IdentifierExpression('foo.client_id')],
-                ], new TypeMap($this->clientsTypeMap->defaults()))
+                ], new TypeMap($this->clientsTypeMap->getDefaults()))
             ]])
             ->will($this->returnValue($query));
 
@@ -568,9 +568,9 @@ class EagerLoaderTest extends TestCase
      */
     protected function _quoteArray($elements)
     {
-        if ($this->connection->driver()->autoQuoting()) {
+        if ($this->connection->getDriver()->isAutoQuotingEnabled()) {
             $quoter = function ($e) {
-                return $this->connection->driver()->quoteIdentifier($e);
+                return $this->connection->getDriver()->quoteIdentifier($e);
             };
 
             return array_combine(

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -667,7 +667,7 @@ class QueryRegressionTest extends TestCase
         $tags = TableRegistry::get('Tags');
 
         $this->skipIf(
-            $tags->connection()->driver() instanceof \Cake\Database\Driver\Sqlserver,
+            $tags->connection()->getDriver() instanceof \Cake\Database\Driver\Sqlserver,
             'SQL server is temporarily weird in this test, will investigate later'
         );
         $tags = TableRegistry::get('Tags');
@@ -1169,13 +1169,13 @@ class QueryRegressionTest extends TestCase
         $ratio = $table->find()
             ->select(function ($query) use ($table) {
                 $allCommentsCount = $table->find()->select($query->func()->count('*'));
-                $countToFloat = $query->newExpr([$query->func()->count('*'), '1.0'])->type('*');
+                $countToFloat = $query->newExpr([$query->func()->count('*'), '1.0'])->setConjunction('*');
 
                 return [
                     'ratio' => $query
                         ->newExpr($countToFloat)
                         ->add($allCommentsCount)
-                        ->type('/')
+                        ->setConjunction('/')
                 ];
             })
             ->where(['user_id' => 1])

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1177,7 +1177,7 @@ class QueryTest extends TestCase
         $query->select(['id']);
 
         $first = $query->hydrate(false)
-            ->bufferResults(false)->first();
+            ->enableBufferedResults(false)->first();
 
         $this->assertEquals(['id' => 1], $first);
     }
@@ -1712,7 +1712,7 @@ class QueryTest extends TestCase
      */
     public function testUpdateWithTableExpression()
     {
-        $this->skipIf(!$this->connection->driver() instanceof \Cake\Database\Driver\Mysql);
+        $this->skipIf(!$this->connection->getDriver() instanceof \Cake\Database\Driver\Mysql);
         $table = TableRegistry::get('articles');
 
         $query = $table->query();
@@ -1745,7 +1745,7 @@ class QueryTest extends TestCase
 
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
             $this->assertEquals(2, $result->rowCount());
         } else {
             $this->assertEquals(-1, $result->rowCount());
@@ -2495,7 +2495,7 @@ class QueryTest extends TestCase
         $table->hasMany('articles');
         $query = $table->find()
             ->where(['id > ' => 1])
-            ->bufferResults(false)
+            ->enableBufferedResults(false)
             ->hydrate(false)
             ->matching('articles')
             ->applyOptions(['foo' => 'bar'])
@@ -2509,7 +2509,7 @@ class QueryTest extends TestCase
         $expected = [
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $query->sql(),
-            'params' => $query->valueBinder()->bindings(),
+            'params' => $query->getValueBinder()->bindings(),
             'defaultTypes' => [
                 'authors__id' => 'integer',
                 'authors.id' => 'integer',
@@ -2832,7 +2832,7 @@ class QueryTest extends TestCase
             ->bind(':end', 2);
         $copy = $query->cleanCopy();
 
-        $this->assertNotEmpty($copy->valueBinder()->bindings());
+        $this->assertNotEmpty($copy->getValueBinder()->bindings());
     }
 
     /**

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -78,7 +78,7 @@ class ResultSetTest extends TestCase
      */
     public function testRewindStreaming()
     {
-        $query = $this->table->find('all')->bufferResults(false);
+        $query = $this->table->find('all')->enableBufferedResults(false);
         $results = $query->all();
         $first = $second = [];
         foreach ($results as $result) {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -310,7 +310,7 @@ class TableTest extends TestCase
      */
     public function testSchema()
     {
-        $schema = $this->connection->schemaCollection()->describe('users');
+        $schema = $this->connection->getSchemaCollection()->describe('users');
         $table = new Table([
             'table' => 'users',
             'connection' => $this->connection,
@@ -337,7 +337,7 @@ class TableTest extends TestCase
      */
     public function testSchemaInitialize()
     {
-        $schema = $this->connection->schemaCollection()->describe('users');
+        $schema = $this->connection->getSchemaCollection()->describe('users');
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->setMethods(['_initializeSchema'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
@@ -2568,7 +2568,7 @@ class TableTest extends TestCase
             ->setMethods(['begin', 'commit', 'inTransaction'])
             ->setConstructorArgs([$config])
             ->getMock();
-        $connection->driver($this->connection->driver());
+        $connection->setDriver($this->connection->getDriver());
 
         $table = $this->getMockBuilder('\Cake\ORM\Table')
             ->setMethods(['getConnection'])
@@ -2601,7 +2601,7 @@ class TableTest extends TestCase
             ->setMethods(['begin', 'rollback'])
             ->setConstructorArgs([ConnectionManager::config('test')])
             ->getMock();
-        $connection->driver(ConnectionManager::get('test')->driver());
+        $connection->setDriver(ConnectionManager::get('test')->getDriver());
         $table = $this->getMockBuilder('\Cake\ORM\Table')
             ->setMethods(['query', 'getConnection'])
             ->setConstructorArgs([['table' => 'users']])
@@ -2641,7 +2641,7 @@ class TableTest extends TestCase
             ->setMethods(['begin', 'rollback'])
             ->setConstructorArgs([ConnectionManager::config('test')])
             ->getMock();
-        $connection->driver(ConnectionManager::get('test')->driver());
+        $connection->setDriver(ConnectionManager::get('test')->getDriver());
         $table = $this->getMockBuilder('\Cake\ORM\Table')
             ->setMethods(['query', 'getConnection', 'exists'])
             ->setConstructorArgs([['table' => 'users']])
@@ -3635,7 +3635,7 @@ class TableTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Query', $result);
         $this->assertNull($result->clause('limit'));
         $expected = new QueryExpression();
-        $expected->typeMap()->defaults($this->usersTypeMap->toArray());
+        $expected->getTypeMap()->setDefaults($this->usersTypeMap->toArray());
         $expected->add(
             ['or' => ['Users.author_id' => 1, 'Users.published' => 'Y']]
         );
@@ -6554,7 +6554,7 @@ class TableTest extends TestCase
     public function skipIfSqlServer()
     {
         $this->skipIf(
-            $this->connection->driver() instanceof \Cake\Database\Driver\Sqlserver,
+            $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver,
             'SQLServer does not support the requirements of this test.'
         );
     }

--- a/tests/TestCase/Shell/SchemaCacheShellTest.php
+++ b/tests/TestCase/Shell/SchemaCacheShellTest.php
@@ -79,7 +79,7 @@ class SchemaCacheShellTest extends TestCase
 
         $this->shell->params['connection'] = 'test';
         $this->shell->clear();
-        $this->assertInstanceOf('Cake\Database\Schema\CachedCollection', $ds->schemaCollection());
+        $this->assertInstanceOf('Cake\Database\Schema\CachedCollection', $ds->getSchemaCollection());
     }
 
     /**
@@ -94,7 +94,7 @@ class SchemaCacheShellTest extends TestCase
 
         $this->shell->params['connection'] = 'test';
         $this->shell->build();
-        $this->assertInstanceOf('Cake\Database\Schema\CachedCollection', $ds->schemaCollection());
+        $this->assertInstanceOf('Cake\Database\Schema\CachedCollection', $ds->getSchemaCollection());
     }
 
     /**


### PR DESCRIPTION
Add deprecation warnings to classes in the Database package. 

@lorenzo I was not able to add warnings to `Cake\Database\Query::orWhere()` as I was not able to easily replace it with `Query::where()` as we had originally thought. The problematic uses were in the [Marshaller](https://github.com/cakephp/cakephp/blob/database-deprecations/src/ORM/Marshaller.php#L689) and in [TupleComparisonTranslatorTrait](https://github.com/cakephp/cakephp/blob/b27ebbd6a4e9b6062bd45e13a439b7ab7f29d0af/src/Database/Dialect/TupleComparisonTranslatorTrait.php#L82). Any ideas on how that usage could be updated?