### PR TITLE
- DigestAuthenticate modification for cakephp 2.X

### DIFF
--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -44,7 +44,7 @@ App::uses('BasicAuthenticate', 'Controller/Component/Auth');
  * Due to the Digest authentication specification, digest auth requires a special password value. You
  * can generate this password using `DigestAuthenticate::password()`
  *
- * `$digestPass = DigestAuthenticate::password($username, env('SERVER_NAME'), $password);`
+ * `$digestPass = DigestAuthenticate::password($username, $passwordm env('SERVER_NAME'));`
  *
  * Its recommended that you store this digest auth only password separate from password hashes used for other
  * login methods. For example `User.digest_pass` could be used for a digest password, while `User.password` would


### PR DESCRIPTION
In [password](https://github.com/cakephp/cakephp/blob/24e4acf9a38dc6a3a96fa5bebf9939988e715d77/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php#L203) function realm is the third parameter but in [documentation](https://github.com/cakephp/cakephp/blob/24e4acf9a38dc6a3a96fa5bebf9939988e715d77/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php#L47) is the seconde