### PR TITLE
Fix Response __debugInfo() to get body content

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -2589,7 +2589,7 @@ class Response implements ResponseInterface
             'fileRange' => $this->_fileRange,
             'cookies' => $this->_cookies,
             'cacheDirectives' => $this->_cacheDirectives,
-            'body' => $this->getBody()->getContents(),
+            'body' => (string)$this->getBody(),
         ];
     }
 }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -3137,6 +3137,7 @@ class ResponseTest extends TestCase
     public function testDebugInfo()
     {
         $response = new Response();
+        $response = $response->withStringBody('Foo');
         $result = $response->__debugInfo();
 
         $expected = [
@@ -3149,7 +3150,7 @@ class ResponseTest extends TestCase
             'fileRange' => [],
             'cookies' => new CookieCollection(),
             'cacheDirectives' => [],
-            'body' => ''
+            'body' => 'Foo'
         ];
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Currently, debugging the response, always returns `'body' => ''`.
I added a type cast and updated the test.