### PR TITLE
3.next - Add deprecation warnings to the Utility package

### DIFF
--- a/src/Utility/Crypto/Mcrypt.php
+++ b/src/Utility/Crypto/Mcrypt.php
@@ -34,6 +34,7 @@ class Mcrypt
      * @param string $operation Operation to perform, encrypt or decrypt
      * @throws \LogicException When there are errors.
      * @return string Encrytped binary string data, or decrypted data depending on operation.
+     * @deprecated 3.3.0 This method will be removed in 4.0.0.
      */
     public static function rijndael($text, $key, $operation)
     {
@@ -65,9 +66,14 @@ class Mcrypt
      * @param string $key The 256 bit/32 byte key to use as a cipher key.
      * @return string Encrypted data.
      * @throws \InvalidArgumentException On invalid data or key.
+     * @deprecated 3.3.0 Use Cake\Utility\Crypto\OpenSsl::encrypt() instead.
      */
     public static function encrypt($plain, $key)
     {
+        deprecationWarning(
+            'Mcrypt::encrypt() is deprecated. ' .
+            'Use Cake\Utility\Crypto\OpenSsl::encrypt() instead.'
+        );
         $algorithm = MCRYPT_RIJNDAEL_128;
         $mode = MCRYPT_MODE_CBC;
 
@@ -88,9 +94,14 @@ class Mcrypt
      * @param string $key The 256 bit/32 byte key to use as a cipher key.
      * @return string Decrypted data. Any trailing null bytes will be removed.
      * @throws \InvalidArgumentException On invalid data or key.
+     * @deprecated 3.3.0 Use Cake\Utility\Crypto\OpenSsl::decrypt() instead.
      */
     public static function decrypt($cipher, $key)
     {
+        deprecationWarning(
+            'Mcrypt::decrypt() is deprecated. ' .
+            'Use Cake\Utility\Crypto\OpenSsl::decrypt() instead.'
+        );
         $algorithm = MCRYPT_RIJNDAEL_128;
         $mode = MCRYPT_MODE_CBC;
         $ivSize = mcrypt_get_iv_size($algorithm, $mode);

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -752,7 +752,7 @@ class Inflector
     {
         deprecationWarning(
             'Inflector::slug() is deprecated. ' .
-            'Use Text::getSalt()/setSalt() instead.'
+            'Use Text::slug() instead.'
         );
         $quotedReplacement = preg_quote($replacement, '/');
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -750,6 +750,10 @@ class Inflector
      */
     public static function slug($string, $replacement = '-')
     {
+        deprecationWarning(
+            'Inflector::slug() is deprecated. ' .
+            'Use Text::getSalt()/setSalt() instead.'
+        );
         $quotedReplacement = preg_quote($replacement, '/');
 
         $map = [

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -353,6 +353,10 @@ class Security
      */
     public static function salt($salt = null)
     {
+        deprecationWarning(
+            'Security::salt() is deprecated. ' .
+            'Use Security::getSalt()/setSalt() instead.'
+        );
         if ($salt === null) {
             return static::$_salt;
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -521,6 +521,7 @@ class Text
      */
     public static function stripLinks($text)
     {
+        deprecationWarning('This method will be removed in 4.0.0.');
         do {
             $text = preg_replace('#</?a([/\s][^>]*)?(>|$)#i', '', $text, -1, $count);
         } while ($count);

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -256,7 +256,7 @@ class FormAuthenticateTest extends TestCase
         $PluginModel = TableRegistry::get('TestPlugin.AuthUsers');
         $user['id'] = 1;
         $user['username'] = 'gwoo';
-        $user['password'] = password_hash(Security::salt() . 'cake', PASSWORD_BCRYPT);
+        $user['password'] = password_hash(Security::getSalt() . 'cake', PASSWORD_BCRYPT);
         $PluginModel->save(new Entity($user));
 
         $this->auth->config('userModel', 'TestPlugin.AuthUsers');

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -33,7 +33,7 @@ class WeakPasswordHasherTest extends TestCase
     {
         parent::setUp();
 
-        Security::salt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
+        Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
     }
 
     /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -59,7 +59,7 @@ class AuthComponentTest extends TestCase
     {
         parent::setUp();
 
-        Security::salt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
+        Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
         static::setAppNamespace();
 
         Router::scope('/', function ($routes) {

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -174,7 +174,7 @@ class SecurityComponentTest extends TestCase
         $this->Controller->Security->config('blackHoleCallback', 'fail');
         $this->Security = $this->Controller->Security;
         $this->Security->session = $session;
-        Security::salt('foo!');
+        Security::setSalt('foo!');
     }
 
     /**
@@ -940,7 +940,7 @@ class SecurityComponentTest extends TestCase
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
         $fields = urlencode(
-            hash_hmac('sha1', '/articles/index' . serialize($fields) . $unlocked . 'cli', Security::salt())
+            hash_hmac('sha1', '/articles/index' . serialize($fields) . $unlocked . 'cli', Security::getSalt())
         );
         $debug = 'not used';
 
@@ -970,7 +970,7 @@ class SecurityComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $this->Security->startup($event);
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
-        $fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . Security::getSalt()));
 
         $this->Controller->request->data = [
             'Model' => [
@@ -998,7 +998,7 @@ class SecurityComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $this->Security->startup($event);
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
-        $fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . Security::getSalt()));
         $unlocked = '';
 
         $this->Controller->request->data = [
@@ -1027,7 +1027,7 @@ class SecurityComponentTest extends TestCase
         $event = new Event('Controller.startup', $this->Controller);
         $this->Security->startup($event);
         $fields = ['Model.hidden', 'Model.password', 'Model.username'];
-        $fields = urlencode(Security::hash(serialize($fields) . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . Security::getSalt()));
         $unlocked = '';
 
         $this->Controller->request->data = [
@@ -1056,7 +1056,7 @@ class SecurityComponentTest extends TestCase
         $this->Security->startup($event);
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
-        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $debug = urlencode(json_encode([
             '/articles/index',
             ['Model.hidden', 'Model.password'],
@@ -1196,7 +1196,7 @@ class SecurityComponentTest extends TestCase
         $unlocked = '';
         $hashFields = ['TaxonomyData'];
         $fields = urlencode(
-            hash_hmac('sha1', '/articles/index' . serialize($hashFields) . $unlocked . 'cli', Security::salt())
+            hash_hmac('sha1', '/articles/index' . serialize($hashFields) . $unlocked . 'cli', Security::getSalt())
         );
         $debug = 'not used';
 
@@ -1474,7 +1474,7 @@ class SecurityComponentTest extends TestCase
         $this->Security->startup($event);
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
-        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $debug = urlencode(json_encode([
             '/articles/index',
             ['Model.hidden', 'Model.password'],
@@ -1556,7 +1556,7 @@ class SecurityComponentTest extends TestCase
             $fields,
             []
         ]));
-        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $fields .= urlencode(':Model.hidden|Model.id');
         $this->Controller->request->data = [
             'Model' => [
@@ -1589,7 +1589,7 @@ class SecurityComponentTest extends TestCase
             $fields,
             []
         ]));
-        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $fields .= urlencode(':Model.hidden|Model.id');
         $this->Controller->request->data = [
             'Model' => [
@@ -1622,7 +1622,7 @@ class SecurityComponentTest extends TestCase
             $fields,
             []
         ]));
-        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::salt()));
+        $fields = urlencode(Security::hash(serialize($fields) . $unlocked . Security::getSalt()));
         $fields .= urlencode(':Model.hidden|Model.id');
         $this->Controller->request->data = [
             'Model' => [

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -41,7 +41,7 @@ class RequestActionTraitTest extends TestCase
     {
         parent::setUp();
         static::setAppNamespace();
-        Security::salt('not-the-default');
+        Security::setSalt('not-the-default');
         DispatcherFactory::add('Routing');
         DispatcherFactory::add('ControllerFactory');
         $this->object = $this->getObjectForTrait('Cake\Routing\RequestActionTrait');

--- a/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
+++ b/tests/TestCase/TestSuite/CookieEncryptedUsingControllerTest.php
@@ -34,7 +34,7 @@ class CookieEncryptedUsingControllerTest extends IntegrationTestCase
         parent::setUp();
         static::setAppNamespace();
 
-        Security::salt('abcdabcdabcdabcdabcdabcdabcdabcdabcd');
+        Security::setSalt('abcdabcdabcdabcdabcdabcdabcdabcdabcd');
         Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
         DispatcherFactory::clear();
         DispatcherFactory::add('Routing');
@@ -96,12 +96,12 @@ class CookieEncryptedUsingControllerTest extends IntegrationTestCase
     }
 
     /**
-     * Can be used Security::salt() as the encryption key.
+     * Can be used in Security::setSalt() as the encryption key.
      */
     public function testCanBeUsedSecuritySaltAsEncryptionKey()
     {
         $key = 'another salt xxxxxxxxxxxxxxxxxxx';
-        Security::salt($key);
+        Security::setSalt($key);
         $this->cookieEncrypted('NameOfCookie', 'Value of Cookie', 'aes');
 
         $this->get('/cookie_component_test/view/' . urlencode($key));
@@ -135,7 +135,7 @@ class CookieEncryptedUsingControllerTest extends IntegrationTestCase
     public function testCanAssertCookieEncryptedWithAnotherEncryptionKey()
     {
         $key = 'another salt xxxxxxxxxxxxxxxxxxx';
-        Security::salt($key);
+        Security::setSalt($key);
         $this->get('/cookie_component_test/set_cookie');
         $this->assertCookieEncrypted('abc', 'NameOfCookie', 'aes', $key);
     }

--- a/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -165,7 +165,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
      */
     public function testCookieEncrypted()
     {
-        Security::salt('abcdabcdabcdabcdabcdabcdabcdabcdabcd');
+        Security::setSalt('abcdabcdabcdabcdabcdabcdabcdabcdabcd');
         $this->cookieEncrypted('KeyOfCookie', 'Encrypted with aes by default');
         $request = $this->_buildRequest('/tasks/view', 'GET', []);
         $this->assertStringStartsWith('Q2FrZQ==.', $request['cookies']['KeyOfCookie']);

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -301,8 +301,8 @@ class SecurityTest extends TestCase
      */
     public function testSalt()
     {
-        Security::salt('foobarbaz');
-        $this->assertEquals('foobarbaz', Security::salt());
+        Security::setSalt('foobarbaz');
+        $this->assertEquals('foobarbaz', Security::getSalt());
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -183,7 +183,7 @@ class FormHelperTest extends TestCase
             ]
         ];
 
-        Security::salt('foo!');
+        Security::setSalt('foo!');
         Router::connect('/:controller', ['action' => 'index']);
         Router::connect('/:controller/:action/*');
     }
@@ -1135,7 +1135,7 @@ class FormHelperTest extends TestCase
         $fields = ['anything'];
         $result = $this->Form->secure($fields);
 
-        $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::salt());
+        $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
         $this->assertContains($hash, $result);
     }
 
@@ -1167,7 +1167,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->params['_Token'] = 'testKey';
         $result = $this->Form->secure($fields);
 
-        $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::salt());
+        $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
         $hash .= ':' . 'Model.valid';
         $hash = urlencode($hash);
         $tokenDebug = urlencode(json_encode([
@@ -1215,7 +1215,7 @@ class FormHelperTest extends TestCase
         $this->Form->request->params['_Token'] = 'testKey';
         $result = $this->Form->secure($fields);
 
-        $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::salt());
+        $hash = hash_hmac('sha1', serialize($fields) . session_id(), Security::getSalt());
         $hash .= ':' . 'Model.valid';
         $hash = urlencode($hash);
         $expected = [

--- a/tests/test_app/TestApp/Model/Behavior/SluggableBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/SluggableBehavior.php
@@ -21,7 +21,7 @@ namespace TestApp\Model\Behavior;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
-use Cake\Utility\Inflector;
+use Cake\Utility\Text;
 
 class SluggableBehavior extends Behavior
 {
@@ -42,6 +42,6 @@ class SluggableBehavior extends Behavior
 
     public function slugify($value)
     {
-        return Inflector::slug($value);
+        return Text::slug($value);
     }
 }


### PR DESCRIPTION
- There are still a ton of Inflector::slug() tests. Should these be moved/consolidated to Text?
- OpenSsl does not support the rijndael method, so I've just set it as "to be removed".

Refs #11385
