### PR TITLE
3.next wrape deprecated test with deprecated helper()

### DIFF
--- a/tests/TestCase/Utility/Crypto/McryptTest.php
+++ b/tests/TestCase/Utility/Crypto/McryptTest.php
@@ -62,32 +62,38 @@ class McryptTest extends TestCase
     /**
      * Test encrypt/decrypt.
      *
+     * @group deprecated
      * @return void
      */
     public function testEncryptDecrypt()
     {
-        $txt = 'The quick brown fox';
-        $key = 'This key is enough bytes';
-        $result = $this->crypt->encrypt($txt, $key);
-        $this->assertNotEquals($txt, $result, 'Should be encrypted.');
-        $this->assertNotEquals($result, $this->crypt->encrypt($txt, $key), 'Each result is unique.');
-        $this->assertEquals($txt, $this->crypt->decrypt($result, $key));
+        $this->deprecated(function () {
+            $txt = 'The quick brown fox';
+            $key = 'This key is enough bytes';
+            $result = $this->crypt->encrypt($txt, $key);
+            $this->assertNotEquals($txt, $result, 'Should be encrypted.');
+            $this->assertNotEquals($result, $this->crypt->encrypt($txt, $key), 'Each result is unique.');
+            $this->assertEquals($txt, $this->crypt->decrypt($result, $key));
+        });
     }
 
     /**
      * Test that changing the key causes decryption to fail.
      *
+     * @group deprecated
      * @return void
      */
     public function testDecryptKeyFailure()
     {
-        $txt = 'The quick brown fox';
+        $this->deprecated(function () {
+            $txt = 'The quick brown fox';
 
-        $key = substr(hash('sha256', 'This key is enough bytes'), 0, 32);
-        $result = $this->crypt->encrypt($txt, $key);
+            $key = substr(hash('sha256', 'This key is enough bytes'), 0, 32);
+            $result = $this->crypt->encrypt($txt, $key);
 
-        $key = substr(hash('sha256', 'Not the same key.'), 0, 32);
-        $this->assertFalse($this->crypt->decrypt($txt, $key), 'Modified key will fail.');
+            $key = substr(hash('sha256', 'Not the same key.'), 0, 32);
+            $this->assertFalse($this->crypt->decrypt($txt, $key), 'Modified key will fail.');
+        });
     }
 
     /**
@@ -95,19 +101,22 @@ class McryptTest extends TestCase
      *
      * The $cipher variable is base64 encoded data from 2.x encrypt()
      *
+     * @group deprecated
      * @return
      */
     public function testDecryptOldData()
     {
-        $key = 'My password is nice and long really it is';
-        $key = substr(hash('sha256', $key), 0, 32);
+        $this->deprecated(function () {
+            $key = 'My password is nice and long really it is';
+            $key = substr(hash('sha256', $key), 0, 32);
 
-        $cipher = 'ZmFkMjdmY2U2NjgzOTkwMGZmMWJiMzY0ZDA5ZDUwZmNjYTdjNWVkZThkMzhmNzdiY' .
-            'Tg3ZDFjMzNjNmViMDljMnk9k0LmYpwSZH5eq7GmDozMwHxzh37YaXFQ2TK5gXb5OfTKXv83K+NjAS9lIo/Zvw==';
-        $data = base64_decode($cipher);
-        $cipher = substr($data, 64);
+            $cipher = 'ZmFkMjdmY2U2NjgzOTkwMGZmMWJiMzY0ZDA5ZDUwZmNjYTdjNWVkZThkMzhmNzdiY' .
+                'Tg3ZDFjMzNjNmViMDljMnk9k0LmYpwSZH5eq7GmDozMwHxzh37YaXFQ2TK5gXb5OfTKXv83K+NjAS9lIo/Zvw==';
+            $data = base64_decode($cipher);
+            $cipher = substr($data, 64);
 
-        $result = $this->crypt->decrypt($cipher, $key);
-        $this->assertEquals('This is a secret message', $result);
+            $result = $this->crypt->decrypt($cipher, $key);
+            $this->assertEquals('This is a secret message', $result);
+        });
     }
 }

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -359,117 +359,129 @@ class InflectorTest extends TestCase
     /**
      * testSlug method
      *
+     * @group deprecated
      * @return void
      */
     public function testSlug()
     {
-        $result = Inflector::slug('Foo Bar: Not just for breakfast any-more');
-        $expected = 'Foo-Bar-Not-just-for-breakfast-any-more';
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $result = Inflector::slug('Foo Bar: Not just for breakfast any-more');
+            $expected = 'Foo-Bar-Not-just-for-breakfast-any-more';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('this/is/a/path');
-        $expected = 'this-is-a-path';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('this/is/a/path');
+            $expected = 'this-is-a-path';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '_');
-        $expected = 'Foo_Bar_Not_just_for_breakfast_any_more';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '_');
+            $expected = 'Foo_Bar_Not_just_for_breakfast_any_more';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '+');
-        $expected = 'Foo+Bar+Not+just+for+breakfast+any+more';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '+');
+            $expected = 'Foo+Bar+Not+just+for+breakfast+any+more';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('Äpfel Über Öl grün ärgert groß öko', '-');
-        $expected = 'Aepfel-Ueber-Oel-gruen-aergert-gross-oeko';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('Äpfel Über Öl grün ärgert groß öko', '-');
+            $expected = 'Aepfel-Ueber-Oel-gruen-aergert-gross-oeko';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('The truth - and- more- news', '-');
-        $expected = 'The-truth-and-more-news';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('The truth - and- more- news', '-');
+            $expected = 'The-truth-and-more-news';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('The truth: and more news', '-');
-        $expected = 'The-truth-and-more-news';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('The truth: and more news', '-');
+            $expected = 'The-truth-and-more-news';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('La langue française est un attribut de souveraineté en France', '-');
-        $expected = 'La-langue-francaise-est-un-attribut-de-souverainete-en-France';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('La langue française est un attribut de souveraineté en France', '-');
+            $expected = 'La-langue-francaise-est-un-attribut-de-souverainete-en-France';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('!@$#exciting stuff! - what !@-# was that?', '-');
-        $expected = 'exciting-stuff-what-was-that';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('!@$#exciting stuff! - what !@-# was that?', '-');
+            $expected = 'exciting-stuff-what-was-that';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('20% of profits went to me!', '-');
-        $expected = '20-of-profits-went-to-me';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('20% of profits went to me!', '-');
+            $expected = '20-of-profits-went-to-me';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('#this melts your face1#2#3', '-');
-        $expected = 'this-melts-your-face1-2-3';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('#this melts your face1#2#3', '-');
+            $expected = 'this-melts-your-face1-2-3';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('controller/action/りんご/1');
-        $expected = 'controller-action-りんご-1';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('controller/action/りんご/1');
+            $expected = 'controller-action-りんご-1';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('の話が出たので大丈夫かなあと');
-        $expected = 'の話が出たので大丈夫かなあと';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('の話が出たので大丈夫かなあと');
+            $expected = 'の話が出たので大丈夫かなあと';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('posts/view/한국어/page:1/sort:asc');
-        $expected = 'posts-view-한국어-page-1-sort-asc';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('posts/view/한국어/page:1/sort:asc');
+            $expected = 'posts-view-한국어-page-1-sort-asc';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug("non\xc2\xa0breaking\xc2\xa0space");
-        $this->assertEquals('non-breaking-space', $result);
+            $result = Inflector::slug("non\xc2\xa0breaking\xc2\xa0space");
+            $this->assertEquals('non-breaking-space', $result);
 
-        $result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '');
-        $expected = 'FooBarNotjustforbreakfastanymore';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('Foo Bar: Not just for breakfast any-more', '');
+            $expected = 'FooBarNotjustforbreakfastanymore';
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
      * Test slug() with a complete list of special chars.
      *
+     * @group deprecated
      * @return void
      */
     public function testSlugCharList()
     {
-        foreach (self::$maps as $language => $list) {
-            foreach ($list as $from => $to) {
-                $result = Inflector::slug($from);
-                $this->assertEquals($to, $result, $from . ' (' . $language . ') should be ' . $to . ' - but is ' . $result);
+        $this->deprecated(function () {
+            foreach (self::$maps as $language => $list) {
+                foreach ($list as $from => $to) {
+                    $result = Inflector::slug($from);
+                    $this->assertEquals($to, $result, $from . ' (' . $language . ') should be ' . $to . ' - but is ' . $result);
+                }
             }
-        }
+        });
     }
 
     /**
      * testSlugWithMap method
      *
+     * @group deprecated
      * @return void
      */
     public function testSlugWithMap()
     {
-        Inflector::rules('transliteration', ['r' => '1']);
-        $result = Inflector::slug('replace every r');
-        $expected = '1eplace-eve1y-1';
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            Inflector::rules('transliteration', ['r' => '1']);
+            $result = Inflector::slug('replace every r');
+            $expected = '1eplace-eve1y-1';
+            $this->assertEquals($expected, $result);
 
-        $result = Inflector::slug('replace every r', '_');
-        $expected = '1eplace_eve1y_1';
-        $this->assertEquals($expected, $result);
+            $result = Inflector::slug('replace every r', '_');
+            $expected = '1eplace_eve1y_1';
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
      * testSlugWithMapOverridingDefault method
      *
+     * @group deprecated
      * @return void
      */
     public function testSlugWithMapOverridingDefault()
     {
-        Inflector::rules('transliteration', ['å' => 'aa', 'ø' => 'oe']);
-        $result = Inflector::slug('Testing æ ø å', '-');
-        $expected = 'Testing-ae-oe-aa';
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            Inflector::rules('transliteration', ['å' => 'aa', 'ø' => 'oe']);
+            $result = Inflector::slug('Testing æ ø å', '-');
+            $expected = 'Testing-ae-oe-aa';
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -644,17 +656,20 @@ class InflectorTest extends TestCase
     /**
      * testCustomTransliterationRule method
      *
+     * @group deprecated
      * @return void
      */
     public function testCustomTransliterationRule()
     {
-        $this->assertEquals('Testing-ae-o-a', Inflector::slug('Testing æ ø å'));
+        $this->deprecated(function () {
+            $this->assertEquals('Testing-ae-o-a', Inflector::slug('Testing æ ø å'));
 
-        Inflector::rules('transliteration', ['å' => 'aa', 'ø' => 'oe']);
-        $this->assertEquals('Testing-ae-oe-aa', Inflector::slug('Testing æ ø å'));
+            Inflector::rules('transliteration', ['å' => 'aa', 'ø' => 'oe']);
+            $this->assertEquals('Testing-ae-oe-aa', Inflector::slug('Testing æ ø å'));
 
-        Inflector::rules('transliteration', ['æ' => 'ae', 'å' => 'aa'], true);
-        $this->assertEquals('Testing-ae-ø-aa', Inflector::slug('Testing æ ø å'));
+            Inflector::rules('transliteration', ['æ' => 'ae', 'å' => 'aa'], true);
+            $this->assertEquals('Testing-ae-ø-aa', Inflector::slug('Testing æ ø å'));
+        });
     }
 
     /**

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -268,30 +268,32 @@ class SecurityTest extends TestCase
     /**
      * Test that values encrypted with open ssl can be decrypted with mcrypt and the reverse.
      *
+     * @group deprecated
      * @return void
      */
     public function testEngineEquivalence()
     {
         $this->skipIf(!function_exists('mcrypt_encrypt') || version_compare(PHP_VERSION, '7.1', '>='), 'This needs mcrypt extension to be loaded.');
+        $this->deprecated(function () {
+            $restore = Security::engine();
+            $txt = "Obi-wan you're our only hope";
+            $key = 'This is my secret key phrase it is quite long.';
+            $salt = 'A tasty salt that is delicious';
 
-        $restore = Security::engine();
-        $txt = "Obi-wan you're our only hope";
-        $key = 'This is my secret key phrase it is quite long.';
-        $salt = 'A tasty salt that is delicious';
+            Security::engine(new Mcrypt());
+            $cipher = Security::encrypt($txt, $key, $salt);
+            $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
 
-        Security::engine(new Mcrypt());
-        $cipher = Security::encrypt($txt, $key, $salt);
-        $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
+            Security::engine(new OpenSsl());
+            $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
 
-        Security::engine(new OpenSsl());
-        $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
+            Security::engine(new OpenSsl());
+            $cipher = Security::encrypt($txt, $key, $salt);
+            $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
 
-        Security::engine(new OpenSsl());
-        $cipher = Security::encrypt($txt, $key, $salt);
-        $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
-
-        Security::engine(new Mcrypt());
-        $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
+            Security::engine(new Mcrypt());
+            $this->assertEquals($txt, Security::decrypt($cipher, $key, $salt));
+        });
     }
 
     /**

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -816,38 +816,41 @@ HTML;
     /**
      * testStripLinks method
      *
+     * @group deprecated
      * @return void
      */
     public function testStripLinks()
     {
-        $text = 'This is a test text';
-        $expected = 'This is a test text';
-        $result = $this->Text->stripLinks($text);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $text = 'This is a test text';
+            $expected = 'This is a test text';
+            $result = $this->Text->stripLinks($text);
+            $this->assertEquals($expected, $result);
 
-        $text = 'This is a <a href="#">test</a> text';
-        $expected = 'This is a test text';
-        $result = $this->Text->stripLinks($text);
-        $this->assertEquals($expected, $result);
+            $text = 'This is a <a href="#">test</a> text';
+            $expected = 'This is a test text';
+            $result = $this->Text->stripLinks($text);
+            $this->assertEquals($expected, $result);
 
-        $text = 'This <strong>is</strong> a <a href="#">test</a> <a href="#">text</a>';
-        $expected = 'This <strong>is</strong> a test text';
-        $result = $this->Text->stripLinks($text);
-        $this->assertEquals($expected, $result);
+            $text = 'This <strong>is</strong> a <a href="#">test</a> <a href="#">text</a>';
+            $expected = 'This <strong>is</strong> a test text';
+            $result = $this->Text->stripLinks($text);
+            $this->assertEquals($expected, $result);
 
-        $text = 'This <strong>is</strong> a <a href="#">test</a> and <abbr>some</abbr> other <a href="#">text</a>';
-        $expected = 'This <strong>is</strong> a test and <abbr>some</abbr> other text';
-        $result = $this->Text->stripLinks($text);
-        $this->assertEquals($expected, $result);
+            $text = 'This <strong>is</strong> a <a href="#">test</a> and <abbr>some</abbr> other <a href="#">text</a>';
+            $expected = 'This <strong>is</strong> a test and <abbr>some</abbr> other text';
+            $result = $this->Text->stripLinks($text);
+            $this->assertEquals($expected, $result);
 
-        $text = '<a<a h> href=\'bla\'>test</a</a>>';
-        $this->assertEquals('test', $this->Text->stripLinks($text));
+            $text = '<a<a h> href=\'bla\'>test</a</a>>';
+            $this->assertEquals('test', $this->Text->stripLinks($text));
 
-        $text = '<a/href="#">test</a/>';
-        $this->assertEquals('test', $this->Text->stripLinks($text));
+            $text = '<a/href="#">test</a/>';
+            $this->assertEquals('test', $this->Text->stripLinks($text));
 
-        $text = '<a href="#"';
-        $this->assertEquals('', $this->Text->stripLinks($text));
+            $text = '<a href="#"';
+            $this->assertEquals('', $this->Text->stripLinks($text));
+        });
     }
 
     /**


### PR DESCRIPTION
before these changes 
```php
There were 10 errors:

1) Cake\Test\TestCase\Utility\Crypto\McryptTest::testEncryptDecrypt
Mcrypt::encrypt() is deprecated. Use Cake\Utility\Crypto\OpenSsl::encrypt() instead. - [internal], line: ??

2) Cake\Test\TestCase\Utility\Crypto\McryptTest::testDecryptKeyFailure
Mcrypt::encrypt() is deprecated. Use Cake\Utility\Crypto\OpenSsl::encrypt() instead. - [internal], line: ??

3) Cake\Test\TestCase\Utility\Crypto\McryptTest::testDecryptOldData
Mcrypt::decrypt() is deprecated. Use Cake\Utility\Crypto\OpenSsl::decrypt() instead. - [internal], line: ??

4) Cake\Test\TestCase\Utility\InflectorTest::testSlug
Inflector::slug() is deprecated. Use Text::slug() instead. - [internal], line: ??

5) Cake\Test\TestCase\Utility\InflectorTest::testSlugCharList
Inflector::slug() is deprecated. Use Text::slug() instead. - [internal], line: ??

6) Cake\Test\TestCase\Utility\InflectorTest::testSlugWithMap
Inflector::slug() is deprecated. Use Text::slug() instead. - [internal], line: ??

7) Cake\Test\TestCase\Utility\InflectorTest::testSlugWithMapOverridingDefault
Inflector::slug() is deprecated. Use Text::slug() instead. - [internal], line: ??

8) Cake\Test\TestCase\Utility\InflectorTest::testCustomTransliterationRule
Inflector::slug() is deprecated. Use Text::slug() instead. - [internal], line: ??

9) Cake\Test\TestCase\Utility\SecurityTest::testEngineEquivalence
Mcrypt::encrypt() is deprecated. Use Cake\Utility\Crypto\OpenSsl::encrypt() instead. - .../tests/TestCase/Utility/SecurityTest.php, line: 283

10) Cake\Test\TestCase\Utility\TextTest::testStripLinks
This method will be removed in 4.0.0. - [internal], line: ??

```