### PR TITLE
Fix Exception message to be optional as parent signature demands

### DIFF
--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -60,7 +60,7 @@ class Exception extends RuntimeException
      * @param int|null $code The code of the error, is also the HTTP status code for the error.
      * @param \Exception|null $previous the previous exception.
      */
-    public function __construct($message, $code = null, $previous = null)
+    public function __construct($message = '', $code = null, $previous = null)
     {
         if ($code === null) {
             $code = $this->_defaultCode;


### PR DESCRIPTION
```php
throw new NotImplementedException();
```

This should work, but throws a notice and also displays small IDE error as per PHP core signature of

```php
    /**
     * Construct the exception. Note: The message is NOT binary safe.
     * @link http://php.net/manual/en/exception.construct.php
     * @param string $message [optional] The Exception message to throw.
     * @param int $code [optional] The Exception code.
     * @param Throwable $previous [optional] The previous throwable used for the exception chaining.
     * @since 5.1.0
     */
    public function __construct($message = "", $code = 0, Throwable $previous = null) { }
```

fully BC afaik