### PR TITLE
3.next - Add deprecation warnings to the Validation package

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -67,7 +67,10 @@ class Validation
      */
     public static function notEmpty($check)
     {
-        trigger_error('Validation::notEmpty() is deprecated. Use Validation::notBlank() instead.', E_USER_DEPRECATED);
+        deprecationWarning(
+            'Validation::notEmpty() is deprecated. ' .
+            'Use Validation::notBlank() instead.'
+        );
 
         return static::notBlank($check);
     }
@@ -132,11 +135,13 @@ class Validation
      *
      * @param string $check Value to check
      * @return bool Success
-     * @deprecated 3.0.2
+     * @deprecated 3.0.2 Validation::blank() is deprecated.
      */
     public static function blank($check)
     {
-        trigger_error('Validation::blank() is deprecated.', E_USER_DEPRECATED);
+        deprecationWarning(
+            'Validation::blank() is deprecated.'
+        );
 
         return !static::_check($check, '/[^\\s]/');
     }
@@ -976,9 +981,9 @@ class Validation
      */
     public static function userDefined($check, $object, $method, $args = null)
     {
-        trigger_error(
-            'Validation::userDefined() is deprecated. Just set a callable for `rule` key when adding validators instead.',
-            E_USER_DEPRECATED
+        deprecationWarning(
+            'Validation::userDefined() is deprecated. ' .
+            'You can just set a callable for `rule` key when adding validators.'
         );
 
         return $object->$method($check, $args);

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -271,6 +271,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function provider($name, $object = null)
     {
+        deprecationWarning(
+            'Validator::provider() is deprecated. ' .
+            'Use Validator::setProvider()/getProvider() instead.'
+        );
         if ($object !== null) {
             return $this->setProvider($name, $object);
         }

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -83,7 +83,7 @@ trait ValidatorAwareTrait
      *  ->add('email', 'valid-email', ['rule' => 'email'])
      *  ->add('password', 'valid', ['rule' => 'notBlank'])
      *  ->allowEmpty('bio');
-     * $table->validator('forSubscription', $validator);
+     * $table->setValidator('forSubscription', $validator);
      * ```
      *
      * You can implement the method in `validationDefault` in your Table subclass
@@ -99,6 +99,10 @@ trait ValidatorAwareTrait
      */
     public function validator($name = null, Validator $validator = null)
     {
+        deprecationWarning(
+            'ValidatorAwareTrait::validator() is deprecated. ' .
+            'Use ValidatorAwareTrait::getValidator()/setValidator() instead.'
+        );
         if ($validator !== null) {
             $name = $name ?: self::DEFAULT_VALIDATOR;
             $this->setValidator($name, $validator);

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -23,6 +23,7 @@
     },
     "require": {
         "php": ">=5.6.0",
+        "cakephp/core": "^3.0.0",
         "cakephp/utility": "^3.0.0",
         "psr/http-message": "^1.0.0"
     },

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1623,7 +1623,7 @@ class TranslateBehaviorTest extends TestCase
             'validator' => 'custom'
         ]);
         $validator = (new Validator)->add('title', 'notBlank', ['rule' => 'notBlank']);
-        $table->validator('custom', $validator);
+        $table->setValidator('custom', $validator);
         $translate = $table->behaviors()->get('Translate');
 
         $entity = $table->newEntity();
@@ -1706,7 +1706,7 @@ class TranslateBehaviorTest extends TestCase
             'validator' => 'custom'
         ]);
         $validator = (new Validator)->add('title', 'notBlank', ['rule' => 'notBlank']);
-        $table->validator('custom', $validator);
+        $table->setValidator('custom', $validator);
         $translate = $table->behaviors()->get('Translate');
 
         $entity = $table->newEntity();

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -441,7 +441,7 @@ class TableLocatorTest extends TestCase
         $this->_locator->config('users', ['validator' => $validator]);
         $table = $this->_locator->get('users');
 
-        $this->assertSame($table->validator('default'), $validator);
+        $this->assertSame($table->getValidator('default'), $validator);
     }
 
     /**
@@ -464,9 +464,9 @@ class TableLocatorTest extends TestCase
         ]);
         $table = $this->_locator->get('users');
 
-        $this->assertSame($table->validator('default'), $validator1);
-        $this->assertSame($table->validator('secondary'), $validator2);
-        $this->assertSame($table->validator('tertiary'), $validator3);
+        $this->assertSame($table->getValidator('default'), $validator1);
+        $this->assertSame($table->getValidator('secondary'), $validator2);
+        $this->assertSame($table->getValidator('tertiary'), $validator3);
     }
 
     /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -2903,7 +2903,7 @@ class MarshallerTest extends TestCase
             'body' => 'hey'
         ];
 
-        $this->articles->validator()->requirePresence('thing');
+        $this->articles->getValidator()->requirePresence('thing');
         $marshall = new Marshaller($this->articles);
         $entity = $marshall->one($data);
         $this->assertNotEmpty($entity->errors('thing'));
@@ -2944,12 +2944,12 @@ class MarshallerTest extends TestCase
             ]
         ];
         $validator = (new Validator)->add('body', 'numeric', ['rule' => 'numeric']);
-        $this->articles->validator('custom', $validator);
+        $this->articles->setValidator('custom', $validator);
 
         $validator2 = (new Validator)->requirePresence('thing');
-        $this->articles->Users->validator('customThing', $validator2);
+        $this->articles->Users->setValidator('customThing', $validator2);
 
-        $this->articles->Comments->validator('default', $validator2);
+        $this->articles->Comments->setValidator('default', $validator2);
 
         $entity = (new Marshaller($this->articles))->one($data, [
             'validate' => 'custom',
@@ -2985,8 +2985,8 @@ class MarshallerTest extends TestCase
             ],
         ];
         $validator = (new Validator)->requirePresence('thing');
-        $this->articles->validator('default', $validator);
-        $this->articles->Users->validator('default', $validator);
+        $this->articles->setValidator('default', $validator);
+        $this->articles->Users->setValidator('default', $validator);
 
         $entity = (new Marshaller($this->articles))->one($data, [
             'validate' => false,
@@ -3014,7 +3014,7 @@ class MarshallerTest extends TestCase
             'body' => 'hey'
         ];
 
-        $validator = clone $this->articles->validator();
+        $validator = clone $this->articles->getValidator();
         $validator->requirePresence('thing');
         $marshall = new Marshaller($this->articles);
         $entity = $marshall->one($data, ['validate' => $validator]);
@@ -3064,7 +3064,7 @@ class MarshallerTest extends TestCase
         $entity->isNew(false);
         $entity->clean();
 
-        $this->articles->validator()
+        $this->articles->getValidator()
             ->requirePresence('thing', 'update')
             ->requirePresence('id', 'update')
             ->add('author_id', 'numeric', ['rule' => 'numeric'])
@@ -3078,7 +3078,7 @@ class MarshallerTest extends TestCase
         $this->assertNotEmpty($result->errors('thing'));
         $this->assertEmpty($result->errors('id'));
 
-        $this->articles->validator()->requirePresence('thing', 'create');
+        $this->articles->getValidator()->requirePresence('thing', 'create');
         $result = $marshall->merge($entity, $data, []);
 
         $this->assertEmpty($result->errors('thing'));
@@ -3106,7 +3106,7 @@ class MarshallerTest extends TestCase
         $entity->isNew(true);
         $entity->clean();
 
-        $this->articles->validator()
+        $this->articles->getValidator()
             ->requirePresence('thing', 'update')
             ->add('author_id', 'numeric', ['rule' => 'numeric', 'on' => 'update']);
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3355,7 +3355,7 @@ class TableTest extends TestCase
     {
         $table = new Table();
         $validator = $table->getValidator();
-        $this->assertSame($table, $validator->provider('table'));
+        $this->assertSame($table, $validator->getProvider('table'));
         $this->assertInstanceOf('Cake\Validation\Validator', $validator);
         $default = $table->getValidator('default');
         $this->assertSame($validator, $default);
@@ -3391,7 +3391,7 @@ class TableTest extends TestCase
         $other = $table->getValidator('forOtherStuff');
         $this->assertInstanceOf('Cake\Validation\Validator', $other);
         $this->assertNotSame($other, $table->getValidator());
-        $this->assertSame($table, $other->provider('table'));
+        $this->assertSame($table, $other->getProvider('table'));
     }
 
     /**
@@ -3435,7 +3435,7 @@ class TableTest extends TestCase
         $validator = new \Cake\Validation\Validator;
         $table->setValidator('other', $validator);
         $this->assertSame($validator, $table->getValidator('other'));
-        $this->assertSame($table, $validator->provider('table'));
+        $this->assertSame($table, $validator->getProvider('table'));
     }
 
     /**
@@ -5991,7 +5991,7 @@ class TableTest extends TestCase
         $table = TableRegistry::get('Users');
         $validator = new Validator;
         $validator->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
-        $validator->provider('table', $table);
+        $validator->setProvider('table', $table);
 
         $data = ['username' => ['larry', 'notthere']];
         $this->assertNotEmpty($validator->errors($data));
@@ -6031,7 +6031,7 @@ class TableTest extends TestCase
             'rule' => ['validateUnique', ['derp' => 'erp', 'scope' => 'id']],
             'provider' => 'table'
         ]);
-        $validator->provider('table', $table);
+        $validator->setProvider('table', $table);
         $data = ['username' => 'larry', 'id' => 3];
         $this->assertNotEmpty($validator->errors($data));
 
@@ -6071,7 +6071,7 @@ class TableTest extends TestCase
             'provider' => 'table',
             'message' => 'Must be unique.',
         ]);
-        $validator->provider('table', $table);
+        $validator->setProvider('table', $table);
 
         $data = ['site_id' => 1, 'author_id' => null, 'title' => 'Null dupe'];
         $expected = ['site_id' => ['unique' => 'Must be unique.']];

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -68,7 +68,7 @@ class ValidatorTest extends TestCase
     public function testAddNestedSingleProviders()
     {
         $validator = new Validator();
-        $validator->provider('test', $this);
+        $validator->setProvider('test', $this);
 
         $inner = new Validator();
         $inner->add('username', 'not-blank', ['rule' => function () use ($inner, $validator) {
@@ -105,7 +105,7 @@ class ValidatorTest extends TestCase
     public function testAddNestedManyProviders()
     {
         $validator = new Validator();
-        $validator->provider('test', $this);
+        $validator->setProvider('test', $this);
 
         $inner = new Validator();
         $inner->add('comment', 'not-blank', ['rule' => function () use ($inner, $validator) {
@@ -926,15 +926,15 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $object = new \stdClass;
-        $this->assertSame($validator, $validator->provider('foo', $object));
-        $this->assertSame($object, $validator->provider('foo'));
-        $this->assertNull($validator->provider('bar'));
+        $this->assertSame($validator, $validator->setProvider('foo', $object));
+        $this->assertSame($object, $validator->getProvider('foo'));
+        $this->assertNull($validator->getProvider('bar'));
 
         $another = new \stdClass;
-        $this->assertSame($validator, $validator->provider('bar', $another));
-        $this->assertSame($another, $validator->provider('bar'));
+        $this->assertSame($validator, $validator->setProvider('bar', $another));
+        $this->assertSame($another, $validator->getProvider('bar'));
 
-        $this->assertEquals(new \Cake\Validation\RulesProvider, $validator->provider('default'));
+        $this->assertEquals(new \Cake\Validation\RulesProvider, $validator->getProvider('default'));
     }
 
     /**
@@ -997,7 +997,7 @@ class ValidatorTest extends TestCase
                 return "That ain't cool, yo";
             }));
 
-        $validator->provider('thing', $thing);
+        $validator->setProvider('thing', $thing);
         $errors = $validator->errors(['email' => '!', 'title' => 'bar']);
         $expected = [
             'email' => ['alpha' => 'The provided value is invalid'],
@@ -1044,7 +1044,7 @@ class ValidatorTest extends TestCase
 
                 return "That ain't cool, yo";
             }));
-        $validator->provider('thing', $thing);
+        $validator->setProvider('thing', $thing);
         $errors = $validator->errors(['email' => '!', 'title' => 'bar']);
         $expected = [
             'title' => ['cool' => "That ain't cool, yo"]
@@ -1220,8 +1220,8 @@ class ValidatorTest extends TestCase
     public function testDebugInfo()
     {
         $validator = new Validator();
-        $validator->provider('test', $this);
-        $validator->add('title', 'not-empty', ['rule' => 'notEmpty']);
+        $validator->setProvider('test', $this);
+        $validator->add('title', 'not-empty', ['rule' => 'notBlank']);
         $validator->requirePresence('body');
         $validator->allowEmpty('published');
 

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -719,11 +719,11 @@ class EntityContextTest extends TestCase
             'type' => 'boolean'
         ]);
 
-        $validator = $articles->validator();
+        $validator = $articles->getValidator();
         $validator->add('comments_on', 'is_bool', [
             'rule' => 'boolean'
         ]);
-        $articles->validator('default', $validator);
+        $articles->setValidator('default', $validator);
 
         $this->assertFalse($context->isRequired('title'));
     }
@@ -761,7 +761,7 @@ class EntityContextTest extends TestCase
         $this->_setupTables();
 
         $comments = TableRegistry::get('Comments');
-        $validator = $comments->validator();
+        $validator = $comments->getValidator();
         $validator->add('user_id', 'number', [
             'rule' => 'numeric',
         ]);
@@ -796,7 +796,7 @@ class EntityContextTest extends TestCase
 
         $comments = TableRegistry::get('Comments');
         $comments->schema()->addColumn('starred', 'boolean');
-        $comments->validator()->add('starred', 'valid', ['rule' => 'boolean']);
+        $comments->getValidator()->add('starred', 'valid', ['rule' => 'boolean']);
 
         $row = new Article([
             'title' => 'My title',
@@ -827,11 +827,11 @@ class EntityContextTest extends TestCase
         $users = TableRegistry::get('Users');
         $articles = TableRegistry::get('Articles');
 
-        $validator = $articles->validator();
+        $validator = $articles->getValidator();
         $validator->notEmpty('title', 'nope', function ($context) {
             return $context['providers']['entity']->isRequired();
         });
-        $articles->validator('default', $validator);
+        $articles->setValidator('default', $validator);
 
         $row = new Entity([
             'username' => 'mark'
@@ -855,7 +855,7 @@ class EntityContextTest extends TestCase
         $this->_setupTables();
 
         $comments = TableRegistry::get('Comments');
-        $validator = $comments->validator();
+        $validator = $comments->getValidator();
         $validator->allowEmpty('comment', function ($context) {
             return $context['providers']['entity']->isNew();
         });
@@ -1290,24 +1290,24 @@ class EntityContextTest extends TestCase
         ->add('body', 'maxlength', [
             'rule' => ['maxlength', 1000]
         ])->allowEmpty('body');
-        $articles->validator('create', $validator);
+        $articles->setValidator('create', $validator);
 
         $validator = new Validator();
         $validator->add('username', 'length', [
             'rule' => ['minlength', 10]
         ]);
-        $users->validator('custom', $validator);
+        $users->setValidator('custom', $validator);
 
         $validator = new Validator();
         $validator->add('comment', 'length', [
             'rule' => ['minlength', 10]
         ]);
-        $comments->validator('custom', $validator);
+        $comments->setValidator('custom', $validator);
 
         $validator = new Validator();
         $validator->requirePresence('article_id', 'create');
         $validator->requirePresence('tag_id', 'create');
-        $articlesTags->validator('default', $validator);
+        $articlesTags->setValidator('default', $validator);
     }
 
     /**
@@ -1342,7 +1342,7 @@ class EntityContextTest extends TestCase
         ]);
         $context->isRequired('title');
         $articles = TableRegistry::get('Articles');
-        $this->assertSame($row, $articles->validator()->provider('entity'));
+        $this->assertSame($row, $articles->getValidator()->getProvider('entity'));
 
         $row = new Article([
             'title' => 'First post',
@@ -1360,14 +1360,14 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $validator = $articles->validator();
+        $validator = $articles->getValidator();
         $context->isRequired('user.articles.0.title');
-        $this->assertSame($row->user->articles[0], $validator->provider('entity'));
+        $this->assertSame($row->user->articles[0], $validator->getProvider('entity'));
 
         $context->isRequired('user.articles.1.title');
-        $this->assertSame($row->user->articles[1], $validator->provider('entity'));
+        $this->assertSame($row->user->articles[1], $validator->getProvider('entity'));
 
         $context->isRequired('title');
-        $this->assertSame($row, $validator->provider('entity'));
+        $this->assertSame($row, $validator->getProvider('entity'));
     }
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8237,7 +8237,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         TableRegistry::get('Comments')
-            ->validator('default')
+            ->getValidator('default')
             ->allowEmpty('comment', false);
         $result = $this->Form->control('0.comments.1.comment');
         //@codingStandardsIgnoreStart


### PR DESCRIPTION
- Added missing cakephp/core dependency so that the deprecationWarning() is pulled in
- Added missing docblock deprecation message to Validation::blank()

Refs #11385
