### PR TITLE
Fix collections when iterating over certain classes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,6 +22,7 @@ parameters:
         - '#Access to an undefined property Exception::\$queryString#'
         - '#Access to an undefined property PHPUnit\\Framework\\Test::\$fixtureManager#'
         - '#Method Redis::#'
+        - '#Call to an undefined method Traversable::getArrayCopy().#'
     earlyTerminatingMethodCalls:
         Cake\Shell\Shell:
             - abort

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -819,7 +819,7 @@ trait CollectionTrait
     {
         $iterator = $this->unwrap();
 
-        if (get_class($iterator) === ArrayIterator::class) {
+        if (get_class($iterator) === ArrayIterator::class && $iterator instanceof ArrayIterator) {
             $iterator = $iterator->getArrayCopy();
         }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -819,7 +819,7 @@ trait CollectionTrait
     {
         $iterator = $this->unwrap();
 
-        if (get_class($iterator) === ArrayIterator::class && $iterator instanceof ArrayIterator) {
+        if (get_class($iterator) === ArrayIterator::class) {
             $iterator = $iterator->getArrayCopy();
         }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -512,7 +512,7 @@ trait CollectionTrait
     public function toArray($preserveKeys = true)
     {
         $iterator = $this->unwrap();
-        if (get_class($iterator) === ArrayIterator::class) {
+        if ($iterator instanceof ArrayIterator) {
             $items = $iterator->getArrayCopy();
 
             return $preserveKeys ? $items : array_values($items);

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -512,7 +512,7 @@ trait CollectionTrait
     public function toArray($preserveKeys = true)
     {
         $iterator = $this->unwrap();
-        if ($iterator instanceof ArrayIterator) {
+        if (get_class($iterator) === ArrayIterator::class) {
             $items = $iterator->getArrayCopy();
 
             return $preserveKeys ? $items : array_values($items);
@@ -819,7 +819,7 @@ trait CollectionTrait
     {
         $iterator = $this->unwrap();
 
-        if ($iterator instanceof ArrayIterator) {
+        if (get_class($iterator) === ArrayIterator::class) {
             $iterator = $iterator->getArrayCopy();
         }
 

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -88,7 +88,7 @@ class ExtractIterator extends Collection
             $iterator = $iterator->unwrap();
         }
 
-        if (!$iterator instanceof ArrayIterator) {
+        if (get_class($iterator) !== ArrayIterator::class) {
             return $this;
         }
 

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -88,7 +88,7 @@ class ExtractIterator extends Collection
             $iterator = $iterator->unwrap();
         }
 
-        if (get_class($iterator) !== ArrayIterator::class || !$iterator instanceof ArrayIterator) {
+        if (get_class($iterator) !== ArrayIterator::class) {
             return $this;
         }
 

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -88,7 +88,7 @@ class ExtractIterator extends Collection
             $iterator = $iterator->unwrap();
         }
 
-        if (get_class($iterator) !== ArrayIterator::class) {
+        if (get_class($iterator) !== ArrayIterator::class || !$iterator instanceof ArrayIterator) {
             return $this;
         }
 

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -74,7 +74,7 @@ class FilterIterator extends Collection
             $iterator = $iterator->unwrap();
         }
 
-        if (!$iterator instanceof ArrayIterator) {
+        if (get_class($iterator) !== ArrayIterator::class) {
             return $filter;
         }
 

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -86,7 +86,7 @@ class ReplaceIterator extends Collection
             $iterator = $iterator->unwrap();
         }
 
-        if (!$iterator instanceof ArrayIterator) {
+        if (get_class($iterator) !== ArrayIterator::class) {
             return $this;
         }
 

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -97,7 +97,7 @@ class StoppableIterator extends Collection
             $iterator = $iterator->unwrap();
         }
 
-        if (!$iterator instanceof ArrayIterator) {
+        if (get_class($iterator) !== ArrayIterator::class) {
             return $this;
         }
 


### PR DESCRIPTION
When a class that extends the base ArrayIterator class are iterated
over, the collection class would replace the class with a basic array or
ArrayIterator, breaking any custom logic in the original class.

This fixes the issue by checking if the class is an ArrayIterator,
rather than if it is simply a instance of ArrayIterator.